### PR TITLE
fix issue with map formatting by adding a small vertical space

### DIFF
--- a/server/views/map/show.jade
+++ b/server/views/map/show.jade
@@ -6,6 +6,7 @@ block content
                 button.center-block.btn.btn-sm.btn-block.btn-primary.active#manipAll Show incomplete challenges
                 button.center-block.btn.btn-sm.btn-block.btn-primary.active#showAll Collapse all
             hr
+        .spacer
         #accordion.map-accordion
           for superBlock, index in superBlocks
               h2


### PR DESCRIPTION
I didn't notice when I was QA'ing @hallaathrad's final map formatting pull request. 
I've fixed this issue by adding a small vertical space in the right place. 
@BerkeleyTrue Please QA and merge this before we do our next deploy.

Closes #6564
