### PR TITLE
Fixes incorrect redirection to map-aside

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -178,7 +178,11 @@ module.exports = function(User) {
       debug('user logged in');
 
       if (req.session && req.session.returnTo) {
-        return res.redirect(req.session.returnTo);
+        var redirectTo = req.session.returnTo;
+        if (redirectTo === '/map-aside') {
+          redirectTo = '/map';
+        }
+        return res.redirect(redirectTo);
       }
 
       req.flash('success', { msg: 'Success! You are logged in.' });

--- a/server/middlewares/add-return-to.js
+++ b/server/middlewares/add-return-to.js
@@ -36,7 +36,8 @@ export default function addReturnToUrl() {
     ) {
       return next();
     }
-    req.session.returnTo = req.originalUrl;
+    req.session.returnTo = req.originalUrl === '/map-aside'
+    ? '/map' : req.originalUrl;
     next();
   };
 }


### PR DESCRIPTION
Closes #6230. Tested locally.
This was an interesting issue. I've tried to reproduce and here is what I've got in my console:
![](http://i.imgur.com/PhrD1r0.png)
Here you can see that I'm redirected to the last place I've been, which is `/map-aside` (but `/map-aside` actually isn't where we want to be redirected). Then I searched `freecc:user:remote` in the entire codebase and one of the matches was in `common/models/user.js`. Then I searched `user logged in` and [found this](https://github.com/FreeCodeCamp/FreeCodeCamp/blob/staging/common/models/user.js#L175-L187):

``` js
return req.logIn({ id: accessToken.userId.toString() }, function(err) {
  if (err) { return next(err); }

  debug('user logged in');

  if (req.session && req.session.returnTo) {
    return res.redirect(req.session.returnTo);
  }

  req.flash('success', { msg: 'Success! You are logged in.' });
  return res.redirect('/');
});
```

As you can see here we're getting redirected to `req.session.returnTo`. By using `debug` funcs I've found out that:
![](http://i.imgur.com/PZRPbKT.png)
 `req.session.returnTo` actually is `/map-aside` and that is why I was redirected to `/map-aside`.

**UPD.**
Made a similar fix in [`server/middlewares/add-return-to.js`](https://github.com/FreeCodeCamp/FreeCodeCamp/blob/staging/server/middlewares/add-return-to.js#L39) so now this works not only for email login but for GitHub login too.
