### PR TITLE
Fixes the example text for Waypoint: Assignment with a Returned Value

### DIFF
--- a/seed/challenges/01-front-end-development-certification/basic-javascript.json
+++ b/seed/challenges/01-front-end-development-certification/basic-javascript.json
@@ -2008,7 +2008,7 @@
       "description": [
         "If you'll recall from our discussion of <a href=\"waypoint-storing-values-with-the-equal-operator\" target=\"_blank\">Storing Values with the Equal Operator</a>, everything to the right of the equal sign is resolved before the value is assigned. This means we can take the return value of a function and assign it to a variable.",
         "Assume we have pre-defined a function <code>sum</code> which adds two numbers together, then: ",
-        "<code>var ourSum = sum(5, 12);</code>",
+        "<code>ourSum = sum(5, 12);</code>",
         "will call <code>sum</code> function, which returns a value of <code>17</code> and assigns it to <code>ourSum</code> variable.",
         "<h4>Instructions</h4>",
         "Call the <code>process</code> function with an argument of <code>7</code> and assign its return value to the variable <code>processed</code>."


### PR DESCRIPTION
closes #6062 

Changed the example to as in the discussion:
`ourSum = sum(5, 12);`

Tested locally.
