### PR TITLE
fix(auth): Add keyword in email support for passwordless

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -515,7 +515,7 @@ module.exports = function(User) {
           .flatMap(token => {
 
           const { id: loginToken } = token;
-          const loginEmail = user.email;
+          const loginEmail = new Buffer(user.email).toString('base64');
           const host = getServerFullURL();
           const mailOptions = {
             type: 'email',

--- a/server/boot/user.js
+++ b/server/boot/user.js
@@ -269,7 +269,7 @@ module.exports = function(app) {
     }
 
     const authTokenId = req.query.token;
-    const authEmailId = req.query.email;
+    const authEmailId = new Buffer(req.query.email, 'base64').toString();
 
     return AccessToken.findOne$({ where: {id: authTokenId} })
      .map(authToken => {
@@ -319,7 +319,7 @@ module.exports = function(app) {
       return res.redirect('/email-signin');
     }
 
-    const email = req.query.email;
+    const email = new Buffer(req.query.email, 'base64').toString();
 
     return User.findOne$({ where: { email }})
       .map(user => {


### PR DESCRIPTION
This adds the support for keyword in emails, by adding simple base64 encoding.

Closes #16070 