### PR TITLE
Fix(routes): user sensitive routes redirect to map

### DIFF
--- a/common/app/create-app.jsx
+++ b/common/app/create-app.jsx
@@ -5,7 +5,7 @@ import { compose, createStore, applyMiddleware } from 'redux';
 // main app
 import App from './App.jsx';
 // app routes
-import childRoutes from './routes';
+import createChildRoute from './routes';
 
 // redux
 import { createEpic } from 'redux-epic';
@@ -16,8 +16,6 @@ import sagas from './sagas';
 import servicesCreator from '../utils/services-creator';
 
 const createRouteProps = Observable.fromNodeCallback(match);
-
-const routes = { components: App, ...childRoutes };
 
 //
 // createApp(settings: {
@@ -75,7 +73,12 @@ export default function createApp({
   // sync history client side with store.
   // server side this is an identity function and history is undefined
   history = syncHistoryWithStore(history, store, syncOptions);
-
+  const routes = {
+    components: App,
+    ...createChildRoute({
+      getState() { return store.getState(); }
+    })
+  };
   // createRouteProps({
   //   redirect: LocationDescriptor,
   //   history: History,

--- a/common/app/routes/challenges/index.js
+++ b/common/app/routes/challenges/index.js
@@ -1,23 +1,29 @@
 import Show from './components/Show.jsx';
-import Map from './components/map/Map.jsx';
+import ShowMap from './components/map/Map.jsx';
 
-export const challenges = {
-  path: 'challenges(/:dashedName)',
-  component: Show,
-  onEnter(nextState, replace) {
-    // redirect /challenges to /map
-    if (nextState.location.pathname === '/challenges') {
-      replace('/map');
+export function challengesRoute() {
+  return {
+    path: 'challenges(/:dashedName)',
+    component: Show,
+    onEnter(nextState, replace) {
+      // redirect /challenges to /map
+      if (nextState.location.pathname === '/challenges') {
+        replace('/map');
+      }
     }
-  }
-};
+  };
+}
 
-export const modernChallenges = {
-  path: 'challenges/:block/:dashedName',
-  component: Show
-};
+export function modernChallengesRoute() {
+  return {
+    path: 'challenges/:block/:dashedName',
+    component: Show
+  };
+}
 
-export const map = {
-  path: 'map',
-  component: Map
-};
+export function mapRoute() {
+  return {
+    path: 'map',
+    component: ShowMap
+  };
+}

--- a/common/app/routes/index.js
+++ b/common/app/routes/index.js
@@ -1,25 +1,31 @@
-import { modernChallenges, map, challenges } from './challenges';
+import {
+  modernChallengesRoute,
+  mapRoute,
+  challengesRoute
+} from './challenges';
 import NotFound from '../components/NotFound/index.jsx';
 import { addLang } from '../utils/lang';
-import settings from './settings';
+import settingsRoute from './settings';
 
-export default {
-  path: '/:lang',
-  indexRoute: {
-    onEnter(nextState, replace) {
-      const { lang } = nextState.params;
-      const { pathname } = nextState.location;
-      replace(addLang(pathname, lang));
-    }
-  },
-  childRoutes: [
-    challenges,
-    modernChallenges,
-    map,
-    settings,
-    {
-      path: '*',
-      component: NotFound
-    }
-  ]
-};
+export default function createChildRoute(deps) {
+  return {
+    path: '/:lang',
+    indexRoute: {
+      onEnter(nextState, replace) {
+        const { lang } = nextState.params;
+        const { pathname } = nextState.location;
+        replace(addLang(pathname, lang));
+      }
+    },
+    childRoutes: [
+      challengesRoute(deps),
+      modernChallengesRoute(deps),
+      mapRoute(deps),
+      settingsRoute(deps),
+      {
+        path: '*',
+        component: NotFound
+      }
+    ]
+  };
+}

--- a/common/app/routes/settings/index.js
+++ b/common/app/routes/settings/index.js
@@ -1,10 +1,19 @@
 import Settings from './components/Settings.jsx';
-import updateEmail from './routes/update-email';
+import updateEmailRoute from './routes/update-email';
 
-export default {
-  path: 'settings',
-  component: Settings,
-  childRoutes: [
-    updateEmail
-  ]
-};
+export default function settingsRoute(deps) {
+  const { getState } = deps;
+  return {
+    path: 'settings',
+    component: Settings,
+    onEnter(nextState, replace) {
+      const { app: { user } } = getState();
+      if (!user) {
+        replace('/map');
+      }
+    },
+    childRoutes: [
+      updateEmailRoute(deps)
+    ]
+  };
+}

--- a/common/app/routes/settings/routes/update-email/index.js
+++ b/common/app/routes/settings/routes/update-email/index.js
@@ -1,6 +1,8 @@
 import UpdateEmail from './Update-Email.jsx';
 
-export default {
-  path: 'update-email',
-  component: UpdateEmail
-};
+export default function updateEmailRoute() {
+  return {
+    path: 'update-email',
+    component: UpdateEmail
+  };
+}


### PR DESCRIPTION
When an un-authenticated user visits the settings page it will redirect to the map.

Since we no longer load user data on first render, refreshing on the settings page will also redirect to map.

closes #10175
