### PR TITLE
Persist night mode on page load

### DIFF
--- a/client/sagas/night-mode-saga.js
+++ b/client/sagas/night-mode-saga.js
@@ -1,4 +1,6 @@
 import { Observable } from 'rx';
+import store from 'store';
+
 import { postJSON$ } from '../../common/utils/ajax-stream';
 import types from '../../common/app/redux/types';
 import {
@@ -6,6 +8,10 @@ import {
   updateTheme,
   createErrorObservable
 } from '../../common/app/redux/actions';
+
+function persistTheme(theme) {
+  store.set('fcc-theme', theme);
+}
 
 export default function nightModeSaga(
   actions,
@@ -17,6 +23,8 @@ export default function nightModeSaga(
     .doOnNext(({ payload: theme }) => {
       if (theme === 'night') {
         body.classList.add('night');
+        // catch existing night mode users
+        persistTheme(theme);
       } else {
         body.classList.remove('night');
       }
@@ -29,6 +37,7 @@ export default function nightModeSaga(
     .flatMap(() => {
       const { app: { theme } } = getState();
       const newTheme = !theme || theme === 'default' ? 'night' : 'default';
+      persistTheme(newTheme);
       return Observable.of(
         updateTheme(newTheme),
         addThemeToBody(newTheme)

--- a/server/views/layout-react.jade
+++ b/server/views/layout-react.jade
@@ -11,5 +11,17 @@ html(lang='en')
     script!= state
     script.
       window.webpackManifest = !{JSON.stringify(chunkManifest || {})};
+      (function setTheme() {
+        let fccTheme;
+        try {
+          fccTheme = JSON.parse(localStorage.getItem('fcc-theme'));
+          if (fccTheme && fccTheme === 'night') {
+            document.body.classList.add('night');
+          }
+        }
+        catch(e) {
+          fccTheme = null;
+        }
+      })();
     script(src=rev('/js', 'vendor-challenges.js'))
     script(src=rev('/js', 'bundle.js'))


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Closes currently open issue (replace XXXX with an issue no): Closes #12560 

#### Description
<!-- Describe your changes in detail -->
Adds a key to `localStorage` which holds the theme preference of the user. This enables night mode to be enabled on page load whilst the bundle evals.