### PR TITLE
feat(euler-problem): Add tests and solution for Problem 4: Largest palindrome product

### DIFF
--- a/seed/challenges/08-coding-interview-questions-and-take-home-assignments/project-euler-problems.json
+++ b/seed/challenges/08-coding-interview-questions-and-take-home-assignments/project-euler-problems.json
@@ -94,17 +94,20 @@
       "type": "bonfire",
       "title": "Problem 4: Largest palindrome product",
       "tests": [
-        "assert.strictEqual(euler4(), 906609, 'message: <code>euler4()</code> should return 906609.');"
+        "assert.strictEqual(largestPalindromeProduct(2), 9009, 'message: <code>largestPalindromeProduct(2)</code> should return 9009.');",
+        "assert.strictEqual(largestPalindromeProduct(3), 906609, 'message: <code>largestPalindromeProduct(3)</code> should return 906609.');"
       ],
-      "solutions": [],
+      "solutions": [
+        "const largestPalindromeProduct = (digit)=>{\n  let start = 1;\n  let end = Number(`1e${digit}`) - 1;\n let palindrome = [];\n  for(let i=start;i<=end;i++){\n    for(let j=start;j<=end;j++){\n      let product = i*j;\n      let palindromeRegex = new RegExp('\\b(\\d)(\\d?)(\\d?).?\\3\\2\\1\\b','gi');\n      palindromeRegex.test(product) && palindrome.push(product);\n    }\n }\n return Math.max(...palindrome);\n}"
+      ],
       "translations": {},
       "challengeSeed": [
-        "function euler4() {",
+        "function largestPalindromeProduct(digit) {",
         "  // Good luck!",
         "  return true;",
         "}",
         "",
-        "euler4();"
+        "largestPalindromeProduct(3);"
       ],
       "description": [
         "A palindromic number reads the same both ways. The largest palindrome made from the product of two 2-digit numbers is 9009 = 91 × 99.",

--- a/seed/challenges/08-coding-interview-questions-and-take-home-assignments/project-euler-problems.json
+++ b/seed/challenges/08-coding-interview-questions-and-take-home-assignments/project-euler-problems.json
@@ -98,7 +98,7 @@
         "assert.strictEqual(largestPalindromeProduct(3), 906609, 'message: <code>largestPalindromeProduct(3)</code> should return 906609.');"
       ],
       "solutions": [
-        "const largestPalindromeProduct = (digit)=>{\n  let start = 1;\n  let end = Number(`1e${digit}`) - 1;\n let palindrome = [];\n  for(let i=start;i<=end;i++){\n    for(let j=start;j<=end;j++){\n      let product = i*j;\n      let palindromeRegex = new RegExp('\\b(\\d)(\\d?)(\\d?).?\\3\\2\\1\\b','gi');\n      palindromeRegex.test(product) && palindrome.push(product);\n    }\n }\n return Math.max(...palindrome);\n}"
+        "const largestPalindromeProduct = (digit)=>{\n  let start = 1;\n  let end = Number(`1e${digit}`) - 1;\n let palindrome = [];\n  for(let i=start;i<=end;i++){\n    for(let j=start;j<=end;j++){\n      let product = i*j;\n      let palindromeRegex = /\\b(\\d)(\\d?)(\\d?).?\\3\\2\\1\\b/gi;\n      palindromeRegex.test(product) && palindrome.push(product);\n    }\n }\n return Math.max(...palindrome);\n}"
       ],
       "translations": {},
       "challengeSeed": [

--- a/seed/test-challenges.js
+++ b/seed/test-challenges.js
@@ -215,10 +215,12 @@ Observable.from(getChallenges())
   .toArray()
   .subscribe(
     (noSolutions) => {
-      console.log(
-        '# These challenges have no solutions\n- [ ] ' +
-          noSolutions.join('\n- [ ] ')
-      );
+      if(noSolutions){
+        console.log(
+          '# These challenges have no solutions\n- [ ] ' +
+            noSolutions.join('\n- [ ] ')
+        );
+      }
     },
     err => { throw err; },
     () => process.exit(0)


### PR DESCRIPTION
 Add tests and solution for Problem 4: Largest palindrome product
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [ ] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [ ] Closes currently open issue (replace XXXX with an issue no): Closes #XXXX

#### Description
<!-- Describe your changes in detail -->
