### PR TITLE
Append '+ GitHub' to match GitHub icon

### DIFF
--- a/server/views/home.jade
+++ b/server/views/home.jade
@@ -65,7 +65,7 @@ block content
                     h2.black-text Databases
                 .col-xs-12.col-sm-12.col-md-3
                     .landing-skill-icon.ion-social-github
-                    h2.black-text Git
+                    h2.black-text Git + GitHub
                 .col-xs-12.col-sm-12.col-md-3
                     .landing-skill-icon.ion-social-nodejs
                     h2.black-text Node.js


### PR DESCRIPTION
Since Git logo is not as pervasive and ubiquitous as GitHub logo, append "+ GitHub" to "Git" on landing in the "skills you'll learn" section to match GitHub logo already present.
