### PR TITLE
Scrolling issues be gone

### DIFF
--- a/client/less/map.less
+++ b/client/less/map.less
@@ -40,18 +40,9 @@
 
       background-color: @body-bg;
     }
-    .iframeWrapper {
-      height:100%;
-      width:100%;
-      overflow-x: hidden;
-      overflow-y: scroll;
-      -webkit-overflow-scrolling: touch;
-      iframe {
-        flex: 1;
-        width: 100%;
-        height: 100%;
-        border: 0;
-      }
+    iframe {
+      width: 100%;
+      height: 100%;
     }
 }
 
@@ -139,10 +130,16 @@
   }
 }
 
+.mapWrapper {
+  position:absolute;
+  display: block;
+  height: 100%;
+  width: 100%; 
+}
+
 .map-accordion {
-  margin: 135px auto 0;
-  width:700px;
-  overflow-y: auto;
+  width:700px; 
+  margin:155px auto 0; 
   position:relative;
   #nested {
     margin:0 15px;
@@ -228,10 +225,19 @@
     left:0;
     right:0;
     width:100%;
-    margin-top:180px;
+    top:195px;
+    bottom:0;
+    margin:0;
+    position:absolute;
+    overflow-x: hidden;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
     h2 {
       margin:15px 0;
       padding:0;
+      &:first-of-type {
+        margin-top:0;
+      }
       > a {
         padding:10px 0;
         padding-left:50px;
@@ -249,7 +255,7 @@
     }
   }
 }
-
+    
 .map-aside-action-item {
     display: -webkit-flex;
     display: flex;

--- a/client/less/wiki.less
+++ b/client/less/wiki.less
@@ -6,7 +6,6 @@
 #wikiFrame {
     width: 100%;
     height: 100%;
-    padding-top: 30px;
     top:0;
     bottom: 0;
     position: absolute;
@@ -53,18 +52,13 @@
       background-color: @body-bg;
     }
 
-    .iframeWrapper {
-      height:100%;
-      width:100%;
-      overflow-x: hidden;
-      overflow-y: scroll;
-      -webkit-overflow-scrolling: touch;
-      iframe {
-        flex: 1;
-        width: 100%;
-        height: 100%;
-        border: 0;
-      }
+    iframe {
+      width: 100%;
+      height: 100%;
+      top:0;
+      bottom:0;
+      position:absolute;
+      overflow: hidden;
     }
 }
 
@@ -83,14 +77,14 @@
 .wiki-aside-action-bar {
     position: absolute;
     top: 0;
-    right: 0;
+    right: 15px;
 
     display: -webkit-flex;
     display: flex;
     justify-content: flex-end;
 
     padding-bottom: 5px;
-    padding-right:10px;
+    padding-right:0px;
     padding-top:5px;
     z-index: 100;
 }

--- a/client/main.js
+++ b/client/main.js
@@ -357,9 +357,9 @@ $(document).ready(function() {
       var mapAside = $('<iframe>');
       mapAside.attr({
         src: '/map-aside',
-        scrolling: 'yes'
+        frameBorder: '0'
       });
-      $('.map-aside .iframeWrapper').append(mapAside);
+      $('.map-aside').append(mapAside);
       main.isMapAsideLoad = true;
     }
     $('.map-aside').removeClass('is-collapsed');
@@ -391,9 +391,9 @@ $(document).ready(function() {
       var wikiAside = $('<iframe>');
       wikiAside.attr({
         src: wikiURL,
-        scrolling: 'yes'
+        frameBorder: '0'
       });
-      $('.wiki-aside .iframeWrapper').append(wikiAside);
+      $('.wiki-aside').append(wikiAside);
       main.isWikiAsideLoad = true;
     }
     $('.wiki-aside').removeClass('is-collapsed');

--- a/server/views/map/show.jade
+++ b/server/views/map/show.jade
@@ -1,5 +1,6 @@
 extends ../layout-wide
 block content
+      .mapWrapper
         .text-center.map-fixed-header
             p Challenges required for certifications are marked with a *
             .row.map-buttons

--- a/server/views/partials/footer.jade
+++ b/server/views/partials/footer.jade
@@ -4,9 +4,7 @@ aside.map-aside.is-collapsed
   .map-aside-action-bar
       a.map-aside-action-item.map-aside-action-pop-out(href='/map' target='_blank' aria-label='open map in new tab')
       button.map-aside-action-item.map-aside-action-collapse(aria-label='close map aside')
-  .iframeWrapper
 aside.wiki-aside.is-collapsed
   .wiki-aside-action-bar
       a.wiki-aside-action-item.wiki-aside-action-pop-out(href='/wiki' target='_blank' aria-label='open wiki in new tab')
       button.wiki-aside-action-item.wiki-aside-action-collapse(aria-label='close wiki aside')
-  .iframeWrapper

--- a/server/views/wiki/show.jade
+++ b/server/views/wiki/show.jade
@@ -1,8 +1,7 @@
 extends ../layout-wide
 block content
-  .iframeWrapper
-    iframe#wikiFrame(frameborder='no')
-    script.
-        var lang = window.location.toString().match(/\/\w{2}\//);
-        lang = (lang) ? lang[0] : '/en/';
-        $('#wikiFrame').attr('src','http://freecodecamp.github.io/wiki' + lang);
+  iframe#wikiFrame(frameborder='no')
+  script.
+      var lang = window.location.toString().match(/\/\w{2}\//);
+      lang = (lang) ? lang[0] : '/en/';
+      $('#wikiFrame').attr('src','http://freecodecamp.github.io/wiki' + lang);


### PR DESCRIPTION
So... After weeks of studying the issue I've finally been able to come up with an all-around solution to our several scrolling issues. Closes #7088 #7271 #7088 
Makes https://github.com/FreeCodeCamp/FreeCodeCamp/pull/7276 unnecessary.

Note: While using iOS devices, it temporarily redisables scrolling for the wiki on the sidecar, but they can always check the detached version. -> This will be corrected as we fix the wiki generator.

Come at me, evil bots!
