### PR TITLE
feat(user): Report profiles

### DIFF
--- a/client/less/main.less
+++ b/client/less/main.less
@@ -1145,7 +1145,7 @@ and (max-width : 400px)  {
   -webkit-overflow-scrolling: touch;
 }
 
-// Reset/Delete Account Modal Styles
+// Account Modal Styles
 .modal-dialog {
   margin: 80px;
 
@@ -1183,6 +1183,14 @@ and (max-width : 400px)  {
       color: #eee;
       background-color: #208e36;
       border-color: darkgreen;
+    }
+
+    .modal-textarea {
+      width: 100%;
+      max-width: 590px;
+      border: 2px solid #ccc;
+      border-radius: 5px;
+      padding: 5px;
     }
   }
 }

--- a/server/middlewares/validator.js
+++ b/server/middlewares/validator.js
@@ -26,6 +26,30 @@ export default function() {
           // every file has contents
           keys.map(key => value[key]).every(file => isPoly(file));
       }
+    },
+    customSanitizers: {
+      // Refer : http://stackoverflow.com/a/430240/1932901
+      trimTags(value) {
+       const tagBody = '(?:[^"\'>]|"[^"]*"|\'[^\']*\')*';
+       const tagOrComment = new RegExp(
+           '<(?:'
+           // Comment body.
+           + '!--(?:(?:-*[^->])*--+|-?)'
+           // Special "raw text" elements whose content should be elided.
+           + '|script\\b' + tagBody + '>[\\s\\S]*?</script\\s*'
+           + '|style\\b' + tagBody + '>[\\s\\S]*?</style\\s*'
+           // Regular name
+           + '|/?[a-z]'
+           + tagBody
+           + ')>',
+           'gi');
+         let rawValue;
+         do {
+           rawValue = value;
+           value = value.replace(tagOrComment, '');
+         } while (value !== rawValue);
+         return value.replace(/</g, '&lt;');
+      }
     }
   });
 }

--- a/server/utils/middleware.js
+++ b/server/utils/middleware.js
@@ -29,21 +29,17 @@ export function ifNoUser401(req, res, next) {
   return res.status(401).end();
 }
 
-export function flashIfNotVerified(req, res, next) {
-  return next();
-  /*
-  // disabled until authorized required bug is fixed
-  const user = req.user;
+export function ifNotVerifiedRedirectToSettings(req, res, next) {
+  const { user } = req;
   if (!user) {
     return next();
   }
-  const email = req.user.email;
-  const emailVerified = req.user.emailVerified;
-  if (!email || !emailVerified) {
-    req.flash('info', {
-      msg: 'Please verify your email address ' +
-      '<a href="/update-email">here</a>.'
+  if (!user.emailVerified) {
+    req.flash('error', {
+      msg: 'We do not have your verified email address on record, '
+      + 'please add it in the settings to continue with your request.'
     });
+    return res.redirect('/settings');
   }
-  */
+  return next();
 }

--- a/server/views/account/report-profile.jade
+++ b/server/views/account/report-profile.jade
@@ -1,0 +1,29 @@
+extends ../layout
+block content
+    #modal-dialog.modal
+        .modal-dialog
+            .modal-content
+                .modal-header
+                    a.close(href='/settings', data-dismiss='modal', aria-hidden='true') ×
+                    h3 Do you want to report #{username}'s profile for abuse?
+                .modal-body
+                    p We will notify the community moderators' team,
+                      | and a send copy of this report to your email:
+                      strong  #{user.email}
+                      | . We may get back to you for more information, if required.
+                .modal-footer
+                    form(action='/' + username +'/report-user/', method='POST')
+                        input(type='hidden', name='_csrf', value=_csrf)
+                        div
+                          textarea.modal-textarea(name='reportDescription', cols='40', rows='5')
+                        .spacer
+                        button.btn.btn-danger.btn-block(type='submit')
+                            | Yes, submit my report about this user's profile.
+                        .spacer
+                        a.btn.btn-success.btn-block(href='/settings', data-dismiss='modal', aria-hidden='true')
+                            | Nevermind, I don't want to report this user.
+    script.
+      document.addEventListener('DOMContentLoaded', function() {
+        const modal$ = document.getElementById('modal-dialog');
+        modal$.classList.add('show');
+      });

--- a/server/views/account/show.jade
+++ b/server/views/account/show.jade
@@ -56,6 +56,9 @@ block content
                     if isBackEndCert
                         .button-spacer
                         a.btn.btn-primary.btn-block(href='/' + username + '/back-end-certification') View My Back End Development Certification
+                    if (user && user.username != username)
+                        .button-spacer
+                        a.btn.btn-primary.btn-block(href='/' + username + '/report-user/') Report this user's profile for abuse
     .row
       .col-xs-12.text-center
         if (badges.coreTeam && badges.coreTeam.length)


### PR DESCRIPTION
This adds a simple email-based mechanism to report profiles for abuse. An email with text from the report is sent to Free Code Camp's support account with the reporter's account in copy. This also adds the reporter's details to the report for follow ups.

Tested locally.

Closes #11891 