### PR TITLE
Fix test for Iterate Through an Array with a For Loop

### DIFF
--- a/seed/challenges/01-front-end-development-certification/basic-javascript.json
+++ b/seed/challenges/01-front-end-development-certification/basic-javascript.json
@@ -4165,12 +4165,12 @@
         "(function(){if(typeof total !== 'undefined') { return \"total = \" + total; } else { return \"total is undefined\";}})()"
       ],
       "solutions": [
-        "var myArr = [ 2, 3, 4, 5, 6];\nvar total = 0;\n\nfor (var i = 0; i < myArr.length; i++) {\n  total += myArr[i];\n}"
+        "var ourArr = [ 9, 10, 11, 12];\nvar ourTotal = 0;\n\nfor (var i = 0; i < ourArr.length; i++) {\n  ourTotal += ourArr[i];\n}\n\nvar myArr = [ 2, 3, 4, 5, 6];\nvar total = 0;\n\nfor (var i = 0; i < myArr.length; i++) {\n  total += myArr[i];\n}"
       ],
       "tests": [
         "assert(code.match(/var\\s*total\\s*=\\s*0\\s*;/), 'message: <code>total</code> should be declared and initialized to 0');",
         "assert(total === 20, 'message: <code>total</code> should equal 20');",
-        "assert(code.match(/for\\s*\\((.*?)myArr\\.length/), 'message: You should use a <code>for</code> loop to iterate through <code>myArr</code>.');",
+        "assert(code.match(/for\\s*\\(/g).length > 1 && code.match(/\\+=\\s*myArr/), 'message: You should use a <code>for</code> loop to iterate through <code>myArr</code>');",
         "assert(!code.match(/total[\\s\\+\\-]*=\\s*(\\d(?!\\s*;)|[1-9])/g), 'message: Do not set <code>total</code> to 20 directly');"
       ],
       "type": "waypoint",


### PR DESCRIPTION
The test to check that a for loop is used to iterate through `myArr` is now less strict to allow users to substitute `myArr.length` with a variable within the for loop statement. It still checks to make sure that `myArr` is referenced.

Rewrote solution to include the example `for` loop from the seed.

closes #6724 
