### PR TITLE
Fix Plus-Equals Concatenation Waypoint

### DIFF
--- a/seed/challenges/01-front-end-development-certification/basic-javascript.json
+++ b/seed/challenges/01-front-end-development-certification/basic-javascript.json
@@ -1005,7 +1005,7 @@
       ],
       "tests": [
         "assert(myStr === \"This is the first sentence. This is the second sentence.\", 'message: <code>myStr</code> should have a value of <code>This is the first sentence. This is the second sentence.</code>');",
-        "assert(code.match(/\\w\\s*\\+=\\s*\"/g).length > 1 && code.match(/\\w\\s*\\=\\s*\"/g).length > 1, 'message: Use the <code>+=</code> operator to build <code>myStr</code>');"
+        "assert(code.match(/\\w\\s*\\+=\\s*[\"']/g).length > 1 && code.match(/\\w\\s*\\=\\s*[\"']/g).length > 1, 'message: Use the <code>+=</code> operator to build <code>myStr</code>');"
       ],
       "type": "waypoint",
       "challengeType": "1",


### PR DESCRIPTION
The "Waypoint: Concatenating Strings with the Plus Equals Operator" expects students to use double-quotes and doesn't take into consideration single quotes.

Updated the test to take into account single quotes.

closes #5666 
