### PR TITLE
Add ability to filter beta challenges from production

### DIFF
--- a/seed/index.js
+++ b/seed/index.js
@@ -43,6 +43,7 @@ Challenge.destroyAll(function(err, info) {
     var challengeSpec = require('./challenges/' + file);
     var order = challengeSpec.order;
     var block = challengeSpec.name;
+    var isBeta = !!challengeSpec.isBeta;
 
     // challenge file has no challenges...
     if (challengeSpec.challenges.length === 0) {
@@ -66,6 +67,7 @@ Challenge.destroyAll(function(err, info) {
         challenge.order = order;
         challenge.suborder = index + 1;
         challenge.block = block;
+        challenge.isBeta = challenge.isBeta || isBeta;
 
         return challenge;
       });

--- a/server/boot/challenge.js
+++ b/server/boot/challenge.js
@@ -16,6 +16,8 @@ import {
   ifNoUserSend
 } from '../utils/middleware';
 
+const isDev = process.env.NODE_ENV !== 'production';
+const isBeta = !!process.env.BETA;
 const debug = debugFactory('freecc:challenges');
 const challengesRegex = /^(bonfire|waypoint|zipline|basejump)/i;
 const firstChallenge = 'waypoint-say-hello-to-html-elements';
@@ -105,6 +107,9 @@ module.exports = function(app) {
       null,
       Scheduler.default
     ))
+    // filter out all challenges that have isBeta flag set
+    // except in development or beta site
+    .filter(challenge => isDev || isBeta || !challenge.isBeta)
     .shareReplay();
 
   // create a stream of challenge blocks
@@ -543,8 +548,10 @@ module.exports = function(app) {
           }
           return sum;
         }, 0);
+        const isBeta = _.every(blockArray, 'isBeta');
 
         return {
+          isBeta,
           name: blockArray[0].block,
           dashedName: dasherize(blockArray[0].block),
           challenges: blockArray,

--- a/server/server.js
+++ b/server/server.js
@@ -16,6 +16,7 @@ var getUsernameFromProvider = require('./utils/auth').getUsernameFromProvider;
 var generateKey =
   require('loopback-component-passport/lib/models/utils').generateKey;
 
+var isBeta = !!process.env.BETA;
 var app = loopback();
 
 expressState.extend(app);
@@ -96,10 +97,13 @@ app.start = function() {
   app.listen(app.get('port'), function() {
     app.emit('started');
     console.log(
-      'FreeCodeCamp server listening on port %d in %s mode',
+      'FreeCodeCamp server listening on port %d in %s',
       app.get('port'),
       app.get('env')
     );
+    if (isBeta) {
+      console.log('Free Code Camp is in beta mode');
+    }
   });
 };
 


### PR DESCRIPTION
This PR adds the ability to test out challenges in beta
without fear that they will leak to production servers.

In development all challenges will display.

In production all challenges marked 'isBeta' will be filtered out
except in the case the environmental variable `BETA` is set true,
in which case all challenges will display.

To set a single challenge as a beta challenge add the property `isBeta = true` on the challenge.

To set a whole block of challenges (A single JSON file in the challenges directory) add `isBeta = true` at the top level object.
