### PR TITLE
[Waypoint: Remove Classes from an element with jQuery] usually expected to not validate if using removeClass() without parameters

### DIFF
--- a/seed/challenges/jquery.json
+++ b/seed/challenges/jquery.json
@@ -315,7 +315,7 @@
       "tests": [
         "assert($(\".btn-default\").length === 0, 'Remove the <code>btn-default</code> class from all of your <code>button</code> elements.')",
         "assert(editor.match(/btn btn-default/g), 'Only use jQuery to remove this class from the element.')",
-        "assert(editor.match(/\\.[\\v\\s]*removeClass[\\s\\v]*\\([\\s\\v]*('|\")\\s*btn-default\\s*('|\")[\\s\\v]*\\)/gm), 'Only remove the <code>btn-default</code> class.'"
+        "assert(editor.match(/\\.[\\v\\s]*removeClass[\\s\\v]*\\([\\s\\v]*('|\")\\s*btn-default\\s*('|\")[\\s\\v]*\\)/gm), 'Only remove the <code>btn-default</code> class.')"
       ],
       "challengeSeed": [
         "fccss",

--- a/seed/challenges/jquery.json
+++ b/seed/challenges/jquery.json
@@ -314,7 +314,8 @@
       ],
       "tests": [
         "assert($(\".btn-default\").length === 0, 'Remove the <code>btn-default</code> class from all of your <code>button</code> elements.')",
-        "assert(editor.match(/btn btn-default/g), 'Only use jQuery to remove this class from the element.')"
+        "assert(editor.match(/btn btn-default/g), 'Only use jQuery to remove this class from the element.')",
+        "assert(editor.match(/\\.[\\v\\s]*removeClass[\\s\\v]*\\([\\s\\v]*('|\")\\s*btn-default\\s*('|\")[\\s\\v]*\\)/gm), 'Only remove the <code>btn-default</code> class.'"
       ],
       "challengeSeed": [
         "fccss",


### PR DESCRIPTION
Added extra test to the waypoint to check if `.removeClass` was used with the `"btn-default"` parameter as most people expect to have to do (and are confused when the code validates before they've finished writing their function, as seen by the myriad of issues opened about it).

Closes #2302
Closes #2402
Closes #2301
Closes #2197
Closes #2160
Closes #1923
Closes #1898
