### PR TITLE
Add Docker and Docker Compose recipe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:4
+
+RUN mkdir /FreeCodeCamp
+
+WORKDIR /FreeCodeCamp
+
+RUN npm install -g gulp
+RUN npm install -g bower
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+mongo:
+  image: mongo:latest
+fcc:
+  build: .
+  volumes:
+    - ".:/FreeCodeCamp"
+  env_file: .env
+  command: bash -c "npm install && bower install --allow-root && npm run only-once && gulp"
+  ports:
+    - "3000:3000"
+    - "3001:3001"
+    - "1337:1337"
+  links:
+    - mongo


### PR DESCRIPTION
Docker and Docker Compose provide a convenient way for developers to get started on a project. Compose can reduce a multi-page “developer getting started guide” to a single machine readable Compose file and a few commands.

More info: [Docker](https://www.docker.com/) [Docker Compose](https://docs.docker.com/compose/overview/)
### Files
- `Dockerfile`: Contains the recipe to build the docker image (NodeJS, gulp, bower).
- `docker-compose.yml`: Document and configure all of the application’s service dependencies (MongoDB and NodeJS).
### Requirements
- [Docker and Docker Compose](https://docs.docker.com/compose/install/)
### Prerequisites
- Modify the `.env` file

``` bash
MONGOHQ_URL=mongodb://mongo:27017/freecodecamp
```
### Usage

``` bash
$ docker-compose up # Start containers
$ docker-compose stop # Stop containers
$ docker-compose build # Build/Rebuild containers
```
