### PR TITLE
Changed ordered list to unordered list in project challenges

### DIFF
--- a/server/views/challenges/showZiplineOrBasejump.jade
+++ b/server/views/challenges/showZiplineOrBasejump.jade
@@ -8,12 +8,15 @@ block content
                     | &nbsp;
                     i.ion-checkmark-circled.text-primary(title="Completed")
             hr
-            ol
+            ul
                 for step, index in description
                     .row.checklist-element(id="#{dashedName + index}")
-                        .col-xs-3.col-sm-1.col-md-2.padded-ionic-icon.text-center
-                            input(type='checkbox' class='challenge-list-checkbox')
-                        .col-xs-9.col-sm-11.col-md-10
+                        if step.match(/User Story:/)
+                            .col-xs-1.col-sm-1.col-md-1.padded-ionic-icon.text-center
+                                input(type='checkbox' class='challenge-list-checkbox')
+                        else
+                            .col-xs-1.col-sm-1.col-md-1.padded-ionic-icon.text-center
+                        .col-xs-11.col-sm-11.col-md-11
                             li.step-text.wrappable!= step
         .col-xs-12.col-sm-12.col-md-8
             .embed-responsive.embed-responsive-16by9


### PR DESCRIPTION
<!-- FreeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/FreeCodeCamp/FreeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->

<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/HelpContributors -->

<!-- Make sure that your PR is not a duplicate -->
#### Pre-Submission Checklist

<!-- Go over all points below, and put an `x` in all the boxes that apply. -->

<!-- All points should be checked, otherwise, read the CONTRIBUTING guidelines from above-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of FreeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](https://github.com/FreeCodeCamp/FreeCodeCamp/wiki/git-rebase#squashing-multiple-commits-into-one) them into one commit).
- [x] All new and existing tests pass the command `npm run test-challenges`. Use `git commit --amend` to amend any fixes.
#### Type of Change

<!-- What type of change does your code introduce? Put an `x` in the box that applies. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)
#### Checklist:

<!-- Go over all points below, and put an `x` in all the boxes that apply. -->

<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Closes currently open issue : Closes #8867 
#### Description

<!-- Describe your changes in detail -->

Changed ordered list to unordered list in project challenges and removed checkboxes as mentioned in #8867. Now it looks like 

![screenshot from 2016-06-01 21-28-30](https://cloud.githubusercontent.com/assets/11391128/15716649/c85e8080-2840-11e6-882f-cc7aed4980ec.png)
