### PR TITLE
feat(challenges): Added feedback for non-front-facing glitch url

### DIFF
--- a/common/app/routes/Challenges/Solution-Input.jsx
+++ b/common/app/routes/Challenges/Solution-Input.jsx
@@ -10,10 +10,15 @@ const propTypes = {
 
 export default function SolutionInput({ solution, placeholder }) {
   const validationState = getValidationState(solution);
+
   return (
     <FormGroup
       controlId='solution'
-      validationState={ validationState }
+      validationState={
+        (validationState && validationState.includes('warning')) ?
+          'warning' :
+          validationState
+      }
       >
       <FormControl
         name='solution'
@@ -22,9 +27,16 @@ export default function SolutionInput({ solution, placeholder }) {
         { ...DOMOnlyProps(solution) }
       />
       {
-        validationState === 'error' ?
-          <HelpBlock>Make sure you provide a proper URL.</HelpBlock> :
-          null
+        validationState === 'error' &&
+          <HelpBlock>Make sure you provide a proper URL.</HelpBlock>
+      }
+      {
+        validationState === 'glitch-warning' &&
+          <HelpBlock>
+            Make sure you have entered a shareable URL
+            (e.g. "https://green-camper.glitch.me", not
+            "https://glitch.com/#!/edit/green-camper".)
+          </HelpBlock>
       }
     </FormGroup>
   );

--- a/common/app/utils/form.js
+++ b/common/app/utils/form.js
@@ -65,6 +65,10 @@ export function getValidationState(field) {
     return null;
   }
 
+  if ((/https?:\/\/glitch\.com\/edit\/#!\/.*/g).test(field.value)) {
+    return 'glitch-warning';
+  }
+
   return field.error ?
     'error' :
     'success';


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #16660

#### Description

From personal experience and the creators of #16660 and #16707, the users are putting a direct Glitch URL (`https://glitch.com/edit/#!/crimson-swim`) into the solution input, when they should instead be giving the front-facing URL (`https://crimson-swim.glitch.me`)

This PR includes a few changes to help the user differentiate these two types of Glitch URLs.

If need be, I'd be glad to add more instructions in text or add more `SolutionInput` component tests.