### PR TITLE
Changed icon color to improve general UX

### DIFF
--- a/client/less/challenge.less
+++ b/client/less/challenge.less
@@ -138,7 +138,7 @@
 }
 
 .refresh-icon {
-  color: darkgreen;
+  color: @icon-grey;
 }
 
 .night {
@@ -167,6 +167,9 @@
     .cm-keyword, .cm-attribute {
       color:#9BBBDC;
     }
+  }
+  .refresh-icon {
+    color: @icon-light-grey;
   }
 }
 

--- a/client/less/lib/bootstrap/variables.less
+++ b/client/less/lib/bootstrap/variables.less
@@ -20,7 +20,8 @@
 @brand-warning:         #f0ad4e;
 @brand-danger:          #d9534f;
 
-
+@icon-grey:             #575757;
+@icon-light-grey:       #888888;
 //== Scaffolding
 //
 //## Settings for some of the most global styles.


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Closes currently open issue: Closes #12844

#### Description
<!-- Describe your changes in detail -->
Changed icon color to be better appealing and less distracting to the user. Was previously too light, then changed to green which was mis-informative, now it is dark grey similar to color of the text (see image below). 
<img width="356" alt="screen shot 2017-03-03 at 11 07 50 am" src="https://cloud.githubusercontent.com/assets/16144158/23561513/8e441e06-000c-11e7-9886-0c7fd00f7447.png">
