### PR TITLE
Fixes "Use Comments to Clarify Code" Ambiguity

### DIFF
--- a/seed/challenges/bootstrap.json
+++ b/seed/challenges/bootstrap.json
@@ -2121,7 +2121,7 @@
         "Add a comment at the top of your HTML that says <code>Only change code above this line.</code>"
       ],
       "tests": [
-        "assert(editor.match(/<!--/g) && editor.match(/<!--/g).length > 0, 'Start a comment with <code>&#60;!--</code>.')",
+        "assert(editor.match(/^<!--/) && editor.match(/<!--/g).length > 0, 'Start a comment with <code>&#60;!--</code> at the top of your HTML.')",
         "assert(editor.match(/this line/g) && editor.match(/this line/g).length > 0, 'Your comment should have the text <code>Only change code above this line</code>.')",
         "assert(editor.match(/-->.*\\n+.+/g), 'Be sure to close your comment with <code>--&#62;</code>.')"
       ],


### PR DESCRIPTION
Narrowed the Regex to require that the comment open be on the first character of the first line.  Added verbiage to test to clarify requirement.

Rested locally.

Closes #4713
