### PR TITLE
feat(challenges): Add default project image when none exists

### DIFF
--- a/common/app/routes/Challenges/views/project/Project.jsx
+++ b/common/app/routes/Challenges/views/project/Project.jsx
@@ -41,7 +41,7 @@ export class Project extends PureComponent {
     const {
       id,
       title,
-      image,
+      image = 'ovKSXMs',
       isCompleted,
       description
     } = this.props;
@@ -59,7 +59,7 @@ export class Project extends PureComponent {
         <Image
           id={ id }
           responsive={ true }
-          src={ image ? imageURL : false }
+          src={ imageURL }
         />
         <br />
         <ToolPanel />


### PR DESCRIPTION
BREAKING CHANGE: none

Closes #16426

#### Pre-Submission Checklist
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
- [x] Tested changes locally. Tested in both Chrome and Firefox.
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #16426

#### Description
Add a default image from Imgur of FCC fire on `#006400` dark green background when project submission page does not have an image associated with it.

  