### PR TITLE
Update test for "Use Comments to Clarify Code"

### DIFF
--- a/seed/challenges/01-front-end-development-certification/bootstrap.json
+++ b/seed/challenges/01-front-end-development-certification/bootstrap.json
@@ -2256,7 +2256,7 @@
         "Add a comment at the top of your HTML that says <code>Only change code above this line.</code>"
       ],
       "tests": [
-        "assert(code.match(/^<!--/) && code.match(/^<!--/g).length > 0, 'message: Start a comment with <code>&#60;!--</code> at the top of your HTML.');",
+        "assert(code.match(/^\\s*<!--/), 'message: Start a comment with <code>&#60;!--</code> at the top of your HTML.');",
         "assert(code.match(/<!--(?!(>|->|.*-->.*this line)).*this line.*-->/gi), 'message: Your comment should have the text <code>Only change code above this line</code>.');",
         "assert(code.match(/-->.*\\n+.+/g), 'message: Be sure to close your comment with <code>--&#62;</code>.');",
         "assert(code.match(/<!--/g).length === code.match(/-->/g).length, 'message: You should have the same number of comment openers and closers.');"


### PR DESCRIPTION
Allow blank lines before comment for "Waypoint: Use Comments to Clarify Code" challenge.

closes #6019 
