### PR TITLE
fix: current-challenge redirect

### DIFF
--- a/seed/index.js
+++ b/seed/index.js
@@ -84,7 +84,7 @@ Observable.combineLatest(
           .map(function(challenge, index) {
             challenge.name = nameify(challenge.title);
 
-            challenge.dashedName = dasherize(challenge.name);
+            challenge.dashedName = dasherize(challenge.title);
 
             challenge.checksum = adler32.sum(
               Buffer(


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change - im not sure which one of these two this falls in
- [x] Small bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] Tested changes locally.
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #17496
Closes #17463

#### Description
After quite a bit of digging, I think I have a fix for this - In the seeding process, `name` and `dashedName` are created for the db like this…
`challenge.name = namify(challenge.title);`
`challenge.dashedName = dasherize(challenge.name);`
As shown here https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/seed/index.js#L85
namify() removes the hyphens from the title to create `name` - and `name` is used to create `dashedName` - If we use the original title to create the `dashedName` like this - `challenge.dashedName = dasherize(challenge.title)` - the db entries look like this…

	"name" : "Say Hello to HTMLElements",
	"title" : "Say Hello to HTML-Elements",
	"dashedName" : "say-hello-to-html-elements",

instead of this…

	"name" : "Say Hello to HTMLElements",
	"title" : "Say Hello to HTML-Elements",
	"dashedName" : "say-hello-to-htmlelements",

Notice the hyphen in `dashedName` on top is still there - this is the first challenge and doesn’t include a hyphen which I added and used for testing - It can be tested like this…

1. Change this line https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/seed/index.js#L87
To this - `challenge.dashedName = dasherize(challenge.title);`

2. Change the title of the first challenge to this - `”Say Hello to HTML-Elements”` (added a hyphen) - this is the line…
https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/seed/challenges/01-responsive-web-design/basic-html-and-html5.json#L9 - I did this because we can't sign in locally so the current-challenge is always the first one - so I added a hyphen to the first challenge

3. Seed the DB

4. Change `learnURL` variable to `http://localhost:8000` so it will redirect to the local learn - this line…
https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/server/boot/challenge.js#L14

5. Run local FCC and Learn environments

6. Go to `localhost:3000/challenges/current-challenge` - and it will redirect correctly to `http://localhost:8000/responsive-web-design/basic-html-and-html5/say-hello-to-html-elements`

If you omit step 1 and do steps 2-6 it will incorrectly redirect to `http://localhost:8000/responsive-web-design/basic-html-and-html5/say-hello-to-htmlelements`

I think this is all accurate and it seems to work - my only concern with this solution is that `dashedName` needs to stay how it is now for other reasons I am unaware of - another possible solution would maybe be to remove all the hyphens from the seed files, or maybe change namify() so it doesn't remove hyphens
