### PR TITLE
Fix challenge type for data structure and ES6 challenges

### DIFF
--- a/seed/challenges/02-javascript-algorithms-and-data-structures/basic-data-structures.json
+++ b/seed/challenges/02-javascript-algorithms-and-data-structures/basic-data-structures.json
@@ -36,7 +36,7 @@
       ],
       "type": "waypoint",
       "solutions": [],
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -73,7 +73,7 @@
       ],
       "type": "waypoint",
       "solutions": [],
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -109,7 +109,7 @@
       ],
       "type": "waypoint",
       "solutions": [],
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -145,7 +145,7 @@
       ],
       "type": "waypoint",
       "solutions": [],
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -176,7 +176,7 @@
       ],
       "type": "waypoint",
       "solutions": [],
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -213,7 +213,7 @@
       ],
       "type": "waypoint",
       "solutions": [],
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -247,7 +247,7 @@
       ],
       "type": "waypoint",
       "solutions": [],
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -289,7 +289,7 @@
       ],
       "type": "waypoint",
       "solutions": [],
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -337,7 +337,7 @@
       ],
       "type": "waypoint",
       "solutions": [],
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -366,7 +366,7 @@
       ],
       "type": "waypoint",
       "solutions": [],
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -400,7 +400,7 @@
       ],
       "type": "waypoint",
       "solutions": [],
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -430,7 +430,7 @@
       ],
       "type": "waypoint",
       "solutions": [],
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -464,7 +464,7 @@
       ],
       "type": "waypoint",
       "solutions": [],
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -492,7 +492,7 @@
       ],
       "type": "waypoint",
       "solutions": [],
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -536,7 +536,7 @@
       ],
       "type": "waypoint",
       "solutions": [],
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -580,7 +580,7 @@
       ],
       "type": "waypoint",
       "solutions": [],
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -620,7 +620,7 @@
       ],
       "type": "waypoint",
       "solutions": [],
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -661,7 +661,7 @@
       ],
       "type": "waypoint",
       "solutions": [],
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -688,7 +688,7 @@
       ],
       "type": "waypoint",
       "solutions": [],
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     }
   ]

--- a/seed/challenges/02-javascript-algorithms-and-data-structures/es6.json
+++ b/seed/challenges/02-javascript-algorithms-and-data-structures/es6.json
@@ -66,7 +66,7 @@
         "assert(favorite === \"Rudolph is Santa's favorite reindeer.\", \"message: <code>favorite</code> should return Santa's favorite reindeer.\");"
       ],
       "type": "waypoint",
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -145,7 +145,7 @@
         "assert(newCampers[2].roleCall() === \"Camper # 3 has arrived.\", \"message: <code>newCampers[0].call()</code> should call the index of the third camper\");"
       ],
       "type": "waypoint",
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -184,7 +184,7 @@
         "// Test pi and calulateCircumference has been renamed"
       ],
       "type": "waypoint",
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -220,7 +220,7 @@
         "// Test s is still mutable, and object freeze was not invoked"
       ],
       "type": "waypoint",
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -265,7 +265,7 @@
         "// Test arrow => was used"
       ],
       "type": "waypoint",
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -298,7 +298,7 @@
         "// Test arrow => was used"
       ],
       "type": "waypoint",
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -344,7 +344,7 @@
         "// Test map and filter were used"
       ],
       "type": "waypoint",
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -377,7 +377,7 @@
         "// Test default parameter was used for 'value'"
       ],
       "type": "waypoint",
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -411,7 +411,7 @@
         "assert(sum() === 0, 'The result of sum() should be 0');"
       ],
       "type": "waypoint",
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -446,7 +446,7 @@
         "// Test spread operator was used"
       ],
       "type": "waypoint",
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -480,7 +480,7 @@
         "// Test destructuring was used"
       ],
       "type": "waypoint",
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -511,7 +511,7 @@
         "// Test destructuring was used"
       ],
       "type": "waypoint",
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -544,7 +544,7 @@
         "// Test destructuring was used"
       ],
       "type": "waypoint",
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -576,7 +576,7 @@
         "// Test slice was not used"
       ],
       "type": "waypoint",
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -617,7 +617,7 @@
         "// Test destructuring was used"
       ],
       "type": "waypoint",
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -669,7 +669,7 @@
         "// Test template strings were used"
       ],
       "type": "waypoint",
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -708,7 +708,7 @@
         "// Test no : was present"
       ],
       "type": "waypoint",
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -756,7 +756,7 @@
         "// Test no : was present"
       ],
       "type": "waypoint",
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -795,7 +795,7 @@
         "// Test that other objects could be created with the class"
       ],
       "type": "waypoint",
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -849,7 +849,7 @@
         "// Test that other objects could be created with the class"
       ],
       "type": "waypoint",
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -875,7 +875,7 @@
         "assert(code.match(/import\\s+\\{\\s?capitalizeString\\s?\\}\\s+from\\s+\"string_functions\"/ig)"
       ],
       "type": "waypoint",
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -908,7 +908,7 @@
         "assert(code.match(/export\\s+const\\s+boo\\s+=+\\s\"far\"/ig))"
       ],
       "type": "waypoint",
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -935,7 +935,7 @@
         "assert(code.match(/import\\s+\\*\\s+as\\s+myStringModule\\s+from\\s+\"capitalize_strings\"/ig))"
       ],
       "type": "waypoint",
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -959,7 +959,7 @@
         "assert(code.match(/export\\s+default\\s+const\\s+subtract\\s+=\\s+\\(x,y\\)\\s+=>\\s+{return\\s+x\\s-\\s+y;}/ig))"
       ],
       "type": "waypoint",
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     },
     {
@@ -981,7 +981,7 @@
         "assert(code.match(/import\\s+subtract\\s+from\\s+\"math_functions\"/ig))"
       ],
       "type": "waypoint",
-      "challengeType": 0,
+      "challengeType": 1,
       "translations": {}
     }
   ]


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
- [x] Tested changes locally.
- [x] Closes currently open issue (replace XXXX with an issue no): Closes #12667

#### Description
As discussed in the issue, these sections had the wrong challenge type. This PR fixes that.

/cc @HKuz 
