### PR TITLE
Adds 'new' callouts to top level challenge blocks

### DIFF
--- a/server/views/challengeMap/show.jade
+++ b/server/views/challengeMap/show.jade
@@ -53,6 +53,10 @@ block content
                                     .col-xs-12.col-sm-9.col-md-10
                                         li.map-p.faded.negative-10
                                             a(href='#' + challengeBlock.dashedName)= challengeBlock.name
+                                            if challengeBlock.markNew
+                                                span.text-danger.small &thinsp; &thinsp;
+                                                    strong
+                                                        em NEW
                                 else
                                     .hidden-xs.col-sm-3.col-md-2
                                         .progress.progress-bar-padding.text-center.thin-progress-bar
@@ -60,12 +64,20 @@ block content
                                     .col-xs-12.col-sm-9.col-md-10
                                         li.map-p.negative-10
                                             a(href='#' + challengeBlock.dashedName)= challengeBlock.name
+                                            if challengeBlock.markNew
+                                                span.text-danger.small &thinsp; &thinsp;
+                                                    strong
+                                                        em NEW
                             else
                                 .hidden-xs.col-sm-3.col-md-2
                                     span.negative-10
                                 .col-xs-12.col-sm-9.col-md-10
                                     li.map-p.negative-10
                                         a(href='#' + challengeBlock.dashedName)= challengeBlock.name
+                                        if challengeBlock.markNew
+                                            span.text-danger.small &thinsp; &thinsp;
+                                                strong
+                                                    em NEW
 
                 .row
                     .col-xs-12.col-sm-8.col-sm-offset-2.negative-28


### PR DESCRIPTION
If all challenges in a challenge block are considered new, the top level block link on the challenge map will be flagged as new as well as the individual challenges.

Can easily be changed to call out if **any** challenges are considered new.
