### PR TITLE
fix(AuthToken): Namespace observable methods

### DIFF
--- a/server/boot/authentication.js
+++ b/server/boot/authentication.js
@@ -138,7 +138,7 @@ module.exports = function enableAuthentication(app) {
                 }
               );
             }
-            return authToken.validate()
+            return authToken.validate$()
               .map(isValid => {
                 if (!isValid) {
                   throw wrapHandledError(
@@ -153,7 +153,7 @@ module.exports = function enableAuthentication(app) {
                     }
                   );
                 }
-                return authToken.destroy();
+                return authToken.destroy$();
               })
               .map(() => user);
           });

--- a/server/models/auth-token.js
+++ b/server/models/auth-token.js
@@ -5,10 +5,10 @@ export default function(AuthToken) {
     AuthToken.findOne$ = Observable.fromNodeCallback(
       AuthToken.findOne.bind(AuthToken)
     );
-    AuthToken.prototype.validate = Observable.fromNodeCallback(
+    AuthToken.prototype.validate$ = Observable.fromNodeCallback(
       AuthToken.prototype.validate
     );
-    AuthToken.prototype.destroy = Observable.fromNodeCallback(
+    AuthToken.prototype.destroy$ = Observable.fromNodeCallback(
       AuthToken.prototype.destroy
     );
   });


### PR DESCRIPTION
This prevents methods that use the regular methods internally from
clashing

When a token is no longer valid (ttl has expired) validate() will attempt to `delete` before completing. This delete was overwritten to return an observable. 



![assertionerror__err_assertion___the_options_argument_should_be_an_object_](https://user-images.githubusercontent.com/6775919/35241990-2b9f5c3c-ff6d-11e7-9f34-efb90d1b82aa.png)
![error__token_is_invalid_](https://user-images.githubusercontent.com/6775919/35241998-2f8065b2-ff6d-11e7-8934-19b1809eda59.png)
