### PR TITLE
fix shareable challenges solution undefined

### DIFF
--- a/server/boot/challenge.js
+++ b/server/boot/challenge.js
@@ -267,12 +267,13 @@ module.exports = function(app) {
         }
 
         if (dasherize(challenge.name) !== origChallengeName) {
-          return Observable.just(
-            '/challenges/' +
-            dasherize(challenge.name) +
-            '?solution=' +
-            encodeURIComponent(solutionCode)
-          );
+          let redirectUrl = `/challenges/${dasherize(challenge.name)}`;
+
+          if (solutionCode) {
+            redirectUrl += `?solution=${encodeURIComponent(solutionCode)}`;
+          }
+
+          return Observable.just(redirectUrl);
         }
 
         // save user does nothing if user does not exist


### PR DESCRIPTION
During challenges when a user tries to navigate to a challenge
and hits the name redirect, the solution is filled with
undefined starting the user with an empty box.
This PR fixes the issue by ignoring the solution param
if it is empty
