### PR TITLE
Disregard order in 'Symmetric Difference', again

### DIFF
--- a/seed/challenges/advanced-bonfires.json
+++ b/seed/challenges/advanced-bonfires.json
@@ -80,10 +80,10 @@
         "sym([1, 2, 3], [5, 2, 1, 4]);"
       ],
       "tests": [
-        "assert.deepEqual(sym([1, 2, 3], [5, 2, 1, 4]), [3, 5, 4], 'should return an array of unique values');",
-        "assert.deepEqual(sym([1, 2, 5], [2, 3, 5], [3, 4, 5]), [1, 4, 5], 'should return the symmetric difference of the given arrays');",
-        "assert.deepEqual(sym([1, 1, 2, 5], [2, 2, 3, 5], [3, 4, 5, 5]), [1, 4, 5], 'should return an array of unique values');",
-        "assert.deepEqual(sym([1, 1]), [1], 'should return an array of unique values');"
+        "assert.deepEqual(sym([1, 2, 3], [5, 2, 1, 4]).sort(), [3, 4, 5], 'should return an array of unique values');",
+        "assert.deepEqual(sym([1, 2, 5], [2, 3, 5], [3, 4, 5]).sort(), [1, 4, 5], 'should return the symmetric difference of the given arrays');",
+        "assert.deepEqual(sym([1, 1, 2, 5], [2, 2, 3, 5], [3, 4, 5, 5]).sort(), [1, 4, 5], 'should return an array of unique values');",
+        "assert.deepEqual(sym([1, 1]).sort(), [1], 'should return an array of unique values');"
       ],
       "MDNlinks": [
         "Array.reduce()",


### PR DESCRIPTION
Not sure what happened to #1671, but looks like it was lost in migration.

Fix #2224
