### PR TITLE
Fixed regexp on both ul and li opening tags

### DIFF
--- a/seed_data/challenges/basic-html5-and-css.json
+++ b/seed_data/challenges/basic-html5-and-css.json
@@ -1302,8 +1302,8 @@
       "tests": [
         "assert($('ul').length > 0, 'Create a <code>ul</code> element.')",
         "assert($('li').length > 2, 'Add three <code>li</code> elements to your <code>ul</code> element.')",
-        "assert(editor.match(/<\\/ul>/g) && editor.match(/<\\/ul>/g).length === editor.match(/<ul(?=>| )/g).length, 'Make sure your <code>ul</code> element has a closing tag.')",
-        "assert(editor.match(/<\\/li>/g) && editor.match(/<\\/li>/g).length === editor.match(/<li(?=>| )/g).length, 'Make sure your <code>li</code> element has a closing tag.')"
+        "assert(editor.match(/<\\/ul>/g) && editor.match(/<\\/ul>/g).length === editor.match(/<ul/g).length, 'Make sure your <code>ul</code> element has a closing tag.')",
+        "assert(editor.match(/<\\/li>/g) && editor.match(/<\\/li>/g).length === editor.match(/<li/g).length, 'Make sure your <code>li</code> element has a closing tag.')"
       ],
       "challengeSeed": [
         "<link href='http://fonts.googleapis.com/css?family=Lobster' rel='stylesheet' type='text/css'>",

--- a/seed_data/challenges/basic-html5-and-css.json
+++ b/seed_data/challenges/basic-html5-and-css.json
@@ -1302,8 +1302,8 @@
       "tests": [
         "assert($('ul').length > 0, 'Create a <code>ul</code> element.')",
         "assert($('li').length > 2, 'Add three <code>li</code> elements to your <code>ul</code> element.')",
-        "assert(editor.match(/<\\/ul>/g) && editor.match(/<\\/ul>/g).length === editor.match(/<ul>/g).length, 'Make sure your <code>ul</code> element has a closing tag.')",
-        "assert(editor.match(/<\\/li>/g) && editor.match(/<\\/li>/g).length === editor.match(/<li>/g).length, 'Make sure your <code>li</code> element has a closing tag.')"
+        "assert(editor.match(/<\\/ul>/g) && editor.match(/<\\/ul>/g).length === editor.match(/<ul(?=>| )/g).length, 'Make sure your <code>ul</code> element has a closing tag.')",
+        "assert(editor.match(/<\\/li>/g) && editor.match(/<\\/li>/g).length === editor.match(/<li(?=>| )/g).length, 'Make sure your <code>li</code> element has a closing tag.')"
       ],
       "challengeSeed": [
         "<link href='http://fonts.googleapis.com/css?family=Lobster' rel='stylesheet' type='text/css'>",


### PR DESCRIPTION
Ref: #864 

The `ul` and `li` opening tags will now return true if a class happens to be added to either of them.
