### PR TITLE
Add missing punctuation in hexadecimal waypoint

### DIFF
--- a/seed/challenges/01-front-end-development-certification/html5-and-css.json
+++ b/seed/challenges/01-front-end-development-certification/html5-and-css.json
@@ -3775,9 +3775,9 @@
       "title": "Use Hex Code for Specific Colors",
       "description": [
         "Did you know there are other ways to represent colors in CSS? One of these ways is called hexadecimal code, or <code>hex code</code> for short.",
-        "The word <code>Hexadecimal</code> can be broken down into the words <code>hexa</code> and <code>decimal</code>. You may be familiar with <code>decimal</code> being a number like 0.10 or 0.333. In CSS, <code>decimal</code> can be thought of as the numbers zero through nine, giving a total of ten numbers. The word <code>hexa</code>, as you might guess, means six. In CSS, this refers to the letters A, B, C, D, E, and F. Putting these together, each place value of a <code>hexadecimal</code> can be a number 0 to 9 or A through F, giving us a total of 16 possible values. You can find more information about hexadecimal numbers <a href=\"https://en.wikipedia.org/wiki/Hexadecimal\">here</a>",
+        "The word <code>Hexadecimal</code> can be broken down into the words <code>hexa</code> and <code>decimal</code>. You may be familiar with <code>decimal</code> being a number like 0.10 or 0.333. In CSS, <code>decimal</code> can be thought of as the numbers zero through nine, giving a total of ten numbers. The word <code>hexa</code>, as you might guess, means six. In CSS, this refers to the letters A, B, C, D, E, and F. Putting these together, each place value of a <code>hexadecimal</code> can be a number 0 to 9 or A through F, giving us a total of 16 possible values. You can find more information about hexadecimal numbers <a href=\"https://en.wikipedia.org/wiki/Hexadecimal\">here</a>.",
         "With CSS, we use 6 hexadecimal numbers to represent colors. For example, <code>#000000</code> is the lowest possible value, and it represents the color black.",
-        "Replace the word <code>black</code> in our <code>body</code> element's background-color with its <code>hex code</code> representation, <code>#000000</code> "
+        "Replace the word <code>black</code> in our <code>body</code> element's background-color with its <code>hex code</code> representation, <code>#000000</code>."
       ],
       "tests": [
         "assert($(\"body\").css(\"background-color\") === \"rgb(0, 0, 0)\", 'message: Give your <code>body</code> element the background-color of black.');",


### PR DESCRIPTION
I saw there was some missing punctuation (shown below) in the end of the last and second to last paragraph and decided to fix them.

![image](https://cloud.githubusercontent.com/assets/2754821/12080799/f0d71b26-b21b-11e5-882a-10a0f0cfe128.png)
