### PR TITLE
Fixes missing backslash in waypoints' instructions'

### DIFF
--- a/seed/challenges/basic-javascript.json
+++ b/seed/challenges/basic-javascript.json
@@ -1036,7 +1036,7 @@
       ],
       "tests":[
         "assert(test === 2, 'Your RegEx should have found two numbers in the testString');",
-        "assert(editor.getValue().match(/\\/\\\\d\\+\\//gi), 'You should be using the following expression /\\d+/gi to find the numbers in the testString');"
+        "assert(editor.getValue().match(/\\/\\\\d\\+\\//gi), 'You should be using the following expression /\\\\d+/gi to find the numbers in the testString');"
       ],
       "challengeSeed":[
         "var test = (function() {",
@@ -1066,7 +1066,7 @@
       ],
       "tests":[
         "assert(test === 7, 'Your RegEx should have found seven spaces in the <code>testString</code>.');",
-        "assert(editor.getValue().match(/\\/\\\\s\\+\\//gi), 'You should be using the following expression /\\s+/gi to find the spaces in the <code>testString</code>.');"
+        "assert(editor.getValue().match(/\\/\\\\s\\+\\//gi), 'You should be using the following expression /\\\\s+/gi to find the spaces in the <code>testString</code>.');"
       ],
       "challengeSeed":[
         "var test = (function(){",
@@ -1094,7 +1094,7 @@
       ],
       "tests":[
         "assert(test === 49, 'Your RegEx should have found forty nine non-space characters in the <code>testString</code>.');",
-        "assert(editor.getValue().match(/\\/\\\\S\\/gi/gi), 'You should be using the following expression <code>/\\S/gi</code> to find non-space characters in the <code>testString</code>.');"
+        "assert(editor.getValue().match(/\\/\\\\S\\/gi/gi), 'You should be using the following expression <code>/\\\\S/gi</code> to find non-space characters in the <code>testString</code>.');"
       ],
       "challengeSeed":[
         "var test = (function(){",


### PR DESCRIPTION
There are confusing instructions in these three waypoints: [Find Numbers with Regular Expressions](http://www.freecodecamp.com/challenges/waypoint-find-numbers-with-regular-expressions), [Find White Space with Regular Expressions](http://www.freecodecamp.com/challenges/waypoint-find-white-space-with-regular-expressions), [Invert Regular Expression Matches with JavaScript](http://www.freecodecamp.com/challenges/waypoint-invert-regular-expression-matches-with-javascript) .
`/d+/gi` instead of `/\d+/gi`, `/s+/gi` instead of `/\s+/gi`, `/S+/gi` instead of `/\S+/gi`.This commit fixes them and closes #1522.
