### PR TITLE
Iterate over Array with .map: Allow whitespace

### DIFF
--- a/seed/challenges/object-oriented-and-functional-programming.json
+++ b/seed/challenges/object-oriented-and-functional-programming.json
@@ -185,7 +185,7 @@
       ],
       "tests":[
         "assert.deepEqual(array, [4,5,6,7,8], 'message: You should add three to each value in the array.');",
-        "assert(editor.getValue().match(/\\.map\\(/gi), 'message: You should be making use of the map method.');",
+        "assert(editor.getValue().match(/\\.map\\s*\\(/gi), 'message: You should be making use of the map method.');",
         "assert(editor.getValue().match(/\\[1\\,2\\,3\\,4\\,5\\]/gi), 'message: You should only modify the array with <code>.map</code>.');"
       ],
       "challengeSeed":[


### PR DESCRIPTION
Prevents the test case checking if `.map` had been used from failing if there is whitespace between `.map` and `(`.

Fix #3577
