### PR TITLE
[Beta] Fix(16258) - Update beta lesson buttons to match production

### DIFF
--- a/common/app/routes/Challenges/Tool-Panel.jsx
+++ b/common/app/routes/Challenges/Tool-Panel.jsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { Button, ButtonGroup, Tooltip, OverlayTrigger } from 'react-bootstrap';
+import { Button, Tooltip, OverlayTrigger } from 'react-bootstrap';
 
 const unlockWarning = (
   <Tooltip id='tooltip'>
@@ -99,6 +99,7 @@ export default class ToolPanel extends PureComponent {
       openBugModal,
       unlockUntrustedCode
     } = this.props;
+
     return (
       <div>
         { this.renderHint(hint, this.makeHint) }
@@ -110,36 +111,31 @@ export default class ToolPanel extends PureComponent {
           )
         }
         <div className='button-spacer' />
-        <ButtonGroup
-          className='input-group'
-          justified={ true }
-          >
           <Button
-            bsSize='large'
             bsStyle='primary'
-            componentClass='label'
+            className='btn-big btn-block'
             onClick={ this.makeReset }
             >
-            Reset
+          Reset your code
           </Button>
+          <div className='button-spacer' />
           <Button
-            bsSize='large'
             bsStyle='primary'
+            className='btn-big btn-block'
             componentClass='a'
             href={ `https://gitter.im/freecodecamp/${helpChatRoom}` }
             target='_blank'
             >
-            Help
+          Get a hint
           </Button>
+          <div className='button-spacer' />
           <Button
-            bsSize='large'
             bsStyle='primary'
-            componentClass='label'
+            className='btn-big btn-block'
             onClick={ openBugModal }
             >
-            Bug
+          Ask for help on the forum
           </Button>
-        </ButtonGroup>
         <div className='button-spacer' />
       </div>
     );


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [ ] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #XXXXX

#### Description
This PR makes the buttons for a lesson like the production ... I figured out that we were using ButtonGroup module and didn't use btn-Block class for each button so a button can stretch and take the whole space. Also had to add " <div className='button-spacer' /> " after each button to keep elegant look.
