### PR TITLE
Fix Typo in User.js that breaks Certificate Display

### DIFF
--- a/server/boot/user.js
+++ b/server/boot/user.js
@@ -35,7 +35,7 @@ const certViews = {
 };
 
 const certText = {
-  [certTypes.fronEnd]: 'Front End certified',
+  [certTypes.frontEnd]: 'Front End certified',
   [certTypes.dataVis]: 'Data Vis Certified',
   [certTypes.backEnd]: 'Back End Certified',
   [certTypes.fullStack]: 'Full Stack Certified'


### PR DESCRIPTION
Currently if you visit https://www.freecodecamp.com/karel1980/front-end-certification you get a message saying 'Looks like user karel1980 is not undefined' because of a typo.
This commit fixes that typo
