### PR TITLE
Remove suprious parameters from early Bonfires

### DIFF
--- a/seed/challenges/basic-bonfires.json
+++ b/seed/challenges/basic-bonfires.json
@@ -60,7 +60,7 @@
         "  return str;",
         "}",
         "",
-        "reverseString(\"hello\", \"\");"
+        "reverseString(\"hello\");"
       ],
       "MDNlinks": [
         "Global String Object",
@@ -103,7 +103,7 @@
         "  return num;",
         "}",
         "",
-        "factorialize(5, '');"
+        "factorialize(5);"
       ],
       "MDNlinks": [
         "Arithmetic Operators"
@@ -224,7 +224,7 @@
         "  return str;",
         "}",
         "",
-        "titleCase(\"I'm a little tea pot\", \"\");"
+        "titleCase(\"I'm a little tea pot\");"
       ],
       "tests": [
         "assert(typeof(titleCase(\"I&#39;m a little tea pot\")) === \"string\", 'message: <code>titleCase()</code> should return a string.');",
@@ -300,7 +300,7 @@
         "  return str;",
         "}",
         "",
-        "end(\"Bastian\", \"n\", \"\");"
+        "end(\"Bastian\", \"n\");"
       ],
       "tests": [
         "assert(end(\"Bastian\", \"n\") === true, 'message: <code>end(\"Bastian\", \"n\")</code> should return true.');",
@@ -338,7 +338,7 @@
         "  return str;",
         "}",
         "",
-        "repeat(\"abc\", 3, \"\");"
+        "repeat(\"abc\", 3);"
       ],
       "tests": [
         "assert(repeat(\"*\", 3) === \"***\", 'message: <code>repeat(\"*\", 3)</code> should return <code>\"***\"</code>.');",
@@ -375,7 +375,7 @@
         "  return str;",
         "}",
         "",
-        "truncate(\"A-tisket a-tasket A green and yellow basket\", 11, \"\");"
+        "truncate(\"A-tisket a-tasket A green and yellow basket\", 11);"
       ],
       "tests": [
         "assert(truncate(\"A-tisket a-tasket A green and yellow basket\", 11) === \"A-tisket...\", 'message: <code>truncate(\"A-tisket a-tasket A green and yellow basket\", 11)</code> should return \"A-tisket...\".');",
@@ -412,7 +412,7 @@
         "  return arr;",
         "}",
         "",
-        "chunk([\"a\", \"b\", \"c\", \"d\"], 2, \"\");"
+        "chunk([\"a\", \"b\", \"c\", \"d\"], 2);"
       ],
       "tests": [
         "assert.deepEqual(chunk([\"a\", \"b\", \"c\", \"d\"], 2), [[\"a\", \"b\"], [\"c\", \"d\"]], 'message: <code>chunk([\"a\", \"b\", \"c\", \"d\"], 2)</code> should return <code>[[\"a\", \"b\"], [\"c\", \"d\"]]</code>.');",
@@ -450,7 +450,7 @@
         "  return arr;",
         "}",
         "",
-        "slasher([1, 2, 3], 2, \"\");"
+        "slasher([1, 2, 3], 2);"
       ],
       "tests": [
         "assert.deepEqual(slasher([1, 2, 3], 2), [3], 'message: <code>slasher([1, 2, 3], 2, [3])</code> should return <code>[3]</code>.');",
@@ -489,7 +489,7 @@
         "  return arr;",
         "}",
         "",
-        "mutation([\"hello\", \"hey\"], \"\");"
+        "mutation([\"hello\", \"hey\"]);"
       ],
       "tests": [
         "assert(mutation([\"hello\", \"hey\"]) === false, 'message: <code>mutation([\"hello\", \"hey\"])</code> should return false.');",
@@ -531,7 +531,7 @@
         "  return arr;",
         "}",
         "",
-        "bouncer([7, \"ate\", \"\", false, 9], \"\");"
+        "bouncer([7, \"ate\", \"\", false, 9]);"
       ],
       "tests": [
         "assert.deepEqual(bouncer([7, \"ate\", \"\", false, 9]), [7, \"ate\", 9], 'message: <code>bouncer([7, \"ate\", \"\", false, 9])</code> should return <code>[7, \"ate\", 9]</code>.');",
@@ -608,7 +608,7 @@
         "  return num;",
         "}",
         "",
-        "where([40, 60], 50, \"\");"
+        "where([40, 60], 50);"
       ],
       "MDNlinks": [
         "Array.sort()"


### PR DESCRIPTION
For reasons I don't understand, there were extra parameters, usually extra double quotes, on the Bonfire Seeds for many of the early Bonfires.  These were confusing campers as they came though the  code.

Tested locally, seems to be fine.
