### PR TITLE
fix(email): Check unquiness of email

### DIFF
--- a/server/boot/user.js
+++ b/server/boot/user.js
@@ -608,7 +608,14 @@ module.exports = function(app) {
     return User.findById(req.accessToken.userId, function(err, user) {
       if (err) { return next(err); }
       return user.updateAttribute('password', password, function(err) {
-        if (err) { return next(err); }
+        if (err) {
+          debug(err);
+          req.flash('error', {
+            msg: err.message ||
+                 'Oops, something went wrong, please try again later'
+          });
+          return res.redirect('/');
+        }
 
         debug('password reset processed successfully');
         req.flash('info', { msg: 'You\'ve successfully reset your password.' });

--- a/server/utils/url-utils.js
+++ b/server/utils/url-utils.js
@@ -1,0 +1,37 @@
+const isDev = process.env.NODE_ENV !== 'production';
+const isBeta = !!process.env.BETA;
+
+export function getEmailSender() {
+  return process.env.EMAIL_SENDER || 'team@freecodecamp.com';
+}
+
+export function getPort() {
+  if (!isDev) {
+    return '443';
+  }
+  return process.env.SYNC_PORT || '3000';
+}
+
+export function getProtocol() {
+  return isDev ? 'http' : 'https';
+}
+
+export function getHost() {
+  if (isDev) {
+    return process.env.HOST || 'localhost';
+  }
+  return isBeta ? 'beta.freecodecamp.com' : 'freecodecamp.com';
+}
+
+export function getServerFullURL() {
+  if (!isDev) {
+   return getProtocol()
+        + '://'
+        + getHost();
+  }
+  return getProtocol()
+       + '://'
+       + getHost()
+       + ':'
+       + getPort();
+}

--- a/server/views/account/reset.jade
+++ b/server/views/account/reset.jade
@@ -7,10 +7,10 @@ block content
       input(type='hidden', name='_csrf', value=_csrf)
       .form-group
         label(for='password') New Password
-        input.form-control(type='password', name='password', value='', placeholder='New password', autofocus=true)
+        input.form-control(type='password', name='password', value='', placeholder='New password', autofocus=true, required)
       .form-group
         label(for='confirm') Confirm Password
-        input.form-control(type='password', name='confirm', value='', placeholder='Confirm password')
+        input.form-control(type='password', name='confirm', value='', placeholder='Confirm password', required)
       .form-group
         button.btn.btn-primary.btn-reset(type='submit')
           i.fa.fa-keyboard-o


### PR DESCRIPTION
This should let us check for uniqueness of email when the user attributes are updated via the API.

- I have back-ported some utils from #9660 
- Tested this with a duplicate user instance and reset password logic, which is the most cited area of this issue.