### PR TITLE
update git icon for landing

### DIFF
--- a/server/views/home.jade
+++ b/server/views/home.jade
@@ -64,7 +64,7 @@ block content
                     .landing-skill-icon.fa.fa-database.font-awesome-padding
                     h2.black-text Databases
                 .col-xs-12.col-sm-12.col-md-3
-                    .landing-skill-icon.ion-social-github
+                    .landing-skill-icon.fa.fa-git.font-awesome-padding
                     h2.black-text Git
                 .col-xs-12.col-sm-12.col-md-3
                     .landing-skill-icon.ion-social-nodejs


### PR DESCRIPTION
Update landing icon for Git to Git logo, obtained from Font Awesome Icons. To replace existing icon which belongs to GitHub rather than Git.
