### PR TITLE
Fixed bug in return string text in 'Else If' waypoint

### DIFF
--- a/seed/challenges/01-front-end-development-certification/basic-javascript.json
+++ b/seed/challenges/01-front-end-development-certification/basic-javascript.json
@@ -2740,7 +2740,7 @@
       "challengeSeed": [
         "function myTest(val) {",
         "  if(val > 10) {",
-        "    return \"10 or Bigger\";",
+        "    return \"Greater than 10\";",
         "  }",
         "  ",
         "  if(val < 5) {",


### PR DESCRIPTION
Updated the .json file to have correct return string in the
seed of 'Waypoint Challenge: Introduction to Else If Statements'
