### PR TITLE
Fix typo in chaining if/else statements Waypoint

### DIFF
--- a/seed/challenges/01-front-end-development-certification/basic-javascript.json
+++ b/seed/challenges/01-front-end-development-certification/basic-javascript.json
@@ -2777,7 +2777,7 @@
       "title": "Chaining If Else Statements",
       "description": [
         "<code>if/else</code> statements can be chained together for complex logic. Here is <dfn>pseudocode</dfn> of multiple chained <code>if</code> / <code>else if</code> statements:",
-        "<blockquote>if(<em>condition1</em>) {<br>  <em>statement1</em><br>} else if (<em>condition1</em>) {<br>  <em>statement1</em><br>} else if (<em>condition3</em>) {<br>  <em>statement3</em><br>. . .<br>} else {<br>  <em>statementN</em><br>}</blockquote>",
+        "<blockquote>if(<em>condition1</em>) {<br>  <em>statement1</em><br>} else if (<em>condition2</em>) {<br>  <em>statement2</em><br>} else if (<em>condition3</em>) {<br>  <em>statement3</em><br>. . .<br>} else {<br>  <em>statementN</em><br>}</blockquote>",
         "<h4>Instructions</h4>",
         "Write chained <code>if</code>/<code>else if</code> statements to fulfill the following conditions:",
         "<code>num &lt;   5</code> - return \"Tiny\"<br><code>num &lt;  10</code> - return \"Small\"<br><code>num &lt; 15</code> - return \"Medium\"<br><code>num &lt; 20</code> - return \"Large\"<br><code>num >= 20</code>  - return \"Huge\""


### PR DESCRIPTION
This PR is to fix a typo in Waypoint: Chaining If/Else Statements.
The typo lies in the example shown below (note condition1/statement1 repeated twice): 

```
if(condition1) {
  statement1
} else if (condition1) {
  statement1
} else if (condition3) {
  statement3
. . .
} else {
  statementN
}
```

This was corrected to reflect proper condition/statement numbers (e.g. `condition2` & `statement2`).

closes #5663 
