### PR TITLE
Fixed example code in Use-Spans-for-Inline-Elements Challenge

### DIFF
--- a/seed/challenges/01-front-end-development-certification/bootstrap.json
+++ b/seed/challenges/01-front-end-development-certification/bootstrap.json
@@ -868,7 +868,7 @@
         "By using the <code>span</code> element, you can put several elements together, and even style different parts of the same element differently.",
         "Nest the word \"love\" in your \"Things cats love\" element below within a <code>span</code> element. Then give that <code>span</code> the class <code>text-danger</code> to make the text red.",
         "Here's how you would do this with the \"Top 3 things cats hate\" element:",
-        "<code>&#60;p&#62;Top 3 things cats &#60;span class = \"text-danger\"&#62;hate&#60;/span&#62;&#60;/p&#62;</code>"
+        "<code>&#60;p&#62;Top 3 things cats &#60;span class = \"text-danger\"&#62;hate:&#60;/span&#62;&#60;/p&#62;</code>"
       ],
       "challengeSeed": [
         "<link href=\"http://fonts.googleapis.com/css?family=Lobster\" rel=\"stylesheet\" type=\"text/css\">",


### PR DESCRIPTION
In the _Use-Spans-for-Inline-Elements_ challenge, changed 

`<p>Top 3 things cats <span class = "text-danger">hate</span></p>` to 
`<p>Top 3 things cats <span class = "text-danger">hate:</span></p>` 

to reflect the codemirror

npm tests pass:
total:     710
passing:   710

<img width="1057" alt="screen shot 2016-02-19 at 12 16 09 pm" src="https://cloud.githubusercontent.com/assets/1487616/13187827/9ea5ebc8-d702-11e5-8fa9-2e43dfc9d18e.png">

closes #7118 
