### PR TITLE
Added missing semi-colons in example code

### DIFF
--- a/seed/challenges/json-apis-and-ajax.json
+++ b/seed/challenges/json-apis-and-ajax.json
@@ -166,9 +166,9 @@
         "Then, let's loop through our JSON, adding more HTML to that variable. When the loop is finished, we'll render it.",
         "Here's the code that does this:",
         "<code>json.map(function(val) {</code>",
-        "<code>&thinsp;&thinsp;html = html + \"&lt;div class = 'cat'&gt;\"</code>",
+        "<code>&thinsp;&thinsp;html = html + \"&lt;div class = 'cat'&gt;;\"</code>",
         "<code>&thinsp;&thinsp;html = html + '&lt;div&gt;' + val + '&lt;/div&gt;';</code>",
-        "<code>&thinsp;&thinsp;html = html + \"&lt;/div&gt;&lt;br/&gt;\"</code>",
+        "<code>&thinsp;&thinsp;html = html + \"&lt;/div&gt;&lt;br/&gt;;\"</code>",
         "<code>});</code>"
       ],
       "tests": [


### PR DESCRIPTION
In the "Here's the code that does this" example code, two of the statements were missing their ending semi-colons. If someone were to verbatim copy this syntactically incorrect code in a real JS runtime, it would throw errors.
