### PR TITLE
Fix article loading on direct link to wiki

### DIFF
--- a/server/boot/t-wiki.js
+++ b/server/boot/t-wiki.js
@@ -1,11 +1,17 @@
 module.exports = function(app) {
   var router = app.loopback.Router();
   router.get('/wiki/*', showWiki);
-  router.get('/wiki', showWiki);
+  router.get('/wiki', (req, res) => res.redirect(301, '/wiki/en/'));
 
   app.use(router);
 
   function showWiki(req, res) {
-    res.render('wiki/show', { title: 'Wiki | Free Code Camp' });
+    res.render(
+      'wiki/show',
+      {
+        title: 'Wiki | Free Code Camp',
+        path: req.path.replace(/^\/wiki/, '')
+      }
+    );
   }
 };

--- a/server/views/wiki/show.jade
+++ b/server/views/wiki/show.jade
@@ -2,6 +2,10 @@ extends ../layout-wide
 block content
   iframe#wikiFrame(frameborder='no')
   script.
-      var lang = window.location.toString().match(/\/\w{2}\//);
-      lang = (lang) ? lang[0] : '/en/';
-      $('#wikiFrame').attr('src','//freecodecamp.github.io/wiki' + lang);
+    var requestedPath = !{JSON.stringify(path) || ''};
+    var lang = window.location.toString().match(/\/\w{2}\//);
+    lang = (lang) ? lang[0] : '/en/';
+    $('#wikiFrame').attr(
+      'src',
+      '//freecodecamp.github.io/wiki' + (requestedPath ? requestedPath : lang)
+    );

--- a/server/views/wiki/show.jade
+++ b/server/views/wiki/show.jade
@@ -2,10 +2,19 @@ extends ../layout-wide
 block content
   iframe#wikiFrame(frameborder='no')
   script.
+    var wikiUrl = '//freecodecamp.github.io/wiki';
+    var wikiOrigin = /https?:\/\/freecodecamp.github.io/;
     var requestedPath = !{JSON.stringify(path) || ''};
     var lang = window.location.toString().match(/\/\w{2}\//);
     lang = (lang) ? lang[0] : '/en/';
     $('#wikiFrame').attr(
       'src',
-      '//freecodecamp.github.io/wiki' + (requestedPath ? requestedPath : lang)
+      wikiUrl + (requestedPath ? requestedPath : lang)
     );
+    window.addEventListener('message', function(e) {
+      if (!wikiOrigin.test(e.origin)) {
+        return null;
+      }
+      history.replaceState(history.state, null, e.data);
+      return null;
+    });


### PR DESCRIPTION
This PR allows direct links to wiki articles using the freecodecamp domain load the appropriate page from the wiki. This does not however update the URL when the wiki page changes. 

Originally I was going to include that logic here as well, but it looks like that might be more involved, so I'll submit it as a separate PR .
