### PR TITLE
Change decay rate of hot stories to 48 hours

### DIFF
--- a/controllers/story.js
+++ b/controllers/story.js
@@ -19,7 +19,7 @@ function hotRank(timeValue, rank) {
      */
     var hotness;
     var z = Math.log(rank) / Math.log(10);
-    hotness = z + (timeValue / 45000000);
+    hotness = z + (timeValue / 1728000000);
     return hotness;
 
 }


### PR DESCRIPTION
450,000 seconds equates to 12.5 hours. 172,800,800 equates to 48 hours. This should keep a "hotter" look to our hot stories.
