### PR TITLE
Correct stringify to JSON.stringify

### DIFF
--- a/seed/challenges/01-front-end-development-certification/basic-javascript.json
+++ b/seed/challenges/01-front-end-development-certification/basic-javascript.json
@@ -4559,7 +4559,7 @@
         "    }",
         "};",
         "// Keep a copy of the collection for tests",
-        "var collectionCopy = JSON.parse(stringify(collection));",
+        "var collectionCopy = JSON.parse(JSON.stringify(collection));",
         "",
         "// Only change code below this line",
         "function updateRecords(id, prop, value) {",


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Your pull request targets the `staging` branch of FreeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](https://github.com/FreeCodeCamp/FreeCodeCamp/wiki/git-rebase#squashing-multiple-commits-into-one) them into one commit).
- [x] All new and existing tests pass the command `npm run test-challenges`. Use `git commit --amend` to amend any fixes.
#### Type of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)
#### Checklist:
- [x] Tested changes locally.
- [x] Closes #9276
#### Description

Reverts line `var collectionCopy = JSON.parse(stringify(collection)` to `var collectionCopy = JSON.parse(JSON.stringify(collection))` as intended by https://github.com/FreeCodeCamp/FreeCodeCamp/commit/3fa86377f87c98cb5a3ea3bae84daee3424cf58c (this commit omitted `JSON.` from `JSON.stringify`)
