### PR TITLE
fix(challenge): Update tail section for "Return a Value from a Function with Return"

### DIFF
--- a/seed/challenges/02-javascript-algorithms-and-data-structures/basic-javascript.json
+++ b/seed/challenges/02-javascript-algorithms-and-data-structures/basic-javascript.json
@@ -2636,7 +2636,7 @@
         "<blockquote>function plusThree(num) {<br>  return num + 3;<br>}<br>var answer = plusThree(5); // 8</blockquote>",
         "<code>plusThree</code> takes an <dfn>argument</dfn> for <code>num</code> and returns a value equal to <code>num + 3</code>.",
         "<hr>",
-        "Create a function <code>timesFive</code> that accepts one argument, multiplies it by <code>5</code>, and returns the new value."
+        "Create a function <code>timesFive</code> that accepts one argument, multiplies it by <code>5</code>, and returns the new value. See the last line in the editor for an example of how you can test your <code>timesFive</code> function."
       ],
       "releasedOn": "January 1, 2016",
       "challengeSeed": [
@@ -2647,11 +2647,11 @@
         "",
         "// Only change code below this line",
         "",
-        ""
+        "",
+        "",
+        "console.log(minusSeven(10));"
       ],
-      "tail": [
-        "(function() { if(typeof timesFive === 'function'){ return \"timesfive(5) === \" + timesFive(5); } else { return \"timesFive is not a function\"} })();"
-      ],
+      "tail": [],
       "solutions": [
         "function timesFive(num) {\n  return num * 5;\n}"
       ],


### PR DESCRIPTION
#### Pre-Submission Checklist
- [X] Your pull request targets the `staging` branch of freeCodeCamp.
- [X] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [X] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [X] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
- [X] Tested changes locally.
- [X] Closes currently open issue (replace XXXX with an issue no): Closes #9583 

#### Description
Implements @erictleung's suggested changes from [#9651 (comment)](https://github.com/freeCodeCamp/freeCodeCamp/pull/9651/files#r71084020).

This solves the issue mentioned above, but I'm still not happy with the result. Ideally, campers should be able to add `console.log(timesFive(someNumber))` to test their function and see the result in the simulated console to the left on their screen.

However, it's currently only possible to see this test output when the challenge is freshly loaded from the seed (either by visiting it for the first time or by resetting it). As soon as tests has been run, all that's displayed is 
```txt
// running test
// tests completed
```

I'm open for any suggestions!