### PR TITLE
add public/js/frame-runner.js to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ public/js/iFrameScripts*
 public/js/plugin*
 public/js/vendor*
 public/js/faux*
+public/js/frame-runner*
 public/css/main*
 
 server/rev-manifest.json


### PR DESCRIPTION
@BerkeleyTrue 

Can we add this temporarily to staging, I know this is already on the react branch but I have accidentally added this file many a times while trying to work on other branches.  

Thanks.
