### PR TITLE
extend session cookie past browser close

### DIFF
--- a/server/middlewares/sessions.js
+++ b/server/middlewares/sessions.js
@@ -6,6 +6,8 @@ const MongoStore = MongoStoreFactory(session);
 
 export default function sessionsMiddleware() {
   return session({
+    // 900 day session cookie
+    cookie: { maxAge: 900 * 24 * 60 * 60 * 1000 },
     resave: true,
     saveUninitialized: true,
     secret: secrets.sessionSecret,


### PR DESCRIPTION
Added a session cookie with an expiration 900 days in the future so users won't be logged out unless they do it explicitly. 

closes #3513
