### PR TITLE
Improved regex to properly test "Do not change code below the line"

### DIFF
--- a/seed/challenges/01-front-end-development-certification/basic-javascript.json
+++ b/seed/challenges/01-front-end-development-certification/basic-javascript.json
@@ -208,7 +208,7 @@
         "assert(typeof a === 'number' && a === 6, 'message: <code>a</code> should be defined and have a value of <code>6</code>');",
         "assert(typeof b === 'number' && b === 15, 'message: <code>b</code> should be defined and have a value of <code>15</code>');",
         "assert(!/undefined/.test(c) && c === \"I am a String!\", 'message: <code>c</code> should not contain <code>undefined</code> and should have a value of \"I am a String!\"');",
-        "assert(/a = a \\+ 1;/.test(code) && /b = b \\+ 5;/.test(code) && /c = c \\+ \" String!\";/.test(code), 'message: Do not change code below the line');"
+        "assert(/\\/\\/ Do not change code below this line[\\n]\\s*[\\n]a = a \\+ 1;\\s*[\\n]b = b \\+ 5;\\s*[\\n]c = c \\+ \" String!\";(\\s*|\\n)$/.test(code), 'message: Do not change code below the line. Reset the code if this test fails!');"
       ],
       "type": "waypoint",
       "challengeType": "1",


### PR DESCRIPTION
The last test will now properly check to make sure the camper did not change any of the code below the line.  It allows for spaces and newlines as long as they are not in between the text/code below the line. 

Fixes #5875 

This will also work for code that should not be changed in other waypoints/bonfires if it is adjusted to reflect the text specific to that waypoint/bonfire.
