### PR TITLE
Check all children instead of just one in 'Target Children with jQuery'

### DIFF
--- a/seed/challenges/jquery.json
+++ b/seed/challenges/jquery.json
@@ -679,7 +679,7 @@
         "Here's an example of how you would use the <code>children()</code> function: <code>$(\"#left-well\").children().css(\"color\", \"blue\")</code>"
       ],
       "tests": [
-        "assert($(\"#target6\").css(\"color\") === 'rgb(0, 128, 0)', 'Your <code>target6</code> element should have green text.')",
+        "assert($(\"#right-well\").children().css(\"color\") === 'rgb(0, 128, 0)', 'All children of <code>#right-well</code> should have green text.')",
         "assert(editor.match(/\\.children\\(\\)\\.css/g), 'You should use the <code>children&#40&#41</code> function to modify these elements.')",
         "assert(editor.match(/<div class=\"well\" id=\"right-well\">/g), 'Only use jQuery to add these classes to the element.')"
       ],


### PR DESCRIPTION
Instead of just checking the color of `#target6`, the test case now checks the color of all children of `#right-well`.

Tested in Firefox 40 and Chromium 44

Fixes #2573 
