### PR TITLE
Fix typo in WP: Get Set for Ziplines

### DIFF
--- a/seed/challenges/basic-ziplines.json
+++ b/seed/challenges/basic-ziplines.json
@@ -35,7 +35,7 @@
         [
           "http://i.imgur.com/Wzt6Y9Y.gif",
           "A gif showing the process of saving and forking a pen.",
-          "Save your pen with the \"Save\" button. Then click the \"Fork\" button. This will create a fork (copy) of your pen that you can experimient with.",
+          "Save your pen with the \"Save\" button. Then click the \"Fork\" button. This will create a fork (copy) of your pen that you can experiment with.",
           ""
         ]
       ],


### PR DESCRIPTION
Changes the spelling of one word.
