### PR TITLE
ci: remove stale config for node 4 and below

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,10 @@
 language: node_js
 
 node_js:
-  - '8'
+  - 'lts/*'
 
 cache:
   directories:
     - node_modules
-
-env:
-  - CXX=g++-4.8
-
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-4.8
 
 sudo: false


### PR DESCRIPTION
We do not need the tooling for node 4 and below. Also, this commits lets us have, named LTS tags. This should speed up the CI even further.