### PR TITLE
Added MDN links to Bonfire 19: Diff Two Arrays

### DIFF
--- a/seed_data/bonfires.json
+++ b/seed_data/bonfires.json
@@ -316,7 +316,8 @@
       "assert.deepEqual(diff([1, 2, 3, 5], [1, 2, 3, 4, 5]), [4], 'arrays with numbers');",
       "assert.includeMembers(diff([1, 'calf', 3, 'piglet'], [1, 'calf', 3, 4]), ['piglet', 4], 'arrays with numbers and strings');",
       "assert.deepEqual(diff([], ['snuffleupagus', 'cookie monster', 'elmo']), ['snuffleupagus', 'cookie monster', 'elmo'], 'empty array');"
-    ]
+    ],
+    "MDNlinks" : ["String.slice()", "Array.filter()", "Array.indexOf()", "String.concat()"]
   },
   {
     "_id": "a7f4d8f2483413a6ce226cac",


### PR DESCRIPTION
Fixes FreeCodeCamp/freecodecamp#374

I added the following links to Bonfire 19: "String.slice()", "Array.filter()", "Array.indexOf()", and  "String.concat()".
