### PR TITLE
Fix count a element assertion in 'waypoint-nest-an-anchor-element-within-a-paragraph' to avoid 'undefined is not an object' error

### DIFF
--- a/seed/challenges/html5-and-css.json
+++ b/seed/challenges/html5-and-css.json
@@ -1168,7 +1168,7 @@
         "Now nest your existing <code>a</code> element within a new <code>p</code> element so that the surrounding paragraph says \"View more cat photos\", but where only \"cat photos\" is a link, and the rest of the text is plain text."
       ],
       "tests": [
-        "assert($(\"a\").attr(\"href\").match(/freecatphotoapp.com/gi).length > 0, 'You need an <code>a</code> element that links to \"freecatphotoapp.com\".')",
+        "assert($(\"a[href=\\\"http://www.freecatphotoapp.com\\\"]\").length > 0, 'You need an <code>a</code> element that links to \"freecatphotoapp.com\".')",
         "assert($(\"a\").text().match(/cat\\sphotos/gi), 'Your <code>a</code> element should have the anchor text of \"cat photos\"')",
         "assert($(\"p\") && $(\"p\").length > 2, 'Create a new <code>p</code> element around your <code>a</code> element.')",
         "assert($(\"a[href=\\\"http://www.freecatphotoapp.com\\\"]\").parent().is(\"p\"), 'Your <code>a</code> element should be nested within your new <code>p</code> element.')",

--- a/seed/challenges/html5-and-css.json
+++ b/seed/challenges/html5-and-css.json
@@ -1168,7 +1168,7 @@
         "Now nest your existing <code>a</code> element within a new <code>p</code> element so that the surrounding paragraph says \"View more cat photos\", but where only \"cat photos\" is a link, and the rest of the text is plain text."
       ],
       "tests": [
-        "assert($(\"a[href=\\\"http://www.freecatphotoapp.com\\\"]\").length > 0, 'You need an <code>a</code> element that links to \"freecatphotoapp.com\".')",
+        "assert($(\"a[href=\\\"http://www.freecatphotoapp.com\\\"]\").length > 0, 'You need an <code>a</code> element that links to \"http://www.freecatphotoapp.com\".')",
         "assert($(\"a\").text().match(/cat\\sphotos/gi), 'Your <code>a</code> element should have the anchor text of \"cat photos\"')",
         "assert($(\"p\") && $(\"p\").length > 2, 'Create a new <code>p</code> element around your <code>a</code> element.')",
         "assert($(\"a[href=\\\"http://www.freecatphotoapp.com\\\"]\").parent().is(\"p\"), 'Your <code>a</code> element should be nested within your new <code>p</code> element.')",


### PR DESCRIPTION
Adjusted the original "a" element count assertion to be resilient to the case when "a" element is completely missing in the code editor (the previous assertion resulted in 'undefined is not an object' error message under the very same conditions) to fix issue #899.

This snip of how would the original assertion would react upon the missing element (the first one in the list on the left):
<img width="1440" alt="screen shot 2015-11-07 at 9 34 14 pm" src="https://cloud.githubusercontent.com/assets/3822219/11019106/0261e3b2-859e-11e5-8b33-756a5298743c.png">

Here is the snip of how the proposed change would react upon the missing element:
<img width="1440" alt="screen shot 2015-11-07 at 9 34 54 pm" src="https://cloud.githubusercontent.com/assets/3822219/11019103/d1ecff82-859d-11e5-8e07-375b29231a9e.png">

And here is the snip of how the proposed change would react upon the completed challenge:
<img width="1440" alt="screen shot 2015-11-07 at 9 33 10 pm" src="https://cloud.githubusercontent.com/assets/3822219/11019110/35da4b94-859e-11e5-9e9f-ae7fee32838c.png">

Appreciate your feedback very much!
