### PR TITLE
Add test for Smallest Common Multiple

### DIFF
--- a/seed/challenges/01-front-end-development-certification/intermediate-bonfires.json
+++ b/seed/challenges/01-front-end-development-certification/intermediate-bonfires.json
@@ -728,7 +728,8 @@
         "assert.deepEqual(typeof smallestCommons([1, 5]), 'number', 'message: <code>smallestCommons([1, 5])</code> should return a number.');",
         "assert.deepEqual(smallestCommons([1, 5]), 60, 'message: <code>smallestCommons([1, 5])</code> should return 60.');",
         "assert.deepEqual(smallestCommons([5, 1]), 60, 'message: <code>smallestCommons([5, 1])</code> should return 60.');",
-        "assert.deepEqual(smallestCommons([1, 13]), 360360, 'message: <code>smallestCommons([1, 13])</code> should return 360360.');"
+        "assert.deepEqual(smallestCommons([1, 13]), 360360, 'message: <code>smallestCommons([1, 13])</code> should return 360360.');",
+        "assert.deepEqual(smallestCommons([23, 18]), 6056820, 'message: <code>smallestCommons([23, 18])</code> should return 6056820.');"
       ],
       "type": "bonfire",
       "MDNlinks": [


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Your pull request targets the `staging` branch of FreeCodeCamp.
- [x] Branch starts with `fix/`
- [x] You have only one commit
- [x] All new and existing tests pass the command `npm run test-challenges`.
#### Type of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
#### Checklist:
- [x] Tested changes locally.
- [x] Closes #7292
#### Description

Adds a new test for Smallest Common Multiple, with input `[23,18]`. Solution code from both the Wiki and seed provide the correct output in testing, and the incorrect code in #7292 does not. (Tests now include a case which does not have 1 as the low end of the range)
