### PR TITLE
Fix use the document as the proxy for jquery

### DIFF
--- a/client/iFrameScripts.js
+++ b/client/iFrameScripts.js
@@ -8,10 +8,8 @@ window.__$(function() {
   var tests = parent.tests;
   var common = parent.common;
   var editor = common.editor.getValue();
-  // grab the iframe body element
-  var body = document.getElementsByTagName('body');
   // change the context of $ so it uses the iFrame for testing
-  var $ = __$.proxy(__$.fn.find, __$(body));
+  var $ = __$.proxy(__$.fn.find, __$(document));
 
   common.runPreviewTests$ =
     function runPreviewTests$({ tests = [], ...rest }) {


### PR DESCRIPTION
We proxy the jquery object. This lets us use the jQuery that FCC
uses in the iframe.

Since jQuery sets the context, the main document object or DOM, at script
load, we need to create a proxy with the context of the iframe,
the document object of the iframe.

This was originally set to the body element. But not all challenges
require a body element.

closes #4833
