### PR TITLE
fix(user): new function to compute unique days within hours.

### DIFF
--- a/server/boot/user.js
+++ b/server/boot/user.js
@@ -17,7 +17,7 @@ import {
 } from '../utils/middleware';
 import { observeQuery } from '../utils/rx';
 import {
-  prepUniqueDays,
+  prepUniqueDaysByHours,
   calcCurrentStreak,
   calcLongestStreak
 } from '../utils/user-stats';
@@ -492,7 +492,7 @@ module.exports = function(app) {
     // not of the profile she is viewing
     const timezone = user && user.timezone ?
       user.timezone :
-      'UTC';
+      'EST';
 
     const query = {
       where: { username },
@@ -517,10 +517,10 @@ module.exports = function(app) {
               objOrNum.timestamp;
           });
 
-        const uniqueDays = prepUniqueDays(timestamps, timezone);
+        const uniqueHours = prepUniqueDaysByHours(timestamps, timezone);
 
-        userPortfolio.currentStreak = calcCurrentStreak(uniqueDays, timezone);
-        userPortfolio.longestStreak = calcLongestStreak(uniqueDays, timezone);
+        userPortfolio.currentStreak = calcCurrentStreak(uniqueHours, timezone);
+        userPortfolio.longestStreak = calcLongestStreak(uniqueHours, timezone);
 
         const calender = userPortfolio
           .progressTimestamps

--- a/server/utils/user-stats.js
+++ b/server/utils/user-stats.js
@@ -1,25 +1,64 @@
-import _ from 'lodash';
+import compose from 'lodash/fp/compose';
+import map from 'lodash/fp/map';
+import sortBy from 'lodash/fp/sortBy';
+import trans from 'lodash/fp/transform';
+import last from 'lodash/fp/last';
+import forEachRight from 'lodash/fp/forEachRight';
 import moment from 'moment-timezone';
 import { dayCount } from '../utils/date-utils';
 
-const daysBetween = 1.5;
+const transform = trans.convert({ cap: false });
 
-export function prepUniqueDays(cals, tz = 'UTC') {
-  return _.uniq(
-    _.map(cals, ts => moment(ts).tz(tz).startOf('day').valueOf())
-  ).sort();
+const hoursBetween = 24;
+const hoursDay = 24;
+
+export function prepUniqueDaysByHours(cals, tz = 'UTC') {
+
+  let prev = null;
+
+  // compose goes bottom to top (map > sortBy > transform)
+  return compose(
+    transform((data, cur, i) => {
+      if (i < 1) {
+        data.push(cur);
+        prev = cur;
+      } else if (
+        moment(cur)
+          .tz(tz)
+          .diff(moment(prev).tz(tz).startOf('day'), 'hours')
+        >= hoursDay
+      ) {
+        data.push(cur);
+        prev = cur;
+      }
+    }, []),
+    sortBy(e => e),
+    map(ts => moment(ts).tz(tz).startOf('hours').valueOf())
+  )(cals);
 }
 
 export function calcCurrentStreak(cals, tz = 'UTC') {
 
-  let prev = _.last(cals);
-  if (moment().tz(tz).startOf('day').diff(prev, 'days') > daysBetween) {
+  let prev = last(cals);
+  if (
+    moment()
+      .tz(tz)
+      .startOf('day')
+      .diff(moment(prev).tz(tz), 'hours')
+    > hoursBetween
+  ) {
     return 0;
   }
   let currentStreak = 0;
   let streakContinues = true;
-  _.forEachRight(cals, cur => {
-    if (moment(prev).diff(cur, 'days') < daysBetween) {
+  forEachRight(cur => {
+    if (
+      moment(prev)
+        .tz(tz)
+        .startOf('day')
+        .diff(moment(cur).tz(tz), 'hours')
+      <= hoursBetween
+    ) {
       prev = cur;
       currentStreak++;
     } else {
@@ -27,7 +66,7 @@ export function calcCurrentStreak(cals, tz = 'UTC') {
       streakContinues = false;
     }
     return streakContinues;
-  });
+  })(cals);
 
   return currentStreak;
 }
@@ -38,7 +77,8 @@ export function calcLongestStreak(cals, tz = 'UTC') {
   const longest = cals.reduce((longest, head, index) => {
     const last = cals[index === 0 ? 0 : index - 1];
     // is streak broken
-    if (moment(head).tz(tz).diff(moment(last).tz(tz), 'days') > daysBetween) {
+    if (moment(head).tz(tz).startOf('day').diff(moment(last).tz(tz), 'hours')
+        > hoursBetween) {
       tail = head;
     }
     if (dayCount(longest, tz) < dayCount([head, tail], tz)) {

--- a/server/utils/user-stats.test.js
+++ b/server/utils/user-stats.test.js
@@ -3,7 +3,7 @@ import moment from 'moment-timezone';
 import sinon from 'sinon';
 
 import {
-  prepUniqueDays,
+  prepUniqueDaysByHours,
   calcCurrentStreak,
   calcLongestStreak
 } from './user-stats';
@@ -17,48 +17,48 @@ test('Prepare calendar items', function(t) {
   t.plan(5);
 
   t.deepEqual(
-    prepUniqueDays([
+    prepUniqueDaysByHours([
       moment.utc('8/3/2015 2:00', 'M/D/YYYY H:mm').valueOf(),
       moment.utc('8/3/2015 14:00', 'M/D/YYYY H:mm').valueOf(),
       moment.utc('8/3/2015 20:00', 'M/D/YYYY H:mm').valueOf()
     ]),
-    [1438560000000],
+    [1438567200000],
     'should return correct epoch when all entries fall into one day in UTC'
   );
 
   t.deepEqual(
-    prepUniqueDays([
+    prepUniqueDaysByHours([
       moment.utc('8/3/2015 2:00', 'M/D/YYYY H:mm').valueOf(),
       moment.utc('8/3/2015 2:00', 'M/D/YYYY H:mm').valueOf()
     ]),
-    [1438560000000],
+    [1438567200000],
     'should return correct epoch when given two identical dates'
   );
 
 
   t.deepEqual(
-    prepUniqueDays([
+    prepUniqueDaysByHours([
       // 8/2/2015 in America/Los_Angeles
       moment.utc('8/3/2015 2:00', 'M/D/YYYY H:mm').valueOf(),
       moment.utc('8/3/2015 14:00', 'M/D/YYYY H:mm').valueOf(),
       moment.utc('8/3/2015 20:00', 'M/D/YYYY H:mm').valueOf()
     ], PST),
-    [1438498800000, 1438585200000],
+    [1438567200000, 1438610400000],
     'should return 2 epochs when dates fall into two days in PST'
   );
 
   t.deepEqual(
-    prepUniqueDays([
+    prepUniqueDaysByHours([
       moment.utc('8/1/2015 2:00', 'M/D/YYYY H:mm').valueOf(),
       moment.utc('3/3/2015 14:00', 'M/D/YYYY H:mm').valueOf(),
       moment.utc('9/30/2014 20:00', 'M/D/YYYY H:mm').valueOf()
     ]),
-    [1412035200000, 1425340800000, 1438387200000],
+    [1412107200000, 1425391200000, 1438394400000],
     'should return 3 epochs when dates fall into three days'
   );
 
   t.deepEqual(
-    prepUniqueDays([
+    prepUniqueDaysByHours([
       1438387200000, 1425340800000, 1412035200000
     ]),
     [1412035200000, 1425340800000, 1438387200000],
@@ -73,7 +73,7 @@ test('Current streak calculation', function(t) {
 
   t.equal(
     calcCurrentStreak(
-      prepUniqueDays([
+      prepUniqueDaysByHours([
         moment.utc(moment.utc().subtract(1, 'hours')).valueOf()
       ])
     ),
@@ -83,7 +83,7 @@ test('Current streak calculation', function(t) {
 
   t.equal(
     calcCurrentStreak(
-      prepUniqueDays([
+      prepUniqueDaysByHours([
         moment.utc(moment.utc().subtract(1, 'hours')).valueOf(),
         moment.utc(moment.utc().subtract(1, 'hours')).valueOf()
       ])
@@ -94,7 +94,7 @@ test('Current streak calculation', function(t) {
 
   t.equal(
     calcCurrentStreak(
-      prepUniqueDays([
+      prepUniqueDaysByHours([
         moment.utc('9/11/2015 4:00', 'M/D/YYYY H:mm').valueOf()
       ])
     ),
@@ -104,7 +104,7 @@ test('Current streak calculation', function(t) {
 
   t.equal(
     calcCurrentStreak(
-      prepUniqueDays([
+      prepUniqueDaysByHours([
         moment.utc(moment.utc().subtract(1, 'days')).valueOf(),
         moment.utc(moment.utc().subtract(1, 'hours')).valueOf()
       ])
@@ -115,7 +115,7 @@ test('Current streak calculation', function(t) {
 
   t.equal(
     calcCurrentStreak(
-      prepUniqueDays([
+      prepUniqueDaysByHours([
         moment.utc('8/3/2015 2:00', 'M/D/YYYY H:mm').valueOf(),
         moment.utc('9/11/2015 4:00', 'M/D/YYYY H:mm').valueOf(),
         moment.utc('9/12/2015 1:00', 'M/D/YYYY H:mm').valueOf(),
@@ -135,7 +135,7 @@ test('Current streak calculation', function(t) {
 
   t.equal(
     calcCurrentStreak(
-      prepUniqueDays([
+      prepUniqueDaysByHours([
         moment.utc(moment.utc().subtract(47, 'hours')).valueOf(),
         moment.utc(moment.utc().subtract(11, 'hours')).valueOf()
       ])
@@ -147,7 +147,7 @@ test('Current streak calculation', function(t) {
 
   t.equal(
     calcCurrentStreak(
-      prepUniqueDays([
+      prepUniqueDaysByHours([
         moment.utc(moment.utc().subtract(40, 'hours')).valueOf(),
         moment.utc(moment.utc().subtract(1, 'hours')).valueOf()
       ])
@@ -159,7 +159,7 @@ test('Current streak calculation', function(t) {
 
   t.equal(
     calcCurrentStreak(
-      prepUniqueDays([
+      prepUniqueDaysByHours([
         moment.utc(moment.utc().subtract(1, 'hours')).valueOf(),
         moment.utc(moment.utc().subtract(1, 'hours')).valueOf()
       ])
@@ -171,7 +171,7 @@ test('Current streak calculation', function(t) {
 
   t.equal(
     calcCurrentStreak(
-      prepUniqueDays([
+      prepUniqueDaysByHours([
         moment.utc(moment.utc().subtract(1, 'days')).valueOf(),
         moment.utc(moment.utc().subtract(1, 'hours')).valueOf()
       ], PST),
@@ -184,7 +184,7 @@ test('Current streak calculation', function(t) {
 
   t.equal(
     calcCurrentStreak(
-      prepUniqueDays([
+      prepUniqueDaysByHours([
         1453174506164, 1453175436725, 1453252466853, 1453294968225,
         1453383782844, 1453431903117, 1453471373080, 1453594733026,
         1453645014058, 1453746762747, 1453747659197, 1453748029416,
@@ -201,7 +201,7 @@ test('Current streak calculation', function(t) {
 
   t.equal(
     calcCurrentStreak(
-      prepUniqueDays([
+      prepUniqueDaysByHours([
         1453174506164, 1453175436725, 1453252466853, 1453294968225,
         1453383782844, 1453431903117, 1453471373080, 1453594733026,
         1453645014058, 1453746762747, 1453747659197, 1453748029416,
@@ -221,7 +221,7 @@ test('Longest streak calculation', function(t) {
 
   t.equal(
     calcLongestStreak(
-      prepUniqueDays([
+      prepUniqueDaysByHours([
         moment.utc('9/12/2015 4:00', 'M/D/YYYY H:mm').valueOf()
       ])
     ),
@@ -231,7 +231,7 @@ test('Longest streak calculation', function(t) {
 
   t.equal(
     calcLongestStreak(
-      prepUniqueDays([
+      prepUniqueDaysByHours([
         moment.utc('9/11/2015 4:00', 'M/D/YYYY H:mm').valueOf(),
         moment.utc('9/12/2015 2:00', 'M/D/YYYY H:mm').valueOf(),
         moment.utc('9/13/2015 3:00', 'M/D/YYYY H:mm').valueOf(),
@@ -245,7 +245,7 @@ test('Longest streak calculation', function(t) {
 
   t.equal(
     calcLongestStreak(
-      prepUniqueDays([
+      prepUniqueDaysByHours([
         moment.utc(moment.utc().subtract(1, 'hours')).valueOf()
       ])
     ),
@@ -255,7 +255,7 @@ test('Longest streak calculation', function(t) {
 
   t.equal(
     calcLongestStreak(
-      prepUniqueDays([
+      prepUniqueDaysByHours([
         moment.utc(moment.utc().subtract(1, 'days')).valueOf(),
         moment.utc(moment.utc().subtract(1, 'hours')).valueOf()
       ])
@@ -266,7 +266,7 @@ test('Longest streak calculation', function(t) {
 
   t.equal(
     calcLongestStreak(
-      prepUniqueDays([
+      prepUniqueDaysByHours([
         moment.utc('8/3/2015 2:00', 'M/D/YYYY H:mm').valueOf(),
         moment.utc('9/11/2015 4:00', 'M/D/YYYY H:mm').valueOf(),
         moment.utc('9/12/2015 2:00', 'M/D/YYYY H:mm').valueOf(),
@@ -283,7 +283,7 @@ test('Longest streak calculation', function(t) {
 
   t.equal(
     calcLongestStreak(
-      prepUniqueDays([
+      prepUniqueDaysByHours([
         moment.utc('8/3/2015 2:00', 'M/D/YYYY H:mm').valueOf(),
         moment.utc('9/11/2015 4:00', 'M/D/YYYY H:mm').valueOf(),
         moment.utc('9/12/2015 15:30', 'M/D/YYYY H:mm').valueOf(),
@@ -302,7 +302,7 @@ test('Longest streak calculation', function(t) {
 
   t.equal(
     calcLongestStreak(
-      prepUniqueDays([
+      prepUniqueDaysByHours([
         moment.utc('8/3/2015 2:00', 'M/D/YYYY H:mm').valueOf(),
         moment.utc('9/11/2015 4:00', 'M/D/YYYY H:mm').valueOf(),
         moment.utc('9/12/2015 1:00', 'M/D/YYYY H:mm').valueOf(),
@@ -323,7 +323,7 @@ test('Longest streak calculation', function(t) {
 
   t.equal(
     calcLongestStreak(
-      prepUniqueDays([
+      prepUniqueDaysByHours([
         moment.utc('8/3/2015 2:00', 'M/D/YYYY H:mm').valueOf(),
         moment.utc('9/11/2015 4:00', 'M/D/YYYY H:mm').valueOf(),
         moment.utc('9/12/2015 1:00', 'M/D/YYYY H:mm').valueOf(),
@@ -346,14 +346,14 @@ test('Longest streak calculation', function(t) {
   }
 
   t.equal(
-    calcLongestStreak(prepUniqueDays(cals)),
+    calcLongestStreak(prepUniqueDaysByHours(cals)),
     n,
     'should return correct longest streak when there is a very long period'
   );
 
   t.equal(
     calcLongestStreak(
-      prepUniqueDays([
+      prepUniqueDaysByHours([
         moment.utc(moment.utc().subtract(1, 'days')).valueOf(),
         moment.utc(moment.utc().subtract(1, 'hours')).valueOf()
       ])
@@ -365,7 +365,7 @@ test('Longest streak calculation', function(t) {
 
   t.equal(
     calcLongestStreak(
-      prepUniqueDays([
+      prepUniqueDaysByHours([
         moment.utc('9/11/2015 4:00', 'M/D/YYYY H:mm').valueOf(),
         moment.utc('9/12/2015 2:00', 'M/D/YYYY H:mm').valueOf(),
         moment.utc('9/13/2015 3:00', 'M/D/YYYY H:mm').valueOf(),
@@ -379,7 +379,7 @@ test('Longest streak calculation', function(t) {
 
   t.equal(
     calcLongestStreak(
-      prepUniqueDays([
+      prepUniqueDaysByHours([
         moment.utc('9/11/2015 23:00', 'M/D/YYYY H:mm').valueOf(),
         moment.utc('9/12/2015 2:00', 'M/D/YYYY H:mm').valueOf(),
         moment.utc('9/13/2015 2:00', 'M/D/YYYY H:mm').valueOf(),
@@ -393,7 +393,7 @@ test('Longest streak calculation', function(t) {
 
   t.equal(
     calcLongestStreak(
-      prepUniqueDays([
+      prepUniqueDaysByHours([
         1453174506164, 1453175436725, 1453252466853, 1453294968225,
         1453383782844, 1453431903117, 1453471373080, 1453594733026,
         1453645014058, 1453746762747, 1453747659197, 1453748029416,
@@ -410,7 +410,7 @@ test('Longest streak calculation', function(t) {
 
   t.equal(
     calcLongestStreak(
-      prepUniqueDays([
+      prepUniqueDaysByHours([
         1453174506164, 1453175436725, 1453252466853, 1453294968225,
         1453383782844, 1453431903117, 1453471373080, 1453594733026,
         1453645014058, 1453746762747, 1453747659197, 1453748029416,


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #7925

### Description
<!-- Describe your changes in detail -->
Made a new function to prep unique days based on hours from the previous data instead of startOf day.
#### Then

- Everything is turned into `startOf('day')` and then `.uniq()` to avoid duplicates. This method turns all timestamp's hours into 12am(?) of that day thus difference in days within timestamps can only be integers.

#### Now

- Timestamps are sorted then reduced. If the data is over hoursDay(24) of the previous data it is pushed into the accumulator. This method keeps the hours of the timestamps.

- Calculations uses hoursBetween(24) instead of daysBetween(1.5).

- Calculations are done by taking 12am of the latest day and checks if the previous timestamp is within 24 hours.

- Also changed default to EST.

### Findings
![heatmapfix](https://user-images.githubusercontent.com/23107862/32370234-a3eda134-c062-11e7-9310-48b7056ac05a.png)

hoursBetween 24 is more accurate but despite being accurate it still has a leeway between timestamps as the timestamp's difference is calculated using the previous timestamp's 12am and the time of current timestamp and checks if it's within 24 hours.
e.g.
`2017-11-02T23:00:00.000` and `2017-11-01T08:00:00.000` would still count as a streak despite being 39 hours apart because we check using `2017-11-02T00:00:00.000` and see if `2017-11-01T08:00:00.000` is still within 24 hours.

@QuincyLarson 

PS: I didn't delete prepUniqueDays although it's not being used anymore. Also haven't made unit tests.