### PR TITLE
fix(gitignore): bower_components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ node_modules
 *.iml
 .DS_Store
 Thumbs.db
+bower_components
 main.css
 bundle.js
 coverage


### PR DESCRIPTION
Add `bower_components` to `.gitignore` to prevent contributors from adding this accidentally.