### PR TITLE
Offsets user displayed time to server timezone(EST) for the heatmap

### DIFF
--- a/server/views/account/show.jade
+++ b/server/views/account/show.jade
@@ -80,14 +80,29 @@ block content
                     #cal-heatmap.d3-centered
                         script.
                             $(document).ready(function () {
+                                var estUTCOffset = -5;
+                                // moment returns the utc offset in minutes
+                                var userUTCOffset = moment().utcOffset() / 60;
+                                var secondsToOffset =
+                                  (estUTCOffset - userUTCOffset) * 3600;
                                 var cal = new CalHeatMap();
                                 var calendar = !{JSON.stringify(calender)};
+                                var offsetCalendar = {};
+                                for (var prop in calendar) {
+                                  if (calendar.hasOwnProperty(prop)) {
+                                    var offsetProp = +prop + secondsToOffset;
+                                      offsetCalendar[offsetProp] =
+                                        calendar[prop];
+                                  }
+                                }
+                                console.log(calendar);
+                                console.log(offsetCalendar);
                                 cal.init({
                                     itemSelector: "#cal-heatmap",
                                     domain: "month",
                                     subDomain: "x_day",
                                     domainGutter: 10,
-                                    data: calendar,
+                                    data: offsetCalendar,
                                     cellSize: 15,
                                     align: 'center',
                                     cellRadius: 3,

--- a/server/views/account/show.jade
+++ b/server/views/account/show.jade
@@ -95,8 +95,6 @@ block content
                                         calendar[prop];
                                   }
                                 }
-                                console.log(calendar);
-                                console.log(offsetCalendar);
                                 cal.init({
                                     itemSelector: "#cal-heatmap",
                                     domain: "month",


### PR DESCRIPTION
This forces the timestamps loaded into cal-heatmap in the profile view (account/show.jade) to morph into the timestamps they'd be if the user was sitting next to the server.

To test it to make sure everything jives you'll need to set your computer's timezone to EST otherwise the _server_ will take up your local time and then the heatmap won't match the completed list further down in the profile.

This PR closes #2290 
