### PR TITLE
Fixes info buttons' text in Camper News search results

### DIFF
--- a/server/views/stories/news-nav.jade
+++ b/server/views/stories/news-nav.jade
@@ -103,7 +103,7 @@ script.
                                                 "</a>" +
                                             "</div>" +
                                             "<div class='story-byline col-xs-12 wrappable'>" +
-                                                "<a class='btn btn-no-shadow btn-primary btn-xs btn-primary-ghost' href='/news/" + linkedName + "'>more info.more info...</a> · " +
+                                                "<a class='btn btn-no-shadow btn-primary btn-xs btn-primary-ghost' href='/news/" + linkedName + "'>more info...</a> · " +
                                                     rank + (rank > 1 ? " points" : " point") + " · posted " +
                                                     moment(data[i].timePosted).fromNow() +
                                                     " by <a href='/" + data[i].author.username + "'>@" + data[i].author.username +


### PR DESCRIPTION
In Camper News search results "more info..." buttons' text changes to "more info.more info...". This commit fixes that.
