### PR TITLE
Changed instructions on basic JS challenge

### DIFF
--- a/seed/challenges/01-front-end-development-certification/basic-javascript.json
+++ b/seed/challenges/01-front-end-development-certification/basic-javascript.json
@@ -3912,7 +3912,7 @@
         "<blockquote>var myObj = {<br>  \"Space Name\": \"Kirk\",<br>  \"More Space\": \"Spock\"<br>};<br>myObj[\"Space Name\"]; // Kirk<br>myObj['More Space']; // Spock</blockquote>",
         "Note that property names with spaces in them must be in quotes (single or double).",
         "<h4>Instructions</h4>",
-        "Read the values of the properties <code>\"an entree\"</code> and <code>\"the drink\"</code> of <code>testObj</code> using bracket notation."
+        "Read the values of the properties <code>\"an entree\"</code> and <code>\"the drink\"</code> of <code>testObj</code> using bracket notation and assign them to <code>entreeValue</code> and <code>drinkValue</code> respectively."
       ],
       "releasedOn": "January 1, 2016",
       "challengeSeed": [


### PR DESCRIPTION
Fixed the instructions on the Basic Javascript module "Accessing Objects Properties with Bracket Notation". Made the instructions more clear by emphasizing that the object properties must be assigned to variables. Tested on local.

closes #7870
