### PR TITLE
Improve Challenge Link Readability

### DIFF
--- a/client/less/challenge.less
+++ b/client/less/challenge.less
@@ -1,5 +1,5 @@
 .bonfire-instructions h4 {
-  margin-bottom: 0px;
+  margin-bottom: 0;
 }
 
 .bonfire-instructions blockquote {
@@ -22,3 +22,15 @@
   background-color: @code-bg;
   border-radius: @border-radius-base;
 }
+
+.bonfire-instructions a, #MDN-links a {
+  color: #31708f;
+}
+
+.bonfire-instructions a::after, #MDN-links a::after {
+  font-size: 70%;
+  font-family: FontAwesome;
+  content: " \f08e";
+}
+
+


### PR DESCRIPTION
Closes #6018

As per the above, and my personal observations, the green color of links is very hard to read in context, so I've tried changing them to slate blue and making them bold:
![image](https://cloud.githubusercontent.com/assets/553494/12272192/f0f31bc4-b913-11e5-8cea-68cd56cfd0f7.png)

This does make all links in the instructions bold and blue:
![image](https://cloud.githubusercontent.com/assets/553494/12272207/0070e7c0-b914-11e5-9fbf-a3d62ecc2c23.png)

@FreeCodeCamp/issue-moderators and @QuincyLarson - what do you think?
