### PR TITLE
Constrain Style HTML Body test need semicolon

### DIFF
--- a/seed/challenges/01-front-end-development-certification/html5-and-css.json
+++ b/seed/challenges/01-front-end-development-certification/html5-and-css.json
@@ -3830,7 +3830,8 @@
       ],
       "tests": [
         "assert($(\"body\").css(\"background-color\") === \"rgb(0, 0, 0)\", 'message: Give your <code>body</code> element the <code>background-color</code> of black.');",
-        "assert(code.match(/<style>\\s*body\\s*\\{\\s*background.*\\s*:\\s*.*;?\\s*\\}\\s*<\\/style>/i), 'message: Make sure your CSS rule is properly formatted with both opening and closing curly brackets.');"
+        "assert(code.match(/<style>\\s*body\\s*\\{\\s*background.*\\s*:\\s*.*;\\s*\\}\\s*<\\/style>/i), 'message: Make sure your CSS rule is properly formatted with both opening and closing curly brackets.');",
+        "assert(code.match(/<style>\\s*body\\s*\\{\\s*background.*\\s*:\\s*.*;\\s*\\}\\s*<\\/style>/i), 'message: Make sure your CSS rule ends with a semi-colon.');"
       ],
       "descriptionPtBR": [
         "Agora vamos recomeçar e falar sobre herança em CSS.",


### PR DESCRIPTION
<!-- FreeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/FreeCodeCamp/FreeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->

<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/HelpContributors -->

<!-- Make sure that your PR is not a duplicate -->
#### Pre-Submission Checklist

<!-- Go over all points below, and put an `x` in all the boxes that apply. -->

<!-- All points should be checked, otherwise, read the CONTRIBUTING guidelines from above-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of FreeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](https://github.com/FreeCodeCamp/FreeCodeCamp/wiki/git-rebase#squashing-multiple-commits-into-one) them into one commit).
- [x] All new and existing tests pass the command `npm run test-challenges`. Use `git commit --amend` to amend any fixes.
#### Type of Change

<!-- What type of change does your code introduce? Put an `x` in the box that applies. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Add new translation (feature adding new translations)
#### Checklist:

<!-- Go over all points below, and put an `x` in all the boxes that apply. -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Tested changes locally.
- [ ] Closes currently open issue (`Closes #XXXX`): Closes 
#### Description

<!-- Describe your changes in detail -->

In Issue #8274, we reiterated that for CSS rules, semicolons are required in ending all rules, even block CSS rules. In trying to see if other challenges were requiring semicolons or not, I stumbled upon this challenge which allowed optional semicolons.
