### PR TITLE
Fix Concatenating Strings with Plus Operator test

### DIFF
--- a/seed/challenges/01-front-end-development-certification/basic-javascript.json
+++ b/seed/challenges/01-front-end-development-certification/basic-javascript.json
@@ -987,7 +987,7 @@
       ],
       "tests": [
         "assert(myStr === \"This is the start. This is the end.\", 'message: <code>myStr</code> should have a value of <code>This is the start. This is the end.</code>');",
-        "assert(code.match(/This is the start\\.\\s*[\"']\\s*(.)\\s*[\"']This is the end\\.[\"'];\\s*$/)[1] === \"+\", 'message: Use the <code>+</code> operator to build <code>myStr</code>');"
+        "assert(/var\\s+myStr\\s*=\\s*([\"'])This is the start\\. \\1\\s*\\+\\s*([\"'])This is the end\\.\\2/.test(code), 'message: Use the <code>+</code> operator to build <code>myStr</code>');"
       ],
       "type": "waypoint",
       "challengeType": "1",


### PR DESCRIPTION
Fixed test case

``` js
// not working due to space before semicolon
var myStr = "This is the start. " + "This is the end." ;
```

Now it works even for this **TESTED OK**

``` js

var           

                            myStr     =            

    "This is the start. "



+ 




    'This is the end.'                  ;

```

> Reported by @Philosophist  :point_right: [FreeCodeCamp/FreeCodeCamp](https://gitter.im/FreeCodeCamp/FreeCodeCamp?at=56882f1435e1a316162f0ebb)
