### PR TITLE
Make translated challenge names searchable

### DIFF
--- a/common/app/routes/challenges/redux/fetch-challenges-saga.js
+++ b/common/app/routes/challenges/redux/fetch-challenges-saga.js
@@ -10,7 +10,8 @@ import {
 } from './actions';
 import {
   createMapUi,
-  filterComingSoonBetaFromEntities
+  filterComingSoonBetaFromEntities,
+  updateForLang
 } from '../utils';
 import {
   delayedRedirect,
@@ -68,6 +69,16 @@ export default function fetchChallengesSaga(action$, getState, { services }) {
             entities,
             isDev
           );
+          if (lang !== 'en') {
+            const langFilteredEntities = updateForLang(filteredEntities);
+            return Observable.of(
+              fetchChallengesCompleted(
+                createNameIdMap(langFilteredEntities),
+                result
+              ),
+              initMap(createMapUi(langFilteredEntities, result)),
+            );
+          }
           return Observable.of(
             fetchChallengesCompleted(
               createNameIdMap(filteredEntities),

--- a/common/app/routes/challenges/utils.js
+++ b/common/app/routes/challenges/utils.js
@@ -1,4 +1,6 @@
 import flow from 'lodash/flow';
+
+// import { dasherize } from '../../../../server/utils'; See note at line 311
 import { bonfire, html, js } from '../../utils/challengeTypes';
 import { decodeScriptTags } from '../../../utils/encode-decode';
 import protect from '../../utils/empty-protector';
@@ -305,6 +307,52 @@ export function filterComingSoonBetaFromEntities(
 //     }]
 //   }]
 // }
+
+/* ****************************************************************************
+* dasherized will be removed when I have found a fix for an import/export issue
+* left in place to get a review on the PR
+*******************************************************************************/
+
+function dasherize(name) {
+  return ('' + name)
+    .toLowerCase()
+    .replace(/\s/g, '-')
+    .replace(/[^a-z0-9\-\.]/gi, '')
+    .replace(/\:/g, '');
+}
+
+export function updateForLang(entities) {
+  const newEntities = Object.assign({}, entities);
+  let newChallenge = {};
+  Object.keys(newEntities.challenge)
+    .map(dashedName => newEntities.challenge[dashedName])
+    .map(challenge => {
+        const { challenges } = newEntities.block[challenge.block];
+        const index = challenges.indexOf(challenge.dashedName);
+        const newDashedName = dasherize(challenge.title);
+        // update entities.block[challenge.block].challenges
+        newEntities.block[challenge.block].challenges = [
+          ...challenges.slice(0, index),
+          newDashedName,
+          ...challenges.slice(index + 1)
+        ];
+        // update entities.challenge
+        newChallenge = {
+          ...newChallenge,
+          [newDashedName]: {
+            ...challenge,
+            dashedName: newDashedName
+          }
+        };
+    });
+  return {
+    ...newEntities,
+    challenge: {
+      ...newChallenge
+    }
+  };
+}
+
 export function createMapUi(
   { superBlock: superBlockMap, block: blockMap } = {},
   superBlocks


### PR DESCRIPTION
<!-- FreeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/FreeCodeCamp/FreeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of FreeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Closes currently open issue (replace XXXX with an issue no): Closes #11828

#### Description
<!-- Describe your changes in detail -->

If `lang` does not equal `'en'`, `entities.block[challenge.block].challenges`, `entities.challenge` and `challenge.dashedName` get language specific `dashedName`'s.

`Map` can then build its UI from this language specific `entities` allowing the translated challenge names to become searchable.

This PR also forces the URI to become language specific as the two are so tightly bound. This should give us bonus SEO points in non-English speaking countries though.