### PR TITLE
Fixes sidebar scrolling behavior on iOS

### DIFF
--- a/client/less/map.less
+++ b/client/less/map.less
@@ -11,7 +11,13 @@
     bottom: 0;
     right: 0;
 
+    overflow-x: hidden;
+    overflow-y: scroll;
+    -webkit-overflow-scrolling: touch;
+
+    display: -webkit-flex;
     display: flex;
+    -webkit-flex-direction: row;
     flex-direction: row;
 
     background-color: @body-bg;
@@ -21,6 +27,7 @@
     transition: transform 0.3s cubic-bezier(0.16, 0.22, 0.22, 1.7);
 
     &.is-collapsed {
+      -webkit-transform: translateY(110%);
       transform: translateX(110%);
     }
 
@@ -52,9 +59,9 @@
 .map-aside-action-bar {
     position: absolute;
     top: 0;
-    left: 0;
     right: 0;
 
+    display: -webkit-flex;
     display: flex;
     justify-content: flex-end;
 
@@ -120,6 +127,7 @@
   .fa {
     position:absolute;
     top:50%;
+    -webkit-transform: translateY(-50%);
     transform: translateY(-50%);
     right:10px;
   }
@@ -178,7 +186,7 @@
           margin-left:30px;
       }
     }
-  }  
+  }
 
   .challengeBlockDescription {
       margin:0;
@@ -237,6 +245,7 @@
 }
 
 .map-aside-action-item {
+    display: -webkit-flex;
     display: flex;
     /* main axis */
     justify-content: center;


### PR DESCRIPTION
This update will allow for the sidebar to scroll independently of the main page on iOS.

Tested in local environment on iPad, iPhone 5S, and desktop.

Closes #6227
