### PR TITLE
Fix/invalid challenge url

### DIFF
--- a/common/app/NotFound/Not-Found.jsx
+++ b/common/app/NotFound/Not-Found.jsx
@@ -1,15 +1,22 @@
 import React from 'react';
-
 // import PropTypes from 'prop-types';
+import { Alert } from 'react-bootstrap';
 
 const propTypes = {};
 
 export default function NotFound() {
   return (
-    <div>404 Not Found</div>
+    <Alert bsStyle='danger'>
+      <h4>Oh snap! Page not found!</h4>
+      <p>
+        Head back to
+      </p>
+        <a href='/challenges/current-challenge'>
+            your current challenge
+        </a>
+    </Alert>
   );
 }
 
 NotFound.displayName = 'NotFound';
 NotFound.propTypes = propTypes;
-

--- a/common/app/routes/Challenges/Show.jsx
+++ b/common/app/routes/Challenges/Show.jsx
@@ -11,6 +11,7 @@ import Project from './views/project';
 import BackEnd from './views/backend';
 import Quiz from './views/quiz';
 import Modern from './views/Modern';
+import NotFound from '../../NotFound';
 
 import {
   fetchChallenge,
@@ -27,7 +28,8 @@ const views = {
   project: Project,
   quiz: Quiz,
   simple: Project,
-  step: Step
+  step: Step,
+  invalid: NotFound
 };
 
 const mapDispatchToProps = {

--- a/common/app/routes/Challenges/redux/index.js
+++ b/common/app/routes/Challenges/redux/index.js
@@ -218,7 +218,10 @@ export const challengeMetaSelector = createSelector(
   (...args) => challengeSelector(...args),
   challenge => {
     if (!challenge.id) {
-      return {};
+      const viewType = 'invalid';
+      return {
+        viewType
+      };
     }
     const challengeType = challenge && challenge.challengeType;
     const type = challenge && challenge.type;

--- a/common/app/utils/challengeTypes.js
+++ b/common/app/utils/challengeTypes.js
@@ -10,3 +10,4 @@ export const bonfire = 5;
 export const video = 6;
 export const step = 7;
 export const quiz = 8;
+export const invalid = 9;


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] Your pull request targets the `staging` branch of freeCodeCamp.
- [X] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [X] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [X] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Contributors room linked above. We're here to help! -->
- [X] Tested changes locally.
- [X] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #16257 

#### Description
Added new NotFound React component and added redux states for invalid challenge. Now navigating to invalid URL will load an error message and a button to navigate back to Map
