### PR TITLE
Removes dotted outlines on links in Firefox

### DIFF
--- a/public/css/main.less
+++ b/public/css/main.less
@@ -74,6 +74,10 @@ h1, h2, h3, h4, h5, h6, p, li {
   padding-bottom: 5px;
 }
 
+a:focus {
+  outline: none;
+}
+
 // Alerts
 // -------------------------
 


### PR DESCRIPTION
Stops all anchor elements from doing this when clicked...
![fcc-pre](https://cloud.githubusercontent.com/assets/3090888/8627096/0f28c31c-2749-11e5-8733-b8d51907a647.png)
...and makes them do this instead:
![fcc-post](https://cloud.githubusercontent.com/assets/3090888/8627095/0f24d4f0-2749-11e5-9e64-02963e197cce.png)
