### PR TITLE
Fixes RegExp so it matches the class .blue-text

### DIFF
--- a/seed_data/challenges/basic-html5-and-css.json
+++ b/seed_data/challenges/basic-html5-and-css.json
@@ -659,7 +659,7 @@
         "Now see if you can make sure the <code>h2</code> element is rendered in the color red without removing the \"blue-text\" class, doing an in-line styling, and without changing the sequence of CSS class declarations."
       ],
       "tests": [
-        "assert(new RegExp('.blue-text', 'gi').test(editor), 'Create the CSS class \"blue-text\"')",
+        "assert(new RegExp(/\.blue-text/gi).test(editor), 'Create the CSS class \"blue-text\"')",
         "assert(new RegExp('.urgently-red', 'gi').test(editor), 'Create the CSS class \"urgently-red\"')",
         "assert(new RegExp('red.?!important', 'gi').test(editor), 'Add the \"!important\" declaration!')",
         "assert($('h2').hasClass('blue-text'), 'Your h2 element should have the class \"blue-text\".')",

--- a/seed_data/challenges/basic-html5-and-css.json
+++ b/seed_data/challenges/basic-html5-and-css.json
@@ -659,8 +659,8 @@
         "Now see if you can make sure the <code>h2</code> element is rendered in the color red without removing the \"blue-text\" class, doing an in-line styling, and without changing the sequence of CSS class declarations."
       ],
       "tests": [
-        "assert(new RegExp(/\.blue-text/gi).test(editor), 'Create the CSS class \"blue-text\"')",
-        "assert(new RegExp('.urgently-red', 'gi').test(editor), 'Create the CSS class \"urgently-red\"')",
+        "assert(new RegExp('\\.blue-text', 'gi').test(editor), 'Create the CSS class \"blue-text\"')",
+        "assert(new RegExp('\\.urgently-red', 'gi').test(editor), 'Create the CSS class \"urgently-red\"')",
         "assert(new RegExp('red.?!important', 'gi').test(editor), 'Add the \"!important\" declaration!')",
         "assert($('h2').hasClass('blue-text'), 'Your h2 element should have the class \"blue-text\".')",
         "assert($('h2').hasClass('urgently-red'), 'Your h2 element should have the class \"urgently-red\".')",


### PR DESCRIPTION
Ref: #841 

The current expression on the site now works but the dot/period isn't escaped which is causing the challenge to pass that step if any characters (except line breaks) are in front of the word "blue-text"

So to fix this I just escaped the dot/period and changed the format to literal notation.
