### PR TITLE
Move Sign out and Send Email to User Page

### DIFF
--- a/server/views/account/settings.jade
+++ b/server/views/account/settings.jade
@@ -29,12 +29,6 @@ block content
                       a.btn.btn-lg.btn-block.btn-google-plus.btn-link-social(href='/link/google')
                           i.fa.fa-google-plus
                           | Add my Google+ to my portfolio
-          .col-xs-12
-              a.btn.btn-lg.btn-block.btn-primary.btn-link-social(href='/logout')
-                  | Sign me out of Free Code Camp
-          .col-xs-12
-              a.btn.btn-lg.btn-block.btn-primary.btn-link-social(href='mailto:team@freecodecamp.com')
-                  | Email us at team@freecodecamp.com
         .spacer
         h2.text-center Account Settings
         .row

--- a/server/views/account/show.jade
+++ b/server/views/account/show.jade
@@ -12,6 +12,12 @@ block content
         .col-xs-12
             a.btn.btn-lg.btn-block.btn-primary.btn-link-social(href='/settings')
                 | Update your settings
+        .col-xs-12
+            a.btn.btn-lg.btn-block.btn-primary.btn-link-social(href='/logout')
+                | Sign me out of Free Code Camp
+        .col-xs-12
+            a.btn.btn-lg.btn-block.btn-primary.btn-link-social(href='mailto:team@freecodecamp.com')
+                | Email us at team@freecodecamp.com
         .spacer
     h1.text-center #{username}'s code portfolio
     hr


### PR DESCRIPTION
This commit moves the Sign out from Free Code Camp and the
Email us buttons to the User page as they are not related
to the accounts page.

Tested Locally.

Closes #7684
