### PR TITLE
fix(sign-in): Changed left-padding of sign-in buttons to prevent text overflow

### DIFF
--- a/client/less/lib/bootstrap-social/bootstrap-social.less
+++ b/client/less/lib/bootstrap-social/bootstrap-social.less
@@ -31,7 +31,7 @@
     border-right: 1px solid rgba(0, 0, 0, 0.2);
   }
   &.btn-lg {
-    padding-left: (@bs-height-lg + @padding-large-horizontal);
+    padding-left: ((@bs-height-lg + @padding-large-horizontal) - 3);
     > :first-child {
       line-height: @bs-height-lg;
       width: @bs-height-lg;


### PR DESCRIPTION
### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [ ] Addressed currently open issue (replace XXXXX with an issue no in next line)

### Description

**Before:**
The Facebook social button text was overflowing from the horizontal button area.
![before](https://user-images.githubusercontent.com/26724128/34957223-b646dc2c-fa52-11e7-8133-903fa0879368.PNG)

**After:**
Subtracting `3px` from the base height and horizontal padding fixed the issue. 
![after](https://user-images.githubusercontent.com/26724128/34957221-b5a7e6c6-fa52-11e7-9ebf-41d4c52a0df8.PNG)

