### PR TITLE
Use strict equality operator for each sumFibs test

### DIFF
--- a/seed/challenges/01-front-end-development-certification/intermediate-bonfires.json
+++ b/seed/challenges/01-front-end-development-certification/intermediate-bonfires.json
@@ -715,11 +715,11 @@
       ],
       "tests": [
         "assert(typeof sumFibs(1) === \"number\", 'message: <code>sumFibs(1)</code> should return a number.');",
-        "assert.deepEqual(sumFibs(1000), 1785, 'message: <code>sumFibs(1000)</code> should return 1785.');",
-        "assert.deepEqual(sumFibs(4000000), 4613732, 'message: <code>sumFibs(4000000)</code> should return 4613732.');",
-        "assert.deepEqual(sumFibs(4), 5, 'message: <code>sumFibs(4)</code> should return 5.');",
-        "assert.deepEqual(sumFibs(75024), 60696, 'message: <code>sumFibs(75024)</code> should return 60696.');",
-        "assert.deepEqual(sumFibs(75025), 135721, 'message: <code>sumFibs(75025)</code> should return 135721.');"
+        "assert(sumFibs(1000) === 1785, 'message: <code>sumFibs(1000)</code> should return 1785.');",
+        "assert(sumFibs(4000000) === 4613732, 'message: <code>sumFibs(4000000)</code> should return 4613732.');",
+        "assert(sumFibs(4) === 5, 'message: <code>sumFibs(4)</code> should return 5.');",
+        "assert(sumFibs(75024) === 60696, 'message: <code>sumFibs(75024)</code> should return 60696.');",
+        "assert(sumFibs(75025) === 135721, 'message: <code>sumFibs(75025)</code> should return 135721.');"
       ],
       "type": "bonfire",
       "MDNlinks": [


### PR DESCRIPTION
<!-- FreeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/FreeCodeCamp/FreeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of FreeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Closes currently open issue (replace XXXX with an issue no): Closes #11830 

#### Description
<!-- Describe your changes in detail -->
It's likely for `loopProtect` to break out of `sumFibs(4000000)`, but not any other case. Thus for every other case an array of size `num` is returned and tested by `assert.deepEqual`—which will freeze the browser for large `num`s.

This PR piggybacks off of @marzelin's [comment](https://github.com/FreeCodeCamp/FreeCodeCamp/issues/11830#issuecomment-264170612), which suggests comparing the expected and actual results manually with the equality operator.