### PR TITLE
[WIP] Export Solutions to Github

### DIFF
--- a/client/commonFramework/show-completion.js
+++ b/client/commonFramework/show-completion.js
@@ -68,6 +68,70 @@ window.common = (function(global) {
       });
   }
 
+  function submitGithubHandler(e) {
+    e.preventDefault();
+
+    var solution = common.editor.getValue();
+
+    $('#save-challenge')
+      .attr('disabled', 'true')
+      .removeClass('btn-primary')
+      .addClass('btn-warning disabled');
+
+    var $checkmarkContainer = $('#checkmark-container');
+    $checkmarkContainer.css({ height: $checkmarkContainer.innerHeight() });
+
+    $('#challenge-checkmark')
+      .addClass('zoomOutUp')
+      // .removeClass('zoomInDown')
+      .delay(1000)
+      .queue(function(next) {
+        $(this).replaceWith(
+          '<div id="challenge-spinner" ' +
+          'class="animated zoomInUp inner-circles-loader">' +
+          'submitting...</div>'
+        );
+        next();
+      });
+
+    let timezone = 'UTC';
+    try {
+      timezone = moment.tz.guess();
+    } catch (err) {
+      err.message = `
+          known bug, see: https://github.com/moment/moment-timezone/issues/294:
+          ${err.message}
+        `;
+      console.error(err);
+    }
+    const data = JSON.stringify({
+      id: common.challengeId,
+      name: common.challengeName,
+      challengeType: +common.challengeType,
+      solution,
+      timezone
+    });
+
+    $.ajax({
+        url: '/github-export/',
+        type: 'POST',
+        data,
+        contentType: 'application/json',
+        dataType: 'json'
+      })
+      .success(function(res) {
+          if (res) {
+            window.location =
+              '/challenges/next-challenge?id=' + common.challengeId;
+          }
+        })
+      .fail(function() {
+        window.location.replace(window.location.href);
+      });
+
+  }
+
+
   common.showCompletion = function showCompletion() {
 
     ga(
@@ -84,6 +148,9 @@ window.common = (function(global) {
 
     $('#submit-challenge').off('click');
     $('#submit-challenge').on('click', submitChallengeHandler);
+    $('#save-challenge').off('click');
+    $('#save-challenge').on('click', submitGithubHandler);
+
   };
 
   return common;

--- a/common/models/User-Identity.js
+++ b/common/models/User-Identity.js
@@ -146,6 +146,7 @@ export default function(UserIdent) {
         userChanged = true;
       }
 
+      console.log('GIVEN PROVIDER: ' + provider);
       if (!githubRegex.test(provider) && profile) {
         user[provider] = getUsernameFromProvider(provider, profile);
         userChanged = true;

--- a/common/models/user.json
+++ b/common/models/user.json
@@ -40,6 +40,10 @@
       "type": "boolean",
       "default": false
     },
+    "isGithubRepoCool": {
+      "type": "boolean",
+      "default": false
+    },
     "githubId": {
       "type": "string"
     },

--- a/server/passport-providers.js
+++ b/server/passport-providers.js
@@ -159,5 +159,20 @@ module.exports = {
     scope: ['email'],
     link: true,
     failureFlash: true
+  },
+  'github-repo': {
+    provider: 'github-repo',
+    authScheme: 'oauth2',
+    module: 'passport-github',
+    authPath: '/link/github/repos',
+    callbackURL: '/auth/github/callback/repos',
+    callbackPath: '/auth/github/callback/repos',
+    successRedirect: successRedirect,
+    failureRedirect: successRedirect,
+    clientID: process.env.GITHUB_ID,
+    clientSecret: process.env.GITHUB_SECRET,
+    scope: ['email', 'repo'],
+    link: true,
+    failureFlash: true
   }
 };

--- a/server/utils/auth.js
+++ b/server/utils/auth.js
@@ -7,6 +7,8 @@ const providerHash = {
   google: ({ id }) => id
 };
 
+import request from 'request';
+
 export function getUsernameFromProvider(provider, profile) {
   return typeof providerHash[provider] === 'function' ?
     providerHash[provider](profile) :
@@ -93,6 +95,28 @@ export function getFirstImageFromProfile(profile) {
   return profile && profile.photos && profile.photos[0] ?
     profile.photos[0].value :
     null;
+}
+
+export function checkRepoAccess(token, callback) {
+  const authToken = 'token ' + token;
+  request({
+      url: 'https://api.github.com/orgs/FreeCodeCamp',
+      method: 'GET',
+      headers: {
+          Authorization: authToken,
+          'user-agent': 'FreeCodeCamp-Export'
+      }
+  }, function(error, response) {
+      const access = response.headers['x-oauth-scopes'].split(',');
+      let returnBool = false;
+      for (let i = 0; i < access.length; i++) {
+        if (access[i] === 'repo') {
+          returnBool = true;
+        }
+      }
+
+      callback(returnBool);
+  });
 }
 
 export function getSocialProvider(provider) {

--- a/server/utils/auth.js
+++ b/server/utils/auth.js
@@ -51,6 +51,44 @@ export function setProfileFromGithub(
   );
 }
 
+export function setProfileFromRepoAccess(
+  user,
+  {
+    profileUrl: githubURL,
+    username
+  },
+  {
+    id: githubId,
+    avatar_url: picture,
+    email: githubEmail,
+    created_at: joinedGithubOn,
+    blog: website,
+    location,
+    bio,
+    name
+  }
+) {
+  return Object.assign(
+    user,
+    {
+      name,
+      email: user.email || githubEmail,
+      username: username.toLowerCase(),
+      location,
+      bio,
+      joinedGithubOn,
+      website,
+      isGithubCool: true,
+      isGithubRepoCool: true,
+      picture,
+      githubId,
+      githubURL,
+      githubEmail,
+      githubProfile: githubURL
+    }
+  );
+}
+
 export function getFirstImageFromProfile(profile) {
   return profile && profile.photos && profile.photos[0] ?
     profile.photos[0].value :

--- a/server/views/challenges/showBonfire.jade
+++ b/server/views/challenges/showBonfire.jade
@@ -78,6 +78,10 @@ block content
                       .row
                       if (user)
                           #submit-challenge.animated.fadeIn.btn.btn-lg.btn-primary.btn-block Submit and go to my next challenge (ctrl + enter)
+                          if (!user.isGithubRepoCool)
+                              a.animated.fadeIn.btn.btn-lg.btn-primary.btn-block(href='/link/github/repos') Link to my GitHub Repos to unlock GitHub Export
+                          else
+                            #save-challenge.animated.fadeIn.btn.btn-lg.btn-primary.btn-block Save to GitHub and go to my next challenge
                       else
                           a#next-challenge.btn.btn-lg.btn-primary.btn-block(href="/challenges/next-challenge?id="+id) Go to my next challenge (ctrl + enter)
     include ../partials/challenge-modals

--- a/server/views/challenges/showHTML.jade
+++ b/server/views/challenges/showHTML.jade
@@ -67,8 +67,12 @@ block content
                                 #challenge-checkmark.animated.zoomInDown.delay-half
                                     span.completion-icon.ion-checkmark-circled.text-primary
                             .spacer
-                            if(user)
-                                button#submit-challenge.animated.fadeIn.btn.btn-lg.btn-primary.btn-block Submit and go to my next challenge (ctrl + enter)
+                            if (user)
+                                #submit-challenge.animated.fadeIn.btn.btn-lg.btn-primary.btn-block Submit and go to my next challenge (ctrl + enter)
+                                if (!user.isGithubRepoCool)
+                                    a.animated.fadeIn.btn.btn-lg.btn-primary.btn-block(href='/link/github/repos') Link to my GitHub Repos to unlock GitHub Export
+                                else
+                                  #save-challenge.animated.fadeIn.btn.btn-lg.btn-primary.btn-block Save to GitHub and go to my next challenge
                             else
                                 a#next-challenge.btn.btn-lg.btn-primary.btn-block(href="/challenges/next-challenge?id="+id) Go to my next challenge (ctrl + enter)
     include ../partials/challenge-modals

--- a/server/views/challenges/showJS.jade
+++ b/server/views/challenges/showJS.jade
@@ -75,9 +75,13 @@ block content
                         .spacer
                         .row
                         if (user)
-                            button#submit-challenge.animated.fadeIn.btn.btn-lg.btn-primary.btn-block Submit and go to my next challenge (ctrl + enter)
+                            #submit-challenge.animated.fadeIn.btn.btn-lg.btn-primary.btn-block Submit and go to my next challenge (ctrl + enter)
+                            if (!user.isGithubRepoCool)
+                                a.animated.fadeIn.btn.btn-lg.btn-primary.btn-block(href='/link/github/repos') Link to my GitHub Repos to unlock GitHub Export
+                            else
+                              #save-challenge.animated.fadeIn.btn.btn-lg.btn-primary.btn-block Save to GitHub and go to my next challenge
                         else
-                            a#next-challenge.animated.fadeIn.btn.btn-lg.btn-primary.btn-block(href="/challenges/next-challenge?id="+id) Go to my next challenge (ctrl + enter)
+                            a#next-challenge.btn.btn-lg.btn-primary.btn-block(href="/challenges/next-challenge?id="+id) Go to my next challenge (ctrl + enter)
     include ../partials/challenge-modals
     script(type="text/javascript").
       var common = window.common = { init: [] };


### PR DESCRIPTION
## Github Export Feature [Work in Progress]

Feature referenced in issue #5138 

**Features:**
- [x] Available only to logged in users, and on challenges that the solutions are in FCC
- [x] Exports Solution with Date to a Github Repo.
- [ ] Checks if the user has authenticated, and then allows the commit to their repo.

**Summery of Changes:**
- Edit the challenges view files to include a new button
- Click handler calls submitGithubHandler (see `client/commonFramework/show-completion.js`, line 71
- Adds Parameter `isGithubRepoCool`, which while not currently implemented, will be used to see if the user has authenticated repo access
- Adds endpoint (POST method) `/github-export/`, which is called in the submitGithubHandler function. This makes calls to the github api with the access token, which would have repo access if the user has authenticated (hence the use of `isGithubRepoCool`), to take the solution and add it to a github repo named `Free-Code-Camp-Solutions`.
- New authentication target - github-repo, uses the same github client id etc. but asks for repo access. This is so that only users that want to use the feature have to give repo access.
- Function setProfileFromRepoAccess - This is the same as the one above it, but adds a true value to `isGithubRepoCool` **Not Implemented in Code Yet**

**Thats all that is changed for now, will update as I continue.**

Feedback on the code would be great @BerkeleyTrue

@raisedadead 

_NOTE: There is a `console.log` in there that I forgot to remove, please ignore_
