### PR TITLE
Animate #testSuite to focus user on errors

### DIFF
--- a/client/commonFramework/display-test-results.js
+++ b/client/commonFramework/display-test-results.js
@@ -2,6 +2,7 @@ window.common = (function({ $, common = { init: [] }}) {
 
   common.displayTestResults = function displayTestResults(data = []) {
     $('#testSuite').children().remove();
+    $('#testSuite').show();
     data.forEach(({ err = false, text = '' }) => {
       var iconClass = err ?
         '"ion-close-circled big-error-icon"' :

--- a/client/commonFramework/end.js
+++ b/client/commonFramework/end.js
@@ -89,6 +89,7 @@ $(document).ready(function() {
     common.submitBtn$
   )
     .flatMap(() => {
+      $('#testSuite').hide('slow');
       common.appendToOutputDisplay('\n// testing challenge...');
       return common.executeChallenge$()
         .map(({ tests, ...rest }) => {


### PR DESCRIPTION
#### Pre-Submission Checklist
- [X] Your pull request targets the `staging` branch of FreeCodeCamp.
- [ ] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [X] You have only one commit.
- [X] All new and existing tests pass the command `npm run test-challenges`. Use `git commit --amend` to amend any fixes.
#### Type of Change

<!-- What type of change does your code introduce? Put an `x` in the box that applies. -->
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)
#### Checklist:
- [ ] Tested changes locally.
- [X ] Closes currently open issue: Closes #9148
#### Description

Very simple hide/show animation using JS

As soon as the user clicks the button we hide('slow') the div #testSuite
Then on displayTestResults we show it.
