### PR TITLE
fix(a11y): using button instead of div

### DIFF
--- a/server/views/challenges/showStep.jade
+++ b/server/views/challenges/showStep.jade
@@ -19,12 +19,12 @@ block content
                         if index === 0
                             .col-sm-4.hidden-xs &nbsp;
                         else
-                            .btn.btn-primary.btn-primary-ghost.col-sm-4.col-xs-12.challenge-step-btn-prev.btn-lg(id='#{index - 1}') Go to my previous step
+                            button.btn.btn-primary.btn-primary-ghost.col-sm-4.col-xs-12.challenge-step-btn-prev.btn-lg(id='#{index - 1}') Go to my previous step
                         .challenge-step-counter.large-p.col-sm-4.col-xs-12.text-center (#{index + 1} / #{description.length})
                         if index + 1 === description.length
-                            .btn.btn-primary.col-sm-4.col-xs-12.challenge-step-btn-finish.btn-lg(id='last' class=step[3] && !isCompleted ? 'disabled' : '') Finish challenge
+                            button.btn.btn-primary.col-sm-4.col-xs-12.challenge-step-btn-finish.btn-lg(id='last' class=step[3] && !isCompleted ? 'disabled' : '') Finish challenge
                         else
-                            .btn.btn-primary.col-sm-4.col-xs-12.challenge-step-btn-next.btn-lg(id='#{index}' class=step[3] && !isCompleted ? 'disabled' : '') Go to my next step
+                            button.btn.btn-primary.col-sm-4.col-xs-12.challenge-step-btn-next.btn-lg(id='#{index}' class=step[3] && !isCompleted ? 'disabled' : '') Go to my next step
                     .clearfix
     .spacer
     #challenge-step-modal.modal(tabindex='-1')


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Your pull request targets the `staging` branch of FreeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](https://github.com/FreeCodeCamp/FreeCodeCamp/wiki/git-rebase#squashing-multiple-commits-into-one) them into one commit).
- [x] All new and existing tests pass the command `npm run test-challenges`. Use `git commit --amend` to amend any fixes.
#### Type of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)
#### Checklist:
- [x] Tested changes locally.
- [x] Closes currently open issue (e.g. `Closes #8575`): Closes 
#### Description

using `button` instead of `div`, `div` can be styled to look like a `button`, but it does not behave as a `button` semantically, for example receiving focus, respect the `tab` order, trigger `click` event when `space` is pressed. Above all, for assistive technology, `div` will never be presented or read out as `button`. A visually challenged user will never know about those `CTA`s

fixed #8575
