### PR TITLE
Add more tests to Slasher Flick and fix formatting

### DIFF
--- a/seed/challenges/01-front-end-development-certification/basic-bonfires.json
+++ b/seed/challenges/01-front-end-development-certification/basic-bonfires.json
@@ -452,8 +452,8 @@
     {
       "id": "ab31c21b530c0dafa9e241ee",
       "description": [
-        "Return the remaining elements of an array after chopping off n elements from the head.",
-        "The head meaning the beginning of the array, or the zeroth index",
+        "Return the remaining elements of an array after chopping off <code>n</code> elements from the head.",
+        "The head means the beginning of the array, or the zeroth index.",
         "Remember to use <a href=\"//github.com/FreeCodeCamp/freecodecamp/wiki/How-to-get-help-when-you-get-stuck\" target=\"_blank\">Read-Search-Ask</a> if you get stuck. Write your own code."
       ],
       "challengeSeed": [
@@ -473,7 +473,9 @@
         "assert.deepEqual(slasher([1, 2, 3], 2), [3], 'message: <code>slasher([1, 2, 3], 2)</code> should return <code>[3]</code>.');",
         "assert.deepEqual(slasher([1, 2, 3], 0), [1, 2, 3], 'message: <code>slasher([1, 2, 3], 0)</code> should return <code>[1, 2, 3]</code>.');",
         "assert.deepEqual(slasher([1, 2, 3], 9), [], 'message: <code>slasher([1, 2, 3], 9)</code> should return <code>[]</code>.');",
-        "assert.deepEqual(slasher([1, 2, 3], 4), [], 'message: <code>slasher([1, 2, 3], 4)</code> should return <code>[]</code>.');"
+        "assert.deepEqual(slasher([1, 2, 3], 4), [], 'message: <code>slasher([1, 2, 3], 4)</code> should return <code>[]</code>.');",
+        "assert.deepEqual(slasher(['burgers', 'fries', 'shake'], 1), ['fries', 'shake'], 'message: <code>slasher([\"burgers\", \"fries\", \"shake\"], 1)</code> should return <code>[\"fries\", \"shake\"]</code>.');",
+        "assert.deepEqual(slasher([1, 2, 'chicken', 3, 'potatoes', 'cheese', 4], 5), ['cheese', 4], 'message: <code>slasher([1, 2, \"chicken\", 3, \"potatoes\", \"cheese\", 4], 5)</code> should return <code>[\"cheese\", 4]</code>.');"
       ],
       "type": "bonfire",
       "MDNlinks": [


### PR DESCRIPTION
Tested locally. Fixes #6279.
- Added two more tests that involve a mix of strings and numbers
- Put `n` in code tags
- Add missing period in second sentence
