### PR TITLE
Fix odd spacing in JS challenge

### DIFF
--- a/server/views/challenges/showJS.jade
+++ b/server/views/challenges/showJS.jade
@@ -18,7 +18,7 @@ block content
                             .col-xs-12
                                 .challenge-instructions
                                     for sentence in description
-                                        if (/blockquote|h4|table/.test(sentence))
+                                        if (/blockquote|\<ol|h4|table/.test(sentence))
                                             !=sentence
                                         else
                                             p.wrappable!= sentence


### PR DESCRIPTION
Addresses the JS challenge generator trying to wrap the `<ol>` element inside of a paragraph (and obviously failing)

Closes #6840
