### PR TITLE
fix(seed): strengthened buggy regex in an Applied Accessibility test

### DIFF
--- a/seed/challenges/01-responsive-web-design/applied-accessibility.json
+++ b/seed/challenges/01-responsive-web-design/applied-accessibility.json
@@ -406,7 +406,7 @@
       ],
       "tests": [
         "assert($('audio').length === 1, 'message: Your code should have one <code>audio</code> tag.');",
-        "assert(code.match(/<\\/audio>/g) && code.match(/<\\/audio>/g).length === code.match(/<audio id=\"meowClip\" controls>/g).length, 'message: Make sure your <code>audio</code> element has a closing tag.');",
+        "assert(code.match(/<\\/audio>/g) && code.match(/<audio controls>/g) && code.match(/<\\/audio>/g).length === code.match(/<audio controls>/g).length, 'message: Make sure your <code>audio</code> element has a closing tag.');",
         "assert($('audio').attr('controls'), 'message: The <code>audio</code> tag should have the <code>controls</code> attribute.');",
         "assert($('source').length === 1, 'message: Your code should have one <code>source</code> tag.');",
         "assert($('audio').children('source').length === 1, 'message: Your <code>source</code> tag should be inside the <code>audio</code> tags.');",


### PR DESCRIPTION
Closes #16645

#### Pre-Submission Checklist
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #16645 

#### Description

There was an error in one of the tests for [this Applied Accessibility challenge](https://beta.freecodecamp.org/en/challenges/applied-accessibility/improve-accessibility-of-audio-content-with-the-audio-element). The test failed to detect a closed audio tag and threw an error (`cannot read property 'length' of null`) in the console.

Faulty regex: `/<audio id=\"meowClip\" controls>/g`. The addition of the "meowClip" id attribute in the audio tag test was never specified in the directions and seems to have mistaken the challenge description (which uses a `<audio id="meowClip">` tag as an example) for a solution. 

Since the faulty regex would never match anything and the test used a `.match(...).length` to check if the number of closing tags matched the number of opening tags, it threw the aforementioned error `cannot read property 'length' of null`. 

I've replaced the regex to simply be `/<audio>/g` and added an extra boolean to prevent the null-case.
