### PR TITLE
fix codeStorage not saving on keyUp events

### DIFF
--- a/client/commonFramework.js
+++ b/client/commonFramework.js
@@ -200,7 +200,7 @@ var myCodeMirror = editor;
 editor.on('keyup', function() {
   clearTimeout(codeStorage.updateTimeoutId);
   codeStorage.updateTimeoutId = setTimeout(
-    codeStorage.updateStorage,
+    codeStorage.updateStorage.bind(codeStorage),
     codeStorage.updateWait
   );
 });


### PR DESCRIPTION
method loses context when using setTimeout. This PR binds method to codeStorage instance.

closes #2894 
