### PR TITLE
fix(error-reporter): Only report uncaught errors

### DIFF
--- a/server/middlewares/error-reporter.js
+++ b/server/middlewares/error-reporter.js
@@ -8,7 +8,8 @@ import {
 
 const log = debug('fcc:middlewares:error-reporter');
 
-export default function errorHandler() {
+const isOpbeatDisabled = !opbeat.appId;
+export default function errrorReporter() {
   if (process.env.NODE_ENV !== 'production') {
     return (err, req, res, next) => {
       if (isHandledError(err)) {
@@ -22,7 +23,14 @@ export default function errorHandler() {
   return (err, req, res, next) => {
     // handled errors do not need to be reported
     // the report a message and redirect the user
-    if (isHandledError(err)) {
+    if (
+      isOpbeatDisabled ||
+      isHandledError(err) ||
+      // errors with status codes shouldn't be reported
+      // as they are usually user messages
+      err.statusCode ||
+      err.status
+    ) {
       return next(err);
     }
     return opbeat.captureError(err, { request: req }, () => next(err));


### PR DESCRIPTION
Errors that have status codes do not need reporting. If opbeat is not
enabled, do not report.
