### PR TITLE
Remove rev helper use in ssl redirect

### DIFF
--- a/server/views/partials/small-head.jade
+++ b/server/views/partials/small-head.jade
@@ -1,7 +1,7 @@
 script(src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js")
 script(src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.4/js/bootstrap.min.js")
 link(rel='stylesheet', href='/bower_components/font-awesome/css/font-awesome.min.css')
-link(rel='stylesheet', href=rev('/css', 'main.css'))
+link(rel='stylesheet', href='/css/main.css')
 link(rel='stylesheet', href='/css/Vimeo.css')
 // End **REQUIRED** includes
 


### PR DESCRIPTION
This PR fixes SSL redirect. It was originally broken when static file versioning. 
