### PR TITLE
Fix next/current challenge routes

### DIFF
--- a/server/boot/user.js
+++ b/server/boot/user.js
@@ -105,6 +105,7 @@ function buildDisplayChallenges(challengeMap = {}, timezone) {
 
       return finalChallenge;
     })
+    .filter(({ challengeType }) => challengeType !== 6)
     .groupBy(getChallengeGroup)
     .flatMap(group$ => {
       return group$.toArray().map(challenges => ({


### PR DESCRIPTION
prevent bad id's from throwing

To QA

go to /challenges/next-challenge?id=foo should take you first challenge
go to /challenges/current-challenge?id=foo should take you first challenge
go to /challenges/current-challenge?id=bg9997c9c79feddfaeb9bdef should take you to /challenges/access-array-data-with-indexes
go to /challenges/next-challenge?id=bg9997c9c79feddfaeb9bdef should take you to challenges/modify-array-data-with-indexes

Non mongo ids should just take you to first challenge
