### PR TITLE
fix(user): Update email pre-confirm config

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -83,11 +83,6 @@ function getWaitPeriod(ttl) {
   return 0;
 }
 module.exports = function(User) {
-  // NOTE(berks): user email validation currently not needed but build in. This
-  // work around should let us sneak by
-  // see:
-  // https://github.com/strongloop/loopback/issues/1137#issuecomment-109200135
-  delete User.validations.email;
   // set salt factor for passwords
   User.settings.saltWorkFactor = 5;
   // set user.rand to random number

--- a/common/models/user.js
+++ b/common/models/user.js
@@ -472,7 +472,7 @@ module.exports = function(User) {
     }
   );
 
-  User.requestAuthLink = function requestAuthLink(email) {
+  User.requestAuthEmail = function requestAuthEmail(email) {
     if (!isEmail(email)) {
       return Promise.reject(
         new Error('The submitted email not valid.')
@@ -545,7 +545,7 @@ module.exports = function(User) {
   };
 
   User.remoteMethod(
-    'requestAuthLink',
+    'requestAuthEmail',
     {
       description: 'request a link on email with temporary token to sign in',
       accepts: [{
@@ -560,7 +560,7 @@ module.exports = function(User) {
     }
   );
 
-  User.prototype.updateEmail = function updateEmail(email) {
+  User.prototype.requestUpdateEmail = function requestUpdateEmail(email) {
     const ownEmail = email === this.email;
     if (!isEmail('' + email)) {
       return Observable.throw(createEmailError());

--- a/common/models/user.js
+++ b/common/models/user.js
@@ -625,7 +625,7 @@ module.exports = function(User) {
             'server',
             'views',
             'emails',
-            'user-email-verify.ejs'
+            'user-request-update-email.ejs'
           )
         };
         return this.verify(mailOptions);

--- a/common/models/user.json
+++ b/common/models/user.json
@@ -277,7 +277,7 @@
       "principalType": "ROLE",
       "principalId": "$owner",
       "permission": "ALLOW",
-      "property": "updateEmail"
+      "property": "requestUpdateEmail"
     },
     {
       "accessType": "EXECUTE",
@@ -298,7 +298,7 @@
       "principalType": "ROLE",
       "principalId": "$everyone",
       "permission": "ALLOW",
-      "property": "requestAuthLink"
+      "property": "requestAuthEmail"
     }
   ],
   "methods": {}

--- a/common/models/user.json
+++ b/common/models/user.json
@@ -16,7 +16,7 @@
         }
       }
     },
-    "emailUpdateNew":{
+    "newEmail":{
       "type": "string"
     },
     "emailVerifyTTL": {

--- a/common/models/user.json
+++ b/common/models/user.json
@@ -16,6 +16,9 @@
         }
       }
     },
+    "emailUpdateNew":{
+      "type": "string"
+    },
     "emailVerifyTTL": {
       "type": "date"
     },

--- a/server/boot/settings.js
+++ b/server/boot/settings.js
@@ -21,7 +21,7 @@ export default function settingsController(app) {
 
   function updateMyEmail(req, res, next) {
     const { user, body: { email } } = req;
-    return user.updateEmail(email)
+    return user.requestUpdateEmail(email)
       .subscribe(
         (message) => res.json({ message }),
         next

--- a/server/boot/user.js
+++ b/server/boot/user.js
@@ -248,7 +248,7 @@ module.exports = function(app) {
       return res.redirect('/');
     }
 
-    return User.requestAuthLink(req.body.email)
+    return User.requestAuthEmail(req.body.email)
       .then(msg => {
           return res.status(200).send({ message: msg });
       })

--- a/server/views/emails/user-request-sign-in.ejs
+++ b/server/views/emails/user-request-sign-in.ejs
@@ -14,4 +14,4 @@ Good luck with the challenges!
 
 Thanks,
 The freeCodeCamp Team.
-team@freecodecamp.com
+team@freecodecamp.org

--- a/server/views/emails/user-request-sign-up.ejs
+++ b/server/views/emails/user-request-sign-up.ejs
@@ -9,9 +9,9 @@ This above link is valid for 15 minutes.
 
 And when you have a moment:
 1. Visit the settings page and link your account to GitHub.
-2. Follow our Medium Publication: https://medium.freecodecamp.com
-3. Checkout our forum: https://forum.freecodecamp.com
-4. Join the conversation: https://gitter.im/FreeCodeCamp/FreeCodeCamp
+2. Follow our Medium Publication: https://medium.freecodecamp.org
+3. Checkout our forum: https://forum.freecodecamp.org
+4. Join the conversation: https://gitter.im/freeCodeCamp/freeCodeCamp
 
 IMPORTANT NOTE:
 If you did not make any such request, simply delete or ignore this email.
@@ -21,4 +21,4 @@ Good luck with the challenges!
 
 Thanks,
 The freeCodeCamp Team.
-team@freecodecamp.com
+team@freecodecamp.org

--- a/server/views/emails/user-request-update-email.ejs
+++ b/server/views/emails/user-request-update-email.ejs
@@ -10,4 +10,4 @@ Good luck with the challenges!
 
 Thanks,
 The freeCodeCamp Team.
-team@freecodecamp.com
+team@freecodecamp.org


### PR DESCRIPTION
This request aims to make the following changes to the user model and email auth:

- [x] Re-add the native LoopBack email validation support.
- [x] Align the naming convention for the brand in the email templates.
- [x] Not update the user email, unless its confirmed.
- [ ] ~~Refactor common code for creating verification tokens for update and login paths.~~ This can be taken up in a separate pull request.

Closes #15822 

