### PR TITLE
improve github linking copy and error message

### DIFF
--- a/server/boot/a-extendUserIdent.js
+++ b/server/boot/a-extendUserIdent.js
@@ -53,10 +53,9 @@ export default function({ models }) {
           return Observable.throw(
             new Error(
               dedent`
-Your GitHub is already associated with another account.
-You may have accidentally created a duplicate account.
-No worries, though. We can fix this real quick.
-Please email us with your GitHub username: team@freecodecamp.com.
+Your GitHub account is already linked to another Free Code Camp
+account. To access it, <a href='/signout'>Sign out</a> of Free Code Camp, 
+then sign in again using the "Sign in with GitHub" button.
               `.split('/n').join(' ')
             )
           );

--- a/server/boot/user.js
+++ b/server/boot/user.js
@@ -227,7 +227,10 @@ module.exports = function(app) {
 
   function signout(req, res) {
     req.logout();
-    res.redirect('/');
+    req.flash('success', {
+      msg: `You have successfully signed out.`
+    });
+    res.redirect('/signin');
   }
 
 

--- a/server/boot/user.js
+++ b/server/boot/user.js
@@ -228,7 +228,7 @@ module.exports = function(app) {
   function signout(req, res) {
     req.logout();
     req.flash('success', {
-      msg: `You have successfully signed out.`
+      msg: 'You have successfully signed out.'
     });
     res.redirect('/signin');
   }

--- a/server/views/account/settings.jade
+++ b/server/views/account/settings.jade
@@ -11,7 +11,7 @@ block content
               if (!user.isGithubCool)
                   a.btn.btn-lg.btn-block.btn-github.btn-link-social(href='/link/github')
                       i.fa.fa-github
-                      | Link my GitHub to unlock my portfolio
+                      | Link my GitHub to enable my public profile
               else
                   a.btn.btn-lg.btn-block.btn-github.btn-link-social(href='/link/github')
                       i.fa.fa-github

--- a/server/views/account/show.jade
+++ b/server/views/account/show.jade
@@ -9,10 +9,10 @@ block content
         if (!user.isGithubCool)
           a.btn.btn-lg.btn-block.btn-github.btn-link-social(href='/link/github')
               i.fa.fa-github
-              | Link my GitHub to unlock my portfolio
+              | Link my GitHub to enable my public profile
         .col-xs-12
             a.btn.btn-lg.btn-block.btn-primary.btn-link-social(href='/settings')
-                | Update your settings
+                | Update my settings
         .col-xs-12
             a.btn.btn-lg.btn-block.btn-primary.btn-link-social(href='/signout')
                 | Sign me out of Free Code Camp


### PR DESCRIPTION
- if a camper has already linked their GitHub account with an account, it instructs them to sign out, then sign in using GitHub.
- /signout now takes campers to /signin with a flash message that they've successfully signed out.
- updated copy of settings buttons to remove reference to old "code portfolio" terminology.