### PR TITLE
fix(html-challenge-preload): HTML sample code preload has been fixed

### DIFF
--- a/client/sagas/build-challenge-epic.js
+++ b/client/sagas/build-challenge-epic.js
@@ -19,7 +19,7 @@ import {
 
 export default function buildChallengeEpic(actions, getState) {
   return actions
-    ::ofType(types.executeChallenge, types.updateMain)
+    ::ofType(types.executeChallenge, types.updateMain, types.loadCode)
     // if isCodeLocked do not run challenges
     .filter(() => !getState().challengesApp.isCodeLocked)
     .debounce(750)


### PR DESCRIPTION
HTML sample code preload has been fixed on the challenge pages.
This also means that now JS challenges sample code is also getting executed on the
first load of the challenge, but I think that this is not a problem.

<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All existing tests pass the command `npm test`. 

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Closes currently open issue (replace XXXX with an issue no): Closes #15620 

#### Description
In `buildChallengeEpic` of `client/sagas/build-challenge-epic.js` current content of the code editor gets executed/tested/built and the result goes to the preview iframe, at least in the case of CSS and HTML challenges this is the case. But this epic was listening to the `executeChallenge` and `updateMain` actions, but none of them is called on the initial render of the challenge page. It seems that this was the cause of the issue. On initial render `loadCode` action is called and I added this action to the above epic to listen to, so it could build the sample code too. 
<!-- Describe your changes in detail -->
