### PR TITLE
Consistently capitalize "Delete" in the description and the tests

### DIFF
--- a/seed/challenges/bootstrap.json
+++ b/seed/challenges/bootstrap.json
@@ -614,7 +614,7 @@
         "Note that these buttons still need the <code>btn</code> and <code>btn-block</code> classes."
       ],
       "tests": [
-        "assert(new RegExp(\"delete\",\"gi\").test($(\"button\").text()), 'Create a new <code>button</code> element with the text \"delete\".')",
+        "assert(new RegExp(\"Delete\",\"gi\").test($(\"button\").text()), 'Create a new <code>button</code> element with the text \"Delete\".')",
         "assert($(\"button.btn-block.btn\").length > 2, 'All of your Bootstrap buttons should have the <code>btn</code> and <code>btn-block</code> classes.')",
         "assert($(\"button\").hasClass(\"btn-danger\"), 'Your new button should have the class <code>btn-danger</code>.')",
         "assert(editor.match(/<\\/button>/g) && editor.match(/<button/g) && editor.match(/<\\/button>/g).length === editor.match(/<button/g).length, 'Make sure all your <code>button</code> elements have a closing tag.')"


### PR DESCRIPTION
- http://www.freecodecamp.com/challenges/waypoint-warn-your-users-of-a-dangerous-action.
- The first test was passing if either the button text was written as
  "delete" or "Delete", due to the case-insensitive regexp flag, `i`.
  Yet, the description of the task specified a capitalized "Delete",
  so we should be consistent over a) what we advertise in the tests,
  and b) what we accept as correct.
- Fixes #1405.
