### PR TITLE
Improve assertions to ensure well-formed img elements

### DIFF
--- a/seed/challenges/bootstrap.json
+++ b/seed/challenges/bootstrap.json
@@ -96,9 +96,10 @@
         "Fortunately, with Bootstrap, all we need to do is add the <code>img-responsive</code> class to your image. Do this, and the image should perfectly fit the width of your page."
       ],
       "tests": [
-        "assert($(\"img\").length > 1, 'You should have a total of two images.')",
+        "assert($(\"img\").length === 2, 'You should have a total of two images.')",
+        "assert(editor.match(/<img/g) && editor.match(/<img.*>/g).length === 2 && editor.match(/<img/g).length === 2, 'Make sure your new <code>img</code> element has a closing angle bracket.')",
         "assert($(\"img\").hasClass(\"img-responsive\"), 'Your new image should have the class <code>img-responsive</code>.')",
-        "assert(new RegExp(\"http://bit.ly/fcc-running-cats\", \"gi\").test($(\"img.img-responsive\").attr(\"src\")), 'Add a second image with the <code>src</code> of <code>http&#58;//bit.ly/fcc-running-cats</code>.')"
+        "assert(new RegExp(\"http://bit.ly/fcc-running-cats\", \"gi\").test($(\"img.img-responsive\").attr(\"src\")), 'Your new image should have <code>src</code> attribute of <code>http&#58;//bit.ly/fcc-running-cats</code>.')"
       ],
       "challengeSeed": [
         "<link href=\"http://fonts.googleapis.com/css?family=Lobster\" rel=\"stylesheet\" type=\"text/css\">",


### PR DESCRIPTION
Reused the original approach from Waypoint: Headline with the h2 Element (http://freecodecamp.com/challenges/waypoint-headline-with-the-h2-element) by using the very same technique. Also, slightly adjusted assertion messages to use similar wording (for consistency).

Here is the snip of how these changes would react upon not-well-formed img element:
![image](https://cloud.githubusercontent.com/assets/3822219/9897988/3929cce4-5c03-11e5-9b51-04cce64aff90.png)

And here is the snip of how these changes would react upon the completed challenge:
![image](https://cloud.githubusercontent.com/assets/3822219/9898026/9140c770-5c03-11e5-9267-47034e3bd818.png)

Appreciate your feedback very much!
