### PR TITLE
Add escape as a hotkey to close the map drawer

### DIFF
--- a/client/sagas/mouse-trap-saga.js
+++ b/client/sagas/mouse-trap-saga.js
@@ -4,6 +4,7 @@ import { push } from 'react-router-redux';
 import {
   toggleNightMode,
   toggleMapDrawer,
+  closeMapDrawer,
   toggleMainChat,
   hardGoTo
 } from '../../common/app/redux/actions';
@@ -37,6 +38,7 @@ export default function mouseTrapSaga(actions$) {
       () => hardGoTo('http://forum.freecodecamp.com')
     ),
     bindKey$('g m', toggleMapDrawer),
+    bindKey$('esc', closeMapDrawer),
     bindKey$('g t n', toggleNightMode),
     bindKey$('g c', toggleMainChat)
   ];

--- a/common/app/routes/challenges/components/map/Header.jsx
+++ b/common/app/routes/challenges/components/map/Header.jsx
@@ -41,7 +41,7 @@ export class Header extends PureComponent {
 
   handleKeyDown(e) {
     if (e.keyCode === ESC) {
-      e.preventDefault();
+      document.activeElement.blur();
       this.props.clearFilter();
     }
   }


### PR DESCRIPTION
<!-- FreeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/FreeCodeCamp/FreeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of FreeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [x] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Closes currently open issue (replace XXXX with an issue no): Closes #9530

#### Description
<!-- Describe your changes in detail -->
This PR allows you to close the map drawer by pressing escape.
Currently, pressing escape clears out the input. This behavior was altered, it now clears and blurs the input.
If the input is in focus, escape has to be pressed twice. First to bring the input out of focus, then to close the drawer.

Any input on this PR is welcome, as the issue doesn't include a lot of implementation detail.
