### PR TITLE
Add loopProtect error object

### DIFF
--- a/client/rechallenge/transformers.js
+++ b/client/rechallenge/transformers.js
@@ -10,12 +10,12 @@ import { updateContents } from '../../common/utils/polyvinyl';
 
 const babelOptions = { presets: [ presetEs2015, presetReact ] };
 loopProtect.hit = function hit(line) {
-  var err = 'Error: Exiting potential infinite loop at line ' +
+  var err = 'Exiting potential infinite loop at line ' +
     line +
-    '. To disable loop protection, write: \n\\/\\/ noprotect\nas the first' +
-    'line. Beware that if you do have an infinite loop in your code' +
+    '. To disable loop protection, write: \n\/\/ noprotect\nas the first ' +
+    'line. Beware that if you do have an infinite loop in your code, ' +
     'this will crash your browser.';
-  console.error(err);
+  throw new Error(err);
 };
 
 const transformersForHtmlJS = {


### PR DESCRIPTION
<!-- FreeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/FreeCodeCamp/FreeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->

<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->

<!-- Make sure that your PR is not a duplicate -->
#### Pre-Submission Checklist

<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->

<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of FreeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm run test-challenges`. Use `git commit --amend` to amend any fixes.
#### Type of Change

<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)
#### Checklist:

<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->

<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Closes currently open issue (replace XXXX with an issue no): Closes #10000
#### Description

<!-- Describe your changes in detail -->

Changed our loopProtect error handling, now loopProtect throws an Error object.

Can be merged now, but depends on #11058 for correct functionality.
