### PR TITLE
fixes user agent semicolon replacement

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -83,7 +83,7 @@ $(document).ready(function() {
           var textMessage = 'https://github.com/freecodecamp/freecodecamp/issues/new?&body=Challenge ' + window.location.href + ' has an issue.';
           textMessage += ' User Agent is: <code>' + navigator.userAgent + '</code>.';
           textMessage += ' Please describe how to reproduce this issue, and include links to screenshots if possible.%0A%0A';
-          textMessage = textMessage.replace(';', ','); //GitHub cuts User Agent text because of ';' symbol so I just replace it with ','
+          textMessage = textMessage.replace(/;/g, ',');
           $('#issue-modal').modal('hide');
           window.open(textMessage, '_blank');
       });


### PR DESCRIPTION
As I mentioned is main.js GitHub cuts user agent text because of ';' symbol. So I did `replace(';', ',')`. But this replaces  **only first** matched semicolon. Here you can see what it [looks like](http://prntscr.com/8epzfx).
cc @FreeCodeCamp/owners 
