### PR TITLE
fix(challenges): Revert CSS regex test

### DIFF
--- a/seed/challenges/01-responsive-web-design/applied-visual-design.json
+++ b/seed/challenges/01-responsive-web-design/applied-visual-design.json
@@ -1387,9 +1387,9 @@
         "<div class=\"raspberry\"></div>"
       ],
       "tests": [
-        "assert(code.match(/.orange\\s*\\{\\s*background-color:\\s*(#FF7D00|#ff7d00);?\\s*\\}/g), 'message: The <code>div</code> element with class <code>orange</code> should have a <code>background-color</code> of orange.');",
-        "assert(code.match(/.cyan\\s*\\{\\s*background-color:\\s*(#00FFFF|#00ffff);?\\s*\\}/g), 'message: The <code>div</code> element with class <code>cyan</code> should have a <code>background-color</code> of cyan.');",
-        "assert(code.match(/.raspberry\\s*\\{\\s*background-color:\\s*(#FF007D|#ff007d);?\\s*\\}/g), 'message: The <code>div</code> element with class <code>raspberry</code> should have a <code>background-color</code> of raspberry.');"
+        "assert($('.orange').css('background-color') == 'rgb(255, 125, 0)', 'message: The <code>div</code> element with class <code>orange</code> should have a <code>background-color</code> of orange.');",
+        "assert($('.cyan').css('background-color') == 'rgb(0, 255, 255)', 'message: The <code>div</code> element with class <code>cyan</code> should have a <code>background-color</code> of cyan.');",
+        "assert($('.raspberry').css('background-color') == 'rgb(255, 0, 125)', 'message: The <code>div</code> element with class <code>raspberry</code> should have a <code>background-color</code> of raspberry.');"
       ],
       "solutions": [],
       "hints": [],

--- a/seed/challenges/01-responsive-web-design/basic-css.json
+++ b/seed/challenges/01-responsive-web-design/basic-css.json
@@ -88,7 +88,7 @@
         "</main>"
       ],
       "tests": [
-        "assert(code.match(/<h2\\s+style\\s*=\\s*(\\'|\")\\s*color\\s*:\\s*(?:rgb\\(\\s*255\\s*,\\s*0\\s*,\\s*0\\s*\\)|rgb\\(\\s*100%\\s*,\\s*0%\\s*,\\s*0%\\s*\\)|red|#ff0000|#f00|hsl\\(\\s*0\\s*,\\s*100%\\s*,\\s*50%\\s*\\))\\s*\\;?(\\'|\")>\\s*CatPhotoApp\\s*<\\/h2>/), 'message: Your <code>h2</code> element should be red.');",
+        "assert($(\"h2\").css(\"color\") === \"rgb(255, 0, 0)\", 'message: Your <code>h2</code> element should be red.');",
         "assert(code.match(/<h2\\s+style\\s*=\\s*(\\'|\")\\s*color\\s*:\\s*(?:rgb\\(\\s*255\\s*,\\s*0\\s*,\\s*0\\s*\\)|rgb\\(\\s*100%\\s*,\\s*0%\\s*,\\s*0%\\s*\\)|red|#ff0000|#f00|hsl\\(\\s*0\\s*,\\s*100%\\s*,\\s*50%\\s*\\))\\s*\\;(\\'|\")>\\s*CatPhotoApp\\s*<\\/h2>/),' message: Your <code>style</code> declaration should end with a <code>;</code> .');"
       ],
       "type": "waypoint",

--- a/seed/challenges/01-responsive-web-design/responsive-web-design.json
+++ b/seed/challenges/01-responsive-web-design/responsive-web-design.json
@@ -97,7 +97,7 @@
         "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus quis tempus massa. Aenean erat nisl, gravida vel vestibulum cursus, interdum sit amet lectus. Sed sit amet quam nibh. Suspendisse quis tincidunt nulla. In hac habitasse platea dictumst. Ut sit amet pretium nisl. Vivamus vel mi sem. Aenean sit amet consectetur sem. Suspendisse pretium, purus et gravida consequat, nunc ligula ultricies diam, at aliquet velit libero a dui.</p>"
       ],
       "tests": [
-        "assert(code.match(/p\\s*\\{\\s*font-size:\\s*10px;\\s*\\}/g), 'message: Your <code>p</code> element should have the <code>font-size</code> of 10px when the device <code>height</code> is less than or equal to 800px.');",
+        "assert($('p').css('font-size') == '10px', 'message: Your <code>p</code> element should have the <code>font-size</code> of 10px when the device <code>height</code> is less than or equal to 800px.');",
         "assert(code.match(/@media \\(max-height:\\s*?800px\\)/g), 'message: Declare a <code>@media</code> query for devices with a <code>height</code> less than or equal to 800px.');"
       ],
       "type": "waypoint",


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
- [x] Tested changes locally.
- [x] Closes currently open issue (replace XXXX with an issue no): Closes #15567 

#### Description
Some CSS tests were changed to regex tests while the CSS tests weren't working on Firefox. Now that the original issue has been fixed (#15775), these changes can be reverted.
This allows more correct answers to pass as a valid solution again.

The changes reverted were originally made in #13389, #13491 and #13709.

Ignore the first camperbot message, it conflicts with the commitizen guidelines.
