### PR TITLE
Fixes #5688 random space in challengeSeed of Storing Values

### DIFF
--- a/seed/challenges/01-front-end-development-certification/basic-javascript.json
+++ b/seed/challenges/01-front-end-development-certification/basic-javascript.json
@@ -117,7 +117,7 @@
         "var b = 2;",
         "",
         "// Only change code below this line",
-        " "
+        ""
       ],
       "tail": [
         "(function(a,b){return \"a = \" + a + \", b = \" + b;})(a,b);"


### PR DESCRIPTION
In the challengeSeed of Waypoint: Storing Values with the Equal Operator, there was a random space input after the line:

> "// Only change code below this line"
