### PR TITLE
fix(sitemap): Update challenge urls to use new url format

### DIFF
--- a/server/boot/sitemap.js
+++ b/server/boot/sitemap.js
@@ -10,19 +10,19 @@ const appUrl = 'https://www.freecodecamp.org';
 //   app: ExpressApp,
 //   modelName: String,
 //   nameProp: String,
+//   blockProp: String,
 //   map: (nameProp: String) => String
 // ) => Observable[models]
-function getCachedObservable(app, modelName, nameProp, map) {
+function getCachedObservable(app, modelName, nameProp, blockProp, map) {
   return observeQuery(
     app.models[modelName],
     'find',
-    { fields: { [nameProp]: true } }
+    { fields: { [nameProp]: true, [blockProp]: true } }
   )
     .flatMap(models => {
       return Observable.from(models, null, null, Scheduler.default);
     })
-    .filter(model => !!model[nameProp])
-    .map(model => model[nameProp])
+    .filter(model => !!model[nameProp] && !!model[blockProp])
     .map(map ? map : (x) => x)
     .toArray()
     ::timeCache(cacheTimeout[0], cacheTimeout[1]);
@@ -30,7 +30,8 @@ function getCachedObservable(app, modelName, nameProp, map) {
 
 export default function sitemapRouter(app) {
   const router = app.loopback.Router();
-  const challenges$ = getCachedObservable(app, 'Challenge', 'dashedName');
+  const challengeProps = ['dashedName', 'block'];
+  const challenges$ = getCachedObservable(app, 'Challenge', ...challengeProps);
   const stories$ = getCachedObservable(app, 'Story', 'storyLink', dasherize);
   function sitemap(req, res, next) {
     const now = moment(new Date()).format('YYYY-MM-DD');

--- a/server/views/resources/sitemap.jade
+++ b/server/views/resources/sitemap.jade
@@ -87,7 +87,7 @@ urlset(xmlns="http://www.sitemaps.org/schemas/sitemap/0.9")
 
   each challenge in challenges
     url
-      loc #{appUrl}/challenges/#{challenge}
+      loc #{appUrl}/challenges/#{challenge.block}/#{challenge.dashedName}
       lastmod= now
       changefreq weekly
       priority= 0.9


### PR DESCRIPTION
Closes #16121

<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #16121 

#### Description
<!-- Describe your changes in detail -->

I updated the query to the Challenge model coming from `sitemap.js` to include the model's `block` field so that I could use it to update the urls in `sitemap.xml`.
