### PR TITLE
Move time text out of icon element on map page

### DIFF
--- a/server/views/challengeMap/show.jade
+++ b/server/views/challengeMap/show.jade
@@ -87,7 +87,8 @@ block content
                     .row
                         .hidden-xs.col-sm-3.col-md-2
                             h3.text-primary.text-right.nowrap
-                                i.fa.fa-clock-o &thinsp;#{challengeBlock.time}
+                                i.fa.fa-clock-o
+                                = challengeBlock.time
                         .col-xs-12.col-sm-9.col-md-10
                             h3 #{challengeBlock.name} &thinsp;
 


### PR DESCRIPTION
The text next to the little clock icons ("3h" etc.) should not be inside the `<i>` element itself on which the icon classes are applied. FontAwesome is not designed to be used like this, so currently the FontAwesome font gets applied to the text as well, giving it a serif typeface that looks out of place.
