### PR TITLE
fake iphone display overlap fix (#976 fix)

### DIFF
--- a/public/js/main_0.0.3.js
+++ b/public/js/main_0.0.3.js
@@ -350,6 +350,23 @@ $(document).ready(function() {
   };
 
   $('#comment-button').on('click', commentSubmitButtonHandler);
+  
+  //fakeiphone positioning hotfix 
+  if($('.iphone-position')!=undefined && $('.iphone') !=undefined){
+    var startIphonePosition = parseInt($('.iphone-position').css('top').replace('px', ''));
+    var startIphone = parseInt($('.iphone').css('top').replace('px', ''));
+    $(window).on('scroll', function(){
+    	if((($('.courseware-height').height() + $('.courseware-height').offset().top)-$(window).scrollTop()-$('.iphone-position').height()) <= 0){
+    		$('.iphone-position').css('top', startIphonePosition+(($('.courseware-height').height() + $('.courseware-height').offset().top)-$(window).scrollTop()-$('.iphone-position').height()));
+    		$('.iphone').css('top', startIphonePosition+(($('.courseware-height').height() + $('.courseware-height').offset().top)-$(window).scrollTop()-$('.iphone-position').height())+120);
+    	}
+    	else{
+    		$('.iphone-position').css('top', startIphonePosition);
+    		$('.iphone').css('top', startIphone);
+    	}
+    });
+  }
+  
 });
 
 var profileValidation = angular.module('profileValidation',


### PR DESCRIPTION
Fixes the over-lapping with the footer on challenges the involve the fake iphone result iframe (issue #976) tested in chrome (latest), firefox(latest) safari (last windows build) and IE11. It look slightly weird in IE 11 but the phone didn't overlap.Will still require testing on mac/linux
