### PR TITLE
Add editor focus and unfocus hotkeys

### DIFF
--- a/common/app/routes/challenges/components/classic/Editor.jsx
+++ b/common/app/routes/challenges/components/classic/Editor.jsx
@@ -7,6 +7,8 @@ import Codemirror from 'react-codemirror';
 import NoSSR from 'react-no-ssr';
 import PureComponent from 'react-pure-render/component';
 
+import MouseTrap from 'mousetrap';
+
 import CodeMirrorSkeleton from '../CodeMirrorSkeleton.jsx';
 
 const mapStateToProps = createSelector(
@@ -58,6 +60,9 @@ export class Editor extends PureComponent {
       ...options,
       mode,
       extraKeys: {
+        Esc() {
+          document.activeElement.blur();
+        },
         Tab(cm) {
           if (cm.somethingSelected()) {
             return cm.indentSelection('add');
@@ -99,6 +104,10 @@ export class Editor extends PureComponent {
         updateFile,
         err => { throw err; }
       );
+
+    MouseTrap.bind('e', () => {
+      this.refs.editor.focus();
+    }, 'keyup');
   }
 
   componentWillUnmount() {
@@ -106,6 +115,7 @@ export class Editor extends PureComponent {
       this._subscription.dispose();
       this._subscription = null;
     }
+    MouseTrap.unbind('e', 'keyup');
   }
 
   handleChange(value) {
@@ -129,6 +139,7 @@ export class Editor extends PureComponent {
           <Codemirror
             onChange={ this.handleChange }
             options={ this.createOptions({ executeChallenge, mode, options }) }
+            ref='editor'
             value={ content }
           />
         </NoSSR>


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
- [x] Tested changes locally.
- [x] Closes currently open issue (replace XXXX with an issue no): Closes #12828

#### Description
Added `e` as a hotkey to focus the editor, and `esc` to unfocus the editor.

`e` has been bound to `keyup`, because otherwise the letter 'e' would show up in the editor. I think this is fine, as you're going to have to release it before you can continue typing anyway.

/cc @raisedadead This is the new PR, because I messed up the git history on the previous one. 😅 
