### PR TITLE
Remove leftover question from JavaScript Lingo challenge

### DIFF
--- a/seed/challenges/04-video-challenges/jslingo.json
+++ b/seed/challenges/04-video-challenges/jslingo.json
@@ -26,11 +26,6 @@
         [
           "Mozilla Developer Network is a great resource that should be referenced regularly.",
           true
-        ],
-        [
-          "Question 3",
-          true,
-          "Hint 3 - Optional"
         ]
       ],
       "type": "hike",


### PR DESCRIPTION
This commit removes the leftover question from the JavaScript Lingo challenge
Tested locally.

closes #6826
