### PR TITLE
Fix #5663 - Correct typo in challenge description

### DIFF
--- a/seed/challenges/01-front-end-development-certification/basic-javascript.json
+++ b/seed/challenges/01-front-end-development-certification/basic-javascript.json
@@ -2777,7 +2777,7 @@
       "title": "Chaining If Else Statements",
       "description": [
         "<code>if/else</code> statements can be chained together for complex logic. Here is <dfn>pseudocode</dfn> of multiple chained <code>if</code> / <code>else if</code> statements:",
-        "<blockquote>if(<em>condition1</em>) {<br>  <em>statement1</em><br>} else if (<em>condition1</em>) {<br>  <em>statement1</em><br>} else if (<em>condition3</em>) {<br>  <em>statement3</em><br>. . .<br>} else {<br>  <em>statementN</em><br>}</blockquote>",
+        "<blockquote>if(<em>condition1</em>) {<br>  <em>statement1</em><br>} else if (<em>condition2</em>) {<br>  <em>statement2</em><br>} else if (<em>condition3</em>) {<br>  <em>statement3</em><br>. . .<br>} else {<br>  <em>statementN</em><br>}</blockquote>",
         "<h4>Instructions</h4>",
         "Write chained <code>if</code>/<code>else if</code> statements to fulfill the following conditions:",
         "<code>num &lt;   5</code> - return \"Tiny\"<br><code>num &lt;  10</code> - return \"Small\"<br><code>num &lt; 15</code> - return \"Medium\"<br><code>num &lt; 20</code> - return \"Large\"<br><code>num >= 20</code>  - return \"Huge\""


### PR DESCRIPTION
Corrected typo error in the description of
'Waypoint: Chaining If Else Statements'

**Tests**:
`npm run test-challenges` returned `Pass` and also tested locally.

![image](https://cloud.githubusercontent.com/assets/1938039/12068923/18e7ff24-b03f-11e5-9825-02bf58402bf3.png)
