### PR TITLE
removed "white-space: pre-line" rule from pre.wrappable elements to p…

### DIFF
--- a/public/css/main.less
+++ b/public/css/main.less
@@ -20,6 +20,16 @@ li, .wrappable {
   word-wrap: break-word;      /* IE 5+ */
 }
 
+pre.wrappable {
+  white-space: pre;           /* CSS 2.0 */
+  white-space: pre-wrap;      /* CSS 2.1 */
+  white-space: -pre-wrap;     /* Opera 4-6 */
+  white-space: -o-pre-wrap;   /* Opera 7 */
+  white-space: -moz-pre-wrap; /* Mozilla */
+  white-space: -hp-pre-wrap;  /* HP Printers */
+  word-wrap: break-word;      /* IE 5+ */
+}
+
 html {
   position: relative;
   min-height: 100%;


### PR DESCRIPTION
…rettify bonfire solution formatting.

Before:
![phoenixstormcrow-459-before](https://cloud.githubusercontent.com/assets/2560986/7717148/2e13885a-fe51-11e4-8722-33b36241b10d.png)

After:
![phoenixstormcrow-459-after](https://cloud.githubusercontent.com/assets/2560986/7717147/2e105d24-fe51-11e4-9b91-8cdf421d6719.png)

closes #459 
