### PR TITLE
Add test cases to Bonfire:Check for Palindrome

### DIFF
--- a/seed/challenges/basic-bonfires.json
+++ b/seed/challenges/basic-bonfires.json
@@ -142,7 +142,10 @@
         "assert.deepEqual(palindrome(\"A man, a plan, a canal. Panama\"), true);",
         "assert.deepEqual(palindrome(\"never odd or even\"), true);",
         "assert.deepEqual(palindrome(\"nope\"), false);",
-        "assert.deepEqual(palindrome(\"almostomla\"), false);"
+        "assert.deepEqual(palindrome(\"almostomla\"), false);",
+        "assert.deepEqual(palindrome(\"My age is 0, 0 si ega ym.\"), true);",
+        "assert.deepEqual(palindrome(\"I'm 23 non 32 m'I?\"), true);",
+        "assert.deepEqual(palindrome(\"1 eye for of 1 eye.\"), false);"
       ],
       "challengeSeed": [
         "function palindrome(str) {",

--- a/seed/challenges/basic-bonfires.json
+++ b/seed/challenges/basic-bonfires.json
@@ -569,7 +569,7 @@
       "title": "Where art thou",
       "difficulty": "1.55",
       "description": [
-        "Make a function that looks through an array (first argument) and returns an array of all objects that have equivalent property and value pair (second argument).",
+        "Make a function that looks through an array (first argument) and returns an array of all objects that have equivalent property and value pairs (second argument).",
         "For example, if the first argument is <code>[{ first: 'Romeo', last: 'Montague' }, { first: 'Mercutio', last: null }, { first: 'Tybalt', last: 'Capulet' }]</code>, and the second argument is <code>{ last: 'Capulet' }</code>, then you must return the the third object from the array (the first argument), because it contains the property and it's value, that was passed on as the second argument.",
         "Remember to use <a href='//github.com/FreeCodeCamp/freecodecamp/wiki/How-to-get-help-when-you-get-stuck' target='_blank'>Read-Search-Ask</a> if you get stuck. Write your own code."
       ],


### PR DESCRIPTION
Add test cases with numbers in the string to also check for numbers.

**Bonfire:Check for Palindrome Description**

> Return `true` if the given string is a palindrome. Otherwise, return `false`. A palindrome is a word or sentence that's spelled the same way both forward and backward, ignoring **punctuation**, **case**, and **spacing**. (but not **numbers** )

Hence, added number in the test cases.

cc: @benmcmahon100 
