### PR TITLE
chore(CI): Update Travis CI Config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: node_js
 node_js:
   - '6'
 
-before_install: if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi
-
 cache:
   directories:
     - node_modules


### PR DESCRIPTION
Removes a check for `npm@^3` which is now a part of `node@^6`