### PR TITLE
fix: Homepage responsiveness

### DIFF
--- a/server/views/home.jade
+++ b/server/views/home.jade
@@ -51,29 +51,29 @@ block content
         .spacer
         .row
             .text-center.negative-35
-                .col-xs-12.col-sm-12.col-md-3
+                .col-xs-12.col-sm-6.col-md-3
                     .landing-skill-icon.ion-social-html5
                     h2.black-text HTML5
-                .col-xs-12.col-sm-12.col-md-3
+                .col-xs-12.col-sm-6.col-md-3
                     .landing-skill-icon.ion-social-css3
                     h2.black-text CSS3
-                .col-xs-12.col-sm-12.col-md-3
+                .col-xs-12.col-sm-6.col-md-3
                     .landing-skill-icon.ion-social-javascript
                     h2.black-text JavaScript
-                .col-xs-12.col-sm-12.col-md-3
+                .col-xs-12.col-sm-6.col-md-3
                     .landing-skill-icon.fa.fa-database.font-awesome-padding
                     h2.black-text Databases
-                .col-xs-12.col-sm-12.col-md-3
+                .col-xs-12.col-sm-6.col-md-3
                     .landing-skill-icon.ion-social-github
                     h2.black-text Git & GitHub
-                .col-xs-12.col-sm-12.col-md-3
+                .col-xs-12.col-sm-6.col-md-3
                     .landing-skill-icon.ion-social-nodejs
                     h2.black-text Node.js
-                .col-xs-12.col-sm-12.col-md-3
+                .col-xs-12.col-sm-6.col-md-3
                     .landing-skill-icon.custom-landing-skill-icon
                         img(src='https://s3.amazonaws.com/freecodecamp/react.svg')
                     h2.black-text React.js
-                .col-xs-12.col-sm-12.col-md-3
+                .col-xs-12.col-sm-6.col-md-3
                     .landing-skill-icon.custom-landing-skill-icon
                         img(src='https://s3.amazonaws.com/freecodecamp/d3-logo.svg')
                     h2.black-text D3.js


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #16323

#### Description
<!-- Describe your changes in detail -->
Changed the Bootstrap class on skills from `col-sm-12` to `col-sm-6`. This makes it so screen width between 768px and 1030px have 2 skills per row instead of just one. It is now much easier to read without all the whitespace around, see screenshots.
Note: This does not change the styles for screens under 768px(1 per row) and over 1030px(4 per row)

BEFORE
![before](https://user-images.githubusercontent.com/13804601/34345043-3ec40cce-e9c2-11e7-8d6e-cb005084ae70.png)

AFTER
![after](https://user-images.githubusercontent.com/13804601/34345045-4311da90-e9c2-11e7-8f03-093671a864bb.png)
