### PR TITLE
fix(redirects): Do not add private blocks/challenges to the map

### DIFF
--- a/server/utils/map.js
+++ b/server/utils/map.js
@@ -33,7 +33,8 @@ const getFirstChallenge = _.once(_getFirstChallenge);
  */
 export function _cachedMap({ Block, Challenge }) {
   const challenges = Challenge.find$({
-    order: [ 'order ASC', 'suborder ASC' ]
+    order: [ 'order ASC', 'suborder ASC' ],
+    where: { isPrivate: false }
   });
   const challengeMap = challenges
     .map(
@@ -44,7 +45,10 @@ export function _cachedMap({ Block, Challenge }) {
           return hash;
         }, {})
     );
-  const blocks = Block.find$({ order: [ 'superOrder ASC', 'order ASC' ] });
+  const blocks = Block.find$({
+    order: [ 'superOrder ASC', 'order ASC' ],
+    where: { isPrivate: false }
+  });
   const blockMap = Observable.combineLatest(
     blocks.map(
       blocks => blocks


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #16753

#### Description
<!-- Describe your changes in detail -->
This change was originally included in a version of the new Settings page updates. In the subsequent refactors and re-writes, this change was missed out.

New challenges were added solely for the purpose of verifying a users challenge map contained the required completed challenges for a certain certificate. These blocks/challenges were given a field of `isPrivate` to enable the ability to filtre them out of the `challengeMap` used in the client., whilst still having access to them in the db server-side.

After these changes, the path `/responsive-web-design-certificate/responsive-web-design-certificate` should now lead to `Not Found`