### PR TITLE
Fix Codemirror Emmet Plugin Support

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -85,7 +85,7 @@ var paths = {
     'public/bower_components/CodeMirror/mode/xml/xml.js',
     'public/bower_components/CodeMirror/mode/css/css.js',
     'public/bower_components/CodeMirror/mode/htmlmixed/htmlmixed.js',
-    'public/bower_components/CodeMirror/addon/emmet/emmet.js'
+    'node_modules/emmet-codemirror/dist/emmet.js'
   ],
 
   vendorMain: [
@@ -517,4 +517,3 @@ gulp.task('default', [
   'watch',
   'sync'
 ]);
-

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "debug": "^2.2.0",
     "dedent": "~0.6.0",
     "dotenv": "^1.2.0",
+    "emmet-codemirror": "^1.2.5",
     "errorhandler": "^1.4.2",
     "es6-map": "~0.1.1",
     "eslint": "~1.10.2",


### PR DESCRIPTION
Emmet is no longer included in the codemirror addons and is not available as a bower package, so must be installed via npm.

Closes #4875
