### PR TITLE
Fix WP Manipulate Arrays with Shift Example Code

### DIFF
--- a/seed/challenges/basic-javascript.json
+++ b/seed/challenges/basic-javascript.json
@@ -597,17 +597,15 @@
       "challengeSeed": [
         "var ourArray = [\"Stimpson\", \"J\", [\"cat\"]];",
         "",
-        "removedFromOurArray = ourArray.shift(); // removedFromOurArray now equals \"Stimpson\" and ourArray now equals [\"J\", [\"cat\"]].",
+        "var removedFromOurArray = ourArray.shift(); // removedFromOurArray now equals \"Stimpson\" and ourArray now equals [\"J\", [\"cat\"]].",
         "",
         "var myArray = [\"John\", 23, [\"dog\", 3]];",
         "",
         "// Only change code below this line.",
         "",
-        "var removedFromMyArray;",
-        "",
-        "// Only change code above this line.",
-        "",
-        "",
+        "var removedFromMyArray;"
+      ],
+      "tail":[
         "(function(y, z){return 'myArray = ' + JSON.stringify(y) + ' & removedFromMyArray = ' + JSON.stringify(z);})(myArray, removedFromMyArray);"
       ],
       "type": "waypoint",


### PR DESCRIPTION
Also move display function to tail.

Closes #4864
