### PR TITLE
fixes broken test when 'children()' has an argument

### DIFF
--- a/seed/challenges/jquery.json
+++ b/seed/challenges/jquery.json
@@ -684,7 +684,7 @@
       ],
       "tests": [
         "assert($(\"#right-well\").children().css(\"color\") === 'rgb(0, 128, 0)', 'All children of <code>#right-well</code> should have green text.')",
-        "assert(editor.match(/\\.children\\(\\)\\.css/g), 'You should use the <code>children&#40&#41</code> function to modify these elements.')",
+        "assert(editor.match(/\\.children\\(.*\\)\\.css/g), 'You should use the <code>children&#40&#41</code> function to modify these elements.')",
         "assert(editor.match(/<div class=\"well\" id=\"right-well\">/g), 'Only use jQuery to add these classes to the element.')"
       ],
       "challengeSeed": [


### PR DESCRIPTION
Now `$("#right-well").children("#target6").css("color", "green");` should work. If you give children() an incorrect argument first test will not let you to go to next challenge. 
Closes #2214.
