### PR TITLE
fix(challenges): Provide accessible test description and status

### DIFF
--- a/common/app/routes/challenges/Test-Suite.jsx
+++ b/common/app/routes/challenges/Test-Suite.jsx
@@ -8,6 +8,20 @@ const propTypes = {
   tests: PropTypes.arrayOf(PropTypes.object)
 };
 
+function getAccessibleText(err, pass, text) {
+  let accessibleText = 'Waiting';
+
+  // Determine test status (i.e. icon)
+  if (err) {
+    accessibleText = 'Error';
+  } else if (pass) {
+    accessibleText = 'Pass';
+  }
+
+  // Append the text itself
+  return accessibleText + ' - ' + text;
+}
+
 export default class TestSuite extends PureComponent {
   renderTests(tests = []) {
     // err && pass > invalid state
@@ -22,14 +36,22 @@ export default class TestSuite extends PureComponent {
         'ion-refresh refresh-icon': !err && !pass
       });
       return (
-        <Row key={ text.slice(-6) + index }>
+        <Row
+          aria-label={ getAccessibleText(err, pass, text) }
+          key={ text.slice(-6) + index }
+          tabIndex='0'
+          >
           <Col
             className='text-center'
             xs={ 2 }
             >
-            <i className={ iconClass } />
+            <i
+              aria-hidden='true'
+              className={ iconClass }
+            />
           </Col>
           <Col
+            aria-hidden='true'
             className='test-output'
             dangerouslySetInnerHTML={{ __html: text }}
             xs={ 10 }

--- a/common/app/routes/challenges/Test-Suite.jsx
+++ b/common/app/routes/challenges/Test-Suite.jsx
@@ -8,6 +8,20 @@ const propTypes = {
   tests: PropTypes.arrayOf(PropTypes.object)
 };
 
+function getAccessibleText(err, pass, text) {
+  let accessibleText = 'Waiting';
+
+  // Determine test status (i.e. icon)
+  if (err) {
+    accessibleText += 'Error ';
+  } else if (pass) {
+    accessibleText += 'Pass';
+  }
+
+  // Append the text itself
+  return accessibleText + ' - ' + text;
+}
+
 export default class TestSuite extends PureComponent {
   renderTests(tests = []) {
     // err && pass > invalid state
@@ -22,14 +36,22 @@ export default class TestSuite extends PureComponent {
         'ion-refresh refresh-icon': !err && !pass
       });
       return (
-        <Row key={ text.slice(-6) + index }>
+        <Row
+          aria-label={ getAccessibleText(err, pass, text) }
+          key={ text.slice(-6) + index }
+          tabIndex='0'
+          >
           <Col
             className='text-center'
             xs={ 2 }
             >
-            <i className={ iconClass } />
+            <i
+              aria-hidden='true'
+              className={ iconClass }
+            />
           </Col>
           <Col
+            aria-hidden='true'
             className='test-output'
             dangerouslySetInnerHTML={{ __html: text }}
             xs={ 10 }


### PR DESCRIPTION
Closes #13013

fix(challenges): Provide accessible test description and status

#### Pre-Submission Checklist
- [X] Your pull request targets the `staging` branch of freeCodeCamp.
- [X] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [X] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [X] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [X] Tested changes locally.
- [x] Closes currently open issue: Closes #13013

#### Description
* Use aria-hide on elements that aren't independently relevant for visually impaired or challenged users
* Merge test status and text on a single string
* Add the string as the aria text / label of the row element
* Force the row element to be a tab stop

Changes have been tested with Mac's VoiceOver on Chrome and Safari. Changes _should_ work on NVDA and JAWS (don't have a test environment at the moment). npm test / lint runs fine.
<img width="600" alt="screen shot 2017-08-12 at 2 32 46 pm" src="https://user-images.githubusercontent.com/309783/29244364-4a26f7b4-7f6b-11e7-899b-ba80801076c5.png">
<img width="535" alt="screen shot 2017-08-12 at 2 33 24 pm" src="https://user-images.githubusercontent.com/309783/29244365-4a27c2b6-7f6b-11e7-8b47-abb6b34bf7b2.png">


