### PR TITLE
Add more Free Code Camp places in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ For this certification, you'll work on **two projects from scratch** and then **
 
 ---
 
-This code is running live at [FreeCodeCamp.com](https://www.freecodecamp.com). We also have [Gitter chat rooms](https://gitter.im/FreeCodeCamp/FreeCodeCamp), a [Medium publication](https://medium.freecodecamp.com), and even a [YouTube channel](https://youtube.com/freecodecamp).
+This code is running live at [FreeCodeCamp.com](https://www.freecodecamp.com). We also have [Gitter chat rooms](https://gitter.im/FreeCodeCamp/FreeCodeCamp), a [Medium publication](https://medium.freecodecamp.com), an [interactive forum](https://forum.freecodecamp.com), a [technology wiki](https://forum.freecodecamp.com/c/wiki), and even a [YouTube channel](https://youtube.com/freecodecamp).
 
 ### [Join our community here](https://www.freecodecamp.com/signin).
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ For this certification, you'll work on **two projects from scratch** and then **
 
 ---
 
-This code is running live at [FreeCodeCamp.com](https://www.freecodecamp.com). We also have [Gitter chat rooms](https://gitter.im/FreeCodeCamp/FreeCodeCamp), a [Medium publication](https://medium.freecodecamp.com), an [interactive forum](https://forum.freecodecamp.com), a [technology wiki](https://forum.freecodecamp.com/c/wiki), and even a [YouTube channel](https://youtube.com/freecodecamp).
+This code is running live at [FreeCodeCamp.com](https://www.freecodecamp.com). We also have [Gitter chat rooms](https://gitter.im/FreeCodeCamp/FreeCodeCamp), a [Medium publication](https://medium.freecodecamp.com), an [interactive forum](https://forum.freecodecamp.com), a [wiki knowledgebase](https://forum.freecodecamp.com/c/wiki), and even a [YouTube channel](https://youtube.com/freecodecamp).
 
 ### [Join our community here](https://www.freecodecamp.com/signin).
 


### PR DESCRIPTION
#### Proposed documentation enhancement to README.md

Free Code Camp also has an awesome forum and wiki which are not mentioned with our other places (Gitter, Youtube, Medium, etc.). I propose we add links to these places in the relevant section as people viewing the repository may be interested in viewing them.

Issue: https://github.com/freeCodeCamp/freeCodeCamp/issues/12502

Old pull request: https://github.com/freeCodeCamp/freeCodeCamp/pull/12503