### PR TITLE
WayPoint: Comment your JavaScript code: fixed assert messages & enable multi-line /* */ comments

### DIFF
--- a/seed/challenges/basic-javascript.json
+++ b/seed/challenges/basic-javascript.json
@@ -16,9 +16,9 @@
         "Try creating one of each."
       ],
       "tests":[
-        "assert(editor.getValue().match(/(\\/\\/)...../g), 'Create a <code>\\/\\/</code> style comment that contains at least five letters');",
-        "assert(editor.getValue().match(/(\\/\\*)...../g), 'Create a <code>\/\\* \\*\/</code> style comment that contains at least five letters.');",
-        "assert(editor.getValue().match(/(\\*\\/)/g), 'Make sure that you close the comment with a <code>\\*\/</code>');"
+        "assert(editor.getValue().match(/(\\/\\/)...../g), 'Create a <code>//</code> style comment that contains at least five letters');",
+        "assert(editor.getValue().match(/(\\/\\*)[\\w\\W]{5,}(?=\\*\\/)/gm), 'Create a <code>/* */</code> style comment that contains at least five letters.');",
+        "assert(editor.getValue().match(/(\\*\\/)/g), 'Make sure that you close the comment with a <code>*/</code>');"
       ],
       "challengeSeed":[
       ],


### PR DESCRIPTION
- fixed assert messages for Waypoint: comment your JavaScript code ( `//` instead of the current `\/\/` and `/* */` instead of the current `/\* \*/`)

Closes #2179 

Closes #2141 

Closes #1999 
- fixed regular expression in assert to allow multi-line `/* */` comments

Closes #2141 

Closes #2077 
