### PR TITLE
Adds a desctiption to avoid confusion in JS challenges

### DIFF
--- a/seed/challenges/basic-javascript.json
+++ b/seed/challenges/basic-javascript.json
@@ -13,7 +13,8 @@
         "<code>// This is a comment.</code>",
         "The slash-star-star-slash comment will comment out everything between the <code>/*</code> and the <code>*/</code> characters:",
         "<code>/* This is also a comment */</code>",
-        "Try creating one of each."
+        "Try creating one of each.",
+        "And one more thing you need to notice. Starting at this waypoint in JavaScript related challenges (except AngularJS, all Ziplines, Git, Node.js and Express.js, MongoDB and Full Stack JavaScript Projects) you can see contents of <code>assert()</code> functions (in some challenges <code>except()</code>, <code>assert.equal()</code> and so on) which are used to test your code. It's part of these challenges that you are able to see the tests that are running against your code."
       ],
       "tests":[
         "assert(editor.getValue().match(/(\\/\\/)...../g), 'Create a <code>\\/\\/</code> style comment that contains at least five letters');",


### PR DESCRIPTION
A lot of campers are confused as they are able to see the contents of testing functions (assert, expect etc.). This commit "tries" to resolve such situations.
Closes #2599.
Closes #2153.
