### PR TITLE
fix map header and scrolling

### DIFF
--- a/client/less/map.less
+++ b/client/less/map.less
@@ -54,13 +54,25 @@
   width: 100%;
 }
 
+.map-fixed-header {
+  position: fixed;
+  background: white;
+  width: 100%;
+  padding-top: 5px;
+  z-index: 1;
+  left: 0;
+  top: 0;
+}
 
 .drawer .map-fixed-header {
   padding-top: 30px;
+  position: static;
+  margin-bottom: -100px;
 }
 
 .map-accordion {
   width: 100%;
+  margin-top: 100px;
   max-width: 700px;
   overflow-y: auto;
 
@@ -237,7 +249,7 @@
     padding-left: 0;
   }
   .map-accordion {
-    top: 180px;
+    top: 160px;
     h2 {
       margin: 15px 0;
       a {

--- a/common/app/routes/challenges/components/map/Map.jsx
+++ b/common/app/routes/challenges/components/map/Map.jsx
@@ -61,13 +61,17 @@ export class ShowMap extends PureComponent {
   }
 
   render() {
-    const { height, superBlocks } = this.props;
+    const { superBlocks } = this.props;
+    let height = 'auto';
+    if (!this.props.params) {
+      height = this.props.height + 'px';
+    }
     return (
       <Col xs={ 12 }>
         <MapHeader />
         <div
           className='map-accordion center-block'
-          style={{ height: height + 'px' }}
+          style={{ height: height }}
           >
           { this.renderSuperBlocks(superBlocks) }
           <div className='spacer' />


### PR DESCRIPTION
<!-- FreeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/FreeCodeCamp/FreeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->

<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->

<!-- Make sure that your PR is not a duplicate -->
#### Pre-Submission Checklist

<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->

<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] Your pull request targets the `staging` branch of FreeCodeCamp.
- [X] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [X] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [X] All new and existing tests pass the command `npm run test-challenges`. Use `git commit --amend` to amend any fixes.
#### Type of Change

<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)
#### Checklist:

<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->

<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [X] Tested changes locally.
- [X] Closes currently open issue (replace XXXX with an issue no): Closes #10621 
#### Description

<!-- Describe your changes in detail -->

I updated the Map.jsx file with a variable that changes depending on if the map is generated in a drawer or not. I updated the CSS to apply the fixed classes to the map when it's not in the drawer. The margins are a bit hackish but it's the only way I could get it to work since both the drawer map and full page map use the same module.
