### PR TITLE
fix(user): removed timezone to be more consistent with cal-heatmap.

### DIFF
--- a/server/utils/user-stats.js
+++ b/server/utils/user-stats.js
@@ -1,22 +1,22 @@
 import _ from 'lodash';
-import moment from 'moment-timezone';
+import moment from 'moment';
 import { dayCount } from '../utils/date-utils';
 
 const daysBetween = 1.5;
 
-export function prepUniqueDays(cals, tz = 'UTC') {
+export function prepUniqueDays(cals) {
 
   return _(cals)
-    .map(ts => moment(ts).tz(tz).startOf('day').valueOf())
+    .map(ts => moment(ts).startOf('day').valueOf())
     .uniq()
     .sort()
     .value();
 }
 
-export function calcCurrentStreak(cals, tz = 'UTC') {
+export function calcCurrentStreak(cals) {
 
   let prev = _.last(cals);
-  if (moment().tz(tz).startOf('day').diff(prev, 'days') > daysBetween) {
+  if (moment().startOf('day').diff(prev, 'days') > daysBetween) {
     return 0;
   }
   let currentStreak = 0;
@@ -35,20 +35,20 @@ export function calcCurrentStreak(cals, tz = 'UTC') {
   return currentStreak;
 }
 
-export function calcLongestStreak(cals, tz = 'UTC') {
+export function calcLongestStreak(cals) {
 
   let tail = cals[0];
   const longest = cals.reduce((longest, head, index) => {
     const last = cals[index === 0 ? 0 : index - 1];
     // is streak broken
-    if (moment(head).tz(tz).diff(moment(last).tz(tz), 'days') > daysBetween) {
+    if (moment(head).diff(moment(last), 'days') > daysBetween) {
       tail = head;
     }
-    if (dayCount(longest, tz) < dayCount([head, tail], tz)) {
+    if (dayCount(longest) < dayCount([head, tail])) {
       return [head, tail];
     }
     return longest;
   }, [cals[0], cals[0]]);
 
-  return dayCount(longest, tz);
+  return dayCount(longest);
 }


### PR DESCRIPTION
#### Description
I removed timezone from streak calculations to be more consistent with cal-heatmap since the cal-heatmap doesn't support setting your own timezone but instead it uses the browser timezone. More information here https://github.com/wa0x6e/cal-heatmap/issues/122.
Until we can set timezone on cal-heatmap I think it's a good idea to just use the browser timezone for consistency.

#### Heatmap
![heatmap](https://user-images.githubusercontent.com/23107862/32306403-7178de4c-bf51-11e7-8ba4-fbf16511038b.png)

#### Breaking Changes
The calculations in user-stats doesn't account for timezone parameters anymore therefore failing the user-stats.test.js

#### How to test
If you want to test this, this is the dummy account I used:
```
{ "_id" : ObjectId("59f9529123672248182de3d6"), "email" : "kennethlumalicay@gmail.com", "progressTimestamps" : [ { "timestamp" : 1509541091275 }, { "timestamp" : 1509422976454 }, { "timestamp" : 1509118429888 }, { "timestamp" : 1509094011916 }, { "timestamp" : 1508846560747 }, { "timestamp" : 1509090884785 }, { "timestamp" : 1508791163758 }, { "timestamp" : 1507882693520 }, { "timestamp" : 1508387868838 }, { "timestamp" : 1507886207014 }, { "timestamp" : 1508414926232 }, { "timestamp" : 1507737863410 }, { "timestamp" : 1508133780391 }, { "timestamp" : 1506752150466 }, { "timestamp" : 1506090458406 }, { "timestamp" : 1507106660736 }, { "timestamp" : 1507942473334 }, { "timestamp" : 1506043951235 }, { "timestamp" : 1505811257010 }, { "timestamp" : 1507783973798 }, { "timestamp" : 1508592804369 }, { "timestamp" : 1506652147775 }, { "timestamp" : 1507404720249 }, { "timestamp" : 1505705265824 }, { "timestamp" : 1503433539235 }, { "timestamp" : 1505534443634 }, { "timestamp" : 1508031845713 }, { "timestamp" : 1507279352595 }, { "timestamp" : 1505731069627 }, { "timestamp" : 1506556326690 }, { "timestamp" : 1505883327572 }, { "timestamp" : 1506930022608 }, { "timestamp" : 1505276999495 }, { "timestamp" : 1502163788147 }, { "timestamp" : 1504117987682 }, { "timestamp" : 1506395309181 }, { "timestamp" : 1504896728871 }, { "timestamp" : 1501431054701 }, { "timestamp" : 1500091166401 }, { "timestamp" : 1501959484269 }, { "timestamp" : 1505530603848 }, { "timestamp" : 1499048584372 }, { "timestamp" : 1505996284607 }, { "timestamp" : 1506622944991 }, { "timestamp" : 1505775602089 }, { "timestamp" : 1506035444312 }, { "timestamp" : 1506231335691 }, { "timestamp" : 1498150900835 }, { "timestamp" : 1503809524114 }, { "timestamp" : 1506843817921 }, { "timestamp" : 1501814760198 }, { "timestamp" : 1498296425718 }, { "timestamp" : 1497766918671 }, { "timestamp" : 1495942021469 }, { "timestamp" : 1506884485608 }, { "timestamp" : 1499856043770 }, { "timestamp" : 1497671844083 }, { "timestamp" : 1499495519435 }, { "timestamp" : 1504185599654 }, { "timestamp" : 1501041166579 }, { "timestamp" : 1499762283970 }, { "timestamp" : 1498650447835 }, { "timestamp" : 1494335206747 }, { "timestamp" : 1496950114198 }, { "timestamp" : 1500463538838 }, { "timestamp" : 1494860755255 }, { "timestamp" : 1493172988571 }, { "timestamp" : 1497024560620 }, { "timestamp" : 1503193962472 }, { "timestamp" : 1500332674008 }, { "timestamp" : 1492122996493 }, { "timestamp" : 1493893096413 }, { "timestamp" : 1495332696040 }, { "timestamp" : 1497035194606 }, { "timestamp" : 1504884808574 }, { "timestamp" : 1504502626439 }, { "timestamp" : 1503944181630 }, { "timestamp" : 1498558764920 }, { "timestamp" : 1504541691365 }, { "timestamp" : 1502057587229 }, { "timestamp" : 1501939784394 }, { "timestamp" : 1493863633174 }, { "timestamp" : 1505859770347 }, { "timestamp" : 1499500359638 }, { "timestamp" : 1499660925053 }, { "timestamp" : 1490649529283 }, { "timestamp" : 1490499865807 }, { "timestamp" : 1489645140769 }, { "timestamp" : 1489321470670 }, { "timestamp" : 1488422740024 }, { "timestamp" : 1495857201419 }, { "timestamp" : 1502179763962 }, { "timestamp" : 1495482119826 }, { "timestamp" : 1501900891920 }, { "timestamp" : 1496254283799 }, { "timestamp" : 1487457523475 }, { "timestamp" : 1485896704009 }, { "timestamp" : 1497273324811 }, { "timestamp" : 1488793437407 }, { "timestamp" : 1499130753072 } ], "isBanned" : false, "isCheater" : false, "isGithubCool" : false, "isMigrationGrandfathered" : false, "username" : "kenneth", "bio" : "", "name" : "", "gender" : "", "location" : "", "picture" : "https://s3.amazonaws.com/freecodecamp/camper-image-placeholder.png", "currentStreak" : 0, "longestStreak" : 0, "sendMonthlyEmail" : true, "sendNotificationEmail" : true, "sendQuincyEmail" : true, "isLocked" : false, "isAvailableForHire" : false, "currentChallengeId" : "", "isUniqMigrated" : false, "isHonest" : false, "isFrontEndCert" : false, "isDataVisCert" : false, "isBackEndCert" : false, "isFullStackCert" : false, "isChallengeMapMigrated" : true, "challengeMap" : {  }, "completedChallenges" : [ ], "rand" : 0.8931794562530122, "theme" : "default", "languageTag" : "en", "badges" : { "coreTeam" : [ ] }, "emailVerified" : true, "emailAuthLinkTTL" : null, "emailVerifyTTL" : null }
```
Insert this in freecodecamp db under user collections. Then go to http://localhost:3000/en/kenneth.

<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [ ] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [x] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #7925
