### PR TITLE
Unsub from all FCC emails regardless of unsub link

### DIFF
--- a/server/boot/randomAPIs.js
+++ b/server/boot/randomAPIs.js
@@ -178,9 +178,9 @@ module.exports = function(app) {
         return res.redirect('/map');
       }
       return user.updateAttributes({
-        'sendMonthlyEmail': false,
-        'sendQuincyEmail': false,
-        'sendNotificationEmail': false
+        sendMonthlyEmail: false,
+        sendQuincyEmail: false,
+        sendNotificationEmail: false
       }, (err) => {
         if (err) { return next(err); }
         req.flash('info', {
@@ -224,9 +224,9 @@ module.exports = function(app) {
         return res.redirect('/map');
       }
       return user.updateAttributes({
-        'sendQuincyEmail': false,
-        'sendMonthlyEmail': false,
-        'sendNotificationEmail': false
+        sendQuincyEmail: false,
+        sendMonthlyEmail: false,
+        sendNotificationEmail: false
       }, (err) => {
         if (err) { return next(err); }
         req.flash('info', {

--- a/server/boot/randomAPIs.js
+++ b/server/boot/randomAPIs.js
@@ -177,7 +177,11 @@ module.exports = function(app) {
         });
         return res.redirect('/map');
       }
-      return user.updateAttribute('sendMonthlyEmail', false, (err) => {
+      return user.updateAttributes({
+        'sendMonthlyEmail': false,
+        'sendQuincyEmail': false,
+        'sendNotificationEmail': false
+      }, (err) => {
         if (err) { return next(err); }
         req.flash('info', {
           msg: 'We\'ve successfully updated your Email preferences.'
@@ -219,7 +223,11 @@ module.exports = function(app) {
         });
         return res.redirect('/map');
       }
-      return user.updateAttribute('sendQuincyEmail', false, (err) => {
+      return user.updateAttributes({
+        'sendQuincyEmail': false,
+        'sendMonthlyEmail': false,
+        'sendNotificationEmail': false
+      }, (err) => {
         if (err) { return next(err); }
         req.flash('info', {
           msg: 'We\'ve successfully updated your Email preferences.'


### PR DESCRIPTION
Closes #8115 
#### Description

Unsubscribes the user from all three types of emails regardless of the link they use to unsubscribe. Couple of concerns with the original issue that I think need to be addressed:
- This unsubscribes the user from _all 3_ (Quincy's newsletter, notifications, and announcements) types of emails because the original issue specifically mentioned all. Just wanted to ensure that this is the desired behaviour.
- I haven't done this but perhaps the copy should be updated to clearly state that the user was unsubscribed from all the emails (in the case they didn't actually intend to).
