### PR TITLE
feat(test-suite): add temporary es6 testing support

### DIFF
--- a/client/frame-runner.js
+++ b/client/frame-runner.js
@@ -7,6 +7,7 @@ document.addEventListener('DOMContentLoaded', function() {
   var helpers = Rx.helpers;
   var chai = parent.chai;
   var source = document.__source;
+  var originalCode = document.__originalCode;
   var __getUserInput = document.__getUserInput || (x => x);
   var checkChallengePayload = document.__checkChallengePayload;
 
@@ -30,6 +31,7 @@ document.addEventListener('DOMContentLoaded', function() {
     /* eslint-disable no-unused-vars */
     const editor = { getValue() { return source; } };
     const code = source;
+    const es6 = originalCode;
     /* eslint-enable no-unused-vars */
     if (window.__err) {
       return Rx.Observable.from(tests)

--- a/client/sagas/build-challenge-epic.js
+++ b/client/sagas/build-challenge-epic.js
@@ -26,7 +26,14 @@ export default function buildChallengeEpic(actions, getState) {
     .flatMapLatest(({ type }) => {
       const shouldProxyConsole = type === types.updateMain;
       const state = getState();
-      const { files } = state.challengesApp;
+      const {
+        files,
+        files: {
+          indexjs: {
+            contents: originalCode
+          }
+        }
+      } = state.challengesApp;
       const {
         challenge: {
           required = [],
@@ -44,7 +51,7 @@ export default function buildChallengeEpic(actions, getState) {
             frameMain(payload)
           ];
           if (type === types.executeChallenge) {
-            actions.push(saveCode(), frameTests(payload));
+            actions.push(saveCode(), frameTests({ ...payload, originalCode }));
           }
           return Observable.from(actions, null, null, Scheduler.default);
         })

--- a/client/sagas/frame-epic.js
+++ b/client/sagas/frame-epic.js
@@ -72,12 +72,18 @@ function frameMain({ build } = {}, document, proxyLogger) {
   main.close();
 }
 
-function frameTests({ build, sources, checkChallengePayload } = {}, document) {
+function frameTests({
+  build,
+  sources,
+  originalCode,
+  checkChallengePayload
+} = {}, document) {
   const { frame: tests } = getFrameDocument(document, testId);
   refreshFrame(tests);
   tests.Rx = Rx;
-  // default for classic challenges
-  // should not be used for modern
+  // default for classic challenges should not be used for modern
+  // attach the original code string for use in challneges that use ES6 syntax
+  tests.__originalCode = originalCode;
   tests.__source = sources['index'] || '';
   tests.__getUserInput = key => sources[key];
   tests.__checkChallengePayload = checkChallengePayload;

--- a/seed/challenges/02-javascript-algorithms-and-data-structures/basic-data-structures.json
+++ b/seed/challenges/02-javascript-algorithms-and-data-structures/basic-data-structures.json
@@ -290,7 +290,7 @@
         "assert.deepEqual(copyMachine([1, 2, 3], 5), [[1, 2, 3], [1, 2, 3], [1, 2, 3], [1, 2, 3], [1, 2, 3]], 'message: <code>copyMachine([1, 2, 3], 5)</code> should return <code>[[1, 2, 3], [1, 2, 3], [1, 2, 3], [1, 2, 3], [1, 2, 3]]</code>');",
         "assert.deepEqual(copyMachine([true, true, null], 1), [[true, true, null]], 'message: <code>copyMachine([true, true, null], 1)</code> should return <code>[[true, true, null]]</code>');",
         "assert.deepEqual(copyMachine(['it works'], 3), [['it works'], ['it works'], ['it works']], 'message: <code>copyMachine([\"it works\"], 3)</code> should return <code>[[\"it works\"], [\"it works\"], [\"it works\"]]</code>');",
-        "assert.notStrictEqual(copyMachine.toString().indexOf('.concat(_toConsumableArray(arr))'), -1, 'message: The <code>copyMachine</code> function should utilize the <code>spread operator</code> with array <code>arr</code>');"
+        "assert.notStrictEqual(es6.search(/\\.\\.\\./), -1, 'message: The <code>copyMachine</code> function should utilize the <code>spread operator</code> with array <code>arr</code>');"
       ],
       "type": "waypoint",
       "releasedOn": "Feb 17, 2017",
@@ -320,7 +320,7 @@
       ],
       "tests": [
         "assert.deepEqual(spreadOut(), ['learning', 'to', 'code', 'is', 'fun'], 'message: <code>spreadOut</code> should return <code>[\"learning\", \"to\", \"code\", \"is\", \"fun\"]</code>');",
-        "assert.notStrictEqual(spreadOut.toString().search(/[...]/), -1, 'message: The <code>spreadOut</code> function should utilize spread syntax');"
+        "assert.notStrictEqual(es6.search(/\\.\\.\\./), -1, 'message: The <code>spreadOut</code> function should utilize spread syntax');"
       ],
       "type": "waypoint",
       "releasedOn": "Feb 17, 2017",

--- a/seed/challenges/02-javascript-algorithms-and-data-structures/es6.json
+++ b/seed/challenges/02-javascript-algorithms-and-data-structures/es6.json
@@ -111,7 +111,7 @@
         "<strong>Note</strong><br>Don't forget to add <code>\"use strict\";</code> to the top of your code."
       ],
       "challengeSeed": [
-        "// change 'var' to 'let' or 'const'",
+        "// declare variables as 'let' or 'const'",
         "// rename constant variables",
         "var pi = 3.14;",
         "var radius = 10;",
@@ -124,10 +124,11 @@
         "console.log(calculateCircumference(radius));"
       ],
       "tests": [
-        "// Test user replaced all var keyword",
-        "// Test PI is const",
-        "// Test calculateCircumference is const",
-        "// Test pi and calculateCircumference has been renamed"
+        "assert.strictEqual(es6.search(/var(?!iables)/), -1, 'message: There should be no variable declared with the <code>var</code> keyword.');",
+        "assert.notStrictEqual(es6.search(/const\\s+pi|const\\s+PI/), -1, 'message: The variable that represents pi should be declared with the <code>const</code> keyword.');",
+        "assert.notStrictEqual(es6.search(/const\\s+calculateCircumference|const\\s+CALCULATE_CIRCUMFERENCE/), -1, 'message: The function that calculates circumference should be declared with the <code>const</code> keyword.');",
+        "assert.notStrictEqual(es6.search(/PI/), -1, 'message: The variable that represents pi should be declared using best practice naming conventions.');",
+        "assert.notStrictEqual(es6.search(/CALCULATE_CIRCUMFERENCE/), -1, 'message: The function that calculates circumference should be declared using best practice naming conventions.');"
       ],
       "type": "waypoint",
       "releasedOn": "Feb 17, 2017",
@@ -194,12 +195,11 @@
         "console.log(magic());"
       ],
       "tests": [
-        "// Test user did replace var keyword",
-        "// Test magic is const",
-        "// Test magic is a function",
-        "// Test magic() returns the correct date",
-        "// Test function keyword was not used",
-        "// Test arrow => was used"
+        "assert.strictEqual(es6.search(/var/), -1, 'message: There should be no variables declared with the <code>var</code> keyword.');",
+        "assert.notStrictEqual(es6.search(/const\\s+magic|const\\s+MAGIC/), -1, 'message: <code>magic</code> should be declared with the <code>const</code> keyword.');",
+        "assert.isFunction(magic, 'message: <code>magic</code> should be a function.');",
+        "assert.strictEqual(es6.search(/function/), -1, 'message: The <code>function</code> keyword should not be used.');",
+        "assert.notStrictEqual(es6.search(/=>/), -1, 'message: Arrow function syntax, <code>=></code>, should be used to declare the function.');"
       ],
       "type": "waypoint",
       "releasedOn": "Feb 17, 2017",


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [ ] Closes currently open issue (replace XXXX with an issue no): Closes #XXXX

#### Description
<!-- Describe your changes in detail -->
@BerkeleyTrue @QuincyLarson This PR implements support for testing ES6 code, albeit probably not in the correct way, so this could just be a stop-gap to allow us to write and test the missing test cases for any code that uses ES6 syntax (ES6 section, etc.). 

I realize that this may conflict with @BerkeleyTrue's big PR #14707, however, even if we overwrite or remove this change when that PR is submitted, this will at least have allowed us to begin writing the ES6 challenges in the meantime, which will put us that much closer to shipping beta once Berkeley's changes are made. 

This takes the original code from the state within `buildChallengeEpic`, passes it to `frameTests`, deconstructs it in `frameTests` and adds it as a global variable to the testing environment in 'frame-epic` && `frame-runner` in the same way that `code` is added. In this case, the variable is called `es6`. 

Thoughts?

I've included a POC with a few challenges to show that this works, testing it with `let`, `const`, `...`, and `=>` syntaxes. See the following challenges if you want to pull down the code and test:
- Basic Data Structures - Copy an Array with Spread Syntax
- Basic Data Structures - Combine Array's with Spread Syntax
- ES6 - Use Arrow Functions to Write Concise Anonymous Functions
- ES6 - Declare a Read-Only Variable with the const Keyword


