### PR TITLE
'Create a Text Field' now makes sure the input type is text.

### DIFF
--- a/seed/challenges/basic-html5-and-css.json
+++ b/seed/challenges/basic-html5-and-css.json
@@ -1559,7 +1559,7 @@
         "You can create one like this: <code>&#60;input type='text'&#62;</code>. Note that <code>input</code> elements are self-closing."
       ],
       "tests": [
-        "assert($('input').length > 0, 'Your app should have a text field input element.')"
+        "assert($('input[type=text]').length > 0, 'Your app should have a text field input element.')"
       ],
       "challengeSeed": [
         "<link href='http://fonts.googleapis.com/css?family=Lobster' rel='stylesheet' type='text/css'>",


### PR DESCRIPTION
Instead of just checking if there's an `input` tag, the test now checks for an `input` tag with the `type` attribute set to `text`.

Fixes #1241.
