### PR TITLE
Keyboard shortcuts to open/close map and chat

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,7 @@
     "rxjs": "~4.0.6",
     "CodeMirror": "~5.8.0",
     "chai": "~3.4.1",
-    "clipboard": "~1.5.5"
+    "clipboard": "~1.5.5",
+    "mousetrap": "~1.5.3"
   }
 }

--- a/client/main.js
+++ b/client/main.js
@@ -95,10 +95,26 @@ main = (function(main) {
     });
 
 
-    $('#nav-chat-btn').on('click', function() {
-      if (!main.chat.isOpen) {
+    $('#nav-chat-btn').on('click', showMainChat);
 
+    function showMainChat() {
+      if (!main.chat.isOpen) {
         main.chat.mainChat.toggleChat(true);
+      }
+    }
+
+    function collapseMainChat() {
+      $('#chat-embed-main').addClass('is-collapsed');
+    }
+
+    // keyboard shortcuts: open main chat
+    Mousetrap.bind('g c', function() {
+      var isCollapsed = $('#chat-embed-main').hasClass('is-collapsed');
+
+      if (isCollapsed) {
+        showMainChat();
+      } else {
+        collapseMainChat();
       }
     });
   });
@@ -287,7 +303,11 @@ $(document).ready(function() {
   }
 
   // map
-  $('#nav-map-btn').on('click', () => {
+  $('#nav-map-btn').on('click', showMap);
+
+  $('.map-aside-action-collapse').on('click', collapseMap);
+
+  function showMap() {
     if (!main.isMapAsideLoad) {
       var mapAside = $('<iframe>');
       mapAside.attr('src', '/map-aside');
@@ -295,11 +315,11 @@ $(document).ready(function() {
       main.isMapAsideLoad = true;
     }
     $('.map-aside').removeClass('is-collapsed');
-  });
+  }
 
-  $('.map-aside-action-collapse').on('click', () => {
+  function collapseMap() {
     $('.map-aside').addClass('is-collapsed');
-  });
+  }
 
   $('#accordion').on('show.bs.collapse', function(e) {
       $(e.target)
@@ -362,6 +382,17 @@ $(document).ready(function() {
       });
       $('#showAll').text('Expand all challenges');
       return $('#showAll').removeClass('active');
+    }
+  });
+
+  // keyboard shortcuts: open map
+  Mousetrap.bind('g m', function() {
+    var isCollapsed = $('.map-aside').hasClass('is-collapsed');
+
+    if (isCollapsed) {
+      showMap();
+    } else {
+      collapseMap();
     }
   });
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -99,6 +99,7 @@ var paths = {
     'public/bower_components/bootstrap/dist/js/bootstrap.min.js',
     'public/bower_components/d3/d3.min.js',
     'public/bower_components/moment/min/moment.min.js',
+    'public/bower_components/mousetrap/mousetrap.min.js',
     'public/bower_components/lightbox2/dist/js/lightbox.min.js',
     'public/bower_components/rxjs/dist/rx.all.min.js'
   ],


### PR DESCRIPTION
I have considered writing key capture logic from scratch, but given how minimal is Mousetrap (2k gzipped and minified) I thought it would be best to use an existing, well-tested tool for this. Perhaps the biggest advantage is cross-browser compatibility.

<kbd>g</kbd> + <kbd>c</kbd> = open chat.
<kbd>g</kbd> + <kbd>m</kbd> = open map.

Fixes https://github.com/FreeCodeCamp/FreeCodeCamp/issues/6379.

![untitled_gif_01-24-16](https://cloud.githubusercontent.com/assets/544954/12539133/ba9f05c4-c2b9-11e5-86ed-08cbae783cee.gif)
