### PR TITLE
fix regex to test h1 tag spanning multiple lines

### DIFF
--- a/seed/challenges/html5-and-css.json
+++ b/seed/challenges/html5-and-css.json
@@ -3660,7 +3660,7 @@
         "assert($(\"h1\").hasClass(\"pink-text\"), 'message: Your <code>h1</code> element should have the class <code>pink-text</code>.');",
         "assert($(\"h1\").hasClass(\"blue-text\"), 'message: Your <code>h1</code> element should have the class <code>blue-text</code>.');",
         "assert($(\"h1\").attr(\"id\") === \"orange-text\", 'message: Your <code>h1</code> element should have the id of <code>orange-text</code>.');",
-        "assert(code.match(/<h1.*style/gi) && code.match(/<h1.*style.*color\\s*?:/gi), 'message: Give your <code>h1</code> element the inline style of <code>color&#58; white</code>.');",
+        "assert(code.match(/<h1[\\s\\S]*?style/gi) && code.match(/<h1[\\s\\S]*?style[\\s\\S]*?color\\s*?:/gi), 'message: Give your <code>h1</code> element the inline style of <code>color&#58; white</code>.');",
         "assert($(\"h1\").css(\"color\") === \"rgb(255, 255, 255)\", 'message: Your <code>h1</code> element should be white.');"
       ],
       "challengeSeed": [


### PR DESCRIPTION
Fixes issues arised when this h1 tag spans multiple lines.
`.*` does not match when a tag spans multiple lines. 

> <h1 id="orange-text" 
> class="pink-text blue-text"
> style="color: white">Hello World!</h1>

whereas the below code passes.
`<h1 id="orange-text" class="pink-text blue-text" style="color: white">Hello World!</h1>`

This PR fixes that issue. #5027 
