### PR TITLE
fix(visual): Flash notifications now do not overlap with naviga

### DIFF
--- a/server/views/partials/flash.jade
+++ b/server/views/partials/flash.jade
@@ -1,5 +1,5 @@
 .container
-    .row.flashMessage.negative-30
+    .row.flashMessage
         .col-xs-12.col-sm-8.col-sm-offset-2.col-md-6.col-md-offset-3
             if (messages.errors || messages.error)
               .alert.alert-danger.fade.in


### PR DESCRIPTION
removed negative-30 class used in partial view

Closes #16267
