### PR TITLE
feature (map) : carets rotate as map accordion expands or contracts

### DIFF
--- a/client/less/map.less
+++ b/client/less/map.less
@@ -137,8 +137,36 @@
     display: block;
   }
 
+  a[aria-expanded=true]:active span.fa-caret-down {
+    -webkit-transform:rotate(-90deg);
+    -moz-transform:rotate(-90deg);
+    -ms-transform:rotate(-90deg);
+    transform:rotate(-90deg);
+  }
+
+  a[aria-expanded=false]:active span.fa-caret-right {
+    -webkit-transform:rotate(90deg);
+    -moz-transform:rotate(90deg);
+    -ms-transform:rotate(90deg);
+    transform:rotate(90deg);
+  }
+
+  span.fa {
+    -webkit-transition: 0.2s ease transform;
+    -moz-transition: 0.2s ease transform;
+    -ms-transition: 0.2s ease transform;
+    transition: 0.2s ease transform;
+  }
+
+  .map-accordion-panel-title span.no-link-underline{
+    width:30px;
+    text-align:center;
+  }
+
   .map-accordion-block {
-    :before {
+    span.no-link-underline {
+      width:20px;
+      text-align:center;
       margin-right: 15px;
     }
 
@@ -173,6 +201,10 @@
         padding-left: 50px;
         padding-right: 20px;
         font-size: 20px;
+        span.no-link-underline{
+          width:20px;
+          text-align:center;
+        }
       }
     }
     a {
@@ -181,6 +213,10 @@
       > h3 {
         clear:both;
         font-size:20px;
+        span.no-link-underline{
+          width:20px;
+          text-align:center;
+        }
       }
     }
   }


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Closes currently open issue (replace XXXX with an issue no): Closes #13286 

#### Description
<!-- Describe your changes in detail -->

CSS transition added so that the carets rotate from right to down or vice versa when the accordion panels expand / contract. Vendor prefixes included for webkit, moz and ms.

SLIGHT ISSUE: the carets for the nested headings sit within a rectangular shaped span box and so when they rotate they go off centre (but only for a moment). See photos:

![screen shot 2017-02-15 at 18 21 32](https://cloud.githubusercontent.com/assets/22368483/22997994/ce64123a-f3cc-11e6-9dfe-4739718399a5.png)
![screen shot 2017-02-15 at 18 21 35](https://cloud.githubusercontent.com/assets/22368483/22997995/ce698774-f3cc-11e6-803f-559245177e3d.png)

I've tried to fix this using transform-origin but didn't see it making any difference. 

The carets in panel titles rotate correctly.