### PR TITLE
fix(accessibility): Add main and complementary landmarks

### DIFF
--- a/common/app/routes/challenges/views/classic/Editor.jsx
+++ b/common/app/routes/challenges/views/classic/Editor.jsx
@@ -118,7 +118,10 @@ export class Editor extends PureComponent {
       mode
     } = this.props;
     return (
-      <div className={ `${ns}-editor` }>
+      <div
+        className={ `${ns}-editor` }
+        role='main'
+        >
         <NoSSR onSSR={ <CodeMirrorSkeleton content={ content } /> }>
           <Codemirror
             onChange={ classicEditorUpdated }

--- a/common/app/routes/challenges/views/classic/Side-Panel.jsx
+++ b/common/app/routes/challenges/views/classic/Side-Panel.jsx
@@ -127,6 +127,7 @@ export class SidePanel extends PureComponent {
       <div
         className={ `${ns}-instructions-panel` }
         ref='panel'
+        role='complementary'
         >
         <div>
           <ChallengeTitle>


### PR DESCRIPTION
Screen readers and other assistive technologies use it for navigation

Closes #15658

<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] Your pull request targets the `staging` branch of freeCodeCamp.
- [X] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [X] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [X] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [X] Tested changes locally.
- [X] Closes currently open issue (replace XXXX with an issue no): Closes #15658

#### Description
Assistive technologies (i.e. screen readers used by people with visual impairments, or navigation software used by people with motor impairments) create a "map" or "topography" of a web page based on the landmarks as outlined by either:
1. Syntactic elements (i.e. main, section), or,
2. The corresponding 'role' attributes

An example of the available landmark roles can be seen [here](https://www.w3.org/TR/wai-aria/roles#landmark_roles). For this change, I'm considering:
* the **editor** to be the '**main**' landmark, and
* **instructions** to be a '**complementary**' section that explains the purpose or goal of '_main_' (editor).

I have verified that these changes work on voiceover. Screenshot attached. Changes should also work with NVDA and JAWS for Windows users.

Thanks!

![untitled copy](https://user-images.githubusercontent.com/309783/29246314-b2e3377e-7faa-11e7-9415-3908a68764cb.jpg)

