### PR TITLE
Fix Contributing Guide To Remove Need For Wiki Article

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,60 +1,33 @@
 # Contributor's Guide
 
-## Table of Contents
+We welcome pull requests from Free Code Camp campers (our students) and seasoned JavaScript developers alike! Follow these steps to contribute:
 
--   [I want to help!](#i-want-to-help)
--   [Contribution Guidelines](#contribution-guidelines)
--   [Prerequisites](#prerequisites)
--   [Getting Started](#getting-started)
--   [Linting Setup](#linting-setup)
--   [Found a bug?](#found-a-bug)
--   [Creating Pull Requests](#creating-pull-requests)
--   [Common Steps](#common-steps)
--   [Next Steps](#next-steps)
+1. Find an issue that needs assistance by searching for the [Help Wanted](https://github.com/FreeCodeCamp/FreeCodeCamp/labels/help%20wanted) tag.
 
-### I want to help!
+2. Let us know you are working on it by posting a comment on the issue.
 
-We welcome pull requests from Free Code Camp campers (our students) and seasoned
-JavaScript developers alike! Follow these steps to contribute:
+3. Follow the [Contribution Guidelines](#contribution-guidelines) to start working on the issue.
 
-1.  Find an issue that needs assistance by searching for the [Help Wanted](https://github.com/FreeCodeCamp/FreeCodeCamp/labels/help%20wanted) tag.
+Remember to feel free to ask for help in our [Contributors](https://gitter.im/FreeCodeCamp/Contributors) Gitter room.
 
-2.  Let us know you are working on it by posting a comment on the issue.
+###### If you've found a bug that is not on the board, [follow these steps](#found-a-bug).
 
-3.  Feel free to ask for help in our
-    [Contributors](https://gitter.im/FreeCodeCamp/Contributors) Gitter room.
+--------------------------------------------------------------------------------
 
-If you've found a bug that is not on the board, [follow these steps](#found-a-bug).
+## Contribution Guidelines
 
-### Contribution Guidelines
-
-1.  Fork the project: [How To Fork And Maintain a Local Instance of Free Code
-    Camp](http://forum.freecodecamp.com/t/how-to-fork-and-maintain-a-local-instance-of-free-code-camp/19116)
-
-2.  Create a branch specific to the issue or feature you are working on. Push
-    your work to that branch. ([Need help with
-    branching?](https://github.com/Kunena/Kunena-Forum/wiki/Create-a-new-branch-with-git-and-manage-branches))
-
-3.  Name the branch something like `fix/xxx` or `feature/xxx` where `xxx` is a
-    short description of the changes or feature you are attempting to add. For
-    example `fix/email-login` would be a branch where I fix something specific
-    to email login.
-
-4.  [Set up Linting](#linting-setup) to run as you make changes.
-
-5.  When you are ready to share your code, run the test suite `npm test` and
-    ensure all tests pass.  For Windows contributors, skip the jsonlint pretest
-    run by using `npm run test-challenges`, as jsonlint will always fail on
-    Windows, given the wildcard parameters.
-
-6.  Squash your Commits. Ref: [rebasing](http://forum.freecodecamp.com/t/how-to-use-git-rebase/13226)
-
-7.  Submit a [pull
-    request](http://forum.freecodecamp.com/t/how-to-make-a-pull-request-on-free-code-camp/19114)
-    from your branch to Free Code Camp's `staging` branch.  [Travis
-    CI](https://travis-ci.org/FreeCodeCamp/FreeCodeCamp) will then take your
-    code and run `npm test`.  Make sure this passes, then we'll do a quick code
-    review and give you feedback, then iterate from there.
+- [Prerequisites](#prerequisites)
+- [Forking The Project](#forking-the-project)
+- [Create A Branch](#create-a-branch)
+- [Setup Linting](#setup-linting)
+- [Setup FreeCodeCamp](#setup-freecodecamp)
+- [Make Changes](#make-changes)
+- [Run The Test Suite](#run-the-test-suite)
+- [Squash Your Commits](#squash-your-commits)
+- [Creating A Pull Request](#creating-a-pull-request)
+- [Common Steps](#common-steps)
+- [Next Steps](#next-steps)
+- [Other resources](#other-resources)
 
 ### Prerequisites
 
@@ -66,22 +39,118 @@ If you've found a bug that is not on the board, [follow these steps](#found-a-bu
 
 > _Updating to the latest releases is recommended_.
 
-### Getting Started
+### Forking The Project
 
-Note: If this is your first time working with a node-gyp dependent module,
-please follow the [node-gyp installation
-guide](https://github.com/nodejs/node-gyp#installation) to ensure a working npm
-build.
+#### Setting Up Your System
 
-The easiest way to get started is to clone the repository:
+1. Install [Git](https://git-scm.com/) or your favorite Git client.
+2. (Optional) [Setup an SSH Key](https://help.github.com/articles/generating-an-ssh-key/) for GitHub.
+3. Create a parent projects directory on your system. For this guide, it will be assumed that it is `/mean/`
+
+#### Forking FreeCodeCamp
+
+1. Go to the top level Free Code Camp repository: <https://github.com/FreeCodeCamp/freecodecamp>
+2. Click the "Fork" Button in the upper right hand corner of the interface ([More Details Here](https://help.github.com/articles/fork-a-repo/))
+3. After the repository has been forked, you will be taken to your copy of the FCC repo at `yourUsername/freecodecamp`
+
+#### Cloning Your Fork
+
+1. Open a Terminal / Command Line / Bash Shell in your projects directory (_i.e.: `/yourprojectdirectory/`_)
+2. Clone your fork of FreeCodeCamp
+
+```shell
+$ git clone https://github.com/yourUsername/FreeCodeCamp.git
+```
+
+##### (make sure to replace `yourUsername` with your GitHub Username)
+
+This will download the entire FCC repo to your projects directory.
+
+#### Setup Your Upstream
+
+1. Change directory to the new FreeCodeCamp directory (`cd FreeCodeCamp`)
+2. Add a remote to the official FCC repo:
+
+```shell
+$ git remote add upstream https://github.com/FreeCodeCamp/FreeCodeCamp.git
+```
+
+Congratulations, you now have a local copy of the FCC repo!
+
+#### Maintaining Your Fork
+
+Now that you have a copy of your fork, there is work you will need to do to keep it current.
+
+##### **Rebasing from Upstream**
+
+Do this prior to every time you create a branch for a PR:
+
+1. Make sure you are on the `staging` branch
+
+  > ```shell
+  > $ git status
+  > On branch staging
+  > Your branch is up-to-date with 'origin/staging'.
+  > ```
+
+  > If your aren't on `staging`, resolve outstanding files / commits and checkout the `staging` branch
+
+  > ```shell
+  > $ git checkout staging
+  > ```
+
+2. Do A Pull with Rebase Against `upstream`
+
+  > ```shell
+  > $ git pull --rebase upstream staging
+  > ```
+
+  > This will pull down all of the changes to the official staging branch, without making an additional commit in your local repo.
+
+3. (_Optional_) Force push your updated staging branch to your GitHub fork
+
+  > ```shell
+  > $ git push origin staging --force
+  > ```
+
+  > This will overwrite the staging branch of your fork.
+
+### Create A Branch
+
+Before you start working, you will need to create a separate branch specific to the issue / feature you're working on. You will push your work to this branch.
+
+#### Naming Your Branch
+
+Name the branch something like `fix/xxx` or `feature/xxx` where `xxx` is a short description of the changes or feature you are attempting to add. For example `fix/email-login` would be a branch where I fix something specific to email login.
+
+#### Adding Your Branch
+
+To create a branch on your local machine (and switch to this branch):
+
+```shell
+$ git checkout -b [name_of_your_new_branch]
+```
+
+and to push to GitHub:
+
+```shell
+$ git push origin [name_of_your_new_branch]
+```
+
+##### If you need more help with branching, take a look at _[this](https://github.com/Kunena/Kunena-Forum/wiki/Create-a-new-branch-with-git-and-manage-branches)_.
+
+### Setup Linting
+
+You should have [ESLint running in your editor](http://eslint.org/docs/user-guide/integrations.html), and it will highlight anything doesn't conform to [Free Code Camp's JavaScript Style Guide](http://forum.freecodecamp.com/t/free-code-camp-javascript-style-guide/19121) (you can find a summary of those rules [here](https://github.com/FreeCodeCamp/FreeCodeCamp/blob/staging/.eslintrc)).
+
+> Please do not ignore any linting errors, as they are meant to **help** you and to ensure a clean and simple code base.
+
+Make sure none of your JavaScript is longer than 80 characters per line. The reason we enforce this is because one of our dependent NPM modules, [jsonlint](https://github.com/zaach/jsonlint), does not fully support wildcard paths in Windows.
+
+### Setup FreeCodeCamp
+Once you have FreeCodeCamp cloned, before you start the application, you first need to install all of the dependencies:
 
 ```bash
-# Get the latest snapshot
-git clone --depth=1 https://github.com/freecodecamp/freecodecamp.git freecodecamp
-
-# Change directory
-cd freecodecamp
-
 # Install NPM dependencies
 npm install
 
@@ -95,24 +164,20 @@ npm install -g bower
 bower install
 ```
 
-_Private Environment Variables (API Keys)_
+Then you need to add the private environment variables (API Keys):
 
 ```bash
 # Create a copy of the "sample.env" and name it as ".env".
 # Populate it with the necessary API keys and secrets:
 cp sample.env .env
 ```
+Then edit the `.env` file and modify the API keys only for services that you will use.
 
-Edit your `.env` file and modify the API keys only for services that you will
-use.
+Note: Not all keys are required, to run the app locally, however `MONGOHQ_URL` is the most important one. Unless you have MongoDB running in a setup different than the defaults, the URL in the sample.env should work fine.
 
-Note : Not all keys are required, to run the app locally, however `MONGOHQ_URL`
-is the most important one. Unless you have MongoDB running in a setup different
-than the defaults, the URL in the `sample.env` should work fine.
+You can leave the other keys as they are. Keep in mind if you want to use more services you'll have to get your own API keys for those services and edit those entries accordingly in the .env file.
 
-You can leave the other keys as they are. Keep in mind if you want to use more
-services you'll have to get your own API keys for those services and edit those
-entries accordingly in the `.env` file.
+Now you will need to start MongoDB, and then seed the database, then you can start the application:
 
 ```bash
 # Start the mongo server in a separate terminal
@@ -129,37 +194,33 @@ gulp
 
 Now navigate to your browser and open
 <http://localhost:3000>. If the app loads,
-congratulations – you're all set. Otherwise, let us know by opening a GitHub
-issue and with your error.
+congratulations – you're all set. Otherwise, let us know by asking in the [Contributors Room](https://gitter.im/FreeCodeCamp/Contributors) on Gitter. There also might be an error in the console of your browser or in Bash / Terminal / Command Line that will help identify the problem.
 
-### Linting Setup
+### Make Changes
+This bit is up to you!
 
-You should have [ESLint running in your
-editor](http://eslint.org/docs/user-guide/integrations.html), and it will
-highlight anything doesn't conform to [Free Code Camp's JavaScript Style
-Guide](http://forum.freecodecamp.com/t/free-code-camp-javascript-style-guide/19121)
-(you can find a summary of those rules
-[here](https://github.com/FreeCodeCamp/FreeCodeCamp/blob/staging/.eslintrc).
-Please do not ignore any linting errors, as they are meant to **help** you and
-to ensure a clean and simple code base. Make sure none of your JavaScript is
-longer than 80 characters per line.  The reason we enforce this is because one
-of our dependent NPM modules, [jsonlint](https://github.com/zaach/jsonlint),
-does not fully support wildcard paths in Windows.
+### Run The Test Suite
+When your are ready to share your code, run the test suite:
 
-### Found a bug?
+```shell
+$ npm test
+```
 
-Do not file an issue until you have followed these steps:
+and ensure all tests pass. For Windows contributors, skip the jsonlint pretest by using this instead:
 
-1.  Read [Help I've Found a
-    Bug](http://forum.freecodecamp.com/t/how-to-report-a-bug/19543)
-    wiki page and follow the instructions there.
+```shell
+npm run test-challenges
+```
+This is because jsonlint will always fail on Windows, due to the wildcard parameters.
 
-2.  Asked for confirmation in the appropriate [Help Room](http://forum.freecodecamp.com/t/free-code-camp-official-chat-rooms/19390/2)
+### Squash Your Commits
+When you make a pull request, all of your changes need to be in one commit.
 
-3.  Please _do not_ open an issue without a 3rd party confirmation of your
-    problem.
+If you have made more then one commit, then you will need to _squash_ your commits.
 
-### Creating Pull Requests
+To do this, see To do this, see [Squashing Your Commits](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231).
+
+### Creating A Pull Request
 
 #### What is a Pull Request?
 


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Your pull request targets the `staging` branch of FreeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm run test-challenges`. Use `git commit --amend` to amend any fixes.
#### Type of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
#### Checklist:
- [x] Tested changes locally.
- [x] Closes currently open issue: Closes #11006
#### Description

Following on from issue #11006 - this removes the need for the [http://forum.freecodecamp.com/t/how-to-fork-and-maintain-a-local-instance-of-free-code-camp/19116](http://forum.freecodecamp.com/t/how-to-fork-and-maintain-a-local-instance-of-free-code-camp/19116) Wiki page, creating just a CONTRIBUTING document.

If someone wouldn't mind looking over the new CONTRIBUTING.md file, it would be great to get a second opinion to make sure I haven't missed anything 👍 
