### PR TITLE
Pull request twitter pic

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -59,7 +59,7 @@ passport.use(new TwitterStrategy(secrets.twitter, function(req, accessToken, tok
           user.tokens.push({ kind: 'twitter', accessToken: accessToken, tokenSecret: tokenSecret });
           user.profile.name = user.profile.name || profile.displayName;
           user.profile.location = user.profile.location || profile._json.location;
-          user.profile.picture = user.profile.picture || profile._json.profile_image_url_https;
+          user.profile.picture = user.profile.picture || profile._json.profile_image_url_https.substring(0, profile_image_url_https.length - 11);
           user.save(function(err) {
             req.flash('info', { msg: 'Twitter account has been linked.' });
             done(err, user);
@@ -81,7 +81,7 @@ passport.use(new TwitterStrategy(secrets.twitter, function(req, accessToken, tok
       user.tokens.push({ kind: 'twitter', accessToken: accessToken, tokenSecret: tokenSecret });
       user.profile.name = profile.displayName;
       user.profile.location = profile._json.location;
-      user.profile.picture = profile._json.profile_image_url_https;
+      user.profile.picture = profile._json.profile_image_url_https.substring(0, profile_image_url_https.length - 11);
       user.save(function(err) {
         done(err, user);
       });

--- a/config/passport.js
+++ b/config/passport.js
@@ -59,7 +59,7 @@ passport.use(new TwitterStrategy(secrets.twitter, function(req, accessToken, tok
           user.tokens.push({ kind: 'twitter', accessToken: accessToken, tokenSecret: tokenSecret });
           user.profile.name = user.profile.name || profile.displayName;
           user.profile.location = user.profile.location || profile._json.location;
-          user.profile.picture = user.profile.picture || profile._json.profile_image_url_https.substring(0, profile_image_url_https.length - 11);
+          user.profile.picture = user.profile.picture || profile._json.profile_image_url_https.substring(0, profile_image_url_https.length - 11) + '.png';
           user.save(function(err) {
             req.flash('info', { msg: 'Twitter account has been linked.' });
             done(err, user);
@@ -81,7 +81,7 @@ passport.use(new TwitterStrategy(secrets.twitter, function(req, accessToken, tok
       user.tokens.push({ kind: 'twitter', accessToken: accessToken, tokenSecret: tokenSecret });
       user.profile.name = profile.displayName;
       user.profile.location = profile._json.location;
-      user.profile.picture = profile._json.profile_image_url_https.substring(0, profile_image_url_https.length - 11);
+      user.profile.picture = profile._json.profile_image_url_https.substring(0, profile_image_url_https.length - 11) + '.png';
       user.save(function(err) {
         done(err, user);
       });


### PR DESCRIPTION
The profile picture pulled from twitter with `profile_image_url_https` will have `_normal.png` attached to the end of the url. According to the [Twitter Docs](https://dev.twitter.com/overview/general/user-profile-images-and-banners), normal = 48x48px (too small for the new bio pages).

I removed the last 11 characters ('_normal.png') and then added the `.png` back. I'm sure there is more elegant way to do it.
