### PR TITLE
This commit fixes broken OL lists in IE

### DIFF
--- a/public/css/main.less
+++ b/public/css/main.less
@@ -73,6 +73,14 @@ h1, h2, h3, h4, h5, h6, p, li {
   padding-top: 5px;
   padding-bottom: 5px;
 }
+ol {
+  counter-reset: section;
+  list-style-type: none;
+}
+ol li:before {
+  counter-increment: section;
+  content: counter(section) ". ";
+}
 
 // Alerts
 // -------------------------


### PR DESCRIPTION
I went the easy way and added a few lines of CSS which solved the problem. BUT in my opinion this is not the right way because I used some tricky CSS (many thanks to @Craggle). I repeat this is the **easy** way. The **hard** way is editing all jade files starting from the Map and ending with Ziplines and Basejumps which is a very painful and long job. You need to know that this issue is caused by incorrect HTML structure (my own [investigation](https://github.com/FreeCodeCamp/FreeCodeCamp/issues/1354#issuecomment-124004635) and [proof](https://github.com/FreeCodeCamp/FreeCodeCamp/issues/1354#issuecomment-124007456) by @Xunrel) and as mentioned @benmcmahon100 we need to fix that and not **CSS**. So, dear owners, I'm waiting for your judgment.
If applied closes #1354.
