### PR TITLE
Fix typo in basic-javascript waypoint

### DIFF
--- a/seed/challenges/basic-javascript.json
+++ b/seed/challenges/basic-javascript.json
@@ -1109,7 +1109,7 @@
       "title": "Invert Regular Expression Matches with JavaScript",
       "difficulty":"9.987",
       "description":[
-        "Use <code>/\\S/gi;</code> to match everything that isn't a space in the string.",
+        "Use <code>/\\S/gi</code> to match everything that isn't a space in the string.",
         "You can invert any match by using the uppercase version of the selector <code>\\s</code> versus <code>\\S</code> for example."
       ],
       "tests":[


### PR DESCRIPTION
Waypoint 'Invert Regular Expression Matches with JavaScript' had a semi-colon in the description for the regex example which is not needed.
closes #3148
