### PR TITLE
fix(challenges): Call resetQuiz() when dashedName of the quiz changes

### DIFF
--- a/common/app/routes/Challenges/views/quiz/Quiz.jsx
+++ b/common/app/routes/Challenges/views/quiz/Quiz.jsx
@@ -62,13 +62,21 @@ const propTypes = {
   correct: PropTypes.number,
   currentIndex: PropTypes.number,
   dashedName: PropTypes.string,
-  description: PropTypes.string,
+  description: PropTypes.arrayOf(
+    PropTypes.shape({
+      answer: PropTypes.number,
+      choices: PropTypes.arrayOf(PropTypes.string),
+      explanation: PropTypes.string,
+      question: PropTypes.string,
+      subtitle: PropTypes.string
+    })
+  ),
   meta: PropTypes.object,
-  nextQuestion: PropTypes.fun,
-  resetChoice: PropTypes.fun,
-  resetQuiz: PropTypes.fun,
+  nextQuestion: PropTypes.func,
+  resetChoice: PropTypes.func,
+  resetQuiz: PropTypes.func,
   selectedChoice: PropTypes.number,
-  submitChallenge: PropTypes.fun
+  submitChallenge: PropTypes.func
 };
 
 export class QuizChallenge extends PureComponent {
@@ -77,6 +85,12 @@ export class QuizChallenge extends PureComponent {
     super(props);
     this.nextQuestion = this.nextQuestion.bind(this);
     this.submitChallenge = this.submitChallenge.bind(this);
+  }
+
+  componentWillReceiveProps(nextProps) {
+      if (this.props.dashedName !== nextProps.dashedName) {
+        this.props.resetQuiz();
+      }
   }
 
   nextQuestion() {


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #16801

#### Description
'currentIndex', 'selectedChoice' and 'correct' state variables of the Quiz
component were not changing when navigating to other quiz challenges
through map. Fixed it by calling resetQuiz() whenever dashedName of
the quiz changes. 