### PR TITLE
Changed Footer Padding Size

### DIFF
--- a/public/css/main.less
+++ b/public/css/main.less
@@ -663,7 +663,7 @@ thead {
   height: 50px;
   text-align: center;
   background-color: #4a2b0f;
-  padding: 12px;
+  padding: 10px;
   bottom: 0;
   left: 0;
   position: absolute;


### PR DESCRIPTION
Changed the footer padding size from 12px to 10px to eliminate the extra
space that is created when hovering the footer links.
