### PR TITLE
fix invisible div blocking run button

### DIFF
--- a/server/views/coursewares/showBonfire.jade
+++ b/server/views/coursewares/showBonfire.jade
@@ -16,7 +16,7 @@ block content
     script(type='text/javascript', src='/js/lib/jailed/jailed.js')
 
     .row(ng-controller="pairedWithController")
-        .col-xs-12.col-sm-12.col-md-4.col-lg-3
+        .col-md-4.col-lg-3
             .scroll-locker(id = "scroll-locker")
               .innerMarginFix(style=' width: 99%')
                 #testCreatePanel.well
@@ -122,7 +122,7 @@ block content
                     var _ = R;
                     var dashed = !{JSON.stringify(dashedName)};
 
-        .col-xs-12.col-sm-12.col-md-8
+        .col-md-8.col-lg-9
             .editorScrollDiv(style = "overflow-y: auto; overflow-x: hidden;")
                 #mainEditorPanel
                     form.code

--- a/server/views/coursewares/showHTML.jade
+++ b/server/views/coursewares/showHTML.jade
@@ -19,7 +19,7 @@ block content
     script(src='/js/lib/codemirror/mode/htmlmixed/htmlmixed.js')
     script(src='/js/lib/codemirror/addon/emmet/emmet.js')
     .row.courseware-height
-        .col-xs-12.col-sm-12.col-md-3.col-lg-3
+        .col-md-3.col-lg-3
             .scroll-locker(id = "scroll-locker")
                 .innerMarginFix(style = "width: 99%;")
                     .well
@@ -64,7 +64,7 @@ block content
                         var dashedName = !{JSON.stringify(dashedName)};
                         var challengeType = !{JSON.stringify(challengeType)};
                         var started = Math.floor(Date.now());
-        .col-xs-12.col-sm-12.col-md-5.col-lg-6
+        .col-md-5.col-lg-6
             .editorScrollDiv(style = "overflow-y: auto; overflow-x: hidden;")
                     #mainEditorPanel
                         form.code

--- a/server/views/coursewares/showJS.jade
+++ b/server/views/coursewares/showJS.jade
@@ -14,7 +14,7 @@ block content
     script(type='text/javascript', src='/js/lib/codemirror/mode/javascript/javascript.js')
     script(type='text/javascript', src='/js/lib/jailed/jailed.js')
     .row(ng-controller="pairedWithController")
-        .col-xs-12.col-sm-12.col-md-4.col-lg-3
+        .col-md-4.col-lg-3
             .scroll-locker(id = "scroll-locker")
                 .innerMarginFix(style = "width: 99%;")
                     #testCreatePanel.well
@@ -71,7 +71,7 @@ block content
                         var challengeType = !{JSON.stringify(challengeType)};
                         var _ = R;
                         var dashed = !{JSON.stringify(dashedName)};
-        .col-xs-12.col-sm-12.col-md-8
+        .col-md-8.col-lg-9
             .editorScrollDiv(style = "overflow-y: auto; overflow-x: hidden;")
                 #mainEditorPanel
                     form.code

--- a/server/views/coursewares/showZiplineOrBasejump.jade
+++ b/server/views/coursewares/showZiplineOrBasejump.jade
@@ -1,7 +1,7 @@
 extends ../layout-wide
 block content
     .row
-        .col-xs-12.col-sm-12.col-md-4.bonfire-top
+        .col-md-4.bonfire-top
             h1.text-center= name
             .well
                 h4
@@ -12,7 +12,7 @@ block content
                                     input(type='checkbox' class='challenge-list-checkbox')
                                 .col-xs-9.col-sm-11.col-md-10
                                     li.step-text.wrappable!= step
-        .col-xs-12.col-sm-12.col-md-8
+        .col-md-8
             .embed-responsive.embed-responsive-16by9
                 iframe.embed-responsive-item(src='//player.vimeo.com/video/#{video}')
             br


### PR DESCRIPTION
bootstrap classes stack on smaller screens if breakpoints are not
met. This fix removes the smaller screen classes that forced divs
that would otherwise stack to instead overlay each other. This is
the cause of the run button being blocks on smaller screens as a
col that should stack to the bottom was instead being pushed to
top.

closes #1466
