### PR TITLE
fix a typo - Waypoint: Sift through Text with Regular Expressions

### DIFF
--- a/seed/challenges/01-front-end-development-certification/basic-javascript.json
+++ b/seed/challenges/01-front-end-development-certification/basic-javascript.json
@@ -1489,7 +1489,7 @@
     },
     {
       "id": "cf1111c1c12feddfaeb6bdef",
-      "title": "Sift through Text with Regular Expressions",
+      "title": "Shift through Text with Regular Expressions",
       "description": [
         "<code>Regular expressions</code> are used to find certain words or patterns inside of <code>strings</code>.",
         "For example, if we wanted to find the word <code>the</code> in the string <code>The dog chased the cat</code>, we could use the following <code>regular expression</code>: <code>/the/gi</code>",


### PR DESCRIPTION
This fixes a typo in the challenge title:
[Waypoint: Sift through Text with Regular Expressions](http://www.freecodecamp.com/challenges/waypoint-sift-through-text-with-regular-expressions)

to
[Waypoint: Shift through Text with Regular Expressions](http://www.freecodecamp.com/challenges/waypoint-shift-through-text-with-regular-expressions)

Tested locally.

No issues are open for this AFAIK, please merge as deemed fit!
