### PR TITLE
Change .fa class style text-decoration property to none

### DIFF
--- a/public/css/themes/modern.less
+++ b/public/css/themes/modern.less
@@ -67,6 +67,12 @@ p {
   font-weight: 300;
 }
 
+// Fontawesome icons
+// -------------------------
+.fa {
+  text-decoration: none !important;
+}
+
 // Buttons
 // -------------------------
 


### PR DESCRIPTION
Added `.fa` class to `modern.less` file and set it's `text-decoration` property to `none !important` to remove the underline from the social icons when you hover over them with mouse.

(Fix #3796)
