### PR TITLE
Fixing inconsistent text size in challenge instructions

### DIFF
--- a/server/views/challenges/showHTML.jade
+++ b/server/views/challenges/showHTML.jade
@@ -17,7 +17,7 @@ block content
                             hr
                             .challenge-instructions
                                 for sentence in description
-                                    if (/blockquote|h4|table/.test(sentence))
+                                    if (/\<blockquote|\<h4|\<table/.test(sentence))
                                         !=sentence
                                     else
                                         p.wrappable!= sentence


### PR DESCRIPTION
- Changed the `.challenge-instructions` sentence conditional `if` block
- in the `if block`, if the conditional came across an `h4` in the sentence, it didn't give it a `p.wrappable`
- ran `npm test` and all tests passed
