### PR TITLE
repair broken regexp in "Confirm the ending"

### DIFF
--- a/seed/challenges/01-front-end-development-certification/basic-bonfires.json
+++ b/seed/challenges/01-front-end-development-certification/basic-bonfires.json
@@ -346,7 +346,7 @@
         "assert(confirmEnding(\"Open sesame\", \"same\") === true, 'message: <code>confirmEnding(\"Open sesame\", \"same\")</code> should return true.');",
         "assert(confirmEnding(\"Open sesame\", \"pen\") === false, 'message: <code>confirmEnding(\"Open sesame\", \"pen\")</code> should return false.');",
         "assert(confirmEnding(\"If you want to save our world, you must hurry. We dont know how much longer we can withstand the nothing\", \"mountain\") === false, 'message: <code>confirmEnding(\"If you want to save our world, you must hurry. We dont know how much longer we can withstand the nothing\", \"mountain\")</code> should return false.');",
-        "assert(!/\\.endsWith\\(.*?\\)\\s*?;/.test(code), 'message: Do not use the built-in method <code>.endsWith()</code> to solve the challenge.');"
+        "assert(!/\\.\\s*endsWith\\s*\\(\\s*.*\\s*\\)\\s*/.test(code), 'message: Do not use the built-in method <code>.endsWith()</code> to solve the challenge.');"
       ],
       "type": "bonfire",
       "isRequired": true,


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Closes currently open issue: Closes #14077

#### Description
<!-- Describe your changes in detail -->
The regexp in `Confirm the ending` challenge that checks if user is using `endsWith()` function is not correct.
It does not account for spaces and expects a `;` at the end.
`/\.endsWith\(.*?\)\s*?;/`

So `if (str.endsWith('dude'))` is considered a valid solution.

My commit adds a regexp that checks spaces/carriage return and prevents above issue.
See it in action.
![image](https://cloud.githubusercontent.com/assets/4972399/24312986/58173306-10db-11e7-8873-9fc0e8481550.png)


Thanks!