### PR TITLE
changed expire time for currentChallengeId cookie to 'never'

### DIFF
--- a/server/boot/challenge.js
+++ b/server/boot/challenge.js
@@ -515,7 +515,8 @@ module.exports = function(app) {
           }
           var view = challengeView[data.challengeType];
           if (data.id) {
-            res.cookie('currentChallengeId', data.id);
+            res.cookie('currentChallengeId', data.id, {
+              expires: new Date(2147483647000)});
           }
           return res.render(view, data);
         },


### PR DESCRIPTION
Changed the currentChallengeId cookie expire time to 'never'. Currently set to session which doesnt not allow redirect. 

Have not tested on locally. Chrome and Firefox debugs indicate cookie is set to 'session' as does express documentation if its not set. Modifying cookies allows me to sign in to website as intended. 

This should at least fix the cases where redirect works fine with cookies.

-This is a re-submit of an earlier PR, i couldn't seem to squash my commits, i think cause i did the edits via github first and then tried to clone and squash.
