### PR TITLE
Restore emmet.io support

### DIFF
--- a/client/commonFramework.js
+++ b/client/commonFramework.js
@@ -216,6 +216,14 @@ var allSeeds = '';
     });
 })();
 
+var defaultKeymap = {
+  'Cmd-E': 'emmet.expand_abbreviation',
+  'Tab': 'emmet.expand_abbreviation_with_tab',
+  'Enter': 'emmet.insert_formatted_line_break_only'
+};
+
+emmetCodeMirror(editor, defaultKeymap);
+
 editor.setOption('extraKeys', {
   Tab: function(cm) {
     if (cm.somethingSelected()) {


### PR DESCRIPTION
Restores emmet.io support removed in https://github.com/FreeCodeCamp/FreeCodeCamp/commit/8f54932cab39880fa595301e507b76756c72f793?diff=split#diff-1c15d6cc7cf56b4c36a76e6a51384cdaL86

closes #2720

> NOTE: I've not tested it locally if this breaks anything else.

cc: @BerkeleyTrue 
