### PR TITLE
Added additional tests to Sorted Union Bonfire

### DIFF
--- a/seed/challenges/basic-bonfires.json
+++ b/seed/challenges/basic-bonfires.json
@@ -1074,9 +1074,12 @@
       ],
       "tests": [
         "assert.deepEqual(unite([1, 3, 2], [5, 2, 1, 4], [2, 1]), [1, 3, 2, 5, 4], 'should return the union of the given arrays');",
-        "assert.deepEqual(unite([1, 3, 2], [1, [5]], [2, [4]]), [1, 3, 2, [5], [4]], 'should not flatten nested arrays');"
+        "assert.deepEqual(unite([1, 3, 2], [1, [5]], [2, [4]]), [1, 3, 2, [5], [4]], 'should not flatten nested arrays');",
+        "assert.deepEqual(unite([1, 2, 3], [5, 2, 1]), [1, 2, 3, 5], 'should correctly handle exactly two arguments');",
+        "assert.deepEqual(unite([1, 2, 3], [5, 2, 1, 4], [2, 1], [6, 7, 8]), [ 1, 2, 3, 5, 4, 6, 7, 8 ], 'should correctly handle higher numbers of arguments');"
       ],
       "MDNlinks": [
+        "Arguments object",
         "Array.reduce()"
       ],
       "challengeType": 5,


### PR DESCRIPTION
Based on comments on #1431, I have added the two additional tests which @clintoncampbell proposed.  These test catch two case:  Having exactly 2 arguments and having more than 3 arguments.

I have also added an MDN reference to the Arguments Object, since it will be needed for a general solution.

I've tested the tests against chai.js, but not in the full site context. (I don't have a working local copy).
