### PR TITLE
Fix rounded heatmap square corners

### DIFF
--- a/server/views/account/show.jade
+++ b/server/views/account/show.jade
@@ -90,7 +90,7 @@ block content
                                     data: calendar,
                                     cellSize: 15,
                                     align: 'center',
-                                    cellRadius: 3,
+                                    cellRadius: 0,
                                     cellPadding: 2,
                                     tooltip: true,
                                     range: 6,


### PR DESCRIPTION
Changed the heatmap squares cellRadius from 3 to 0 in order for the heatmap squares to be truly square instead of having rounded corners. Rounded corners proved to be inconsistent in the way they would render in browsers such as Safari and Firefox.

Closes #3715 
