### PR TITLE
Added test to check for well-formed input element

### DIFF
--- a/seed/challenges/01-front-end-development-certification/html5-and-css.json
+++ b/seed/challenges/01-front-end-development-certification/html5-and-css.json
@@ -1637,7 +1637,8 @@
       ],
       "tests": [
         "assert($(\"input[placeholder]\").length > 0, 'message: Add a <code>placeholder</code> attribute text <code>input</code> element.');",
-        "assert($(\"input\") && $(\"input\").attr(\"placeholder\") && $(\"input\").attr(\"placeholder\").match(/cat\\s+photo\\s+URL/gi), 'message: Set the value of your placeholder attribute to \"cat photo URL\".');"
+        "assert($(\"input\") && $(\"input\").attr(\"placeholder\") && $(\"input\").attr(\"placeholder\").match(/cat\\s+photo\\s+URL/gi), 'message: Set the value of your placeholder attribute to \"cat photo URL\".');",
+        "assert($(\"input[type=text]\").length > 0 && code.match(/URL\\s*[\"\\']\\s*\\/?>/gi), 'message: The finished <code>input</code> element should have valid syntax.');"
       ],
       "challengeType": 0,
       "nameEs": "Agrega un texto de relleno a un campo de texto",


### PR DESCRIPTION
In challenge _Add Placeholder Text to a Text Field_

added test:

`"assert($(\"input[type=text]\").length > 0 && code.match(/URL\\s*\"\\s*>/g), 'message: The finished <code>input</code> element should have valid syntax.');"` 
which validates that the input element has a proper closing bracket

<img width="618" alt="screen shot 2016-02-24 at 4 33 58 pm" src="https://cloud.githubusercontent.com/assets/1487616/13305977/6f1287ac-db14-11e5-9375-b176abf3146b.png">

**npm tests pass**
  total:     710
  passing:   710

There seems to be many different ways of solving this problem, so I'm open to feedback. I'm not sure if this is a 'best practice' solution...

closes #7185 
