### PR TITLE
Set RSS feed correct content-type

### DIFF
--- a/server/boot/story.js
+++ b/server/boot/story.js
@@ -115,6 +115,7 @@ module.exports = function(app) {
       function(stories) {
         var sliceVal = stories.length >= 100 ? 100 : stories.length;
         var data = stories.sort(sortByRank).slice(0, sliceVal);
+        res.set('Content-Type', 'text/xml');
         res.render('feed', {
           title: 'FreeCodeCamp Camper News RSS Feed',
           description: 'RSS Feed for FreeCodeCamp Top 100 Hot Camper News',


### PR DESCRIPTION
By following W3C's RSS feed validator's recommendation. Not sure if this is a correct use of `res.set` so feel free to point me the right way, thanks.
