### PR TITLE
Updated mongodb running command in c9.io

### DIFF
--- a/seed/challenges/03-back-end-development-certification/mongodb.json
+++ b/seed/challenges/03-back-end-development-certification/mongodb.json
@@ -25,7 +25,7 @@
         "Make sure that you are always in your project's \"workspace\" directory. You can always navigate back to this directory by running this command: <code>cd ~/workspace</code>.",
         "You can view this Node School module's source code on GitHub at <a href='https://github.com/evanlucas/learnyoumongo'>https://github.com/evanlucas/learnyoumongo</a>.",
         "Complete \"Mongod\"",
-        "Complete \"Connect\"<br><br><strong>Note:</strong> Use the command <code>mongod --port 27017</code> in place of <code>mongod --port 27017 --dbpath=./data</code> to avoid a duplicate parameter error.<br><br><code>--dbpath=./data</code> is already included in the <code>./mongod</code> command.",
+        "Complete \"Connect\"<br><br><strong>Note:</strong> Use the command <code>mongod --port 27017 --smallfiles</code> in place of <code>mongod --port 27017 --dbpath=./data</code> to avoid a duplicate parameter error.<br><br><code>--dbpath=./data</code> is already included in the <code>./mongod</code> command.",
         "Complete \"Find\"",
         "Complete \"Find Project\"",
         "Complete \"Insert\"",


### PR DESCRIPTION
<!-- FreeCodeCamp Pull Request Template -->

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [ ] Tested changes locally.
- [ ] Closes currently open issue (replace 12379 with an issue no): Closes #12379

#### Description
<!-- Describe your changes in detail -->
For free users, c9.io provide only 2GB memory for single workspace. But to run mongodb it requires at least 3379MB in journal. So we should use mongod --port 27017 --smallfiles to allow run mongodb within the provided 2GB memory.