### PR TITLE
Improve 'Convert HTML Entities' Bonfire

### DIFF
--- a/seed_data/bonfireMDNlinks.js
+++ b/seed_data/bonfireMDNlinks.js
@@ -12,6 +12,7 @@ var links =
   "Currying": "https://leanpub.com/javascript-allonge/read#pabc",
   "Smallest Common Multiple": "https://www.mathsisfun.com/least-common-multiple.html",
   "Permutations": "https://www.mathsisfun.com/combinatorics/combinations-permutations.html",
+  "HTML Entities": "http://dev.w3.org/html5/html-author/charref",
 
 	// ========= GLOBAL OBJECTS
 	"Global Array Object" : "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array",

--- a/seed_data/challenges/basic-bonfires.json
+++ b/seed_data/challenges/basic-bonfires.json
@@ -1065,7 +1065,7 @@
       "name": "Bonfire: Convert HTML Entities",
       "difficulty": "2.07",
       "description": [
-        "Convert the characters \"&\", \"<\", \">\", '\"', and \"'\", in a string to their corresponding HTML entities.",
+        "Convert the characters \"&\", \"<\", \">\", '\"' (double quote), and \"'\" (apostrophe), in a string to their corresponding HTML entities.",
         "Remember to use <a href='/field-guide/how-do-i-get-help-when-I-get-stuck' target='_blank'>RSAP</a> if you get stuck. Try to pair program. Write your own code."
       ],
       "challengeSeed": [
@@ -1078,10 +1078,12 @@
       ],
       "tests": [
         "assert.strictEqual(convert('Dolce & Gabbana'), 'Dolce &amp; Gabbana', 'should escape characters');",
+        "assert.strictEqual('<input type="submit">Submit</input>', '&lt;input type=&quot;submit&quot;&gt;Submit&lt;/input&gt;', 'should escape characters');",
         "assert.strictEqual(convert('abc'), 'abc', 'should handle strings with nothing to escape');"
       ],
       "MDNlinks": [
-        "RegExp"
+        "RegExp",
+        "HTML Entities"
       ],
       "challengeType": 5,
       "nameCn": "",


### PR DESCRIPTION
Add a reference link to the w3.org ref for HTML Entities list.
Improve the Bonfire text to clarify the double quote and apostrophe entities.
Add a test to check '<', '>', and '"' (double quote).
