### PR TITLE
fix: add 2nd regex check for bracket notation

### DIFF
--- a/seed/challenges/02-javascript-algorithms-and-data-structures/basic-algorithm-scripting.json
+++ b/seed/challenges/02-javascript-algorithms-and-data-structures/basic-algorithm-scripting.json
@@ -391,7 +391,7 @@
         "assert(confirmEnding(\"Open sesame\", \"game\") === false, 'message: <code>confirmEnding(\"Open sesame\", \"game\")</code> should return false.');",
         "assert(confirmEnding(\"If you want to save our world, you must hurry. We dont know how much longer we can withstand the nothing\", \"mountain\") === false, 'message: <code>confirmEnding(\"If you want to save our world, you must hurry. We dont know how much longer we can withstand the nothing\", \"mountain\")</code> should return false.');",
         "assert(confirmEnding(\"Abstraction\", \"action\") === true, 'message: <code>confirmEnding(\"Abstraction\", \"action\")</code> should return true.');",
-        "assert(!/\\.endsWith\\(.*?\\)\\s*?;?/.test(code), 'message: Do not use the built-in method <code>.endsWith()</code> to solve the challenge.');"
+        "assert(!(/\\.endsWith\\(.*?\\)\\s*?;?/.test(code)) && !(/\\['endsWith'\\]/.test(code)), 'message: Do not use the built-in method <code>.endsWith()</code> to solve the challenge.');"
       ],
       "type": "bonfire",
       "isRequired": true,


### PR DESCRIPTION
Fixes #15984.

Small bug fix to catch bracket notation when using String method endsWith() is prohibited.  Adding a second regex check is preferred to other methods such as monkey patching a global object.