### PR TITLE
fix(a11y): using button instead of div

### DIFF
--- a/server/views/challenges/showBonfire.jade
+++ b/server/views/challenges/showBonfire.jade
@@ -30,15 +30,18 @@ block content
                                         ul: li: a(href=""+link, target="_blank") !{MDNkeys[index]}
                             .button-spacer
                 if (user)
-                label.btn.btn-primary.btn-block.btn-lg#submitButton
+                button.btn.btn-primary.btn-block.btn-lg#submitButton
                         | Run tests (ctrl + enter)
                 .button-spacer
                 .btn-group.input-group.btn-group-justified
-                    label.btn.btn-primary.btn-primary-ghost.btn-lg#trigger-reset-modal
+                    .btn-group
+                        button.btn.btn-primary.btn-primary-ghost.btn-lg#trigger-reset-modal
                             | &nbsp; Reset
-                    label.btn.btn-primary.btn-primary-ghost.btn-lg#challenge-help-btn
+                    .btn-group
+                        button.btn.btn-primary.btn-primary-ghost.btn-lg#challenge-help-btn
                             | &nbsp; Help
-                    label.btn.btn-primary.btn-primary-ghost.btn-lg#trigger-issue-modal
+                    .btn-group
+                        button.btn.btn-primary.btn-primary-ghost.btn-lg#trigger-issue-modal
                             | &nbsp; Bug
                 if (!user)
                     .button-spacer

--- a/server/views/challenges/showHTML.jade
+++ b/server/views/challenges/showHTML.jade
@@ -24,15 +24,17 @@ block content
                                         p.wrappable!= sentence
                                 .negative-bottom-margin-30
                     .button-spacer
-                    .btn-big.btn.btn-primary.btn-block#submitButton
+                    button.btn-big.btn.btn-primary.btn-block#submitButton
                         | Run tests (ctrl + enter)
                     .button-spacer
-                    .btn-group.input-group.btn-group-justified
-                        label.btn.btn-primary.btn-primary-ghost.btn-lg#trigger-reset-modal Reset
-                        label.btn.btn-primary.btn-primary-ghost.hidden-sm.hidden-md.hidden-lg
-                            a(href='//gitter.im/freecodecamp/help') Help
-                        label.btn.btn-primary.btn-primary-ghost.hidden-xs.btn-lg#challenge-help-btn Help
-                        label.btn.btn-primary.btn-primary-ghost.btn-lg#trigger-issue-modal Bug
+                    .btn-group.btn-group-justified
+                        .btn-group
+                          button.btn.btn-primary.btn-primary-ghost.btn-lg#trigger-reset-modal Reset
+                        a.btn.btn-primary.btn-primary-ghost.hidden-sm.hidden-md.hidden-lg(href='//gitter.im/freecodecamp/help') Help
+                        .btn-group
+                          button.btn.btn-primary.btn-primary-ghost.hidden-xs.btn-lg#challenge-help-btn Help
+                        .btn-group
+                          button.btn.btn-primary.btn-primary-ghost.btn-lg#trigger-issue-modal Bug
                     script.
                         var userLoggedIn = true;
                     if (!user)
@@ -67,7 +69,7 @@ block content
                                     span.completion-icon.ion-checkmark-circled.text-primary
                             .spacer
                             if(user)
-                                #submit-challenge.animated.fadeIn.btn.btn-lg.btn-primary.btn-block Submit and go to my next challenge (ctrl + enter)
+                                button#submit-challenge.animated.fadeIn.btn.btn-lg.btn-primary.btn-block Submit and go to my next challenge (ctrl + enter)
                             else
                                 a#next-challenge.btn.btn-lg.btn-primary.btn-block(href="/challenges/next-challenge?id="+id) Go to my next challenge (ctrl + enter)
     include ../partials/challenge-modals

--- a/server/views/challenges/showJS.jade
+++ b/server/views/challenges/showJS.jade
@@ -35,12 +35,15 @@ block content
                             .form-group.text-center
                                 .col-xs-12
                                     // extra field to distract password tools like lastpass from injecting css into our username field
-                    label.btn.btn-primary.btn-big.btn-block#submitButton Run tests (ctrl + enter)
+                    button.btn.btn-primary.btn-big.btn-block#submitButton Run tests (ctrl + enter)
                     .button-spacer
                     .btn-group.input-group.btn-group-justified
-                        label.btn.btn-primary.btn-lg#trigger-reset-modal Reset
-                        label.btn.btn-primary.btn-lg#challenge-help-btn Help
-                        label.btn.btn-primary.btn-lg#trigger-issue-modal Bug
+                        .btn-group
+                            button.btn.btn-primary.btn-lg#trigger-reset-modal Reset
+                        .btn-group
+                            button.btn.btn-primary.btn-lg#challenge-help-btn Help
+                        .btn-group
+                            button.btn.btn-primary.btn-lg#trigger-issue-modal Bug
                     if (!user)
                         .button-spacer
                         a.btn.signup-btn.btn-block.btn-block(href='/signin') Sign in so you can save your progress
@@ -72,7 +75,7 @@ block content
                         .spacer
                         .row
                         if (user)
-                            #submit-challenge.animated.fadeIn.btn.btn-lg.btn-primary.btn-block Submit and go to my next challenge (ctrl + enter)
+                            button#submit-challenge.animated.fadeIn.btn.btn-lg.btn-primary.btn-block Submit and go to my next challenge (ctrl + enter)
                         else
                             a#next-challenge.animated.fadeIn.btn.btn-lg.btn-primary.btn-block(href="/challenges/next-challenge?id="+id) Go to my next challenge (ctrl + enter)
     include ../partials/challenge-modals


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Your pull request targets the `staging` branch of FreeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](https://github.com/FreeCodeCamp/FreeCodeCamp/wiki/git-rebase#squashing-multiple-commits-into-one) them into one commit).
- [x] All new and existing tests pass the command `npm run test-challenges`. Use `git commit --amend` to amend any fixes.
#### Type of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)
#### Checklist:
- [x] Tested changes locally.
- [x] Closes currently open issue: Closes #8590
#### Description

using `button` instead of `div`, `div` can be styled to look like a `button`, but it does not behave as a `button` semantically, for example receiving focus, respect the `tab` order, trigger `click` event when `space` is pressed. Above all, for assistive technology, `div` will never be presented or read out as `button`. A visually challenged user will never know about those `CTA`s

![a11y-button](https://cloud.githubusercontent.com/assets/949380/15234412/69a1bc72-1866-11e6-9fb6-6ebe47a05a88.gif)
