### PR TITLE
Fixed the labs page "Start Learning" button to centered

### DIFF
--- a/server/views/resources/labs.jade
+++ b/server/views/resources/labs.jade
@@ -18,5 +18,8 @@ block content
                                 p= project.description
 
             if !user
-                a.btn.btn-cta.signup-btn.btn-primary(href="/login") Start learning to code (it's free)
-            .spacer
+                .spacer
+                .row
+                    .col-xs-12.col-sm-8.col-sm-offset-2
+                        a.btn.btn-cta.signup-btn.btn-block(href="/signin") Learn to code today (it's free)
+                .spacer


### PR DESCRIPTION
closes #5343 

This PR fixes the [Labs page](www.freecodecamp.com/labs), "Start Learning to code" button to centered, as pointed in the issue.

I have tested locally.
