### PR TITLE
Ga/show completion event mod

### DIFF
--- a/client/commonFramework/execute-challenge-stream.js
+++ b/client/commonFramework/execute-challenge-stream.js
@@ -13,8 +13,32 @@ window.common = (function(global) {
     challengeTypes
   } = common;
 
-  let attempts = 0;
-
+  let attempts = "NaN";
+  let attempts_val = 0;
+  let attempts_ranges = function(attempts){
+	if (attempts == 0){
+		return "0";
+	}
+	else if (attempts > 0 && attempts <= 5){
+		return "1-5";
+	}
+	else if (attempts > 5 && attempts <= 10){
+		return "6-10";
+	}
+	else if (attempts > 10 && attempts <= 20){
+		return "11-20";
+	}
+	else if (attempts > 20 && attempts <= 30){
+		return "21-30";
+	}
+	else if (attempts > 30 && attempts <= 50){
+		return "31-50";
+	}
+	else{
+		return "51+";
+	} 
+  }
+  
   common.executeChallenge$ = function executeChallenge$() {
     const code = common.editor.getValue();
     const originalCode = code;
@@ -22,7 +46,9 @@ window.common = (function(global) {
     const tail = common.arrayToNewLineString(common.tail);
     const combinedCode = head + code + tail;
 
-    attempts++;
+    attempts_val++;
+	attempts = attempts_ranges(attempts_val);
+	
 
     ga('send', 'event', 'Challenge', 'ran-code', common.challengeName);
 

--- a/client/commonFramework/show-completion.js
+++ b/client/commonFramework/show-completion.js
@@ -9,9 +9,10 @@ window.common = (function(global) {
     ga(
       'send',
       'event',
-      'Challenge',
-      'solved',
-      common.challengeName + ', Attempts: '
+      'Challenge', //category
+      'solved',    //action
+      common.challengeName + ' Attempts: ', //label
+	  true //opt_noninteraction: not counting as bounce
     );
 
     var solution = common.editor.getValue();

--- a/client/commonFramework/show-completion.js
+++ b/client/commonFramework/show-completion.js
@@ -6,14 +6,12 @@ window.common = (function(global) {
   } = global;
 
   common.showCompletion = function showCompletion() {
-    var time = Math.floor(Date.now() - common.started);
-
     ga(
       'send',
       'event',
       'Challenge',
       'solved',
-      common.challengeName + ', Time: ' + time + ', Attempts: ' + 0
+      common.challengeName + ', Attempts: '
     );
 
     var solution = common.editor.getValue();


### PR DESCRIPTION
Changed the original ga event tracking:
--- to exclude the Time label variable (show-completion)
--- keeps Attempts label variable but instead of numeric, only reports ranges in a string format (label set at show-completion; code at execute-challenge-stream)

Requests are similar. The most recent one has the last corrections.
