### PR TITLE
Everything Be True bug fix v1

### DIFF
--- a/seed_data/challenges/basic-bonfires.json
+++ b/seed_data/challenges/basic-bonfires.json
@@ -1421,6 +1421,7 @@
       "tests": [
         "assert.strictEqual(every([{'user': 'Tinky-Winky', 'sex': 'male'}, {'user': 'Dipsy', 'sex': 'male'}, {'user': 'Laa-Laa', 'sex': 'female'}, {'user': 'Po', 'sex': 'female'}], 'sex'), true, 'should return true if predicate returns truthy for all elements in the collection');",
         "assert.strictEqual(every([{'user': 'Tinky-Winky', 'sex': 'male'}, {'user': 'Dipsy', 'sex': 'male'}, {'user': 'Laa-Laa', 'sex': 'female'}, {'user': 'Po', 'sex': 'female'}], {'sex': 'female'}), false, 'should return false if predicate returns falsey for any element in the collection');"
+        "assert.strictEqual(every([{'user': 'Tinky-Winky', 'sex': 'female'}, {'user': 'Dipsy', 'sex': 'male'}, {'user': 'Laa-Laa', 'sex': 'female'}, {'user': 'Po', 'sex': 'female'}], {'sex': 'female'}), false, 'should return false if predicate returns falsey for any element in the collection');"
       ],
       "MDNlinks": [
         "Object.hasOwnProperty()",


### PR DESCRIPTION
Temporary fix to bug found in "Everything Be True" bonfire mission (additional test case to prevent "return collection[0].hasProperty(pre)" from passing)
