### PR TITLE
Improve console.log output

### DIFF
--- a/common/app/routes/challenges/utils.js
+++ b/common/app/routes/challenges/utils.js
@@ -46,16 +46,37 @@ export function createTests({ tests = [] }) {
     });
 }
 
+function logReplacer(value) {
+  if (Array.isArray(value)) {
+    const replaced = value.map(logReplacer);
+    return '[' + replaced.join(', ') + ']';
+  }
+  if (typeof value === 'string' && !value.startsWith('//')) {
+    return '"' + value + '"';
+  }
+  if (typeof value === 'number' && isNaN(value)) {
+    return value.toString();
+  }
+  if (typeof value === 'undefined') {
+    return 'undefined';
+  }
+  if (value === null) {
+    return 'null';
+  }
+  if (typeof value === 'function') {
+    return value.name;
+  }
+  if (typeof value === 'object') {
+    return JSON.stringify(value, null, 2);
+  }
+
+  return value;
+}
+
 export function loggerToStr(args) {
   args = Array.isArray(args) ? args : [args];
   return args
-    .map(arg => typeof arg === 'undefined' ? 'undefined' : arg)
-    .map(arg => {
-      if (typeof arg !== 'string') {
-        return JSON.stringify(arg);
-      }
-      return arg;
-    })
+    .map(logReplacer)
     .reduce((str, arg) => str + arg + '\n', '');
 }
 


### PR DESCRIPTION
<!-- FreeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/FreeCodeCamp/FreeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of FreeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Closes currently open issue (replace XXXX with an issue no): Closes #12271

#### Description
<!-- Describe your changes in detail -->

Here's my test code:
```js
var hi = 'potato';

function right() {
  return 'wrong';
}

console.log('normal thing');
console.log('// this should not really do what it does, but oh well');
console.log(NaN);
console.log([8, null, 0, NaN, undefined, "", 'text', hi, right]);
console.log(['array', ['nested array', ['nested nested array', undefined]]]);
console.log(right());
console.log({
  property: '1',
  otherProperty: 1,
  'anotherProperty': NaN
});
```
This is what that looks like on the current staging branch
![chrome_2017-01-02_15-23-24](https://cloud.githubusercontent.com/assets/7262039/21590857/802bd14c-d0ff-11e6-96b8-8a85ecbc1d2a.png)
This is what it looks like after my changes
![chrome_2017-01-02_14-06-49](https://cloud.githubusercontent.com/assets/7262039/21590858/802bf1e0-d0ff-11e6-86a3-38e638b90093.png)

### Things that work great now
- Strings actually show up as strings
- Previously, `undefined` and `NaN` were converted to `null`. They now stay as is.
- Objects are prettified.
- Arrays get an extra space, like they have in the browser console.

### Things that aren't perfect yet
_Nested arrays are now recursively parsed._
- ~Nested arrays and~ property values are still handled by `JSON.stringify`, so they still have the `NaN` -> `null` issue.
- All strings that start with // are displayed as comments.
- ~The indentation of indented arrays doesn't necessarily have to be this way. I guess it comes down to our preference.~
- If there is a lot of logging output, the performance hit may be too big. This change doesn't affect that a whole lot though. It might be good to not log anything larger than `x`.


~Tests are still broken as per #12305. I ran them with the fix from #12317, and they passed.~ Tests have been fixed