### PR TITLE
fix isInitRun flag not set

### DIFF
--- a/client/commonFramework.js
+++ b/client/commonFramework.js
@@ -401,9 +401,13 @@ var postError = function(data) {
 var goodTests = 0;
 var testSuccess = function() {
   goodTests++;
+  // test successful run show completion
   if (goodTests === tests.length) {
-    showCompletion();
+    return showCompletion();
   }
+
+  // test unsuccessful, make sure initRun is set to false
+  isInitRun = false;
 };
 
 function showCompletion() {
@@ -624,7 +628,9 @@ var runTests = function(err, data) {
     ) {
       try {
         if (chaiTestFromJSON) {
+          /* eslint-disable no-eval */
           var output = eval(reassembleTest(chaiTestFromJSON, data));
+          /* eslint-enable no-eval */
         }
       } catch (error) {
         allTestsPassed = false;
@@ -639,8 +645,7 @@ var runTests = function(err, data) {
     if (allTestsPassed) {
       allTestsPassed = false;
       showCompletion();
-    }
-    else{
+    } else {
       isInitRun = false;
     }
   }


### PR DESCRIPTION
When doing jQuery challenges and starting with failing tests
isInitRun, the flag that prevents initial run from auto submitting
a challenge does not get set due to bonfireExecute not running in
this situation. This fixes that by setting consitantly setting
the flag on failing tests so that when tests do pass by camper
the flag will always be set and allow the camper to continue.

Also includes some lint fixes.

closes #2772
