### PR TITLE
Seek and Destory: Remove problematic argument

### DIFF
--- a/seed/challenges/basic-bonfires.json
+++ b/seed/challenges/basic-bonfires.json
@@ -568,7 +568,7 @@
         "  return arr;",
         "}",
         "",
-        "destroyer([1, 2, 3, 1, 2, 3], 2, 3, \"\");"
+        "destroyer([1, 2, 3, 1, 2, 3], 2, 3);"
       ],
       "tests": [
         "assert.deepEqual(destroyer([1, 2, 3, 1, 2, 3], 2, 3), [1, 1], 'message: <code>destroyer([1, 2, 3, 1, 2, 3], 2, 3)</code> should return <code>[1, 1]</code>.');",


### PR DESCRIPTION
Remove an empty string passed as an argument to `destroy()`. This argument, being the last, caused people to think their code worked correctly when it, in fact, worked correctly on all arguments except the last one.

Fix #3653
