### PR TITLE
added test for object for steamroller bonfire

### DIFF
--- a/seed/challenges/intermediate-bonfires.json
+++ b/seed/challenges/intermediate-bonfires.json
@@ -675,7 +675,8 @@
       "tests": [
         "assert.deepEqual(steamroller([[['a']], [['b']]]), ['a', 'b'], 'should flatten nested arrays');",
         "assert.deepEqual(steamroller([1, [2], [3, [[4]]]]), [1, 2, 3, 4], 'should flatten nested arrays');",
-        "assert.deepEqual(steamroller([1, [], [3, [[4]]]]), [1, 3, 4], 'should work with empty arrays');"
+        "assert.deepEqual(steamroller([1, [], [3, [[4]]]]), [1, 3, 4], 'should work with empty arrays');",
+        "assert.deepEqual(steamroller([1, {}, [3, [[4]]]]), [1, {}, 3, 4], 'should work with actual objects');"
       ],
       "MDNlinks": [
         "Array.isArray()"


### PR DESCRIPTION
Now tests if code works with objects.

Incorrect code like the following will not work since it can't handle objects.

``` javascript
function steamroller(arr) {
  arr = arr.toString().split(',');

  for (var i = 0; i < arr.length; i++) {

    test = parseInt(arr[i], 10);

    if ( !isNaN(test) ) {  // if test not is not a num
      arr[i] = test;

    } else if (arr[i] === '') { // Object is '' after .toString(), so remove empty strings

      arr.splice(i, 1);
      i--;
    }
  }

  return arr;
}
```
