### PR TITLE
fix clicking on modal closes

### DIFF
--- a/client/commonFramework.js
+++ b/client/commonFramework.js
@@ -433,7 +433,7 @@ function showCompletion() {
   );
   var bonfireSolution = myCodeMirror.getValue();
   var didCompleteWith = $('#completed-with').val() || null;
-  $('#complete-courseware-dialog').modal('show');
+  $('#complete-courseware-dialog').modal({ backdrop: 'static' });
   $('#complete-courseware-dialog .modal-header').click();
   $('#submit-challenge').click(function(e) {
     e.preventDefault();


### PR DESCRIPTION
This prevents clicking on modal before modal has completed init
closing modal prematurely at the expense of removing the ability
to close the modal by clicking on the backdrop

closes #2792
