### PR TITLE
fix(nav): Open about page in same tab

### DIFF
--- a/common/app/components/Nav/links.json
+++ b/common/app/components/Nav/links.json
@@ -4,8 +4,7 @@
   "target": "_blank"
 },{
   "content": "About",
-  "link": "/about",
-  "target": "_blank"
+  "link": "/about"
 },{
   "content": "Shop",
   "link": "/shop"


### PR DESCRIPTION
Addresses https://github.com/FreeCodeCamp/FreeCodeCamp/issues/9975#issuecomment-236192869
