### PR TITLE
Fix ES6 linting

### DIFF
--- a/common/app/routes/challenges/components/classic/Editor.jsx
+++ b/common/app/routes/challenges/components/classic/Editor.jsx
@@ -18,7 +18,7 @@ const mapStateToProps = createSelector(
 const editorDebounceTimeout = 750;
 
 const options = {
-  lint: true,
+  lint: {esversion: 6},
   lineNumbers: true,
   mode: 'javascript',
   theme: 'monokai',


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
- [x] Tested changes locally.
- [ ] Closes currently open issue (replace XXXX with an issue no): Closes #XXXX
Haha, so this is a bit awkward. I had seen this pop up multiple times (or so I thought), so I decided to just start working on it. Then I checked when creating the PR, and I couldn't find an open issue on this 😅 I'm not the only one that thought there was an issue about it: #12693 😄 

#### Description
So with ES6 syntax, the linter was complaining that you had to use the `esversion: 6` option. This PR makes sure we use that option. The linter no longer complains now 🙌 
