### PR TITLE
Fix validation for "Fill in the Blank with Placeholder Text"

### DIFF
--- a/seed/challenges/01-front-end-development-certification/html5-and-css.json
+++ b/seed/challenges/01-front-end-development-certification/html5-and-css.json
@@ -215,7 +215,7 @@
         "<p>Hello Paragraph</p>"
       ],
       "tests": [
-        "assert.isTrue((/Kitty(\\s)+ipsum(\\s)+dolor/gi).test($(\"p\").text()), 'message: Your <code>p</code> element should contain the first few words of the provided <code>kitty ipsum text</code>.');"
+        "assert.isTrue((/Kitty(\\s)+ipsum/gi).test($(\"p\").text()), 'message: Your <code>p</code> element should contain the first few words of the provided <code>kitty ipsum text</code>.');"
       ],
       "type": "waypoint",
       "challengeType": 0,


### PR DESCRIPTION
The validation should accept the first 2 words if we're going to request "the first few words". The 3rd word shouldn't be required.

Closes #6299.
