### PR TITLE
Replaced String.substr() with String.endsWith()

### DIFF
--- a/seed/challenges/basic-bonfires.json
+++ b/seed/challenges/basic-bonfires.json
@@ -310,7 +310,7 @@
         "assert(end(\"If you want to save our world, you must hurry. We dont know how much longer we can withstand the nothing\", \"mountain\") === false, 'message: <code>end(\"If you want to save our world, you must hurry. We dont know how much longer we can withstand the nothing\", \"mountain\")</code> should return false.');"
       ],
       "MDNlinks": [
-        "String.substr()"
+        "String.endsWith()"
       ],
       "type": "bonfire",
       "challengeType": 5,


### PR DESCRIPTION
I replaced the "String.substr()" method with the "String.endsWith()" method to correlate with my Bonfire MDNlink pull request, where I suggested using .endsWith rather than .substr in the Bonfire Challenge: Confirm The Ending.
