### PR TITLE
Add links to open source for good projects to map

### DIFF
--- a/server/views/map/show.jade
+++ b/server/views/map/show.jade
@@ -71,30 +71,30 @@ block content
             a(data-toggle='collapse', data-parent='#accordion', href='#collapse-full-stack-development-certification')
               span.no-link-underline
                 i.fa.fa-caret-down &thinsp;
-              | Full Stack Development Certification
+              | Open Source for Good
           div.margin-left-10(id = 'collapse-full-stack-development-certification' class = "collapse in map-collapse no-transition certBlock")
               #nested
-                h3
-                  a(data-toggle='collapse', data-parent='#nested', href='#nested-collapse-nonprofit-projects')
-                    span.no-link-underline
-                      i.fa.fa-caret-down &thinsp;
-                    | Nonprofit Projects
-                  span.challengeBlockTime (800 hours)
-                div.margin-left-10(id = "nested-collapse-nonprofit-projects" class = "collapse in map-collapse no-transition chapterBlock")
-                      .challengeBlockDescription To qualify for these nonprofit projects, you must first earn all three foundational certifications: Front End, Data Visualization, and Back End
-                      p.challenge-title.disabled.text-primary.ion-locked.padded-ionic-icon.negative-15(name="Greenfield Nonprofit Project #1") Greenfield Nonprofit Project #1
-                        span.text-primary &thinsp; &thinsp;
-                          strong *
-                      p.challenge-title.disabled.text-primary.ion-locked.padded-ionic-icon.negative-15(name="Greenfield Nonprofit Project #2") Greenfield Nonprofit Project #2
-                        span.text-primary &thinsp; &thinsp;
-                          strong *
-                      p.challenge-title.disabled.text-primary.ion-locked.padded-ionic-icon.negative-15(name="Legacy Code Nonprofit Project #1") Legacy Code Nonprofit Project #1
-                        span.text-primary &thinsp; &thinsp;
-                          strong *
-                      p.challenge-title.disabled.text-primary.ion-locked.padded-ionic-icon.negative-15(name="Legacy Code Nonprofit Project #2") Legacy Code Nonprofit Project #2
-                        span.text-primary &thinsp; &thinsp;
-                          strong *
-                      p.challenge-title.disabled.text-primary.ion-locked.padded-ionic-icon.negative-15(name="Claim your Full Stack Development Certification") Claim your Full Stack Development Certification
+                a(data-toggle='collapse', data-parent='#nested', href='#nested-collapse-nonprofit-projects')
+                div.margin-left-10(class = "chapterBlock")
+                    .challengeBlockDescription Once you feel ready, you can get real-world experience by contributing to these open source tools used by nonprofits.
+                    p.challenge-title.text-primary.fa.fa-envelope-o.negative-15(name="Mail for Good")
+                      a(href="https://github.com/FreeCodeCamp/mail-for-good" target="_blank")
+                        span Mail for Good
+                    p.challenge-title.text-primary.fa.fa-cutlery.negative-15(name="Pantry for Good")
+                      a(href="https://github.com/FreeCodeCamp/pantry-for-good" target="_blank")
+                        span Pantry for Good
+                    p.challenge-title.text-primary.fa.fa-globe.negative-15(name="Meeting for Good")
+                      a(href="https://github.com/FreeCodeCamp/meeting-for-good" target="_blank")
+                        span Meeting for Good
+                    p.challenge-title.text-primary.fa.fa-futbol-o.negative-15(name="League for Good")
+                      a(href="https://github.com/FreeCodeCamp/league-for-good" target="_blank")
+                        span League for Good
+                    p.challenge-title.text-primary.fa.fa-users.negative-15(name="Conference for Good")
+                      a(href="https://github.com/FreeCodeCamp/conference-for-good" target="_blank")
+                        span Conference for Good
+                    p.challenge-title.text-primary.fa.fa-heart.negative-15(name="freeCodeCamp")
+                      a(href="https://github.com/FreeCodeCamp/freecodecamp" target="_blank")
+                        span freeCodeCamp
           h2
             a(data-toggle='collapse', data-parent='#accordion', href='#collapse-coding-interview-preparation')
               span.no-link-underline


### PR DESCRIPTION
This PR adds the Open Source for Good projects directly to the challenge map, and replaces our existing nonprofit project explanation.

I'm having trouble getting these entries to line up properly. @BerkeleyTrue can you see if you can fix this before merging?

![learn_to_code_and_help_nonprofits___freecodecamp](https://user-images.githubusercontent.com/985197/28890069-8dd47dd4-778b-11e7-8511-2829e3aafbdd.png)
