### PR TITLE
Changed input type from checkbox to radio and attribute comparison name from trait to personality

### DIFF
--- a/seed/challenges/basic-html5-and-css.json
+++ b/seed/challenges/basic-html5-and-css.json
@@ -1892,7 +1892,7 @@
         "assert($('input[type=\"checkbox\"]').length > 2, 'Your page should have three checkbox elements.')",
         "assert($('label:has(input[type=\"checkbox\"])').length > 2, 'Each of your three checkbox elements should be wrapped in its own <code>label</code> element.')",
         "assert(editor.match(/<\\/label>/g) && editor.match(/<label/g) && editor.match(/<\\/label>/g).length === editor.match(/<label/g).length, 'Make sure each of your <code>label</code> elements has a closing tag.')",
-        "assert($('input[type=\"checkbox\"]:nth-child(1)').attr('name') === 'trait', 'Give your radio buttons the <code>name</code> attribute of \"personality\".')"
+        "assert($('input[type=\"radio\"]:nth-child(1)').attr('name') === 'personality', 'Give your radio buttons the <code>name</code> attribute of \"personality\".')"
       ],
       "challengeSeed": [
         "<link href='http://fonts.googleapis.com/css?family=Lobster' rel='stylesheet' type='text/css'>",


### PR DESCRIPTION
Issue below:

> Challenge http://www.freecodecamp.com/challenges/waypoint-create-a-set-of-checkboxes has an >issue. Please describe how to reproduce it, and include links to screen shots if possible.
> 
> Give your radio buttons the name attribute of "personality".
> 
> Cannot satisfy this request. This waypoint is on checkboxes and it is asking for me to edit the radio >button. I've changed the checkboxes and the radio buttons to have name="personality" nothing works.

The problem seems to be in the test. If you add the name trait to a checkbox then the challenge will pass. So to fix this I just changed the input type from a checkbox to a radio (which is what the instructions tell you to do it on) and I changed the attribute comparison from trait to personality (which is what the instructions tell you to name it).

I've tested this with console.log and my update works for me. Please review and let me know.

Thanks,
Charles
