### PR TITLE
Prevent eslint 2.3.0 from installing

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "emmet-codemirror": "^1.2.5",
     "errorhandler": "^1.4.2",
     "es6-map": "~0.1.1",
-    "eslint": "^2.2.0",
+    "eslint": "~2.2.0",
     "eslint-plugin-react": "^4.1.0",
     "express": "^4.13.3",
     "express-flash": "~0.0.2",


### PR DESCRIPTION
Eslint 2.3.0 is broken. This will prevent us from using that version until Greenkeeper alerts us to a patched version that isn't broken.

See this eslint repo issue for details: https://github.com/eslint/eslint/issues/5476

Closes #7410
