### PR TITLE
Fix the instruction text in the Accessing Nested objects challenge

### DIFF
--- a/seed/challenges/01-front-end-development-certification/basic-javascript.json
+++ b/seed/challenges/01-front-end-development-certification/basic-javascript.json
@@ -3562,7 +3562,7 @@
         "Here is a nested JSON Object:",
         "<blockquote>var ourStorage = {<br>  \"desk\": {<br>    \"drawer\": \"stapler\"<br>  },<br>  \"cabinet\": {<br>    \"top drawer\": { <br>      \"folder1\": \"a file\",<br>      \"folder2\": \"secrets\"<br>    },<br>    \"bottom drawer\": \"soda\"<br>  }<br>}<br>ourStorage.cabinet[\"top drawer\"].folder2;  // \"secrets\"<br>ourStorage.desk.drawer; // \"stapler\"</blockquote>",
         "<h4>Instructions</h4>",
-        "Access the <code>myStorage</code> JSON object to retrieve the contents of the <code>glove box</code>. Only use object notation for properties with a space in their name."
+        "Access the <code>myStorage</code> JSON object to retrieve the contents of the <code>glove box</code>. Use bracket notation for properties with a space in their name."
       ],
       "releasedOn": "January 1, 2016",
       "challengeSeed": [


### PR DESCRIPTION
This commit fixes the instruction text in the challenge to
`Use bracket notation for properties with a space in their name.`
from
`Only use object notation for properties with a space in their name.`
I have removed the extra `Only` on purpose for sake of grammar.

closes #6422
