### PR TITLE
Fix broken tests

### DIFF
--- a/seed/challenges/html5-and-css.json
+++ b/seed/challenges/html5-and-css.json
@@ -156,7 +156,7 @@
         "assert($(\"h1\").length > 0, 'message: Make your <code>h1</code> element visible on your page by uncommenting it.');",
         "assert($(\"h2\").length > 0, 'message: Make your <code>h2</code> element visible on your page by uncommenting it.');",
         "assert($(\"p\").length > 0, 'message: Make your <code>p</code> element visible on your page by uncommenting it.');",
-        "assert(!new RegExp(\"-->\", 'message: gi').test(editor), 'Be sure to delete all trailing comment tags&#44; i.e. <code>--&#62;</code>.');"
+        "assert(!new RegExp(\"-->\", \"gi\").test(code), 'message: Be sure to delete all trailing comment tags&#44; i.e. <code>--&#62;</code>.');"
       ],
       "challengeSeed": [
         "<!--",
@@ -688,7 +688,7 @@
         "Apply the <code>font-family</code> of <code>Lobster</code> to your <code>h2</code> element."
       ],
       "tests": [
-        "assert(new RegExp(\"googleapis\", \"gi\").test(editor), 'message: Import the <code>Lobster</code> font.');",
+        "assert(new RegExp(\"googleapis\", \"gi\").test(code), 'message: Import the <code>Lobster</code> font.');",
         "assert($(\"h2\").css(\"font-family\").match(/lobster/i), 'message: Your <code>h2</code> element should use the font <code>Lobster</code>.');",
         "assert($(\"p\").css(\"font-family\").match(/monospace/i), 'message: Your <code>p</code> element should still use the font <code>Monospace</code>.');"
       ],
@@ -752,8 +752,8 @@
       "tests": [
         "assert($(\"h2\").css(\"font-family\").match(/^\"?lobster/i), 'message: Your h2 element should use the font <code>Lobster</code>.');",
         "assert($(\"h2\").css(\"font-family\").match(/lobster.*,.*monospace/i), 'message: Your h2 element should degrade to the font <code>Monospace</code> when <code>Lobster</code> is not available.');",
-        "assert(new RegExp(\"<!--\", \"gi\").test(editor), 'message: Comment out your call to Google for the <code>Lobster</code> font by putting <code>&#60!--</code> in front of it.');",
-        "assert(new RegExp(\"-->\", \"gi\").test(editor), 'message: Be sure to close your comment by adding <code>--&#62;</code>.');"
+        "assert(new RegExp(\"<!--\", \"gi\").test(code), 'message: Comment out your call to Google for the <code>Lobster</code> font by putting <code>&#60!--</code> in front of it.');",
+        "assert(new RegExp(\"-->\", \"gi\").test(code), 'message: Be sure to close your comment by adding <code>--&#62;</code>.');"
       ],
       "challengeSeed": [
         "<link href=\"http://fonts.googleapis.com/css?family=Lobster\" rel=\"stylesheet\" type=\"text/css\">",


### PR DESCRIPTION
Should use editor.getValue() or `code` when you need code
as a string.

closes #4956
closes #4955 
closes #4954 
