### PR TITLE
Animate #testSuite to focus user on errors

### DIFF
--- a/client/commonFramework/display-test-results.js
+++ b/client/commonFramework/display-test-results.js
@@ -2,6 +2,7 @@ window.common = (function({ $, common = { init: [] }}) {
 
   common.displayTestResults = function displayTestResults(data = []) {
     $('#testSuite').children().remove();
+    $('#testSuite').fadeIn('slow');
     data.forEach(({ err = false, text = '' }) => {
       var iconClass = err ?
         '"ion-close-circled big-error-icon"' :
@@ -20,7 +21,7 @@ window.common = (function({ $, common = { init: [] }}) {
       `)
         .appendTo($('#testSuite'));
     });
-
+    $('#scroll-locker').animate({ scrollTop: $(document).height() }, 'slow');
     return data;
   };
 

--- a/client/commonFramework/end.js
+++ b/client/commonFramework/end.js
@@ -89,6 +89,7 @@ $(document).ready(function() {
     common.submitBtn$
   )
     .flatMap(() => {
+      $('#testSuite').fadeOut('slow');
       common.appendToOutputDisplay('\n// testing challenge...');
       return common.executeChallenge$()
         .map(({ tests, ...rest }) => {


### PR DESCRIPTION
<!-- FreeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/FreeCodeCamp/FreeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->

<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/HelpContributors -->

<!-- Make sure that your PR is not a duplicate -->
#### Pre-Submission Checklist

<!-- Go over all points below, and put an `x` in all the boxes that apply. -->

<!-- All points should be checked, otherwise, read the CONTRIBUTING guidelines from above-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of FreeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](https://github.com/FreeCodeCamp/FreeCodeCamp/wiki/git-rebase#squashing-multiple-commits-into-one) them into one commit).
- [x] All new and existing tests pass the command `npm run test-challenges`. Use `git commit --amend` to amend any fixes.
#### Type of Change

<!-- What type of change does your code introduce? Put an `x` in the box that applies. -->
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)
#### Checklist:

<!-- Go over all points below, and put an `x` in all the boxes that apply. -->

<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Closes currently open issue: Closes #9148
#### Description

<!-- Describe your changes in detail -->

Very very simple change, just a small JS hide/show trick to bring users attention to the testSuite.
- As soon as the user clicks the button we hide('slow') the div #testSuite
- Then on displayTestResults we show it.
