### PR TITLE
fix(settings): redirect to map if not logged in

### DIFF
--- a/common/app/routes/settings/Settings.jsx
+++ b/common/app/routes/settings/Settings.jsx
@@ -126,7 +126,7 @@ export class Settings extends React.Component {
       toggleMonthlyEmail,
       toggleNotificationEmail
     } = this.props;
-    if (!username && !showLoading) {
+    if (!username && showLoading) {
       return <SettingsSkeleton />;
     }
     if (children) {

--- a/server/boot/react.js
+++ b/server/boot/react.js
@@ -5,6 +5,7 @@ import { renderToString } from 'redux-epic';
 
 import createApp from '../../common/app';
 import provideStore from '../../common/app/provide-store';
+import { ifNoUserRedirectTo } from '../utils/middleware';
 
 
 const log = debug('fcc:react-server');
@@ -32,6 +33,10 @@ export default function reactSubRouter(app) {
 
   // These routes are in production
   routes.forEach((route) => {
+    if (route.startsWith('/settings')) {
+      router.get(route, ifNoUserRedirectTo('/map'), serveReactApp);
+      return;
+    }
     router.get(route, serveReactApp);
   });
 


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Closes currently open issue (replace XXXX with an issue no): Closes #15809

#### Description
<!-- Describe your changes in detail -->
Something during the course of rendering the old version of settings used to make a call to an API that checked if a user was logged in. (I assume this call was to `/accounts`). The new version does not make any such call, so instead I've gated the call that renders the React app itself on the `/settings` endpoint.