### PR TITLE
fix(update-email): Update error handling in backend and use error message from JSON in frontend

### DIFF
--- a/client/epics/err-epic.js
+++ b/client/epics/err-epic.js
@@ -1,10 +1,16 @@
 import { makeToast } from '../../common/app/Toasts/redux';
 
-export default function errorSaga(actions) {
+export default function errorEpic(actions) {
   return actions.filter(({ error }) => !!error)
     .map(({ error }) => error)
     .doOnNext(error => console.error(error))
-    .map(() => makeToast({
-      message: 'Something went wrong, please try again later'
-    }));
+    .map((error) => {
+      // Get data according to normalized ajax error.
+      const data = error.xhr.responseText ? JSON.parse(error.xhr.responseText)
+      : {};
+      return makeToast({
+        message: data.message ? data.message :
+      'Something went wrong, please try again later'
+      });
+    });
 }

--- a/server/middlewares/error-handlers.js
+++ b/server/middlewares/error-handlers.js
@@ -1,12 +1,7 @@
-import errorHandler from 'errorhandler';
 import accepts from 'accepts';
 import { unwrapHandledError } from '../utils/create-handled-error.js';
 
 export default function prodErrorHandler() {
-  if (process.env.NODE_ENV === 'development') {
-    return errorHandler({ log: true });
-  }
-  // error handling in production.
   // disabling eslint due to express parity rules for error handlers
   return function(err, req, res, next) { // eslint-disable-line
     // respect err.status
@@ -22,7 +17,11 @@ export default function prodErrorHandler() {
     // parse res type
     const accept = accepts(req);
     const type = accept.type('html', 'json', 'text');
-    const handled = unwrapHandledError(err);
+
+    // If err is array then use the unwrap function,
+    // otherwise it wasn't wrapped so we build the handled object.
+    const handled = err.constructor === Array ? unwrapHandledError(err) :
+      { message: err.message, stack: err.stack };
 
     const redirectTo = handled.redirectTo || '/map';
     const message = handled.message ||


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #15876

#### Description
<!-- Describe your changes in detail -->
1. Homogenize the error handler for production and development environments.
2. In the error handler we used to consider only errors wrapped with https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/server/utils/create-handled-error.js#L11 but now we also have errors normalized with https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/common/utils/ajax-stream.js#L79 therefore I added the logic to consider both cases.
3. The errorEpic had only a hardcoded error message so I added the logic to display the message from Ajax Error.