### PR TITLE
fix quoting strings challenge

### DIFF
--- a/seed/challenges/02-javascript-algorithms-and-data-structures/basic-javascript.json
+++ b/seed/challenges/02-javascript-algorithms-and-data-structures/basic-javascript.json
@@ -1111,12 +1111,12 @@
       "title": "Quoting Strings with Single Quotes",
       "description": [
         "<dfn>String</dfn> values in JavaScript may be written with single or double quotes, so long as you start and end with the same type of quote. Unlike some languages, single and double quotes are functionally identical in JavaScript.",
-        "<code>\"This string has \\\"double quotes\\\" in it\"</code>",
+        "<blockquote>\"This string has \\\"double quotes\\\" in it\"</blockquote>",
         "The value in using one or the other has to do with the need to <dfn>escape</dfn> quotes of the same type. Unless they are escaped, you cannot have more than one pair of whichever quote type begins a string.",
         "If you have a string with many double quotes, this can be difficult to read and write. Instead, use single quotes:",
-        "<code>'This string has \"double quotes\" in it. And \"probably\" lots of them.'</code>",
+        "<blockquote>'This string has \"double quotes\" in it. And \"probably\" lots of them.'</blockquote>",
         "<hr>",
-        "Change the provided string from double to single quotes and remove the escaping."
+        "Change the provided string from double to single quotes and remove the escaping. Do not change anything else."
       ],
       "releasedOn": "January 1, 2016",
       "challengeSeed": [
@@ -1128,12 +1128,13 @@
         "(function() { return \"myStr = \" + myStr; })();"
       ],
       "solutions": [
-        "var myStr = '<a href=\"http://www.example.com\" target=\"_blank\">Link</a>';"
+        "/* head */ 'use strict'; /* solution */ var myStr = '<a href=\"http://www.example.com\" target=\"_blank\">Link</a>'; /* tail */ (function() { return \"myStr = \" + myStr; })();"
       ],
       "tests": [
         "assert(!/\\\\/g.test(code) && myStr === '<a href=\"http://www.example.com\" target=\"_blank\">Link</a>', 'message: Remove all the <code>backslashes</code> (<code>\\</code>)');",
-        "assert(code.match(/\"/g).length === 4 && code.match(/'/g).length === 2, 'message: You should have two single quotes <code>&#39;</code> and four double quotes <code>&quot;</code>');"
+        "assert(code.match(/\"/g).length === 6 && code.match(/'/g).length === 4, 'message: You should have two single quotes <code>&#39;</code> and four double quotes <code>&quot;</code>');"
       ],
+
       "type": "waypoint",
       "challengeType": 1,
       "translations": {


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Closes currently open issue: Closes #12865 

#### Description
<!-- Describe your changes in detail -->

The [Quoting Strings with Single Quotes](http://beta.freecodecamp.com/en/challenges/basic-javascript/quoting-strings-with-single-quotes) challenge was affected when `'use-strict'` was added to the comment that is invisible to users. Similar to the issue seen in #12722. This challenge uses a regex to count the quotes in the `code` variable, so `'use strict'` and the `tail` was throwing off the count. Logging `code` looks like this:
```
<script>

;/*fcc*/
'use strict';

var myStr = '<a href="http://www.example.com" target="_blank">Link</a>;';
;/*fcc*/

(function() { return "myStr = " + myStr; })();

;/*fcc*/
</script>
<!--fcc-->
```

So there is an additional pair of both `'` and `"`. I tried to just accommodate for this by changing the test to account for the extra quotes, but my guess is that since this comment is not actually generated in nodes test environment, approaching it this way caused running `npm test` to fail.

So instead, I created an IIFE that executes within the assert and returns `true` or `false`. It slices `code` down to only the relevant parts then just runs the original regex matches against the new string.

I also added `blockquote`s for the examples to be consistent with other challenges and added `Do not change anything else.` to the instructions because we are also testing that the string remains unchanged in the first test but don't explicitly say it anywhere, so if someone does what the tests ask but changes the URL in the string, the tests will fail with an erroneous error message.  