### PR TITLE
Fixed Map menu content positioning for small screens.

### DIFF
--- a/client/less/map.less
+++ b/client/less/map.less
@@ -2,7 +2,7 @@
  * based off of https://github.com/gitterHQ/sidecar
  * license: MIT
  */
- 
+
 .map-aside {
     width:500px;
 
@@ -132,7 +132,6 @@
 }
 
 .mapWrapper {
-  position:absolute;
   display: block;
   height: 100%;
   width: 100%;


### PR DESCRIPTION
<!-- FreeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/FreeCodeCamp/FreeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->

<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/HelpContributors -->

<!-- Make sure that your PR is not a duplicate -->
#### Pre-Submission Checklist

<!-- Go over all points below, and put an `x` in all the boxes that apply. -->

<!-- All points should be checked, otherwise, read the CONTRIBUTING guidelines from above-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of FreeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](https://github.com/FreeCodeCamp/FreeCodeCamp/wiki/git-rebase#squashing-multiple-commits-into-one) them into one commit).
- [x] All new and existing tests pass the command `npm run test-challenges`. Use `git commit --amend` to amend any fixes.
#### Type of Change

<!-- What type of change does your code introduce? Put an `x` in the box that applies. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)
#### Checklist:

<!-- Go over all points below, and put an `x` in all the boxes that apply. -->

<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Closes currently open issue (e.g. `Closes #XXXX`): Closes  #8524
#### Description

<!-- Describe your changes in detail -->

Issue #8524 reports that `padding: 5px` needed adding the the paragraph at the top of the map menu. In actual fact, the `.mapWrapper` was set to `position: absolute` causing the map menu contents to be shifted over to the right. Removing this property (so it will be set back to the browser default of static) re-aligns the menu & removes the issue from the map content. It also allows the accordion to span the width of the container.

_Note_: This fix goes hand in hand with line 143 of maps.less - the position property of `.map-accordion` has already been set to `relative` on the staging branch (live site is currently set to `position: absolute`). So once this fix along with the fix on line 143 is pushed, it should all sit properly again.

Tested this fix using Chrome Dev Tools with the Nexus 6P, Neuxs 5X and Galaxy S5.

_Before_
![fcc-map-issue-before](https://cloud.githubusercontent.com/assets/9949268/15120881/ba800e72-160f-11e6-8d0e-1094cfc33e5f.png)

_After_
![fcc-map-issue-after](https://cloud.githubusercontent.com/assets/9949268/15120914/eadebc44-160f-11e6-9ec2-c49f3e24f4ee.png)
