### PR TITLE
feat(panes/nav): persist pane state; rename side panel to lesson

### DIFF
--- a/common/app/Panes/redux/index.js
+++ b/common/app/Panes/redux/index.js
@@ -10,7 +10,6 @@ import * as utils from './utils.js';
 import windowEpic from './window-epic.js';
 import dividerEpic from './divider-epic.js';
 import ns from '../ns.json';
-import { types as challengeTypes } from '../../routes/Challenges/redux';
 
 export const epics = [
   windowEpic,
@@ -58,11 +57,10 @@ const defaultState = {
   height: 600,
   width: 800,
   navHeight: 50,
-  isMapPaneHidden: false,
   panes: [],
   panesByName: {},
-  pressedDivider: null,
-  panesMap: {}
+  panesMap: {},
+  pressedDivider: null
 };
 export const getNS = state => state[ns];
 export const heightSelector = state => {
@@ -159,10 +157,6 @@ export default function createPanesAspects({ createPanesMap }) {
         [types.updateNavHeight]: (state, { payload: navHeight }) => ({
           ...state,
           navHeight
-        }),
-        [challengeTypes.toggleMap]: state => ({
-          ...state,
-          isMapPaneHidden: !state.isMapPaneHidden
         })
       }),
       defaultState
@@ -172,19 +166,24 @@ export default function createPanesAspects({ createPanesMap }) {
         const panesMap = action.meta.panesMap;
         const panes = _.map(panesMap, (name, type) => ({ name, type }));
         const numOfPanes = Object.keys(panes).length;
+        const panesByName = _.isEqual(state.panes, panes) && state.panesByName;
         return {
           ...state,
           panesMap,
           panes,
-          panesByName: panes.reduce((panes, { name }, index) => {
-            const dividerLeft = utils.getDividerLeft(numOfPanes, index);
-            panes[name] = {
-              name,
-              dividerLeft,
-              isHidden: name === 'Map' ? state.isMapPaneHidden : false
-            };
-            return panes;
-          }, {})
+          panesByName: panesByName
+            ? panesByName
+            : panes.reduce((panes, { name }, index) => {
+                const dividerLeft = utils.getDividerLeft(numOfPanes, index);
+                panes[name] = {
+                  name,
+                  dividerLeft,
+                  isHidden: false
+                };
+                return panes;
+              },
+            {}
+          )
         };
       }
       if (action.meta && action.meta.isPaneAction) {

--- a/common/app/routes/Challenges/views/Modern/Show.jsx
+++ b/common/app/routes/Challenges/views/Modern/Show.jsx
@@ -50,7 +50,7 @@ export const mapStateToPanes = addNS(
         return map;
       }, {
         [types.toggleMap]: 'Map',
-        [types.toggleSidePanel]: 'Side Panel'
+        [types.toggleSidePanel]: 'Lesson'
       });
 
       if (showPreview) {
@@ -63,7 +63,7 @@ export const mapStateToPanes = addNS(
 
 const nameToComponent = {
   Map: _Map,
-  'Side Panel': SidePanel,
+  Lesson: SidePanel,
   Preview: Preview
 };
 

--- a/common/app/routes/Challenges/views/quiz/Show.jsx
+++ b/common/app/routes/Challenges/views/quiz/Show.jsx
@@ -13,13 +13,13 @@ export const mapStateToPanes = addNS(
   ns,
   () => ({
     [types.toggleMap]: 'Map',
-    [types.toggleMain]: 'Main'
+    [types.toggleMain]: 'Lesson'
   })
 );
 
 const nameToComponent = {
   Map: _Map,
-  Main: Main
+  Lesson: Main
 };
 
 const renderPane = name => {

--- a/common/app/routes/Challenges/views/step/Show.jsx
+++ b/common/app/routes/Challenges/views/step/Show.jsx
@@ -13,13 +13,13 @@ export const mapStateToPanes = addNS(
   ns,
   () => ({
     [types.toggleMap]: 'Map',
-    [types.toggleStep]: 'Step'
+    [types.toggleStep]: 'Lesson'
   })
 );
 
 const nameToComponent = {
   Map: _Map,
-  Step: Step
+  Lesson: Step
 };
 
 const renderPane = name => {


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [ ] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #16407 
Closes #16453

Closes #16492 

#### Description
<!-- Describe your changes in detail -->
@BerkeleyTrue this implements tracking pane state (panes opened/closed, and position) per your suggestion in #16407 

**EDIT: RESOLVED.** 

~~however, there are a few issues and this is a work in progress. I discovered that in some cases, with certain panes closed (e.g. map & preview), when the next challenge loads, an unnecessary vertical divider would appear (you can drag it, but it doesn't resize anything).~~

~~I also thought that persisting pane width might be good, and this appeared to remove the extraneous divider in that instance, however it raised some other issues.~~

~~Since "Map" pane already has state by the time "Preview", "Side Panel" and "index" load, map already has a value of `50` which effectively hides the "Side Panel". **Edit:** see comment below for possible solution to one issue.~~

~~Any suggestions regarding the extraneous dividers?~~
