### PR TITLE
Fix/Function in Comments (No Error Thrown)

### DIFF
--- a/client/commonFramework/detect-unsafe-code-stream.js
+++ b/client/commonFramework/detect-unsafe-code-stream.js
@@ -7,6 +7,9 @@ window.common = (function(global) {
   const detectFunctionCall = /function\s*?\(|function\s+\w+\s*?\(/gi;
   const detectUnsafeJQ = /\$\s*?\(\s*?\$\s*?\)/gi;
   const detectUnsafeConsoleCall = /if\s\(null\)\sconsole\.log\(1\);/gi;
+  const detectInComment = new RegExp(['\\/\\/[\\W\\w\\s]*?function.|',
+                                    '\\/\\*[\\s\\w\\W]*?function',
+                                    '[\\s\\W\\w]*?\\*\\/'].join(''), 'gi');
 
   common.detectUnsafeCode$ = function detectUnsafeCode$(code) {
     const openingComments = code.match(/\/\*/gi);
@@ -35,7 +38,8 @@ window.common = (function(global) {
 
     if (
       code.match(/function/g) &&
-      !code.match(detectFunctionCall)
+      !code.match(detectFunctionCall) &&
+      !code.match(detectInComment)
     ) {
       return Observable.throw(
         new Error('SyntaxError: Unsafe or unfinished function declaration')


### PR DESCRIPTION
<!-- FreeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/FreeCodeCamp/FreeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->

<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/HelpContributors -->

<!-- Make sure that your PR is not a duplicate -->
#### Pre-Submission Checklist

<!-- Go over all points below, and put an `x` in all the boxes that apply. -->

<!-- All points should be checked, otherwise, read the CONTRIBUTING guidelines from above-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of FreeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](https://github.com/FreeCodeCamp/FreeCodeCamp/wiki/git-rebase#squashing-multiple-commits-into-one) them into one commit).
- [x] All new and existing tests pass the command `npm run test-challenges`. Use `git commit --amend` to amend any fixes.
#### Type of Change

<!-- What type of change does your code introduce? Put an `x` in the box that applies. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
#### Checklist:

<!-- Go over all points below, and put an `x` in all the boxes that apply. -->

<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
#### Description

<!-- Describe your changes in detail -->

Resubmit of PR that was reverted. Original issue was that the word `function` in comments threw an `unsafe function declaration` to the console.

This PR creates a regex to check if the word function is in either a single line or multi-line comment.
