### PR TITLE
Current Streak update so specific times aren't missed

### DIFF
--- a/server/utils/user-stats.js
+++ b/server/utils/user-stats.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import moment from 'moment-timezone';
 import { dayCount } from '../utils/date-utils';
 
-const daysBetween = 1.5;
+const daysBetween = 2;
 
 export function prepUniqueDays(cals, tz = 'UTC') {
 
@@ -16,7 +16,7 @@ export function prepUniqueDays(cals, tz = 'UTC') {
 export function calcCurrentStreak(cals, tz = 'UTC') {
 
   let prev = _.last(cals);
-  if (moment().tz(tz).startOf('day').diff(prev, 'days') > daysBetween) {
+  if (moment().tz(tz).diff(prev, 'days') > daysBetween) {
     return 0;
   }
   let currentStreak = 0;

--- a/server/utils/user-stats.test.js
+++ b/server/utils/user-stats.test.js
@@ -285,12 +285,12 @@ test('Longest streak calculation', function(t) {
     calcLongestStreak(
       prepUniqueDays([
         moment.utc('8/3/2015 2:00', 'M/D/YYYY H:mm').valueOf(),
-        moment.utc('9/11/2015 4:00', 'M/D/YYYY H:mm').valueOf(),
-        moment.utc('9/12/2015 15:30', 'M/D/YYYY H:mm').valueOf(),
+        moment.utc('9/10/2015 4:00', 'M/D/YYYY H:mm').valueOf(),
+        moment.utc('9/11/2015 15:30', 'M/D/YYYY H:mm').valueOf(),
         moment.utc(moment.utc('9/12/2015 15:30', 'M/D/YYYY H:mm')
           .add(37, 'hours')).valueOf(),
 
-        moment.utc('9/14/2015 22:00', 'M/D/YYYY H:mm').valueOf(),
+        moment.utc('9/14/2015 23:59', 'M/D/YYYY H:mm').valueOf(),
         moment.utc('9/15/2015 4:00', 'M/D/YYYY H:mm').valueOf(),
         moment.utc('10/3/2015 2:00', 'M/D/YYYY H:mm').valueOf()
       ])
@@ -419,8 +419,8 @@ test('Longest streak calculation', function(t) {
         1454519128123, moment.utc().valueOf()
       ])
     ),
-    4,
-    'should return 4 when there is a break in UTC (but no break in PST)'
+    16,
+    'should return 16 when there is a break in UTC (but no break in PST)'
   );
 });
 


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
- [x] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] Tested changes locally.
- [x] Closes currently open issue: Closes #7925

#### Description
I made a few updates to how the current streak works to cover all cases close to the "next day" where a streak wasn't continuing even though it should have.
