### PR TITLE
Fix infinite loop in challenges

### DIFF
--- a/client/commonFramework.js
+++ b/client/commonFramework.js
@@ -342,12 +342,10 @@ var sandBox = (function(jailed, codeOutput) {
         endLoading();
         console.log('resetting on fatal plugin error');
 
-        if (common.challengeType === 0) {
-          codeOutput.setValue(
-            'Sorry, your code is either too slow, has a fatal error, ' +
-            'or contains an infinite loop.'
-          );
-        }
+        codeOutput.setValue(
+          'Sorry, your code is either too slow, has a fatal error, ' +
+          'or contains an infinite loop.'
+        );
         reset();
       }, 10);
     });
@@ -842,35 +840,33 @@ var runTests = function(err, data) {
     }];
     createTestDisplay();
   } else if (userTests) {
-    userTests.push(false);
-    pushed = true;
-    userTests.forEach(function(
-      chaiTestFromJSON,
-      indexOfTestArray,
-      __testArray
-    ) {
-      try {
-        if (chaiTestFromJSON) {
-          /* eslint-disable no-eval, no-unused-vars */
-          var output = eval(reassembleTest(chaiTestFromJSON, data));
-          /* eslint-enable no-eval, no-unused-vars */
-        }
-      } catch (error) {
-        allTestsPassed = false;
-        __testArray[indexOfTestArray].err = error.message;
-      } finally {
-        if (!chaiTestFromJSON) {
-          createTestDisplay();
-        }
-      }
-    });
+    var recurse = function(indexOfTestArray) {
+      if (userTests.length === indexOfTestArray) {
+        createTestDisplay();
 
-    if (allTestsPassed) {
-      allTestsPassed = false;
-      showCompletion();
-    } else {
-      isInitRun = false;
-    }
+        if (allTestsPassed) {
+          allTestsPassed = false;
+          showCompletion();
+        } else {
+          isInitRun = false;
+        }
+
+        return;
+      }
+
+      var chaiTestFromJSON = reassembleTest(userTests[indexOfTestArray], data);
+      setTimeout(function() {
+        sandBox.submit(chaiTestFromJSON, function(cls, message) {
+          if (cls) {
+            allTestsPassed = false;
+            userTests[indexOfTestArray].err = message.error;
+          }
+
+          recurse(indexOfTestArray + 1);
+        });
+      }, 10);
+    };
+    recurse(0);
   }
 };
 


### PR DESCRIPTION
- Remove the if statement to display a feedback when there is an
  infinite loop and prevent issues; #3840, #3811, #3791, #3705, #3608...
- Replace the simple for-each loop with `async.series` implementation
  and execute the tests in the sandbox as well.
- Without the setTimeout around the `sandBox.submit`, this is printed on
  the console: `Uncaught TypeError: Cannot read property 'run' of null`
  at line 283 in this file.

If this PR is merged, it closes #3732.
