### PR TITLE
Return Programming Videos to order 0.05

### DIFF
--- a/seed/challenges/hikes/programming.json
+++ b/seed/challenges/hikes/programming.json
@@ -1,6 +1,6 @@
 {
   "name": "Programming",
-  "order": 0,
+  "order": 0.05,
   "time": "3 hours",
   "challenges": [
     {


### PR DESCRIPTION
Fixes an error that COM1000 introduced which changed floating point order numbers to integers.

Fixes display order of hikes.

Tested locally.
