### PR TITLE
HTML Entities: Fix missing 'convert' function call

### DIFF
--- a/seed_data/challenges/basic-bonfires.json
+++ b/seed_data/challenges/basic-bonfires.json
@@ -1078,7 +1078,7 @@
       ],
       "tests": [
         "assert.strictEqual(convert('Dolce & Gabbana'), 'Dolce &amp; Gabbana', 'should escape characters');",
-        "assert.strictEqual('<>', '&lt;&gt;', 'should escape characters');",
+        "assert.strictEqual(convert('<>'), '&lt;&gt;', 'should escape characters');",
         "assert.strictEqual(convert('abc'), 'abc', 'should handle strings with nothing to escape');"
       ],
       "MDNlinks": [


### PR DESCRIPTION
Added test for '<>' did not properly call the 'convert' function, so the test can never be completed.
