### PR TITLE
Improved 'Using typeof' waypoint

### DIFF
--- a/seed/bonfireMDNlinks.js
+++ b/seed/bonfireMDNlinks.js
@@ -87,7 +87,11 @@ var links =
 	"Arithmetic Operators" : "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators",
 	"Comparison Operators" : "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Comparison_Operators",
 	"Details of the Object Model" : "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Details_of_the_Object_Model",
-  "For Loops": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for"
-	};
+  "For Loops": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for",
+
+
+  // ======== EXPRESSIONS AND OPERATORS
+  "typeof" : "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof"
+};
 
 module.exports = links;

--- a/seed/challenges/automated-testing-and-debugging.json
+++ b/seed/challenges/automated-testing-and-debugging.json
@@ -28,19 +28,22 @@
       "title":"Using typeof",
       "difficulty":0,
       "description":[
-        "<code>typeof</code> is a useful method that we can use to check the type of a variable.",
-        "One thing to be careful of is that an array has the type objects.",
+        "<code>typeof</code> is a useful operator that we can use to check the type of a variable.",
+        "One thing to be careful of is that an array has the type <code>object</code>, and not <code>array</code> as you might expect.",
         "Try using each of these to see the types they have.",
-        "<code>console.log(typeof(\"\"));</code>",
-        "<code>console.log(typeof(0));</code>",
-        "<code>console.log(typeof([]));</code>",
-        "<code>console.log(typeof({}));</code>"
+        "<code>console.log(typeof \"\");</code>",
+        "<code>console.log(typeof 0);</code>",
+        "<code>console.log(typeof []);</code>",
+        "<code>console.log(typeof {});</code>"
       ],
       "tests":[
-        "assert(editor.getValue().match(/console\\.log\\(typeof\\(\"\"\\)\\);/gi), 'You should <code>console.log</code> the <code>typeof</code> a string.');",
-        "assert(editor.getValue().match(/console\\.log\\(typeof\\(0\\)\\);/gi), 'You should <code>console.log</code> the <code>typeof</code> a number.');",
-        "assert(editor.getValue().match(/console\\.log\\(typeof\\(\\[\\]\\)\\);/gi), 'You should <code>console.log</code> the <code>typeof</code> an array.');",
-        "assert(editor.getValue().match(/console\\.log\\(typeof\\(\\{\\}\\)\\);/gi), 'You should <code>console.log</code> the <code>typeof</code> a object.');"
+        "assert(editor.getValue().match(/console\\.log\\(typeof \"\"\\);/gi), 'You should <code>console.log</code> the <code>typeof</code> a string.');",
+        "assert(editor.getValue().match(/console\\.log\\(typeof 0\\);/gi), 'You should <code>console.log</code> the <code>typeof</code> a number.');",
+        "assert(editor.getValue().match(/console\\.log\\(typeof \\[\\]\\);/gi), 'You should <code>console.log</code> the <code>typeof</code> an array.');",
+        "assert(editor.getValue().match(/console\\.log\\(typeof \\{\\}\\);/gi), 'You should <code>console.log</code> the <code>typeof</code> a object.');"
+      ],
+      "MDNlinks":[
+        "typeof"
       ],
       "challengeSeed":[
         "",


### PR DESCRIPTION
- Now properly refers to typeof as an operator vs a method.
- Added a link to MDN's article about typeof.
- Added some `<code>` tags and extra auxiliary text.
- Changed the examples and test cases to not use parenhteses.

Fix #3047
