### PR TITLE
More 'Convert HTML Entities' test cases. Fixes #924

### DIFF
--- a/seed/challenges/basic-bonfires.json
+++ b/seed/challenges/basic-bonfires.json
@@ -1104,6 +1104,10 @@
       ],
       "tests": [
         "assert.strictEqual(convert('Dolce & Gabbana'), 'Dolce &amp; Gabbana', 'should escape characters');",
+        "assert.strictEqual(convert('Hamburgers < Pizza < Tacos'), 'Hamburgers &lt; Pizza &lt; Tacos', 'should escape characters');",
+        "assert.strictEqual(convert('Sixty > twelve'), 'Sixty &gt; twelve', 'should escape characters');",
+        "assert.strictEqual(convert('Stuff in \"quotation marks\"'), 'Stuff in &quot;quotation marks&quot;', 'should escape characters');",
+        "assert.strictEqual(convert(\"Shindler's List\"), 'Shindler&apos;s List', 'should escape characters');",
         "assert.strictEqual(convert('abc'), 'abc', 'should handle strings with nothing to escape');"
       ],
       "MDNlinks": [


### PR DESCRIPTION
This adds more test cases to the 'Convert HTML Entities'-bonfire. The new test cases now checks for all the characters instead of just '&', and they also check that mutlitple characters in a string is converted, preventing solutions which would only convert the first character, like this one:

``` javascript
function converter(m) {
    switch(m) {
        case '&':
            return "&amp;";
        case '<':
            return "&lt;";
        case '>':
            return "&gt;";
        case '"':
            return "&quot;";
        case "'":
            return "&apos;";
    }
}

function convert(str) {
    return str.replace(/([&<>"'])/, converter);
}
```
