### PR TITLE
fix for issue #1021

### DIFF
--- a/seed/challenges/bootstrap.json
+++ b/seed/challenges/bootstrap.json
@@ -96,9 +96,10 @@
         "Fortunately, with Bootstrap, all we need to do is add the <code>img-responsive</code> class to your image. Do this, and the image should perfectly fit the width of your page."
       ],
       "tests": [
-        "assert($(\"img\").length > 1, 'You should have a total of two images.')",
+        "assert($(\"img\").length === 2, 'You should have a total of two images.')",
+        "assert(editor.match(/<img/g) && editor.match(/<img.*>/g).length === 2 && editor.match(/<img/g).length === 2, 'Make sure your new <code>img</code> element has a closing angle bracket.')",
         "assert($(\"img\").hasClass(\"img-responsive\"), 'Your new image should have the class <code>img-responsive</code>.')",
-        "assert(new RegExp(\"http://bit.ly/fcc-running-cats\", \"gi\").test($(\"img.img-responsive\").attr(\"src\")), 'Add a second image with the <code>src</code> of <code>http&#58;//bit.ly/fcc-running-cats</code>.')"
+        "assert(new RegExp(\"http://bit.ly/fcc-running-cats\", \"gi\").test($(\"img.img-responsive\").attr(\"src\")), 'Your new image should have <code>src</code> attribute of <code>http&#58;//bit.ly/fcc-running-cats</code>.')"
       ],
       "challengeSeed": [
         "<link href=\"http://fonts.googleapis.com/css?family=Lobster\" rel=\"stylesheet\" type=\"text/css\">",


### PR DESCRIPTION
Re-used the original technique for scanning not-well-formed tags from Waipoint: Headline with the h2 Element (http://www.freecodecamp.com/challenges/waypoint-headline-with-the-h2-element). Also adjusted assertion messages to be worded in the same way as much as possible (for consistency).

Here is the preview snip of how these changes would actually render in the context of waypoint (see areas highlighted in red):

![image](https://cloud.githubusercontent.com/assets/3822219/9870895/c40f661c-5b44-11e5-91b6-730fc6d52a28.png)

Appreciate your feedback very much!
