### PR TITLE
Bug with hover effect on footer's social links.

### DIFF
--- a/public/css/main.less
+++ b/public/css/main.less
@@ -685,7 +685,7 @@ thead {
     padding-right: 10px;
     &:hover {
       padding-top: 14px;
-      padding-bottom: 14px;
+      padding-bottom: 12px;
       color: #4a2b0f;
       background-color: #eee;
       text-decoration: none;


### PR DESCRIPTION
The footer's social link changes itself's height when it is hovered. This leads to appearing scroll bar and as a result changing page's width. The content jumps.
![screenshot_1](https://cloud.githubusercontent.com/assets/9296248/9353787/d9e38b48-4673-11e5-8e2c-3d46202959ca.png)
![screenshot_2](https://cloud.githubusercontent.com/assets/9296248/9353792/deee4e66-4673-11e5-9306-9a2fb1d6d6d8.png)
