### PR TITLE
Update main.less to fix #1510

### DIFF
--- a/public/css/main.less
+++ b/public/css/main.less
@@ -577,6 +577,7 @@ thead {
   margin: 0 auto;
   position: relative;
   top: 50%;
+  -webkit-transform: translateY(-50%);
   transform: translateY(-50%);
 }
 


### PR DESCRIPTION
Update main.less to fix #1510. There was an alignment issue on Safari because of missing vendor prefix `-webkit` on `transform` on the `.points-on-top` class.
