### PR TITLE
fix(challenges): Navigating to an invalid challenge URL now loads an error page with a button redirected to Map

### DIFF
--- a/common/app/routes/Challenges/Show.jsx
+++ b/common/app/routes/Challenges/Show.jsx
@@ -11,6 +11,7 @@ import Project from './views/project';
 import BackEnd from './views/backend';
 import Quiz from './views/quiz';
 import Modern from './views/Modern';
+import NotFound from './views/invalid';
 
 import {
   fetchChallenge,
@@ -27,7 +28,8 @@ const views = {
   project: Project,
   quiz: Quiz,
   simple: Project,
-  step: Step
+  step: Step,
+  invalid: NotFound
 };
 
 const mapDispatchToProps = {

--- a/common/app/routes/Challenges/redux/index.js
+++ b/common/app/routes/Challenges/redux/index.js
@@ -218,7 +218,10 @@ export const challengeMetaSelector = createSelector(
   (...args) => challengeSelector(...args),
   challenge => {
     if (!challenge.id) {
-      return {};
+      const viewType = 'invalid';
+      return {
+        viewType
+      };
     }
     const challengeType = challenge && challenge.challengeType;
     const type = challenge && challenge.type;

--- a/common/app/routes/Challenges/utils/index.js
+++ b/common/app/routes/Challenges/utils/index.js
@@ -24,7 +24,8 @@ export const viewTypes = {
   [ challengeTypes.step ]: 'step',
   [ challengeTypes.quiz ]: 'quiz',
   backend: 'backend',
-  modern: 'modern'
+  modern: 'modern',
+  invalid: 'invalid'
 };
 
 // determine the type of submit function to use for the challenge on completion

--- a/common/app/routes/Challenges/views/invalid/NotFound.jsx
+++ b/common/app/routes/Challenges/views/invalid/NotFound.jsx
@@ -1,0 +1,32 @@
+import React, { PureComponent } from 'react';
+
+// import PropTypes from 'prop-types';
+
+const propTypes = {};
+
+export class NotFound extends PureComponent {
+  render() {
+    return (
+        <div className='container'>
+          <div className='row'>
+            <div className='col-sm'>
+            <div className='alert alert-danger' role='alert'>
+              <h4 className='alert-heading' className='mb-12'>
+                This challenge is not found.</h4>
+               <p>Head back to <a className='alert-link'
+                   href='/en/challenges/basic-html-and-html5/learn-how-freecodecamp-works'
+                   >
+                    Map
+                </a>
+               </p>
+            </div>
+            </div>
+           </div>
+        </div>
+    );
+  }
+}
+
+NotFound.displayName = 'NotFound';
+NotFound.propTypes = propTypes;
+export default NotFound;

--- a/common/app/routes/Challenges/views/invalid/Show.jsx
+++ b/common/app/routes/Challenges/views/invalid/Show.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { addNS } from 'berkeleys-redux-utils';
+
+import ChildContainer from '../../Child-Container.jsx';
+import NotFound from './NotFound.jsx';
+import { types } from '../../redux';
+import Panes from '../../../../Panes';
+import _Map from '../../../../Map';
+
+const propTypes = {};
+
+export const mapStateToPanes = addNS(
+  'invalid',
+  () => ({
+    [types.toggleMap]: 'Map',
+    [types.toggleMain]: 'Main'
+  })
+);
+
+const nameToComponent = {
+  Map: _Map,
+  Main: NotFound
+};
+
+const renderPane = name => {
+  console.log('rendered Pane');
+  const Comp = nameToComponent[name];
+  return Comp ? <Comp /> : <span>Pane { name } not found</span>;
+};
+
+export default function ShowNotFound() {
+  return (
+    <ChildContainer isFullWidth={ true }>
+      <Panes render={ renderPane } />
+    </ChildContainer>
+  );
+}
+
+ShowNotFound.displayName = 'ShowNotFound';
+ShowNotFound.propTypes = propTypes;
+

--- a/common/app/routes/Challenges/views/invalid/index.js
+++ b/common/app/routes/Challenges/views/invalid/index.js
@@ -1,0 +1,1 @@
+export { default } from './NotFound.jsx';

--- a/common/app/utils/challengeTypes.js
+++ b/common/app/utils/challengeTypes.js
@@ -10,3 +10,4 @@ export const bonfire = 5;
 export const video = 6;
 export const step = 7;
 export const quiz = 8;
+export const invalid = 9;


### PR DESCRIPTION
Added new React component and added redux states for invalid challenge

BREAKING CHANGE: nN/A

Closes #16257

<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] Your pull request targets the `staging` branch of freeCodeCamp.
- [X] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [X] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [X] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Contributors room linked above. We're here to help! -->
- [X] Tested changes locally.
- [X] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #16257 

#### Description
<!-- Describe your changes in detail -->
Created a NotFound React component under challenges/views. Then added viewType: 'invalid' to the redux state so that when challenge.id is invalid, render this invalid view.
<img width="1113" alt="screen shot 2018-02-15 at 12 56 12 am" src="https://user-images.githubusercontent.com/20694114/36274573-21bfb940-1256-11e8-9f95-9efd82ffdfab.png">

