### PR TITLE
Fix issues where bad user code hits the tail

### DIFF
--- a/client/commonFramework/end.js
+++ b/client/commonFramework/end.js
@@ -35,7 +35,7 @@ $(document).ready(function() {
       .flatMap(code => {
         return common.detectUnsafeCode$(code)
           .map(() => {
-            const combinedCode = common.head + code + common.tail;
+            const combinedCode = common.head + '\n;;' + code + '\n;;' + common.tail;
 
             return addLoopProtect(combinedCode);
           })

--- a/client/commonFramework/execute-challenge-stream.js
+++ b/client/commonFramework/execute-challenge-stream.js
@@ -18,7 +18,7 @@ window.common = (function(global) {
     const originalCode = code;
     const head = common.arrayToNewLineString(common.head);
     const tail = common.arrayToNewLineString(common.tail);
-    const combinedCode = head + code + tail;
+    const combinedCode = head + '\n;;' + code + '\n;;' + tail;
 
     ga('send', 'event', 'Challenge', 'ran-code', common.challengeName);
 


### PR DESCRIPTION
In some cases user code can be improperly terminated (or missing a semicolon) resulting on confusing errors.  Force the head and tail sections to be somewhat separated from the code section.  Same as what we're using for test-challenges.

Tested locally.
