### PR TITLE
Fix zipline/basejump completed endpoint

### DIFF
--- a/client/commonFramework/bindings.js
+++ b/client/commonFramework/bindings.js
@@ -74,14 +74,14 @@ window.common = (function(global) {
       $('#next-courseware-button').unbind('click');
       if ($('.signup-btn-nav').length < 1) {
         var data;
-        var completedWith = $('#completed-with').val() || null;
-        var publicURL = $('#public-url').val() || null;
-        var githubURL = $('#github-url').val() || null;
+        var solution = $('#public-url').val() || null;
+        var githubLink = $('#github-url').val() || null;
         switch (common.challengeType) {
           case common.challengeTypes.VIDEO:
             data = {
               id: common.challengeId,
-              name: common.challengeName
+              name: common.challengeName,
+              challengeType: common.challengeType
             };
             $.post('/completed-challenge/', data)
               .success(function(res) {
@@ -99,15 +99,11 @@ window.common = (function(global) {
           case common.challengeTypes.BASEJUMP:
           case common.challengeTypes.ZIPLINE:
             data = {
-              challengeInfo: {
-                challengeId: common.challengeId,
-                challengeName: common.challengeName,
-                completedWith: completedWith,
-                publicURL: publicURL,
-                githubURL: githubURL,
-                challengeType: common.challengeType,
-                verified: false
-              }
+              id: common.challengeId,
+              name: common.challengeName,
+              challengeType: +common.challengeType,
+              solution,
+              githubLink
             };
 
             $.post('/completed-zipline-or-basejump/', data)

--- a/server/views/account/show.jade
+++ b/server/views/account/show.jade
@@ -126,15 +126,17 @@ block content
                       table.table.table-striped
                           thead
                               tr
-                                  th.col-xs-6 Projects
-                                  th.col-xs-3.hidden-xs Completed
-                                  th.col-xs-3.hidden-xs Link
+                                  th.col-xs-5 Projects
+                                  th.col-xs-2.hidden-xs Completed
+                                  th.col-xs-2.hidden-xs Last Updated
+                                  th.col-xs-2.hidden-xs Link
                           for challenge in projects
                               tr
-                                  td.col-xs-4.hidden-xs
+                                  td.col-xs-5.hidden-xs
                                       a(href='/challenges/' + removeOldTerms(challenge.name), target='_blank')= removeOldTerms(challenge.name)
                                   td.col-xs-2.hidden-xs= challenge.completedDate ? moment(challenge.completedDate, 'x').format("MMM DD, YYYY") : 'Not Available'
-                                  td.col-xs-6.hidden-xs
+                                  td.col-xs-2.hidden-xs= challenge.lastUpdated ? moment(challenge.lastUpdated, 'x').format("MMM DD, YYYY") : ''
+                                  td.col-xs-2.hidden-xs
                                       a(href=challenge.solution, target='_blank') View my project
                                   td.col-xs-12.visible-xs
                                       a(href=challenge.solution, target='_blank')= removeOldTerms(challenge.name)


### PR DESCRIPTION
This PR refactors and normalizes the endpoint and the ajax request.
Some weird bug keeps popping up on the server, but keymetrics has
decided to take a crap and not actually report back with the error
I don't know what exactly is causing it.

Normally I don't like fixing something I can't see, but I'm getting
a constant flood of emails because of some obscure bug here.

We removed the `completedWith` functionality a while back so that
was removed from this endpoint and the ajax call.

To test, verify that you can complete both a zipline/basejump.

Also show last updated date since it is possible a user might want
to update links
