### PR TITLE
Fix HTML Challenge Display for blockquote, h4, and table

### DIFF
--- a/server/views/challenges/showHTML.jade
+++ b/server/views/challenges/showHTML.jade
@@ -17,7 +17,10 @@ block content
                             hr
                             .bonfire-instructions
                                 for sentence in description
-                                    p.wrappable!= sentence
+                                    if (/blockquote|h4|table/.test(sentence))
+                                        !=sentence
+                                    else
+                                        p.wrappable!= sentence
                                 .negative-bottom-margin-30
                     .button-spacer
                     .btn-big.btn.btn-primary.btn-block#submitButton


### PR DESCRIPTION
Apply the same exceptions to `p` wrapping in the `showHTML.jade` that exist in the `showJS` and `showBonfire` sections.

Tested locally.
