### PR TITLE
fix modal showing when challenge already completed

### DIFF
--- a/client/commonFramework.js
+++ b/client/commonFramework.js
@@ -244,6 +244,7 @@ editor.setOption('extraKeys', {
     }
   },
   'Ctrl-Enter': function() {
+    isInitRun = false;
     bonfireExecute(true);
     return false;
   }
@@ -415,9 +416,6 @@ var testSuccess = function() {
   if (goodTests === tests.length) {
     return showCompletion();
   }
-
-  // test unsuccessful, make sure initRun is set to false
-  isInitRun = false;
 };
 
 function showCompletion() {
@@ -762,6 +760,7 @@ function bonfireExecute(shouldTest) {
 }
 
 $('#submitButton').on('click', function() {
+  isInitRun = false;
   bonfireExecute(true);
 });
 


### PR DESCRIPTION
This fix fixes a regression introduced in an earlier commit.
Now, isInitRun is always set false on user involvement.
This prevents the completion modal from poping up during challenges
that have preview windows.
