### PR TITLE
fix(poly): Check we are working with Poly from code-storage

### DIFF
--- a/common/app/routes/Challenges/redux/code-storage-epic.js
+++ b/common/app/routes/Challenges/redux/code-storage-epic.js
@@ -20,7 +20,7 @@ import {
 } from '../../../redux';
 import { filesSelector } from '../../../files';
 import { makeToast } from '../../../Toasts/redux';
-import { setContent } from '../../../../utils/polyvinyl.js';
+import { setContent, isPoly } from '../../../../utils/polyvinyl.js';
 
 const legacyPrefixes = [
   'Bonfire: ',
@@ -55,8 +55,11 @@ function getLegacyCode(legacy) {
 }
 
 function legacyToFile(code, files, key) {
-  return { [key]: setContent(code, files[key]) };
-}
+  if (isPoly(files)) {
+    return { [key]: setContent(code, files[key]) };
+  }
+  return false;
+  }
 
 export function clearCodeEpic(actions, { getState }) {
   return actions::ofType(types.submitChallenge.complete)
@@ -113,7 +116,7 @@ export function loadCodeEpic(actions, { getState }, { window, location }) {
       }
 
       const codeFound = getCode(id);
-      if (codeFound) {
+      if (codeFound && isPoly(codeFound)) {
         finalFiles = codeFound;
       } else {
         const legacyCode = getLegacyCode(legacyKey);

--- a/common/app/routes/Challenges/redux/index.js
+++ b/common/app/routes/Challenges/redux/index.js
@@ -216,7 +216,10 @@ export const isCodeLockedSelector = state => getNS(state).isCodeLocked;
 export const isJSEnabledSelector = state => getNS(state).isJSEnabled;
 export const chatRoomSelector = state => getNS(state).helpChatRoom;
 export const challengeModalSelector =
-  state => getNS(state).isChallengeModalOpen;
+  state => (
+    getNS(state).isChallengeModalOpen &&
+    challengeSelector(state).type !== 'backend'
+  );
 
 export const bugModalSelector = state => getNS(state).isBugOpen;
 export const helpModalSelector = state => getNS(state).isHelpOpen;

--- a/common/app/routes/Challenges/views/backend/Back-End.jsx
+++ b/common/app/routes/Challenges/views/backend/Back-End.jsx
@@ -14,7 +14,6 @@ import SolutionInput from '../../Solution-Input.jsx';
 import TestSuite from '../../Test-Suite.jsx';
 import Output from '../../Output.jsx';
 import {
-  submitChallenge,
   executeChallenge,
   testsSelector,
   outputSelector
@@ -41,7 +40,6 @@ const propTypes = {
   executeChallenge: PropTypes.func.isRequired,
   id: PropTypes.string,
   output: PropTypes.string,
-  submitChallenge: PropTypes.func.isRequired,
   tests: PropTypes.array,
   title: PropTypes.string,
   ...reduxFormPropTypes
@@ -75,8 +73,7 @@ const mapStateToProps = createSelector(
 );
 
 const mapDispatchToActions = {
-  executeChallenge,
-  submitChallenge
+  executeChallenge
 };
 
 export class BackEnd extends PureComponent {


### PR DESCRIPTION
Closes #16334 

Sometimes we get `{ }` from `filesSelector` and/or `code-storage` when we are working on a `backend` project. This PR adds checks to ensure we don't try any `Poly` methods on an empty object.