### PR TITLE
fix(rechallenge): Use includes instead of contains

### DIFF
--- a/common/app/routes/Challenges/rechallenge/transformers.js
+++ b/common/app/routes/Challenges/rechallenge/transformers.js
@@ -56,7 +56,7 @@ export const addLoopProtectHtmlJsJsx = _.cond([
       testHTMLJS,
       _.partial(
         vinyl.testContents,
-        contents => contents.toLowerCase().contians('<script>')
+        contents => contents.toLowerCase().includes('<script>')
       )
     ),
     addLoopProtect


### PR DESCRIPTION
https://github.com/freeCodeCamp/freeCodeCamp/blob/d3bbf27dab0247c1590531de0f966f1cb5636783/common/app/routes/Challenges/rechallenge/transformers.js#L59

There is a typo above that is renders the challenges not executable.

`contians`

Closes #16193 