### PR TITLE
Make Confirm the Ending function name unique

### DIFF
--- a/seed/challenges/01-front-end-development-certification/basic-bonfires.json
+++ b/seed/challenges/01-front-end-development-certification/basic-bonfires.json
@@ -321,31 +321,31 @@
       "id": "acda2fb1324d9b0fa741e6b5",
       "title": "Confirm the Ending",
       "description": [
-        "Check if a string (first argument) ends with the given target string (second argument).",
+        "Check if a string (first argument, <code>str</code>) ends with the given target string (second argument, <code>target</code>).",
         "Remember to use <a href=\"//github.com/FreeCodeCamp/freecodecamp/wiki/How-to-get-help-when-you-get-stuck\" target=\"_blank\">Read-Search-Ask</a> if you get stuck. Write your own code."
       ],
       "challengeSeed": [
-        "function end(str, target) {",
+        "function confirmEnding(str, target) {",
         "  // \"Never give up and good luck will find you.\"",
         "  // -- Falcor",
         "  return str;",
         "}",
         "",
-        "end(\"Bastian\", \"n\");"
+        "confirmEnding(\"Bastian\", \"n\");"
       ],
       "tests": [
-        "assert(end(\"Bastian\", \"n\") === true, 'message: <code>end(\"Bastian\", \"n\")</code> should return true.');",
-        "assert(end(\"Connor\", \"n\") === false, 'message: <code>end(\"Connor\", \"n\")</code> should return false.');",
-        "assert(end(\"Walking on water and developing software from a specification are easy if both are frozen\", \"specification\") === false, 'message: <code>end(\"Walking on water and developing software from a specification are easy if both are frozen\"&#44; \"specification\"&#41;</code> should return false.');",
-        "assert(end(\"He has to give me a new name\", \"name\") === true, 'message: <code>end(\"He has to give me a new name\", \"name\")</code> should return true.');",
-        "assert(end(\"He has to give me a new name\", \"me\") === true, 'message: <code>end(\"He has to give me a new name\", \"me\")</code> should return true.');",
-        "assert(end(\"He has to give me a new name\", \"na\") === false, 'message: <code>end(\"He has to give me a new name\", \"na\")</code> should return false.');",
-        "assert(end(\"If you want to save our world, you must hurry. We dont know how much longer we can withstand the nothing\", \"mountain\") === false, 'message: <code>end(\"If you want to save our world, you must hurry. We dont know how much longer we can withstand the nothing\", \"mountain\")</code> should return false.');"
+        "assert(confirmEnding(\"Bastian\", \"n\") === true, 'message: <code>confirmEnding(\"Bastian\", \"n\")</code> should return true.');",
+        "assert(confirmEnding(\"Connor\", \"n\") === false, 'message: <code>confirmEnding(\"Connor\", \"n\")</code> should return false.');",
+        "assert(confirmEnding(\"Walking on water and developing software from a specification are easy if both are frozen\", \"specification\") === false, 'message: <code>confirmEnding(\"Walking on water and developing software from a specification are easy if both are frozen\"&#44; \"specification\"&#41;</code> should return false.');",
+        "assert(confirmEnding(\"He has to give me a new name\", \"name\") === true, 'message: <code>confirmEnding(\"He has to give me a new name\", \"name\")</code> should return true.');",
+        "assert(confirmEnding(\"He has to give me a new name\", \"me\") === true, 'message: <code>confirmEnding(\"He has to give me a new name\", \"me\")</code> should return true.');",
+        "assert(confirmEnding(\"He has to give me a new name\", \"na\") === false, 'message: <code>confirmEnding(\"He has to give me a new name\", \"na\")</code> should return false.');",
+        "assert(confirmEnding(\"If you want to save our world, you must hurry. We dont know how much longer we can withstand the nothing\", \"mountain\") === false, 'message: <code>confirmEnding(\"If you want to save our world, you must hurry. We dont know how much longer we can withstand the nothing\", \"mountain\")</code> should return false.');"
       ],
       "type": "bonfire",
       "isRequired": true,
       "solutions": [
-        "function end(str, target) {\n  return str.substring(str.length-target.length) === target;\n};\n"
+        "function confirmEnding(str, target) {\n  return str.substring(str.length-target.length) === target;\n};\n"
       ],
       "MDNlinks": [
         "String.substr()"


### PR DESCRIPTION
Tested locally. Passed npm run test-challenges. References #7085.
- Change `end` function name to `confirmEnding`
- Add clarity on arguments used in function
