### PR TITLE
Move to actual-react-router-bootstrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "license": "(BSD-3-Clause AND CC-BY-SA-4.0)",
   "dependencies": {
     "accepts": "^1.3.0",
+    "actual-react-router-bootstrap": "^1.0.0",
     "adler32": "~0.1.7",
     "async": "^1.5.0",
     "babel-cli": "^6.3.17",
@@ -110,7 +111,6 @@
     "react-pure-render": "^1.0.2",
     "react-redux": "^4.0.6",
     "react-router": "^2.0.0",
-    "react-router-bootstrap": "~0.20.1",
     "react-router-redux": "^2.1.0",
     "react-toastr": "^2.4.0",
     "react-vimeo": "~0.1.0",


### PR DESCRIPTION
react-router-bootstrap has moved from React-Router to RRTR. Since we still depend on React-Router I've created this fork of that project.

https://github.com/react-bootstrap/react-router-bootstrap/issues/156
