### PR TITLE
fix(challenge): Cleaner assertion for "Copy an Array with slice()".

### DIFF
--- a/seed/challenges/02-javascript-algorithms-and-data-structures/basic-data-structures.json
+++ b/seed/challenges/02-javascript-algorithms-and-data-structures/basic-data-structures.json
@@ -256,7 +256,7 @@
       ],
       "tests": [
         "assert.deepEqual(forecast(['cold', 'rainy', 'warm', 'sunny', 'cool', 'thunderstorms']), ['warm', 'sunny'], 'message: <code>forecast</code> should return <code>[\"warm\", \"sunny\"]');",
-        "assert.notStrictEqual(forecast.toString().search(/\\.slice\\(/), -1, 'message: The <code>forecast</code> function should utilize the <code>slice()</code> method');"
+        "assert(/\\.slice\\(/.test(code), 'message: The <code>forecast</code> function should utilize the <code>slice()</code> method');"
       ],
       "type": "waypoint",
       "solutions": [],


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [ ] Closes currently open issue (replace XXXX with an issue no): Progress towards #13110 

#### Description

Improve a test case. As this challenge doesn't function properly because of the remaining tasks in #13110, this was tested by evaluating the assertion in a browser console, against a string containing the valid solution.
![proof](https://cloud.githubusercontent.com/assets/6125097/22600461/d413b988-ea3a-11e6-95b4-5c6cefec2a33.png)
