### PR TITLE
fix(lang): Refetch mapUi on language change

### DIFF
--- a/common/app/entities/index.js
+++ b/common/app/entities/index.js
@@ -21,6 +21,7 @@ export const types = createTypes([
   'addPortfolioItem',
   'optoUpdatePortfolio',
   'regresPortfolio',
+  'resetFullBlocks',
   'updateMultipleUserFlags',
   'updateTheme',
   'updateUserFlag',
@@ -56,6 +57,8 @@ export const updateUserLang = createAction(
   types.updateUserLang,
   (username, lang) => ({ username, languageTag: lang })
 );
+
+export const resetFullBlocks = createAction(types.resetFullBlocks);
 
 export const updateUserCurrentChallenge = createAction(
   types.updateUserCurrentChallenge
@@ -207,11 +210,14 @@ export default composeReducers(
           map.fetchMapUi.complete
         )
       ]: (state, { payload: { entities } }) => merge({}, state, entities),
-      [app.fetchNewBlock.complete]:
-      (state, { payload: { entities: { block }}}) => ({
+      [app.fetchNewBlock.complete]: (
+        state,
+        { payload: { entities: { block } } }
+      ) => ({
         ...state,
         fullBlocks: union(state.fullBlocks, [ Object.keys(block)[0] ])
       }),
+      [types.resetFullBlocks]: state => ({ ...state, fullBlocks: [] }),
       [
         challenges.submitChallenge.complete
       ]: (state, { payload: { username, points, challengeInfo } }) => ({

--- a/common/app/redux/index.js
+++ b/common/app/redux/index.js
@@ -55,7 +55,6 @@ export const types = createTypes([
   createAsyncTypes('fetchChallenge'),
   createAsyncTypes('fetchChallenges'),
   createAsyncTypes('fetchNewBlock'),
-  'updateChallenges',
   createAsyncTypes('fetchOtherUser'),
   createAsyncTypes('fetchUser'),
   'showSignIn',
@@ -131,8 +130,6 @@ export const fetchNewBlockComplete = createAction(
   ({ entities }) => ({ entities }),
   ({ meta: { challenge } }) => ({ ...createCurrentChallengeMeta(challenge) })
 );
-
-export const updateChallenges = createAction(types.updateChallenges);
 
 // updateTitle(title: String) => Action
 export const updateTitle = createAction(types.updateTitle);

--- a/common/app/redux/index.js
+++ b/common/app/redux/index.js
@@ -238,7 +238,7 @@ export const isSignedInSelector = state => !!userSelector(state).username;
 export const challengeSelector = state => {
   const challengeName = currentChallengeSelector(state);
   const challengeMap = entitiesSelector(state).challenge || {};
-  return challengeMap[challengeName] || {};
+  return challengeMap[challengeName] || firstChallengeSelector(state);
 };
 
 export const isCurrentBlockCompleteSelector = state => {

--- a/common/app/routes/Settings/redux/update-user-epic.js
+++ b/common/app/routes/Settings/redux/update-user-epic.js
@@ -9,8 +9,8 @@ import {
   updateMyPortfolioComplete
 } from './';
 import { makeToast } from '../../../Toasts/redux';
+import { fetchMapUi } from '../../../Map/redux';
 import {
-  updateChallenges,
   doActionOnError,
   usernameSelector,
   userSelector,
@@ -21,7 +21,8 @@ import {
   updateUserLang,
   updateMultipleUserFlags,
   regresPortfolio,
-  optoUpdatePortfolio
+  optoUpdatePortfolio,
+  resetFullBlocks
 } from '../../../entities';
 
 import { postJSON$ } from '../../../../utils/ajax-stream';
@@ -214,8 +215,10 @@ export function updateUserLangEpic(actions, { getState }) {
             makeToast({ message }),
             // update url to reflect change
             onRouteSettings({ lang }),
-            // refetch challenges in new language
-            updateChallenges()
+            // clear fullBlocks so challenges are fetched in correct language
+            resetFullBlocks(),
+            // refetch mapUi in new language
+            fetchMapUi()
           );
         })
         .catch(doActionOnError(() => {


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [ ] Addressed currently open issue (replace XXXXX with an issue no in next line)

#### Description
<!-- Describe your changes in detail -->
The map was not being re-fetched on language change, this PR fixes that. Also, on language change we reset `state.entities.fullBlocks` to force the app to re-fetch challenges for the correct language.