### PR TITLE
Prevent tail appending to trailing comments

### DIFF
--- a/client/commonFramework/init.js
+++ b/client/commonFramework/init.js
@@ -28,7 +28,7 @@ window.common = (function(global) {
     seedData = Array.isArray(seedData) ? seedData : [seedData];
     return seedData.reduce(function(seed, line) {
       return '' + seed + line + '\n';
-    }, '');
+    }, '\n');
   };
 
   common.seed = common.arrayToNewLineString(common.challengeSeed);


### PR DESCRIPTION
If the code does not have a newline at the end and ends with a comment, then the first line of the tail will be cut off and will occasionally not evaluate correctly when calling eval(code).

For example:
var secondTree = myPlants[1].list[2]; // Change this line(function(x) {
  if (typeof x != 'undefined') {
    return "secondTree = " + x;
  }
  return "secondTree is undefined";
})(secondTree);

The function declaration after '// Change this line' will be cut off and the return statements below will throw an error. A newline before the tail prevents this from occurring. 

closes #7799
