### PR TITLE
remove the word simply from a couple challenges

### DIFF
--- a/public/c7979f1c69945c59.html
+++ b/public/c7979f1c69945c59.html
@@ -1,1 +1,0 @@
-simply-hired-verification: c7979f1c69945c59.html

--- a/seed/challenges/01-front-end-development-certification/basic-javascript.json
+++ b/seed/challenges/01-front-end-development-certification/basic-javascript.json
@@ -3656,7 +3656,7 @@
         "You may recall from <a href=\"waypoint-comparison-with-the-equality-operator\" target=\"_blank\">Comparison with the Equality Operator</a> that all comparison operators return a boolean <code>true</code> or <code>false</code> value.",
         "A common <dfn>anti-pattern</dfn> is to use an <code>if/else</code> statement to do a comparison and then <code>return</code> <code>true</code>/<code>false</code>:",
         "<blockquote>function isEqual(a,b) {<br>  if (a === b) {<br>    return true;<br>  } else {<br>    return false;<br>  }<br>}</blockquote>",
-        "Since <code>===</code> returns <code>true</code> or <code>false</code>, we can simply return the result of the comparison:",
+        "Since <code>===</code> returns <code>true</code> or <code>false</code>, we can return the result of the comparison:",
         "<blockquote>function isEqual(a,b) {<br>  return a === b;<br>}</blockquote>",
         "<h4>Instructions</h4>",
         "Fix the function <code>isLess</code> to remove the <code>if/else</code> statements."
@@ -4968,7 +4968,7 @@
       "description": [
         "Random numbers are useful for creating random behavior.",
         "JavaScript has a <code>Math.random()</code> function that generates a random decimal number between <code>0</code> (inclusive) and not quite up to <code>1</code> (exclusive). Thus <code>Math.random()</code> can return a <code>0</code> but never quite return a <code>1</code>",
-        "<strong>Note</strong><br>Like <a href='storing-values-with-the-assignment-operator' target='_blank'>Storing Values with the Equal Operator</a>, all function calls will be resolved before the <code>return</code> executes, so we can simply <code>return</code> the value of the <code>Math.random()</code> function.",
+        "<strong>Note</strong><br>Like <a href='storing-values-with-the-assignment-operator' target='_blank'>Storing Values with the Equal Operator</a>, all function calls will be resolved before the <code>return</code> executes, so we can <code>return</code> the value of the <code>Math.random()</code> function.",
         "<h4>Instructions</h4>",
         "Change <code>randomFraction</code> to return a random number instead of returning <code>0</code>."
       ],

--- a/seed/challenges/01-front-end-development-certification/jquery.json
+++ b/seed/challenges/01-front-end-development-certification/jquery.json
@@ -76,7 +76,7 @@
       "title": "Target HTML Elements with Selectors Using jQuery",
       "description": [
         "Now we have a <code>document ready function</code>.",
-        "Now let's write our first jQuery statement. All jQuery functions start with a <code>$</code>, usually referred to as a <code>dollar sign operator</code>, or simply as <code>bling</code>.",
+        "Now let's write our first jQuery statement. All jQuery functions start with a <code>$</code>, usually referred to as a <code>dollar sign operator</code>, or as <code>bling</code>.",
         "jQuery often selects an HTML element with a <code>selector</code>, then does something to that element.",
         "For example, let's make all of your <code>button</code> elements bounce. Just add this code inside your document ready function:",
         "<code>$(\"button\").addClass(\"animated bounce\");</code>",


### PR DESCRIPTION
This is to be consistent with the observation that "simply" is a presumptuous word that generally doesn't belong in tutorials or lessons. I'm writing a big Medium article about this.
