### PR TITLE
Fixes misspelling that caused 'undefined is not function' error

### DIFF
--- a/server/boot/challenge.js
+++ b/server/boot/challenge.js
@@ -50,7 +50,7 @@ var challengeMapWithDashedNames = utils.getChallengeMapWithDashedNames();
 var challangesRegex = /^(bonfire|waypoint|zipline|basejump)/i;
 
 var dasherize = utils.dasherize;
-var unDasherize = utils.unDashedName;
+var unDasherize = utils.unDasherize;
 
 var getMDNLinks = utils.getMDNLinks;
 


### PR DESCRIPTION
`unDasherize` was assigned an undefined variable, causing 500 TypeErrors when trying to call it on `origChallengeName` at line 194 in `server/boot/challenge.js`, effectively rendering all challenges inaccessible.
