### PR TITLE
Fixes #352 - Camper News email notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <img src="https://s3.amazonaws.com/freecodecamp/logo4.0LG.png">
 
 Free Code Camp!
-=======================
+========================
 
 We're a community of busy people learning to code by collaborating on projects for nonprofits. We learn, then use, the JavaScript MEAN stack - MongoDB, Express.js, Angular.js and Node.js. 
 

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -287,6 +287,8 @@ $(document).ready(function() {
       {
         data: {
           associatedPost: storyId,
+          originalStoryLink: originalStoryLink,
+          originalStoryAuthorEmail: originalStoryAuthorEmail,
           body: data
         }
       })

--- a/views/stories/comments.jade
+++ b/views/stories/comments.jade
@@ -108,6 +108,7 @@
                                             data: {
                                                 associatedPost: commentId,
                                                 originalStoryLink: originalStoryLink,
+                                                originalStoryAuthorEmail: originalStoryAuthorEmail,
                                                 body: $('#comment-to-comment-textinput').val(),
                                             }
                                         })

--- a/views/stories/show.jade
+++ b/views/stories/show.jade
@@ -2,6 +2,7 @@
     script.
         var storyId = !{JSON.stringify(id)};
         var originalStoryLink = !{JSON.stringify(originalStoryLink)};
+        var originalStoryAuthorEmail = !{JSON.stringify(originalStoryAuthorEmail)};
         var comments = !{JSON.stringify(comments)};
         var upVotes = !{JSON.stringify(upVotes)};
         var image = !{JSON.stringify(image)};


### PR DESCRIPTION
The logic behind the Camper News email notifications now fits these requirements:

> - As a person who posted the story, I want to receive a notification when someone comments on it.
> - As a person who comments on a story, I want to receive a notification if someone replies to my comment.
> - As a person receiving such a notification email, I can see who commented and click a link to go directly to the story.
