### PR TITLE
Fixes loop protect triggering in comments

### DIFF
--- a/public/js/lib/loop-protect/loop-protect.js
+++ b/public/js/lib/loop-protect/loop-protect.js
@@ -50,13 +50,17 @@ if (typeof DEBUG === 'undefined') { DEBUG = true; }
     var openPos = -1;
 
     do {
-      j -= 1;
       DEBUG && debug('looking backwards ' + lines[j]); // jshint ignore:line
       closePos = lines[j].indexOf('*/');
       openPos = lines[j].indexOf('/*');
 
       if (closePos !== -1) {
         closeCommentTags++;
+      }
+
+      // check for single line /* comment */ formatted comments
+      if (closePos === lines[j].length - 2 && openPos !== -1) {
+        closeCommentTags--;
       }
 
       if (openPos !== -1) {
@@ -67,6 +71,7 @@ if (typeof DEBUG === 'undefined') { DEBUG = true; }
           return true;
         }
       }
+      j -= 1;
     } while (j !== 0);
 
     return false;


### PR DESCRIPTION
Closes #5341 
This is my attempt to fix loop-protect triggering in comment styled like 
`/* comment */`

this was occurring because loop protects function for checking multi-line comments ignores the line that the keyword, such as "for" was found on. I edited the function so that if an opening /\* and a closing */ were found on the same line. it will recognize that as a complete comment.

All tests are passing on my local machine. and the code in the issue now runs as expected

```
function palindrome(str) {

  //have to remove all non-alphanumeric characters - punctuation, spaces, symbols. Assume you have to use regular expressions for this. 
  var stripWord = str.replace(/\W|\s|_/g,'');

  //set all words to lowercase
  var palinWord = stripWord.toLowerCase(); 
  console.log(palinWord); 


    /* reverse palinWord for comparison*/
  var checkPalindrome = palinWord.split('').reverse().join('');
  console.log(checkPalindrome); 

   /* Check to see if str is a Palindrome */
   if (palinWord === checkPalindrome) {
     return true;
   } else {
     return false; 
   }



}



palindrome("A man, a plan, a canal. Panama");
```
