### PR TITLE
Improve wording on jQuery selectors challenge

### DIFF
--- a/seed/challenges/03-front-end-libraries/jquery.json
+++ b/seed/challenges/03-front-end-libraries/jquery.json
@@ -109,7 +109,7 @@
         "For example, let's make all of your <code>button</code> elements bounce. Just add this code inside your document ready function:",
         "<code>$(\"button\").addClass(\"animated bounce\");</code>",
         "Note that we've already included both the jQuery library and the Animate.css library in the background so that you can use them in the editor. So you are using jQuery to apply the Animate.css <code>bounce</code> class to your <code>button</code> elements.",
-        "Additionally make sure to use <code>$(\"button\").addClass(\"animated bounce\");</code> instead of <code>$('button').addClass(\"animated bounce\");</code> since single-quote selectors will not pass our tests."
+        "If your code is still failing then make sure to use <code>$(\"button\").addClass(\"animated bounce\");</code> instead of <code>$('button').addClass(\"animated bounce\");</code> since single-quote selectors might not pass our tests."
       ],
       "challengeSeed": [
         "fccss",
@@ -145,7 +145,7 @@
       "tests": [
         "assert($(\"button\").hasClass(\"animated\") && $(\"button\").hasClass(\"bounce\"), 'message: Use the jQuery <code>addClass&#40&#41</code> function to give the classes <code>animated</code> and <code>bounce</code> to your <code>button</code> elements.');",
         "assert(!code.match(/class.*animated/g), 'message: Only use jQuery to add these colors to the element.');",
-        "assert(/'/g.test(code) === false , 'message: Only use double quotes in your jQuery code, as is stated in the jQuery style guide.');"
+        "assert(/'/g.test(code) === false , 'message: Try using double quotes in your jQuery code, as described in challenge description');"
       ],
       "type": "waypoint",
       "challengeType": 0,


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Closes currently open issue (replace XXXX with an issue no): Closes #14207 

#### Description
<!-- Describe your changes in detail -->

Since single quotes might work on some machines and might not work on other machines it might be better to use softer wording. :)