### PR TITLE
Fix typo on one of the tasks

### DIFF
--- a/seed/challenges/04-data-visualization/data-visualization-with-d3.json
+++ b/seed/challenges/04-data-visualization/data-visualization-with-d3.json
@@ -1437,7 +1437,7 @@
       ],
       "description": [
         "By default, scales use the identity relationship - the input value maps to the output value. But scales can be much more flexible and interesting.",
-        "Say a data set has values ranging from 50 to 480. This in the input information for a scale, and is also known as the domain.",
+        "Say a data set has values ranging from 50 to 480. This is the input information for a scale, and is also known as the domain.",
         "You want to map those points along the <code>x</code> axis on the SVG canvas, between 10 units and 500 units. This is the output information, which is also known as the range.",
         "The <code>domain()</code> and <code>range()</code> methods set these values for the scale. Both methods take an array of at least two elements as an argument. Here's an example:",
         "<blockquote>// Set a domain<br>// The domain covers the set of input values<br>scale.domain([50, 480]);<br>// Set a range<br>// The range covers the set of output values<br>scale.range([10, 500]);<br>scale(50) // Returns 10<br>scale(480) // Returns 500<br>scale(325) // Returns 323.37<br>scale(750) // Returns 807.67<br>d3.scaleLinear()</blockquote>",


### PR DESCRIPTION
This changes "Say a data set has values ranging from 50 to 480. This in the input information for a scale, and is also known as the domain." to "Say a data set has values ranging from 50 to 480. This is the input information for a scale, and is also known as the domain.", as the former has a typo.

This PR fixes #15399

I have not tested this on a local site, but this should work fine, as this is only a minor change that fixes a typo.