### PR TITLE
Step Challenge - Prev from end, x/y step display

### DIFF
--- a/client/commonFramework.js
+++ b/client/commonFramework.js
@@ -1179,14 +1179,12 @@ common.init.push((function() {
   var submitModalId = '#challenge-step-modal';
 
   function getPreviousStep($challengeSteps) {
-    var length = $challengeSteps.length;
     var $prevStep = false;
     var prevStepIndex = 0;
     $challengeSteps.each(function(index) {
       var $step = $(this);
       if (
-        !$step.hasClass('hidden') &&
-        index + 1 !== length
+        !$step.hasClass('hidden')
       ) {
         prevStepIndex = index - 1;
       }
@@ -1220,7 +1218,7 @@ common.init.push((function() {
     e.preventDefault();
     var prevStep = getPreviousStep($(stepClass));
     $(this)
-      .parent()
+      .parent().parent()
       .removeClass('fadeOutLeft')
       .addClass('animated fadeOutRight fast-animation')
       .delay(250)
@@ -1244,7 +1242,7 @@ common.init.push((function() {
     e.preventDefault();
     var nextStep = getNextStep($(stepClass));
     $(this)
-      .parent()
+      .parent().parent()
       .removeClass('fadeOutRight')
       .addClass('animated fadeOutLeft fast-animation')
       .delay(250)

--- a/server/views/coursewares/showStep.jade
+++ b/server/views/coursewares/showStep.jade
@@ -8,16 +8,23 @@ block content
                             img.gif-block.img-center.img-responsive.thumbnail(src='#{step[0]}' alt='#{step[1]}')
                         .caption
                             p.large-p!= step[2]
-                        if step[3]
-                            a.btn.btn-block.btn-primary.challenge-step-btn-action(id='#{index}' href='#{step[3]}' target='_blank') Open link in new tab
-                            .button-spacer
-                        if index + 1 === description.length
-                            .btn.btn-block.btn-primary.challenge-step-btn-finish(id='last' class=step[3] ? 'disabled' : '') Finish challenge
-                        else if index !== 0
-                            .btn.btn-block.btn-primary.challenge-step-btn-next(id='#{index}' class=step[3] ? 'disabled' : '') Go to my next step
-                            .btn.btn-block.btn-warning-ghost.challenge-step-btn-prev(id='#{index - 1}') Go to my previous step
-                        else
-                            .btn.btn-block.btn-primary.challenge-step-btn-next(id='#{index}' class=step[3] ? 'disabled' : '') Go to my next step
+                        .challenge-button-block
+                            if step[3]
+                                a.btn.btn-block.btn-primary.challenge-step-btn-action(id='#{index}' href='#{step[3]}' target='_blank') Open link in new tab
+                                .button-spacer
+                            if index + 1 === description.length
+                                .btn.btn-warning.col-sm-5.col-xs-12.challenge-step-btn-prev(id='#{index - 1}') Go to my previous step
+                                .challenge-step-counter.large-p.col-sm-2.col.xs-12.text-center (#{index + 1} / #{description.length})
+                                .btn.btn-primary.col-sm-5.col-xs-12.challenge-step-btn-finish(id='last' class=step[3] ? 'disabled' : '') Finish challenge
+                            else if index !== 0
+                               .btn.btn-warning.col-sm-5.col-xs-12.challenge-step-btn-prev(id='#{index - 1}') Go to my previous step
+                               .challenge-step-counter.large-p.col-sm-2.col.xs-12.text-center (#{index + 1} / #{description.length})
+                               .btn.btn-primary.col-sm-5.col-xs-12.challenge-step-btn-next(id='#{index}' class=step[3] ? 'disabled' : '') Go to my next step
+                            else
+                                .col-sm-5.hidden-xs &nbsp;
+                                .challenge-step-counter.large-p.col-sm-2.col-xs-6.text-center (#{index + 1} / #{description.length})
+                                .btn.btn-primary.col-sm-5.col-xs-6.challenge-step-btn-next(id='#{index}' class=step[3] ? 'disabled' : '') Go to my next step
+                        .clearfix
     #challenge-step-modal.modal(tabindex='-1')
         .modal-dialog.animated.fadeIn.fast-animation
             .modal-content


### PR DESCRIPTION
Added two features I'd called out in #4437 -
1) You can now see a "Prev" button on the last page of the challenge.
2) Display an "X / Y" for current / total steps.
![image](https://cloud.githubusercontent.com/assets/553494/11174233/e07f6290-8bd5-11e5-9b66-495de54ce119.png)
![image](https://cloud.githubusercontent.com/assets/553494/11174234/e580f01a-8bd5-11e5-9773-da0c883f69f3.png)
![image](https://cloud.githubusercontent.com/assets/553494/11174235/e8ed7296-8bd5-11e5-8ca5-d88dea0743fc.png)
![image](https://cloud.githubusercontent.com/assets/553494/11174237/f003e3c6-8bd5-11e5-83d6-7f9a8c679bf9.png)
![image](https://cloud.githubusercontent.com/assets/553494/11174243/f55ea2a2-8bd5-11e5-8f58-c23e208fce0b.png)

Tested locally.
