### PR TITLE
Update the Sign in and Sign up Pages

### DIFF
--- a/server/boot/user.js
+++ b/server/boot/user.js
@@ -148,6 +148,7 @@ module.exports = function(app) {
   router.post('/reset-password', postReset);
   router.get('/email-signup', getEmailSignup);
   router.get('/email-signin', getEmailSignin);
+  router.get('/deprecated-signin', getDepSignin);
   router.get(
     '/toggle-lockdown-mode',
     sendNonUserToMap,
@@ -223,6 +224,15 @@ module.exports = function(app) {
   function signout(req, res) {
     req.logout();
     res.redirect('/');
+  }
+
+  function getDepSignin(req, res) {
+    if (req.user) {
+      return res.redirect('/');
+    }
+    return res.render('account/deprecated-signin', {
+      title: 'Sign in to Free Code Camp using a Deprecated Login'
+    });
   }
 
   function getEmailSignin(req, res) {

--- a/server/views/account/deprecated-signin.jade
+++ b/server/views/account/deprecated-signin.jade
@@ -1,25 +1,28 @@
 extends ../layout
 block content
     .text-center
-        h2 Sign in with one of these options:
-        a.btn.btn-lg.btn-block.btn-social.btn-primary(href='/email-signin')
-            i.fa.fa-envelope
-            | Sign in with Email
-        a.btn.btn-lg.btn-block.btn-social.btn-github(href='/auth/github')
-            i.fa.fa-github
-            | Sign in with GitHub
+        h2 Sign in with one of these options if you used them as your original login methods :
+        br
+        a.btn.btn-lg.btn-block.btn-social.btn-facebook(href='/auth/facebook')
+            i.fa.fa-facebook
+            | Sign in with Facebook
+        a.btn.btn-lg.btn-block.btn-social.btn-google(href='/auth/google')
+            i.fa.fa-google
+            | Sign in with Google
+        a.btn.btn-lg.btn-block.btn-social.btn-linkedin(href='/auth/linkedin')
+            i.fa.fa-linkedin
+            | Sign in with LinkedIn
+        a.btn.btn-lg.btn-block.btn-social.btn-twitter(href='/auth/twitter')
+            i.fa.fa-twitter
+            | Sign in with Twitter
         br
         p
-            a(href="/deprecated-signin") Or click here to signin with one of the deprecated methods.
-
-        h2 New to Free Code Camp ? Sign up now:
-        a.btn.btn-lg.btn-block.btn-social.btn-primary(href='/email-signup')
-            i.fa.fa-envelope
-            | Sign up with Email
-        a.btn.btn-lg.btn-block.btn-social.btn-github(href='/auth/github')
-            i.fa.fa-github
-            | Sign up with GitHub
-
+          strong IMPORTANT NOTICE 
+          br
+          em These options are under deprecation and will be removed soon. 
+          br
+          em After you are signed in, go to the settings page and add GitHub and/or Email as your sign in option
+          
     script.
       $(document).ready(function() {
         var method = localStorage.getItem('lastSigninMethod'),

--- a/server/views/account/show.jade
+++ b/server/views/account/show.jade
@@ -14,7 +14,7 @@ block content
             a.btn.btn-lg.btn-block.btn-primary.btn-link-social(href='/settings')
                 | Update your settings
         .col-xs-12
-            a.btn.btn-lg.btn-block.btn-primary.btn-link-social(href='/logout')
+            a.btn.btn-lg.btn-block.btn-primary.btn-link-social(href='/signout')
                 | Sign me out of Free Code Camp
         .col-xs-12
             a.btn.btn-lg.btn-block.btn-primary.btn-link-social(href='mailto:team@freecodecamp.com')


### PR DESCRIPTION
This changes the Sign In and Sign Up flows to allow transition period, for deprecating the social logins other than Github.

**The main Sign In view `/signin` :**

![image](https://cloud.githubusercontent.com/assets/1884376/14713129/7f7d620e-07fd-11e6-9522-b6dd4d9fa906.png)

**The deprecated logins are available at the view `/deprecated-signin` :**

![image](https://cloud.githubusercontent.com/assets/1884376/14713214/dd494b3c-07fd-11e6-9f73-e9e8f475ca10.png)

Addresses parts of #8165 and #8167
