### PR TITLE
Video challenges content appears out of mobile screens

### DIFF
--- a/common/app/routes/Hikes/components/Hike.jsx
+++ b/common/app/routes/Hikes/components/Hike.jsx
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { Col, Row } from 'react-bootstrap';
+import { Col } from 'react-bootstrap';
 import { createSelector } from 'reselect';
 
 import Lecture from './Lecture.jsx';
@@ -55,18 +55,16 @@ export class Hike extends React.Component {
 
     return (
       <Col xs={ 12 }>
-        <Row>
-          <header className='text-center'>
-            <h4>{ title }</h4>
-          </header>
-          <hr />
-          <div className='spacer' />
-          <section
-            className={ 'text-center' }
-            title={ title }>
-            { this.renderBody(shouldShowQuestions) }
-          </section>
-        </Row>
+        <header className='text-center'>
+          <h4>{ title }</h4>
+        </header>
+        <hr />
+        <div className='spacer' />
+        <section
+          className={ 'text-center' }
+          title={ title }>
+          { this.renderBody(shouldShowQuestions) }
+        </section>
       </Col>
     );
   }

--- a/common/app/routes/Hikes/components/Hikes.jsx
+++ b/common/app/routes/Hikes/components/Hikes.jsx
@@ -1,7 +1,6 @@
 import React, { PropTypes } from 'react';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
-import { Row } from 'react-bootstrap';
 import PureComponent from 'react-pure-render/component';
 import { createSelector } from 'reselect';
 // import debug from 'debug';
@@ -59,17 +58,14 @@ export class Hikes extends PureComponent {
 
   render() {
     const { hikes } = this.props;
-    const preventOverflow = { overflow: 'hidden' };
     return (
       <div>
-        <Row style={ preventOverflow }>
-          {
-            // render sub-route
-            this.props.children ||
-            // if no sub-route render hikes map
-            this.renderMap(hikes)
-          }
-        </Row>
+        {
+          // render sub-route
+          this.props.children ||
+          // if no sub-route render hikes map
+          this.renderMap(hikes)
+        }
       </div>
     );
   }


### PR DESCRIPTION
Removing react-bootstrap component Row from Hikes.jsx and Hike.jsx as it adds a row class which broadens the margins making it unresponsive for mobile. Now using just a div in Hikes.jsx and a col-xs-12 in Hike.jsx to render video challenges. Also removing inline overflow: hidden attribute that seemed to not affect anything as well as extraneous html elements.

Manually Tested On:
Google Chrome Version 49.0.2623.87 (64-bit)
Developer Tools + Device Mode (portrait & landscape mode):
Galaxy S5, Nexus 5X, Nexus 5P, iPhone 5, iPhone 6, iPhone 6 Plus, iPad

Also tested with my iPhone 5. Screenshots posted below. 

![7565_1](https://cloud.githubusercontent.com/assets/6289711/14010858/6e2ebf56-f156-11e5-89d9-02e0168b8298.png)
![7565_2](https://cloud.githubusercontent.com/assets/6289711/14010860/716b3e4c-f156-11e5-8be4-81e9bb66c05b.png)
![7565_3](https://cloud.githubusercontent.com/assets/6289711/14010863/76e6e380-f156-11e5-9ef1-013c9b85f8aa.png)

Closes #7565
