### PR TITLE
Adds ability to search posts in Camper News by searching the username

### DIFF
--- a/client/less/main.less
+++ b/client/less/main.less
@@ -814,7 +814,8 @@ iframe.iphone {
 
 .news-box-search {
   @media (min-width: 768px) {
-    margin-top: -50px;
+    margin-top: -30px;
+    padding-bottom: 20px;
   }
   @media (max-width: 767px) {
     padding: 5px;

--- a/server/boot/story.js
+++ b/server/boot/story.js
@@ -62,6 +62,7 @@ module.exports = function(app) {
   var findStoryById = observeMethod(Story, 'findById');
   var countStories = observeMethod(Story, 'count');
 
+  router.post('/news/userstories', userStories);
   router.get('/news/hot', hotJSON);
   router.get('/stories/hotStories', hotJSON);
   router.get(
@@ -102,6 +103,27 @@ module.exports = function(app) {
       },
       next
     );
+  }
+
+  function userStories({ body: { search = '' } = {} }, res, next) {
+    if (!search || typeof search !== 'string') {
+      return res.sendStatus(404);
+    }
+
+    return app.dataSources.db.connector
+      .collection('story')
+      .find({
+        'author.username': search.replace('$', '')
+      })
+      .toArray(function(err, items) {
+        if (err) {
+          return next(err);
+        }
+        if (items && items.length !== 0) {
+          return res.json(items.sort(sortByRank));
+        }
+        return res.sendStatus(404);
+      });
   }
 
   function hot(req, res) {

--- a/server/views/stories/news-nav.jade
+++ b/server/views/stories/news-nav.jade
@@ -31,11 +31,16 @@ script.
     });
     function executeSearch() {
         $('#stories').empty();
-        var searchTerm = $('#searchArea').val();
+        var searchTerm = $('#searchArea').val(),
+        url = '/stories/search';
+        if (searchTerm.match(/^\@\w+$/)) {
+            url = '/news/userstories';
+            searchTerm = searchTerm.match(/^\@\w+$/)[0].split('@')[1];
+        }
         var getLinkedName = function getLinkedName(name) {
             return name.toLowerCase().replace(/\s/g, '-');
         }
-        $.post('/stories/search', { search: searchTerm })
+        $.post(url, { search: searchTerm })
                 .fail(function(xhr, textStatus, errorThrown) {
                     $('#search-results').empty();
                     var div = document.createElement("div");


### PR DESCRIPTION
If you want to find particular user's posts just type `@username` (**only**) in Camper News search box.
[Demo](http://sendvid.com/n54g36ir). FF related issue is the [following](http://prntscr.com/8yxosy).
Closes #1289.
