### PR TITLE
Improve 'Turn an image to a Link'-waypoint

### DIFF
--- a/seed/challenges/html5-and-css.json
+++ b/seed/challenges/html5-and-css.json
@@ -1259,8 +1259,8 @@
         "Once you've done this, hover over your image with your cursor. Your cursor's normal pointer should become the link clicking pointer. The photo is now a link."
       ],
       "tests": [
+        "assert($('a').children('img').length > 0, 'Nest your <code>img</code> element within an <code>a</code> element.')",
         "assert(new RegExp('#').test($('a').children('img').parent().attr('href')), 'Your <code>a</code> element should be a dead link with a <code>href</code> attribute set to \"#\".')",
-        "assert($('a').children('img').length > 0, 'Nest your image element within an <code>a</code> element.')",
         "assert(editor.match(/<\\/a>/g) && editor.match(/<a/g) && editor.match(/<\\/a>/g).length === editor.match(/<a/g).length, 'Make sure each of your <code>a</code> elements has a closing tag.')"
       ],
       "challengeSeed": [


### PR DESCRIPTION
Changed test order as described in #1467 and added replaced `image` with `<code>img</code>` for consistency.

Fixes #1467
