### PR TITLE
Skip Button/Go to next step functionality enhancement

### DIFF
--- a/server/boot/challenge.js
+++ b/server/boot/challenge.js
@@ -41,6 +41,14 @@ const challengeView = {
   7: 'coursewares/showStep'
 };
 
+function isChallengeCompleted(user, challengeId) {
+  if (!user) {
+    return false;
+  }
+  return user.completedChallenges.some(challenge =>
+    challenge.id === challengeId );
+}
+
 function numberWithCommas(x) {
   return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
 }
@@ -292,6 +300,9 @@ module.exports = function(app) {
           head: challenge.head,
           tail: challenge.tail,
           tests: challenge.tests,
+
+          // identifies if a challenge is completed
+          isCompleted: isChallengeCompleted(req.user, challenge.id),
 
           // video challenges
           video: challenge.challengeSeed[0],

--- a/server/views/coursewares/showStep.jade
+++ b/server/views/coursewares/showStep.jade
@@ -18,9 +18,9 @@ block content
                                 .btn.btn-warning.col-sm-5.col-xs-12.challenge-step-btn-prev(id='#{index - 1}') Go to my previous step
                             .challenge-step-counter.large-p.col-sm-2.col-xs-12.text-center (#{index + 1} / #{description.length})
                             if index + 1 === description.length
-                                .btn.btn-primary.col-sm-5.col-xs-12.challenge-step-btn-finish(id='last' class=step[3] ? 'disabled' : '') Finish challenge
+                                .btn.btn-primary.col-sm-5.col-xs-12.challenge-step-btn-finish(id='last' class=step[3] && !isCompleted ? 'disabled' : '') Finish challenge
                             else
-                                .btn.btn-primary.col-sm-5.col-xs-12.challenge-step-btn-next(id='#{index}' class=step[3] ? 'disabled' : '') Go to my next step
+                                .btn.btn-primary.col-sm-5.col-xs-12.challenge-step-btn-next(id='#{index}' class=step[3] && !isCompleted ? 'disabled' : '') Go to my next step
                         .clearfix
     #challenge-step-modal.modal(tabindex='-1')
         .modal-dialog.animated.fadeIn.fast-animation


### PR DESCRIPTION
This enhances 'Step Challenges' functionality. Currently, Step Challenges force user to click on 'Open in New Tab'. 
The improvement is that 'Open in New Tab' is not forced on users if they have completed the challenge already. The code verifies if a user has completed a challenge or not. If completed, he will have a free pass at 'Go to next Step'.

Tested in local machine. Chrome-- both for 'logged in' users and 'not logged in' users.
To test in local machine, I removed completed challenges using mongo shell.
To remove the `completedChallenges` list in your database, in order to simulate that you are doing challenge/waypoint for the first time, I followed the following steps.
- Open mongo shell `mongo shell`
- `use freecodecamp`
- `db.user.find().pretty()`
- Identify the `"username"`.
- `db.user.update({"username":__username__},{$set:{"completedChallenges":[ ]}})`

Closes #3690 
