### PR TITLE
Improves 'Bug' button search method

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -69,12 +69,14 @@ $(document).ready(function() {
       $('#search-issue').unbind('click');
       $('#search-issue').on('click', function() {
           var queryIssue = window.location.href.toString();
-          window.open('https://github.com/FreeCodeCamp/FreeCodeCamp/issues?q=is:issue is:all '+ queryIssue.substr(queryIssue.lastIndexOf('challenges/') + 11).replace('/', ''), '_blank');
+          window.open('https://github.com/FreeCodeCamp/FreeCodeCamp/issues?q=' +
+            'is:issue is:all ' + (challenge_Name || challengeName) + ' OR ' +
+            queryIssue.substr(queryIssue.lastIndexOf('challenges/') + 11)
+            .replace('/', ''), '_blank');
       });
 
       $('#help-ive-found-a-bug-wiki-article').unbind('click');
       $('#help-ive-found-a-bug-wiki-article').on('click', function() {
-        var queryIssue = window.location.href.toString();
         window.open("https://github.com/FreeCodeCamp/FreeCodeCamp/wiki/Help-I've-Found-a-Bug", '_blank');
       });
 


### PR DESCRIPTION
PR https://github.com/FreeCodeCamp/FreeCodeCamp/pull/3269 changes the link title to the challenge to a readable one (for example, from `http://freecodecamp.com/challenges/waypoint-condense-arrays-with-reduce` to `Waypoint: Condense arrays with reduce`). This means that campers won't be able to search new issues because Search button uses a part of that link (`waypoint-condense-arrays-with-reduce` for `Condense arrays with reduce`) to search issues. This PR solves this by using logical `OR` in search query.
Also removes unused `queryIssue` variable.
