### PR TITLE
Fix test to fail on incorrect input

### DIFF
--- a/seed/challenges/bootstrap.json
+++ b/seed/challenges/bootstrap.json
@@ -1141,7 +1141,7 @@
       ],
       "tests": [
         "assert($(\"i\").hasClass(\"fa fa-thumbs-up\"), 'message: Add an <code>i</code> element with the classes <code>fa</code> and <code>fa-thumbs-up</code>.');",
-        "assert($(\"i.fa-thumbs-up\").parent().text().match(/Like/gi), 'message: Your <code>fa-thumbs-up</code> icon should be located within the Like button.');",
+        "assert($(\"i.fa-thumbs-up\").parent().text().match(/Like/gi) && $(\".btn-primary > i\").hasClass(\"fa fa-thumbs-up\"), 'message: Your <code>fa-thumbs-up</code> icon should be located within the Like button.');",
         "assert($(\"button\").children(\"i\").length > 0, 'message: Nest your <code>i</code> element within your <code>button</code> element.');",
         "assert(code.match(/<\\/i>/g), 'message: Make sure your <code>i</code> element has a closing tag.');"
       ],


### PR DESCRIPTION
In 'Waypoint: Add Font Awesome Icons to our Buttons' challenge changed a test to check whether <i> element is within Like button (did it the same way as it is done in 'Waypoint: Add Font Awesome Icons to all of our Buttons' challenge). 
closes #4981
