### PR TITLE
Fix for map's block overlapping

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -298,12 +298,12 @@ $(document).ready(function() {
   }
 
   function expandBlock(item) {
-    $(item).addClass('in').css('height', '100%');
+    $(item).addClass('in');
     expandCaret(item);
   }
 
   function collapseBlock(item) {
-    $(item).removeClass('in').css('height', '100%');
+    $(item).removeClass('in');
     collapseCaret(item);
   }
 


### PR DESCRIPTION
Removed unnecessary offending `height:100%` from the JS on collapse
Closes #7385
