### PR TITLE
Add note about how jQuery is zero-indexed to avoid confusion

### DIFF
--- a/seed/challenges/jquery.json
+++ b/seed/challenges/jquery.json
@@ -791,6 +791,7 @@
       "description": [
         "You can also target all the even-numbered elements.",
         "Here's how you would target all the odd-numbered elements with class <code>target</code> and give them classes: <code>$(\".target:odd\").addClass(\"animated shake\");</code>",
+        "Note that jQuery is zero-indexed, meaning that, counter-intuitively, <code>:odd</code> selects the second element, fourth element, and so on.",
         "Try selecting all the even-numbered elements - that is, what your browser will consider even-numbered elements - and giving them the classes of <code>animated</code> and <code>shake</code>."
       ],
       "tests": [


### PR DESCRIPTION
These commits add a note about how jQuery is zero-indexed in order to avoid confusion in students on why when you use the `:even` selector it appears that the odd elements are chosen.
Closes #3388.
