### PR TITLE
Fix test in Bonfire - Check for Palindrome

### DIFF
--- a/seed/challenges/basic-bonfires.json
+++ b/seed/challenges/basic-bonfires.json
@@ -143,7 +143,7 @@
         "assert(palindrome(\"almostomla\") === false, 'message: <code>palindrome(\"almostomla\")</code> should return false.');",
         "assert(palindrome(\"My age is 0, 0 si ega ym.\") === true, 'message: <code>palindrome(\"My age is 0, 0 si ega ym.\")</code> should return true.');",
         "assert(palindrome(\"1 eye for of 1 eye.\") === false, 'message: <code>palindrome(\"1 eye for of 1 eye.\")</code> should return false.');",
-        "assert(palindrome(\"0_0 (: /-\\ :) 0-0\") === true, 'message: <code>palindrome(\"0_0 (: /-\\\\ :) 0-0\")</code> should return true.');"
+        "assert(palindrome(\"0_0 (: /-\\ :) 0-0\") === true, 'message: <code>palindrome(\"0_0 (: /-\\ :) 0-0\")</code> should return true.');"
       ],
       "challengeSeed": [
         "function palindrome(str) {",


### PR DESCRIPTION
Challenge: http://www.freecodecamp.com/challenges/bonfire-check-for-palindromes

Test Case: `"assert(palindrome(\"0_0 (: /-\\ :) 0-0\") === true, 'message: <code>palindrome(\"0_0 (: /-\\\\ :) 0-0\")</code> should return true.');"`
Remove extra **`\`** (backslash) character from test case.

![](http://i.imgur.com/lFA8XHe.png)

close FreeCodeCamp/FreeCodeCamp#3762
