### PR TITLE
fix(travis-ci): Speed up the build for TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,12 @@ language: node_js
 node_js:
   - '4.2.1'
 
+before_install: if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi
+
+cache:
+  directories:
+    - node_modules
+
 env:
   - CXX=g++-4.8
 


### PR DESCRIPTION
This commit speeds up the builds by upto 3 times than the current.
It uses npm 3 over npm 2 (travis default), and caches the
dependencies.

This is okay, because our prime two testing areas are, linting and
tests for the challenges.

NOTE: The speed up should happen from the second build,
as it will take at least one build to cache the dependencies.

Just a supporting Screenshot
![image](https://cloud.githubusercontent.com/assets/1884376/17699143/c3709c48-63dc-11e6-8c43-f61238180828.png)

Perf improvement of about 4 minutes. 
