### PR TITLE
fix(lint): disable import extension requirement

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -260,6 +260,6 @@
     "import/no-duplicates": 2,
     "import/newline-after-import": 2,
     "import/unambiguous": 2,
-    "import/extensions": [ 1, "always" ]
+    "import/extensions": [ 0, "always" ]
   }
 }


### PR DESCRIPTION
There is an issue with modules so I'm disabling it until https://github.com/benmosher/eslint-plugin-import/issues/394 and https://github.com/benmosher/eslint-plugin-import/issues/414

The rule going forward should be any new import statements must include the extentions

Please ensure you have update your dependencies
