### PR TITLE
Site speed

### DIFF
--- a/app.js
+++ b/app.js
@@ -253,12 +253,8 @@ app.use(express.static(__dirname + '/public', { maxAge: 86400000 }));
 
 app.get('/', homeController.index);
 
-app.get('/privacy', function(req, res) {
-    res.redirect(301, "/field-guide/free-code-camp's-privacy-policy");
-});
-
 app.get('/nonprofit-project-instructions', function(req, res) {
-    res.redirect(301, "/field-guide/free-code-camp's-privacy-policy");
+    res.redirect(301, '/field-guide/nonprofit-project-instructions');
 });
 
 app.get('/chat', resourcesController.chat);
@@ -384,16 +380,16 @@ app.post(
   passportConf.isAuthenticated,
   contactController.postDoneWithFirst100Hours
 );
-//app.get(
-//  '/nonprofit-project-instructions',
-//  passportConf.isAuthenticated,
-//  resourcesController.nonprofitProjectInstructions
-//);
+
 app.post(
   '/update-progress',
   passportConf.isAuthenticated,
   userController.updateProgress
 );
+
+app.get('/privacy', function(req, res) {
+  res.redirect(301, '/field-guide/the-free-code-camp-privacy-policy');
+});
 
 app.get('/api/slack', function(req, res) {
   if (req.user) {
@@ -590,7 +586,7 @@ app.post('/completed-bonfire/', bonfireController.completedBonfire);
 
 app.get('/field-guide/:fieldGuideName', fieldGuideController.returnIndividualFieldGuide);
 
-app.get('/field-guide', fieldGuideController.returnNextFieldGuide);
+app.get('/field-guide/', fieldGuideController.returnNextFieldGuide);
 
 app.post('/completed-field-guide/', fieldGuideController.completedFieldGuide);
 

--- a/controllers/bonfire.js
+++ b/controllers/bonfire.js
@@ -63,12 +63,12 @@ exports.returnNextBonfire = function(req, res, next) {
   var uncompletedBonfires = req.user.uncompletedBonfires;
 
   var displayedBonfires =  Bonfire.find({'_id': uncompletedBonfires[0]});
-  displayedBonfires.exec(function(err, bonfire) {
+  displayedBonfires.exec(function(err, bonfireFromMongo) {
     if (err) {
       return next(err);
     }
-    bonfire = bonfire.pop();
-    if (bonfire === undefined) {
+    var bonfire = bonfireFromMongo.pop();
+    if (typeof bonfire === 'undefined') {
       req.flash('errors', {
         msg: "It looks like you've completed all the bonfires we have available. Good job!"
       });
@@ -84,13 +84,13 @@ exports.returnIndividualBonfire = function(req, res, next) {
 
   var bonfireName = dashedName.replace(/\-/g, ' ');
 
-  Bonfire.find({'name': new RegExp(bonfireName, 'i')}, function(err, bonfire) {
+  Bonfire.find({'name': new RegExp(bonfireName, 'i')}, function(err, bonfireFromMongo) {
     if (err) {
       next(err);
     }
 
 
-    if (bonfire.length < 1) {
+    if (bonfireFromMongo.length < 1) {
       req.flash('errors', {
         msg: "404: We couldn't find a bonfire with that name. Please double check the name."
       });
@@ -98,9 +98,9 @@ exports.returnIndividualBonfire = function(req, res, next) {
       return res.redirect('/bonfires');
     }
 
-    bonfire = bonfire.pop();
+    var bonfire = bonfireFromMongo.pop();
     var dashedNameFull = bonfire.name.toLowerCase().replace(/\s/g, '-');
-    if (dashedNameFull != dashedName) {
+    if (dashedNameFull !== dashedName) {
       return res.redirect('../bonfires/' + dashedNameFull);
     }
     res.render('bonfire/show', {

--- a/controllers/courseware.js
+++ b/controllers/courseware.js
@@ -50,14 +50,14 @@ exports.returnNextCourseware = function(req, res, next) {
     }
 
     courseware = courseware.pop();
-    if (courseware === undefined) {
+    if (typeof courseware === 'undefined') {
       req.flash('errors', {
         msg: "It looks like you've completed all the courses we have " +
         "available. Good job!"
       });
       return res.redirect('../challenges/learn-how-free-code-camp-works');
     }
-    nameString = courseware.name.toLowerCase().replace(/\s/g, '-');
+    var nameString = courseware.name.toLowerCase().replace(/\s/g, '-');
     return res.redirect('../challenges/' + nameString);
   });
 };
@@ -68,23 +68,23 @@ exports.returnIndividualCourseware = function(req, res, next) {
   var coursewareName = dashedName.replace(/\-/g, ' ');
 
   Courseware.find({'name': new RegExp(coursewareName, 'i')},
-    function(err, courseware) {
+    function(err, coursewareFromMongo) {
     if (err) {
       next(err);
     }
     // Handle not found
-    if (courseware.length < 1) {
+    if (coursewareFromMongo.length < 1) {
       req.flash('errors', {
         msg: "404: We couldn't find a challenge with that name. " +
         "Please double check the name."
       });
       return res.redirect('/challenges');
     }
-    courseware = courseware.pop();
+    var courseware = coursewareFromMongo.pop();
 
     // Redirect to full name if the user only entered a partial
     var dashedNameFull = courseware.name.toLowerCase().replace(/\s/g, '-');
-    if (dashedNameFull != dashedName) {
+    if (dashedNameFull !== dashedName) {
       return res.redirect('../challenges/' + dashedNameFull);
     }
 
@@ -292,7 +292,7 @@ exports.completedZiplineOrBasejump = function (req, res, next) {
 
   if (isCompletedWith) {
     var paired = User.find({'profile.username': isCompletedWith.toLowerCase()}).limit(1);
-    paired.exec(function (err, pairedWith) {
+    paired.exec(function (err, pairedWithFromMongo) {
       if (err) {
         return next(err);
       } else {
@@ -301,7 +301,7 @@ exports.completedZiplineOrBasejump = function (req, res, next) {
           req.user.progressTimestamps.push(Date.now() || 0);
           req.user.uncompletedCoursewares.splice(index, 1);
         }
-        pairedWith = pairedWith.pop();
+        var pairedWith = pairedWithFromMongo.pop();
 
         req.user.completedCoursewares.push({
           _id: coursewareHash,

--- a/controllers/fieldGuide.js
+++ b/controllers/fieldGuide.js
@@ -9,12 +9,12 @@ exports.returnIndividualFieldGuide = function(req, res, next) {
 
     var fieldGuideName = dashedName.replace(/\-/g, ' ');
 
-    FieldGuide.find({'name': new RegExp(fieldGuideName, 'i')}, function(err, fieldGuide) {
+    FieldGuide.find({'name': new RegExp(fieldGuideName, 'i')}, function(err, fieldGuideFromMongo) {
         if (err) {
             next(err);
         }
 
-        if (fieldGuide.length < 1) {
+        if (fieldGuideFromMongo.length < 1) {
             req.flash('errors', {
                 msg: "404: We couldn't find a field guide entry with that name. Please double check the name."
             });
@@ -22,9 +22,9 @@ exports.returnIndividualFieldGuide = function(req, res, next) {
             return res.redirect('/field-guide');
         }
 
-        fieldGuide = fieldGuide.pop();
+        fieldGuide = fieldGuideFromMongo.pop();
         var dashedNameFull = fieldGuide.name.toLowerCase().replace(/\s/g, '-').replace(/\?/g, '');
-        if (dashedNameFull != dashedName) {
+        if (dashedNameFull !== dashedName) {
             return res.redirect('../field-guide/' + dashedNameFull);
         }
         res.render('field-guide/show', {
@@ -69,7 +69,7 @@ exports.returnNextFieldGuide = function(req, res, next) {
       return next(err);
     }
     fieldGuide = fieldGuide.pop();
-    if (fieldGuide === undefined) {
+    if (typeof fieldGuide === 'undefined') {
       req.flash('success', {
         msg: "You've read all our current Field Guide entries. You can contribute to our Field Guide <a href='https://github.com/FreeCodeCamp/freecodecamp/blob/master/seed_data/field-guides.json'>here</a>."
       });

--- a/controllers/fieldGuide.js
+++ b/controllers/fieldGuide.js
@@ -22,7 +22,7 @@ exports.returnIndividualFieldGuide = function(req, res, next) {
             return res.redirect('/field-guide');
         }
 
-        fieldGuide = fieldGuideFromMongo.pop();
+        var fieldGuide = fieldGuideFromMongo.pop();
         var dashedNameFull = fieldGuide.name.toLowerCase().replace(/\s/g, '-').replace(/\?/g, '');
         if (dashedNameFull !== dashedName) {
             return res.redirect('../field-guide/' + dashedNameFull);

--- a/controllers/fieldGuide.js
+++ b/controllers/fieldGuide.js
@@ -42,7 +42,7 @@ exports.showAllFieldGuides = function(req, res) {
     if (req.user && req.user.completedFieldGuides) {
       data.completedFieldGuides = req.user.completedFieldGuides;
     } else {
-      data.completedFieldGuides = []
+      data.completedFieldGuides = [];
     }
     res.send(data);
 };

--- a/controllers/resources.js
+++ b/controllers/resources.js
@@ -44,12 +44,6 @@ Array.zip = function(left, right, combinerFunction) {
 };
 
 module.exports = {
-  privacy: function privacy(req, res) {
-    res.render('resources/privacy', {
-      title: 'Privacy'
-    });
-  },
-
   sitemap: function sitemap(req, res, next) {
     var appUrl = 'http://www.freecodecamp.com';
     var now = moment(new Date()).format('YYYY-MM-DD');

--- a/controllers/resources.js
+++ b/controllers/resources.js
@@ -8,7 +8,6 @@ var async = require('async'),
   Nonprofit = require('./../models/Nonprofit'),
   Comment = require('./../models/Comment'),
   resources = require('./resources.json'),
-  steps = resources.steps,
   secrets = require('./../config/secrets'),
   bonfires = require('../seed_data/bonfires.json'),
   nonprofits = require('../seed_data/nonprofits.json'),
@@ -186,19 +185,11 @@ module.exports = {
         return next(err);
       }
 
-      // todo is this necessary anymore?
-      User.count({'points': {'$gt': 53}}, function (err, all) {
-        if (err) {
-          debug('User err: ', err);
-          return next(err);
-        }
-
-        res.render('resources/learn-to-code', {
-          title: 'About Free Code Camp',
-          daysRunning: daysRunning,
-          c3: numberWithCommas(c3),
-          announcements: announcements
-        });
+      res.render('resources/learn-to-code', {
+        title: 'About Free Code Camp',
+        daysRunning: daysRunning,
+        c3: numberWithCommas(c3),
+        announcements: announcements
       });
     });
   },

--- a/controllers/resources.js
+++ b/controllers/resources.js
@@ -49,53 +49,77 @@ module.exports = {
 
 
     async.parallel({
+        users: function(callback) {
+          User.aggregate()
+            .group({_id: 1, usernames: { $addToSet: '$profile.username'}})
+            .match({'profile.username': { $ne: ''}})
+            .exec(function(err, users) {
+              if (err) {
+                debug('User err: ', err);
+                callback(err);
+              } else {
+                callback(null, users[0].usernames);
+              }
+            });
+        },
+
         challenges: function (callback) {
-          Courseware.find({}, function (err, challenges) {
-            if (err) {
-              debug('Courseware err: ', err);
-              callback(err);
-            } else {
-              callback(null, challenges);
-            }
-          });
+          Courseware.aggregate()
+            .group({_id: 1, names: { $addToSet: '$name'}})
+            .exec(function (err, challenges) {
+              if (err) {
+                debug('Courseware err: ', err);
+                callback(err);
+              } else {
+                callback(null, challenges[0].names);
+              }
+            });
         },
         bonfires: function (callback) {
-          Bonfire.find({}, function (err, bonfires) {
+          Bonfire.aggregate()
+          .group({_id: 1, names: { $addToSet: '$name'}})
+          .exec(function (err, bonfires) {
             if (err) {
               debug('Bonfire err: ', err);
               callback(err);
             } else {
-              callback(null, bonfires);
+              callback(null, bonfires[0].names);
             }
           });
         },
         stories: function (callback) {
-          Story.find({}, function (err, stories) {
+          Story.aggregate()
+            .group({_id: 1, links: {$addToSet: '$link'}})
+          .exec(function (err, stories) {
             if (err) {
               debug('Story err: ', err);
               callback(err);
             } else {
-              callback(null, stories);
+              callback(null, stories[0].links);
             }
           });
         },
         nonprofits: function (callback) {
-          Nonprofit.find({}, function (err, nonprofits) {
+          Nonprofit.aggregate()
+            .group({_id: 1, names: { $addToSet: '$name'}})
+            .exec(function (err, nonprofits) {
             if (err) {
               debug('User err: ', err);
               callback(err);
             } else {
-              callback(null, nonprofits);
+              callback(null, nonprofits[0].names);
             }
           });
         },
         fieldGuides: function (callback) {
-          FieldGuide.find({}, function (err, fieldGuides) {
+          FieldGuide.aggregate()
+            .group({_id: 1, names: { $addToSet: '$name'}})
+            .exec(function (err, fieldGuides) {
             if (err) {
               debug('User err: ', err);
               callback(err);
             } else {
-              callback(null, fieldGuides);
+              callback(null, fieldGuides[0].names);
             }
           });
         }
@@ -108,6 +132,7 @@ module.exports = {
             res.render('resources/sitemap', {
               appUrl: appUrl,
               now: now,
+              users: results.users,
               challenges: results.challenges,
               bonfires: results.bonfires,
               stories: results.stories,
@@ -371,7 +396,6 @@ module.exports = {
     })();
   },
 
-  // todo analyze this function in detail
   updateUserStoryPictures: function(userId, picture, username, cb) {
 
     var counter = 0,

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -253,7 +253,7 @@ exports.checkExistingUsername = function(req, res, next) {
 exports.checkUniqueEmail = function(req, res, next) {
     User.count({'email': decodeURIComponent(req.params.email).toLowerCase()}, function (err, data) {
         if (err) { return next(err); }
-        if (data == 1) {
+        if (data === 1) {
             return res.send(true);
         } else {
             return res.send(false);
@@ -271,7 +271,7 @@ exports.returnUser = function(req, res, next) {
   User.find({'profile.username': req.params.username.toLowerCase()}, function(err, user) {
     if (err) { debug('Username err: ', err); next(err); }
     if (user[0]) {
-      var user = user[0];
+      user = user[0];
 
       user.progressTimestamps = user.progressTimestamps.sort(function(a, b) {
         return a - b;
@@ -284,6 +284,7 @@ exports.returnUser = function(req, res, next) {
 
       var tmpLongest = 1;
       var timeKeys = R.keys(timeObject);
+
       for (var i = 1; i <= timeKeys.length; i++) {
         if (moment(timeKeys[i - 1]).add(1, 'd').toString()
           === moment(timeKeys[i]).toString()) {
@@ -305,13 +306,17 @@ exports.returnUser = function(req, res, next) {
 
       var data = {};
       var progressTimestamps = user.progressTimestamps;
-      for (var i = 0; i < progressTimestamps.length; i++) {
-        data[(progressTimestamps[i] / 1000).toString()] = 1;
-      }
+      progressTimestamps.forEach(function(timeStamp) {
+        data[(timeStamp / 1000)] = 1;
+      });
+
+      //for (var i = 0; i < progressTimestamps.length; i++) {
+      //  data[(progressTimestamps[i] / 1000).toString()] = 1;
+      //}
 
       user.currentStreak = user.currentStreak || 1;
       user.longestStreak = user.longestStreak || 1;
-      challenges = user.completedCoursewares.filter(function ( obj ) {
+      var challenges = user.completedCoursewares.filter(function ( obj ) {
         return !!obj.solution;
       });
       res.render('account/show', {

--- a/seed_data/bonfires.json
+++ b/seed_data/bonfires.json
@@ -644,7 +644,8 @@
     "difficulty": "3.12",
     "description": [
       "Fill in the object constructor with the methods specified in the tests.",
-      "Those methods are getFirstName(), getLastName(), getFullName(), setFirstName(), setLastName(), and setFullName().",
+      "Those methods are getFirstName(), getLastName(), getFullName(), setFirstName(first), setLastName(last), and setFullName(firstAndLast).",
+      "All functions that take an argument have an arity of 1, and the argument will be a string.",
       "These methods must be the only available means for interacting with the object."
     ],
     "challengeSeed": "var Person = function(firstAndLast) {\n    return firstAndLast;\r\n};\n\nvar bob = new Person('Bob Ross');\nbob.getFullName();",

--- a/views/resources/sitemap.jade
+++ b/views/resources/sitemap.jade
@@ -32,14 +32,6 @@ urlset(xmlns="http://www.sitemaps.org/schemas/sitemap/0.9")
     changefreq daily
     priority= 0.8
 
-  //- Users
-  each user in users
-    url
-      loc #{appUrl}/#{user.profile.username}
-      lastmod= now
-      changefreq daily
-      priority= 0.9
-
   //- Products
   each bonfire in bonfires
     url

--- a/views/resources/sitemap.jade
+++ b/views/resources/sitemap.jade
@@ -32,10 +32,19 @@ urlset(xmlns="http://www.sitemaps.org/schemas/sitemap/0.9")
     changefreq daily
     priority= 0.8
 
+  //- User
+  each user in users
+    url
+      loc #{appUrl}/#{user}
+      lastmod= now
+      changefreq daily
+      priority= 0.9
+
+
   //- Products
   each bonfire in bonfires
     url
-      loc #{appUrl}/bonfires/#{bonfire.name.replace(/\s/g, '-')}
+      loc #{appUrl}/bonfires/#{bonfire.replace(/\s/g, '-')}
       lastmod= now
       changefreq weekly
       priority= 0.5
@@ -43,7 +52,7 @@ urlset(xmlns="http://www.sitemaps.org/schemas/sitemap/0.9")
   //- Challenges
   each challenge in challenges
     url
-      loc #{appUrl}/challenges/#{challenge.name.replace(/\s/g, '-')}
+      loc #{appUrl}/challenges/#{challenge.replace(/\s/g, '-')}
       lastmod= now
       changefreq weekly
       priority= 0.5
@@ -51,7 +60,7 @@ urlset(xmlns="http://www.sitemaps.org/schemas/sitemap/0.9")
   //- Stories
   each story in stories
     url
-      loc #{appUrl}/stories/#{story.storyLink.replace(/\s/g, '-')}
+      loc #{appUrl}/stories/#{story.replace(/\s/g, '-')}
       lastmod= now
       changefreq daily
       priority= 0.9
@@ -59,7 +68,7 @@ urlset(xmlns="http://www.sitemaps.org/schemas/sitemap/0.9")
   //- Nonprofit
   each nonprofit in nonprofits
     url
-      loc #{appUrl}/nonprofits/#{nonprofit.name.replace(/\s/g, '-')}
+      loc #{appUrl}/nonprofits/#{nonprofit.replace(/\s/g, '-')}
       lastmod= now
       changefreq daily
       priority= 0.9
@@ -67,7 +76,7 @@ urlset(xmlns="http://www.sitemaps.org/schemas/sitemap/0.9")
   //- Nonprofit
   each fieldGuide in fieldGuides
     url
-      loc #{appUrl}/field-guide/#{fieldGuide.name.replace(/\s/g, '-')}
+      loc #{appUrl}/field-guide/#{fieldGuide.replace(/\s/g, '-')}
       lastmod= now
       changefreq daily
       priority= 0.9


### PR DESCRIPTION
I've refactored the resources.js controller to respond faster by caching the results of most of the utility functions that get id and name info for our content. 

Controllers have been refactored to separate the return from mongo from the data used further down in the functions. 

The sitemap function in resources has been heavily refactored. Returning all users from the database is a massive network request and was blocking the server. The async.js library has been used in favor of repeatedly nested callbacks to make things easier to read.

The privacy route has been restored and permanently redirects to the correct field-guide.

Minor format changes in code for readability as well as linting cleanup to unify style.

Update Make a Person bonfire for more detailed instructions, closes #336
