### PR TITLE
Added an option to NOT post to server and display a bonfire completion;

### DIFF
--- a/public/js/lib/coursewares/coursewaresJSFramework_0.0.6.js
+++ b/public/js/lib/coursewares/coursewaresJSFramework_0.0.6.js
@@ -94,7 +94,7 @@ $('#submitButton').on('click', function() {
   bonfireExecute();
 });
 
-function bonfireExecute() {
+function bonfireExecute(callback) {
   attempts++;
   ga('send', 'event', 'Challenge', 'ran-code', challenge_Name);
   userTests = null;
@@ -127,6 +127,8 @@ function bonfireExecute() {
       message.input = removeLogs(message.input);
       runTests(null, message);
     }
+
+    if (callback) callback();
   });
 }
 
@@ -260,7 +262,9 @@ var runTests = function(err, data) {
   }
 };
 
+var shouldShowCompletion = true;  // indicates whether to post the succesful completion to server and display the completion dialog
 function showCompletion() {
+  if (!shouldShowCompletion) return;
   var time = Math.floor(Date.now()) - started;
   ga('send', 'event', 'Challenge', 'solved', challenge_Name + ', Time: ' + time +
     ', Attempts: ' + attempts);
@@ -390,5 +394,9 @@ var resetEditor = function resetEditor() {
 };
 
 $(document).ready(function(){
-    bonfireExecute();
+    // on startup, execute the bonfire, but don't log completion if it's done.
+    shouldShowCompletion = false;
+    bonfireExecute( function afterExecution(){
+      shouldShowCompletion = true;  // inidcate to show completion from now on
+    });
 });


### PR DESCRIPTION
This option is used when the view is initially loaded to prevent the completion dialog from popping up,
solves #2600.
The code is still run and you get an indication that it's passed.

please note that this fix also prevents the POST request from going to the server on startup; I'm pretty sure it's OK, but thought I'd mention it just in case.
