### PR TITLE
fix(challenge): Make correct challenge completion pass in Safari 

### DIFF
--- a/seed/challenges/01-responsive-web-design/applied-visual-design.json
+++ b/seed/challenges/01-responsive-web-design/applied-visual-design.json
@@ -820,7 +820,7 @@
         "</div>"
       ],
       "tests": [
-        "assert($('.links').css('opacity') == '0.7', 'message: Your code should set the <code>opacity</code> property to 0.7 on the anchor tags by selecting the class of <code>links</code>.');"
+        "assert.approximately(parseFloat($('.links').css('opacity')), 0.7, 0.1, 'message: Your code should set the <code>opacity</code> property to 0.7 on the anchor tags by selecting the class of <code>links</code>.');"
       ],
       "solutions": [],
       "hints": [],


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Closes currently open issue (replace XXXX with an issue no): Closes #13014

#### Description
<!-- Describe your changes in detail -->
Fixed challenge test in Applied Visual Design.

Correct answer was causing a failure in Safari due to precision error. Fix: Used Assert.approximately() and decreased the opacity of An element.

Confirmed correct answer now passes in both Safari and Chrome.

Before in Safari (Correct answer does not pass):
<img width="830" alt="screen shot 2017-02-02 at 9 04 05 am" src="https://cloud.githubusercontent.com/assets/2976514/22559674/b863e6d2-e926-11e6-94e9-77a583ef93f9.png">

After in Safari (Correct answer passes):
<img width="1153" alt="screen shot 2017-02-02 at 7 31 56 am" src="https://cloud.githubusercontent.com/assets/2976514/22559915/84cfa904-e927-11e6-95ed-b3ce9a13c835.png">

After in Chrome (Correct answer still passes):
<img width="1105" alt="screen shot 2017-02-02 at 8 38 02 am" src="https://cloud.githubusercontent.com/assets/2976514/22559899/7894a69e-e927-11e6-87a7-a39080b7320e.png">

NOTE: Original issue was observed in Mozilla, which turned out to be a different issue that might be resolved once other merges in the pipeline happen. This pull request is addressing the issue with Safari only, as decided in the issue conversation. See conversation in issue #13014 for more detail.

