### PR TITLE
Make Symmetric Difference Order Invarient

### DIFF
--- a/seed/challenges/advanced-bonfires.json
+++ b/seed/challenges/advanced-bonfires.json
@@ -81,9 +81,9 @@
         "sym([1, 2, 3], [5, 2, 1, 4]);"
       ],
       "tests": [
-        "expect(sym([1, 2, 3], [5, 2, 1, 4])).to.equal([3, 5, 4]);",
-        "assert.deepEqual(sym([1, 2, 5], [2, 3, 5], [3, 4, 5]), [1, 4, 5], 'should return the symmetric difference of the given arrays');",
-        "assert.deepEqual(sym([1, 1, 2, 5], [2, 2, 3, 5], [3, 4, 5, 5]), [1, 4, 5], 'should return an array of unique values');",
+        "expect(sym([1, 2, 3], [5, 2, 1, 4]).sort()).to.equal([3, 4, 5]);",
+        "assert.deepEqual(sym([1, 2, 5], [2, 3, 5], [3, 4, 5]).sort(), [1, 4, 5], 'should return the symmetric difference of the given arrays');",
+        "assert.deepEqual(sym([1, 1, 2, 5], [2, 2, 3, 5], [3, 4, 5, 5]).sort(), [1, 4, 5], 'should return an array of unique values');",
         "assert.deepEqual(sym([1, 1]), [1], 'should return an array of unique values');"
       ],
       "MDNlinks": [


### PR DESCRIPTION
As per the discussion in #1402, an actual Symmetric Difference is order independent.  Since it is not possible to test for arbitrary order, we instead will sort the user's answer and compare against a pre-sorted test value.  This will ensure that any returned order will be correct.

I have done basic testing against chai.js's deepEqual/iterableEqual functions and this solution appears to work properly.
