### PR TITLE
Fix #5628 - Remove unwanted test case

### DIFF
--- a/seed/challenges/01-front-end-development-certification/basic-javascript.json
+++ b/seed/challenges/01-front-end-development-certification/basic-javascript.json
@@ -2801,7 +2801,7 @@
       "tests": [
         "assert(code.match(/else/g).length > 3, 'message: You should have at least four <code>else</code> statements');",
         "assert(code.match(/if/g).length > 3, 'message: You should have at least four <code>if</code> statements');",
-        "assert(code.match(/return/g).length === 5, 'message: You should have five <code>return</code> statements');",
+        "assert(code.match(/return/g).length >= 5, 'message: You should have at least five <code>return</code> statements');",
         "assert(myTest(0) === \"Tiny\", 'message: <code>myTest(0)</code> should return \"Tiny\"');",
         "assert(myTest(4) === \"Tiny\", 'message: <code>myTest(4)</code> should return \"Tiny\"');",
         "assert(myTest(5) === \"Small\", 'message: <code>myTest(5)</code> should return \"Small\"');",


### PR DESCRIPTION
Removed test case requiring only 5 'return' statements
be used in 'Waypoint: Chaining If Else Statements'

`npm run test-challenges` returned `Pass` also tested locally.

![image](https://cloud.githubusercontent.com/assets/1938039/12068859/6c0288e8-b03d-11e5-9d4a-1f14bdfcf7df.png)
