### PR TITLE
Remove an instance of evaluating output to prevent code re-execution

### DIFF
--- a/client/commonFramework/execute-challenge-stream.js
+++ b/client/commonFramework/execute-challenge-stream.js
@@ -6,7 +6,6 @@ window.common = (function(global) {
 
   const {
     addLoopProtect,
-    getJsFromHtml,
     detectUnsafeCode$,
     updatePreview$,
     challengeType,
@@ -33,22 +32,10 @@ window.common = (function(global) {
         return addLoopProtect(combinedCode);
       })
       .flatMap(code => updatePreview$(code))
-      .flatMap(code => {
-        let output;
-
-        if (
-          challengeType === challengeTypes.HTML &&
-          common.hasJs(code)
-        ) {
-          output = common.getJsOutput(getJsFromHtml(code));
-        } else if (challengeType !== challengeTypes.HTML) {
-          output = common.getJsOutput(addLoopProtect(combinedCode));
-        }
-
+      .flatMap(() => {
         return common.runPreviewTests$({
           tests: common.tests.slice(),
-          originalCode,
-          output
+          originalCode
         });
       });
   };


### PR DESCRIPTION
<!-- FreeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/FreeCodeCamp/FreeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->

<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/HelpContributors -->

<!-- Make sure that your PR is not a duplicate -->
#### Pre-Submission Checklist

<!-- Go over all points below, and put an `x` in all the boxes that apply. -->

<!-- All points should be checked, otherwise, read the CONTRIBUTING guidelines from above-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of FreeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](https://github.com/FreeCodeCamp/FreeCodeCamp/wiki/git-rebase#squashing-multiple-commits-into-one) them into one commit).
- [x] All new and existing tests pass the command `npm run test-challenges`. Use `git commit --amend` to amend any fixes.
#### Type of Change

<!-- What type of change does your code introduce? Put an `x` in the box that applies. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)
#### Checklist:

<!-- Go over all points below, and put an `x` in all the boxes that apply. -->

<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Closes currently open issue (replace XXXX with an issue no): Closes #5072 
#### Description

<!-- Describe your changes in detail -->
1. Problem: 
   Documented well in #5072 _Waypoint: Clone an Element Using jQuery: I completed the code and now the phone simulator is showing THREE target5 buttons!_
2. Technical Problem:
   By the time we reach in context of this discussion, `code` holds the code written in editor. `detectUnsafeCode$` evaluates
   `code` to prepare `output` and sends it to `runPreviewTests$`, however `runPreviewTests$`
   never cares about output and doesn't do anything with it.
3. Solution:
   IMO this code block is unnecessary and can be removed. When done so, `code` executes only once and side effects described in issue is gone.
4. Inspiration:
   Comment by @augmt: https://github.com/FreeCodeCamp/FreeCodeCamp/issues/5072#issuecomment-163904814 `Both common.updatePreview$ and common.getJsOutput are called within common.executeChallenge$. They both evaluate JavaScript and that leads to scripts being run twice on resets, test runs, and page load.`
5. Should be peer reviewed by:
   I'm removing code at https://github.com/FreeCodeCamp/FreeCodeCamp/pull/4884/commits/3a299daa37674a1fb9463fd2e3f1f0b5da7f2557 by @BerkeleyTrue so should be certainly reviewed to have no oversight.
