### PR TITLE
fix(webpack): Always use browser debug

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,6 +54,11 @@ module.exports = {
       },
       __DEVTOOLS__: !__DEV__
     }),
+    // Use browser version of visionmedia-debug
+    new webpack.NormalModuleReplacementPlugin(
+      /debug\/node/,
+      'debug/src/browser'
+    ),
     new webpack.optimize.DedupePlugin(),
     new webpack.optimize.OccurenceOrderPlugin(true)
   ]


### PR DESCRIPTION
I was running into issues with debug running in browser after this was removed. Adding it back here to get things moving again.