### PR TITLE
Clarify Pig Latin input strings are all lowercase

### DIFF
--- a/seed/challenges/01-front-end-development-certification/intermediate-bonfires.json
+++ b/seed/challenges/01-front-end-development-certification/intermediate-bonfires.json
@@ -280,6 +280,7 @@
         "Translate the provided string to pig latin.",
         "<a href=\"http://en.wikipedia.org/wiki/Pig_Latin\" target=\"_blank\">Pig Latin</a> takes the first consonant (or consonant cluster) of an English word, moves it to the end of the word and suffixes an \"ay\".",
         "If a word begins with a vowel you just add \"way\" to the end.",
+        "Input strings are guaranteed to be English words in all lowercase.",
         "Remember to use <a href='//github.com/FreeCodeCamp/freecodecamp/wiki/FreeCodeCamp-Get-Help' target='_blank'>Read-Search-Ask</a> if you get stuck. Try to pair program. Write your own code."
       ],
       "challengeSeed": [


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Your pull request targets the `staging` branch of FreeCodeCamp.
- [x] Branch starts either `fix/`
- [x] You have only one commit
- [x] All new and existing tests pass the command `npm run test-challenges`.
#### Type of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
#### Checklist:
- [x] Tested changes locally.
- [x] Closes #9576
#### Description

Clarify Pig Latin instructions to indicate that input strings are guaranteed to be English words in all lowercase to address concerns about handling case when solving the challenge.
