### PR TITLE
Text-editor overflow hidden on iPad

### DIFF
--- a/client/less/main.less
+++ b/client/less/main.less
@@ -1175,6 +1175,11 @@ and (max-width : 400px)  {
   font-size: 17px;
 }
 
+// Challange editor CSS for iOS.  Issue 9104.
+.editorScrollDiv {
+  -webkit-overflow-scrolling: touch;
+}
+
 @import "chat.less";
 @import "jobs.less";
 @import "challenge.less";

--- a/client/less/main.less
+++ b/client/less/main.less
@@ -1175,7 +1175,7 @@ and (max-width : 400px)  {
   font-size: 17px;
 }
 
-// Challange editor CSS for iOS.  Issue 9104.
+
 .editorScrollDiv {
   -webkit-overflow-scrolling: touch;
 }


### PR DESCRIPTION
<!-- FreeCodeCamp Pull Request Template -->
#### Type of Change

<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)
#### Checklist:

<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->

<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [X] Tested changes locally.
- [X] Closes currently open issue (replace XXXX with an issue no): Closes #9104 
#### Description

<!-- Describe your changes in detail -->

I added some CSS to client/less/main.less near the bottom of the file.  It makes it so you can scroll to see the overflow text on the iPad.  I tested it in the iOS simulator and seems to fix the issue.  Although I was kind of confused about how they wanted it fixed.  If they would rather the height of the text editor change for the iPad.  I can change it to that also if it's preferred, please let me know. 
