### PR TITLE
Improve Concatenation Strings Descriptions

### DIFF
--- a/seed/challenges/01-front-end-development-certification/basic-javascript.json
+++ b/seed/challenges/01-front-end-development-certification/basic-javascript.json
@@ -951,6 +951,7 @@
         "In JavaScript, when the <code>+</code> operator is used with a <code>String</code> value, it is called the <dfn>concatenation</dfn> operator. You can build a new string out of other strings by <dfn>concatenating</dfn> them together.",
         "<strong>Example</strong>",
         "<blockquote>'My name is Alan,' + ' I concatenate.'</blockquote>",
+        "<strong>Note</strong><br>Watch out for spaces.  Concatenation does not add spaces between concatenated strings, so you'll need to add them yourself.",
         "<h4>Instructions</h4>",
         "Build <code>myStr</code> from the strings <code>\"This is the start. \"</code> and <code>\"This is the end.\"</code> using the <code>+</code> operator."
       ],
@@ -985,6 +986,7 @@
       "title": "Concatenating Strings with the Plus Equals Operator",
       "description": [
         "We can also use the <code>+=</code> operator to <dfn>concatenate</dfn> a string onto the end of an existing string variable. This can be very helpful to break a long string over several lines.",
+        "<strong>Note</strong><br>Watch out for spaces.  Concatenation does not add spaces between concatenated strings, so you'll need to add them yourself.",
         "<h4>Instructions</h4>",
         "Build <code>myStr</code> over several lines by concatenating these two strings:<br><code>\"This is the first sentence. \"</code> and <code>\"This is the second sentence.\"</code> using the <code>+=</code> operator."
       ],


### PR DESCRIPTION
Added a note about watching out for spaces, to reduce confused questions that miss that trailing space.

![image](https://cloud.githubusercontent.com/assets/553494/12061326/b25e97d4-af37-11e5-85c5-3b3c8eca7647.png)

Tested Locally.
