### PR TITLE
Bump JQuery major version - to 3.1.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
   ],
   "dependencies": {
     "d3": "~3.5.5",
-    "jquery": "~2.1.4",
+    "jquery": "~3.1.1",
     "cal-heatmap": "~3.5.2",
     "bootstrap": "~3.3.4",
     "font-awesome": "~4.5.0",

--- a/client/main.js
+++ b/client/main.js
@@ -17,7 +17,7 @@ $(document).ready(function() {
 
   setCSRFToken($('meta[name="csrf-token"]').attr('content'));
 
-  $('img').error(function() {
+  $('img').on('error', function() {
     $(this)
       .unbind('error')
       .attr(
@@ -69,7 +69,7 @@ $(document).ready(function() {
       dataType: 'json'
     };
     return $.ajax(options)
-      .success(() => console.log('theme updated successfully'))
+      .done(() => console.log('theme updated successfully'))
       .fail(err => {
         let message;
         try {


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

#### Checklist:
- [x] Tested changes locally.
- [x] Closes currently open issue: Closes #12015

#### Description

Upgrades jquery to 3.1.1 (major version upgrade).

I used [this official guide](https://jquery.com/upgrade-guide/3.0/#breaking-change-load-unload-and-error-removed) to upgrade API. I have tested some of the pages, including some of the challenges. I would be glad to help with more testing if someone who knows the app well can lay out a plan. From reading the upgrade doc, it didn't appear that the repo had a bunch of deprecated API, though.

Notes:
- lightbox2 library throws a warning during bower build that it requires JQuery 2. I let this one go, because [there hasn't been any issues reported](https://github.com/lokesh/lightbox2/issues/525) and JQuery 3 seems to work fine with this library.