### PR TITLE
fix: open learn in current tab

### DIFF
--- a/server/views/partials/navbar.jade
+++ b/server/views/partials/navbar.jade
@@ -9,7 +9,7 @@ nav.navbar.navbar-default.navbar-static-top.nav-height
     .collapse.navbar-collapse
         ul.nav.navbar-nav.navbar-right.hamburger-dropdown
             li
-                a(href='https://learn.freecodecamp.org' target='_blank' rel='noopener') Curriculum
+                a(href='https://learn.freecodecamp.org' rel='noopener') Curriculum
             li
                 a(href='https://forum.freecodecamp.org', target='_blank' rel='noopener') Forum
             if !user


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
- [x] Small bug fix (non-breaking change which fixes an issue)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/17261

#### Description
Removed the `target="_blank"` from the curriculum link in the `navbar.jade` file - this should make it always open in the current tab - this is what I came up with and it works, not sure if it might cause other problems down the line... this fix in conjunction with the PR I made on the learn repo (https://github.com/freeCodeCamp/learn/pull/148) should make the navbar behave consistently and better I think - to be clear... this fix should make the curriculum link open in the current tab from all pages - and the PR in the learn repo should make the forum open in a new tab from all pages
