### PR TITLE
Fixes sentence cut-off bug in Make Circular Images with a Border Radius

### DIFF
--- a/seed_data/challenges/basic-html5-and-css.json
+++ b/seed_data/challenges/basic-html5-and-css.json
@@ -854,7 +854,7 @@
         "In addition to pixels, you can also specify a <code>border-radius</code> using a percentage."
       ],
       "tests": [
-        "assert(parseInt($('img').css('border-top-left-radius')) > 48, 'Your image should have a border radius of 50 percent, making it perfectly circular.')"
+        "assert(parseInt($('img').css('border-top-left-radius')) > 48, 'Your image should have a border radius of 50 percent&#44; making it perfectly circular.')"
       ],
       "challengeSeed": [
         "<link href='http://fonts.googleapis.com/css?family=Lobster' rel='stylesheet' type='text/css'>",


### PR DESCRIPTION
When completing 'Make Circular Images with a Border Radius', the sentence is cut off at the comma (see left). This fixes it (see right).
![fcc-border-radius](https://cloud.githubusercontent.com/assets/3090888/7894754/a264c2e2-0670-11e5-9710-85a1c74ba40e.png)

Tested i Firefox 38 and Chromium 43.
