### PR TITLE
standardize capitalization and fix typos

### DIFF
--- a/common/models/block.json
+++ b/common/models/block.json
@@ -9,12 +9,12 @@
     "superBlock": {
       "type": "string",
       "required": true,
-      "description": "The super block that this block belongs too"
+      "description": "The super block that this block belongs to"
     },
     "order": {
       "type": "number",
       "required": true,
-      "description": "the order in which this block appears"
+      "description": "The order in which this block appears"
     },
     "name": {
       "type": "string",

--- a/common/models/challenge.json
+++ b/common/models/challenge.json
@@ -70,12 +70,12 @@
     },
     "head": {
       "type": "array",
-      "description": "appended to user code",
+      "description": "Appended to user code",
       "default": []
     },
     "tail": {
       "type": "array",
-      "description": "prepended to user code",
+      "description": "Prepended to user code",
       "default": []
     },
     "helpRoom": {
@@ -85,7 +85,7 @@
     },
     "fileName": {
       "type": "string",
-      "description": "filename challenge comes from. Used in dev mode"
+      "description": "Filename challenge comes from. Used in dev mode"
     },
     "challengeSeed": {
       "type": "array"

--- a/common/models/job.json
+++ b/common/models/job.json
@@ -92,11 +92,11 @@
     "howToApply": {
       "type": "string",
       "required": true,
-      "description": "How do campers apply to job"
+      "description": "How campers apply to a job"
     },
     "promoCodeUsed": {
       "type": "string",
-      "description": "the promocode, if any, that the job uses"
+      "description": "The promocode, if any, that the job uses"
     }
   },
   "validations": [],

--- a/common/models/promo.json
+++ b/common/models/promo.json
@@ -18,7 +18,7 @@
     "buttonId": {
       "type": "string",
       "required": true,
-      "description": "The id of paypal button"
+      "description": "The ID of the paypal button"
     },
     "type": {
       "type": "string",
@@ -35,7 +35,7 @@
     },
     "discountPercent": {
       "type": "number",
-      "description": "The amount of discount as a percentage if applicable"
+      "description": "The amount of the discount as a percentage if applicable"
     }
   },
   "validations": [],

--- a/common/models/user.json
+++ b/common/models/user.json
@@ -33,7 +33,7 @@
     },
     "isCheater": {
       "type": "boolean",
-      "description": "Users who are confirmed to break academic honesty policy are marked as cheaters",
+      "description": "Users who are confirmed to have broken academic honesty policy are marked as cheaters",
       "default": false
     },
     "isGithubCool": {
@@ -123,7 +123,7 @@
     "currentChallengeId": {
       "type": "string",
       "default": "",
-      "description": "the challenge last visited by the user"
+      "description": "The challenge last visited by the user"
     },
     "currentChallenge": {
       "type": {},
@@ -166,7 +166,7 @@
     },
     "challengeMap": {
       "type": "object",
-      "description": "A map by id of all the user completed challenges",
+      "description": "A map by ID of all the user completed challenges",
       "default": {}
     },
     "completedChallenges": {
@@ -204,7 +204,7 @@
     },
     "languageTag": {
       "type": "string",
-      "description": "A IETF language tag",
+      "description": "An IETF language tag",
       "default": "en"
     }
   },


### PR DESCRIPTION
<!-- FreeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/FreeCodeCamp/FreeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->

<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->

<!-- Make sure that your PR is not a duplicate -->
#### Pre-Submission Checklist

<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->

<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of FreeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm run test-challenges`. Use `git commit --amend` to amend any fixes.
#### Type of Change

<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)
#### Checklist:

<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->

<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [ ] Closes currently open issue (replace XXXX with an issue no): Closes #XXXX
#### Description

I noticed that JSON descriptions in models use sentence case and amended those that do not to follow the standard.
[IETF uses the indefinite article `an` instead of `a`](https://en.wikipedia.org/wiki/IETF_language_tag)
