### PR TITLE
Slot Machine false positives

### DIFF
--- a/seed/challenges/basic-javascript.json
+++ b/seed/challenges/basic-javascript.json
@@ -1302,7 +1302,7 @@
         "<code>}</code>"
       ],
       "tests":[
-        "assert((function(){var data = runSlots();if(data === null){return true}else{if(data[0] === data[1] && data[1] === data[2]){return true;}else{return false;}}})(), 'If all three of our random numbers are the same we should return that number. Otherwise we should return <code>null</code>.')"
+        "assert((function(){var data = runSlots();return data === null || data.toString().length === 1;})(), 'If all three of our random numbers are the same we should return that number. Otherwise we should return <code>null</code>.')"
       ],
       "challengeSeed":[
         "fccss",
@@ -1485,9 +1485,10 @@
         "    ",
         "    // Only change code above this line.",
         "    ",
-        "    if(slotOne !== slotTwo || slotTwo !== slotThree){",
-        "      return null;",
+        "    if(slotOne === slotTwo && slotTwo === slotThree){",
+        "      return slotOne;",
         "    }",
+        "    return null;",
         "    ",
         "    if(slotOne !== undefined && slotTwo !== undefined && slotThree !== undefined){",
         "      $(\".logger\").html(slotOne);",
@@ -1655,9 +1656,10 @@
         "    ",
         "    // Only change code above this line.",
         "    ",
-        "    if(slotOne !== slotTwo || slotTwo !== slotThree){",
-        "      return null;",
+        "    if(slotOne === slotTwo && slotTwo === slotThree){",
+        "      return slotOne;",
         "    }",
+        "    return null;",
         "    ",
         "    if(slotOne !== undefined && slotTwo !== undefined && slotThree !== undefined){",
         "      $('.logger').html(slotOne);",


### PR DESCRIPTION
The 'Add your JavaScript Slot Machine Slots' waypoint would throw false positives if all slot numbers were the same, effectively allowing the campers to pass the test without having written any code.

This would fix it, but since it alters the challenge seed, the seed for this challenge would look different from close neighbours, so they might need to be altered as well. I'll look through the other challenges and see if they can be changed, but I wanted to get this up ad quickly as possible to hear what others have to say.

Fixes #3228
