### PR TITLE
Fix Concatenating Strings with Plus Operator tests

### DIFF
--- a/seed/challenges/01-front-end-development-certification/basic-javascript.json
+++ b/seed/challenges/01-front-end-development-certification/basic-javascript.json
@@ -920,7 +920,8 @@
       ],
       "tests": [
         "assert(myStr === \"This is the start. This is the end.\", 'message: <code>myStr</code> should have a value of <code>This is the start. This is the end.</code>');",
-        "assert(/var\\s+myStr\\s*=\\s*([\"'])This is the start\\. \\1\\s*\\+\\s*([\"'])This is the end\\.([\"'])/.test(code), 'message: Use the <code>+</code> operator to build <code>myStr</code>');"
+        "assert(/([\"'])This is the start\\. \\1\\s*\\+\\s*([\"'])This is the end\\.([\"'])/.test(code), 'message: Use the <code>+</code> operator to build <code>myStr</code>');",
+        "assert(/myStr\\s*\\=\\s*([\"'])This is the start\\. \\1\\s*\\+\\s*([\"'])This is the end\\.([\"'])/.test(code),'message: The string should be assigned to <code>myStr</code>');"
       ],
       "type": "waypoint",
       "challengeType": 1


### PR DESCRIPTION
According to @SaintPeter's [comment](https://github.com/FreeCodeCamp/FreeCodeCamp/issues/6028), the tests for "Concatenating Strings with Plus Operator" have been updated to check:
1. If the `+` operator was used to concatenate the two strings, regardless of quotes used (double vs single quotes)
2. If the string has been assigned to `myStr` variable, regardless whether it was assigned on the same line as the declaration (e.g. `var myStr = ...`) or on a separate line (e.g. `var myStr; myStr = ...`)

Closes #6028 
