### PR TITLE
fix(code-uri): disable loading of code from URI

### DIFF
--- a/client/commonFramework/create-editor.js
+++ b/client/commonFramework/create-editor.js
@@ -106,12 +106,17 @@ window.common = (function(global) {
   common.init.push(function() {
     let editorValue;
     if (common.codeUri.isAlive()) {
-      editorValue = common.codeUri.parse();
+      console.warn(
+        'Code sharing and loading challenges from user profiles is disabled,' +
+        'until beta is launched.'
+      );
       common.codeUri.removeCodeUri(location, window.history);
+    }
+
+    if (common.codeStorage.isAlive(common.challengeName)) {
+      editorValue = common.codeStorage.getStoredValue(common.challengeName);
     } else {
-      editorValue = common.codeStorage.isAlive(common.challengeName) ?
-        common.codeStorage.getStoredValue(common.challengeName) :
-        common.seed;
+      editorValue = common.seed;
     }
 
     editor.setValue(common.replaceSafeTags(editorValue));


### PR DESCRIPTION
This disables loading of code in the editor from URI, as a side effect, code sharing and viewing code from, user profiles is disabled as well.

This is handled more elegantly in beta.

Refers: #16510 