### PR TITLE
Update "What is the Free Code Camp Front End Development Certificate?" guide

### DIFF
--- a/seed_data/field-guides.json
+++ b/seed_data/field-guides.json
@@ -1168,7 +1168,7 @@
       "    <li class='large-li'>Zipline: Stylize Stories on Camper News</li>",
       "    <li class='large-li'>Zipline: Wikipedia Viewer</li>",
       "  </ol>",
-      "  <p class='large-p'>This won't be a new curriculum - it will just the first 200 hours of our full stack JavaScript curriculum.</p>",
+      "  <p class='large-p'>This won't be a new curriculum - it will just be the first 200 hours of our full stack JavaScript curriculum.</p>",
       "  <p class='large-p'>All campers who have already completed these challenges are retroactively be eligible for the certificate!</p>",
       "</div>"
     ]


### PR DESCRIPTION
Add the word "be" in the "What is the Free Code Camp Front End Development Certificate?" guide.  Updated sentence is "This won't be a new curriculum - it will just be the first 200 hours of our full stack JavaScript curriculum."
