### PR TITLE
fix(common): Fix for loopProtect undefined error

### DIFF
--- a/common/app/routes/Challenges/rechallenge/builders.js
+++ b/common/app/routes/Challenges/rechallenge/builders.js
@@ -19,6 +19,20 @@ import {
 
 const htmlCatch = '\n<!--fcc-->\n';
 const jsCatch = '\n;/*fcc*/\n';
+const loopProtector = `
+  window.loopProtect = parent.loopProtect;
+  window.__err = null;
+  window.loopProtect.hit = function(line) {
+    window.__err = new Error(
+      'Potential infinite loop at line ' +
+      line +
+      '. To disable loop protection, write:' +
+      ' // noprotect as the first' +
+      ' line. Beware that if you do have an infinite loop in your code' +
+      ' this will crash your browser.'
+    );
+  };
+`;
 const defaultTemplate = ({ source }) => `
   <body style='margin:8px;'>
     <!-- fcc-start-source -->
@@ -28,7 +42,7 @@ const defaultTemplate = ({ source }) => `
 `;
 
 const wrapInScript = partial(transformContents, (content) => (
-  `${htmlCatch}<script>${content}${jsCatch}</script>`
+  `${htmlCatch}<script>${loopProtector}${content}${jsCatch}</script>`
 ));
 const wrapInStyle = partial(transformContents, (content) => (
   `${htmlCatch}<style>${content}</style>`


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #16260

#### Description
<!-- Describe your changes in detail -->

Edited the file so that the loopProtect code, which is in the head of
the iframe on www.freecodecamp.org, is in the same script tag as the
base challenge content that get's rendered to the page. While the
loopProtect code is not rendered to the page like the rest of the
challenge code, it's within the same scope and seems to function
normally.

BREAKING CHANGE: None that I know of, but will keep checking.