### PR TITLE
Remove requirement of i flag in regex

### DIFF
--- a/seed/challenges/02-javascript-algorithms-and-data-structures/regular-expressions.json
+++ b/seed/challenges/02-javascript-algorithms-and-data-structures/regular-expressions.json
@@ -542,7 +542,6 @@
       ],
       "tests": [
         "assert(alphabetRegexV2.global, 'message: Your regex should use the global flag.');",
-        "assert(/i/.test(alphabetRegexV2.flags), 'message: Your regex should use the case insensitive flag.');",
         "assert(\"The five boxing wizards jump quickly.\".match(alphabetRegexV2).length === 31, 'message: Your regex should find 31 alphanumeric characters in <code>\"The five boxing wizards jump quickly.\"</code>');",
         "assert(\"Pack my box with five dozen liquor jugs.\".match(alphabetRegexV2).length === 32, 'message: Your regex should find 32 alphanumeric characters in <code>\"Pack my box with five dozen liquor jugs.\"</code>');",
         "assert(\"How vexingly quick daft zebras jump!\".match(alphabetRegexV2).length === 30, 'message: Your regex should find 30 alphanumeric characters in <code>\"How vexingly quick daft zebras jump!\"</code>');",


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Closes currently open issue (replace XXXX with an issue no): Closes #13153 

#### Description
<!-- Describe your changes in detail -->
As the OP points out in their issue, using the `i` flag shouldn't really matter much when the regex is `\w`. I made a [JS Bin demo](https://jsbin.com/toheje/edit?js,console) with all the test cases using only the `\g` flag, and all the tests returned the expected results. So, the `i` flag requirement could probably be dropped.

Tested locally - challenge passes without `i` flag - 

![screenshot 2017-02-07 00 57 45](https://cloud.githubusercontent.com/assets/11348778/22679592/3e0c0000-ecd1-11e6-9b18-e870268ab0dc.png)

Closes #13153 