### PR TITLE
Fix date format on certificates generation

### DIFF
--- a/server/boot/certificate.js
+++ b/server/boot/certificate.js
@@ -66,7 +66,7 @@ function getIdsForCert$(id, Challenge) {
 // getFormatedDate(challengeMap: Object, challengeId: String) => String, throws
 function getFormatedDate(challengeMap, challengeId) {
   return moment(challengeMap[challengeId].completedDate)
-    .format('MMM Do, YYYY');
+    .format('MMMM D, YYYY');
 }
 
 // sendCertifiedEmail(


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Your pull request targets the `staging` branch of FreeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit
- [x] All new and existing tests pass the command `npm run test-challenges`. Use `git commit --amend` to amend any fixes.
#### Type of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)
#### Checklist:
- [x] Tested changes locally.
- [x] Closes #8859
#### Description

Changed the date format for certificate from ordinal number to natural number. The comma was already in the right place. 
