### PR TITLE
Fix missing semicolon in Symmetric Differences test

### DIFF
--- a/seed_data/challenges/advanced-bonfires.json
+++ b/seed_data/challenges/advanced-bonfires.json
@@ -79,7 +79,7 @@
         "sym([1, 2, 3], [5, 2, 1, 4]);"
       ],
       "tests": [
-        "expect(sym([1, 2, 3], [5, 2, 1, 4])).to.eqls([3, 5, 4])",
+        "expect(sym([1, 2, 3], [5, 2, 1, 4])).to.eqls([3, 5, 4]);",
         "assert.deepEqual(sym([1, 2, 5], [2, 3, 5], [3, 4, 5]), [1, 4, 5], 'should return the symmetric difference of the given arrays');",
         "assert.deepEqual(sym([1, 1, 2, 5], [2, 2, 3, 5], [3, 4, 5, 5]), [1, 4, 5], 'should return an array of unique values');",
         "assert.deepEqual(sym([1, 1]), [1], 'should return an array of unique values');"


### PR DESCRIPTION
The first test of Symmetric Differences is broken because it was missing a semicolon, making it impossible to pass.
