### PR TITLE
Include code in issue + issue body improvements

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -80,12 +80,48 @@ $(document).ready(function() {
 
       $('#report-issue').unbind('click');
       $('#report-issue').on('click', function() {
-          var textMessage = 'https://github.com/freecodecamp/freecodecamp/issues/new?&body=Challenge ' + window.location.href + ' has an issue.';
-          textMessage += ' User Agent is: <code>' + navigator.userAgent + '</code>.';
-          textMessage += ' Please describe how to reproduce this issue, and include links to screenshots if possible.%0A%0A';
-          textMessage = textMessage.replace(/;/g, ',');
+          var textMessage = [
+            'Challenge [',
+            (challenge_Name || challengeName || window.location.href),
+            '](',
+            window.location.href,
+            ') has an issue.\n',
+            'User Agent is: <code>',
+            navigator.userAgent,
+            '</code>.\n',
+            'Please describe how to reproduce this issue, and include ',
+            'links to screenshots if possible.\n\n'
+          ].join('');
+
+          if ($('#include-code').prop('checked')) {
+            var type;
+            switch (challengeType) {
+              case challengeTypes.HTML_CSS_JQ:
+                type = 'html';
+                break;
+              case challengeTypes.JAVASCRIPT:
+                type = 'javascript';
+                break;
+              default:
+                type = '';
+            }
+
+            textMessage += [
+              'Camper\'s code:\n```',
+              type,
+              '\n',
+              editor.getValue(),
+              '\n```'
+            ].join('');
+          }
+
+          textMessage = encodeURIComponent(textMessage);
+
           $('#issue-modal').modal('hide');
-          window.open(textMessage, '_blank');
+          window.open(
+            'https://github.com/freecodecamp/freecodecamp/issues/new?&body=' +
+            textMessage, '_blank'
+          );
       });
 
       $('#completed-courseware').unbind('click');

--- a/server/views/partials/challenge-modals.jade
+++ b/server/views/partials/challenge-modals.jade
@@ -21,7 +21,10 @@
                 h3 Before you submit a new issue, read "Help I've Found a Bug" and browse other issues with this challenge.
                 a.btn.btn-lg.btn-success.btn-block#help-ive-found-a-bug-wiki-article(name='_csrf', value=_csrf) Read "Help I've Found a Bug"
                 a.btn.btn-lg.btn-success.btn-block#search-issue(name='_csrf', value=_csrf) Browse other issues with this challenge
-                a.btn.btn-lg.btn-primary.btn-block#report-issue(name='_csrf', value=_csrf) Create my GitHub issue
+                .btn-group.btn-block
+                  a.btn.btn-lg.btn-primary.col-sm-11.col-xs-10.p-l-lg#report-issue(name='_csrf', value=_csrf) Create my GitHub issue
+                  .btn.btn-lg.btn-primary.col-sm-1.col-xs-2
+                    input(type="checkbox" title="Include code" checked)#include-code
                 a.btn.btn-lg.btn-info.btn-block(href='#', data-dismiss='modal', aria-hidden='true') Cancel
 
 #help-modal.modal(tabindex='-1')


### PR DESCRIPTION
This creates an auto-checked checkbox next to the 'Create my GitHub issue'-button that, when checked, includes the camper's code in the body sent to GitHub when creating a new issue.
Also includes some general improvements to how the way the issue creation is handled and how the output looks.

Fix #3258
