### PR TITLE
Fixes incorrect collection name in getStories function

### DIFF
--- a/server/boot/story.js
+++ b/server/boot/story.js
@@ -211,7 +211,7 @@ module.exports = function(app) {
       if (err) {
         return next(err);
       }
-      database.collection('stories').find({
+      database.collection('story').find({
         '$text': {
           '$search': req.body.data ? req.body.data.searchValue : ''
         }


### PR DESCRIPTION
Still not sure how the Camper News search works. Fixes `stories` to `story`.
