### PR TITLE
Add a message after a user updates profile from Github and redirect to fcc profile

### DIFF
--- a/common/app/routes/settings/components/Social-Settings.jsx
+++ b/common/app/routes/settings/components/Social-Settings.jsx
@@ -8,7 +8,7 @@ export default function SocialSettings({
   isLinkedIn
 }) {
   const githubCopy = isGithubCool ?
-    'Update my portfolio from GitHub' :
+    'Update my profile from GitHub' :
     'Link my GitHub to unlock my portfolio';
   const buttons = [
     <Button

--- a/server/passport-providers.js
+++ b/server/passport-providers.js
@@ -1,6 +1,7 @@
 var successRedirect = '/';
 var failureRedirect = '/signin';
 var linkFailureRedirect = '/account';
+var githubProfileSuccessRedirect = '/settings';
 
 export default {
   local: {
@@ -153,12 +154,15 @@ export default {
     authPath: '/link/github',
     callbackURL: '/auth/github/callback/link',
     callbackPath: '/auth/github/callback/link',
-    successRedirect: successRedirect,
+    successRedirect: githubProfileSuccessRedirect,
     failureRedirect: linkFailureRedirect,
     clientID: process.env.GITHUB_ID,
     clientSecret: process.env.GITHUB_SECRET,
     scope: ['email'],
     link: true,
-    failureFlash: true
+    failureFlash: true,
+    successFlash: [ 'We\'ve updated your profile based ',
+                    'on your your GitHub account.'
+                  ].join('')
   }
 };


### PR DESCRIPTION
- [x] Your pull request targets the `staging` branch of FreeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [ ] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [ ] All new and existing tests pass the command `npm run test-challenges`. Use `git commit --amend` to amend any fixes.
#### Type of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)
#### Checklist:
- [ ] Tested changes locally.
- [ ] Closes currently open issue (replace XXXX with an issue no): Closes #XXXX
#### Description

After updating profile from Github, user gets a success message and he gets redirected to fcc profile.
