### PR TITLE
fix(challenges): Add key prop jsx element to diff between quiz questions

### DIFF
--- a/common/app/routes/Challenges/views/quiz/Quiz.jsx
+++ b/common/app/routes/Challenges/views/quiz/Quiz.jsx
@@ -29,13 +29,15 @@ const mapStateToProps = createSelector(
   (
     {
       description = [],
-      title
+      title,
+      dashedName
     },
     meta,
     currentIndex,
     selectedChoice,
     correct
   ) => ({
+    dashedName,
     title,
     description,
     meta,
@@ -59,6 +61,7 @@ function mapDispatchToProps(dispatch) {
 const propTypes = {
   correct: PropTypes.number,
   currentIndex: PropTypes.number,
+  dashedName: PropTypes.string,
   description: PropTypes.string,
   meta: PropTypes.object,
   nextQuestion: PropTypes.fun,
@@ -139,8 +142,9 @@ export class QuizChallenge extends PureComponent {
   renderQuiz() {
     const currentIndex = this.props.currentIndex;
     const question = this.props.description[currentIndex];
+    const questionKey = this.props.dashedName + currentIndex.toString();
     return (
-      <div>
+      <div key={questionKey} >
         {this.renderTitle()}
         <Row>
           <Col md={6}>


### PR DESCRIPTION
Closes #16483

<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #16483

#### Description
<!-- Describe your changes in detail -->
The key prop was added to the root element returned by the renderQuiz function to solve the issue of the first question being added to subsequent questions due to the behaviour of the dangerouslySetInnerHTML property
