### PR TITLE
style(code-editor): Matching-braces Style Changed

### DIFF
--- a/client/less/code-mirror.less
+++ b/client/less/code-mirror.less
@@ -35,3 +35,8 @@
 .CodeMirror-lint-tooltip {
   z-index: 9999;
 }
+
+div.CodeMirror span.CodeMirror-matchingbracket {
+  border: 0.5px solid #939393 !important;
+  color: #000;
+}


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
- [ ] Tested changes locally. 
**Reason**: Code-mirror doesn't seem to work locally. 
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #16363

#### Description
Added a border around the pair of matching braces like in VSCode and also It's uniform with the night mode. 

Default Setup:
![](https://user-images.githubusercontent.com/26724128/34421606-521e9700-ec36-11e7-8d27-8987550c6b95.gif)

After applying the changes:
![](https://user-images.githubusercontent.com/26724128/34421610-5657ad16-ec36-11e7-827e-b39bf2351aff.gif)
