### PR TITLE
Fixed panes resizing issue when Map pane is hidden

### DIFF
--- a/common/app/Panes/redux/index.js
+++ b/common/app/Panes/redux/index.js
@@ -164,7 +164,9 @@ export default function createPanesAspects({ createPanesMap }) {
           const leftPane =
             state.panesByName[getPaneName(state.panes, paneIndex - 1)] || {};
           const rightBound = (rightPane.dividerLeft || 100) - dividerBuffer;
-          const leftBound = (leftPane.dividerLeft || 0) + dividerBuffer;
+          const leftBound =
+          (leftPane.isHidden || typeof leftPane.isHidden === 'undefined') ?
+          dividerBuffer : (leftPane.dividerLeft + dividerBuffer);
           const newPosition = _.clamp(
             (clientX / width) * 100,
             leftBound,
@@ -199,7 +201,7 @@ export default function createPanesAspects({ createPanesMap }) {
           navHeight
         })
       }),
-      defaultState,
+      defaultState
     ),
     function metaReducer(state = defaultState, action) {
       if (action.meta && action.meta.panesMap) {


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #16300

#### Description
<!-- Describe your changes in detail -->

Added ternary in /Panes/redux/index.js to set leftBound to dividerBuffer if leftPane.name === 'Map', otherwise, set to default behavior.

`leftBound` determines how far the panes can collapse to the left. When the Map pane is hidden, the next visible pane's `leftBound` property was adopting the hidden Map pane's `dividerLeft` property + the `dividerBuffer` property, which prevented the next visible pane from resizing properly. 
