### PR TITLE
Fix Ziplines/Basejumps Not Submitting

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -251,9 +251,7 @@ $(document).ready(function() {
   });
 
   function reBindModals() {
-    if (!window.common) {
-      return;
-    }
+
     var common = window.common;
 
     $('.close-modal').unbind('click');


### PR DESCRIPTION
Closes #4253

@FreeCodeCamp/owners you may want to merge and apply this quickly since campers currently are unable to submit ziplines and basejumps. Making this statement true by including the commonFramework on the zipline/basejump page causes an editor not defined error, so removing this newly added check for a quick fix seems the best option.
