### PR TITLE
Code tags don't appear in output anymore

### DIFF
--- a/client/frame-runner.js
+++ b/client/frame-runner.js
@@ -121,7 +121,7 @@ document.addEventListener('DOMContentLoaded', function() {
             if (assertIndex !== -1) {
               message = message.slice(0, assertIndex);
             }
-            message = message.replace(/<code>(.*)<\/code>/, '$1');
+            message = message.replace(/<code>(.*?)<\/code>/g, '$1');
             newTest.err = err.message + '\n' + err.stack;
             newTest.stack = err.stack;
             newTest.message = message;


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Closes currently open issue (replace XXXX with an issue no): Closes #14479

#### Description
<!-- Describe your changes in detail -->

The solution was to make the regex lazy i.e. matching as little as possible. I also changed matching to global so that it would match more than one time.
