### PR TITLE
Accept grey-background or gray-background in Waypoint Give a Background Color to a Div

### DIFF
--- a/seed/challenges/html5-and-css.json
+++ b/seed/challenges/html5-and-css.json
@@ -2580,8 +2580,8 @@
         "Create a class called <code>gray-background</code> with the <code>background-color</code> of gray. Assign this class to your <code>div</code> element."
       ],
       "tests": [
-        "assert($(\"div\").hasClass(\"gray-background\"), 'message: Give your <code>div</code> element the class <code>gray-background</code>.');",
-        "assert($(\".gray-background\").css(\"background-color\") === \"rgb(128, 128, 128)\", 'message: Your <code>div</code> element should have a gray background.');"
+        "assert(($(\"div\").hasClass(\"gray-background\") || ($(\"div\").hasClass(\"grey-background\")), 'message: Give your <code>div</code> element the class <code>gray-background</code>.');",
+        "assert($(\"div\").css(\"background-color\") === \"rgb(128, 128, 128)\", 'message: Your <code>div</code> element should have a gray background.');"
       ],
       "challengeSeed": [
         "<link href=\"http://fonts.googleapis.com/css?family=Lobster\" rel=\"stylesheet\" type=\"text/css\">",


### PR DESCRIPTION
Some people mistakenly type "grey-background" instead of "gray-background". Could accept either. This commit does however abandon testing whether the colour was set in in the gray-background class or elsewhere.

It is a trade-off.
