### PR TITLE
Add trailing slash to wiki iframe src if omitted

### DIFF
--- a/server/views/wiki/show.jade
+++ b/server/views/wiki/show.jade
@@ -5,6 +5,9 @@ block content
     var wikiUrl = '//freecodecamp.github.io/wiki';
     var wikiOrigin = /https?:\/\/freecodecamp.github.io/;
     var requestedPath = !{JSON.stringify(path) || ''};
+    if (requestedPath !== '' && requestedPath.slice(-1) !== '/') {
+      requestedPath += '/';
+    }
     var lang = window.location.toString().match(/\/\w{2}\//);
     lang = (lang) ? lang[0] : '/en/';
     $('#wikiFrame').attr(


### PR DESCRIPTION
#### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Add new translation (feature adding new translations)

Closes #8109 
#### Description

When the iframe requests the `HTTPS://freecodecamp.github.io/wiki/en/python` page, it redirects to `HTTP://freecodecamp.github.io/wiki/en/python/` which, because it's a HTTP, gets blocked.

This adds a trailing slash to the iframe source if one doesn't exist already so that the page never redirects in the first place.
