### PR TITLE
Fix(challenges): Bug cancel not working

### DIFF
--- a/common/app/routes/challenges/components/Bug-Modal.jsx
+++ b/common/app/routes/challenges/components/Bug-Modal.jsx
@@ -25,12 +25,16 @@ export class BugModal extends PureComponent {
     } = this.props;
     return (
       <Modal
-        onHide={ closeBugModal }
         show={ isOpen }
         >
         <Modal.Header className='challenge-list-header'>
           Did you find a bug?
-          <span className='close closing-x'>×</span>
+          <span
+            className='close closing-x'
+            onClick={ closeBugModal }
+            >
+            ×
+          </span>
         </Modal.Header>
         <Modal.Body className='text-center'>
           <h3>
@@ -67,6 +71,7 @@ export class BugModal extends PureComponent {
             block={ true }
             bsSize='lg'
             bsStyle='primary'
+            onClick={ closeBugModal }
             >
             Cancel
           </Button>


### PR DESCRIPTION
The modal level onHide prop is used when you're using the modal's built-in hide buttons, but since we're rolling our own we just need to pass the action to the onClick handlers for each button.

Closes #10632
