### PR TITLE
Fixes "indoor", "personality" and "label" issues

### DIFF
--- a/seed/challenges/html5-and-css.json
+++ b/seed/challenges/html5-and-css.json
@@ -1998,8 +1998,8 @@
       ],
       "tests": [
         "assert($('input[type=\"radio\"]').length > 1, 'Your page should have two radio button elements.')",
-        "assert($('input[type=\"radio\"]:nth-child(1)').attr('name') === 'indoor-outdoor', 'Give your radio buttons the <code>name</code> attribute of <code>indoor-outdoor</code>.')",
-        "assert($(\"label\").length > 1, 'Each of your two radio button elements should be nested in a <code>label</code> element.')",
+        "assert($('label > input[type=\"radio\"]').filter(\"[name='indoor-outdoor']\").length > 1, 'Give your radio buttons the <code>name</code> attribute of <code>indoor-outdoor</code>.')",
+        "assert($('label > input[type=\"radio\"]:only-child').length > 1, 'Each of your two radio button elements should be nested in its own <code>label</code> element.')",
         "assert(editor.match(/<\\/label>/g) && editor.match(/<label/g) && editor.match(/<\\/label>/g).length === editor.match(/<label/g).length, 'Make sure each of your <code>label</code> elements has a closing tag.')",
         "assert($(\"label\").text().match(/indoor/gi), 'One of your radio buttons should have the label <code>indoor</code>.')",
         "assert($(\"label\").text().match(/outdoor/gi), 'One of your radio buttons should have the label <code>outdoor</code>.')"
@@ -2091,9 +2091,9 @@
       ],
       "tests": [
         "assert($('input[type=\"checkbox\"]').length > 2, 'Your page should have three checkbox elements.')",
-        "assert($('label:has(input[type=\"checkbox\"])').length > 2, 'Each of your three checkbox elements should be nested in its own <code>label</code> element.')",
+        "assert($('label > input[type=\"checkbox\"]:only-child').length > 2, 'Each of your three checkbox elements should be nested in its own <code>label</code> element.')",
         "assert(editor.match(/<\\/label>/g) && editor.match(/<label/g) && editor.match(/<\\/label>/g).length === editor.match(/<label/g).length, \"Make sure each of your <code>label</code> elements has a closing tag.\")",
-        "assert($('input[type=\"checkbox\"]:nth-child(1)').attr(\"name\") === \"personality\", 'Give your checkboxes buttons the <code>name</code> attribute of <code>personality</code>.')"
+        "assert($('label > input[type=\"checkbox\"]').filter(\"[name='personality']\").length > 2, 'Give your checkboxes buttons the <code>name</code> attribute of <code>personality</code>.')"
       ],
       "challengeSeed": [
         "<link href=\"http://fonts.googleapis.com/css?family=Lobster\" rel=\"stylesheet\" type=\"text/css\">",

--- a/seed/challenges/html5-and-css.json
+++ b/seed/challenges/html5-and-css.json
@@ -2093,7 +2093,7 @@
         "assert($('input[type=\"checkbox\"]').length > 2, 'Your page should have three checkbox elements.')",
         "assert($('label > input[type=\"checkbox\"]:only-child').length > 2, 'Each of your three checkbox elements should be nested in its own <code>label</code> element.')",
         "assert(editor.match(/<\\/label>/g) && editor.match(/<label/g) && editor.match(/<\\/label>/g).length === editor.match(/<label/g).length, \"Make sure each of your <code>label</code> elements has a closing tag.\")",
-        "assert($('label > input[type=\"checkbox\"]').filter(\"[name='personality']\").length > 2, 'Give your checkboxes buttons the <code>name</code> attribute of <code>personality</code>.')"
+        "assert($('label > input[type=\"checkbox\"]').filter(\"[name='personality']\").length > 2, 'Give your checkboxes the <code>name</code> attribute of <code>personality</code>.')"
       ],
       "challengeSeed": [
         "<link href=\"http://fonts.googleapis.com/css?family=Lobster\" rel=\"stylesheet\" type=\"text/css\">",


### PR DESCRIPTION
In [Waypoint: Create a Set of Radio Buttons](http://www.freecodecamp.com/challenges/waypoint-create-a-set-of-radio-buttons) camper can pass the challenge by specifying only one correct `name` attribute of `input` element i.e. you can pass it with this code 

``` html
<label><input type="radio" name="indoor-outdoor"> outdoor</label>
<label><input type="radio" name=""> indoor</label>
```

which is incorrect, because you need to

> Give your radio button**s** the `name` attribute of `indoor-outdoor`.

The same applies to [Waypoint: Create a Set of Checkboxes](http://www.freecodecamp.com/challenges/waypoint-create-a-set-of-checkboxes) only here value of the `name` attribute is `personality`.

---

This PR also fixes another type of [issue](https://github.com/FreeCodeCamp/FreeCodeCamp/issues/1017). Tests allow you to pass the challenges with this code.

``` html
<label>
<input type="radio" name="indoor-outdoor">indoor
<input type="radio" name="indoor-outdoor">outdoor<label> </label></label> 
```

and the same for checkboxes. So here one `label` is nested in another but instructions of waypoints' are very clear except [Waypoint: Create a Set of Radio Buttons](http://www.freecodecamp.com/challenges/waypoint-create-a-set-of-radio-buttons)'s one. I changed

> Each of your two radio button elements should be nested in a `label` element.

to

> Each of your two radio button elements should be nested in its own `label` element.

Closes #2750.
Closes #2067.
Closes #1390.
Closes #1323.
Closes #1038.
Closes #1018.
Closes #1017.
