### PR TITLE
Change the text of a jQuery challenge description

### DIFF
--- a/seed/challenges/03-front-end-libraries/jquery.json
+++ b/seed/challenges/03-front-end-libraries/jquery.json
@@ -1195,12 +1195,12 @@
       "id": "bad87fee1348bd9aed208826",
       "title": "Target the Children of an Element Using jQuery",
       "description": [
-        "Many HTML elements have <code>children</code> which <code>inherit</code> their properties from their parent HTML elements.",
-        "For example, every HTML element is a child of your <code>body</code> element, and your \"jQuery Playground\" <code>h3</code> element is a child of your <code>&#60;div class=\"container-fluid\"&#62</code> element.",
+        "When HTML elements are placed one level below another they are called <code>children</code> of that element. For example, the button elements in this challenge with the text \"#target1\", \"#target2\", and \"#target3\" are all <code>children</code> of the <code>&#60;div class=\"well\" id=\"left-well\"&#62;</code> element.",
         "jQuery has a function called <code>children()</code> that allows you to access the children of whichever element you've selected.",
-        "Here's an example of how you would use the <code>children()</code> function to give the children of your <code>left-well</code> element the color of blue:",
+        "Here's an example of how you would use the <code>children()</code> function to give the children of your <code>left-well</code> element the color <code>blue</code>:",
         "<code>$(\"#left-well\").children().css(\"color\", \"blue\")</code>",
-        "Give all the children of your <code>#right-well</code> element a color of orange."
+        "<hr>",
+        "Give all the children of your <code>right-well</code> element the color orange."
       ],
       "challengeSeed": [
         "fccss",


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
- [x] Tested changes locally.
- [x] Closes currently open issue (replace XXXX with an issue no): Closes #14608 

#### Description
Rewrites the description of the challenge "jQuery: Target the Children of an Element Using jQuery".
It doesn't change the challenge itself other than a slight rewording of the instructions.

The reason for the change is that the description was incorrect. It described descendants as if they were children. It also previously talked about property inheritance which is outside the scope of the challenge. Going outside the scope violates the instruction "Each challenge should teach exactly one concept" from the challenge style guide.