### PR TITLE
Fix linting errors

### DIFF
--- a/client/commonFramework/update-preview.js
+++ b/client/commonFramework/update-preview.js
@@ -15,7 +15,8 @@ window.common = (function(global) {
     window.__err = new Error(
       'Potential infinite loop at line ' +
       line +
-      '. To disable loop protection, write: \\n\\/\\/ noprotect\\nas the first' +
+      '. To disable loop protection, write:' +
+      ' \\n\\/\\/ noprotect\\nas the first' +
       ' line. Beware that if you do have an infinite loop in your code' +
       ' this will crash your browser.'
     );

--- a/server/utils/date-utils.js
+++ b/server/utils/date-utils.js
@@ -4,8 +4,8 @@ import moment from 'moment';
 export function dayCount([head, tail]) {
   return Math.ceil(
     moment(moment(head).endOf('day')).diff(
-      moment(tail).startOf('day'), 
-      'days', 
+      moment(tail).startOf('day'),
+      'days',
       true)
     );
 }


### PR DESCRIPTION
Fixed linting errors: 

```
client\commonFramework\update-preview.js
  18:1  warning  Line 18 exceeds the maximum line length of 80  ma

server\utils\date-utils.js
  7:35  warning  Trailing spaces not allowed  no-trailing-spaces
  8:14  warning  Trailing spaces not allowed  no-trailing-spaces
```
