### PR TITLE
Fix test on Waypoint Use Comments to Clarify Code

### DIFF
--- a/seed/challenges/bootstrap.json
+++ b/seed/challenges/bootstrap.json
@@ -2141,7 +2141,7 @@
       "tests": [
         "assert(editor.match(/<!--/g) && editor.match(/<!--/g).length > 0, 'Start a comment with <code>&#60;!--</code>.')",
         "assert(editor.match(/this line/g) && editor.match(/this line/g).length > 0, 'Your comment should have the text <code>You shouldn&#39;t need to modify code below this line</code>.')",
-        "assert(editor.match(/-->.*\\n.+/g), 'Be sure to close your comment with <code>--&#62;</code>.')"
+        "assert(editor.match(/-->.*\\n+.+/g), 'Be sure to close your comment with <code>--&#62;</code>.')"
       ],
       "challengeSeed": [
         "<div class=\"container-fluid\">",

--- a/seed/challenges/bootstrap.json
+++ b/seed/challenges/bootstrap.json
@@ -2141,7 +2141,7 @@
       "tests": [
         "assert(editor.match(/<!--/g) && editor.match(/<!--/g).length > 0, 'Start a comment with <code>&#60;!--</code>.')",
         "assert(editor.match(/this line/g) && editor.match(/this line/g).length > 0, 'Your comment should have the text <code>You shouldn&#39;t need to modify code below this line</code>.')",
-        "assert(editor.match(/-->/g) && editor.match(/-->/g).length > 0, 'Be sure to close your comment with <code>--&#62;</code>.')"
+        "assert(editor.match(/-->.*\\n.+/g), 'Be sure to close your comment with <code>--&#62;</code>.')"
       ],
       "challengeSeed": [
         "<div class=\"container-fluid\">",


### PR DESCRIPTION
Modified regex in last test so that it no longer matches comment closing bracket that is automatically added to end (to prevent page from breaking). Test passes when comment started by user is closed.

The new test looks for presence of newline character (with or without surrounding characters)  following the closing bracket, using regex:

```
/-->.*\\n.+/
```

closes #2591 
