### PR TITLE
Update make-a-person challenge to support ES6 classes

### DIFF
--- a/client/commonFramework/get-iframe.js
+++ b/client/commonFramework/get-iframe.js
@@ -1,5 +1,6 @@
 window.common = (function(global) {
   const {
+    Rx: { Observable },
     common = { init: [] },
     document: doc
   } = global;
@@ -15,8 +16,22 @@ window.common = (function(global) {
       doc.body.appendChild(previewFrame);
     }
 
+    return previewFrame;
+  };
+
+  common.getIframeDocument = function getIframeDocument(id) {
+    const previewFrame = common.getIframe(id);
+
     return previewFrame.contentDocument ||
       previewFrame.contentWindow.document;
+  };
+
+  common.reloadIframe = function reloadIframe(id) {
+    const previewFrame = common.getIframe(id);
+
+    previewFrame.contentWindow.location.reload(true);
+
+    return Observable.fromEvent(previewFrame, 'load').first();
   };
 
   return common;

--- a/client/commonFramework/update-preview.js
+++ b/client/commonFramework/update-preview.js
@@ -115,18 +115,19 @@ AAAAAANAAQAAAILhA+hG5jMDpxvhgIAOw==');
 
 
   common.updatePreview$ = function updatePreview$(code = '') {
-    const preview = common.getIframe('preview');
-
-    return Observable.combineLatest(
-      iFrameScript$,
-      jQueryScript$,
-      (iframe, jQuery) => ({
-        iframeScript: `<script>${iframe}</script>`,
-        jQuery: `<script>${jQuery}</script>`
-      })
-    )
+    return common.reloadIframe('preview')
+      .flatMap(() => Observable.combineLatest(
+        iFrameScript$,
+        jQueryScript$,
+        (iframe, jQuery) => ({
+          iframeScript: `<script>${iframe}</script>`,
+          jQuery: `<script>${jQuery}</script>`
+        })
+      ))
       .first()
       .flatMap(({ iframeScript, jQuery }) => {
+        const preview = common.getIframeDocument('preview');
+
         // we make sure to override the last value in the
         // subject to false here.
         common.previewReady$.onNext(false);

--- a/seed/challenges/01-front-end-development-certification/advanced-bonfires.json
+++ b/seed/challenges/01-front-end-development-certification/advanced-bonfires.json
@@ -392,7 +392,6 @@
         "<blockquote>getFirstName()\ngetLastName()\ngetFullName()\nsetFirstName(first)\nsetLastName(last)\nsetFullName(firstAndLast)</blockquote>",
         "Run the tests to see the expected output for each method.",
         "The methods that take an argument must accept only one argument and it has to be a string.",
-        "These methods must be the only available means of interacting with the object.",
         "Remember to use <a href='//forum.freecodecamp.org/t/how-to-get-help-when-you-are-stuck/19514' target='_blank'>Read-Search-Ask</a> if you get stuck. Try to pair program. Write your own code."
       ],
       "challengeSeed": [
@@ -411,10 +410,7 @@
         "var Person = function(firstAndLast) {\n\n  var firstName, lastName;\n\n  function updateName(str) {    \n    firstName = str.split(\" \")[0];\n    lastName = str.split(\" \")[1];    \n  }\n\n  updateName(firstAndLast);\n\n  this.getFirstName = function(){\n    return firstName;\n  };\n  \n  this.getLastName = function(){\n    return lastName;\n  };\n  \n  this.getFullName = function(){\n    return firstName + \" \" + lastName;\n  };\n  \n  this.setFirstName = function(str){\n    firstName = str;\n  };\n  \n\n  this.setLastName = function(str){\n    lastName = str;\n  };\n  \n  this.setFullName = function(str){\n    updateName(str);\n  };\n};\n\nvar bob = new Person('Bob Ross');\nbob.getFullName();"
       ],
       "tests": [
-        "assert.deepEqual(Object.keys(bob).length, 6, 'message: <code>Object.keys(bob).length</code> should return 6.');",
         "assert.deepEqual(bob instanceof Person, true, 'message: <code>bob instanceof Person</code> should return true.');",
-        "assert.deepEqual(bob.firstName, undefined, 'message: <code>bob.firstName</code> should return undefined.');",
-        "assert.deepEqual(bob.lastName, undefined, 'message: <code>bob.lastName</code> should return undefined.');",
         "assert.deepEqual(bob.getFirstName(), 'Bob', 'message: <code>bob.getFirstName()</code> should return \"Bob\".');",
         "assert.deepEqual(bob.getLastName(), 'Ross', 'message: <code>bob.getLastName()</code> should return \"Ross\".');",
         "assert.deepEqual(bob.getFullName(), 'Bob Ross', 'message: <code>bob.getFullName()</code> should return \"Bob Ross\".');",


### PR DESCRIPTION
This PR addresses issue #8096 and enables ES6 class solution to pass the test.

#### Pre-Submission Checklist
- [ ] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
- [x] Tested changes locally.
- [x] Addressed currently open issue

Closes #8096

#### Description
Three of the tests had to be removed: class solution does not expose methods as public properties, and does permit access to internal attributes. Exercise description has been altered accordingly.

Another problem with classes is global scope. Evaluating the code multiple times results in an error unless the scope is refreshed. Proposed solution involves reloading an iframe. It also makes it possible to use `const` in global scope throughout all exercises.