### PR TITLE
Add two missing semi-colons to challenge seeds

### DIFF
--- a/seed/challenges/01-front-end-development-certification/html5-and-css.json
+++ b/seed/challenges/01-front-end-development-certification/html5-and-css.json
@@ -4181,7 +4181,7 @@
       "challengeSeed": [
         "<style>",
         "  body {",
-        "    background-color: rgb(0, 0, 0)",
+        "    background-color: rgb(0, 0, 0);",
         "  }",
         "</style>"
       ],
@@ -4222,7 +4222,7 @@
       "challengeSeed": [
         "<style>",
         "  body {",
-        "    background-color: rgb(255, 255, 255)",
+        "    background-color: rgb(255, 255, 255);",
         "  }",
         "</style>"
       ],


### PR DESCRIPTION
Added missing semi-colons to two challenge seeds to have proper syntax and match challenge seeds for similar waypoints.

Closes #5575
