### PR TITLE
Fix formatting and add tests for array destructuring

### DIFF
--- a/seed/challenges/02-javascript-algorithms-and-data-structures/es6.json
+++ b/seed/challenges/02-javascript-algorithms-and-data-structures/es6.json
@@ -451,16 +451,18 @@
       "challengeSeed": [
         "let a = 8, b = 6;",
         "// change code below this line",
-        "a = b;",
-        "b = a;",
+        "",
         "// change code above this line",
-        "console.log(a); // should be 6",
-        "console.log(b); // should be 8"
+        "<blockquote>const [a, b] = [1, 2, 3, 4, 5, 7];<br>console.log(a, b); // 1, 2</blockquote>",
+        "The variable a assumes first value, and b takes the second value from the array.",
+        "You can also destructure in a way, that you can pick up values from any other array index position. You simply have to use commas (,).",
+        "Instructions.",
+        "Use destructuring to swap the variables a, b. Swapping is an operation, after which, a gets the value stored in b, and b receives the value stored in a"
       ],
       "tests": [
-        "// Test a is 6",
-        "// Test b is 8",
-        "// Test destructuring was used"
+        "assert(a === 6, 'message: Value of <code>a</code> should be 6, after swapping.');",
+        "assert(b === 8, 'message: Value of <code>b</code> should be 8, after swapping.');",
+        "// assert(/\\[\\s*(\\w)\\s*,\\s*(\\w)\\s*\\]\\s*=\\s*\\[\\s*\\2\\s*,\\s*\\1\\s*\\]/g.test(code), 'message: Use array destructuring to swap a and b.');"
       ],
       "type": "waypoint",
       "releasedOn": "Feb 17, 2017",


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Closes currently open issue (replace XXXX with an issue no): Closes #13268 

#### Description
<!-- Describe your changes in detail -->
1. Used `<blockquote>` to contain the example code, instead of `<code>` tags, as recommended in issue.
2. Removed this from the challenge seed - `a = b; b = a;`. This causes `a` to be `6`, without even using array destructuring, and the first test I wrote passes by default. I think having the first test passing, without writing any code to use array destructuring at all, might confuse campers.
3. Wrote tests to ensure value of `a` and `b` was `6` and `8` respectively after destructuring, and to check array destructuring was used.

Tested locally - 

![screenshot 2017-02-19 02 20 54](https://cloud.githubusercontent.com/assets/11348778/23100326/3e246972-f64c-11e6-9aca-445f2a63cb8a.png)

Closes #13268 