### PR TITLE
Correct misalignment between challenge names and hour estimates

### DIFF
--- a/common/app/Map/map.less
+++ b/common/app/Map/map.less
@@ -77,6 +77,9 @@
   a {
     cursor: pointer;
   }
+  @media (min-width: 721px) {
+    clear: both;
+  }
 }
 
 .@{ns}-accordion-panel-heading a {
@@ -86,6 +89,12 @@
 
 .@{ns}-accordion-panel-collapse {
   transition: height 0.001s;
+}
+
+.@{ns}-accordion-panel-title {
+  @media (min-width: 721px) {
+    clear: both;
+  }
 }
 
 .@{ns}-block-time {


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] Your pull request targets the `staging` branch of freeCodeCamp.
- [X] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [X] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [X] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)



#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [X] Tested changes locally.
- [X] Closes currently open issue (replace XXXX with an issue no): Closes #15706

#### Description
<!-- Describe your changes in detail -->
The misalignment happens when the left panel in challenges view gets too small and the text wraps around the hour estimates, which are floated right. I added two media queries to fix this.