### PR TITLE
fix(code-uri): Chrome iframe error with XSS Auditor

### DIFF
--- a/client/commonFramework/code-uri.js
+++ b/client/commonFramework/code-uri.js
@@ -134,6 +134,20 @@ window.common = (function(global) {
         (location.search || location.hash).replace(queryRegex, ''),
         'run'
       );
+    },
+    removeCodeUri: function(location, history) {
+      if (
+        typeof location.href.split !== 'function' ||
+        typeof history.replaceState !== 'function'
+      ) {
+        return false;
+      }
+      history.replaceState(
+        history.state,
+        null,
+        location.href.split('#')[0]
+      );
+      return true;
     }
   };
 

--- a/client/commonFramework/create-editor.js
+++ b/client/commonFramework/create-editor.js
@@ -103,6 +103,7 @@ window.common = (function(global) {
     let editorValue;
     if (common.codeUri.isAlive()) {
       editorValue = common.codeUri.parse();
+      common.codeUri.removeCodeUri(location, window.history);
     } else {
       editorValue = common.codeStorage.isAlive(common.challengeName) ?
         common.codeStorage.getStoredValue(common.challengeName) :

--- a/client/commonFramework/end.js
+++ b/client/commonFramework/end.js
@@ -24,7 +24,6 @@ $(document).ready(function() {
     code$.subscribe(
         code => {
           common.codeStorage.updateStorage(common.challengeName, code);
-          common.codeUri.querify(code);
         },
         err => console.error(err)
       );
@@ -72,7 +71,6 @@ $(document).ready(function() {
           return common.updateOutputDisplay('' + err);
         }
         common.codeStorage.updateStorage(challengeName, originalCode);
-        common.codeUri.querify(originalCode);
         common.displayTestResults(tests, true);
         common.updateOutputDisplay(output);
         return null;


### PR DESCRIPTION
- [x] remove solution from URI on read
- [ ] ~~disable code auto run~~ auto run works perfectly.
- [ ] ~~add code locking~~ not required as tested.
- [x] disable code uri updating

Closes #13727 

I have tested that this is the minimum required, changes that we need to do get away with the least impact to the existing UX.

Some caveats, that are a part of this, unfortunately, is the ability to share a URL that had the code in it, but IMHO it's for good that we considered deprecating that capability anyways.

Please QA and let me know for changes.