### PR TITLE
update "gulp-webpack" dependency name

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,7 +15,7 @@ var Rx = require('rx'),
   debug = require('debug')('freecc:gulp'),
 
   // react app
-  webpack = require('gulp-webpack'),
+  webpack = require('webpack-stream'),
   webpackConfig = require('./webpack.config.js'),
   webpackConfigNode = require('./webpack.config.node.js'),
 
@@ -408,4 +408,3 @@ gulp.task('default', [
   'watch',
   'sync'
 ]);
-

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "gulp-rev": "^6.0.1",
     "gulp-rev-replace": "^0.4.2",
     "gulp-util": "^3.0.6",
-    "gulp-webpack": "^1.5.0",
+    "webpack-stream": "^2.0.0",
     "helmet": "~0.9.0",
     "helmet-csp": "^0.2.3",
     "jade": "~1.8.0",


### PR DESCRIPTION
I could not install the dependencies of the project, because the "gulp-webpack" dependency name was changed to "webpack-stream" with version 2.0.0 ^.

I am using Node v4.1.1 and npm v2.14.4.

[gulp-webpack](https://www.npmjs.com/package/gulp-webpack) changed for [webpack-stream](https://www.npmjs.com/package/webpack-stream)
