### PR TITLE
chore: add section on how to raise security issues

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -9,7 +9,7 @@
 #### Security
 Trying to report a security issue?
 
-👌 please report security issues to team+security@freecodecamp.org instead of raising a Github issue. We look forward to working with you. If the issue is significant we'll work on resolving it as quickly as we can. We'll be happy to mention you in a published list of security researchers that found issues in our projects if you so desire.
+👌 please report security issues to security@freecodecamp.org instead of raising a Github issue. We look forward to working with you. If the issue is significant we'll work on resolving it as quickly as we can. We'll be happy to mention you in a published list of security researchers that found issues in our projects if you so desire.
 
 
 #### Challenge Name

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -6,6 +6,12 @@
 <!-- NOTE: If your issue is CodePen Project / Test Suite related, please open it using the below URL instead -->
 <!-- https://github.com/freeCodeCamp/testable-projects-fcc/issues/new -->
 
+#### Security
+Trying to report a security issue?
+
+👌 please report security issues to team+security@freecodecamp.org instead of raising a Github issue. We look forward to working with you. If the issue is significant we'll work on resolving it as quickly as we can. We'll be happy to mention you in a published list of security researchers that found issues in our projects if you so desire.
+
+
 #### Challenge Name
 <!-- Insert link to challenge below -->
 


### PR DESCRIPTION
Same text as https://github.com/freeCodeCamp/open-api/pull/155, addresses part of #17154.