### PR TITLE
fix wording and css of Bug Modal

### DIFF
--- a/client/less/main.less
+++ b/client/less/main.less
@@ -1156,7 +1156,6 @@ and (max-width : 400px)  {
   .modal-header .close {
     font-size: 30px;
     padding-left: 10px;
-    margin-top: 22px;
   }
 
   .modal-header {

--- a/common/app/routes/challenges/components/Bug-Modal.jsx
+++ b/common/app/routes/challenges/components/Bug-Modal.jsx
@@ -39,7 +39,7 @@ export class BugModal extends PureComponent {
         <Modal.Body className='text-center'>
           <h3>
             Before you submit a new issue,
-            read "Help I've Found a Bug" and
+            read "How to Report a Bug" and
             browse other issues with this challenge.
           </h3>
           <Button
@@ -49,7 +49,7 @@ export class BugModal extends PureComponent {
             href={ bugLink }
             target='_blank'
             >
-            Read "Help I've Found a Bug"
+            Read "How to Report a Bug"
           </Button>
           <Button
             block={ true }


### PR DESCRIPTION
#### Description
<!-- Describe your changes in detail -->
Removed the margin-top from the X on the bug modal. This also affects the reset account and delete account modals but I think it's a positive in all cases. On the bug modal particularly, the margin-top made it hard to click.

Also changed the wording from Help I've Found A Bug to "How to Report a Bug" since that is the actual name of the article on the forum.