### PR TITLE
Cleaner output form 'Turn an Image into a Link'

### DIFF
--- a/seed_data/challenges/basic-html5-and-css.json
+++ b/seed_data/challenges/basic-html5-and-css.json
@@ -1102,8 +1102,8 @@
         "Once you've done this, hover over your image with your cursor. Your cursor's normal pointer should become the link clicking pointer. The photo is now a link."
       ],
       "tests": [
-        "expect($('a').children('img').length, 'Wrap your image element inside an anchor element that has its <code>href</code> attribute set to \"#\"').to.equal(1);",
-        "expect(new RegExp('#').test($('a').children('img').parent().attr('href')), 'Make sure to specify the \"src\" attribute as \"#\"').to.be.true;"
+        "assert($('a').children('img').length === 1, 'Wrap your image element inside an anchor element that has its <code>href</code> attribute set to \"#\"')",
+        "assert(new RegExp('#').test($('a').children('img').parent().attr('href')) === true, 'Make sure to specify the \"src\" attribute as \"#\"')"
       ],
       "challengeSeed": [
         "<link href='http://fonts.googleapis.com/css?family=Lobster' rel='stylesheet' type='text/css'>",


### PR DESCRIPTION
Seems like using expect() to validate code is clutters up the success message.
![fcc-to be](https://cloud.githubusercontent.com/assets/3090888/7895029/8226231e-0679-11e5-9772-4ac27765c877.png)

After a cursory glance, this was the only similar occurrence in any of the HTML/CSS Waypoints. Changing expect statemtens to assert statments in the bonfires just seemed to mess up the entire thing, and I've found them helpful, so I assume they shouldn't be replaced all over?
What is the general "policy" towards assert vs expect? Seems to be a somewhat even split between the two.
