### PR TITLE
Removes unnecessary 'negative-15' class

### DIFF
--- a/server/views/coursewares/showHTML.jade
+++ b/server/views/coursewares/showHTML.jade
@@ -49,7 +49,7 @@ block content
                             var userLoggedIn = true;
                     else
                         .button-spacer
-                        a.btn.signup-btn.btn-block.btn-block.negative-15(href='/login') Sign in so you can save your progress
+                        a.btn.signup-btn.btn-block.btn-block(href='/login') Sign in so you can save your progress
                             script.
                                 var userLoggedIn = false;
                     .button-spacer


### PR DESCRIPTION
@QuincyLarson, after you've [merged](https://github.com/FreeCodeCamp/FreeCodeCamp/commit/79a396b9c83a680ec6a82e6fd63e8eedb6b47c2c) @tcyrus'es branch, for some reason in **showHTML.jade** that merge removed a `br` tag which reproduces the following result: http://prntscr.com/8d6iky. This commit fixes that.
