### PR TITLE
coding instructions made consistent in Add ID Attributes to Bootstrap…

### DIFF
--- a/seed/challenges/01-front-end-development-certification/bootstrap.json
+++ b/seed/challenges/01-front-end-development-certification/bootstrap.json
@@ -1830,7 +1830,7 @@
         "Let's give a unique id to each of our <code>div</code> elements of class <code>well</code>.",
         "Remember that you can give an element an id like this:",
         "<code>&#60;div class=\"well\" id=\"center-well\"&#62;</code>",
-        "Give the well on the left the id of <code>left-well</code>. Give the well on the right the <code>id</code> of <code>right-well</code>."
+        "Give the well on the left the id of <code>left-well</code>. Give the well on the right the id of <code>right-well</code>."
       ],
       "challengeSeed": [
         "<div class=\"container-fluid\">",


### PR DESCRIPTION
In _Add ID Attributes to Bootstrap Elements_

changed

`Give the well on the right the <code>id</code>` to
`Give the well on the right the id`

<img width="340" alt="screen shot 2016-02-22 at 11 32 26 am" src="https://cloud.githubusercontent.com/assets/1487616/13229973/4de1332a-d958-11e5-9f2f-ca2228cc8fbb.png">

**npm tests pass**
total:     710
passing:   710
duration:  2s

closes #7189
