### PR TITLE
Removed extra word from the description of bootstrap Waypoint: Use Spans for Inline Elements

### DIFF
--- a/seed/challenges/bootstrap.json
+++ b/seed/challenges/bootstrap.json
@@ -893,7 +893,7 @@
       "title": "Use Spans for Inline Elements",
       "difficulty": 2.105,
       "description": [
-        "You can use use spans to create inline elements. Remember when we used the <code>btn-block</code> class to make the button fill the entire row?",
+        "You can use spans to create inline elements. Remember when we used the <code>btn-block</code> class to make the button fill the entire row?",
         "This image illustrates the difference between <code>inline</code> elements and <code>block-level</code> elements:",
         "<img class=\"img-responsive\" src=\"https://www.evernote.com/l/AHTFU358y71AV6mokPeuTEgrZVdUJ4A8v3AB/image.png\" alt=\"An \"inline\" button is as small as the text it contains. In this image, it's centered. Below it is a \"block-level\" button, which stretches to fill the entire horizontal space.'>",
         "By using the <code>span</code> element, you can put several elements together, and even style different parts of the same element differently.",


### PR DESCRIPTION
This Pull Request Closes Issue #2636.
