### PR TITLE
Changed single quotes to double for consistency

### DIFF
--- a/seed/challenges/jquery.json
+++ b/seed/challenges/jquery.json
@@ -849,7 +849,7 @@
       "description": [
         "We're done playing with our jQuery playground. Let's tear it down!",
         "jQuery can target the <code>body</code> element as well.",
-        "Here's how we would make the entire body fade out: <code> $('body').addClass('animated fadeOut')</code>",
+        "Here's how we would make the entire body fade out: <code> $(\"body\").addClass(\"animated fadeOut\")</code>",
         "But let's do something more dramatic. Add the classes <code>animated</code> and <code>hinge</code> to your <code>body</code> element."
       ],
       "tests": [


### PR DESCRIPTION
Though in JS there's no difference, all the prior exercises use double quotes, so using a pair of single quotes suddenly and without explanation could be confusing. If this isn't addressed in the 'basic javascript' portion (I haven't gotten there yet), it should be
