### PR TITLE
Add test cases to Bonfire:Check for Palindrome

### DIFF
--- a/seed/challenges/basic-bonfires.json
+++ b/seed/challenges/basic-bonfires.json
@@ -142,7 +142,10 @@
         "assert.deepEqual(palindrome(\"A man, a plan, a canal. Panama\"), true);",
         "assert.deepEqual(palindrome(\"never odd or even\"), true);",
         "assert.deepEqual(palindrome(\"nope\"), false);",
-        "assert.deepEqual(palindrome(\"almostomla\"), false);"
+        "assert.deepEqual(palindrome(\"almostomla\"), false);",
+        "assert.deepEqual(palindrome(\"My age is 0, 0 si ega ym.\"), true);",
+        "assert.deepEqual(palindrome(\"I'm 23 non 32 m'I?\"), true);",
+        "assert.deepEqual(palindrome(\"1 eye for of 1 eye.\"), false);"
       ],
       "challengeSeed": [
         "function palindrome(str) {",


### PR DESCRIPTION
Add test cases with numbers in the string to also check for numbers.

**Bonfire:Check for Palindrome Description**

> Return `true` if the given string is a palindrome. Otherwise, return `false`. A palindrome is a word or sentence that's spelled the same way both forward and backward, ignoring **punctuation**, **case**, and **spacing**. (but not **numbers** )

Hence, added number in the test cases.

cc: @benmcmahon100 

**Punctuation:** https://en.wikipedia.org/wiki/Punctuation
