### PR TITLE
fix(seed): fixed 'use-strict' warnings and test cases to include both…

### DIFF
--- a/seed/challenges/02-javascript-algorithms-and-data-structures/es6.json
+++ b/seed/challenges/02-javascript-algorithms-and-data-structures/es6.json
@@ -836,11 +836,14 @@
         "}}};"
       ],
       "challengeSeed": [
+        "(function () {",
         "\"use strict\";",
-        "capitalizeString(\"hello!\");"
+        "",
+        "capitalizeString(\"hello!\");",
+        "}) ();"
       ],
       "tests": [
-        "getUserInput => assert(getUserInput('index').match(/import\\s+\\{\\s?capitalizeString\\s?\\}\\s+from\\s+\"string_functions\"/g), 'message: valid <code>import</code> statement');"
+        "getUserInput => assert(getUserInput('index').match(/import\\s+\\{\\s?capitalizeString\\s?\\}\\s+from\\s+(\"|')string_functions(\"|')/g), 'message: Valid <code>import</code> statement');"
       ],
       "type": "waypoint",
       "releasedOn": "Feb 17, 2017",
@@ -864,13 +867,17 @@
         "window.exports = function(){};"
       ],
       "challengeSeed": [
+        "(function () {",
         "\"use strict\";",
+        "",
+        "}) ();",
+        "",
         "const foo = \"bar\";",
         "const boo = \"far\";"
       ],
       "tests": [
-        "getUserInput => assert(getUserInput('index').match(/export\\s+const\\s+foo\\s+=+\\s\"bar\"/g), 'message: <code>foo</code> is exported.');",
-        "getUserInput => assert(getUserInput('index').match(/export\\s+const\\s+boo\\s+=+\\s\"far\"/g), 'message: <code>bar</code> is exported.');"
+        "getUserInput => assert(getUserInput('index').match(/export\\s+const\\s+foo\\s+=+\\s(\"|')bar(\"|')/g), 'message: <code>foo</code> is exported.');",
+        "getUserInput => assert(getUserInput('index').match(/export\\s+const\\s+boo\\s+=+\\s(\"|')far(\"|')/g), 'message: <code>bar</code> is exported.');"
       ],
       "type": "waypoint",
       "releasedOn": "Feb 17, 2017",
@@ -899,12 +906,16 @@
         "}}};"
       ],
       "challengeSeed": [
+        "",
+        "(function () {",
         "\"use strict\";",
+        "",
         "myStringModule.capitalize(\"foo\");",
-        "myStringModule.lowercase(\"Foo\");"
+        "myStringModule.lowercase(\"Foo\");",
+        "}) ();"
       ],
       "tests": [
-        "getUserInput => assert(getUserInput('index').match(/import\\s+\\*\\s+as\\s+myStringModule\\s+from\\s+\"capitalize_strings\"/g), 'message: Properly uses <code>import * as</code> syntax.');"
+        "getUserInput => assert(getUserInput('index').match(/import\\s+\\*\\s+as\\s+myStringModule\\s+from\\s+(\"|')capitalize_strings(\"|')/g), 'message: Properly uses <code>import * as</code> syntax.');"
       ],
       "type": "waypoint",
       "releasedOn": "Feb 17, 2017",
@@ -927,11 +938,15 @@
         "window.exports = function(){};"
       ],
       "challengeSeed": [
+        "( function () {",
         "\"use strict\";",
+        "",
+        "}) ();",
+        "",
         "function subtract(x,y) {return x - y;}"
       ],
       "tests": [
-        "getUserInput => assert(getUserInput('index').match(/export\\s+default\\s+function\\s+subtract\\(x,y\\)\\s+{return\\s+x\\s-\\s+y;}/g), 'message: Proper used of <code>export</code> fallback.');"
+        "getUserInput => assert(getUserInput('index').match(/export\\s+default\\s+function\\s+subtract\\(x,\\s*y\\)\\s+{return\\s+x\\s-\\s+y;}/g), 'message: Proper used of <code>export</code> fallback.');"
       ],
       "type": "waypoint",
       "releasedOn": "Feb 17, 2017",
@@ -957,11 +972,16 @@
         "}}};"
       ],
       "challengeSeed": [
+        "",
+        "(function () {",
         "\"use strict\";",
-        "subtract(7,4);"
+        "",
+        "subtract(7,4);",
+        "}) ();",
+        ""
       ],
       "tests": [
-        "getUserInput => assert(getUserInput('index').match(/import\\s+subtract\\s+from\\s+\"math_functions\"/g), 'message: Properly imports <code>export default</code> method.');"
+        "getUserInput => assert(getUserInput('index').match(/import\\s+subtract\\s+from\\s+(\"|')math_functions(\"|')/g), 'message: Properly imports <code>export default</code> method.');"
       ],
       "type": "waypoint",
       "releasedOn": "Feb 17, 2017",


### PR DESCRIPTION
… single and double quotes

<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #16348 

#### Description
<!-- Describe your changes in detail -->
This PR fixes the errors in **es6.json under ES6 challenges** from `Understand the Differences Between import and require` to `Import a Default Export`.

- Fixes code to use the functional form of `use strict`
- Test cases updated to include single-quotes as well along with double-quotes wherever necessary.