### PR TITLE
chore(translations): Remove empty translation descriptions

### DIFF
--- a/seed/challenges/01-responsive-web-design/responsive-web-design-projects.json
+++ b/seed/challenges/01-responsive-web-design/responsive-web-design-projects.json
@@ -206,16 +206,13 @@
       "challengeType": 3,
       "translations": {
         "es": {
-          "title": "Construye una página Tributo",
-          "description": []
+          "title": "Construye una página Tributo"
         },
         "pt-br": {
-          "title": "Construa uma Página Tributo",
-          "description": []
+          "title": "Construa uma Página Tributo"
         },
         "ru": {
-          "title": "Создайте страницу посвященную тому что вас вдохновляет",
-          "description": []
+          "title": "Создайте страницу посвященную тому что вас вдохновляет"
         }
       }
     },
@@ -292,16 +289,13 @@
       "challengeType": 3,
       "translations": {
         "es": {
-          "title": "Construye una página web para tu portafolio",
-          "description": []
+          "title": "Construye una página web para tu portafolio"
         },
         "pt-br": {
-          "title": "Construa uma Página de Portfólio Pessoal",
-          "description": []
+          "title": "Construa uma Página de Portfólio Pessoal"
         },
         "ru": {
-          "title": "Создайте сайт-портфолио",
-          "description": []
+          "title": "Создайте сайт-портфолио"
         }
       }
     }

--- a/seed/challenges/03-front-end-libraries/front-end-libraries-projects.json
+++ b/seed/challenges/03-front-end-libraries/front-end-libraries-projects.json
@@ -20,12 +20,10 @@
       "challengeType": 3,
       "translations": {
         "es": {
-          "title": "Crea una máquina de frases aleatorias",
-          "description": []
+          "title": "Crea una máquina de frases aleatorias"
         },
         "ru": {
-          "title": "Создайте генератор случайных цитат",
-          "description": []
+          "title": "Создайте генератор случайных цитат"
         }
       }
     },
@@ -46,12 +44,10 @@
       "challengeType": 3,
       "translations": {
         "es": {
-          "title": "Crea una caja de recetas",
-          "description": []
+          "title": "Crea una caja de recetas"
         },
         "ru": {
-          "title": "Создайте хранилище рецептов",
-          "description": []
+          "title": "Создайте хранилище рецептов"
         }
       }
     },
@@ -72,12 +68,10 @@
       "challengeType": 3,
       "translations": {
         "es": {
-          "title": "Crea un Juego de la vida",
-          "description": []
+          "title": "Crea un Juego de la vida"
         },
         "ru": {
-          "title": "Создайте игру \"Жизнь\"",
-          "description": []
+          "title": "Создайте игру \"Жизнь\""
         }
       }
     },
@@ -99,8 +93,7 @@
       "isRequired": true,
       "translations": {
         "es": {
-          "title": "Crea una calculadora JavaScript",
-          "description": []
+          "title": "Crea una calculadora JavaScript"
         }
       }
     },
@@ -120,12 +113,10 @@
       "challengeType": 3,
       "translations": {
         "es": {
-          "title": "Crea un reloj pomodoro",
-          "description": []
+          "title": "Crea un reloj pomodoro"
         },
         "ru": {
-          "title": "Создайте таймер Pomodoro",
-          "description": []
+          "title": "Создайте таймер Pomodoro"
         }
       }
     }

--- a/seed/challenges/04-data-visualization/data-visualization-projects.json
+++ b/seed/challenges/04-data-visualization/data-visualization-projects.json
@@ -23,8 +23,7 @@
       "challengeType": 3,
       "translations": {
         "es": {
-          "title": "Visualiza datos utilizando un gráfico de barras",
-          "description": []
+          "title": "Visualiza datos utilizando un gráfico de barras"
         }
       }
     },
@@ -47,8 +46,7 @@
       "challengeType": 3,
       "translations": {
         "es": {
-          "title": "Visualiza datos utilizando un gráfico de dispersión",
-          "description": []
+          "title": "Visualiza datos utilizando un gráfico de dispersión"
         }
       }
     },
@@ -71,8 +69,7 @@
       "challengeType": 3,
       "translations": {
         "es": {
-          "title": "Visualiza datos utilizando un mapa de calor",
-          "description": []
+          "title": "Visualiza datos utilizando un mapa de calor"
         }
       }
     },

--- a/seed/challenges/05-apis-and-microservices/api-and-microservice-projects.json
+++ b/seed/challenges/05-apis-and-microservices/api-and-microservice-projects.json
@@ -62,8 +62,7 @@
       "releasedOn": "January 1, 2016",
       "translations": {
         "es": {
-          "title": "Microservicio de Marca Temporal",
-          "description": []
+          "title": "Microservicio de Marca Temporal"
         }
       }
     },
@@ -89,8 +88,7 @@
       "releasedOn": "January 1, 2016",
       "translations": {
         "es": {
-          "title": "Microservicio para analizar el encabezado de una petición",
-          "description": []
+          "title": "Microservicio para analizar el encabezado de una petición"
         }
       }
     },
@@ -124,8 +122,7 @@
       "releasedOn": "January 1, 2016",
       "translations": {
         "es": {
-          "title": "Microservicio para acortar URLs",
-          "description": []
+          "title": "Microservicio para acortar URLs"
         }
       }
     },
@@ -167,8 +164,7 @@
       "releasedOn": "February 17, 2017",
       "translations": {
         "es": {
-          "title": "Capa de abstracción para buscar imágenes",
-          "description": []
+          "title": "Capa de abstracción para buscar imágenes"
         }
       }
     },
@@ -198,8 +194,7 @@
       "releasedOn": "January 1, 2016",
       "translations": {
         "es": {
-          "title": "Microservicio de metadatos de archivos",
-          "description": []
+          "title": "Microservicio de metadatos de archivos"
         }
       }
     }


### PR DESCRIPTION
Empty descriptions for translations render empty challenge descriptions for the user.

If the description field is not present for the selected translation preference, the challenge reverts back to English, which is what we want.