### PR TITLE
Fix broken links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ We welcome pull requests from freeCodeCamp campers (our students) and seasoned J
 
 2. Let us know you are working on it by posting a comment on the issue.
 
-3. Follow the [Contribution Guidelines](#contribution-guidelines) to start working on the issue.
+3. Follow the [Contribution Guidelines](#table-of-contents) to start working on the issue.
 
 Remember to feel free to ask for help in our [Contributors](https://gitter.im/FreeCodeCamp/Contributors) Gitter room.
 
@@ -436,7 +436,7 @@ Instance of freeCodeCamp](#maintaining-your-fork).
 4.  Create a branch off of `staging` with git: `git checkout -B
     branch/name-here` **Note:** Branch naming is important. Use a name like
     `fix/short-fix-description` or `feature/short-feature-description`. Review
-     the [Contribution Guidelines](#contribution-guidelines) for more detail.
+     the [Contribution Guidelines](#table-of-contents) for more detail.
 
 5.  Edit your file(s) locally with the editor of your choice. To edit challenges, you may want to use `unpack` and `repack` -- see [Unpack and Repack](#unpack-and-repack) for instructions.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ We welcome pull requests from freeCodeCamp campers (our students) and seasoned J
 
 2. Let us know you are working on it by posting a comment on the issue.
 
-3. Follow the [Contribution Guidelines](#table-of-contents) to start working on the issue.
+3. Follow the instructions in this guide to start working on the issue.
 
 Remember to feel free to ask for help in our [Contributors](https://gitter.im/FreeCodeCamp/Contributors) Gitter room.
 
@@ -435,9 +435,8 @@ Instance of freeCodeCamp](#maintaining-your-fork).
 
 4.  Create a branch off of `staging` with git: `git checkout -B
     branch/name-here` **Note:** Branch naming is important. Use a name like
-    `fix/short-fix-description` or `feature/short-feature-description`. Review
-     the [Contribution Guidelines](#table-of-contents) for more detail.
-
+    `fix/short-fix-description` or `feature/short-feature-description`.
+    
 5.  Edit your file(s) locally with the editor of your choice. To edit challenges, you may want to use `unpack` and `repack` -- see [Unpack and Repack](#unpack-and-repack) for instructions.
 
 4.  Check your `git status` to see unstaged files.


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #17062

#### Description
<!-- Describe your changes in detail -->
Links associated with 'contribution guidelines' were broken, due to change from 'Contribution Guidelines header' to 'Table of Contents' in [this](https://github.com/freeCodeCamp/freeCodeCamp/commit/6bc521815aa68e3296935dec3f292d64dba65e6c) commit. Fixed links so it goes to to 'Table of Contents'.