### PR TITLE
fix(user): Changed streak calculation

### DIFF
--- a/server/utils/user-stats.js
+++ b/server/utils/user-stats.js
@@ -2,7 +2,8 @@ import _ from 'lodash';
 import moment from 'moment-timezone';
 import { dayCount } from '../utils/date-utils';
 
-const daysBetween = 1.5;
+// const daysBetween = 1.5;
+const hoursBetween = 24;
 
 export function prepUniqueDays(cals, tz = 'UTC') {
 
@@ -16,13 +17,13 @@ export function prepUniqueDays(cals, tz = 'UTC') {
 export function calcCurrentStreak(cals, tz = 'UTC') {
 
   let prev = _.last(cals);
-  if (moment().tz(tz).startOf('day').diff(prev, 'days') > daysBetween) {
+  if (moment().tz(tz).startOf('day').diff(prev, 'hours') > hoursBetween) {
     return 0;
   }
   let currentStreak = 0;
   let streakContinues = true;
   _.forEachRight(cals, cur => {
-    if (moment(prev).diff(cur, 'days') < daysBetween) {
+    if (moment(prev).startOf('day').diff(cur, 'hours') <= hoursBetween) {
       prev = cur;
       currentStreak++;
     } else {
@@ -41,7 +42,8 @@ export function calcLongestStreak(cals, tz = 'UTC') {
   const longest = cals.reduce((longest, head, index) => {
     const last = cals[index === 0 ? 0 : index - 1];
     // is streak broken
-    if (moment(head).tz(tz).diff(moment(last).tz(tz), 'days') > daysBetween) {
+    if (moment(head).tz(tz).startOf('day').diff(moment(last).tz(tz), 'hours')
+        > hoursBetween) {
       tail = head;
     }
     if (dayCount(longest, tz) < dayCount([head, tail], tz)) {


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #7925

#### Description
<!-- Describe your changes in detail -->
I first changed the streak calculation to use 24 hoursBetween instead of 1.5 daysBetween. Then I took the difference in hours of startOf('day') of the previous timestamp and current timestamp and compared it to hoursBetween to account for works that has been done the past 24 hours instead of the past day. (Sounds the same but probably worth a try)

BREAKING CHANGE: None that I know of.