### PR TITLE
Added semicolon to end of first statement in the challenge "Regular Expressions: Find Characters with Lazy Matching"

### DIFF
--- a/seed/challenges/02-javascript-algorithms-and-data-structures/regular-expressions.json
+++ b/seed/challenges/02-javascript-algorithms-and-data-structures/regular-expressions.json
@@ -420,7 +420,7 @@
         "Fix the regex <code>/&lt;.*&gt;/</code> to return the HTML tag <code>&lt;h1&gt;</code> and not the text <code>\"&lt;h1&gt;Winter is coming&lt;/h1&gt;\"</code>. Remember the wildcard <code>.</code> in a regular expression matches any character."
       ],
       "challengeSeed": [
-        "let text = \"<h1>Winter is coming</h1>\"",
+        "let text = \"<h1>Winter is coming</h1>\";",
         "let myRegex = /<.*>/; // Change this line",
         "let result = text.match(myRegex);"
       ],


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Closes currently open issue (replace XXXX with an issue no): Closes #13047

#### Description
Added semicolon to the end of the first statement in the challenge. This fix prevents the editor from showing a warning when the challenge loads.

Before fix:
![image](https://cloud.githubusercontent.com/assets/23444446/22619459/3ab79f0a-eaaa-11e6-9569-613cdb26947b.png)

After fix:
![image](https://cloud.githubusercontent.com/assets/23444446/22619477/4d494362-eaaa-11e6-947d-79c52691d3ea.png)


