### PR TITLE
Added left: 0 to mapWrapper class and improved layout of the map page…

### DIFF
--- a/client/less/map.less
+++ b/client/less/map.less
@@ -74,9 +74,19 @@
     padding-top:30px;
   }
   p {
-  margin: 5px 0 20px;
+    margin: 5px 0 20px;
     @media (max-width: 720px) {
       margin-bottom:10px;
+    }
+
+    @media only screen and (min-width: 480px) and (max-width: 640px) {
+      margin-top: 0;
+      margin-bottom: 15px;
+    }     
+
+    @media only screen and (min-width: 320px) and (max-width: 479px) {
+      margin-top: 0;
+      margin-bottom: 15px;
     }
   }
   hr {
@@ -92,6 +102,13 @@
     top: 160px;
     width: 100%;
   }
+  /* phone landscape and portrait */
+  @media only screen and (min-width: 480px) and (max-width: 640px) {
+    padding-top:10px;
+  }   
+  @media only screen and (min-width: 320px) and (max-width: 479px) {
+    padding-top:10px;   
+  }   
  }
 
 .map-buttons {
@@ -136,6 +153,7 @@
   display: block;
   height: 100%;
   width: 100%;
+  left:0;
 }
 
 .map-accordion {
@@ -145,7 +163,7 @@
   #nested {
     margin:0 10px;
     @media (max-width: 400px) {
-    margin:0;
+      margin:0;
     }
   }
   a:focus {
@@ -194,10 +212,10 @@
   }
 
   .challengeBlockDescription {
-      margin:0;
-      margin-top:-10px;
-      padding:0 15px 23px 30px;
-    }
+    margin:0;
+    margin-top:-10px;
+    padding:0 15px 23px 30px;
+  }
 
   span.no-link-underline {
     position:absolute;
@@ -209,6 +227,7 @@
     margin-bottom:30px
   }
 }
+
 .challengeBlockTime {
   font-size: 18px;
   color: #BBBBBB;
@@ -254,6 +273,25 @@
         clear:both;
         font-size:20px;
       }
+    }
+  }
+}
+
+/* phone landscape */
+@media only screen and (min-width: 480px) and (max-width: 640px) {
+  .map-accordion {
+    top:147px;
+    h2 {
+      margin: 7px 0;
+    }    
+  }
+}   
+/* phone portrait */
+@media only screen and (min-width: 320px) and (max-width: 479px) {
+  .map-accordion {
+    top:170px;
+    h2 {
+      margin: 7px 0;
     }
   }
 }


### PR DESCRIPTION
<!-- FreeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/FreeCodeCamp/FreeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->

<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/HelpContributors -->

<!-- Make sure that your PR is not a duplicate -->
#### Pre-Submission Checklist

<!-- Go over all points below, and put an `x` in all the boxes that apply. -->

<!-- All points should be checked, otherwise, read the CONTRIBUTING guidelines from above-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of FreeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](https://github.com/FreeCodeCamp/FreeCodeCamp/wiki/git-rebase#squashing-multiple-commits-into-one) them into one commit).
- [x] All new and existing tests pass the command `npm run test-challenges`. Use `git commit --amend` to amend any fixes.
#### Type of Change

<!-- What type of change does your code introduce? Put an `x` in the box that applies. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Add new translation (feature adding new translations)
#### Checklist:

<!-- Go over all points below, and put an `x` in all the boxes that apply. -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Tested changes locally.
- [x] Closes currently open issue (`Closes #8254`): Closes 
#### Description

<!-- Describe your changes in detail -->

Closes #8254

Things weren't laying out properly when viewing the map on a phone. The div with class of mapWrapper has an absolute position, and needed left: 0 to fix things. Things were getting forced off the page to the right and being cut off.

Improved layout and alignment of elements when being viewed on a phone. Also moved things up when viewing on a phone which gives the scroll box a bit more room, especially in landscape mode.
