### PR TITLE
Fix Uncomment HTML bad 4th test

### DIFF
--- a/seed/challenges/html5-and-css.json
+++ b/seed/challenges/html5-and-css.json
@@ -156,7 +156,7 @@
         "assert($(\"h1\").length > 0, 'message: Make your <code>h1</code> element visible on your page by uncommenting it.');",
         "assert($(\"h2\").length > 0, 'message: Make your <code>h2</code> element visible on your page by uncommenting it.');",
         "assert($(\"p\").length > 0, 'message: Make your <code>p</code> element visible on your page by uncommenting it.');",
-        "assert(!new RegExp(\"-->\", \"gi\").test(code), 'message: Be sure to delete all trailing comment tags&#44; i.e. <code>--&#62;</code>.');"
+        "assert(!/-->/gi.test(code), 'message: Be sure to delete all trailing comment tags&#44; i.e. <code>--&#62;</code>.');"
       ],
       "challengeSeed": [
         "<!--",


### PR DESCRIPTION
The 4th test case in Uncomment HTML had a comma in it, which breaks the message display splitting logic. Changed to an alternate form of regex test.

Tested locally.

Closes #4961 
