### PR TITLE
Fix for buttons covering the scroll bar on aside

### DIFF
--- a/client/less/chat.less
+++ b/client/less/chat.less
@@ -22,3 +22,6 @@
 .gitter-chat-embed.is-collapsed:not(.is-loading) {
   transform: translateX(110%);
 }
+.gitter-chat-embed-action-bar{
+   margin-right:15px;
+}

--- a/client/less/map.less
+++ b/client/less/map.less
@@ -58,14 +58,14 @@
 .map-aside-action-bar {
     position: absolute;
     top: 0;
-    right: 0;
+    right: 15px;
 
     display: -webkit-flex;
     display: flex;
     justify-content: flex-end;
 
     padding-bottom: 5px;
-    padding-right:10px;
+    padding-right:0px;
     padding-top:5px;
     z-index: 100;
 }

--- a/client/less/wiki.less
+++ b/client/less/wiki.less
@@ -83,14 +83,14 @@
 .wiki-aside-action-bar {
     position: absolute;
     top: 0;
-    right: 0;
+    right: 15px;
 
     display: -webkit-flex;
     display: flex;
     justify-content: flex-end;
 
     padding-bottom: 5px;
-    padding-right:10px;
+    padding-right:0px;
     padding-top:5px;
     z-index: 100;
 }


### PR DESCRIPTION
Removes the right padding on the buttons, and instead pushed the positioning over, because it was covering the scrollbar.

closes #7271
