### PR TITLE
Change .fa class style text-decoration property to none

### DIFF
--- a/client/less/main.less
+++ b/client/less/main.less
@@ -96,6 +96,10 @@ h1, h2, h3, h4, h5, h6, p, li {
   margin-right: 5px;
 }
 
+.fa:hover {
+  text-decoration: none;
+}
+
 .img-center {
   margin: 0 auto;
 }


### PR DESCRIPTION
Added `.fa:hover` class to `main.less` file and set it's text-decoration property to `none` to remove the underline from the social icons when you hover over them with mouse.

Thanks @jlslew for the suggestions!

(Fix #3796)
