### PR TITLE
Refactored CompletionMonitor() slightly

### DIFF
--- a/seed/challenge-migration.js
+++ b/seed/challenge-migration.js
@@ -8,20 +8,6 @@ var bonfires = require('./bonfires.json'),
   oldUri='mongodb://localhost:27017/app30893198',
   coursewares = require('./coursewares.json');
 
-var counter = 0;
-var offerings = 2;
-
-var CompletionMonitor = function() {
-  counter++;
-  console.log('call ' + counter);
-
-  if (counter < offerings) {
-    return;
-  } else {
-    process.exit(0);
-  }
-};
-
 MongoClient.connect(oldUri, function(err, database) {
 
   database.collection('users').find({}).batchSize(20).toArray(function(err, users) {

--- a/seed/index.js
+++ b/seed/index.js
@@ -17,18 +17,19 @@ var Nonprofit = app.models.Nonprofit;
 var Job = app.models.Job;
 var counter = 0;
 var challenges = getFilesFor('challenges');
-var offerings = 2 + challenges.length;
 
-var CompletionMonitor = function() {
+function completionMonitor() {
+  // Increment counter
   counter++;
-  console.log('call ' + counter);
 
-  if (counter < offerings) {
-    return;
-  } else {
+  // Exit if all challenges have been checked
+  if (counter > challenges.length) {
     process.exit(0);
   }
-};
+
+  // Log where in the seed order we're currently at
+  console.log('Call: ' + counter + "/" + challenges.length);
+}
 
 Challenge.destroyAll(function(err, info) {
   if (err) {
@@ -66,7 +67,7 @@ Challenge.destroyAll(function(err, info) {
           console.log(err);
         } else {
           console.log('Successfully parsed %s', file);
-          CompletionMonitor();
+          completionMonitor();
         }
       }
     );
@@ -85,7 +86,7 @@ Nonprofit.destroyAll(function(err, info) {
     } else {
       console.log('Saved ', data);
     }
-    CompletionMonitor();
+    completionMonitor();
     console.log('nonprofits');
   });
 });
@@ -103,6 +104,6 @@ Job.destroyAll(function(err, info) {
       console.log('Saved ', data);
     }
     console.log('jobs');
-    CompletionMonitor();
+    completionMonitor();
   });
 });


### PR DESCRIPTION
`node seed` finished properly for me, except that it didn't exit back to my shell, so I took a look at `seed/index.js` and found that the error was that the `counter` was being compared to a variable, `offerings`, which was the length of `challenges` + 2; I tried replacing `offerings` with `challenge.length` and it worked, so maybe offerings was just a remnant of the past, but please double check so I'm not breaking anything. I've tested these changes by, instead of checking the `counter` against `challenges.length`, I checked it against `challenges.length + 1`, and it would finish all the same calls but not put me back in the shell, so just `challenges.length` should be the right amount of calls.

I also decied to do some other changes while in there:
- Removed the function's pseudo-class syntax (CapitalCamelCase and ended with a semicolon).
- Used named function instead of anonymous function in a variable; since it wasn't passed anywhere I decided to follow the same scheme as `getFilesFor()`.
- Shortened `if..else`-statement by removing unnecessary `return`.
- Incremented counter in `if..else`-statement instead of separately before, because looks.
- Added total calls to `console.log()`.
- Commented for good measure.

Oh, and I also found and abandoned `CompletionMonitor()`-function in `seed/challenge-migration.js`, so I removed it.
