### PR TITLE
Save bonfire's solution as a GitHub gist

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -248,7 +248,8 @@ $(document).ready(function() {
             }
           };
           var data = {
-            description: (challenge_Name || challengeName),
+            description: (username ? 'http://www.freecodecamp.com/' + username +
+            ' \'s s' : 'S') + 'olution for ' + (challenge_Name || challengeName),
             public: true,
             files: {}
           },
@@ -257,7 +258,7 @@ $(document).ready(function() {
           .substr(queryIssue.lastIndexOf('challenges/') + 11)
           .replace('/', '') + '.js';
           data['files'][filename] = {
-            content: '// ' + data.description + '\n' +
+            content: '// ' + (challenge_Name || challengeName) + '\n' +
             (username ? '// Author: @' + username + '\n' : '') +
             '// Challenge: ' + queryIssue + '\n' +
             '// Learn to Code at Free Code Camp (www.freecodecamp.com)' +

--- a/server/middlewares/csp.js
+++ b/server/middlewares/csp.js
@@ -48,7 +48,8 @@ const trusted = [
   'http://hn.inspectlet.com/',
   '*.googleapis.com',
   '*.gstatic.com',
-  'https://hn.inspectlet.com/'
+  'https://hn.inspectlet.com/',
+  'https://*.github.com'
 ];
 
 export default function csp() {

--- a/server/views/coursewares/showBonfire.jade
+++ b/server/views/coursewares/showBonfire.jade
@@ -80,6 +80,10 @@ block content
                     var dashedName = !{JSON.stringify(dashedName)};
                     var _ = R;
                     var dashed = !{JSON.stringify(dashedName)};
+                    var username;
+                if (user)
+                    script(type="text/javascript").
+                        username = !{JSON.stringify(user.username)};
 
         .col-md-8.col-lg-9
             .editorScrollDiv(style = "overflow-y: auto; overflow-x: hidden;")
@@ -103,12 +107,14 @@ block content
                       .row
                       if (user)
                           #submit-challenge.animated.fadeIn.btn.btn-lg.btn-primary.btn-block Submit and go to my next challenge (ctrl + enter)
+                          a.animated.fadeIn.btn.btn-lg.btn-danger.btn-block#gist-share Share your solution as a GitHub gist
                           if (user.progressTimestamps.length > 2)
                               a.btn.btn-lg.btn-block.btn-twitter(target="_blank", href="https://twitter.com/intent/tweet?text=I%20just%20#{verb}%20%40FreeCodeCamp%20#{name}&url=http%3A%2F%2Ffreecodecamp.com/challenges/#{dashedName}&hashtags=LearnToCode, JavaScript", onclick="ga('send', 'event', 'twitter', 'share', 'challenge completion share');")
                                   i.fa.fa-twitter &thinsp;
                                       = phrase
                       else
                           #next-challenge.btn.btn-lg.btn-primary.btn-block Go to my next challenge (ctrl + enter)
+                          a.btn.btn-lg.btn-danger.btn-block#gist-share Share your solution as a GitHub gist
     #reset-modal.modal(tabindex='-1')
         .modal-dialog.animated.fadeInUp.fast-animation
             .modal-content


### PR DESCRIPTION
Adds the feature requested in https://github.com/FreeCodeCamp/FreeCodeCamp/issues/1343. Looks like this: http://prntscr.com/8vvgd7, two examples of gists: https://gist.github.com/anonymous/29ee0f9a9e21d34e78eb, https://gist.github.com/anonymous/8a9f708ac77a7c002011.
A couple of words about the implementation. By clicking that "create gists" button a new blank window is opened. After that we perform an AJAX `post` request to `api.github.com/gists` with the appropriate data (`data` object). From `api.github`'s response we get the `html_url` of the newly created **anonymous** gist. Then we change the window's `location.href`.
You should notice two things:
1. These gists are anonymous because we need to get user's authentication info to make them authorized (and I've no idea how to do that). As @BerkeleyTrue said "I don’t think there is going to be a way that we can share that information with the client side" (if user's GitHub account is linked to user's FCC account).
2. The new window is going to be blank until we get the answer from `api.github.com/gists`.
This is done because the browser will normally block the window like any other pop-up. To avoid this we need to open the window immediately after the button click and do any manipulations (in this case changing `location.href`) after AJAX request.
Another way is performing a synchronous AJAX request but this will freeze the browser until GitHub's response.
Closes #1343.
