### PR TITLE
Fixes challengeTypes object's incorrect key names

### DIFF
--- a/client/commonFramework/report-issue.js
+++ b/client/commonFramework/report-issue.js
@@ -21,11 +21,11 @@ window.common = (function({ common = { init: [] } }) {
       ) {
         var type;
         switch (common.challengeType) {
-          case common.challengeTypes.html:
+          case common.challengeTypes.HTML:
             type = 'html';
             break;
-          case common.challengeTypes.js:
-          case common.challengeTypes.bonfire:
+          case common.challengeTypes.JS:
+          case common.challengeTypes.BONFIRE:
             type = 'javascript';
             break;
           default:


### PR DESCRIPTION
When creating a new issue from beta you'll see that there is no syntax highlighting because of mentioned incorrect key names.
