### PR TITLE
Add Tests to Concat with Plus Waypoint

### DIFF
--- a/seed/challenges/01-front-end-development-certification/basic-javascript.json
+++ b/seed/challenges/01-front-end-development-certification/basic-javascript.json
@@ -920,7 +920,9 @@
       ],
       "tests": [
         "assert(myStr === \"This is the start. This is the end.\", 'message: <code>myStr</code> should have a value of <code>This is the start. This is the end.</code>');",
-        "assert(/var\\s+myStr\\s*=\\s*([\"'])This is the start\\. \\1\\s*\\+\\s*([\"'])This is the end\\.([\"'])/.test(code), 'message: Use the <code>+</code> operator to build <code>myStr</code>');"
+        "assert(code.match(/([\"']).*([\"'])\\s*\\+\\s*([\"']).*([\"'])/g).length > 1, 'message: Use the <code>+</code> operator to build <code>myStr</code>');",
+        "assert(/var\\s+myStr/.test(code), 'message: <code>myStr</code> should be created using the <code>var</code> keyword.');",
+        "assert(/myStr\\s*=/.test(code), 'message: Make sure to assign the result to the <code>myStr</code> variable.');"
       ],
       "type": "waypoint",
       "challengeType": 1


### PR DESCRIPTION
Closes #6028 

I added a few tests here as per @SaintPeter 's issue.

We would now be checking for any two strings being added together using the `+` operator,
a variable name `myStr` being equal to the combination of strings we want,
and that `myStr` is being created somewhere using `var myStr`.

Therefore the code 

```
var myStr;
myStr = "This is the start." + " This is the end.";
```

should now be valid.
