### PR TITLE
Fix the navbar links so control-clicking opens them in a new tab

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -97,7 +97,11 @@ main = (function(main, global) {
     });
 
 
-    $('#nav-chat-btn').on('click', toggleMainChat);
+    $('#nav-chat-btn').on('click', function(event) {
+      if (!(event.ctrlKey || event.metaKey)) {
+          toggleMainChat();
+      }
+  });
 
     function showMainChat() {
       if (!main.chat.isOpen) {
@@ -350,7 +354,11 @@ $(document).ready(function() {
   var mapFilter = $('#map-filter');
   var mapShowAll = $('#showAll');
 
-  $('#nav-map-btn').on('click', toggleMap);
+  $('#nav-map-btn').on('click', function(event) {
+      if (!(event.ctrlKey || event.metaKey)) {
+          toggleMap();
+      }
+  });
 
   $('.map-aside-action-collapse').on('click', collapseMap);
 
@@ -381,7 +389,11 @@ $(document).ready(function() {
     }
   }
 
-  $('#nav-wiki-btn').on('click', toggleWiki);
+  $('#nav-wiki-btn').on('click', function(event) {
+      if (!(event.ctrlKey || event.metaKey)) {
+          toggleWiki();
+      }
+  });
 
   $('.wiki-aside-action-collapse').on('click', collapseWiki);
 

--- a/server/views/partials/navbar.jade
+++ b/server/views/partials/navbar.jade
@@ -8,15 +8,15 @@ nav.navbar.navbar-default.navbar-fixed-top.nav-height
     .collapse.navbar-collapse
         ul.nav.navbar-nav.navbar-right.hamburger-dropdown
             li.hidden-xs
-                a#nav-map-btn(href='#' onclick='return false') Map
+                a#nav-map-btn(href='/map' onclick='if (!(event.ctrlKey || event.metaKey)) {return false;}') Map
             li.visible-xs
                 a(href='/map') Map
             li.hidden-xs
-                a#nav-chat-btn(href='#' onclick="return false") Chat
+                a#nav-chat-btn(href='//gitter.im/freecodecamp/freecodecamp' onclick="if (!(event.ctrlKey || event.metaKey)) {return false;}") Chat
             li.visible-xs
                 a(href="//gitter.im/freecodecamp/freecodecamp" target="_blank") Chat
             li.hidden-xs
-                a#nav-wiki-btn(href='#' onclick='return false') Wiki
+                a#nav-wiki-btn(href='/wiki' onclick='if (!(event.ctrlKey || event.metaKey)) {return false;}') Wiki
             li.visible-xs
                 a(href='/wiki', target='_blank') Wiki
             li


### PR DESCRIPTION
The default behaviour for control-clicking links is to open them in a new tab., but this behaviour is currently broken in FCC's navbar for the Map, Chat and Wiki links when the page is viewed on a larger screen.

(closes #7493) 

This change fixes it by checking the event.ctrlKey flag, and if true it allows the default behaviour for the link and does not pull out the side bar.
