### PR TITLE
Update paths to minimize re-directs

### DIFF
--- a/common/app/components/Nav/Nav.jsx
+++ b/common/app/components/Nav/Nav.jsx
@@ -95,7 +95,7 @@ export default class extends React.Component {
       return (
         <NavItem
           eventKey={ 2 }
-          href='/login'>
+          href='/signin'>
           Sign In
         </NavItem>
       );

--- a/server/boot/commit.js
+++ b/server/boot/commit.js
@@ -23,7 +23,7 @@ import {
 } from '../utils/middleware';
 
 const sendNonUserToSignIn = ifNoUserRedirectTo(
-  '/login',
+  '/signin',
   'You must be signed in to commit to a nonprofit.',
   'info'
 );

--- a/server/passport-providers.js
+++ b/server/passport-providers.js
@@ -1,5 +1,5 @@
 var successRedirect = '/';
-var failureRedirect = '/login';
+var failureRedirect = '/signin';
 var linkFailureRedirect = '/account';
 module.exports = {
   local: {

--- a/server/views/challenges/showHTML.jade
+++ b/server/views/challenges/showHTML.jade
@@ -37,7 +37,7 @@ block content
                         var userLoggedIn = true;
                     if (!user)
                         .button-spacer
-                        a.btn.signup-btn.btn-block.btn-block(href='/login') Sign in so you can save your progress
+                        a.btn.signup-btn.btn-block.btn-block(href='/signin') Sign in so you can save your progress
                             script.
                                 var userLoggedIn = false;
                     .button-spacer

--- a/server/views/challenges/showJS.jade
+++ b/server/views/challenges/showJS.jade
@@ -43,7 +43,7 @@ block content
                         label.btn.btn-primary.btn-lg#trigger-issue-modal Bug
                     if (!user)
                         .button-spacer
-                        a.btn.signup-btn.btn-block.btn-block(href='/login') Sign in so you can save your progress
+                        a.btn.signup-btn.btn-block.btn-block(href='/signin') Sign in so you can save your progress
                             script.
                                 var userLoggedIn = false;
                     .button-spacer

--- a/server/views/challenges/showVideo.jade
+++ b/server/views/challenges/showVideo.jade
@@ -31,7 +31,7 @@ block content
                 .btn.btn-primary.btn-big#trigger-issue-modal Report a bug
             if (!user)
                 .button-spacer
-                a.btn.btn-big.signup-btn.btn-block(href='/login') Sign in so you can save your progress
+                a.btn.btn-big.signup-btn.btn-block(href='/signin') Sign in so you can save your progress
                     script.
                         var userLoggedIn = false;
                 br

--- a/server/views/challenges/showZiplineOrBasejump.jade
+++ b/server/views/challenges/showZiplineOrBasejump.jade
@@ -31,7 +31,7 @@ block content
                 .btn.btn-primary.btn-primary-ghost.btn-big#trigger-issue-modal Bug
             if (!user)
                 .button-spacer
-                a.btn.btn-big.signup-btn.btn-block(href='/login') Sign in so you can save your progress
+                a.btn.btn-big.signup-btn.btn-block(href='/signin') Sign in so you can save your progress
                     script.
                         var userLoggedIn = false;
                 br

--- a/server/views/partials/navbar.jade
+++ b/server/views/partials/navbar.jade
@@ -25,7 +25,7 @@ nav.navbar.navbar-default.navbar-fixed-top.nav-height
                 a(href='/shop') Shop
             if !user
                 li
-                    a(href='/login') Sign in
+                    a(href='/signin') Sign in
             else
                 li.brownie-points-nav
                   a(href='/' + user.username) [&thinsp;#{user.points}&thinsp;]

--- a/server/views/resources/stories.jade
+++ b/server/views/resources/stories.jade
@@ -22,4 +22,4 @@ block content
 
                     if !user
                         .text-center
-                            a.btn.btn-cta.signup-btn.btn-block(href="/login") Start learning to code (it's free)
+                            a.btn.btn-cta.signup-btn.btn-block(href="/signin") Start learning to code (it's free)


### PR DESCRIPTION
This changes most of the `/login` calls to `/signin` especially targeting the passport-component failure redirects.

This is trivial change, yet should prevent unnecessary 301s.

For instance on a test setup, the flash error messages sometimes do not show up target rendering view is redirected.
