### PR TITLE
fix(seed): Remove typo from chai-http-IV challenge title

### DIFF
--- a/seed/challenges/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai.json
+++ b/seed/challenges/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai.json
@@ -717,7 +717,7 @@
     },
     {
       "id": "587d824f367417b2b2512c5b",
-      "title": "Run Functional Tests on an API Response using Chai-HTTP IV - PUT method redux",
+      "title": "Run Functional Tests on an API Response using Chai-HTTP IV - PUT method",
       "description": [
         "As a reminder, this project is being built upon the following starter project on <a href='https://glitch.com/#!/import/github/freeCodeCamp/boilerplate-mochachai/'>Glitch</a>, or cloned from <a href='https://github.com/freeCodeCamp/boilerplate-mochachai/'>GitHub</a>.",
         "This exercise is similar to the preceding. Look at it for the details.",


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #17148

#### Description
Removed the typo in the challenge name that was present [here](https://beta.freecodecamp.org/en/challenges/quality-assurance-and-testing-with-chai/run-functional-tests-on-an-api-response-using-chaihttp-iv--put-method-redux) 
