### PR TITLE
Fix Navbar elements

### DIFF
--- a/client/less/main.less
+++ b/client/less/main.less
@@ -279,7 +279,7 @@ ul {
 
 .navbar-right {
   @media (min-width: 767px) {
-    padding-right: 50px;
+    margin-right:0;
   }
   @media (max-width: 991px) and (min-width: 768px) {
     position: absolute;
@@ -299,6 +299,8 @@ ul {
     padding-right: 30px;
   }
 }
+
+li.avatar, li.avatar > a { padding:0; margin:0 }
 
 .thin-progress-bar {
   height: 8px;

--- a/server/views/partials/navbar.jade
+++ b/server/views/partials/navbar.jade
@@ -29,6 +29,6 @@ nav.navbar.navbar-default.navbar-fixed-top.nav-height
             else
                 li.brownie-points-nav
                   a(href='/' + user.username) [&thinsp;#{user.progressTimestamps.length}&thinsp;]
-                .hidden-xs.hidden-sm
-                    a(href='/' + user.username)
+                li.hidden-xs.hidden-sm.avatar
+                  a(href='/' + user.username) 
                         img.profile-picture.float-right(src='#{user.picture}')


### PR DESCRIPTION
Noticed there was an invalid `div` instead of `li`.
Then remade the css to make it fit the same way it was as a div.

(plus a bit of alignment tweaking to the right of that avatar image)
