### PR TITLE
fix(Navbar): stop using removed onClose prop of react-bootstraop Navbar

### DIFF
--- a/common/app/Nav/Nav.jsx
+++ b/common/app/Nav/Nav.jsx
@@ -1,7 +1,6 @@
 import React, { PropTypes } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import noop from 'lodash/noop';
 import capitalize from 'lodash/capitalize';
 import { createSelector } from 'reselect';
 
@@ -143,10 +142,9 @@ export class FCCNav extends React.Component {
           key={ content }
           noCaret={ true }
           onClick={ openDropdown }
-          onClose={ closeDropdown }
           onMouseEnter={ openDropdown }
           onMouseLeave={ closeDropdown }
-          onToggle={ noop }
+          onToggle={ isDropdownOpen ? closeDropdown : openDropdown }
           open={ isDropdownOpen }
           title={ content }
           >


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Closes currently open issue (replace XXXX with an issue no): Closes #15882

#### Description
<!-- Describe your changes in detail -->
As of react-bootstrap 0.31.0 the onClose prop of Dropdown does not exist and should be replaced with onToggle. This seemed like the path of least resistance to fix this problem, but I'm open to making a new toggle action if that would be preferred.