### PR TITLE
fix(challenges): Add top-margin & change comment color of challenges-log

### DIFF
--- a/common/app/routes/Challenges/challenges.less
+++ b/common/app/routes/Challenges/challenges.less
@@ -90,6 +90,7 @@
 
 .@{ns}-log {
   border: 1px solid @brand-primary;
+  margin: 24px 0 0 0;
 }
 
 .night {


### PR DESCRIPTION
### Pre-Submission Checklist
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

### Type of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [ ] Addressed currently open issue (replace XXXXX with an issue no in next line)

### Description
I've added 24px top-margin to the challenges-log and I've changed the comment color only of challenges-log from `#a50500` (default) to `#006400` (brand-primary). The change doesn't affect the night mode.

**Before:**
![before](https://user-images.githubusercontent.com/26724128/35631378-c3d0be34-06c9-11e8-9b96-6418b5de5cfe.PNG)

**After:**
![after](https://user-images.githubusercontent.com/26724128/35631462-f45adcec-06c9-11e8-919f-2c12beeb7763.PNG)


