### PR TITLE
Waypoint: Change Text Inside an Element Using jQuery: Modified for best practice.

### DIFF
--- a/seed/challenges/jquery.json
+++ b/seed/challenges/jquery.json
@@ -545,16 +545,16 @@
       "description": [
         "Using jQuery, you can change the text between the start and end tags of an element. You can even change HTML markup.",
         "jQuery has a function called <code>.html()</code> that lets you add HTML tags and text within an element. Any content previously within the element will be completely replaced with the content you provide using this function.",
-        "Here's how you would rewrite and italicize the text of our heading:",
-        "<code>$(\"h3\").html(\"&#60;i&#62;jQuery Funhouse&#60;/i&#62;\");</code>",
+        "Here's how you would rewrite and emphasize the text of our heading:",
+        "<code>$(\"h3\").html(\"&#60;em&#62;jQuery Funhouse&#60;/em&#62;\");</code>",
         "jQuery also has a similar function called <code>.text()</code> that only alters text without adding tags.",
-        "Change the button with id <code>target4</code> by italicizing its text."
+        "Change the button with id <code>target4</code> by emphasizing its text."
       ],
       "releasedOn": "November 18, 2015",
       "tests": [
-        "assert.isTrue((/<i>/gi).test($(\"#target4\").html()), 'Italicize the text in your <code>target4</code> button by adding HTML tags.')",
+        "assert.isTrue((/<em>/gi).test($(\"#target4\").html()), 'Emphasize the text in your <code>target4</code> button by adding HTML tags.')",
         "assert($(\"#target4\") && $(\"#target4\").text() === '#target4', 'Make sure the text is otherwise unchanged.')",
-        "assert.isFalse((/<i>/gi).test($(\"h3\").html()), 'Do not alter any other text.')"
+        "assert.isFalse((/<em>/gi).test($(\"h3\").html()), 'Do not alter any other text.')"
       ],
       "challengeSeed": [
         "fccss",


### PR DESCRIPTION
I enhanced the jquery waypoint that speaks of <code><i>i</i></code> and changed it to the <code><em>em</em></code> since this is best practice when emphasizing text in html5

![em](https://cloud.githubusercontent.com/assets/7018580/11484255/ea6fed78-9761-11e5-816b-1c33659cb42e.png)
