### PR TITLE
Add background reading for Express.js challenge

### DIFF
--- a/seed/challenges/03-back-end-development-certification/nodejs-and-expressjs.json
+++ b/seed/challenges/03-back-end-development-certification/nodejs-and-expressjs.json
@@ -196,6 +196,7 @@
       "id": "bd7153d8c441eddfaeb5bd1f",
       "title": "Build Web Apps with Express.js",
       "description": [
+        "Before we begin using Express.js, read this article on <a href='http://evanhahn.com/understanding-express/' target='_blank'>Understanding Express.js</a>.",
         "We'll build this Waypoint on Cloud 9, a powerful online code editor with a full Ubuntu Linux workspace, all running in the cloud.",
         "If you don't already have Cloud 9 account, create one now at <a href='http://c9.io' target='_blank'>http://c9.io</a>.",
         "Open up <a href='http://c9.io' target='_blank'>http://c9.io</a> and sign in to your account.",


### PR DESCRIPTION
Tested locally. Passes `npm run test-challenges`. Closes #5323.
