### PR TITLE
Added Monospace to H2 font-family CSS

### DIFF
--- a/seed/challenges/html5-and-css.json
+++ b/seed/challenges/html5-and-css.json
@@ -763,7 +763,7 @@
         "  }",
         "",
         "  h2 {",
-        "    font-family: Lobster;",
+        "    font-family: Lobster, Monospace;",
         "  }",
         "",
         "  p {",


### PR DESCRIPTION
HTML and CSS challenge does not explicitly ask user to add Monospace font.  Adding this as a fallback font demonstrates to user that commenting out the Lobster font will result in using Monspace as a backup.

Closes #4592 
