### PR TITLE
Add last updated date to profile algos/challenges

### DIFF
--- a/server/views/account/show.jade
+++ b/server/views/account/show.jade
@@ -143,14 +143,16 @@ block content
                       table.table.table-striped
                           thead
                               tr
-                                  th.col-xs-6 Algorithms
-                                  th.col-xs-3.hidden-xs Completed
-                                  th.col-xs-3.hidden-xs Solution
+                                  th.col-xs-5 Algorithms
+                                  th.col-xs-2.hidden-xs Completed
+                                  th.col-xs-2.hidden-xs Last Updated
+                                  th.col-xs-2.hidden-xs Solution
                           for challenge in algos
                               tr
-                                  td.col-xs-6.hidden-xs= removeOldTerms(challenge.name)
-                                  td.col-xs-3.hidden-xs= challenge.completedDate ?moment(challenge.completedDate, 'x').format("MMM DD, YYYY") : 'Not Available'
-                                  td.col-xs-3.hidden-xs
+                                  td.col-xs-5.hidden-xs= removeOldTerms(challenge.name)
+                                  td.col-xs-2.hidden-xs= challenge.completedDate ? moment(challenge.completedDate, 'x').format("MMM DD, YYYY") : 'Not Available'
+                                  td.col-xs-2.hidden-xs= challenge.lastUpdated ? moment(challenge.lastUpdated, 'x').format("MMM DD, YYYY") : ''
+                                  td.col-xs-2.hidden-xs
                                     if (challenge.solution)
                                         a(href='/challenges/' + removeOldTerms(challenge.name) + '?solution=' + encodeURIComponent(encodeFcc(challenge.solution)), target='_blank') View my solution
                                     else
@@ -165,14 +167,16 @@ block content
                       table.table.table-striped
                           thead
                               tr
-                                  th.col-xs-6 Challenges
-                                  th.col-xs-3.hidden-xs Completed
-                                  th.col-xs-3.hidden-xs Solution
+                                  th.col-xs-5 Challenges
+                                  th.col-xs-2.hidden-xs Completed
+                                  th.col-xs-2.hidden-xs Last Updated
+                                  th.col-xs-2.hidden-xs Solution
                           for challenge in challenges
                               tr
-                                  td.col-xs-6.hidden-xs= removeOldTerms(challenge.name)
-                                  td.col-xs-3.hidden-xs= challenge.completedDate ?moment(challenge.completedDate, 'x').format("MMM DD, YYYY") : 'Not Available'
-                                  td.col-xs-3.hidden-xs
+                                  td.col-xs-5.hidden-xs= removeOldTerms(challenge.name)
+                                  td.col-xs-2.hidden-xs= challenge.completedDate ?moment(challenge.completedDate, 'x').format("MMM DD, YYYY") : 'Not Available'
+                                  td.col-xs-2.hidden-xs= challenge.lastUpdated ? moment(challenge.lastUpdated, 'x').format("MMM DD, YYYY") : ''
+                                  td.col-xs-2.hidden-xs
                                     if (challenge.solution)
                                         a(href='/challenges/' + removeOldTerms(challenge.name) + '?solution=' + encodeURIComponent(encodeFcc(challenge.solution)), target='_blank') View my solution
                                     else


### PR DESCRIPTION
For a couple of months now we disabled the ability to save multiple solutions and moved to overwriting old solutions with new ones and storing a lastUpdate field.

This PR displays that so it is obvious that old solution is being overwritten.

![camper_berkeleytrue_s_code_portfolio___free_code_camp](https://cloud.githubusercontent.com/assets/6775919/12413020/7c650aa6-be40-11e5-9178-e63fe65d4917.png)

closes #6228
