### PR TITLE
CSS check is now stricter

### DIFF
--- a/seed/challenges/html5-and-css.json
+++ b/seed/challenges/html5-and-css.json
@@ -435,6 +435,7 @@
       "tests": [
         "assert($(\"h2\").css(\"color\") === \"rgb(255, 0, 0)\", 'Your <code>h2</code> element should be red.')",
         "assert($(\"h2\").hasClass(\"red-text\"), 'Your <code>h2</code> element should have the class <code>red-text</code>.')",
+        "assert(editor.match(/\\.red-text\\s*\\{\\s*color:\\s*red;\\s*\\}/g), 'Your stylesheet should declare a <code>red-text</code> class and have its color set to red.')",
         "assert($(\"h2\").attr(\"style\") === undefined, 'Do not use inline style declarations like <code>style=\"color&#58; red\"</code> in your <code>h2</code> element.')"
       ],
       "challengeSeed": [


### PR DESCRIPTION
Closes #2405

Challenge http://freecodecamp.com/challenges/waypoint-use-a-css-class-to-style-an-element CSS check is now stricter so that students cannot accidentally pass even if their implementation is not up to specs.
