### PR TITLE
Center Text with Bootstrap: don't mention <h1> as it doesn't exist

### DIFF
--- a/seed/challenges/bootstrap.json
+++ b/seed/challenges/bootstrap.json
@@ -176,7 +176,7 @@
       "title": "Center Text with Bootstrap",
       "difficulty": 2.03,
       "description": [
-        "Now that we're using Bootstrap, we can center our heading elements to make them look better. All we need to do is add the class <code>text-center</code> to our <code>h1</code> and <code>h2</code> elements.",
+        "Now that we're using Bootstrap, we can center our heading element to make it look better. All we need to do is add the class <code>text-center</code> to our <code>h2</code> element.",
         "Remember that you can add several classes to the same element by separating each of them with a space, like this: <code>&#60h2 class=\"red-text text-center\"&#62your text&#60/h2&#62</code>."
       ],
       "tests": [


### PR DESCRIPTION
- Also change the wording of the preceding sentence to be singular, as
  we only care about `<h2>`s.
- Fixes #1361.
