### PR TITLE
Changed '.map-accordion' margin from 155px to 190px.

### DIFF
--- a/client/less/map.less
+++ b/client/less/map.less
@@ -139,7 +139,7 @@
 
 .map-accordion {
   width:700px; 
-  margin:155px auto 0; 
+  margin:190px auto 0; 
   position:relative;
   #nested {
     margin:0 15px;


### PR DESCRIPTION
This was done otherwise the first accordion panel (Getting started) was half-hidden under the 
`<div class="text-center map-fixed-header">` on the http://www.freecodecamp.com/map-aside page.
