### PR TITLE
Documentation: Link for Maintaining Local Instance of FCC

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -271,8 +271,8 @@ There are two methods of creating a pull request for Free Code Camp:
 
 ##### Method 1: Editing via your Local Fork _(Recommended)_
 
-This is the recommended method. Read about How to Setup and Maintain a Local
-Instance of Free Code Camp.
+This is the recommended method. Read about [How to Setup and Maintain a Local
+Instance of Free Code Camp](#maintaining-your-fork).
 
 1.  Perform the maintenance step of rebasing `staging`.
 2.  Ensure you are on the `staging` branch using `git status`:


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Your pull request targets the `staging` branch of FreeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
- [x] Tested changes locally.
- [ ] Closes currently open issue (replace XXXX with an issue no): Closes #XXXX

#### Description
Documentation improvement.
It seems like How to Setup and Maintain a Local Instance of Free Code Camp was supposed to be a link given it's capitalized. 
Adding a link for easier navigation.

Here is a link to review the change.
https://github.com/user512/FreeCodeCamp/blob/fix/update-link-how-to-maintain-local-instance-of-fcc/CONTRIBUTING.md#methods
Click on `How to Setup and Maintain a Local Instance of Free Code Camp`

