### PR TITLE
Fix closing backticks indentation on bug report

### DIFF
--- a/common/app/routes/challenges/redux/bug-saga.js
+++ b/common/app/routes/challenges/redux/bug-saga.js
@@ -1,5 +1,3 @@
-import dedent from 'dedent';
-
 import types from '../redux/types';
 import { closeBugModal } from '../redux/actions';
 
@@ -12,13 +10,15 @@ function filesToMarkdown(files = {}) {
     }
     const fileName = moreThenOneFile ? `\\ file: ${file.contents}` : '';
     const fileType = file.ext;
-    return fileString + dedent`
-      \`\`\`${fileType}
-      ${fileName}
-      ${file.contents}
-      \`\`\`
-      \n
-    `;
+    return fileString +
+      '\`\`\`' +
+      fileType +
+      '\n' +
+      fileName +
+      '\n' +
+      file.contents +
+      '\n' +
+      '\`\`\`\n\n';
   }, '\n');
 }
 


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
- [x] Tested changes locally.
- [x] Closes currently open issue (replace XXXX with an issue no): Closes #12838

#### Description
As described in the issue, the closing backticks for a codeblock are indented, which makes them display as code.
It appears that there's an issue with dedent. I tried adding newlines before it both as lines that were empty in the editor and as `\n`, but it did not help.
I switched the code from dedent to good old string concatenation, which works fine.
