### PR TITLE
This commit extends 'Bug' button's functionality

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -76,10 +76,8 @@ $(document).ready(function() {
       $('#report-issue').unbind('click');
       $('#report-issue').on('click', function() {
           var textMessage = 'https://github.com/freecodecamp/freecodecamp/issues/new?&body=Challenge ' + window.location.href + ' has an issue. Please describe how to reproduce it, and include links to screenshots if possible.';
-          if($('#user-agent-checkbox').is(':checked')) {
-            textMessage += ' My User Agent is: <code>' + navigator.userAgent + '</code>';
-            textMessage = textMessage.replace(';', ','); //GitHub cuts User Agent text because of ';' symbol so I just replace it with ','
-          }
+          textMessage += ' My User Agent is: <code>' + navigator.userAgent + '</code>.';
+          textMessage = textMessage.replace(';', ','); //GitHub cuts User Agent text because of ';' symbol so I just replace it with ','
           $('#issue-modal').modal('hide');
           window.open(textMessage, '_blank');
       });

--- a/client/main.js
+++ b/client/main.js
@@ -66,10 +66,22 @@ $(document).ready(function() {
         }, 200);
       });
 
+      $('#search-issue').unbind('click');
+      $('#search-issue').on('click', function() {
+          var queryIssue = window.location.href.toString();
+          $('#issue-modal').modal('hide');
+          window.open('https://github.com/FreeCodeCamp/FreeCodeCamp/issues?q=is:issue is:all '+ queryIssue.substr(queryIssue.lastIndexOf('challenges/') + 11).replace('/', ''), '_blank');
+      });
+
       $('#report-issue').unbind('click');
       $('#report-issue').on('click', function() {
+          var textMessage = 'https://github.com/freecodecamp/freecodecamp/issues/new?&body=Challenge ' + window.location.href + ' has an issue. Please describe how to reproduce it, and include links to screenshots if possible.';
+          if($('#user-agent-checkbox').is(':checked')) {
+            textMessage += ' My User Agent is: <code>' + navigator.userAgent + '</code>';
+            textMessage = textMessage.replace(';', ','); //GitHub cuts User Agent text because of ';' symbol so I just replace it with ','
+          }
           $('#issue-modal').modal('hide');
-          window.open('https://github.com/freecodecamp/freecodecamp/issues/new?&body=Challenge '+ window.location.href +' has an issue. Please describe how to reproduce it, and include links to screenshots if possible.', '_blank')
+          window.open(textMessage, '_blank');
       });
 
       $('#completed-courseware').unbind('click');

--- a/server/views/partials/challenge-modals.jade
+++ b/server/views/partials/challenge-modals.jade
@@ -20,6 +20,17 @@
             .modal-body.text-center
                 h3 This will open our GitHub Issues page.
                 h3 Please tell us how to reproduce the bug and link us to screenshots if possible.
+                h4.row
+                    .col-xs-1.col-sm-1.col-md-1
+                        input#user-agent-checkbox(type='checkbox') 
+                    .col-xs-11.col-sm-11.col-md-11
+                        label.text-warning.bg-info(for='user-agent-checkbox' style='cursor:pointer;') Include your OS and Browser version in the text of issue to provide more detailed information
+                h3 It's recommended first to search issues in GitHub. It could be a similar issue opened or already solved!
+                h3 
+                    | Also take a look at this helpful Wiki article: 
+                    br
+                    a(href='https://github.com/FreeCodeCamp/FreeCodeCamp/wiki/Help-I%27ve-Found-a-Bug', target='_blank') Help I've Found a Bug
+                a.btn.btn-lg.btn-success.btn-block#search-issue(name='_csrf', value=_csrf) Search issues on this challenge in GitHub
                 a.btn.btn-lg.btn-primary.btn-block#report-issue(name='_csrf', value=_csrf) Create my GitHub issue
                 a.btn.btn-lg.btn-info.btn-block(href='#', data-dismiss='modal', aria-hidden='true') Cancel
 

--- a/server/views/partials/challenge-modals.jade
+++ b/server/views/partials/challenge-modals.jade
@@ -22,7 +22,7 @@
                 h3 Please tell us how to reproduce the bug and link us to screenshots if possible.
                 h4.row
                     .col-xs-1.col-sm-1.col-md-1
-                        input#user-agent-checkbox(type='checkbox') 
+                        input#user-agent-checkbox(type='checkbox', checked) 
                     .col-xs-11.col-sm-11.col-md-11
                         label.text-warning.bg-info(for='user-agent-checkbox' style='cursor:pointer;') Include your OS and Browser version in the text of issue to provide more detailed information
                 h3 It's recommended first to search issues in GitHub. It could be a similar issue opened or already solved!

--- a/server/views/partials/challenge-modals.jade
+++ b/server/views/partials/challenge-modals.jade
@@ -20,11 +20,6 @@
             .modal-body.text-center
                 h3 This will open our GitHub Issues page.
                 h3 Please tell us how to reproduce the bug and link us to screenshots if possible.
-                h4.row
-                    .col-xs-1.col-sm-1.col-md-1
-                        input#user-agent-checkbox(type='checkbox', checked) 
-                    .col-xs-11.col-sm-11.col-md-11
-                        label.text-warning.bg-info(for='user-agent-checkbox' style='cursor:pointer;') Include your OS and Browser version in the text of issue to provide more detailed information
                 h3 It's recommended first to search issues in GitHub. It could be a similar issue opened or already solved!
                 h3 
                     | Also take a look at this helpful Wiki article: 


### PR DESCRIPTION
Due to huge amount of duplicate issues I decided to add a "Search" button so now campers can search issues in GitHub before opening an issue.
Also sometimes it's helpful to provide more info about what version of OS or browser camper is using so I added a checkbox and our campers now can provide such an information only setting a checkbox. **By default this checkbox is unchecked**.
Also I added a link to our [Help I've Found a Bug](https://github.com/FreeCodeCamp/FreeCodeCamp/wiki/Help-I%27ve-Found-a-Bug) Wiki article.
You can see visual changes [in this video](http://sendvid.com/gxb3l6bf).
