### PR TITLE
Fix bug on Waypoint: Iterate Through an Array with a For Loop

### DIFF
--- a/seed/challenges/01-front-end-development-certification/basic-javascript.json
+++ b/seed/challenges/01-front-end-development-certification/basic-javascript.json
@@ -3875,7 +3875,7 @@
         ""
       ],
       "tail": [
-        "(function(t) { if(typeof t !== 'undefined') { return \"Total = \" + t; } else { return \"Total is undefined\";}})(total);"
+        "(function(){if(typeof total !== 'undefined') { return \"total = \" + total; } else { return \"total is undefined\";}})()"
       ],
       "solutions": [
         "var myArr = [ 2, 3, 4, 5, 6];\nvar total = 0;\n\nfor (var i = 0; i < myArr.length; i++) {\n  total += myArr[i];\n}"


### PR DESCRIPTION
Conditions needed to pass the tests weren't showing. Problem was that the variable `total` was passed before it could be defined. Rewrote tail to fix as per @SaintPeter's suggestion.
closes #6137
