### PR TITLE
Added validation of css color value

### DIFF
--- a/seed/challenges/01-front-end-development-certification/html5-and-css.json
+++ b/seed/challenges/01-front-end-development-certification/html5-and-css.json
@@ -4584,7 +4584,7 @@
         "assert($(\"h1\").hasClass(\"pink-text\"), 'message: Your <code>h1</code> element should have the class <code>pink-text</code>.');",
         "assert($(\"h1\").hasClass(\"blue-text\"), 'message: Your <code>h1</code> element should have the class <code>blue-text</code>.');",
         "assert($(\"h1\").attr(\"id\") === \"orange-text\", 'message: Your <code>h1</code> element should have the id of <code>orange-text</code>.');",
-        "assert(code.match(/<h1[\\s\\S]*?style/gi) && code.match(/<h1[\s\S]*?style\s*?=\s*[\"']{1}\s*\s*\S*;*\s*color\s*?:\s*?white\s*;*\s*['\"]{1}/gi), 'message: Give your <code>h1</code> element the inline style of <code>color&#58; white</code>.');",
+        "assert(code.match(/<h1[\\s\\S]*?style/gi) && code.match(/<h1[\\s\\S]*?style\\s*?=\\s*[\\"']{1}\\s*\\s*\\S*;*\\s*color\\s*?:\\s*?white\\s*;*\\s*['\\"]{1}/gi), 'message: Give your <code>h1</code> element the inline style of <code>color&#58; white</code>.');",
         "assert($(\"h1\").css(\"color\") === \"rgb(255, 255, 255)\", 'message: Your <code>h1</code> element should be white.');"
       ],
       "type": "waypoint",

--- a/seed/challenges/01-front-end-development-certification/html5-and-css.json
+++ b/seed/challenges/01-front-end-development-certification/html5-and-css.json
@@ -4584,7 +4584,7 @@
         "assert($(\"h1\").hasClass(\"pink-text\"), 'message: Your <code>h1</code> element should have the class <code>pink-text</code>.');",
         "assert($(\"h1\").hasClass(\"blue-text\"), 'message: Your <code>h1</code> element should have the class <code>blue-text</code>.');",
         "assert($(\"h1\").attr(\"id\") === \"orange-text\", 'message: Your <code>h1</code> element should have the id of <code>orange-text</code>.');",
-        "assert(code.match(/<h1[\\s\\S]*?style/gi) && code.match(/<h1[\\s\\S]*?style\\s*?=\\s*[\\"']{1}\\s*\\s*\\S*;*\\s*color\\s*?:\\s*?white\\s*;*\\s*['\\"]{1}/gi), 'message: Give your <code>h1</code> element the inline style of <code>color&#58; white</code>.');",
+        "assert(code.match(/<h1[\\s\\S]*?style/gi) && code.match(/<h1[\\s\\S]*?style\\s*?=\\s*[\\\"]{1}\\s*\\s*\\S*;*\\s*color\\s*?:\\s*?white\\s*;*\\s*[\\\"]{1}/gi), 'message: Give your <code>h1</code> element the inline style of <code>color&#58; white</code>.');",
         "assert($(\"h1\").css(\"color\") === \"rgb(255, 255, 255)\", 'message: Your <code>h1</code> element should be white.');"
       ],
       "type": "waypoint",

--- a/seed/challenges/01-front-end-development-certification/html5-and-css.json
+++ b/seed/challenges/01-front-end-development-certification/html5-and-css.json
@@ -4584,7 +4584,7 @@
         "assert($(\"h1\").hasClass(\"pink-text\"), 'message: Your <code>h1</code> element should have the class <code>pink-text</code>.');",
         "assert($(\"h1\").hasClass(\"blue-text\"), 'message: Your <code>h1</code> element should have the class <code>blue-text</code>.');",
         "assert($(\"h1\").attr(\"id\") === \"orange-text\", 'message: Your <code>h1</code> element should have the id of <code>orange-text</code>.');",
-        "assert(code.match(/<h1[\\s\\S]*[\\s]+style\\s*?=\\s*('|\\\")?\\s*([\\s\\S]*;+|)*\\s*color\\s*?:\\s*?white\\s*;*\\s*('|\\\")?/gi), 'message: Give your <code>h1</code> element the inline style of <code>color&#58; white</code>.');",
+        "assert(code.match(/<h1[\\s\\S]*[\\s]+style\\s*?=\\s*(\\'|\\\")?\\s*([\\s\\S]*;+|)*\\s*color\\s*?:\\s*?white\\s*;*\\s*(\\'|\\\")?/gi), 'message: Give your <code>h1</code> element the inline style of <code>color&#58; white</code>.');",
         "assert($(\"h1\").css(\"color\") === \"rgb(255, 255, 255)\", 'message: Your <code>h1</code> element should be white.');"
       ],
       "type": "waypoint",

--- a/seed/challenges/01-front-end-development-certification/html5-and-css.json
+++ b/seed/challenges/01-front-end-development-certification/html5-and-css.json
@@ -4584,7 +4584,7 @@
         "assert($(\"h1\").hasClass(\"pink-text\"), 'message: Your <code>h1</code> element should have the class <code>pink-text</code>.');",
         "assert($(\"h1\").hasClass(\"blue-text\"), 'message: Your <code>h1</code> element should have the class <code>blue-text</code>.');",
         "assert($(\"h1\").attr(\"id\") === \"orange-text\", 'message: Your <code>h1</code> element should have the id of <code>orange-text</code>.');",
-        "assert(code.match(/<h1[\\s\\S]*?style/gi) && code.match(/<h1[\\s\\S]*?style\\s*?=\\s*[\\\"]{1}\\s*\\s*\\S*;*\\s*color\\s*?:\\s*?white\\s*;*\\s*[\\\"]{1}/gi), 'message: Give your <code>h1</code> element the inline style of <code>color&#58; white</code>.');",
+        "assert(code.match(/<h1[\\s\\S]*[\\s]+style\\s*?=\\s*('|\\\")?\\s*\\s*\\S*;*\\s*color\\s*?:\\s*?white\\s*;*\\s*('|\\\")?/gi), 'message: Give your <code>h1</code> element the inline style of <code>color&#58; white</code>.');",
         "assert($(\"h1\").css(\"color\") === \"rgb(255, 255, 255)\", 'message: Your <code>h1</code> element should be white.');"
       ],
       "type": "waypoint",

--- a/seed/challenges/01-front-end-development-certification/html5-and-css.json
+++ b/seed/challenges/01-front-end-development-certification/html5-and-css.json
@@ -4584,7 +4584,7 @@
         "assert($(\"h1\").hasClass(\"pink-text\"), 'message: Your <code>h1</code> element should have the class <code>pink-text</code>.');",
         "assert($(\"h1\").hasClass(\"blue-text\"), 'message: Your <code>h1</code> element should have the class <code>blue-text</code>.');",
         "assert($(\"h1\").attr(\"id\") === \"orange-text\", 'message: Your <code>h1</code> element should have the id of <code>orange-text</code>.');",
-        "assert(code.match(/<h1[\\s\\S]*?style/gi) && code.match(/<h1[\\s\\S]*?style[\\s\\S]*?color\\s*?:/gi), 'message: Give your <code>h1</code> element the inline style of <code>color&#58; white</code>.');",
+        "assert(code.match(/<h1[\\s\\S]*?style/gi) && code.match(/<h1[\\s\\S]*?style\\s*?=\\s*(\"|'){1}\\s*(color|([\\s\\S]*;{1})*\\s*color)\\s*?:\\s*?(white|#ffffff)\\s*(;|'|\")/gi), 'message: Give your <code>h1</code> element the inline style of <code>color&#58; white</code>.');",
         "assert($(\"h1\").css(\"color\") === \"rgb(255, 255, 255)\", 'message: Your <code>h1</code> element should be white.');"
       ],
       "type": "waypoint",

--- a/seed/challenges/01-front-end-development-certification/html5-and-css.json
+++ b/seed/challenges/01-front-end-development-certification/html5-and-css.json
@@ -4584,7 +4584,7 @@
         "assert($(\"h1\").hasClass(\"pink-text\"), 'message: Your <code>h1</code> element should have the class <code>pink-text</code>.');",
         "assert($(\"h1\").hasClass(\"blue-text\"), 'message: Your <code>h1</code> element should have the class <code>blue-text</code>.');",
         "assert($(\"h1\").attr(\"id\") === \"orange-text\", 'message: Your <code>h1</code> element should have the id of <code>orange-text</code>.');",
-        "assert(code.match(/<h1[\\s\\S]*?style/gi) && code.match(/<h1[\\s\\S]*?style\\s*?=\\s*(\"|'){1}\\s*(color|([\\s\\S]*;{1})*\\s*color)\\s*?:\\s*?(white|#ffffff)\\s*(;|'|\")/gi), 'message: Give your <code>h1</code> element the inline style of <code>color&#58; white</code>.');",
+        "assert(code.match(/<h1[\\s\\S]*?style/gi) && code.match(/<h1[\s\S]*?style\s*?=\s*[\"']{1}\s*\s*\S*;*\s*color\s*?:\s*?white\s*;*\s*['\"]{1}/gi), 'message: Give your <code>h1</code> element the inline style of <code>color&#58; white</code>.');",
         "assert($(\"h1\").css(\"color\") === \"rgb(255, 255, 255)\", 'message: Your <code>h1</code> element should be white.');"
       ],
       "type": "waypoint",

--- a/seed/challenges/01-front-end-development-certification/html5-and-css.json
+++ b/seed/challenges/01-front-end-development-certification/html5-and-css.json
@@ -4584,7 +4584,7 @@
         "assert($(\"h1\").hasClass(\"pink-text\"), 'message: Your <code>h1</code> element should have the class <code>pink-text</code>.');",
         "assert($(\"h1\").hasClass(\"blue-text\"), 'message: Your <code>h1</code> element should have the class <code>blue-text</code>.');",
         "assert($(\"h1\").attr(\"id\") === \"orange-text\", 'message: Your <code>h1</code> element should have the id of <code>orange-text</code>.');",
-        "assert(code.match(/<h1[\\s\\S]*[\\s]+style\\s*?=\\s*('|\\\")?\\s*\\s*\\S*;*\\s*color\\s*?:\\s*?white\\s*;*\\s*('|\\\")?/gi), 'message: Give your <code>h1</code> element the inline style of <code>color&#58; white</code>.');",
+        "assert(code.match(/<h1[\\s\\S]*[\\s]+style\\s*?=\\s*('|\\\")?\\s*([\\s\\S]*;+|)*\\s*color\\s*?:\\s*?white\\s*;*\\s*('|\\\")?/gi), 'message: Give your <code>h1</code> element the inline style of <code>color&#58; white</code>.');",
         "assert($(\"h1\").css(\"color\") === \"rgb(255, 255, 255)\", 'message: Your <code>h1</code> element should be white.');"
       ],
       "type": "waypoint",


### PR DESCRIPTION
<!-- FreeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/FreeCodeCamp/FreeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->

<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->

<!-- Make sure that your PR is not a duplicate -->
#### Pre-Submission Checklist

<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->

<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of FreeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm run test-challenges`. Use `git commit --amend` to amend any fixes.
#### Type of Change

<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)
#### Checklist:

<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->

<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Closes currently open issue (replace XXXX with an issue no): Closes #11226
#### Description

<!-- Describe your changes in detail -->

I updated the regex to include validation for allowable values that make the text white including the keyword white as well as hex #ffffff. Additional consideration for typos and extra space/characters that may cause the browser to ignore the color keyword. e.g. if the user types colors:white it will fail validation. I understand there is an existing pull request for this issue but I believe this is more robust.
