### PR TITLE
Don't flash next question before video in hikes

### DIFF
--- a/common/app/routes/Hikes/redux/reducer.js
+++ b/common/app/routes/Hikes/redux/reducer.js
@@ -80,7 +80,7 @@ export default handleActions(
     [types.goToNextHike]: state => ({
       ...state,
       currentHike: findNextHikeName(state.hikes, state.currentHike),
-      showQuestions: false,
+      shouldShowQuestions: false,
       currentQuestion: 1,
       mouse: [ 0, 0 ]
     }),


### PR DESCRIPTION
Fixes a typo that caused the first question belonging to the next hike to flash before showing the video.

Closes #7480
