### PR TITLE
feat(challenges): Call updateSuccessMessage action

### DIFF
--- a/common/app/routes/Challenges/Show.jsx
+++ b/common/app/routes/Challenges/Show.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 
-import { challengeMetaSelector } from './redux';
+import { challengeMetaSelector, updateSuccessMessage } from './redux';
 
 import Classic from './views/classic';
 import Step from './views/step';
@@ -19,6 +19,7 @@ import {
 } from '../../redux';
 import { makeToast } from '../../Toasts/redux';
 import { paramsSelector } from '../../Router/redux';
+import { randomCompliment } from '../../utils/get-words';
 
 const views = {
   backend: BackEnd,
@@ -33,7 +34,8 @@ const views = {
 const mapDispatchToProps = {
   fetchChallenge,
   makeToast,
-  updateTitle
+  updateTitle,
+  updateSuccessMessage
 };
 
 const mapStateToProps = createSelector(
@@ -66,6 +68,7 @@ const propTypes = {
     lang: PropTypes.string.isRequired
   }),
   title: PropTypes.string,
+  updateSuccessMessage: PropTypes.func.isRequired,
   updateTitle: PropTypes.func.isRequired,
   viewType: PropTypes.string
 };
@@ -86,6 +89,7 @@ export class Show extends PureComponent {
 
   componentDidMount() {
     this.props.updateTitle(this.props.title);
+    this.props.updateSuccessMessage(randomCompliment());
     if (this.isNotTranslated(this.props)) {
       this.makeTranslateToast();
     }
@@ -96,11 +100,11 @@ export class Show extends PureComponent {
       this.props.updateTitle(nextProps.title);
     }
     const { params: { dashedName } } = nextProps;
-    if (
-      this.props.params.dashedName !== dashedName &&
-      this.isNotTranslated(nextProps)
-    ) {
-      this.makeTranslateToast();
+    if (this.props.params.dashedName !== dashedName) {
+      this.props.updateSuccessMessage(randomCompliment());
+      if (this.isNotTranslated(nextProps)) {
+        this.makeTranslateToast();
+      }
     }
   }
 


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #16741

#### Description
<!-- Describe your changes in detail -->
Called updateSuccessMessage passing it a random compliment after running the tests in order to show a different quote each time the users see the CompletionModal. 

Note: Currently updateSuccessMessage is called every time the user run the tests. Any insight on how or where to call it only when all the tests are passed in order to improve performance would be great.

I know the logic to display the modal when all the test are passed but it's inside of the updateTests reducer
```js
tests.length > 0 && tests.every(test => test.pass && !test.err)
```