### PR TITLE
[WIP] Add arrow keys to navigate in step challenges

### DIFF
--- a/client/sagas/mouse-trap-saga.js
+++ b/client/sagas/mouse-trap-saga.js
@@ -1,15 +1,22 @@
 import { Observable } from 'rx';
 import MouseTrap from 'mousetrap';
 import { push } from 'react-router-redux';
+
 import {
   toggleNightMode,
   hardGoTo
 } from '../../common/app/redux/actions';
 
-function bindKey(key, actionCreator) {
+import { step } from '../../common/app/utils/challengeTypes';
+import {
+  stepForward,
+  stepBackward
+} from '../../common/app/routes/challenges/redux/actions';
+
+function bindKey(key, actionCreator, direction) {
   return Observable.fromEventPattern(
-    h => MouseTrap.bind(key, h),
-    h => MouseTrap.unbind(key, h)
+    h => MouseTrap.bind(key, h, direction),
+    h => MouseTrap.unbind(key, h, direction)
   )
     .map(actionCreator);
 }
@@ -22,7 +29,18 @@ const softRedirects = {
   'g n o': '/settings'
 };
 
-export default function mouseTrapSaga(actions$) {
+export default function mouseTrapSaga(actions$, getState) {
+  const {
+    challengesApp: { challenge },
+    entities: {
+      challenge: challengeMap
+    }
+  } = getState();
+  const challengeType =
+    challenge ?
+      challengeMap[challenge].challengeType :
+      null;
+
   const traps$ = [
     ...Object.keys(softRedirects)
       .map(key => bindKey(key, () => push(softRedirects[key]))),
@@ -36,5 +54,13 @@ export default function mouseTrapSaga(actions$) {
     ),
     bindKey('g t n', toggleNightMode)
   ];
+
+  if (challengeType === step) {
+    const stepTraps$ = [
+      bindKey('right', stepForward, 'keyup'),
+      bindKey('left', stepBackward, 'keyup')
+    ].concat(traps$);
+    return Observable.merge(stepTraps$).takeUntil(actions$.last());
+  }
   return Observable.merge(traps$).takeUntil(actions$.last());
 }

--- a/common/app/routes/challenges/components/step/Step.jsx
+++ b/common/app/routes/challenges/components/step/Step.jsx
@@ -6,12 +6,14 @@ import PureComponent from 'react-pure-render/component';
 import LightBox from 'react-images';
 
 import {
+  bindStepKeys,
   closeLightBoxImage,
   completeAction,
   openLightBoxImage,
   stepBackward,
   stepForward,
   submitChallenge,
+  unbindStepKeys,
   updateUnlockedSteps
 } from '../../redux/actions';
 import { challengeSelector } from '../../redux/selectors';
@@ -43,16 +45,19 @@ const mapStateToProps = createSelector(
 );
 
 const dispatchActions = {
+  bindStepKeys,
   closeLightBoxImage,
   completeAction,
   openLightBoxImage,
   stepBackward,
   stepForward,
   submitChallenge,
+  unbindStepKeys,
   updateUnlockedSteps
 };
 
 const propTypes = {
+  bindStepKeys: PropTypes.func.isRequired,
   closeLightBoxImage: PropTypes.func.isRequired,
   completeAction: PropTypes.func.isRequired,
   currentIndex: PropTypes.number,
@@ -66,6 +71,7 @@ const propTypes = {
   stepForward: PropTypes.func,
   steps: PropTypes.array,
   submitChallenge: PropTypes.func.isRequired,
+  unbindStepKeys: PropTypes.func.isRequired,
   updateUnlockedSteps: PropTypes.func.isRequired
 };
 
@@ -83,13 +89,21 @@ export class StepChallenge extends PureComponent {
   }
 
   componentWillMount() {
-    const { updateUnlockedSteps } = this.props;
+    const {
+      updateUnlockedSteps,
+      bindStepKeys
+    } = this.props;
     updateUnlockedSteps([]);
+    bindStepKeys();
   }
 
   componentWillUnmount() {
-    const { updateUnlockedSteps } = this.props;
+    const {
+      updateUnlockedSteps,
+      unbindStepKeys
+    } = this.props;
     updateUnlockedSteps([]);
+    unbindStepKeys();
   }
 
   componentWillReceiveProps(nextProps) {
@@ -259,6 +273,7 @@ export class StepChallenge extends PureComponent {
       isLightBoxOpen,
       closeLightBoxImage
     } = this.props;
+    console.log(step);
     return (
       <Col
         md={ 8 }

--- a/common/app/routes/challenges/redux/actions.js
+++ b/common/app/routes/challenges/redux/actions.js
@@ -11,6 +11,8 @@ export const goToStep = createAction(
   types.goToStep,
   (step, isUnlocked) => ({ step, isUnlocked })
 );
+export const bindStepKeys = createAction(types.bindStepKeys);
+export const unbindStepKeys = createAction(types.unbindStepKeys);
 export const completeAction = createAction(types.completeAction);
 export const updateUnlockedSteps = createAction(types.updateUnlockedSteps);
 export const openLightBoxImage = createAction(types.openLightBoxImage);

--- a/common/app/routes/challenges/redux/next-challenge-saga.js
+++ b/common/app/routes/challenges/redux/next-challenge-saga.js
@@ -72,6 +72,7 @@ export default function nextChallengeSaga(actions$, getState) {
             push('/map')
           );
         }
+        console.log(nextChallenge);
         return Observable.of(
           updateCurrentChallenge(nextChallenge),
           resetUi(),

--- a/common/app/routes/challenges/redux/step-challenge-epic.js
+++ b/common/app/routes/challenges/redux/step-challenge-epic.js
@@ -27,6 +27,7 @@ export default function stepChallengeEpic(actions, getState) {
       const stepFwd = currentIndex + 1;
       const stepBwd = currentIndex - 1;
       const isLastStep = stepFwd >= numOfSteps;
+      const isFirstStep = stepBwd < 0;
       if (type === types.completeAction) {
         return unlockStep(currentIndex, unlockedSteps);
       }
@@ -37,6 +38,9 @@ export default function stepChallengeEpic(actions, getState) {
         return goToStep(stepFwd, !!unlockedSteps[stepFwd]);
       }
       if (type === types.stepBackward) {
+        if (isFirstStep) {
+          return false;
+        }
         return goToStep(stepBwd, !!unlockedSteps[stepBwd]);
       }
       return null;

--- a/common/app/routes/challenges/redux/step-challenge-epic.js
+++ b/common/app/routes/challenges/redux/step-challenge-epic.js
@@ -27,7 +27,7 @@ export default function stepChallengeEpic(actions, getState) {
       const stepFwd = currentIndex + 1;
       const stepBwd = currentIndex - 1;
       const isLastStep = stepFwd >= numOfSteps;
-      const isFirstStep = stepBwd < 0;
+      const isFirstStep = currentIndex === 0;
       if (type === types.completeAction) {
         return unlockStep(currentIndex, unlockedSteps);
       }
@@ -39,7 +39,7 @@ export default function stepChallengeEpic(actions, getState) {
       }
       if (type === types.stepBackward) {
         if (isFirstStep) {
-          return false;
+          return null;
         }
         return goToStep(stepBwd, !!unlockedSteps[stepBwd]);
       }

--- a/common/app/routes/challenges/redux/types.js
+++ b/common/app/routes/challenges/redux/types.js
@@ -4,6 +4,8 @@ export default createTypes([
   // step
   'stepForward',
   'stepBackward',
+  'bindStepKeys',
+  'unbindStepKeys',
   'goToStep',
   'completeAction',
   'openLightBoxImage',


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
- [x] Tested changes locally.
- [x] Closes currently open issue (replace XXXX with an issue no): Closes #10056, I think

#### Description
Found this kind-of-old-but-fun issue. I was doing keyboard shortcut stuff today anyway, so I thought I'd go ahead and implement this.
Pressing the left arrow key goes to the previous slide, right arrow key goes to the next. If the next slide is blocked, you'll have to open the link first.
This is on `keyup` instead of `keydown`, so that you don't accidentally skip over a bunch of stuff by holding down the key.

I'm very, very new to React, so feedback would be awesome!
