### PR TITLE
Fixed Spelling Mistake on React Leaderboard

### DIFF
--- a/seed/challenges/02-data-visualization-certification/react-projects.json
+++ b/seed/challenges/02-data-visualization-certification/react-projects.json
@@ -67,7 +67,7 @@
         "<strong>Rule #3:</strong> You must use both Sass and React to build this project.",
         "<strong>User Story:</strong> I can see a table of the Free Code Camp campers who've earned the most brownie points in the past 30 days.",
         "<strong>User Story:</strong> I can see how many brownie points they've earned in the past 30 days, and how many they've earned total.",
-        "<strong>User Story:</strong> I can toggle between sorting the list by how many bronwie points they've earned in the past 30 days and by how many brownie points they've earned total.",
+        "<strong>User Story:</strong> I can toggle between sorting the list by how many brownie points they've earned in the past 30 days and by how many brownie points they've earned total.",
         "<strong>Hint:</strong> To get the top 100 campers for the last 30 days: <a href='http://fcctop100.herokuapp.com/api/fccusers/top/recent' target='_blank'>http://fcctop100.herokuapp.com/api/fccusers/top/recent</a>.",
         "<strong>Hint:</strong> To get the top 100 campers of all time: <a href='http://fcctop100.herokuapp.com/api/fccusers/top/alltime' target='_blank'>http://fcctop100.herokuapp.com/api/fccusers/top/alltime</a>.",
         "Remember to use <a href='//github.com/FreeCodeCamp/freecodecamp/wiki/How-to-get-help-when-you-get-stuck' target='_blank'>Read-Search-Ask</a> if you get stuck.",


### PR DESCRIPTION
3.4. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

Changed bronwie to brownie

closes #7834
