### PR TITLE
Fix video challenge submissions

### DIFF
--- a/common/app/routes/Hikes/flux/Actions.js
+++ b/common/app/routes/Hikes/flux/Actions.js
@@ -257,7 +257,7 @@ export default Actions({
     // challenge completed
     let update$;
     if (isSignedIn) {
-      const body = { id, name, challengeType };
+      const body = { id, name, challengeType: +challengeType };
       update$ = this.postJSON$('/completed-challenge', body)
         // if post fails, will retry once
         .retry(3)


### PR DESCRIPTION
Just need to coerce the string `challengeType` to an integer. This is the same thing we do on the non-react side of things.

Closes #6912
