### PR TITLE
update pull request template with convenient way to test

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@
 - [ ] Your pull request targets the `staging` branch of FreeCodeCamp.
 - [ ] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
 - [ ] You have only one commit (if not, [squash](https://github.com/FreeCodeCamp/FreeCodeCamp/wiki/git-rebase#squashing-multiple-commits-into-one) them into one commit).
-- [ ] All new and existing tests pass the command `npm run test-challenges`. Use `git commit --amend` to amend any fixes.
+- [ ] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.
 
 #### Type of Change
 <!-- What type of change does your code introduce? Put an `x` in the box that applies. -->
@@ -28,4 +28,3 @@
 
 #### Description
 <!-- Describe your changes in detail -->
-


### PR DESCRIPTION
<!-- FreeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/FreeCodeCamp/FreeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->

<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/HelpContributors -->

<!-- Make sure that your PR is not a duplicate -->
#### Pre-Submission Checklist

<!-- Go over all points below, and put an `x` in all the boxes that apply. -->

<!-- All points should be checked, otherwise, read the CONTRIBUTING guidelines from above-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of FreeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](https://github.com/FreeCodeCamp/FreeCodeCamp/wiki/git-rebase#squashing-multiple-commits-into-one) them into one commit).
- [x] All new and existing tests pass the command `npm run test-challenges`. Use `git commit --amend` to amend any fixes.
#### Type of Change

<!-- What type of change does your code introduce? Put an `x` in the box that applies. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)
#### Checklist:

<!-- Go over all points below, and put an `x` in all the boxes that apply. -->

<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [ ] Closes currently open issue (replace XXXX with an issue no): Closes #XXXX (None)
#### Description

<!-- Describe your changes in detail -->

We have 370+ contributors and every time they make a contribution they can actually just run `npm test` instead of `npm run test-challenges`. This is interchangeable because of `"test": "npm run test-challenges"` in npm scripts section. So with this change from now on, PR template would recommend to just run `npm test`. Also the deletion of last line in file as a change is in agreement with `.editorconfig` file.
