### PR TITLE
Remove preceding space to section headings in map

### DIFF
--- a/server/views/map/show.jade
+++ b/server/views/map/show.jade
@@ -21,8 +21,6 @@ block content
                           i.fa.fa-caret-down
                           | &thinsp;
                           a(data-toggle='collapse', data-parent='#nested', href='#nested-collapse'+challengeBlock.name.replace(/(\W)/gi, '').split(' ').join('-'))
-
-                            | &thinsp;
                             | #{challengeBlock.name} (#{challengeBlock.time})
                         div.margin-left-10(id = "nested-collapse"+challengeBlock.name.replace(/\W/gi, '').split(' ').join('-') class = "collapse in map-collapse no-transition")
                             .button-spacer


### PR DESCRIPTION
Closes #6268. Tested locally.
