### PR TITLE
having the text for showing streak should be fine. 

### DIFF
--- a/views/account/show.jade
+++ b/views/account/show.jade
@@ -120,7 +120,7 @@ block content
                                     legend: [1, 2, 3]
                                 });
                     .row
-                        .hidden-xs.col-sm-12.text-center
+                        .col-sm-12.text-center
                             .row
                                 h3.col-sm-6.text-center
                                     .center-block.


### PR DESCRIPTION
Nothing can fix the heatmap graphic. I tried setting HTML attributes:

> **Notes**
> When [_Element_.setAttribute() is] called on an HTML element in an HTML document, setAttribute lower-cases its attribute name argument.

[MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/setAttribute)

However I think just having the streaks visible should be ok. No harm in that.
