### PR TITLE
fix: Claiming respWebDesignCert tests

### DIFF
--- a/seed/challenges/09-certificates/responsive-web-design-certificate.json
+++ b/seed/challenges/09-certificates/responsive-web-design-certificate.json
@@ -28,7 +28,7 @@
           "title": "Build a Technical Documentation Page"
         },
         {
-          "id": "587d78b0367417b2b2512b06",
+          "id": "bd7158d8c242eddfaeb5bd13",
           "title": "Build a Personal Portfolio Webpage"
         }
       ]


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
- [x] Tested changes locally.
- [x] Addressed currently open issue #17031

Closes #17031 

#### Description
Changed the "Build a Personal Portfolio" id in the responsive-web-design-certificate tests to the correct id. Users are now capable of claiming the "Responsive Web Design Certificate".
