### PR TITLE
Added CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,2 @@
+We're getting a lot of duplicate issues and bug reports that just aren't reporting actual bugs.
+So, before you submit your issue, please read the [Help! I've Found a Bug](https://github.com/FreeCodeCamp/FreeCodeCamp/wiki/Help!-I've-Found-a-Bug) wiki page.


### PR DESCRIPTION
I'm sure you guys know that there are a lot of duplicate issues and non-issues being submitted. When I opened a new issue on another repo, I was met with this: 
![contributing](https://cloud.githubusercontent.com/assets/3090888/9425805/7bc41c5e-491f-11e5-8f67-0d3add394cff.png)
The link led to a file called `CONTRIBUTING.md` in their repo root, so I made one for us that links to [Help! I've Found a Bug](https://github.com/FreeCodeCamp/FreeCodeCamp/wiki/Help!-I've-Found-a-Bug) (thanks @issyl0), hopefully, it will prevent some of the unnecessary issues in the future.
