### PR TITLE
reset to top on new challenge

### DIFF
--- a/common/app/routes/challenges/views/classic/Classic.jsx
+++ b/common/app/routes/challenges/views/classic/Classic.jsx
@@ -78,6 +78,7 @@ export class Challenge extends PureComponent {
   componentDidMount() {
     this.props.loadCode();
     this.props.updateSuccessMessage(randomCompliment());
+    window.scrollTo(0, 0);
   }
 
   componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] Your pull request targets the `staging` branch of freeCodeCamp.
- [X] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [X] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [X] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [X] Tested changes locally.
- [X] Closes currently open issue (replace XXXX with an issue no): Closes #12898.

#### Description
<!-- Describe your changes in detail -->
I added a window reset to the `componentDidMount` function of the Classic.jsx component. It fixes the issue above in Firefox and also fixes a scrolling issue on mobile where you scroll through the map, click a challenge, and the page is scrolled halfway through the challenge instructions.