### PR TITLE
fix(app): Removed flex wrap

### DIFF
--- a/common/app/app.less
+++ b/common/app/app.less
@@ -10,6 +10,10 @@
   .grid(@direction: column);
   height: 100%;
   width: 100%;
+
+  // prevents oversized child components
+  // from wrapping outside this container
+  flex-wrap: nowrap;
 }
 
 .@{ns}-content {


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #16632

#### Description

Bootstrap's properties on its row class are as follows:
```css
.row {
    margin-left: -15px;
    margin-right: -15px;
}
```

These styles made the Settings child component wider than the screen. Since the `app-container` derives its properties partially from `grid` in `@direction: column`, this wrapped the Settings' `Show` component to the second column. Subsequently, due to the `width: 100%` on the `app-container`, the Settings component went off the screen rightwards.

The problematic style to the `app-container` was the `flex: wrap` from `grid.less`. I overrode this in `app.less` with a `flex: nowrap`.
