### PR TITLE
Correct typo in How Nonprofit Projects work

### DIFF
--- a/server/views/resources/how-nonprofit-projects-work.jade
+++ b/server/views/resources/how-nonprofit-projects-work.jade
@@ -28,7 +28,7 @@ block content
         h3 Beginning the Project
         p We’ll set an initial meeting with representatives from Free Code Camp, the two campers, and the stakeholder. If the stakeholder and both campers show up promptly, and seem enthusiastic and professional, we’ll start the project. This lengthy process serves an important purpose: it reduces the likelihood that any of our campers or stakeholders will waste their precious time.
         h3 Nonprofit Stakeholders
-        p Each nonprofit project was submitted by a nonprofit. A representative from this nonprofit has agreed to serve as a "stakeholder" - an authorative person who understands the organization and its needs for this particular project.
+        p Each nonprofit project was submitted by a nonprofit. A representative from this nonprofit has agreed to serve as a "stakeholder" - an authoritative person who understands the organization and its needs for this particular project.
         p Stakeholders have a deep understanding of their organizations’ needs. Campers will work with them to figure out the best solutions to these needs.
         p When you and your pair partner first speak with your nonprofit stakeholder, you’ll:
         ol


### PR DESCRIPTION
Corrects 'authorative' to 'authoritative' in How Nonprofit Projects work.

Closes #8049
