### PR TITLE
Fix for overlapping chapter titles

### DIFF
--- a/client/less/map.less
+++ b/client/less/map.less
@@ -142,7 +142,7 @@
   margin:155px auto 0; 
   position:relative;
   #nested {
-    margin:0 15px;
+    margin:0 10px;
     @media (max-width: 400px) {
     margin:0;
     }
@@ -174,6 +174,7 @@
       padding-left: 40px;
       padding-bottom: 10px;
       display:block;
+      max-width: 535px;
     }
   }
 


### PR DESCRIPTION
Change lateral margins for the container (better caret alignments) and set a max-width for nested element titles in full-screen map, in order to avoid overlapping with the chapter duration caption.

Closes #7513
