### PR TITLE
current_challenge_redirect fix

### DIFF
--- a/server/boot/challenge.js
+++ b/server/boot/challenge.js
@@ -515,7 +515,8 @@ module.exports = function(app) {
           }
           var view = challengeView[data.challengeType];
           if (data.id) {
-            res.cookie('currentChallengeId', data.id);
+            res.cookie('currentChallengeId', data.id, {
+              expires: new Date(2147483647000)});
           }
           return res.render(view, data);
         },

--- a/server/boot/challenge.js
+++ b/server/boot/challenge.js
@@ -515,7 +515,7 @@ module.exports = function(app) {
           }
           var view = challengeView[data.challengeType];
           if (data.id) {
-            res.cookie('currentChallengeId', data.id);
+            res.cookie('currentChallengeId', data.id, { expires: new Date(2147483647000)});
           }
           return res.render(view, data);
         },

--- a/server/boot/challenge.js
+++ b/server/boot/challenge.js
@@ -515,7 +515,8 @@ module.exports = function(app) {
           }
           var view = challengeView[data.challengeType];
           if (data.id) {
-            res.cookie('currentChallengeId', data.id, { expires: new Date(2147483647000)});
+            res.cookie('currentChallengeId', data.id, {
+              expires: new Date(2147483647000)});
           }
           return res.render(view, data);
         },


### PR DESCRIPTION
I do not have an environment set-up so no npm test was done, sorry about that. The issue should be a trivial fix and throw no errors, i'd obviously appreciate if someone can check it out and do the npm test. 

Thanks. 

---

currentChallengeId expire was not set, per default it will expire on session. This is what I believe is preventing people after signing in to be redirected to the proper current challenge as each session close erase cookie. This should set the expire to effectively 'never'.
