### PR TITLE
Fix debug webpack replace issue

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -57,7 +57,7 @@ module.exports = {
     // Use browser version of visionmedia-debug
     new webpack.NormalModuleReplacementPlugin(
       /debug\/node/,
-      'debug/browser'
+      'debug'
     ),
     new webpack.optimize.DedupePlugin(),
     new webpack.optimize.OccurenceOrderPlugin(true)


### PR DESCRIPTION
<!-- FreeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/FreeCodeCamp/FreeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of FreeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [ ] Closes currently open issue (replace XXXX with an issue no): Closes #XXXX

#### Description
<!-- Describe your changes in detail -->
It's me again, with another module update + webpack related issue that prevented the bundle from successfully compiling (see #11718 for last time).

This time around, it was an issue with `babel-core` using `debug` improperly, which made things break in a SemVer minor update. A patch was done (https://github.com/visionmedia/debug/issues/389), but we had a module replacement in our webpack config that made things break. This was not restored in the patch.

I changed this replacement plugin to replace with `debug` instead of `debug/browser`, which is the recommended way to use the module. It detects if you're in a browser automatically.

Across all of the modules (this includes the backend), Free Code Camp is dependent on three versions of `debug`: `2.2.0`, `2.3.3` and `2.5.3`. This change should work fine with all of these versions. There are currently three references to `debug/node` in our `node_modules`. One of them is from `babel-core`. 
The other two are in `avj`, a sub-sub-dependency of `eslint`. Interestingly, this module is not dependent on `debug`. The references are in a minified file in the `dist` directory. `eslint` is never processed by webpack, so whatever this module does not matter for this PR.

From what I can tell, everything works fine, but I'm not 100% certain.

@BerkeleyTrue review would be much appreciated 🙂 