### PR TITLE
Add release date to new JQ waypoint

### DIFF
--- a/seed/challenges/jquery.json
+++ b/seed/challenges/jquery.json
@@ -550,6 +550,7 @@
         "jQuery also has a similar function called <code>.text()</code> that only alters text without adding tags.",
         "Change the button with id <code>target4</code> by italicizing its text."
       ],
+      "releasedOn": "November 18, 2015",
       "tests": [
         "assert.isTrue((/<i>/gi).test($(\"#target4\").html()), 'Italicize the text in your <code>target4</code> button by adding HTML tags.')",
         "assert($(\"#target4\") && $(\"#target4\").text() === '#target4', 'Make sure the text is otherwise unchanged.')",


### PR DESCRIPTION
A new jQuery WP was added, but the releasedOn flag was not set, leaving users confused.
REF: #4553

Just added the releasedOn Date.

Limited testing locally.
