### PR TITLE
Fixed the typo on Deleting jQuery functions issue #2832

### DIFF
--- a/seed/challenges/jquery-ajax-and-json.json
+++ b/seed/challenges/jquery-ajax-and-json.json
@@ -212,7 +212,7 @@
         "assert(!editor.match(/e\\'\\);/g) && !editor.match(/t\\'\\);/g), 'Delete all three of your jQuery functions from your \"document ready function\".')",
         "assert(editor.match(/<script>/g), 'Leave your <code>script</code> element intact.')",
         "assert(editor.match(/\\$\\(document\\)\\.ready\\(function\\(\\)\\s?\\{/g), 'Leave your <code>$(document).ready(function() {</code> to the beginning of your <code>script</code> element.')",
-        "assert(editor.match(/\\n\\s+?\\}\\);/g), 'Leave your your \"document ready function\" closing <code>\\}\\);</code> intact.')",
+        "assert(editor.match(/\\n\\s+?\\}\\);/g), 'Leave your \"document ready function\" closing <code>\\}\\);</code> intact.')",
         "assert(editor.match(/<\\/script>/g) && editor.match(/<script/g) && editor.match(/<\\/script>/g).length === editor.match(/<script/g).length, 'Leave your <code>script</code> element closing tag intact.')"
       ],
       "challengeSeed": [


### PR DESCRIPTION
There was a double your.... I do think the original issue was about the extra back-slash... I did not want to change that since the linter did not like it. But the double 'your' is gone!
