### PR TITLE
Lowercase 'Solo' in 'Face-melting guitar Solo'

### DIFF
--- a/server/utils/resources.json
+++ b/server/utils/resources.json
@@ -76,7 +76,7 @@
     "By the power of Grayskull!",
     "You did it!",
     "Storm that castle!",
-    "Face-melting guitar Solo!",
+    "Face-melting guitar solo!",
     "Checkmate!",
     "Bodacious!",
     "Tubular!",


### PR DESCRIPTION
Changed the case of Solo in the message 'Face-melting guitar Solo' because, unless there's an extremely subtle Star Wars reference I'm missing, solo isn't a proper noun here.
