### PR TITLE
Modify challenge instruction to recommend use of double quotes

### DIFF
--- a/seed/challenges/03-front-end-libraries/jquery.json
+++ b/seed/challenges/03-front-end-libraries/jquery.json
@@ -109,7 +109,7 @@
         "For example, let's make all of your <code>button</code> elements bounce. Just add this code inside your document ready function:",
         "<code>$(\"button\").addClass(\"animated bounce\");</code>",
         "Note that we've already included both the jQuery library and the Animate.css library in the background so that you can use them in the editor. So you are using jQuery to apply the Animate.css <code>bounce</code> class to your <code>button</code> elements.",
-        "Additionally make sure to use <code>$(\"button\").addClass(\"animated bounce\");</code> instead of <code>$('button').addClass(\"animated bounce\");</code> since single-quote selectors will not pass our tests."
+        "Though not required, it is recommended to use double quotes on selectors in jQuery as a best practice of the jQuery library."
       ],
       "challengeSeed": [
         "fccss",


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Closes currently open issue (replace XXXX with an issue no): Closes #14207 

#### Description
<!-- Describe your changes in detail -->
I went through the original issue, and based on recommendations by @dhcodes and @erictleung, modified the challenge description to replace the current note about usage of double quotes -  

> Additionally make sure to use $("button").addClass("animated bounce"); instead of $('button').addClass("animated bounce"); since single-quote selectors will not pass our tests.

to 

> Though not required, it is recommended to use double quotes on selectors in jQuery as a best practice of the jQuery library.

I left the current test that checks the usage of `'` as is because if we amend the test to allow both `"` and `'`, we would probably need to make the change across all similar challenges.

Also, requiring the usage of `"` avoids any potential issues as [Eric suggested](https://github.com/freeCodeCamp/freeCodeCamp/issues/14207#issuecomment-291022536). On the other hand, the new note informs campers that they're not restricted to using just `"` outside of this challenge.

Closes #14207 