### PR TITLE
Change Height on Footer element in Bonfire View

### DIFF
--- a/public/css/main.less
+++ b/public/css/main.less
@@ -660,7 +660,7 @@ thead {
 
 .fcc-footer {
   width: 100%;
-  height: 50px;
+  max-height: 55px;
   text-align: center;
   background-color: #4a2b0f;
   padding: 12px;
@@ -675,6 +675,8 @@ thead {
     padding-left: 10px;
     padding-right: 10px;
     &:hover {
+      padding-top: 14px;
+      padding-bottom: 14px;
       color: #4a2b0f;
       background-color: #eee;
       text-decoration: none;

--- a/public/css/main.less
+++ b/public/css/main.less
@@ -675,8 +675,6 @@ thead {
     padding-left: 10px;
     padding-right: 10px;
     &:hover {
-      padding-top: 14px;
-      padding-bottom: 14px;
       color: #4a2b0f;
       background-color: #eee;
       text-decoration: none;


### PR DESCRIPTION
Refer to line 677. Proposing removal of Padding increase on footer links in bonfire view as it causes the page content to exceed viewport height and creates a scrollbar. This issue currently effects all bonfire views. In response to issue #1247 

closes #1247
