### PR TITLE
improve tests for parseInt radix

### DIFF
--- a/seed/challenges/02-javascript-algorithms-and-data-structures/basic-javascript.json
+++ b/seed/challenges/02-javascript-algorithms-and-data-structures/basic-javascript.json
@@ -5673,10 +5673,10 @@
       "tail": [],
       "solutions": [],
       "tests": [
-        "assert(typeof(convertToInteger(\"10011\")) !== \"number\", 'message: <code>convertToInteger(\"10011\")</code> should return a number');",
+        "assert(typeof(convertToInteger(\"10011\")) === \"number\", 'message: <code>convertToInteger(\"10011\")</code> should return a number');",
         "assert(convertToInteger(\"10011\") === 19, 'message: <code>convertToInteger(\"10011\")</code> should return 19');",
         "assert(convertToInteger(\"111001\") === 57, 'message: <code>convertToInteger(\"111001\")</code> should return 57');",
-        "assert(!isNaN(convertToInteger(\"JamesBond\")); , 'message: <code>convertToInteger(\"JamesBond\")</code> should return NaN');"
+        "assert.isNaN(convertToInteger(\"JamesBond\"), 'message: <code>convertToInteger(\"JamesBond\")</code> should return NaN');"
       ],
       "type": "waypoint",
       "challengeType": 1,


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] Your pull request targets the `staging` branch of freeCodeCamp.
- [X] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [X] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [X] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [X] Tested changes locally.
- [X] Closes currently open issue (replace XXXX with an issue no): Closes #12730

#### Description
<!-- Describe your changes in detail -->
Fixed the first and fourth test. The first one was testing for the opposite of what it should've been and the fourth needed the Chai `assert.isNaN` test to accurately detect NaN.