### PR TITLE
Fixed erroneous test in bootstrap waypoint

### DIFF
--- a/seed/challenges/bootstrap.json
+++ b/seed/challenges/bootstrap.json
@@ -1161,7 +1161,7 @@
       "tests": [
         "assert($(\"i\").hasClass(\"fa fa-trash\"), 'You should add a <code>&#60;i class=\"fa fa-trash\"&#62;&#60;/i&#62;</code> within your delete button element.')",
         "assert($(\"i\").hasClass(\"fa fa-info-circle\"), 'You should add a <code>&#60;i class=\"fa fa-info-circle\"&#62;&#60;/i&#62;</code> within your info button element.')",
-        "assert(editor.match(/<\\/i>/g) && editor.match(/<\\/i/g).length > 2, 'Make sure each of your <code>i</code> elements has a closing tag.')"
+        "assert(editor.match(/<\\/i>/g) && editor.match(/<\\/i>/g).length > 2, 'Make sure each of your <code>i</code> elements has a closing tag.')"
       ],
       "challengeSeed": [
         "<link href=\"http://fonts.googleapis.com/css?family=Lobster\" rel=\"stylesheet\" type=\"text/css\">",


### PR DESCRIPTION
Modified the last test in the bootstrap waypoint `Add Font Awesome Icons to all of our Buttons` so that it doesn't validate `</i`, but `</i>`
closes #1031
