### PR TITLE
fix(step-challenge): Fix duplicate keys in Step

### DIFF
--- a/common/app/routes/Challenges/views/step/Step.jsx
+++ b/common/app/routes/Challenges/views/step/Step.jsx
@@ -167,16 +167,17 @@ export class StepChallenge extends PureComponent {
     );
   }
 
-  renderStep({
-    clickOnImage,
-    completeAction,
-    currentIndex,
-    isActionCompleted,
-    isLastStep,
-    numOfSteps,
-    step,
-    stepBackward,
-    stepForward
+  renderStep(
+    {
+      clickOnImage,
+      completeAction,
+      currentIndex,
+      isActionCompleted,
+      isLastStep,
+      numOfSteps,
+      step,
+      stepBackward,
+      stepForward
   }) {
     if (!Array.isArray(step)) {
       return null;

--- a/common/app/routes/Challenges/views/step/Step.jsx
+++ b/common/app/routes/Challenges/views/step/Step.jsx
@@ -177,13 +177,13 @@ export class StepChallenge extends PureComponent {
     step,
     stepBackward,
     stepForward
-  }) {
+  }, index) {
     if (!Array.isArray(step)) {
       return null;
     }
     const [imgUrl, imgAlt, info, action] = step;
     return (
-      <div key={ imgUrl }>
+      <div key={ `${imgUrl}-step-wrapper-${index}` }>
         <a
           href={ imgUrl }
           onClick={ clickOnImage }
@@ -241,8 +241,8 @@ export class StepChallenge extends PureComponent {
     if (!Array.isArray(steps)) {
       return null;
     }
-    return steps.map(([ imgUrl, imgAlt ]) => (
-      <div key={ imgUrl }>
+    return steps.map(([ imgUrl, imgAlt ], index) => (
+      <div key={ `${imgUrl}-images-wrapper-${index}` }>
         <Image
           alt={ imgAlt }
           responsive={ true }

--- a/common/app/routes/Challenges/views/step/Step.jsx
+++ b/common/app/routes/Challenges/views/step/Step.jsx
@@ -177,13 +177,13 @@ export class StepChallenge extends PureComponent {
     step,
     stepBackward,
     stepForward
-  }, index) {
+  }) {
     if (!Array.isArray(step)) {
       return null;
     }
     const [imgUrl, imgAlt, info, action] = step;
     return (
-      <div key={ `${imgUrl}-step-wrapper-${index}` }>
+      <div key={ `${info.slice(0, 15)}` }>
         <a
           href={ imgUrl }
           onClick={ clickOnImage }
@@ -241,8 +241,8 @@ export class StepChallenge extends PureComponent {
     if (!Array.isArray(steps)) {
       return null;
     }
-    return steps.map(([ imgUrl, imgAlt ], index) => (
-      <div key={ `${imgUrl}-images-wrapper-${index}` }>
+    return steps.map(([ imgUrl, imgAlt, info ]) => (
+      <div key={ `${info.slice(0, 15)}` }>
         <Image
           alt={ imgAlt }
           responsive={ true }

--- a/common/app/routes/Challenges/views/step/redux/index.js
+++ b/common/app/routes/Challenges/views/step/redux/index.js
@@ -63,10 +63,7 @@ export const actionCompletedSelector = state => getNS(state).isActionCompleted;
 
 export default handleActions(
   () => ({
-    [challenges.challengeUpdated]: () => {
-      console.log('updating step ui');
-      return initialState;
-    },
+    [challenges.challengeUpdated]: () => initialState,
     [types.goToStep]: (state, { payload: { step = 0, isUnlocked }}) => ({
       ...state,
       currentIndex: step,


### PR DESCRIPTION
This PR fixes an issue in `Step.jsx` where if the step had no associated image, react would lose track of elements because of duplicate keys.

This PR addresses that by assigning unique keys to `Step` elements using strings and an `index`