### PR TITLE
fixed white spacing for Basejump and similar pages

### DIFF
--- a/server/views/challenges/showVideo.jade
+++ b/server/views/challenges/showVideo.jade
@@ -7,9 +7,9 @@ block content
             ol
                 for step, index in description
                     .row.checklist-element(id="#{dashedName + index}")
-                        .col-xs-3.col-sm-1.col-md-2.padded-ionic-icon.text-center
+                        .col-xs-2.col-sm-1.col-md-2.padded-ionic-icon.text-right
                             input(type='checkbox' class='challenge-list-checkbox')
-                        .col-xs-9.col-sm-11.col-md-10
+                        .col-xs-10.col-sm-11.col-md-10
                             li.step-text.wrappable!= step
         .col-xs-12.col-sm-12.col-md-8
             .embed-responsive.embed-responsive-16by9

--- a/server/views/challenges/showZiplineOrBasejump.jade
+++ b/server/views/challenges/showZiplineOrBasejump.jade
@@ -1,15 +1,15 @@
 extends ../layout-wide
 block content
     .row
-        .col-md-4.bonfire-top
+        .col-md-4
             h4.text-center= name
             hr
             ol
                 for step, index in description
                     .row.checklist-element(id="#{dashedName + index}")
-                        .col-xs-3.col-sm-1.col-md-2.padded-ionic-icon.text-center
+                        .col-xs-2.col-sm-1.col-md-2.padded-ionic-icon.text-right
                             input(type='checkbox' class='challenge-list-checkbox')
-                        .col-xs-9.col-sm-11.col-md-10
+                        .col-xs-10.col-sm-11.col-md-10
                             li.step-text.wrappable!= step
         .col-xs-12.col-sm-12.col-md-8
             .embed-responsive.embed-responsive-16by9


### PR DESCRIPTION
there were very wide blank spaces between the checklists and text when the page size was < 760px, also found and fixed the misplaced titles in Basejump pages for Firefox when page size < 760px
closes #5347
