### PR TITLE
Fix steak calculation to not break when challenges are completed everyday

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
     "loopback-component-explorer": "^2.1.1",
     "loopback-testing": "^1.1.0",
     "mocha": "^2.3.3",
+    "sinon": "^1.17.3",
     "tap-spec": "^4.1.1",
     "tape": "^4.2.2"
   }

--- a/server/boot/user.js
+++ b/server/boot/user.js
@@ -14,7 +14,11 @@ import certTypes from '../utils/certTypes.json';
 
 import { ifNoUser401, ifNoUserRedirectTo } from '../utils/middleware';
 import { observeQuery } from '../utils/rx';
-import { calcCurrentStreak, calcLongestStreak } from '../utils/user-stats';
+import {
+  prepUniqueDays,
+  calcCurrentStreak,
+  calcLongestStreak
+} from '../utils/user-stats';
 
 const debug = debugFactory('freecc:boot:user');
 const sendNonUserToMap = ifNoUserRedirectTo('/map');
@@ -192,17 +196,18 @@ module.exports = function(app) {
         const timezone = req.user &&
           req.user.timezone ? req.user.timezone : 'UTC';
 
-        var cals = profileUser
+        const timestamps = profileUser
           .progressTimestamps
           .map(objOrNum => {
             return typeof objOrNum === 'number' ?
               objOrNum :
               objOrNum.timestamp;
-          })
-          .sort();
+          });
 
-        profileUser.currentStreak = calcCurrentStreak(cals, timezone);
-        profileUser.longestStreak = calcLongestStreak(cals, timezone);
+        const uniqueDays = prepUniqueDays(timestamps, timezone);
+
+        profileUser.currentStreak = calcCurrentStreak(uniqueDays, timezone);
+        profileUser.longestStreak = calcLongestStreak(uniqueDays, timezone);
 
         const data = profileUser
           .progressTimestamps

--- a/server/utils/date-utils.js
+++ b/server/utils/date-utils.js
@@ -3,7 +3,7 @@ import moment from 'moment-timezone';
 // day count between two epochs (inclusive)
 export function dayCount([head, tail], timezone = 'UTC') {
   return Math.ceil(
-    moment(moment(head).tz(timezone).endOf('day')).tz(timezone).diff(
+    moment(moment(head).tz(timezone).endOf('day')).diff(
       moment(tail).tz(timezone).startOf('day'),
       'days',
       true)

--- a/test/server/utils/date-utils-test.js
+++ b/test/server/utils/date-utils-test.js
@@ -3,6 +3,7 @@ import moment from 'moment-timezone';
 import { dayCount } from '../../../server/utils/date-utils';
 
 let test = require('tape');
+const PST = 'America/Los_Angeles';
 
 test('Day count between two epochs (inclusive) calculation', function (t) {
   t.plan(7);
@@ -25,18 +26,18 @@ test('Day count between two epochs (inclusive) calculation', function (t) {
   t.equal(dayCount([
     moment.utc("8/4/2015 1:00", "M/D/YYYY H:mm").valueOf(),
     moment.utc("8/3/2015 23:00", "M/D/YYYY H:mm").valueOf()
-  ]), 2, "should return 2 days when the diff is less than 24h but days are different in default timezone UTC");
+  ]), 2, "should return 2 days when the diff is less than 24h but days are different in UTC");
 
   t.equal(dayCount([
     moment.utc("8/4/2015 1:00", "M/D/YYYY H:mm").valueOf(),
     moment.utc("8/3/2015 23:00", "M/D/YYYY H:mm").valueOf()
-  ], 'America/Los_Angeles'), 1, "should return 1 day when the diff is less than 24h and days are different in UTC, but given 'America/Los_Angeles' timezone");
+  ], PST), 1, "should return 1 day when the diff is less than 24h and days are different in UTC, but given PST");
 
   t.equal(dayCount([
     moment.utc("10/27/2015 1:00", "M/D/YYYY H:mm").valueOf(),
     moment.utc("5/12/1982 1:00", "M/D/YYYY H:mm").valueOf()
   ]), 12222, "should return correct count when there is very big period");
-  
+
   t.equal(dayCount([
     moment.utc("8/4/2015 2:00", "M/D/YYYY H:mm").valueOf(),
     moment.utc("8/3/2015 2:00", "M/D/YYYY H:mm").valueOf()

--- a/test/server/utils/user-stats-test.js
+++ b/test/server/utils/user-stats-test.js
@@ -1,31 +1,78 @@
 import moment from 'moment-timezone';
+import sinon from 'sinon';
 
-import { calcCurrentStreak, calcLongestStreak } from '../../../server/utils/user-stats';
+import { 
+  prepUniqueDays,
+  calcCurrentStreak,
+  calcLongestStreak
+} from '../../../server/utils/user-stats';
 
 let test = require('tape');
+let clock = sinon.useFakeTimers(1454526000000); // setting now to 2016-02-03T11:00:00 (PST)
+const PST = 'America/Los_Angeles';
+
+test('Prepare calendar items', function (t) {
+
+  t.plan(5);
+
+  t.deepEqual(prepUniqueDays([
+    moment.utc("8/3/2015 2:00", "M/D/YYYY H:mm").valueOf(),
+    moment.utc("8/3/2015 14:00", "M/D/YYYY H:mm").valueOf(),
+    moment.utc("8/3/2015 20:00", "M/D/YYYY H:mm").valueOf()
+  ]), [1438560000000], "should return correct epoch when all entries fall into one day in UTC");
+
+  t.deepEqual(prepUniqueDays([
+    moment.utc("8/3/2015 2:00", "M/D/YYYY H:mm").valueOf(),
+    moment.utc("8/3/2015 2:00", "M/D/YYYY H:mm").valueOf()
+  ]), [1438560000000], "should return correct epoch when given two identical dates");
+
+
+  t.deepEqual(prepUniqueDays([
+    moment.utc("8/3/2015 2:00", "M/D/YYYY H:mm").valueOf(), // 8/2/2015 in America/Los_Angeles
+    moment.utc("8/3/2015 14:00", "M/D/YYYY H:mm").valueOf(),
+    moment.utc("8/3/2015 20:00", "M/D/YYYY H:mm").valueOf()
+  ], PST), [1438498800000, 1438585200000], "should return 2 epochs when dates fall into two days in PST");
+
+  t.deepEqual(prepUniqueDays([
+    moment.utc("8/1/2015 2:00", "M/D/YYYY H:mm").valueOf(),
+    moment.utc("3/3/2015 14:00", "M/D/YYYY H:mm").valueOf(),
+    moment.utc("9/30/2014 20:00", "M/D/YYYY H:mm").valueOf()
+  ]), [1412035200000, 1425340800000, 1438387200000], "should return 3 epochs when dates fall into three days");
+
+  t.deepEqual(prepUniqueDays([
+    1438387200000, 1425340800000, 1412035200000
+  ]), [1412035200000, 1425340800000, 1438387200000], "should return same but sorted array if all input dates are start of day");
+
+});
 
 test('Current streak calculation', function (t) {
-  t.plan(9);
 
-  t.equal(calcCurrentStreak([
+  t.plan(11);
+
+  t.equal(calcCurrentStreak(
+    prepUniqueDays([
       moment.utc(moment.utc().subtract(1, 'hours')).valueOf()
-    ]), 1, "should return 1 day when today one challenge was completed");
+    ])), 1, "should return 1 day when today one challenge was completed");
 
-  t.equal(calcCurrentStreak([
+  t.equal(calcCurrentStreak(
+    prepUniqueDays([
       moment.utc(moment.utc().subtract(1, 'hours')).valueOf(),
       moment.utc(moment.utc().subtract(1, 'hours')).valueOf()
-    ]), 1, "should return 1 day when today more than one challenge was completed");
+    ])), 1, "should return 1 day when today more than one challenge was completed");
 
-  t.equal(calcCurrentStreak([
+  t.equal(calcCurrentStreak(
+    prepUniqueDays([
       moment.utc("9/11/2015 4:00", "M/D/YYYY H:mm").valueOf()
-    ]), 0, "should return 0 day when today 0 challenges were completed");
+    ])), 0, "should return 0 day when today 0 challenges were completed");
 
-  t.equal(calcCurrentStreak([
+  t.equal(calcCurrentStreak(
+    prepUniqueDays([
       moment.utc(moment.utc().subtract(1, 'days')).valueOf(),
       moment.utc(moment.utc().subtract(1, 'hours')).valueOf()
-    ]), 2, "should return 2 days when today and yesterday challenges were completed");
+    ])), 2, "should return 2 days when today and yesterday challenges were completed");
 
-  t.equal(calcCurrentStreak([
+  t.equal(calcCurrentStreak(
+    prepUniqueDays([
       moment.utc("8/3/2015 2:00", "M/D/YYYY H:mm").valueOf(),
       moment.utc("9/11/2015 4:00", "M/D/YYYY H:mm").valueOf(),
       moment.utc("9/12/2015 1:00", "M/D/YYYY H:mm").valueOf(),
@@ -37,54 +84,81 @@ test('Current streak calculation', function (t) {
       moment.utc(moment.utc().subtract(2, 'days')).valueOf(),
       moment.utc(moment.utc().subtract(1, 'days')).valueOf(),
       moment.utc(moment.utc().subtract(1, 'hours')).valueOf()
-    ]), 3, "should return 3 when today and for two days before user was activity");
+    ])), 3, "should return 3 when today and for two days before user was activity");
 
-  t.equal(calcCurrentStreak([
-      moment.utc(moment.utc().subtract(37, 'hours')).valueOf(),
+  t.equal(calcCurrentStreak(
+    prepUniqueDays([
+      moment.utc(moment.utc().subtract(47, 'hours')).valueOf(),
+      moment.utc(moment.utc().subtract(11, 'hours')).valueOf()
+    ])), 1, "should return 1 when there is 1.5 days long break and dates fall into two days separated by third");
+
+  t.equal(calcCurrentStreak(
+    prepUniqueDays([
+      moment.utc(moment.utc().subtract(40, 'hours')).valueOf(),
       moment.utc(moment.utc().subtract(1, 'hours')).valueOf()
-    ]), 1, "should return 1 when between todays challenge completion and yesterdays there is a 1.5 day (36 hours) long break");  
+    ])), 2, "should return 2 when the break is more than 1.5 days but dates fall into two consecutive days");
 
-  t.ok(calcCurrentStreak([
-      moment.utc(moment.utc().subtract(35, 'hours')).valueOf(),
-      moment.utc(moment.utc().subtract(1, 'hours')).valueOf()
-    ]) >= 2, "should return not less than 2 days when between todays challenge completion and yesterdays there is less than 1.5 day (36 hours) long break");  
-
-    t.equal(calcCurrentStreak([
+  t.equal(calcCurrentStreak(
+    prepUniqueDays([
       moment.utc(moment.utc().subtract(1, 'hours')).valueOf(),
       moment.utc(moment.utc().subtract(1, 'hours')).valueOf()
-    ], undefined), 1, "should return correct count in default timezone UTC given 'undefined' timezone");
-    
-  t.equal(calcCurrentStreak([
+    ]), undefined), 1, "should return correct count in default timezone UTC given 'undefined' timezone");
+
+  t.equal(calcCurrentStreak(
+    prepUniqueDays([
       moment.utc(moment.utc().subtract(1, 'days')).valueOf(),
       moment.utc(moment.utc().subtract(1, 'hours')).valueOf()
-    ], 'America/Los_Angeles'), 2, "should return 2 days when today and yesterday challenges were completed given 'America/Los_Angeles' timezone");
+    ], PST), PST), 2, "should return 2 days when today and yesterday challenges were completed given PST");
+
+  t.equal(calcCurrentStreak(
+    prepUniqueDays([
+      1453174506164, 1453175436725, 1453252466853, 1453294968225, 1453383782844,
+      1453431903117, 1453471373080, 1453594733026, 1453645014058, 1453746762747,
+      1453747659197, 1453748029416, 1453818029213, 1453951796007, 1453988570615,
+      1454069704441, 1454203673979, 1454294055498, 1454333545125, 1454415163903,
+      1454519128123, moment.tz(PST).valueOf()
+    ], PST), PST), 17, "should return 17 when there is no break in given timezone (but would be the break if in UTC)");
+
+  t.equal(calcCurrentStreak(
+    prepUniqueDays([
+      1453174506164, 1453175436725, 1453252466853, 1453294968225, 1453383782844,
+      1453431903117, 1453471373080, 1453594733026, 1453645014058, 1453746762747,
+      1453747659197, 1453748029416, 1453818029213, 1453951796007, 1453988570615,
+      1454069704441, 1454203673979, 1454294055498, 1454333545125, 1454415163903,
+      1454519128123, moment.utc().valueOf()
+    ])), 4, "should return 4 when there is a break in UTC (but would be no break in PST)");
 
 });
 
 test('Longest streak calculation', function (t) {
-  t.plan(12);
+  t.plan(14);
 
-  t.equal(calcLongestStreak([
+  t.equal(calcLongestStreak(
+    prepUniqueDays([
       moment.utc("9/12/2015 4:00", "M/D/YYYY H:mm").valueOf()
-    ]), 1, "should return 1 when there is the only one one-day-long streak available");
+    ])), 1, "should return 1 when there is the only one one-day-long streak available");
 
-  t.equal(calcLongestStreak([
+  t.equal(calcLongestStreak(
+    prepUniqueDays([
       moment.utc("9/11/2015 4:00", "M/D/YYYY H:mm").valueOf(),
       moment.utc("9/12/2015 2:00", "M/D/YYYY H:mm").valueOf(),
       moment.utc("9/13/2015 3:00", "M/D/YYYY H:mm").valueOf(),
       moment.utc("9/14/2015 1:00", "M/D/YYYY H:mm").valueOf()
-    ]), 4, "should return 4 when there is the only one more-than-one-days-long streak available");
+    ])), 4, "should return 4 when there is the only one more-than-one-days-long streak available");
 
-  t.equal(calcLongestStreak([
+  t.equal(calcLongestStreak(
+    prepUniqueDays([
       moment.utc(moment.utc().subtract(1, 'hours')).valueOf()
-    ]), 1, "should return 1 when there is only one one-day-long streak and it is today");
+    ])), 1, "should return 1 when there is only one one-day-long streak and it is today");
 
-  t.equal(calcLongestStreak([
+  t.equal(calcLongestStreak(
+    prepUniqueDays([
       moment.utc(moment.utc().subtract(1, 'days')).valueOf(),
       moment.utc(moment.utc().subtract(1, 'hours')).valueOf()
-    ]), 2, "should return 2 when yesterday and today makes longest streak");
+    ])), 2, "should return 2 when yesterday and today makes longest streak");
 
-  t.equal(calcLongestStreak([
+  t.equal(calcLongestStreak(
+    prepUniqueDays([
       moment.utc("8/3/2015 2:00", "M/D/YYYY H:mm").valueOf(),
       moment.utc("9/11/2015 4:00", "M/D/YYYY H:mm").valueOf(),
       moment.utc("9/12/2015 2:00", "M/D/YYYY H:mm").valueOf(),
@@ -93,19 +167,21 @@ test('Longest streak calculation', function (t) {
       moment.utc("10/6/2015 4:00", "M/D/YYYY H:mm").valueOf(),
       moment.utc("10/7/2015 5:00", "M/D/YYYY H:mm").valueOf(),
       moment.utc("11/3/2015 2:00", "M/D/YYYY H:mm").valueOf()
-    ]), 4, "should return 4 when there is a month long break");
+    ])), 4, "should return 4 when there is a month long break");
 
-   t.equal(calcLongestStreak([
+  t.equal(calcLongestStreak(
+    prepUniqueDays([
       moment.utc("8/3/2015 2:00", "M/D/YYYY H:mm").valueOf(),
       moment.utc("9/11/2015 4:00", "M/D/YYYY H:mm").valueOf(),
-      moment.utc("9/12/2015 1:00", "M/D/YYYY H:mm").valueOf(),
-      moment.utc(moment.utc("9/12/2015 1:00", "M/D/YYYY H:mm").add(37, 'hours')).valueOf(),
+      moment.utc("9/12/2015 15:30", "M/D/YYYY H:mm").valueOf(),
+      moment.utc(moment.utc("9/12/2015 15:30", "M/D/YYYY H:mm").add(37, 'hours')).valueOf(),
       moment.utc("9/14/2015 22:00", "M/D/YYYY H:mm").valueOf(),
       moment.utc("9/15/2015 4:00", "M/D/YYYY H:mm").valueOf(),
       moment.utc("10/3/2015 2:00", "M/D/YYYY H:mm").valueOf()
-    ]), 3, "should return 3 when there is a more than 1.5 days long break of (36 hours)");
+    ])), 2, "should return 2 when there is a more than 1.5 days long break of (36 hours)");
 
-   t.equal(calcLongestStreak([
+  t.equal(calcLongestStreak(
+    prepUniqueDays([
       moment.utc("8/3/2015 2:00", "M/D/YYYY H:mm").valueOf(),
       moment.utc("9/11/2015 4:00", "M/D/YYYY H:mm").valueOf(),
       moment.utc("9/12/2015 1:00", "M/D/YYYY H:mm").valueOf(),
@@ -117,9 +193,10 @@ test('Longest streak calculation', function (t) {
       moment.utc(moment.utc().subtract(2, 'days')).valueOf(),
       moment.utc(moment.utc().subtract(1, 'days')).valueOf(),
       moment.utc().valueOf()
-    ]), 4, "should return 4 when the longest streak consist of several same day timestamps");
+    ])), 4, "should return 4 when the longest streak consist of several same day timestamps");
 
-  t.equal(calcLongestStreak([
+  t.equal(calcLongestStreak(
+    prepUniqueDays([
       moment.utc("8/3/2015 2:00", "M/D/YYYY H:mm").valueOf(),
       moment.utc("9/11/2015 4:00", "M/D/YYYY H:mm").valueOf(),
       moment.utc("9/12/2015 1:00", "M/D/YYYY H:mm").valueOf(),
@@ -129,32 +206,57 @@ test('Longest streak calculation', function (t) {
       moment.utc("10/12/2015 1:00", "M/D/YYYY H:mm").valueOf(),
       moment.utc("10/13/2015 4:00", "M/D/YYYY H:mm").valueOf(),
       moment.utc("10/14/2015 5:00", "M/D/YYYY H:mm").valueOf()
-    ]), 4, "should return 4 when there are several longest streaks (same length)");
+    ])), 4, "should return 4 when there are several longest streaks (same length)");
 
   let cals = [];
   const n = 100;
   for (var i = 0; i < n; i++) {
     cals.push(moment.utc(moment.utc().subtract(i, 'days')).valueOf());
   }
-  cals.sort();
-  t.equal(calcLongestStreak(cals), n, "should return correct longest streak when there is a very long period");
+  t.equal(calcLongestStreak(prepUniqueDays(cals)), n, "should return correct longest streak when there is a very long period");
 
-  t.equal(calcLongestStreak([
+  t.equal(calcLongestStreak(
+    prepUniqueDays([
       moment.utc(moment.utc().subtract(1, 'days')).valueOf(),
       moment.utc(moment.utc().subtract(1, 'hours')).valueOf()
-    ], undefined), 2, "should return correct longest streak in default timezone UTC given 'undefined' timezone");
+    ]), undefined), 2, "should return correct longest streak in default timezone UTC given 'undefined' timezone");
 
-  t.equal(calcLongestStreak([
+  t.equal(calcLongestStreak(
+    prepUniqueDays([
       moment.utc("9/11/2015 4:00", "M/D/YYYY H:mm").valueOf(),
       moment.utc("9/12/2015 2:00", "M/D/YYYY H:mm").valueOf(),
       moment.utc("9/13/2015 3:00", "M/D/YYYY H:mm").valueOf(),
       moment.utc("9/14/2015 1:00", "M/D/YYYY H:mm").valueOf()
-    ], 'America/Los_Angeles'), 4, "should return 4 when there is the only one more-than-one-days-long streak available given 'America/Los_Angeles' timezone");
+    ]), PST), 4, "should return 4 when there is the only one more-than-one-days-long streak available given PST");
 
-  t.equal(calcLongestStreak([
+  t.equal(calcLongestStreak(
+    prepUniqueDays([
       moment.utc("9/11/2015 23:00", "M/D/YYYY H:mm").valueOf(),
       moment.utc("9/12/2015 2:00", "M/D/YYYY H:mm").valueOf(),
       moment.utc("9/13/2015 2:00", "M/D/YYYY H:mm").valueOf(),
-      moment.utc("9/14/2015 1:00", "M/D/YYYY H:mm").valueOf()
-    ], 'America/Los_Angeles'), 3, "should return 3 when longest streak is 3 in given 'America/Los_Angeles' timezone (but would be different in default timezone UTC)");
+      moment.utc("9/14/2015 6:00", "M/D/YYYY H:mm").valueOf()
+    ], PST), PST), 3, "should return 3 when longest streak is 3 in PST (but would be different in default timezone UTC)");
+
+  t.equal(calcLongestStreak(
+    prepUniqueDays([
+      1453174506164, 1453175436725, 1453252466853, 1453294968225, 1453383782844,
+      1453431903117, 1453471373080, 1453594733026, 1453645014058, 1453746762747,
+      1453747659197, 1453748029416, 1453818029213, 1453951796007, 1453988570615,
+      1454069704441, 1454203673979, 1454294055498, 1454333545125, 1454415163903,
+      1454519128123, moment.tz(PST).valueOf()
+    ], PST), PST), 17, "should return 17 when there is no break in PST (but would be break in UTC) and it is current");
+
+  t.equal(calcLongestStreak(
+    prepUniqueDays([
+      1453174506164, 1453175436725, 1453252466853, 1453294968225, 1453383782844,
+      1453431903117, 1453471373080, 1453594733026, 1453645014058, 1453746762747,
+      1453747659197, 1453748029416, 1453818029213, 1453951796007, 1453988570615,
+      1454069704441, 1454203673979, 1454294055498, 1454333545125, 1454415163903,
+      1454519128123, moment.utc().valueOf()
+    ])), 4, "should return 4 when there is a break in UTC (but no break in PST)");
+
+});
+
+test.onFinish(() => {
+  clock.restore();
 });


### PR DESCRIPTION
New function to prepare timestamps for streak calculation was added: it converts all timestamps to start of the day (in given timezone) and filters to distinct days. Tests added for this new function.
Unique days are being sorted only once (instead of twice): current streak calculation is done from right to left, longest streak - from left to right.
Current streak calculation changed to return after current streak is found. 
In unit tests date faking added for `new Date()` or `moment()` to return fixed date all the time. Tests become none time specific.

closes #6721
