### PR TITLE
fixes no url supplied on successful story submission

### DIFF
--- a/server/views/stories/submit-story.jade
+++ b/server/views/stories/submit-story.jade
@@ -35,7 +35,7 @@
             .row
                 .form-group
 
-                    button.btn.btn-big.btn-block.btn-primary#story-submit(type='submit') Submit
+                    button.btn.btn-big.btn-block.btn-primary#story-submit(type='submit', onclick="return false;") Submit
     script.
       if (main.storyImage) {
         $('#image-display').removeClass('hidden-element');


### PR DESCRIPTION
I tested and looked through the code to understand why that flash message is popping up. 
I understand that even though the flash message is shown, the article is actually displayed in the list of news articles. i.e., successful submission.

There is a `GET` request to `stories/submit-story/new-story?<parameters>` twice on two consecutive screens. It works perfectly fine on first screen as expected. It is not supposed to fire on second page. I have submitted a PR that fixes this issue. Closes #5318 
