### PR TITLE
Improves check for catphotoapp.com in 'Link to External Pages with Anchor Elements'

### DIFF
--- a/seed/challenges/basic-html5-and-css.json
+++ b/seed/challenges/basic-html5-and-css.json
@@ -1005,7 +1005,7 @@
       ],
       "tests": [
         "assert((/cat photos/gi).test($('a').text()), 'Your <code>a</code> element should have the anchor text of \"cat photos\"')",
-        "assert($('a').filter(function(index) { return /com/gi.test($('a').attr('href')); }).length > 0, 'You need an <code>a</code> element that links to <code>http&#58;//catphotoapp.com<code>.')",
+        "assert(/http:\\/\\/catphotoapp\\.com/gi.test($('a').attr('href')), 'You need an <code>a</code> element that links to <code>http&#58;//catphotoapp.com<code>.')",
         "assert(editor.match(/<\\/a>/g) && editor.match(/<\\/a>/g).length === editor.match(/<a/g).length, 'Make sure your <code>a</code> element has a closing tag.')"
       ],
       "challengeSeed": [


### PR DESCRIPTION
Makes the test case look for the case-insensitive "http://catphotoapp.com" instead of just "com" in the anchor's href attribute. I chose to use the global, case-insensitive regex instead of just `$('a').attr('href') === 'http://catphotoapp.com'` because it gives the user a bit more freedom (see trailing backslashes etc.) and I've seen it used in other test cases. Let me know if you want a stricter or looser test and I'll change it.

Fixes #914.
