### PR TITLE
Add Update Email View

### DIFF
--- a/client/less/main.less
+++ b/client/less/main.less
@@ -499,6 +499,22 @@ thead {
   }
 }
 
+a[href="/email-signup"], a[href="/email-signin"] {
+  &.btn-social.btn-lg > :first-child {
+    line-height:43px;
+    font-size:26px;
+  }
+}
+
+form.email-update .btn{
+  margin:0;
+  width:40%;
+  display:inline-block;
+  &:last-child {
+    float:right;
+  }
+}
+
 .public-profile-img {
   height: 200px;
   width: 200px;

--- a/common/models/user.js
+++ b/common/models/user.js
@@ -306,6 +306,50 @@ module.exports = function(User) {
     }
   );
 
+  User.prototype.updateEmail = function updateEmail(email) {
+    if (this.email && this.email === email) {
+      debug('same email as current User', email);
+      return Promise.reject(new Error(
+        `${email} is already associated with this account.`
+        ));
+    }
+    return User.doesExist(null, email)
+      .then(exists => {
+        if (!exists) {
+          return this.update$({ email }).toPromise();
+        }
+        debug('same email as another User', email);
+        return Promise.reject(new Error(
+          `${email} is already associated with an account.`
+          ));
+      });
+  };
+
+  User.remoteMethod(
+    'updateEmail',
+    {
+      isStatic: false,
+      description: 'updates the email of the user object',
+      accepts: [
+        {
+          arg: 'email',
+          type: 'string',
+          required: true
+        }
+      ],
+      returns: [
+        {
+          arg: 'status',
+          type: 'object'
+        }
+      ],
+      http: {
+        path: '/email-update',
+        verb: 'POST'
+      }
+    }
+  );
+
   User.giveBrowniePoints =
     function giveBrowniePoints(receiver, giver, data = {}, dev = false, cb) {
       const findUser = observeMethod(User, 'findOne');

--- a/common/models/user.json
+++ b/common/models/user.json
@@ -235,6 +235,13 @@
       "principalId": "$everyone",
       "permission": "ALLOW",
       "property": "giveBrowniePoints"
+    },
+    {
+      "accessType": "EXECUTE",
+      "principalType": "ROLE",
+      "principalId": "$owner",
+      "permission": "ALLOW",
+      "property": "updateEmail"
     }
   ],
   "methods": []

--- a/server/boot/user.js
+++ b/server/boot/user.js
@@ -149,6 +149,7 @@ module.exports = function(app) {
   router.get('/email-signup', getEmailSignup);
   router.get('/email-signin', getEmailSignin);
   router.get('/deprecated-signin', getDepSignin);
+  router.get('/email-update', getUpdateEmail);
   router.get(
     '/toggle-lockdown-mode',
     sendNonUserToMap,
@@ -226,12 +227,22 @@ module.exports = function(app) {
     res.redirect('/');
   }
 
+
   function getDepSignin(req, res) {
     if (req.user) {
       return res.redirect('/');
     }
     return res.render('account/deprecated-signin', {
       title: 'Sign in to Free Code Camp using a Deprecated Login'
+    });
+  }
+
+  function getUpdateEmail(req, res) {
+    if (!req.user) {
+      return res.redirect('/');
+    }
+    return res.render('account/email-update', {
+      title: 'Update your Email'
     });
   }
 

--- a/server/views/account/email-update.jade
+++ b/server/views/account/email-update.jade
@@ -1,0 +1,58 @@
+extends ../layout
+block content
+  .container
+    .row.flashMessage.negative-30
+        .col-xs-12
+            #flash-board.alert.fade.in(style='display: none;')
+                button.close(type='button', data-dismiss='alert')
+                    span.ion-close-circled#flash-close
+                #flash-content
+  h2.text-center Update your email address here:
+  form.form-horizontal.email-update(method='POST', action='/api/users/#{user.id}/email-update', name="updateEmailForm")
+    .row
+      .col-sm-6.col-sm-offset-3
+        input(type='hidden', name='_csrf', value=_csrf)
+        .form-group
+          input.input-lg.form-control(type='email', name='email', id='email', placeholder='Enter your new email', autofocus, required, autocomplete="off")
+        .form-group
+          button.btn.btn-lg.btn-primary.btn-block(type='submit')
+            | Update my Email
+          a.btn.btn-lg.btn-block.btn-primary.btn-link-social(href='/settings')
+            | Go back to Settings
+
+    script.
+       $(document).ready(function() {
+        $('form').submit(function(event){
+          event.preventDefault();
+          $('#flash-board').hide();
+          var $form = $(event.target);
+          $.ajax({
+              type        : 'POST',
+              url         : $form.attr('action'),
+              data        : $form.serialize(),
+              dataType    : 'json',
+              encode      : true,
+              xhrFields   : { withCredentials:  true }
+          })
+          .fail(error => {
+            if (error.responseText){
+                var data = JSON.parse(error.responseText);
+                if(data.error && data.error.message)
+                $('#flash-content').html(data.error.message);
+                $('#flash-board')
+                                .removeClass('alert-success')
+                                .addClass('alert-danger')
+                                .fadeIn();
+              }
+          })
+          .done(data =>{
+            if(data.status && data.status.count){
+              $('#flash-content').html("Your email has been updated successfully!");
+              $('#flash-board')
+                              .removeClass('alert-danger')
+                              .addClass('alert-success')
+                              .fadeIn();
+            }
+          });
+        });
+       });

--- a/server/views/account/settings.jade
+++ b/server/views/account/settings.jade
@@ -48,43 +48,61 @@ block content
 
         .spacer
         h2.text-center Email settings
-        .row
-          .col-xs-12.col-sm-8.col-sm-offset-2.col-md-6.col-md-offset-3
-            .row
-              .col-xs-9
-                p.large-p Send me announcement emails
-                  br
-                  | (we'll send you these every Thursday)
-              if (user.sendMonthlyEmail)
-                .col-xs-3
-                  a.btn.btn-lg.btn-primary.btn-block.active.positive-20(href='/toggle-announcement-email-mode') On
-              else
-                .col-xs-3
-                  a.btn.btn-lg.btn-primary.btn-block.positive-20(href='/toggle-announcement-email-mode') Off
+        if(user.email)
+          .row
+            .col-xs-12
+              p.large-p.text-center
+                em #{user.email}
+            .col-xs-12
+              a.btn.btn-lg.btn-block.btn-primary.btn-link-social(href='/email-update')
+                i.fa.fa-envelope
+                | Update my Email
+          .row
+            .col-xs-12.col-sm-8.col-sm-offset-2.col-md-6.col-md-offset-3
+              .row
+                .col-xs-9
+                  p.large-p Send me announcement emails
+                    br
+                    | (we'll send you these every Thursday)
+                if (user.sendMonthlyEmail)
+                  .col-xs-3
+                    a.btn.btn-lg.btn-primary.btn-block.active.positive-20(href='/toggle-announcement-email-mode') On
+                else
+                  .col-xs-3
+                    a.btn.btn-lg.btn-primary.btn-block.positive-20(href='/toggle-announcement-email-mode') Off
 
-            .row
-              .col-xs-9
-                p.large-p Send me notification emails
-                  br
-                  | (these will pertain to your account)
-              if (user.sendNotificationEmail)
-                .col-xs-3
-                  a.btn.btn-lg.btn-primary.btn-block.active.positive-20(href='/toggle-notification-email-mode') On
-              else
-                .col-xs-3
-                  a.btn.btn-lg.btn-primary.btn-block.positive-20(href='/toggle-notification-email-mode') Off
+              .row
+                .col-xs-9
+                  p.large-p Send me notification emails
+                    br
+                    | (these will pertain to your account)
+                if (user.sendNotificationEmail)
+                  .col-xs-3
+                    a.btn.btn-lg.btn-primary.btn-block.active.positive-20(href='/toggle-notification-email-mode') On
+                else
+                  .col-xs-3
+                    a.btn.btn-lg.btn-primary.btn-block.positive-20(href='/toggle-notification-email-mode') Off
 
-            .row
-              .col-xs-9
-                p.large-p Send me Quincy's weekly email
-                  br
-                  | (with new articles every Tuesday)
-              if (user.sendQuincyEmail)
-                .col-xs-3
-                  a.btn.btn-lg.btn-primary.btn-block.active.positive-20(href='/toggle-quincy-email-mode') On
-              else
-                .col-xs-3
-                  a.btn.btn-lg.btn-primary.btn-block.positive-20(href='/toggle-quincy-email-mode') Off
+              .row
+                .col-xs-9
+                  p.large-p Send me Quincy's weekly email
+                    br
+                    | (with new articles every Tuesday)
+                if (user.sendQuincyEmail)
+                  .col-xs-3
+                    a.btn.btn-lg.btn-primary.btn-block.active.positive-20(href='/toggle-quincy-email-mode') On
+                else
+                  .col-xs-3
+                    a.btn.btn-lg.btn-primary.btn-block.positive-20(href='/toggle-quincy-email-mode') Off
+        else
+          .row
+            .col-xs-12
+              p.large-p.text-center
+                | You don't have an email id associated to this account.
+            .col-xs-12
+              a.btn.btn-lg.btn-block.btn-primary.btn-link-social(href='/email-update')
+                i.fa.fa-envelope
+                | Update my Email
 
         .spacer
         h2.text-center Danger Zone


### PR DESCRIPTION
This commit:
- Displays the user's email that we have on records
- Adds a button in the settings to update email
- Adds a form view to update the email
- Fixes CSS for the Email icons and the email form ~ Credits to @hallaathrad
## **Settings Page - With No-Email**

![screen shot 2016-04-24 at 4 41 48 am](https://cloud.githubusercontent.com/assets/1884376/14764483/ff39e91a-09d6-11e6-8bb6-730cda2fda5c.png)
## **Add/Update Email Form View**
## ![screen shot 2016-04-22 at 2 54 23 am](https://cloud.githubusercontent.com/assets/1884376/14724770/ce8a83e4-0835-11e6-9dd8-81452cee187f.png)
## **Sucess Message**

![screen shot 2016-04-24 at 4 45 02 am](https://cloud.githubusercontent.com/assets/1884376/14764505/7b77008a-09d7-11e6-9f79-b501522d10b0.png)

---

---
## **Settings Page - With Email**

![screen shot 2016-04-24 at 4 46 44 am](https://cloud.githubusercontent.com/assets/1884376/14764510/9d1ebde0-09d7-11e6-82fa-24a739067a4b.png)

---
