### PR TITLE
Adjust tests for accessing multidimensional arrays

### DIFF
--- a/seed/challenges/01-front-end-development-certification/basic-javascript.json
+++ b/seed/challenges/01-front-end-development-certification/basic-javascript.json
@@ -1981,8 +1981,7 @@
       ],
       "tests": [
         "assert(myData === 8, 'message: <code>myData</code> should be equal to <code>8</code>.');",
-        "assert(/myArray\\[\\d+\\]\\[\\d+\\]/g.test(code), 'message: You should be using bracket notation to read the value from <code>myArray</code>.');",
-        "assert(/myData\\s*?=\\s*?myArray\\[\\d+\\]\\[\\d+\\]\\s*?;/g.test(code), 'message: You should only be reading one value from <code>myArray</code>.');"
+        "assert(/myArray\\[2\\]\\[1\\]/g.test(code) && !/myData\\s*=\\s*(?:.*[-+*/%]|\\d)/g.test(code), 'message: You should be using bracket notation to read the correct value from <code>myArray</code>.');"
       ],
       "type": "waypoint",
       "challengeType": 1,


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Your pull request targets the `staging` branch of FreeCodeCamp
- [x] Branch starts with`fix/`
- [x] You have only one commit
- [x] All new and existing tests pass the command `npm run test-challenges`
#### Type of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
#### Checklist:
- [x] Tested changes locally.
- [x] Closes #10126
#### Description

Adjusts tests for challenge "Access MultiDimensional Arrays With Indexes" by checking that a user uses the correct array indices to access the required value (rather than any digit), and that a user does not directly assign to `myData` a number or arithmetic expression.

This makes the final test redundant, so it is removed, and solutions involving assignment of the correctly-accessed value to a new variable and in turn assigning that variable to `myData` will still pass.
