### PR TITLE
Fix/improved test for overriding css style

### DIFF
--- a/seed/challenges/html5-and-css.json
+++ b/seed/challenges/html5-and-css.json
@@ -3544,6 +3544,7 @@
       "tests": [
         "assert($(\"h1\").hasClass(\"pink-text\"), 'message: Your <code>h1</code> element should have the class <code>pink-text</code>.');",
         "assert($(\"h1\").hasClass(\"blue-text\"), 'message: Your <code>h1</code> element should have the class <code>blue-text</code>.');",
+        "assert($(\".pink-text\").hasClass(\"blue-text\"), 'message: Both <code>blue-text</code> and <code>pink-text</code> should belong to the same <code>h1</code> element.');",
         "assert($(\"h1\").css(\"color\") === \"rgb(0, 0, 255)\", 'message: Your <code>h1</code> element should be blue.');"
       ],
       "challengeSeed": [


### PR DESCRIPTION
Improved tests for Challenge [Waypoint: Override Styles in Subsequent CSS](http://www.freecodecamp.com/challenges/waypoint-override-styles-in-subsequent-css#?solution=%3Cstyle%3E%0A%20%20body%20%7B%0A%20%20%20%20background-color%3A%20black%3B%0A%20%20%20%20font-family%3A%20Monospace%3B%0A%20%20%20%20color%3A%20green%3B%0A%20%20%7D%0A%20%20.pink-text%20%7B%0A%20%20%20%20color%3A%20blue%3B%0A%20%20%7D%0A%20%20.blue-text%20%7B%0A%20%20%20%20color%3A%20blue%3B%0A%20%20%7D%0A%3C%2Fstyle%3E%0A%3Ch1%20class%3D%22blue-text%22%3EHello%20World!%3C%2Fh1%3E%0A%3Ch1%20class%3D%22pink-text%22%3EHello%20World!%3C%2Fh1%3E%0A)
- Created a new test to check if both classes belong to the same element

closes #5054 
