### PR TITLE
Modified regex in test case for passing img tag spanning multiple lines

### DIFF
--- a/seed/challenges/bootstrap.json
+++ b/seed/challenges/bootstrap.json
@@ -110,7 +110,7 @@
         "assert($(\"img:eq(1)\").hasClass(\"img-responsive\"), 'message: Your new image should be below your old one and have the class <code>img-responsive</code>.');",
         "assert(!$(\"img:eq(1)\").hasClass(\"smaller-image\"), 'message: Your new image should not have the class <code>smaller-image</code>.');",
         "assert($(\"img:eq(1)\").attr(\"src\") === \"http://bit.ly/fcc-running-cats\", 'message: Your new image should have a <code>src</code> of <code>http&#58;//bit.ly/fcc-running-cats</code>.');",
-        "assert(code.match(/<img/g) && code.match(/<img.*>/g).length === 2 && code.match(/<img/g).length === 2, 'message: Make sure your new <code>img</code> element has a closing angle bracket.');"
+        "assert(code.match(/<img/g) && code.match(/<img[^<]*>/g).length === 2 && code.match(/<img/g).length === 2, 'message: Make sure your new <code>img</code> element has a closing angle bracket.');"
       ],
       "challengeSeed": [
         "<link href=\"http://fonts.googleapis.com/css?family=Lobster\" rel=\"stylesheet\" type=\"text/css\">",


### PR DESCRIPTION
Tested in local copy.
Worked fine in Chrome and Firefox.
Details of the issue:
The following code used to fail as `img` tag spreads in multiple lines.

```
<img src="some value"             
     href="some link">
```

It is supposed to be a test that is GREEN. So modified the regex to even consider new line elements and determine that `img` tag entered by user is valid.

Closes #4793 
