### PR TITLE
Potentially missing ;

### DIFF
--- a/server/views/partials/universal-head.jade
+++ b/server/views/partials/universal-head.jade
@@ -19,7 +19,7 @@ script.
 script(src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.11/angular.js")
 script.
     if (typeof window.angular === 'undefined') {
-        document.write('<script src="/bower_components/angular/angular.min.js"><\/script>')
+        document.write('<script src="/bower_components/angular/angular.min.js"><\/script>');
     }
 script(src="//cdnjs.cloudflare.com/ajax/libs/angular-ui-bootstrap/0.13.0/ui-bootstrap.min.js")
 script.


### PR DESCRIPTION
My browser was throwing an error:
`Uncaught SyntaxError: missing ) after argument list`
That pointed to just after this line in the console as far as I could tell.
If this is a fix, w00t. If not, ignore this.
