### PR TITLE
fix(auth): sign-up/sign-in flow move github to deprecated page

### DIFF
--- a/server/views/account/deprecated-signin.jade
+++ b/server/views/account/deprecated-signin.jade
@@ -3,6 +3,9 @@ block content
     .text-center
         h2 Sign in with one of these options if you used them as your original login methods :
         br
+        a.btn.btn-lg.btn-block.btn-social.btn-github(href='/auth/github')
+            i.fa.fa-github
+            | Sign in with GitHub
         a.btn.btn-lg.btn-block.btn-social.btn-facebook(href='/auth/facebook')
             i.fa.fa-facebook
             | Sign in with Facebook
@@ -15,6 +18,16 @@ block content
         a.btn.btn-lg.btn-block.btn-social.btn-twitter(href='/auth/twitter')
             i.fa.fa-twitter
             | Sign in with Twitter
+        br
+        h4
+         | Note: We are unable to create
+         em new
+         |  accounts using these methods
+        h4 If you haven't updated your email with us, you should do that as soon as possible,
+         | after you login here, to avoid losing access to your account.
+        br
+        p
+          a(href="/signin") Or click here to go back.
           
     script.
       $(document).ready(function() {

--- a/server/views/account/signin.jade
+++ b/server/views/account/signin.jade
@@ -4,8 +4,8 @@ block content
         h2 Are you new to freeCodeCamp?
         .spacer
         a.btn.btn-lg.btn-block.btn-social.btn-primary(href='/email-signup')
-            i.fa.fa-envelope
-            | Sign up with Email
+            i.fa.fa-user-plus
+            | Create new account
         .spacer
         hr
         .spacer
@@ -14,9 +14,6 @@ block content
         a.btn.btn-lg.btn-block.btn-social.btn-primary(href='/email-signin')
             i.fa.fa-envelope
             | Sign in with Email
-        a.btn.btn-lg.btn-block.btn-social.btn-github(href='/auth/github')
-            i.fa.fa-github
-            | Sign in with GitHub
         .button-spacer
         p
             a(href="/deprecated-signin") Click here if you previously signed in using a different method.


### PR DESCRIPTION
Recently we have been getting users, confused with the Sign in with GitHub button on PRODUCTION.

This moves it to deprecated page and also updates the Sign up button to clearly differentiate, account creation and login paths.