### PR TITLE
Slot machine challenge - Fixed Typos and 4th test

### DIFF
--- a/seed/challenges/basic-javascript.json
+++ b/seed/challenges/basic-javascript.json
@@ -1081,7 +1081,7 @@
         "assert(typeof(runSlots($('.slot'))[0]) == 'number', 'slotOne should be a random number');",
         "assert(typeof(runSlots($('.slot'))[1]) == 'number', 'slotTwo should be a random number');",
         "assert(typeof(runSlots($('.slot'))[2]) == 'number', 'slotThree should be a random number');",
-        "assert((function(){if(editor.match(/Math\\.floor\\(Math\\.random\\(\\)\\s\\*\\s\\(5\\s\\-\\s1\\s\\+\\s1\\)\\)\\s\\+\\s1;/gi) !== null){return(editor.match(/Math\\.floor\\(Math\\.random\\(\\)\\s\\*\\s\\(5\\s\\-\\s1\\s\\+\\s1\\)\\)\\s\\+\\s1;/gi).length >= 3);}else{return(false);}})(), 'You should have used Math.floor(Math.random() * (5 - 1 + 1)) + 1; three times to generate your random numbers');"
+        "assert((function(){if(editor.match(/Math\\.floor\\(\\s?Math\\.random\\(\\)\\s?\\*\\s?\\(\\s?5\\s?\\-\\s?1\\s?\\+\\s?1\\s?\\)\\s?\\)\\s?\\+\\s?1;/gi) !== null){return(editor.match(/Math\\.floor\\(\\s?Math\\.random\\(\\)\\s?\\*\\s?\\(\\s?5\\s?\\-\\s?1\\s?\\+\\s?1\\s?\\)\\s?\\)\\s?\\+\\s?1;/gi).length >= 3);}else{return(false);}})(), 'You should have used Math.floor(Math.random() * (5 - 1 + 1)) + 1; three times to generate your random numbers');"
       ],
       "challengeSeed":[
         "fccss",

--- a/seed/challenges/basic-javascript.json
+++ b/seed/challenges/basic-javascript.json
@@ -1071,16 +1071,16 @@
       "title": "Create a JavaScript Slot Machine",
       "difficulty":"9.988",
       "description":[
-        "We are now going to try and combine some of the stuff we've just learnt abd create the logic for a slot machine game",
+        "We are now going to try and combine some of the stuff we've just learned and create the logic for a slot machine game",
         "For this we will need to generate three random numbers between <code>1</code> and <code>5</code> to represent the possible values of each individual slot",
         "Store the three random numbers in <code>slotOne</code>, <code>slotTwo</code> and <code>slotThree</code>",
         "Generate the random numbers by using the system we used earlier in /challenges/random-whole-numbers-in-a-range",
         "<code>Math.floor(Math.random() * (5 - 1 + 1)) + 1; </code>"
       ],
       "tests":[
-        "assert(typeof(runSlots($('.slot'))[0]) == 'number', 'SlotOne should be a random number');",
-        "assert(typeof(runSlots($('.slot'))[1]) == 'number', 'SlotTwo should be a random number');",
-        "assert(typeof(runSlots($('.slot'))[2]) == 'number', 'SlotThree should be a random number');",
+        "assert(typeof(runSlots($('.slot'))[0]) == 'number', 'slotOne should be a random number');",
+        "assert(typeof(runSlots($('.slot'))[1]) == 'number', 'slotTwo should be a random number');",
+        "assert(typeof(runSlots($('.slot'))[2]) == 'number', 'slotThree should be a random number');",
         "assert((function(){if(editor.match(/Math.floor\\(Math\\.random\\(\\)\\s\\*\\s\\(5\\s\\-\\s1\\s\\+\\s1\\)\\)\\s\\+\\s1;/gi) !== null){return(editor.match(/Math.floor\\(Math\\.random\\(\\)\\s\\*\\s\\(5\\s\\-\\s1\\s\\+\\s1\\)\\)\\s\\+\\s1;/gi).length >= 3);}else{return(false);}})(), 'You should have used Math.floor(Math.random() * (5 - 1 + 1)) + 1; three times to generate your random numbers');"
       ],
       "challengeSeed":[

--- a/seed/challenges/basic-javascript.json
+++ b/seed/challenges/basic-javascript.json
@@ -1081,7 +1081,7 @@
         "assert(typeof(runSlots($('.slot'))[0]) == 'number', 'slotOne should be a random number');",
         "assert(typeof(runSlots($('.slot'))[1]) == 'number', 'slotTwo should be a random number');",
         "assert(typeof(runSlots($('.slot'))[2]) == 'number', 'slotThree should be a random number');",
-        "assert((function(){if(editor.match(/Math.floor\\(Math\\.random\\(\\)\\s\\*\\s\\(5\\s\\-\\s1\\s\\+\\s1\\)\\)\\s\\+\\s1;/gi) !== null){return(editor.match(/Math.floor\\(Math\\.random\\(\\)\\s\\*\\s\\(5\\s\\-\\s1\\s\\+\\s1\\)\\)\\s\\+\\s1;/gi).length >= 3);}else{return(false);}})(), 'You should have used Math.floor(Math.random() * (5 - 1 + 1)) + 1; three times to generate your random numbers');"
+        "assert((function(){if(editor.match(/Math\\.floor\\(Math\\.random\\(\\)\\s\\*\\s\\(5\\s\\-\\s1\\s\\+\\s1\\)\\)\\s\\+\\s1;/gi) !== null){return(editor.match(/Math\\.floor\\(Math\\.random\\(\\)\\s\\*\\s\\(5\\s\\-\\s1\\s\\+\\s1\\)\\)\\s\\+\\s1;/gi).length >= 3);}else{return(false);}})(), 'You should have used Math.floor(Math.random() * (5 - 1 + 1)) + 1; three times to generate your random numbers');"
       ],
       "challengeSeed":[
         "fccss",


### PR DESCRIPTION
Hi, I made some changes to the Create a JavaScript Slot Machine Waypoint. http://beta.freecodecamp.com/challenges/waypoint-create-a-javascript-slot-machine

Fixed some typos in Instructions
<img width="254" alt="screen shot 2015-08-10 at 8 06 22 pm" src="https://cloud.githubusercontent.com/assets/6051437/9189282/563321fc-3f9b-11e5-9d51-dadc15ba463e.png">
And some typos in tests (should be slotOne, etc.)
<img width="277" alt="screen shot 2015-08-10 at 8 07 14 pm" src="https://cloud.githubusercontent.com/assets/6051437/9189287/6e77360e-3f9b-11e5-8050-9ffa8507b45e.png">
Also fixed RegEx so that the 4th test would pass
<img width="891" alt="screen shot 2015-08-10 at 8 13 21 pm" src="https://cloud.githubusercontent.com/assets/6051437/9189368/4d509f3c-3f9c-11e5-81cf-c9df68613778.png">

Also made it so that 4th test will accept with or without spaces in places so that it won't fail if there are spaces missing or added (It failed me because I didn't have spaces between numbers ex. (5-1+1)+1).

Also I'm doing this pull request to learn Git right now and I'm still learning RegEx as well, so if I messed up somewhere, I apologize. 
