### PR TITLE
fix(challenges): Load preview of challenge on server render

### DIFF
--- a/common/app/redux/index.js
+++ b/common/app/redux/index.js
@@ -14,6 +14,7 @@ import fetchUserEpic from './fetch-user-epic.js';
 import updateMyCurrentChallengeEpic from './update-my-challenge-epic.js';
 import fetchChallengesEpic from './fetch-challenges-epic.js';
 import nightModeEpic from './night-mode-epic.js';
+import previewOnAppMountedEpic from './preview-on-appmounted-epic.js';
 
 import {
   updateThemeMetacreator,
@@ -42,7 +43,8 @@ export const epics = [
   fetchChallengesEpic,
   fetchUserEpic,
   nightModeEpic,
-  updateMyCurrentChallengeEpic
+  updateMyCurrentChallengeEpic,
+  previewOnAppMountedEpic
 ];
 
 export const types = createTypes([

--- a/common/app/redux/preview-on-appmounted-epic.js
+++ b/common/app/redux/preview-on-appmounted-epic.js
@@ -1,0 +1,25 @@
+import { ofType } from 'redux-epic';
+
+import {
+  types as challengeTypes,
+  previewOnAppMounted
+} from '../routes/Challenges/redux';
+import { types as appTypes } from './';
+import { panesSelector } from '../Panes/redux';
+
+export default function previewOnAppMountedEpic(actions, { getState }) {
+  return actions::ofType(appTypes.appMounted)
+    // make sure we are not SSR
+    .filter(() => !!window)
+    .filter(() => panesSelector(getState()).reduce((acc, pane) =>
+      pane.name === 'Preview' ? true : acc, false))
+    .switchMap(() => actions::ofType(
+        challengeTypes.previousSolutionFound,
+        challengeTypes.storedCodeFound,
+        challengeTypes.noStoredCodeFound
+      )
+      .take(1)
+      .filter((action) => action.type === challengeTypes.noStoredCodeFound)
+      .map(previewOnAppMounted)
+    );
+}

--- a/common/app/routes/Challenges/redux/execute-challenge-epic.js
+++ b/common/app/routes/Challenges/redux/execute-challenge-epic.js
@@ -46,7 +46,8 @@ export function updateMainEpic(actions, { getState }, { document }) {
         types.modernEditorUpdated,
         types.classicEditorUpdated,
         types.executeChallenge,
-        types.challengeUpdated
+        types.challengeUpdated,
+        types.previewOnAppMounted
       )
         .debounce(executeDebounceTimeout)
         // if isCodeLocked do not run challenges

--- a/common/app/routes/Challenges/redux/index.js
+++ b/common/app/routes/Challenges/redux/index.js
@@ -96,7 +96,10 @@ export const types = createTypes([
   // code storage
   'storedCodeFound',
   'noStoredCodeFound',
-  'previousSolutionFound'
+  'previousSolutionFound',
+
+  // on app mounted,
+  'previewOnAppMounted'
 ], ns);
 
 // routes
@@ -173,6 +176,10 @@ export const previousSolutionFound = createAction(
   null,
   challengeToFilesMetaCreator
 );
+
+// preview on app mounted
+export const previewOnAppMounted = createAction(types.previewOnAppMounted);
+
 
 const initialUiState = {
   output: null,


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)

Is related to but not necessarily closes #12923

#### Description
<!-- Describe your changes in detail -->
This change is solves the issue that when you directly go to a challenge and the server renders the page, the challenge preview doesn't load. To reproduce go to any challenge. For example: 
https://beta.freecodecamp.org/en/challenges/basic-html-and-html5/headline-with-the-h2-element

### What this code does:
#### Summed up: 
This change listens for appMounted and code loading related actions. Then based on some filtering it triggers a new action which is being listened for in the updateMainEpic to trigger the preview load.

#### Detailed: 
 - Made a new type:  "challenge.previewOnAppMounted"
 - Made a new action: previewOnAppMounted
 - Made a new epic: previewOnAppMountedEpic

previewOnAppMountedEpic:
 - Listens for the action type "app.appMounted".
 - Filters it so that it only goes further if there is a preview pane.
 - It starts listening for code loading related actions. It should listen for all of them and only once. This is to prevent this epic to fire later when the user selects a new challenge after the initial load. The code loading related actions are: storedCodeFound, noStoredCodeFound, previousSolutionFound. These only fire after appMounted. file:  freeCodeCamp/common/app/routes/Challenges/redux/code-storage-epic.js
 - Filters the code loading actions to fo further if the action fired was "challengeTypes.noStoredCodeFound"
 - Then it fires the action previewOnAppMounted

previewOnAppMounted action:
A simple action only to trigger updateMainEpic, It has no payload. Has the type "challenge.previewOnAppMounted"

This change makes a modification to updateMainEpic epic to listen for the action type "challenge.previewOnAppMounted". This is the trigger for the preview load on app mounted that the previewOnAppMountedEpic fires if it goes through.

##### I found a related issue if you want to test this change out, it is not caused by this change and is present currently on the staging branch. If there is previous code and the app is server rendered the previous code is going to be put into the editor then it gets overwritten by the seed code almost immediately. 