### PR TITLE
Test for almost palindromes in 'Check for Palindromes'

### DIFF
--- a/seed/challenges/basic-bonfires.json
+++ b/seed/challenges/basic-bonfires.json
@@ -180,7 +180,8 @@
         "assert.deepEqual(palindrome(\"not a palindrome\"), false);",
         "assert.deepEqual(palindrome(\"A man, a plan, a canal. Panama\"), true);",
         "assert.deepEqual(palindrome(\"never odd or even\"), true);",
-        "assert.deepEqual(palindrome(\"nope\"), false);"
+        "assert.deepEqual(palindrome(\"nope\"), false);",
+        "assert.deepEqual(palindrome(\"almostomla\"), false);"
       ],
       "challengeSeed": [
         "function palindrome(str) {",


### PR DESCRIPTION
Adds a test for strings that start and end in the same characters but that are not complete palindromes.
Fixes #911
