### PR TITLE
Adds RSS feed for Camper News

### DIFF
--- a/server/boot/story.js
+++ b/server/boot/story.js
@@ -64,6 +64,7 @@ module.exports = function(app) {
 
   router.post('/news/userstories', userStories);
   router.get('/news/hot', hotJSON);
+  router.get('/news/feed', RSSFeed);
   router.get('/stories/hotStories', hotJSON);
   router.get(
     '/stories/submit',
@@ -100,6 +101,26 @@ module.exports = function(app) {
         var sliceVal = stories.length >= 100 ? 100 : stories.length;
         var data = stories.sort(sortByRank).slice(0, sliceVal);
         res.json(data);
+      },
+      next
+    );
+  }
+
+  function RSSFeed(req, res, next) {
+    var query = {
+      order: 'timePosted DESC',
+      limit: 1000
+    };
+    findStory(query).subscribe(
+      function(stories) {
+        var sliceVal = stories.length >= 100 ? 100 : stories.length;
+        var data = stories.sort(sortByRank).slice(0, sliceVal);
+        res.render('feed', {
+          title: 'FreeCodeCamp Camper News RSS Feed',
+          description: 'RSS Feed for FreeCodeCamp Top 100 Hot Camper News',
+          url: 'http://www.freecodecamp.com/news',
+          FeedPosts: data
+        });
       },
       next
     );

--- a/server/views/feed.jade
+++ b/server/views/feed.jade
@@ -1,0 +1,15 @@
+doctype xml
+rss(version="2.0", xmlns:atom="http://www.w3.org/2005/Atom")
+  channel  
+    title= title
+    link= url
+    description= description
+    atom:link(href="http://www.freecodecamp.com/news/feed", rel="self", type="application/rss+xml")
+    for post in FeedPosts
+      if (post.link).match(/https*:\/\/\w+(\.\w+)*/)
+        item
+          title #{ post.headline.replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&quot;/g, '"') }
+          description <![CDATA[!{ post.metaDescription }]]>
+          pubDate= (new Date(post.timePosted)).toUTCString()
+          link= post.link
+          guid(isPermaLink="false")= post.link

--- a/server/views/partials/meta.jade
+++ b/server/views/partials/meta.jade
@@ -60,3 +60,4 @@ link(rel="mstile", sizes="310x150", href="https://s3.amazonaws.com/freecodecamp/
 link(rel="mstile", sizes="70x70", href="https://s3.amazonaws.com/freecodecamp/favicons/mstile-70x70.png")
 link(rel="favicon", href="https://s3.amazonaws.com/freecodecamp/favicons/favicon.ico")
 link(rel='shortcut icon', href='//s3.amazonaws.com/freecodecamp/favicons/favicon.ico')
+link(rel="alternate" type="application/rss+xml" title="RSS Feed for FreeCodeCamp Camper News" href="http://www.freecodecamp.com/news/feed")


### PR DESCRIPTION
Looks like this: http://prntscr.com/90d3bu.
Let me know if I should move `feed.jade` to somewhere else, add/remove/change something, thanks.
Closes #1597.
