### PR TITLE
chore(npm-script): added dev to package.json/script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,15 +57,6 @@ cd freecodecamp
 
 # Install NPM dependencies
 npm install
-
-# Install Gulp globally
-npm install -g gulp
-
-# Install Bower globally
-npm install -g bower
-
-# Install Bower dependencies
-bower install
 ```
 *Private Environment Variables (API Keys)*
 ```bash
@@ -92,7 +83,7 @@ mongod
 npm run only-once
 
 # start the application
-gulp
+npm run dev
 ```
 Now navigate to your browser and open http://localhost:3001
 If the app loads, congratulations - you're all set. Otherwise, let us know by opening a GitHub issue and with your error.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "lint-json": "npm run lint-server && npm run lint-challenges && npm run lint-resources && npm run lint-utils",
     "test-challenges": "babel-node seed/test-challenges.js | tap-spec",
     "pretest": "npm run lint",
-    "test": "npm run test-challenges"
+    "test": "npm run test-challenges",
+    "dev": "bower install && gulp"
   },
   "license": "(BSD-3-Clause AND CC-BY-SA-4.0)",
   "dependencies": {
@@ -135,6 +136,7 @@
     "yargs": "^4.1.0"
   },
   "devDependencies": {
+    "bower": "^1.7.9",
     "browser-sync": "^2.9.12",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-tape": "0.0.7",


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Your pull request targets the `staging` branch of FreeCodeCamp.
- [x] Branch starts with either `chore/`, `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](https://github.com/FreeCodeCamp/FreeCodeCamp/wiki/git-rebase#squashing-multiple-commits-into-one) them into one commit).
- [x] All new and existing tests pass the command `npm run test-challenges`. Use `git commit --amend` to amend any fixes.
#### Type of Change

<!-- What type of change does your code introduce? Put an `x` in the box that applies. -->
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)
- [x] Added dev to package.json/script (npm-script)
#### Checklist:
- [x] Tested changes locally.
- [ ] Closes currently open issue (e.g. `Closes #XXXX`): Closes 
#### Description

chore(npm-script): added `dev` to `package.json/script` to install `bower` dependencies and start the default `gulp` task

> In addition to the shell's pre-existing `PATH`, `npm run` adds `node_modules/.bin` to the `PATH` provided to scripts. Any binaries provided by locally-installed dependencies can be used without the `node_modules/.bin prefix`

For further details please refer [docs.npmjs.com/cli/run-script](https://docs.npmjs.com/cli/run-script)
