### PR TITLE
fix(gulp): run babel-node with inspect flag in debug

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -170,11 +170,17 @@ function delRev(dest, manifestName) {
 
 gulp.task('serve', function(cb) {
   let called = false;
+  let execParams = path.normalize('node_modules/.bin/babel-node');
+  // When in development we can spawn a node debugger
+  // https://nodejs.org/en/docs/inspector/
+  if (__DEV__) {
+    execParams = execParams + ' --inspect';
+  }
   const monitor = nodemon({
     script: paths.server,
     ext: '.jsx .js .json',
     ignore: paths.serverIgnore,
-    exec: path.normalize('node_modules/.bin/babel-node'),
+    exec: execParams,
     env: {
       NODE_ENV: process.env.NODE_ENV || 'development',
       DEBUG: process.env.DEBUG || 'fcc:*',


### PR DESCRIPTION
Allow attaching of a debugger in development mode, and hence any of the methods listed https://nodejs.org/en/docs/inspector/ can be used.