### PR TITLE
Changes test cases to validate correct border-width. Closes #1090, #1012, #1495

### DIFF
--- a/seed/challenges/html5-and-css.json
+++ b/seed/challenges/html5-and-css.json
@@ -867,8 +867,8 @@
       "tests": [
         "assert($(\"img\").hasClass(\"smaller-image\"), 'Your <code>img</code> element should have the class <code>smaller-image</code>.')",
         "assert($(\"img\").hasClass(\"thick-green-border\"), 'Your <code>img</code> element should have the class <code>thick-green-border</code>.')",
-        "assert($(\"img\").hasClass(\"thick-green-border\") && parseInt($(\"img\").css(\"border-top-width\")), 'Give your image a border width of <code>10px</code>.')",
-        "assert(new RegExp(\"solid\", \"gi\").test(editor), 'Give your image a border style of <code>solid</code>.')",
+        "assert($(\"img\").hasClass(\"thick-green-border\") && parseInt($(\"img\").css(\"border-top-width\"), 10) === 10, 'Give your image a border width of <code>10px</code>.')",
+        "assert($(\"img\").css(\"border-right-style\") === \"solid\", 'Give your image a border style of <code>solid</code>.')",
         "assert($(\"img\").css(\"border-left-color\") === \"rgb(0, 128, 0)\", 'The border around your <code>img</code> element should be green.')"
       ],
       "challengeSeed": [


### PR DESCRIPTION
This commit fixes these issues:
- Test cases in waypoint http://www.freecodecamp.com/challenges/waypoint-add-borders-around-your-elements  don't verify for actual `border-width`, so any border width can pass the current tests.
- Current test doesn't verify the `border-style` solid and writing "solid" anywhere in the editor passes it:
  ![bug 2](https://cloud.githubusercontent.com/assets/4247923/9415842/d4855df4-480b-11e5-98a2-1597b844e328.png)

Closes #1012 
Closes #1090
Closes #1495 
