### PR TITLE
feat(views): create global challenge-description component

### DIFF
--- a/common/app/routes/challenges/Challenge-Description.jsx
+++ b/common/app/routes/challenges/Challenge-Description.jsx
@@ -1,0 +1,24 @@
+import React, { PropTypes } from 'react';
+import { Col, Row } from 'react-bootstrap';
+
+import ns from './ns.json';
+
+const propTypes = {
+  children: PropTypes.array
+};
+
+export default function ChallengeDescription({ children }) {
+  return (
+    <Row>
+      <Col
+        className={ `${ns}-instructions` }
+        xs={ 12 }
+        >
+        { children }
+      </Col>
+    </Row>
+  );
+}
+
+ChallengeDescription.displayName = 'ChallengeDescription';
+ChallengeDescription.propTypes = propTypes;

--- a/common/app/routes/challenges/challenges.less
+++ b/common/app/routes/challenges/challenges.less
@@ -38,6 +38,44 @@
   }
 }
 
+.@{ns}-instructions {
+  margin-bottom: 5px;
+  h4 {
+    margin-bottom: 0;
+  }
+  blockquote {
+    font-size: 90%;
+    font-family: @font-family-monospace !important;
+    color: @code-color;
+    background-color: #fffbe5;
+    border-radius: @border-radius-base;
+    border: 1px solid @pre-border-color;
+    white-space: pre;
+    padding: 5px 10px;
+    margin-bottom: 10px;
+    margin-top: -5px;
+    overflow: auto;
+  }
+  dfn {
+    font-family: @font-family-monospace;
+    color: @code-color;
+    background-color: @code-bg;
+    border-radius: @border-radius-base;
+    padding: 1px 5px;
+  }
+  & a, #MDN-links a {
+    color: #31708f;
+  }
+  & a::after, #MDN-links a::after {
+    font-size: 70%;
+    font-family: FontAwesome;
+    content: " \f08e";
+  }
+  ol {
+    font-size: 16px;
+  }
+}
+
 .night {
   .@{ns}-instructions blockquote {
     background-color: #242424;

--- a/common/app/routes/challenges/views/backend/Back-End.jsx
+++ b/common/app/routes/challenges/views/backend/Back-End.jsx
@@ -8,6 +8,7 @@ import {
 } from 'react-bootstrap';
 
 import ChallengeTitle from '../../Challenge-Title.jsx';
+import ChallengeDescription from '../../Challenge-Description.jsx';
 import SolutionInput from '../../Solution-Input.jsx';
 import TestSuite from '../../Test-Suite.jsx';
 import Output from '../../Output.jsx';
@@ -117,13 +118,16 @@ export class BackEnd extends PureComponent {
     return (
       <Row>
         <Col
-          md={ 6 }
-          mdOffset={ 3 }
-          xs={ 12 }
+          xs={ 6 }
+          xsOffset={ 3 }
           >
-          <Row className='challenge-instructions'>
-            <ChallengeTitle>{ title }</ChallengeTitle>
-            { this.renderDescription(description) }
+          <Row>
+            <ChallengeTitle>
+              { title }
+            </ChallengeTitle>
+            <ChallengeDescription>
+              { this.renderDescription(description) }
+            </ChallengeDescription>
           </Row>
           <Row>
             <form

--- a/common/app/routes/challenges/views/classic/Side-Panel.jsx
+++ b/common/app/routes/challenges/views/classic/Side-Panel.jsx
@@ -3,11 +3,11 @@ import ReactDom from 'react-dom';
 import { createSelector } from 'reselect';
 import { connect } from 'react-redux';
 import PureComponent from 'react-pure-render/component';
-import { Col, Row } from 'react-bootstrap';
 
 import ns from './ns.json';
 
 import ChallengeTitle from '../../Challenge-Title.jsx';
+import ChallengeDescription from '../../Challenge-Description.jsx';
 import TestSuite from '../../Test-Suite.jsx';
 import Output from '../../Output.jsx';
 import ToolPanel from './Tool-Panel.jsx';
@@ -125,14 +125,9 @@ export class SidePanel extends PureComponent {
           <ChallengeTitle>
             { title }
           </ChallengeTitle>
-          <Row>
-            <Col
-              className={ `${ns}-instructions` }
-              xs={ 12 }
-              >
-              { this.renderDescription(description) }
-            </Col>
-          </Row>
+          <ChallengeDescription>
+            { this.renderDescription(description) }
+          </ChallengeDescription>
         </div>
         <ToolPanel
           executeChallenge={ executeChallenge }

--- a/common/app/routes/challenges/views/classic/classic.less
+++ b/common/app/routes/challenges/views/classic/classic.less
@@ -21,55 +21,7 @@
   padding-right: 5px;
 }
 
-.@{ns}-instructions {
-  margin-bottom: 5px;
-  h4 {
-    margin-bottom: 0;
-  }
-  blockquote {
-    font-size: 90%;
-    font-family: @font-family-monospace;
-    color: @code-color;
-    background-color: #fffbe5;
-    border-radius: @border-radius-base;
-    border: 1px solid @pre-border-color;
-    white-space: pre;
-    padding: 5px 10px;
-    margin-bottom: 10px;
-    margin-top: -5px;
-    overflow: auto;
-  }
-  dfn {
-    font-family: @font-family-monospace;
-    color: @code-color;
-    background-color: @code-bg;
-    border-radius: @border-radius-base;
-    padding: 1px 5px;
-  }
-  & a, #MDN-links a {
-    color: #31708f;
-  }
-  & a::after, #MDN-links a::after {
-    font-size: 70%;
-    font-family: FontAwesome;
-    content: " \f08e";
-  }
-  ol {
-    font-size: 16px;
-  }
-}
-
-
 .night {
-  .@{ns}-instructions blockquote {
-    background-color: #242424;
-    border-color: #515151;
-    color: #ABABAB
-  }
-  .@{ns}-instructions dfn {
-    background-color: #242424;
-    color: #02a902;
-  }
   .@{ns}-editor .CodeMirror {
     background-color:#242424;
     color:#ABABAB;


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [ ] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [ ] Closes currently open issue (replace XXXX with an issue no): Closes #XXXX

#### Description
<!-- Describe your changes in detail -->
@BerkeleyTrue As discussed, this PR addresses the issue originally addressed in #14986 but couples the challenges less closely with the stylesheets by implementing a global `ChallengeInstructions` component so that both the classic and backend challenge descriptions receive the same styles. Moved the less rules over to `challenges.less`, changing the namespacing of the instructions class names to `challenges` rather than `classic`. 

A couple of notes:
- could not get `npm test` to pass because of the `propTypes` objects in `Back-End.jsx` - it looks like since the redux form prop types are spread out into `propTypes`, the final result is not alphabetical. I didn't make any changes here, so I'm guessing the test was only triggered because I edited the file and that this is an issue that was encountered in the past?
- I was getting some weird behavior with the `challenges-instructions` styles. Everything seems to work correctly (verified in `main.css` that all the rules look correct), but when making and saving changes in JS files, occasionally it would seem as if the styles weren't applied, then I'd make another change and they'd be back. So not sure what's up with that, but I believe the rules are correct. 

Let me know if you think everything looks good.

This PR also makes a slight change to the backend challenges component to improve responsiveness at smaller screen resolutions. Previously, w/ `xs={ 12 }`, the result was too wide and content gets cutoff unless you scroll:

![image](https://cloud.githubusercontent.com/assets/18563015/26385167/ac335fd2-400b-11e7-92c3-cb54e03744f3.png)

So just changed it all too `xs={ 6 }`, && `xsOffset={ 3 }`:

![image](https://cloud.githubusercontent.com/assets/18563015/26385136/7801511a-400b-11e7-9121-9477972acb09.png)

