### PR TITLE
Added missing MDN Link

### DIFF
--- a/seed_data/challenges/basic-bonfires.json
+++ b/seed_data/challenges/basic-bonfires.json
@@ -966,7 +966,8 @@
         "expect(fearNotLetter('yz')).to.be.undefined;"
       ],
       "MDNlinks": [
-        "String.charCodeAt()"
+        "String.charCodeAt()",
+        "String.fromCharCode()"
       ],
       "challengeType": 5,
       "nameCn": "",


### PR DESCRIPTION
This bonfire "Missing letters"seems to be missing an important MDN link to "String.fromCharCode()", which is needed to get the missing character to return for the test. Since the missing character is obviously not in the string supplied, you cannot get the character code for it from the string.
