### PR TITLE
Fix media query for navbar to fit four-digit challenge points

### DIFF
--- a/client/less/main.less
+++ b/client/less/main.less
@@ -747,7 +747,7 @@ div.CodeMirror-scroll {
   }
 }
 
-@media (max-width: 991px) {
+@media (max-width: 1045px) {
   .navbar-header {
     float: none;
   }


### PR DESCRIPTION
tested on Chrome, Firefox and Safari (OSX10.11)
had to drastically increase breakpoint for fixing the issue on Firefox.

closes #6799
