### PR TITLE
Added endsWith() method link to bonfireMDNlinks.js

### DIFF
--- a/seed/bonfireMDNlinks.js
+++ b/seed/bonfireMDNlinks.js
@@ -46,6 +46,7 @@ var links = {
   "String.charCodeAt()": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/charCodeAt",
   "String.concat()": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/concat",
   "String.indexOf()": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/indexOf",
+  "String.endsWith()": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith",
   "String.fromCharCode()": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCharCode",
   "String.lastIndexOf()": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/lastIndexOf",
   "String.match()": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match",


### PR DESCRIPTION
I believe that the Bonfire Challenge "Confirm The Ending" would be more intuitive if utilizing the string method "String.endsWith()" was the recommended approach, rather than "String.substr()". Thus, I have added the necessary information in the MDN file for String.endsWith() to be used in the webpage.

I will be submitting another pull request to change the recommended "String.substr()" method to the more accurate "String.endsWith()" method in the actual challenge file.
