### PR TITLE
Fixed typo in basic bonfire description

### DIFF
--- a/seed/challenges/basic-bonfires.json
+++ b/seed/challenges/basic-bonfires.json
@@ -8,7 +8,7 @@
       "difficulty": "0",
       "description": [
         "Your goal is to fix the failing test.",
-        "First, run all the tests by clicking \"Run code\" or by pressing Control + Enter.",
+        "First, run all the tests by clicking \"Run tests\" or by pressing Control + Enter.",
         "The failing test is in red. Fix the code so that all tests pass. Then you can move on to the next Bonfire.",
         "Make this function return true no matter what."
       ],


### PR DESCRIPTION
Changed 'Meet Bonfire' bonfire's description from `clicking Run code` to `clicking Run tests`
closes #3235
