### PR TITLE
fixes assert and adds a dot

### DIFF
--- a/seed/challenges/basic-javascript.json
+++ b/seed/challenges/basic-javascript.json
@@ -283,7 +283,7 @@
         "Replace the <code>0</code> with the correct number so you can get the result mentioned in the comment."
       ],
       "tests": [
-        "assert((function(){if(sum === 20 && editor.getValue().match(/\\+/g)){return true;}else{return false;}})(), 'Make the variable <code>sum</code> equal 20');"
+        "assert((function(){if(sum === 20 && editor.getValue().match(/\\+/g).length >= 2){return true;}else{return false;}})(), 'Make the variable <code>sum</code> equal 20.');"
       ],
       "challengeSeed": [
         "var sum = 10 + 0; //make this equal to 20 by changing the 0 into the appropriate number.",


### PR DESCRIPTION
The problem is that in [Add Two Numbers with JavaScript](http://www.freecodecamp.com/challenges/waypoint-add-two-numbers-with-javascript) we can pass the test with unexpected code: `var sum = 10 * 2;`. Assert checks if there is a '+' in the code so we'll pass the test because there is already a '+' sign: `'sum='+z;`.
