### PR TITLE
Mocha tests now use ES6

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "prestart-production": "bower cache clean && bower install && gulp build && npm run build-production",
     "start-production": "node pm2Start",
     "lint": "eslint --ext=.js,.jsx .",
-    "test": "mocha"
+    "test": "mocha --compilers js:babel/register"
   },
   "license": "(BSD-3-Clause AND CC-BY-SA-4.0)",
   "contributors": [

--- a/test/basic_routes.js
+++ b/test/basic_routes.js
@@ -1,10 +1,10 @@
 var request = require('supertest');
 var app = require('../server/server.js');
 
-describe('#ROUTES', function() {
+describe('#ROUTES', function () {
 
   describe('GET /', function () {
-    it('should return 200 OK', function (done) {
+    it('should return 200 OK', (done) => {
       request(app)
         .get('/')
         .expect(200, done);
@@ -12,7 +12,7 @@ describe('#ROUTES', function() {
   });
 
   describe('GET /signin', function () {
-    it('should return 200 OK', function (done) {
+    it('should return 200 OK', (done) => {
       request(app)
         .get('/signin')
         .expect(200, done);
@@ -20,7 +20,7 @@ describe('#ROUTES', function() {
   });
 
   describe('GET /email-signup', function () {
-    it('should return 200 OK', function (done) {
+    it('should return 200 OK', (done) => {
       request(app)
         .get('/email-signup')
         .expect(200, done);
@@ -28,15 +28,15 @@ describe('#ROUTES', function() {
   });
 
   describe('GET /random-url', function () {
-    it('should return 302', function (done) {
+    it('should return 302', (done) => {
       request(app)
         .get('/reset')
         .expect(302, done);
     });
   });
 
-  describe('Get /camperName', function () {
-    it('should return 200', function (done) {
+  describe('GET /camperName', function () {
+    it('should return 200', (done) => {
       request(app)
         .get('/terakilobyte')
         .expect(200, done);


### PR DESCRIPTION
`npm test` was failing because `server/utils/auth.js` uses ES6 features, so I updated the test command.
Also, harmony arrows in test/basic_routes.js, because harmony arrows :heart_decoration: 
