### PR TITLE
fix(about): Open links in new tab

### DIFF
--- a/common/app/components/Nav/links.json
+++ b/common/app/components/Nav/links.json
@@ -30,7 +30,8 @@
       },
       {
         "content": "About",
-        "link": "/about"
+        "link": "https://freecodecamp.com/about",
+        "target": "_blank"
       }
     ]
   },

--- a/server/views/partials/navbar.jade
+++ b/server/views/partials/navbar.jade
@@ -21,7 +21,7 @@ nav.navbar.navbar-default.navbar-static-top.nav-height
                     li
                         a(href='https://forum.freecodecamp.com/t/free-code-camp-city-based-local-groups/19574', target='_blank') In your city
                     li
-                        a(href='/about') About
+                        a(href='https://freecodecamp.com/about', target='_blank') About
             li
                 a(href='/map') Map
             li
@@ -33,7 +33,7 @@ nav.navbar.navbar-default.navbar-static-top.nav-height
                 li.avatar-points
                   a(href='/settings')
                     span.brownie-points-nav
-                      span.hidden-md.hidden-lg #{user.username} 
+                      span.hidden-md.hidden-lg #{user.username}
                       span.brownie-points [&thinsp;#{user.points}&thinsp;]
                     span.hidden-xs.hidden-sm.avatar
                       img.profile-picture.float-right(src='#{user.picture}')


### PR DESCRIPTION
This updates the links to open in new tab (synonymous to the current behavior in production)

Closes #13780