### PR TITLE
fixed tests to check for lowercase hex-colors

### DIFF
--- a/seed/challenges/html5-and-css.json
+++ b/seed/challenges/html5-and-css.json
@@ -3516,7 +3516,7 @@
       ],
       "tests": [
         "assert($('body').css('background-color') === 'rgb(0, 255, 0)', 'Give your <code>body</code> element the background-color of green.')",
-        "assert(editor.match(/#00FF00/g) && editor.match(/#00FF00/g).length > 0, 'Use hex code the color green instead of the word \"green\". For example <code>body: { color: #00FF00; }</code>.')"
+        "assert(editor.match(/#00[Ff]{2}00/g) && editor.match(/#00[Ff]{2}00/g).length > 0, 'Use hex code the color green instead of the word \"green\". For example <code>body: { color: #00FF00; }</code>.')"
       ],
       "challengeSeed": [
         "<style>",


### PR DESCRIPTION
Fixed [#1598](https://github.com/FreeCodeCamp/freecodecamp/issues/1598) thanks to @catapixel 's solution.

Tests will now allow lowercase hex-colors.
