### PR TITLE
Add test to check .endsWith() in Confirm Ending

### DIFF
--- a/seed/challenges/01-front-end-development-certification/basic-bonfires.json
+++ b/seed/challenges/01-front-end-development-certification/basic-bonfires.json
@@ -325,6 +325,7 @@
       "title": "Confirm the Ending",
       "description": [
         "Check if a string (first argument, <code>str</code>) ends with the given target string (second argument, <code>target</code>).",
+        "This challenge <em>can</em> be solved with the <code>.endsWith()</code> method, which was introduced in ES2015. But for the purpose of this challenge, we would like you to use one of the JavaScript substring methods instead.",
         "Remember to use <a href=\"//github.com/FreeCodeCamp/freecodecamp/wiki/FreeCodeCamp-Get-Help\" target=\"_blank\">Read-Search-Ask</a> if you get stuck. Write your own code."
       ],
       "challengeSeed": [
@@ -343,7 +344,8 @@
         "assert(confirmEnding(\"He has to give me a new name\", \"name\") === true, 'message: <code>confirmEnding(\"He has to give me a new name\", \"name\")</code> should return true.');",
         "assert(confirmEnding(\"He has to give me a new name\", \"me\") === true, 'message: <code>confirmEnding(\"He has to give me a new name\", \"me\")</code> should return true.');",
         "assert(confirmEnding(\"He has to give me a new name\", \"na\") === false, 'message: <code>confirmEnding(\"He has to give me a new name\", \"na\")</code> should return false.');",
-        "assert(confirmEnding(\"If you want to save our world, you must hurry. We dont know how much longer we can withstand the nothing\", \"mountain\") === false, 'message: <code>confirmEnding(\"If you want to save our world, you must hurry. We dont know how much longer we can withstand the nothing\", \"mountain\")</code> should return false.');"
+        "assert(confirmEnding(\"If you want to save our world, you must hurry. We dont know how much longer we can withstand the nothing\", \"mountain\") === false, 'message: <code>confirmEnding(\"If you want to save our world, you must hurry. We dont know how much longer we can withstand the nothing\", \"mountain\")</code> should return false.');",
+        "assert(!/\\.endsWith\\(.*?\\)\\s*?;/.test(code), 'message: Do not use the built-in method <code>.endsWith()</code> to solve the challenge.');"
       ],
       "type": "bonfire",
       "isRequired": true,
@@ -351,7 +353,8 @@
         "function confirmEnding(str, target) {\n  return str.substring(str.length-target.length) === target;\n};\n"
       ],
       "MDNlinks": [
-        "String.prototype.substr()"
+        "String.prototype.substr()",
+        "String.prototype.substring()"
       ],
       "challengeType": 5,
       "titleEs": "Confirma la terminación",


### PR DESCRIPTION
<!-- FreeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/FreeCodeCamp/FreeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->

<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/HelpContributors -->

<!-- Make sure that your PR is not a duplicate -->
#### Pre-Submission Checklist

<!-- Go over all points below, and put an `x` in all the boxes that apply. -->

<!-- All points should be checked, otherwise, read the CONTRIBUTING guidelines from above-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of FreeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](https://github.com/FreeCodeCamp/FreeCodeCamp/wiki/git-rebase#squashing-multiple-commits-into-one) them into one commit).
- [x] All new and existing tests pass the command `npm run test-challenges`. Use `git commit --amend` to amend any fixes.
#### Type of Change

<!-- What type of change does your code introduce? Put an `x` in the box that applies. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)
#### Checklist:

<!-- Go over all points below, and put an `x` in all the boxes that apply. -->

<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Closes currently open issue (replace XXXX with an issue no): Closes #4764
#### Description

<!-- Describe your changes in detail -->

Add test to make sure user doesn't use ES2015's `.endsWith()` method to solve the challenge.

I couldn't come up with a better test message. I wanted to be transparent on what the test is actually testing (as with any test) but if I wrote it anyway else, I felt like people might question and be confused by the vagueness of the message. If anyone has a better test message, I'm open to ideas.
#### Screenshot

![image](https://cloud.githubusercontent.com/assets/2754821/16256247/9cce54ac-3805-11e6-9751-37a990f9857f.png)
