### PR TITLE
fix(challenges): Change e.meta to e.metaKey

### DIFF
--- a/common/app/routes/Challenges/Completion-Modal.jsx
+++ b/common/app/routes/Challenges/Completion-Modal.jsx
@@ -28,7 +28,7 @@ const mapDispatchToProps = function(dispatch) {
   const dispatchers = {
     close: () => dispatch(closeChallengeModal()),
     handleKeypress: (e) => {
-      if (e.keyCode === 13 && (e.ctrlKey || e.meta)) {
+      if (e.keyCode === 13 && (e.ctrlKey || e.metaKey)) {
         dispatch(submitChallenge());
       }
     },


### PR DESCRIPTION
The Command + Enter was not working on Mac in completition modal

Closes #16352


#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #16352

#### Description
The `Command + Enter` combination was not working on Mac in Completition Modal so I fixed `e.meta` to a `e.metaKey`.
