### PR TITLE
Fix vague variable names in Celsius to Fahrenheit

### DIFF
--- a/seed/challenges/01-front-end-development-certification/basic-javascript.json
+++ b/seed/challenges/01-front-end-development-certification/basic-javascript.json
@@ -775,19 +775,19 @@
       "description": [
         "To test your learning you will create a solution \"from scratch\".  Place your code between the indicated lines and it will be tested against multiple test cases.",
         "The algorithm to convert from Celsius to Fahrenheit is the temperature in Celsius times 9/5, plus 32.",
-        "You are given a variable <code>Tc</code> representing a temperature in Celsius.  Create a variable <code>Tf</code> and apply the algorithm to assign it the corresponding temperature in Fahrenheit."
+        "You are given a variable <code>celsius</code> representing a temperature in Celsius.  Create a variable <code>fahrenheit</code> and apply the algorithm to assign it the corresponding temperature in Fahrenheit."
       ],
       "releasedOn": "January 1, 2016",
       "challengeSeed": [
-        "function convert(Tc) {",
+        "function convert(celsius) {",
         "  // Only change code below this line",
         "  ",
         "",
         "  // Only change code above this line",
-        "  if(typeof Tf !== 'undefined') {",
-        "  return Tf;",
+        "  if ( typeof fahrenheit !== 'undefined' ) {",
+        "  return fahrenheit;",
         "  } else {",
-        "    return \"Tf not defined\";",
+        "    return 'fahrenheit not defined';",
         "  }",
         "}",
         "",
@@ -795,7 +795,7 @@
         "convert(30);"
       ],
       "solutions": [
-        "function convert(Tc) {\n  var Tf = Tc * 9/5 + 32;\n  if(typeof Tf !== 'undefined') {\n  return Tf;\n  } else {\n    return \"Tf not defined\";\n  }\n}"
+        "function convert(celsius) {\n  var fahrenheit = celsius * 9/5 + 32;\n  if ( typeof fahrenheit !== 'undefined' ) {\n  return fahrenheit;\n  } else {\n    return 'fahrenheit not defined';\n  }\n}"
       ],
       "tests": [
         "assert(typeof convert(0) === 'number', 'message: <code>convert(0)</code> should return a number');",


### PR DESCRIPTION
Closes #5565.

In addition to fixing the issue, I edited some other things as well I hope are good:
- fixed spacing in the `if` statement (Lines 787 and 798)
- change double quotes to single quotes (Line 790s and 798)
- updated the solution with the changes as well (Line 798)

I'm not sure what is going on at Line 5144. It says previously there was no newline at the end of the file and presumably my edits added a newline. But there is no newline, otherwise I'd assume there'd be a Line 5145.

Let me know if I should change anything or if anyone knows what's going on with Line 5144. Thanks.
