### PR TITLE
Clarification in telephone-number advanced bonfire

### DIFF
--- a/seed/challenges/01-front-end-development-certification/advanced-bonfires.json
+++ b/seed/challenges/01-front-end-development-certification/advanced-bonfires.json
@@ -9,7 +9,7 @@
       "title": "Validate US Telephone Numbers",
       "description": [
         "Return true if the passed string is a valid US phone number",
-        "The user may fill out the form field any way they choose as long as it is a valid US number. The following are all valid formats for US numbers:",
+        "The user may fill out the form field any way they choose as long as it is a valid US number. The following are examples of valid formats for US numbers (refer to the tests below for other variants):",
         "<code>555-555-5555</code>",
         "<code>(555)555-5555</code>",
         "<code>(555) 555-5555</code>",


### PR DESCRIPTION
Changed language immediately prior to telephone number formats, to better indicate that they're examples and not a complete set of tested formats.
