### PR TITLE
Check for existence of closing multiline comment

### DIFF
--- a/client/commonFramework.js
+++ b/client/commonFramework.js
@@ -1046,7 +1046,7 @@ function bonfireExecute(shouldTest) {
     // checks if the number of opening comments(/*) matches the number of
     // closing comments(*/)
     if (
-      userJavaScript.match(/\/\*/gi) &&
+      userJavaScript.match(/\/\*/gi) && userJavaScript.match(/\*\//gi) &&
       userJavaScript.match(/\/\*/gi).length > userJavaScript.match(/\*\//gi).length
     ) {
       failedCommentTest = true;


### PR DESCRIPTION
Camper's code causes `userJavaScript.match(...) is null` error because of `//* * o * * o $ *` comment. This is a single line comment but `commonFramework` thought that this is multiline comment because of `/*`. There is no closing `*/` part so `userJavaScript.match(...) is null` is generated. We can avoid this by checking the existence of closing multiline comment.
Closes #3878.
