### PR TITLE
Change the label text from "View my solution" to "View solution"

### DIFF
--- a/server/views/account/show.jade
+++ b/server/views/account/show.jade
@@ -156,7 +156,7 @@ block content
                                   td.col-xs-2.hidden-xs= challenge.lastUpdated ? moment(challenge.lastUpdated, 'x').format("MMM DD, YYYY") : ''
                                   td.col-xs-2.hidden-xs
                                     if (challenge.solution)
-                                        a(href='/challenges/' + removeOldTerms(challenge.name) + '?solution=' + encodeURIComponent(encodeFcc(challenge.solution)), target='_blank') View my solution
+                                        a(href='/challenges/' + removeOldTerms(challenge.name) + '?solution=' + encodeURIComponent(encodeFcc(challenge.solution)), target='_blank') View solution
                                     else
                                         a(href='/challenges/' + removeOldTerms(challenge.name)) View this challenge
                                   td.col-xs-12.visible-xs
@@ -180,7 +180,7 @@ block content
                                   td.col-xs-2.hidden-xs= challenge.lastUpdated ? moment(challenge.lastUpdated, 'x').format("MMM DD, YYYY") : ''
                                   td.col-xs-2.hidden-xs
                                     if (challenge.solution)
-                                        a(href='/challenges/' + removeOldTerms(challenge.name) + '?solution=' + encodeURIComponent(encodeFcc(challenge.solution)), target='_blank') View my solution
+                                        a(href='/challenges/' + removeOldTerms(challenge.name) + '?solution=' + encodeURIComponent(encodeFcc(challenge.solution)), target='_blank') View solution
                                     else
                                         a(href='/challenges/' + removeOldTerms(challenge.name)) View this challenge
                                   td.col-xs-12.visible-xs


### PR DESCRIPTION
This commit changes the text of the label from "View my solution" to
"View solution".

As disscussed in the issue, campers visiting profile pages of others,
saw "View my solution" and found this confusing.

Removing the "my" from the text makes it generic, to either user's own
page or other's pages.

Tested locally.

Closes #6598 
