### PR TITLE
Add tests to intermediate bonfire

### DIFF
--- a/seed/challenges/intermediate-bonfires.json
+++ b/seed/challenges/intermediate-bonfires.json
@@ -93,11 +93,25 @@
       "id": "a7f4d8f2483413a6ce226cac",
       "title": "Roman Numeral Converter",
       "tests": [
-        "assert.deepEqual(convert(12), \"XII\", 'message: <code>convert(12)</code> should return \"XII\".');",
         "assert.deepEqual(convert(5), \"V\", 'message: <code>convert(5)</code> should return \"V\".');",
         "assert.deepEqual(convert(9), \"IX\", 'message: <code>convert(9)</code> should return \"IX\".');",
+        "assert.deepEqual(convert(12), \"XII\", 'message: <code>convert(12)</code> should return \"XII\".');",
+        "assert.deepEqual(convert(16), \"XVI\", 'message: <code>convert(16)</code> should return \"XVI\".');",
         "assert.deepEqual(convert(29), \"XXIX\", 'message: <code>convert(29)</code> should return \"XXIX\".');",
-        "assert.deepEqual(convert(16), \"XVI\", 'message: <code>convert(16)</code> should return \"XVI\".');"
+        "assert.deepEqual(convert(44), \"XLIV\", 'message: <code>convert(44)</code> should return \"XLIV\".');",
+        "assert.deepEqual(convert(45), \"XLV\", '<code>convert(45)</code> should return \"XLV\"');",
+        "assert.deepEqual(convert(68), \"LXVIII\", '<code>convert(68)</code> should return \"LXVIII\"');",
+        "assert.deepEqual(convert(83), \"LXXXIII\", '<code>convert(83)</code> should return \"LXXXIII\"');",
+        "assert.deepEqual(convert(97), \"XCVII\", '<code>convert(97)</code> should return \"XCVII\"');",
+        "assert.deepEqual(convert(99), \"XCIX\", '<code>convert(99)</code> should return \"XCIX\"');",
+        "assert.deepEqual(convert(500), \"D\", '<code>convert(500)</code> should return \"D\"');",
+        "assert.deepEqual(convert(501), \"DI\", '<code>convert(501)</code> should return \"DI\"');",
+        "assert.deepEqual(convert(649), \"DCXLIX\", '<code>convert(649)</code> should return \"DCXLIX\"');",
+        "assert.deepEqual(convert(798), \"DCCXCVIII\", '<code>convert(798)</code> should return \"DCCXCVIII\"');",
+        "assert.deepEqual(convert(891), \"DCCCXCI\", '<code>convert(891)</code> should return \"DCCCXCI\"');",
+        "assert.deepEqual(convert(1000), \"M\", '<code>convert(1000)</code> should return \"M\"');",
+        "assert.deepEqual(convert(1004), \"MIV\", '<code>convert(1004)</code> should return \"MIV\"');",
+        "assert.deepEqual(convert(1006), \"MVI\", '<code>convert(1006)</code> should return \"MVI\"');"
       ],
       "description": [
         "Convert the given number into a roman numeral.",


### PR DESCRIPTION
The bonfire only tested the camper's solution for numbers upto 29. This commit adds tests that verify the solution for numbers upto 99. This should motivate the campers to create a more sound logic that will work for more numbers.

Closes https://github.com/FreeCodeCamp/FreeCodeCamp/issues/3338
