### PR TITLE
fix check for existance when getting last challenge

### DIFF
--- a/server/boot/challenge.js
+++ b/server/boot/challenge.js
@@ -519,7 +519,7 @@ module.exports = function(app) {
         const lastCompletedBlock = _.findLast(blocks, (block) => {
           return block.completed === 100;
         });
-        lastCompleted = lastCompletedBlock.name;
+        lastCompleted = lastCompleted && lastCompletedBlock.name || null;
       });
 
     Observable.combineLatest(


### PR DESCRIPTION
This fixes an issue introduced in the Facebook map share feature add.

When a user has no completed blocks the map controller attempted to read the name property of `undefined` which will throw.
