### PR TITLE
[WIP] Add GitHub Export Feature for Challenges

### DIFF
--- a/client/commonFramework/show-completion.js
+++ b/client/commonFramework/show-completion.js
@@ -3,8 +3,21 @@ window.common = (function(global) {
     $,
     moment,
     ga = (() => {}),
+    localStorage,
     common = { init: [] }
   } = global;
+
+  function linkGithubHandler() {
+    if (
+      !localStorage ||
+      typeof localStorage.setItem !== 'function'
+    ) {
+      console.log('unable to save to storage');
+    } else {
+      localStorage.setItem('setRefresh', true);
+    }
+    window.location.href = '/link/github/repos';
+  }
 
   function submitChallengeHandler(e) {
     e.preventDefault();
@@ -68,8 +81,69 @@ window.common = (function(global) {
       });
   }
 
-  common.showCompletion = function showCompletion() {
+  function submitGithubHandler(e) {
+    e.preventDefault();
 
+    const solution = common.editor.getValue();
+
+    $('#save-challenge')
+      .attr('disabled', 'true')
+      .removeClass('btn-primary')
+      .addClass('btn-warning disabled');
+
+    const $checkmarkContainer = $('#checkmark-container');
+    $checkmarkContainer.css({ height: $checkmarkContainer.innerHeight() });
+
+    $('#challenge-checkmark')
+      .addClass('zoomOutUp')
+      .delay(1000)
+      .queue(function(next) {
+        $(this).replaceWith(
+          '<div id="challenge-spinner" ' +
+          'class="animated zoomInUp inner-circles-loader">' +
+          'submitting...</div>'
+        );
+        next();
+      });
+
+    let timezone = 'UTC';
+    try {
+      timezone = moment.tz.guess();
+    } catch (err) {
+      err.message = `
+        known bug, see: https://github.com/moment/moment-timezone/issues/294:
+        ${err.message}
+      `;
+      console.error(err);
+    }
+    const data = JSON.stringify({
+      id: common.challengeId,
+      name: common.challengeName,
+      challengeType: +common.challengeType,
+      solution,
+      timezone
+    });
+
+    $.ajax({
+      url: '/github-export/',
+      type: 'POST',
+      data,
+      contentType: 'application/json',
+      dataType: 'json'
+    })
+    .success(function(res) {
+      if (res) {
+        window.location =
+          '/challenges/next-challenge?id=' + common.challengeId;
+      }
+    })
+    .fail(function() {
+      window.location.replace(window.location.href);
+    });
+  }
+
+
+  common.showCompletion = function showCompletion() {
     ga(
       'send',
       'event',
@@ -84,6 +158,11 @@ window.common = (function(global) {
 
     $('#submit-challenge').off('click');
     $('#submit-challenge').on('click', submitChallengeHandler);
+    $('#save-challenge').off('click');
+    $('#save-challenge').on('click', submitGithubHandler);
+    $('#link-github').off('click');
+    $('#link-github').on('click', linkGithubHandler);
+
   };
 
   return common;

--- a/client/main.js
+++ b/client/main.js
@@ -4,6 +4,11 @@ main.mapShareKey = 'map-shares';
 
 main.ga = window.ga || function() {};
 
+if (localStorage.getItem('setRefresh')) {
+  localStorage.removeItem('setRefresh');
+  window.location.reload(true);
+}
+
 main = (function(main, global) {
   const { Mousetrap } = global;
 

--- a/common/models/user.json
+++ b/common/models/user.json
@@ -40,6 +40,10 @@
       "type": "boolean",
       "default": false
     },
+    "isGithubRepoCool": {
+      "type": "boolean",
+      "default": false
+    },
     "githubId": {
       "type": "string"
     },

--- a/server/boot/challenge.js
+++ b/server/boot/challenge.js
@@ -5,6 +5,7 @@ import { Observable, Scheduler } from 'rx';
 import debug from 'debug';
 import accepts from 'accepts';
 import { isMongoId } from 'validator';
+import request from 'request';
 
 import {
   dasherize,
@@ -339,6 +340,9 @@ function getNextChallenge$(challenge$, blocks$, challengeId) {
 module.exports = function(app) {
   const router = app.loopback.Router();
 
+  // userIdentity model
+  const userIdentity = app.models.UserIdentity;
+
   const challengesQuery = {
     order: [
       'superOrder ASC',
@@ -402,6 +406,11 @@ module.exports = function(app) {
     '/completed-challenge/',
     send200toNonUser,
     completedChallenge
+  );
+  router.post(
+    '/github-export/',
+    send200toNonUser,
+    githubExport
   );
   router.post(
     '/completed-zipline-or-basejump',
@@ -595,6 +604,106 @@ module.exports = function(app) {
       })
       .subscribe(() => {}, next);
   }
+
+  function githubExport(req, res, next) {
+    const {
+      name,
+      solution
+    } = req.body;
+
+    function createRepo(token, repoName, description, callback) {
+      const authToken = 'token ' + token;
+      // NOTE ESLint gives a warning at the json 'auto_init' for not having
+      // CamelCase, but that is the format github wants it in
+      request({
+        url: 'https://api.github.com/user/repos',
+        method: 'POST',
+        json: {
+          name: repoName,
+          description: description,
+          auto_init: true
+        },
+        headers: {
+          Authorization: authToken,
+          'user-agent': 'FreeCodeCamp-Export'
+        }
+      }, function(error, response, body) {
+        callback(error, response, body);
+      });
+    }
+
+    function commitFile(token,
+      repoName,
+      solution,
+      challengeName,
+      dateComplete,
+      userName,
+      callback) {
+        // Setup Variables
+        const authToken = 'token ' + token;
+        // New lines as the template literal takes the indent as chars
+        const solutionEncoded = new Buffer(`\`\`\`\n${solution}\n\`\`\``)
+          .toString('base64');
+        const fileName = `${challengeName} - ${dateComplete}.md`;
+        const commitMessage = `Add Solution For ${challengeName}`;
+
+        const json = {
+          message: commitMessage,
+          content: solutionEncoded
+        };
+        const urlPath = `${userName}/${repoName}/contents/${fileName}`;
+        const url = `https://api.github.com/repos/${urlPath}`;
+
+        console.log(JSON.stringify(json) + ' ' + url);
+
+        request({
+          url: url,
+          method: 'PUT',
+          json: json,
+          headers: {
+            Authorization: authToken,
+            'user-agent': 'FreeCodeCamp-Export'
+          }
+        }, function(error, response, body) {
+          callback(error, response, body);
+        });
+      completedChallenge(req, res, next);
+    }
+    const query = {
+      where: {
+        userId: req.user.id,
+        provider: 'github'
+      }
+    };
+
+    userIdentity.findOne(query, (err, userInfo) => {
+      if (err) {
+        console.error(err);
+      }
+      // You can create the repo, even if it already exists, and it will
+      // still write the file after
+      createRepo(userInfo.credentials.accessToken,
+        'Free-Code-Camp-Solutions',
+        'My Solutions to the FreeCodeCamp Bootcamp',
+        function(err) {
+          if (err) {
+            console.error(err);
+          } else {
+            commitFile(userInfo.credentials.accessToken,
+              'Free-Code-Camp-Solutions',
+              solution,
+              name,
+              (new Date()).toISOString().substring(0, 10),
+              userInfo.profile.username,
+              function(err) {
+                if (err) {
+                  console.log(err);
+                }
+              });
+            }
+        });
+    });
+}
 
   function completedZiplineOrBasejump(req, res, next) {
     const type = accepts(req).type('html', 'json', 'text');

--- a/server/passport-providers.js
+++ b/server/passport-providers.js
@@ -159,5 +159,20 @@ module.exports = {
     scope: ['email'],
     link: true,
     failureFlash: true
+  },
+  'github-repo': {
+    provider: 'github-repo',
+    authScheme: 'oauth2',
+    module: 'passport-github',
+    authPath: '/link/github/repos',
+    callbackURL: '/auth/github/callback/repos',
+    callbackPath: '/auth/github/callback/repos',
+    successRedirect: successRedirect,
+    failureRedirect: successRedirect,
+    clientID: process.env.GITHUB_ID,
+    clientSecret: process.env.GITHUB_SECRET,
+    scope: ['email', 'repo'],
+    link: true,
+    failureFlash: true
   }
 };

--- a/server/utils/auth.js
+++ b/server/utils/auth.js
@@ -1,3 +1,5 @@
+import request from 'request';
+
 const providerHash = {
   facebook: ({ id }) => id,
   twitter: ({ username }) => username,
@@ -51,10 +53,69 @@ export function setProfileFromGithub(
   );
 }
 
+export function setProfileFromRepoAccess(
+  user,
+  {
+    profileUrl: githubURL,
+    username
+  },
+  {
+    id: githubId,
+    avatar_url: picture,
+    email: githubEmail,
+    created_at: joinedGithubOn,
+    blog: website,
+    location,
+    bio,
+    name
+  }
+) {
+  return Object.assign(
+    user,
+    {
+      name,
+      email: user.email || githubEmail,
+      username: username.toLowerCase(),
+      location,
+      bio,
+      joinedGithubOn,
+      website,
+      isGithubCool: true,
+      isGithubRepoCool: true,
+      picture,
+      githubId,
+      githubURL,
+      githubEmail,
+      githubProfile: githubURL
+    }
+  );
+}
+
 export function getFirstImageFromProfile(profile) {
   return profile && profile.photos && profile.photos[0] ?
     profile.photos[0].value :
     null;
+}
+
+export function checkRepoAccess(token, callback) {
+  const authToken = 'token ' + token;
+  request({
+    url: 'https://api.github.com/orgs/FreeCodeCamp',
+    method: 'GET',
+    headers: {
+      Authorization: authToken,
+      'user-agent': 'FreeCodeCamp-Export'
+    }
+  }, function(error, response) {
+    const access = response.headers['x-oauth-scopes'].split(',');
+    let returnBool = false;
+    for (let i = 0; i < access.length; i++) {
+      if (access[i] === 'repo') {
+        returnBool = true;
+      }
+    }
+    callback(returnBool);
+  });
 }
 
 export function getSocialProvider(provider) {

--- a/server/views/challenges/showBonfire.jade
+++ b/server/views/challenges/showBonfire.jade
@@ -78,6 +78,10 @@ block content
                       .row
                       if (user)
                           #submit-challenge.animated.fadeIn.btn.btn-lg.btn-primary.btn-block Submit and go to my next challenge (ctrl + enter)
+                          if (!user.isGithubRepoCool)
+                              a#link-github.animated.fadeIn.btn.btn-lg.btn-primary.btn-block(href='/link/github/repos') Link to my GitHub Repos to unlock GitHub Export
+                          else
+                            #save-challenge.animated.fadeIn.btn.btn-lg.btn-primary.btn-block Save to GitHub and go to my next challenge
                       else
                           a#next-challenge.btn.btn-lg.btn-primary.btn-block(href="/challenges/next-challenge?id="+id) Go to my next challenge (ctrl + enter)
     include ../partials/challenge-modals

--- a/server/views/challenges/showHTML.jade
+++ b/server/views/challenges/showHTML.jade
@@ -67,8 +67,12 @@ block content
                                 #challenge-checkmark.animated.zoomInDown.delay-half
                                     span.completion-icon.ion-checkmark-circled.text-primary
                             .spacer
-                            if(user)
-                                button#submit-challenge.animated.fadeIn.btn.btn-lg.btn-primary.btn-block Submit and go to my next challenge (ctrl + enter)
+                            if (user)
+                                #submit-challenge.animated.fadeIn.btn.btn-lg.btn-primary.btn-block Submit and go to my next challenge (ctrl + enter)
+                                if (!user.isGithubRepoCool)
+                                    a#link-github.animated.fadeIn.btn.btn-lg.btn-primary.btn-block(href='/link/github/repos') Link to my GitHub Repos to unlock GitHub Export
+                                else
+                                  #save-challenge.animated.fadeIn.btn.btn-lg.btn-primary.btn-block Save to GitHub and go to my next challenge
                             else
                                 a#next-challenge.btn.btn-lg.btn-primary.btn-block(href="/challenges/next-challenge?id="+id) Go to my next challenge (ctrl + enter)
     include ../partials/challenge-modals

--- a/server/views/challenges/showJS.jade
+++ b/server/views/challenges/showJS.jade
@@ -75,9 +75,13 @@ block content
                         .spacer
                         .row
                         if (user)
-                            button#submit-challenge.animated.fadeIn.btn.btn-lg.btn-primary.btn-block Submit and go to my next challenge (ctrl + enter)
+                            #submit-challenge.animated.fadeIn.btn.btn-lg.btn-primary.btn-block Submit and go to my next challenge (ctrl + enter)
+                            if (!user.isGithubRepoCool)
+                                #link-github.animated.fadeIn.btn.btn-lg.btn-primary.btn-block Link to my GitHub Repos to unlock GitHub Export
+                            else
+                              #save-challenge.animated.fadeIn.btn.btn-lg.btn-primary.btn-block Save to GitHub and go to my next challenge
                         else
-                            a#next-challenge.animated.fadeIn.btn.btn-lg.btn-primary.btn-block(href="/challenges/next-challenge?id="+id) Go to my next challenge (ctrl + enter)
+                            a#next-challenge.btn.btn-lg.btn-primary.btn-block(href="/challenges/next-challenge?id="+id) Go to my next challenge (ctrl + enter)
     include ../partials/challenge-modals
     script(type="text/javascript").
       var common = window.common = { init: [] };


### PR DESCRIPTION
<!-- FreeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/FreeCodeCamp/FreeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->

<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/HelpContributors -->

<!-- Make sure that your PR is not a duplicate -->
#### Pre-Submission Checklist

<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->

<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of FreeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](https://github.com/FreeCodeCamp/FreeCodeCamp/wiki/Git-Squash) them into one commit).
- [x] All new and existing tests pass the command `npm run test-challenges`. Use `git commit --amend` to amend any fixes.
#### Type of Change

<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Breaking change (fix or feature that would change existing functionality)
#### Checklist:

<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->

<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Closes currently open issue Closes #5138
#### Description

<!-- Describe your changes in detail -->
- Add new key to the user model (`common/models/user.json`) - **isGithubRepoCool**. This will hold if the user has allowed access to their github repos.
- Add new section to the views of showBonfire, showHTML and showJS: Checks if the user has linked their github repos, if no: button to link, if yes, option to save to github and submit/continue.
- New Event (click) handler for the new button, sends calls to submit (current FCC API) and to github (see below).
- New Endpoint `github-export/`, this is implemented in `server/boot/challenge.js`. Makes a call to github to create a new repo, named **Free-Code-Camp-Solutions**, it doesnt matter if it already exists, it will then commit a new file with the file name being the challenge name + the date, and the contents is the solution formatted like normal code in a `.md` file.
- Add Passport Provider `github-repo`, with an extra scope of `repo`, this is to allow users that wont use the feature to not have to give repo access.
- Adds check to see if the accessToken from github has repo access, if yes, sets isGithubRepoCool to true, and updates the users profile.

I think thats it, big thanks to @raisedadead,

Feedback would be great
