### PR TITLE
Change italic method to em in Change Text jQuery

### DIFF
--- a/seed/challenges/01-front-end-development-certification/jquery.json
+++ b/seed/challenges/01-front-end-development-certification/jquery.json
@@ -547,7 +547,7 @@
         "Using jQuery, you can change the text between the start and end tags of an element. You can even change HTML markup.",
         "jQuery has a function called <code>.html()</code> that lets you add HTML tags and text within an element. Any content previously within the element will be completely replaced with the content you provide using this function.",
         "Here's how you would rewrite and italicize the text of our heading:",
-        "<code>$(\"h3\").html(\"&#60;i&#62;jQuery Playground&#60;/i&#62;\");</code>",
+        "<code>$(\"h3\").html(\"&#60;em&#62;jQuery Playground&#60;/em&#62;\");</code>",
         "jQuery also has a similar function called <code>.text()</code> that only alters text without adding tags.",
         "Change the button with id <code>target4</code> by italicizing its text."
       ],
@@ -556,7 +556,7 @@
         "fccss",
         "  $(document).ready(function() {",
         "    $(\"#target1\").css(\"color\", \"red\");",
-        "",
+        "    ",
         "  });",
         "fcces",
         "",
@@ -585,9 +585,9 @@
         "</div>"
       ],
       "tests": [
-        "assert.isTrue((/<i>#target4<\\/i>/gi).test($(\"#target4\").html()), 'message: Italicize the text in your <code>target4</code> button by adding HTML tags.');",
+        "assert.isTrue((/<em>#target4<\\/em>/gi).test($(\"#target4\").html()), 'message: Italicize the text in your <code>target4</code> button by adding HTML tags.');",
         "assert($(\"#target4\") && $(\"#target4\").text() === '#target4', 'message: Make sure the text is otherwise unchanged.');",
-        "assert.isFalse((/<i>/gi).test($(\"h3\").html()), 'message: Do not alter any other text.');"
+        "assert.isFalse((/<em>/gi).test($(\"h3\").html()), 'message: Do not alter any other text.');"
       ],
       "type": "waypoint",
       "challengeType": 0,


### PR DESCRIPTION
Tested locally. Passes `npm run test-challenges`. Closes #7512.
- Change italic example from using i to em tag
- Add spaces in editor for ease of code addition
- Update tests to reflect em tag change
