### PR TITLE
revert(preview): Remove night mode background-color

### DIFF
--- a/common/app/routes/Challenges/challenges.less
+++ b/common/app/routes/Challenges/challenges.less
@@ -215,7 +215,6 @@
 .@{ns}-preview {
   .max-element-height();
   width: 100%;
-  background-color: @silver-chalice;
 }
 
 .@{ns}-preview-frame {


### PR DESCRIPTION
Reverts the preview pane background-color, made via https://github.com/freeCodeCamp/freeCodeCamp/pull/16404

This should go in when in night-mode only.