### PR TITLE
Fix typo and add tests for bonfire Arguments Optional

### DIFF
--- a/seed_data/bonfires.json
+++ b/seed_data/bonfires.json
@@ -628,13 +628,15 @@
     "description": [
       "Create a function that sums two arguments together. If only one argument is provided, return a function that expects one additional argument and will return the sum.",
       "For example, add(2, 3) should return 5, and add(2) should return a function that is waiting for an argument so that <code>var sum2And = add(2); return sum2And(3); // 5</code>",
-      "If either argument isn't a valid numbers, return undefined"
+      "If either argument isn't a valid number, return undefined."
     ],
     "challengeSeed": "function add() {\n  return false;\n}\n\nadd(2,3);",
     "tests": [
       "expect(add(2, 3)).to.equal(5);",
       "expect(add(2)(3)).to.equal(5);",
-      "expect(add('http://bit.ly/IqT6zt')).to.be.undefined;"
+      "expect(add('http://bit.ly/IqT6zt')).to.be.undefined;",
+      "expect(add(2, '3')).to.be.undefined;",
+      "expect(add(2)([3])).to.be.undefined;"
     ],
     "MDNlinks": ["Global Function Object", "Arguments object"]
   },


### PR DESCRIPTION
The instructions for the bonfire Arguments Optional say to return `undefined` when either argument isn't a valid number, but the tests only cover the first argument.

This adds tests for the second argument as well, and fixes a typo.
