### PR TITLE
Profile pictures in 'Camper News' now link to profiles.

### DIFF
--- a/server/views/stories/hot-stories.jade
+++ b/server/views/stories/hot-stories.jade
@@ -44,7 +44,7 @@
                             "<div class='hidden-xs row media-stories'>" +
                                 "<div class='media'>" +
                                     "<div class='media-left'>" +
-                                        "<a href='/'" + data[i].author.username + "'>" +
+                                        "<a href='/" + data[i].author.username + "'>" +
                                             "<img class='img-news' src='" + data[i].author.picture + "'/>" +
                                         "</a>" +
                                     "</div>" +

--- a/server/views/stories/news-nav.jade
+++ b/server/views/stories/news-nav.jade
@@ -91,7 +91,7 @@ script.
                             "<div class='hidden-xs row media-stories'>" +
                                 "<div class='media'>" +
                                     "<div class='media-left'>" +
-                                        "<a href='/'" + data[i].author.username + "'>" +
+                                        "<a href='/" + data[i].author.username + "'>" +
                                             "<img class='img-news' src='" + data[i].author.picture + "'/>" +
                                         "</a>" +
                                     "</div>" +


### PR DESCRIPTION
A minor typo in some Jade files caused profile pictures in 'Camper News' to lead to the homepage instead of the profiles belonging to the news posters. If I found all the typos, this should no longer be a problem.

Fixes #1235
