### PR TITLE
Renamed zipline for consistency

### DIFF
--- a/seed/challenges/intermediate-ziplines.json
+++ b/seed/challenges/intermediate-ziplines.json
@@ -37,7 +37,7 @@
     },
     {
       "id": "bd7158d8c442eddfaeb5bd19",
-      "title": "Wikipedia Viewer",
+      "title": "Build a Wikipedia Viewer",
       "difficulty": 1.03,
       "challengeSeed": ["126415131"],
       "description": [


### PR DESCRIPTION
Renamed the 'Wikipedia Viewer' ziplines to 'Build a Wikipedia Viewer' to make it consistent with the other zipline names.

Fixes https://github.com/FreeCodeCamp/FreeCodeCamp/issues/1237
