### PR TITLE
1705 - Fix to allow the <style> tag to optionally contain the type at…

### DIFF
--- a/seed/challenges/html5-and-css.json
+++ b/seed/challenges/html5-and-css.json
@@ -383,7 +383,7 @@
         "assert(!$(\"h2\").attr(\"style\"), 'Remove the style attribute from your <code>h2</code> element.')",
         "assert(($(\"style\").length > 1), 'Create a <code>style</code> element.')",
         "assert($(\"h2\").css(\"color\") === \"rgb(0, 0, 255)\", 'Your <code>h2</code> element should be blue.')",
-        "assert(editor.match(/<\\/style>/g) && editor.match(/<\\/style>/g).length === editor.match(/<style>/g).length, 'Make sure each of your <code>style</code> elements has a closing tag.')"
+        "assert(editor.match(/<\\/style>/g) && editor.match(/<\\/style>/g).length === editor.match(/<style *((class='text\\/css')|(class=\"text\\/css\"))?>/g).length, 'Make sure each of your <code>style</code> elements has a closing tag.')"
       ],
       "challengeSeed": [
         "<h2 style=\"color: red\">CatPhotoApp</h2>",


### PR DESCRIPTION
The new regex should allow for the following cases:
- <style>
- <style class='text/css'>
- <style class="text/css">

Mix-matching of the single/double quotes will not be matched.
I did allow for more than one space " *", but this can be changed by allowing only 1 or 0 with " ?".
