### PR TITLE
chore(package): Update loopback-boot to remove vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10734,14 +10734,14 @@
       }
     },
     "loopback-boot": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/loopback-boot/-/loopback-boot-2.27.0.tgz",
-      "integrity": "sha512-PO8VMisNyUW8lKAN1oitJn6WveZOazqLPXSi4SRmE0asU6rlOR90dUW0Hr1wkYzVm46CQlKKHvuIOmguTvFN7g==",
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/loopback-boot/-/loopback-boot-2.27.1.tgz",
+      "integrity": "sha512-8w1EYcQCPwUrs5iplJv0iHMzmvfBRDRxsO40ladB8TL4Jat6jXfOaE0zAm1/9gh9pMCstHh01Nr52GpfCIHGZA==",
       "requires": {
         "async": "0.9.2",
         "commondir": "0.0.1",
         "debug": "2.6.9",
-        "lodash": "3.10.1",
+        "lodash": "4.17.5",
         "semver": "4.3.6",
         "strong-globalize": "2.10.0",
         "toposort": "0.2.12"
@@ -10753,9 +10753,9 @@
           "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
         },
         "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+          "version": "4.17.5",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
         },
         "semver": {
           "version": "4.3.6",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "lightbox2": "~2.8.2",
     "lodash": "^4.1.0",
     "loopback": "^3.11.1",
-    "loopback-boot": "^2.26.1",
+    "loopback-boot": "^2.27.1",
     "loopback-component-passport": "git+https://github.com/freeCodeCamp/loopback-component-passport.git#feat/freecodecamp",
     "loopback-connector-mongodb": "^3.2.1",
     "method-override": "^2.3.0",


### PR DESCRIPTION
This `loopback-boot` version bump just upgrades their `lodash` version