### PR TITLE
Clarify instructions for Change Text in jQuery

### DIFF
--- a/seed/challenges/01-front-end-development-certification/jquery.json
+++ b/seed/challenges/01-front-end-development-certification/jquery.json
@@ -548,7 +548,7 @@
         "jQuery has a function called <code>.html()</code> that lets you add HTML tags and text within an element. Any content previously within the element will be completely replaced with the content you provide using this function.",
         "Here's how you would rewrite and italicize the text of our heading:",
         "<code>$(\"h3\").html(\"&#60;em&#62;jQuery Playground&#60;/em&#62;\");</code>",
-        "jQuery also has a similar function called <code>.text()</code> that only alters text without adding tags.",
+        "jQuery also has a similar function called <code>.text()</code> that only alters text without adding tags. In other words, this function will not evaluate any HTML tags passed to it, but will instead treat it as text you want to replace with.",
         "Change the button with id <code>target4</code> by italicizing its text."
       ],
       "releasedOn": "November 18, 2015",
@@ -587,7 +587,8 @@
       "tests": [
         "assert.isTrue((/<em>#target4<\\/em>/gi).test($(\"#target4\").html()), 'message: Italicize the text in your <code>target4</code> button by adding HTML tags.');",
         "assert($(\"#target4\") && $(\"#target4\").text() === '#target4', 'message: Make sure the text is otherwise unchanged.');",
-        "assert.isFalse((/<em>/gi).test($(\"h3\").html()), 'message: Do not alter any other text.');"
+        "assert.isFalse((/<em>/gi).test($(\"h3\").html()), 'message: Do not alter any other text.');",
+        "assert(code.match(/\\.html\\(/g), 'message: Make sure you are using <code>.html()</code> and not <code>.text()</code>.');"
       ],
       "type": "waypoint",
       "challengeType": 0,


### PR DESCRIPTION
Tested locally. Passes `npm run test-challenges`. Closes #7713.
- Clarify to use .html() versus .text()
- Add test to check use of .html()
