### PR TITLE
Improves 'Add Placeholder Text to a Text Field' and fixes #701

### DIFF
--- a/seed_data/challenges/basic-html5-and-css.json
+++ b/seed_data/challenges/basic-html5-and-css.json
@@ -1430,8 +1430,8 @@
         "For example: <code>&#60;input type='text' placeholder='this is placeholder text'&#62;</code>"
       ],
       "tests": [
-        "assert($('[placeholder]').length > 0, 'Your text field should have a placeholder attribute.')",
-        "assert(/url/gi.test($('input').attr('placeholder')), 'Your placeholder field should have the value of \"cat photo URL\".')"
+        "assert($('input[placeholder]').length > 0, 'Your text field should have a placeholder attribute.')",
+        "assert($('input').attr('placeholder') === 'cat photo URL', 'Your placeholder field should have the value of \"cat photo URL\".')"
       ],
       "challengeSeed": [
         "<link href='http://fonts.googleapis.com/css?family=Lobster' rel='stylesheet' type='text/css'>",


### PR DESCRIPTION
This resolves #701 and makes 'Your placeholder field should have the value of "cat photo URL"' false until the placeholder contains "cat photo URL" as opposed to the previous case-insensitive "url".
