### PR TITLE
changed regex for checking style element in challenge "Use CSS Selectors"

### DIFF
--- a/seed/challenges/html5-and-css.json
+++ b/seed/challenges/html5-and-css.json
@@ -383,7 +383,7 @@
         "assert(!$(\"h2\").attr(\"style\"), 'Remove the style attribute from your <code>h2</code> element.')",
         "assert($(\"style\") && $(\"style\").length > 1, 'Create a <code>style</code> element.')",
         "assert($(\"h2\").css(\"color\") === \"rgb(0, 0, 255)\", 'Your <code>h2</code> element should be blue.')",
-        "assert(editor.match(/<\\/style>/g) && editor.match(/<\\/style>/g).length === editor.match(/<style>/g).length, 'Make sure each of your <code>style</code> elements has a closing tag.')"
+        "assert(editor.match(/<\\/style>/g) && editor.match(/<\\/style>/g).length === (editor.match(/<style((\\s)*((type|media|scoped|title|disabled)=\"[^\"]*\")?(\\s)*)*>/g) || []).length, 'Make sure all your <code>style</code> elements are valid amd have a closing tag.')"
       ],
       "challengeSeed": [
         "<h2 style=\"color: red\">CatPhotoApp</h2>",


### PR DESCRIPTION
solves #969.

regex now allows opening style elements to have whitespace before closing '>', and also the allowed attributes (type, media etc..).
I also changed the text to read 'make sure all your style elements are valid and have a closing tag', since the regex only allows the allowed attributes (see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style)

*explanation about the regex: matches '<style' followed by zero or more occurrences of (any amount of whitespace + an allowed attribute + '="anything"'), followed by any amount of whitespace + '>'.

Note that this regex is not perfect, and will allow any value for the attributes, and repeating of attributes (i.e <style type="kuku" type"maluku"> is matched)
