### PR TITLE
Updated Bootstrap Social and remove plus from Google sign in icon

### DIFF
--- a/client/less/lib/bootstrap-social/bootstrap-social.less
+++ b/client/less/lib/bootstrap-social/bootstrap-social.less
@@ -32,7 +32,7 @@
   }
   &.btn-lg {
     padding-left: (@bs-height-lg + @padding-large-horizontal);
-    :first-child {
+    > :first-child {
       line-height: @bs-height-lg;
       width: @bs-height-lg;
       font-size: 1.8em;
@@ -40,7 +40,7 @@
   }
   &.btn-sm {
     padding-left: (@bs-height-sm + @padding-small-horizontal);
-    :first-child {
+    > :first-child {
       line-height: @bs-height-sm;
       width: @bs-height-sm;
       font-size: 1.4em;
@@ -48,7 +48,7 @@
   }
   &.btn-xs {
     padding-left: (@bs-height-xs + @padding-small-horizontal);
-    :first-child {
+    > :first-child {
       line-height: @bs-height-xs;
       width: @bs-height-xs;
       font-size: 1.2em;
@@ -61,7 +61,7 @@
   height: (@bs-height-base + 2);
   width: (@bs-height-base + 2);
   padding: 0;
-  :first-child {
+  > :first-child {
     border: none;
     text-align: center;
     width: 100%!important;
@@ -86,29 +86,14 @@
   }
 }
 
-.btn-social(@color-bg, @color: @color-bg) {
+.btn-social(@color-bg, @color: #fff) {
   background-color: @color-bg;
   .button-variant(@color, @color-bg, rgba(0,0,0,.2));
 }
 
 
-.btn-adn           { .btn-social(#d87a68); }
-.btn-bitbucket     { .btn-social(#205081); }
-.btn-dropbox       { .btn-social(#1087dd); }
 .btn-facebook      { .btn-social(#3b5998); }
-.btn-flickr        { .btn-social(#ff0084); }
-.btn-foursquare    { .btn-social(#f94877); }
 .btn-github        { .btn-social(#444444); }
-.btn-google-plus   { .btn-social(#dd4b39); }
-.btn-instagram     { .btn-social(#3f729b); }
+.btn-google        { .btn-social(#dd4b39); }
 .btn-linkedin      { .btn-social(#007bb6); }
-.btn-microsoft     { .btn-social(#2672ec); }
-.btn-openid        { .btn-social(#f7931e); }
-.btn-pinterest     { .btn-social(#cb2027); }
-.btn-reddit        { .btn-social(#eff7ff, #000); }
-.btn-soundcloud    { .btn-social(#ff5500); }
-.btn-tumblr        { .btn-social(#2c4762); }
 .btn-twitter       { .btn-social(#55acee); }
-.btn-vimeo         { .btn-social(#1ab7ea); }
-.btn-vk            { .btn-social(#587ea3); }
-.btn-yahoo         { .btn-social(#720e9e); }

--- a/server/views/account/signin.jade
+++ b/server/views/account/signin.jade
@@ -8,8 +8,8 @@ block content
         a.btn.btn-lg.btn-block.btn-social.btn-facebook(href='/auth/facebook')
             i.fa.fa-facebook
             | Sign in with Facebook
-        a.btn.btn-lg.btn-block.btn-social.btn-google-plus(href='/auth/google')
-            i.fa.fa-google-plus
+        a.btn.btn-lg.btn-block.btn-social.btn-google(href='/auth/google')
+            i.fa.fa-google
             | Sign in with Google
         a.btn.btn-lg.btn-block.btn-social.btn-linkedin(href='/auth/linkedin')
             i.fa.fa-linkedin


### PR DESCRIPTION
- Updated the [Bootstrap Social](https://lipis.github.io/bootstrap-social/) to the latest version.
- Removed the unused entries that are not part of the sign in options (makes the CSS smaller).
- The [`Sign in with Google`](https://www.freecodecamp.com/signin) icon will no longer have the `+` (No need to confuse people and it's more consistent with the rest)

(P.S. I'm the creator of https://github.com/lipis/bootstrap-social)

---

``` shell
$ npm test
  total:     727
  passing:   727
  duration:  1.7s
```
