### PR TITLE
Fix for failing test on width css property

### DIFF
--- a/seed/challenges/01-responsive-web-design/applied-visual-design.json
+++ b/seed/challenges/01-responsive-web-design/applied-visual-design.json
@@ -126,7 +126,7 @@
         "</div>"
       ],
       "tests": [
-        "assert($('.fullCard').css('width') == '245px', 'message: Your code should change the <code>width</code> property of the card to 245 pixels by using the <code>fullCard</code> class selector.');"
+        "assert(code.match(/.fullCard\\s*{[\\s\\S][^}]*\\n*^\\s*width\\s*:\\s*245px\\s*;/gm), 'message: Your code should change the <code>width</code> property of the card to 245 pixels by using the <code>fullCard</code> class selector.');"
       ],
       "solutions": [],
       "hints": [],


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] Your pull request targets the `staging` branch of freeCodeCamp.
- [X] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [X] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [X] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [X] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [X] Tested changes locally.
- [x] Closes currently open issue (replace XXXX with an issue no): Closes #12687

#### Description
<!-- Describe your changes in detail -->
This is a fix for [Beta] Applied Visual Design: Adjust the Width of an Element Using the Width Property #12687
If the user had certain resolutions or browser zoom levels it could cause the computed width to be returned as a number slightly smaller or slightly larger then 245px i.e. 245.00002340523px which would cause the comparison test to fail. In order to insure the test passed the test was changed to a REGEX test using `/.fullCard\s*{[\s\S][^}]*\n*^\s*width\s*:\s*245px\s*;/gm`
The test will now succeed regardless of the users zoom level.