### PR TITLE
fix(seed): Removed inconsistent and unnecessary ReactDOM.render

### DIFF
--- a/seed/challenges/03-front-end-libraries/react.json
+++ b/seed/challenges/03-front-end-libraries/react.json
@@ -254,11 +254,10 @@
       "tests": [
         "assert.strictEqual(JSX.type, 'div', 'message: The constant <code>JSX</code> should return a <code>div</code> element.');",
         "assert(Enzyme.shallow(JSX).find('br').length === 1, 'message: The <code>div</code> should contain a <code>br</code> tag.');",
-        "assert(Enzyme.shallow(JSX).find('hr').length === 1, 'message: The <code>div</code> should contain an <code>hr</code> tag.');",
-        "assert((() => { const testDiv = document.getElementById('challenge-node').childNodes[0].innerHTML.replace(/\\s/g,''); return testDiv.includes('<h2>WelcometoReact!</h2>') && testDiv.includes('<p>Besuretoclosealltags!</p>'); })(), 'message: The provided JSX element should render as is to the DOM node with <code>id</code> of <code>challenge-node</code>.');"
+        "assert(Enzyme.shallow(JSX).find('hr').length === 1, 'message: The <code>div</code> should contain an <code>hr</code> tag.');"
       ],
       "solutions": [
-        "const JSX = (\n<div>\n  {/* change code below this line */}\n  <h2>Welcome to React!</h2> <br />\n  <p>Be sure to close all tags!</p>\n  <hr />\n  {/* change code above this line */}\n</div>\n);\n\nReactDOM.render(JSX, document.getElementById('challenge-node'));"
+        "const JSX = (\n<div>\n  {/* change code below this line */}\n  <h2>Welcome to React!</h2> <br />\n  <p>Be sure to close all tags!</p>\n  <hr />\n  {/* change code above this line */}\n</div>\n);"
       ],
       "type": "modern",
       "isRequired": false,


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #16710 

#### Description

The tests in [React: Learn About Self-Closing JSX Tags](https://beta.freecodecamp.org/en/challenges/react/learn-about-selfclosing-jsx-tags) required the learner to add this line to the end of their code:
```js
ReactDOM.render(JSX, document.getElementById('challenge-node'));
```

However, this would render the component twice was due to the tail code. The tail in the seed contained a `ReactDOM.render` line, thus resulting in two renders. 

My solution was to just remove the test and modify the solution to match that deletion. Currently, it is inconsistent with the behaviors of all of the other React DOM element challenges. For example, in the challenge before, [Define an HTML Class in JSX](https://beta.freecodecamp.org/en/challenges/react/define-an-html-class-in-jsx), no `ReactDOM.render` is needed to pass the challenge.

