### PR TITLE
Change babel/register to babel-register

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "babel-core": "^6.3.26",
     "babel-eslint": "^4.1.4",
     "babel-loader": "^6.2.1",
+    "babel-register": "^6.3.0",
     "babel-plugin-add-module-exports": "^0.1.2",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",

--- a/seed/index.js
+++ b/seed/index.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-process-exit */
-require('babel/register');
+require('babel-register');
 require('dotenv').load();
 
 var Rx = require('rx'),

--- a/server/debug-entry.js
+++ b/server/debug-entry.js
@@ -1,5 +1,5 @@
 // use this file with runners like node-debug
 // or mocha.
-require('babel/register');
+require('babel-register');
 var app = require('./server');
 app.start();

--- a/server/production-start.js
+++ b/server/production-start.js
@@ -1,5 +1,5 @@
 // this ensures node understands the future
-require('babel/register');
+require('babel-register');
 
 var startTime = Date.now();
 var timeoutHandler;


### PR DESCRIPTION
Looks like the absolute newest version of babel removes `babel/register` and puts it into it's own module.

Closes #6336
