### PR TITLE
Changed z-index of iframe-scroll class to 1

### DIFF
--- a/public/css/main.less
+++ b/public/css/main.less
@@ -1092,7 +1092,7 @@ hr {
   .iframe-scroll {
     position: fixed !important;
     margin-top: 75px;
-    z-index: 9999;
+    z-index: 1;
   }
 }
 @media only screen and (max-width: 992px) {


### PR DESCRIPTION
Fixes the iPhone from covering up the code editor but still keeps the iPhone above the footer.
closes #830 
