### PR TITLE
Fix imperative wording for starring the repo

### DIFF
--- a/seed/challenges/00-getting-started/getting-started.json
+++ b/seed/challenges/00-getting-started/getting-started.json
@@ -162,7 +162,7 @@
         [
           "http://i.imgur.com/pYk0wOk.gif",
           "A gif showing how you can star a GitHub repo.",
-          "Go to Free Code Camp's open-source repository and \"star\" it. \"Starring\" is the GitHub equivalent of \"liking\" something.",
+          "If you want, you can go to Free Code Camp's open-source repository and \"star\" it. \"Starring\" is the GitHub equivalent of \"liking\" something.",
           "https://github.com/freecodecamp/freecodecamp"
         ],
         [
@@ -223,7 +223,7 @@
         [
           "http://i.imgur.com/pYk0wOk.gif",
           "Un gif mostrandote como puedes dar una estrella a un repositorio de GitHub.",
-          "Ve al repositorio de código libre de Free Code Camp y dale una \"estrella\". Las \"estrellas\" son el equivalente en GitHub de los \"me gusta\".",
+          "Si quieres, ve al repositorio de código libre de Free Code Camp y dale una \"estrella\". Las \"estrellas\" son el equivalente en GitHub de los \"me gusta\".",
           "https://github.com/freecodecamp/freecodecamp"
         ],
         [


### PR DESCRIPTION
Hi :wave:! First of, thanks for this amazing job, keep it up!

I've changed the texts of the getting started challenge for the github :star: step.
This way, people now really understand that they're not forced to do so to go to the next step, but it's only a way to support the community.

I would have preferred that clicking the link would be also optional and that the next button was not disabled, but this may add a bit of logic, so I dunno what you think about that.

Thanks!
