### PR TITLE
Change space in population table

### DIFF
--- a/client/less/main.less
+++ b/client/less/main.less
@@ -763,8 +763,27 @@ iframe.iphone {
 }
 
 .population-table {
+  font-size:30px;
+  width:460px;
+  margin:0 auto;
+  padding:0;
+  h2 {
+    margin:0;
+    text-align: left;
+  }
+  .tag {
+      width:165px;
+      display:inline-block;
+  }
+  .text-primary {
+      margin-right:5px;
+  }
   @media (max-width: 767px) {
     font-size: 16px;
+    width: 260px;
+    .tag {
+      width:95px;
+    }
   }
 }
 

--- a/server/views/resources/about.jade
+++ b/server/views/resources/about.jade
@@ -6,25 +6,22 @@ block content
             | who learn to code and help nonprofits.
         .spacer
         .row
-            .col-xs-12.col-sm-10.col-sm-offset-1.col-md-6.col-md-offset-3
-                h2
-                    table.population-table.img-center
-                        tr
-                            td Established:&thinsp;
-                            td
-                                span.text-primary #{daysRunning}&thinsp;
-                                | days ago
-                        tr
-                            td Population:&thinsp;&thinsp;&thinsp;
-                            td
-                                span.text-primary #{camperCount}&thinsp;
-                                | campers
-                        tr
-                            td Completed:&thinsp;&thinsp;&thinsp;
-                            td
-                                span.text-primary #{globalCompletedCount}&thinsp;
-                                | challenges
-
+            .col-xs-12.col-sm-10.col-sm-offset-1.col-md-6.col-md-offset-3                                
+                ul.population-table
+                    li 
+                        span.tag Established:&#9;
+                        span.text-primary #{daysRunning}
+                        | days ago
+                    li 
+                        span.tag Population:&#9;
+                        span.text-primary #{camperCount}
+                        | campers
+                    li
+                        span.tag Completed:&#9;
+                        span.text-primary #{globalCompletedCount}
+                        | challenges
+                        
+        .spacer
         .row
             .col-xs-12.col-sm-10.col-sm-offset-1.col-md-6.col-md-offset-3
                 h2 Free Code Camp around the web:


### PR DESCRIPTION
From a `<table>` inside a single `<h2>` and spacing based on html encoded stuff, to an `<ul>` with light CSS styling... For the sake of _a11y_ and modern html element usage and standards.

Also tweaked around some spacing issues to improve legibility.
## <img width="804" alt="screen shot 2016-01-28 at 12 27 00" src="https://cloud.githubusercontent.com/assets/2107110/12652811/a5f4d2bc-c5ba-11e5-8c99-f8859c4582bb.png">

More cleanup changes for the rest of the page to come in next PR, if approved/requested

.
