### PR TITLE
Add reset progress option to user settings

### DIFF
--- a/common/app/routes/settings/components/Settings.jsx
+++ b/common/app/routes/settings/components/Settings.jsx
@@ -258,6 +258,15 @@ export class Settings extends React.Component {
               >
               Delete my Free Code Camp account
             </Button>
+            <Button
+              block={ true }
+              bsSize='lg'
+              bsStyle='danger'
+              className='btn-link-social'
+              href='/reset-my-progress'
+              >
+              Reset all of my progress and brownie points
+            </Button>
           </Col>
         </Row>
       </div>

--- a/server/boot/user.js
+++ b/server/boot/user.js
@@ -183,6 +183,16 @@ module.exports = function(app) {
     sendNonUserToMap,
     getAccount
   );
+  router.get(
+    '/reset-my-progress',
+    sendNonUserToMap,
+    showResetProgress
+  );
+  api.post(
+    '/account/resetprogress',
+    ifNoUser401,
+    postResetProgress
+  );
 
   // Ensure these are the last routes!
   api.get(
@@ -447,6 +457,35 @@ module.exports = function(app) {
       req.logout();
       req.flash('info', { msg: 'You\'ve successfully deleted your account.' });
       return res.redirect('/');
+    });
+  }
+
+  function showResetProgress(req, res) {
+    return res.render('account/reset-progress', { title: 'Reset My Progress!'
+    });
+  }
+
+  function postResetProgress(req, res, next) {
+    User.findById(req.user.id, function(err, user) {
+      if (err) { return next(err); }
+      return user.updateAttributes({
+        progressTimestamps: [{
+          timestamp: Date.now()
+        }],
+        currentStreak: 0,
+        longestStreak: 0,
+        currentChallengeId: '',
+        isBackEndCert: false,
+        isFullStackCert: false,
+        isDataVisCert: false,
+        isFrontEndCert: false,
+        challengeMap: {},
+        challegesCompleted: []
+      }, function(err) {
+        if (err) { return next(err); }
+        req.flash('info', { msg: 'You\'ve successfully reset your progress.' });
+        return res.redirect('/');
+      });
     });
   }
 

--- a/server/views/account/reset-progress.jade
+++ b/server/views/account/reset-progress.jade
@@ -1,0 +1,25 @@
+extends ../layout
+block content
+    include ../partials/flyer
+    #modal-dialog.modal.animated.wobble
+        .modal-dialog
+            .modal-content
+                .modal-header
+                    a.close(href='/settings', data-dismiss='modal', aria-hidden='true') ×
+                    h3 You don't really want to reset your progress, do you?
+                .modal-body
+                    p This will really delete all of your progress and brownie points.
+                    p We won't be able to recover any of it for you later, even if you change your mind.
+                .modal-footer
+                    a.btn.btn-success.btn-block(href='/settings', data-dismiss='modal', aria-hidden='true')
+                        | Nevermind, I don't want to delete all of my progress and brownie points
+                    .spacer
+                    form(action='/account/resetprogress', method='POST')
+                        input(type='hidden', name='_csrf', value=_csrf)
+                        button.btn.btn-danger.btn-block(type='submit')
+                            | I am 100% sure I want to reset all of my progress and brownie points
+    script.
+      document.addEventListener('DOMContentLoaded', function() {
+        const modal$ = document.getElementById('modal-dialog');
+        modal$.classList.add('show');
+      });


### PR DESCRIPTION
<!-- FreeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/FreeCodeCamp/FreeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->

<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/HelpContributors -->

<!-- Make sure that your PR is not a duplicate -->
#### Pre-Submission Checklist

<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->

<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] Your pull request targets the `staging` branch of FreeCodeCamp.
- [X] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [X] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [X] All new and existing tests pass the command `npm run test-challenges`. Use `git commit --amend` to amend any fixes.
#### Type of Change

<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)
#### Checklist:

<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->

<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [X] Tested changes locally.
- [X] Closes currently open issue (replace XXXX with an issue no): Closes #10806
#### Description

<!-- Describe your changes in detail -->

Made a new jade page for progress reset, updated settings to add new button to reset progress, wrote functions to reset necessary attributes for user and update progressTimestamp to when the progress is reset. I tested this locally by making a new user, checking the mongo record, completing a few challenges, resetting the progress, and then confirming that the reset record matched the original new record.
