### PR TITLE
Fixes the Title Case a Sentence - Add/Remove helpful links waypoint

### DIFF
--- a/seed/challenges/01-front-end-development-certification/basic-bonfires.json
+++ b/seed/challenges/01-front-end-development-certification/basic-bonfires.json
@@ -319,7 +319,7 @@
         "assert(titleCase(\"HERE IS MY HANDLE HERE IS MY SPOUT\") === \"Here Is My Handle Here Is My Spout\", 'message: <code>titleCase(\"HERE IS MY HANDLE HERE IS MY SPOUT\")</code> should return \"Here Is My Handle Here Is My Spout\".');"
       ],
       "MDNlinks": [
-        "String.charAt()"
+        "String.split()"
       ],
       "solutions": [
         "function titleCase(str) {\n  return str.split(' ').map(function(word) {\n    return word.charAt(0).toUpperCase() + word.substring(1).toLowerCase();\n  }).join(' ');\n}\n\ntitleCase(\"I'm a little tea pot\");\n"


### PR DESCRIPTION
closes #5393

This PR fixes the issue as suggested : 
Change the helpful link from `String.charAt()` to `String.split()`

I have tested locally.
