### PR TITLE
Fixes html term to all capslock

### DIFF
--- a/seed/challenges/02-javascript-algorithms-and-data-structures/basic-data-structures.json
+++ b/seed/challenges/02-javascript-algorithms-and-data-structures/basic-data-structures.json
@@ -212,7 +212,7 @@
         "<blockquote>function colorChange(arr, index, newColor) {<br>&nbsp;&nbsp;arr.splice(index, 1, newColor);<br>&nbsp;&nbsp;return arr;<br>}<br><br>let colorScheme = ['#878787', '#a08794', '#bb7e8c', '#c9b6be', '#d1becf'];<br><br>colorScheme = colorChange(colorScheme, 2, '#332327');<br>// we have removed '#bb7e8c' and added '#332327' in its place<br>// colorScheme now equals ['#878787', '#a08794', '#332327', '#c9b6be', '#d1becf']</blockquote>",
         "This function takes an array of hex values, an index at which to remove an element, and the new color to replace the removed element with. The return value is an array containing a newly modified color scheme! While this example is a bit oversimplified, we can see the value that utilizing <code>splice()</code> to its maximum potential can have.",
         "<hr>",
-        "We have defined a function, <code>htmlColorNames</code>, which takes an array of html colors as an argument. Modify the function using <code>splice()</code> to remove the first two elements of the array and add <code>'DarkSalmon'</code> and <code>'BlanchedAlmond'</code> in their respective places."
+        "We have defined a function, <code>htmlColorNames</code>, which takes an array of HTML colors as an argument. Modify the function using <code>splice()</code> to remove the first two elements of the array and add <code>'DarkSalmon'</code> and <code>'BlanchedAlmond'</code> in their respective places."
       ],
       "challengeSeed": [
         "function htmlColorNames(arr) {",


### PR DESCRIPTION
Closes #13069

#### Description
<!-- Describe your changes in detail -->
html on "Basic Data Structures: Add Items Using splice()" is now written all in caps (HTML)