### PR TITLE
Fix test on Waypoint Create Unordered List

### DIFF
--- a/seed/challenges/html5-and-css.json
+++ b/seed/challenges/html5-and-css.json
@@ -1434,7 +1434,7 @@
         "assert($(\"ul\").length > 0, 'Create a <code>ul</code> element.')",
         "assert($(\"ul li\").length > 2, 'You should have three <code>li</code> elements within your <code>ul</code> element.')",
         "assert(editor.match(/<\\/ul>/g) && editor.match(/<ul/g) && editor.match(/<\\/ul>/g).length === editor.match(/<ul/g).length, 'Make sure your <code>ul</code> element has a closing tag.')",
-        "assert(editor.match(/<\\/li>/g) && editor.match(/<li>/g) && editor.match(/<\\/li>/g).length === editor.match(/<li>/g).length, 'Make sure your <code>li</code> element has a closing tag.')"
+        "assert(editor.match(/<\\/li>/g) && editor.match(/<li[\\s>]/g) && editor.match(/<\\/li>/g).length === editor.match(/<li[\\s>]/g).length, 'Make sure your <code>li</code> elements have closing tags.')"
       ],
       "challengeSeed": [
         "<link href=\"http://fonts.googleapis.com/css?family=Lobster\" rel=\"stylesheet\" type=\"text/css\">",


### PR DESCRIPTION
- `match(/<li>/g)` was not finding all `li` elements when user had `class` definition on `li` elements:  `<li class="red-text">` 
- To avoid matching `<link>` element, used `match(/<li[\s>]/g)`

closes #2791 
