### PR TITLE
Fixed typo in palindrome test

### DIFF
--- a/seed/challenges/01-front-end-development-certification/basic-bonfires.json
+++ b/seed/challenges/01-front-end-development-certification/basic-bonfires.json
@@ -181,7 +181,7 @@
         "assert(palindrome(\"almostomla\") === false, 'message: <code>palindrome(\"almostomla\")</code> should return false.');",
         "assert(palindrome(\"My age is 0, 0 si ega ym.\") === true, 'message: <code>palindrome(\"My age is 0, 0 si ega ym.\")</code> should return true.');",
         "assert(palindrome(\"1 eye for of 1 eye.\") === false, 'message: <code>palindrome(\"1 eye for of 1 eye.\")</code> should return false.');",
-        "assert(palindrome(\"0_0 (: /-\\ :) 0-0\") === true, 'message: <code>palindrome(\"0_0 (: /-\\ :) 0-0\")</code> should return true.');"
+        "assert(palindrome(\"0_0 (: /-\\ :) 0_0\") === true, 'message: <code>palindrome(\"0_0 (: /-\\ :) 0-0\")</code> should return true.');"
       ],
       "type": "bonfire",
       "isRequired": true,


### PR DESCRIPTION
Fixes typo in the last palindrome test. It was '"0_0 (: /-\ :) 0-0\") === true' and is supposed to be '"0_0 (: /-\ :) 0_0\") === true'
