### PR TITLE
Add tests for confirm the ending bonfire

### DIFF
--- a/seed_data/challenges/basic-bonfires.json
+++ b/seed_data/challenges/basic-bonfires.json
@@ -336,6 +336,8 @@
       ],
       "tests": [
         "assert.strictEqual(end('Bastian', 'n'), true, 'should equal true if target equals end of string');",
+        "assert.strictEqual(end('Connor', 'n'), false, 'should equal false if target does not equal end of string');",
+        "assert.strictEqual(end('Walking on water and developing software from a specification are easy if both are frozen.', 'specification'), false, 'should equal false if target does not equal end of string');",
         "assert.strictEqual(end('He has to give me a new name', 'name'), true, 'should equal true if target equals end of string');",
         "assert.strictEqual(end('If you want to save our world, you must hurry. We dont know how much longer we can withstand the nothing', 'mountain'), false, 'should equal false if target does not equal end of string');"
       ],


### PR DESCRIPTION
Users searching for just occurrence of target and not the position(in this case the ending of the string) in this bonfire can pass the tests. So , currently this code pass the tests

```
function end(str, target) {
  return str.split(target) != str;
}
```

Added tests to fix this flaw.
