### PR TITLE
fix(certifications): Update text on cert

### DIFF
--- a/server/views/certificate/apis-and-microservices.jade
+++ b/server/views/certificate/apis-and-microservices.jade
@@ -20,7 +20,7 @@ include styles
 				h3 has successfully completed freeCodeCamp's
 				h1
 					strong APIs and Microservices Projects
-				h4 1 of 6 freeCodeCamp certifications, representing approximately 300 hours of coursework
+				h4 Developer Certification, representing approximately 300 hours of coursework
 
 		footer
 			.row.signatures

--- a/server/views/certificate/data-visualization.jade
+++ b/server/views/certificate/data-visualization.jade
@@ -20,7 +20,7 @@ include styles
 				h3 has successfully completed freeCodeCamp's
 				h1
 					strong Data Visualization Projects
-				h4 1 of 6 freeCodeCamp certifications, representing approximately 300 hours of coursework
+				h4 Developer Certification, representing approximately 300 hours of coursework
 
 		footer
 			.row.signatures

--- a/server/views/certificate/front-end-libraries.jade
+++ b/server/views/certificate/front-end-libraries.jade
@@ -20,7 +20,7 @@ include styles
 				h3 has successfully completed freeCodeCamp's
 				h1
 					strong Front End Libraries Projects
-				h4 1 of 6 freeCodeCamp certifications, representing approximately 300 hours of coursework
+				h4 Developer Certification, representing approximately 300 hours of coursework
 
 		footer
 			.row.signatures

--- a/server/views/certificate/information-security-and-quality-assurance.jade
+++ b/server/views/certificate/information-security-and-quality-assurance.jade
@@ -20,7 +20,7 @@ include styles
 				h3 has successfully completed freeCodeCamp's
 				h1
 					strong Information Security and Quality Assurance Projects
-				h4 1 of 6 freeCodeCamp certifications, representing approximately 300 hours of coursework
+				h4 Developer Certification, representing approximately 300 hours of coursework
 
 		footer
 			.row.signatures

--- a/server/views/certificate/javascript-algorithms-and-data-structures.jade
+++ b/server/views/certificate/javascript-algorithms-and-data-structures.jade
@@ -20,7 +20,7 @@ include styles
 				h3 has successfully completed freeCodeCamp's
 				h1
 					strong JavaScript Algorithms and Data Structures Projects
-				h4 1 of 6 freeCodeCamp certifications, representing approximately 300 hours of coursework
+				h4 Developer Certification, representing approximately 300 hours of coursework
 
 		footer
 			.row.signatures

--- a/server/views/certificate/legacy/back-end.jade
+++ b/server/views/certificate/legacy/back-end.jade
@@ -19,8 +19,8 @@ include ../styles
 					strong= name
 				h3 has successfully completed freeCodeCamp's
 				h1
-					strong Back End Development Projects
-				h4 1 of 3 legacy freeCodeCamp certifications, representing approximately 400 hours of coursework
+					strong Back End Development
+				h4 Certification, representing approximately 400 hours of coursework
 
 		footer
 			.row.signatures

--- a/server/views/certificate/legacy/data-visualization.jade
+++ b/server/views/certificate/legacy/data-visualization.jade
@@ -20,7 +20,7 @@ include ../styles
 				h3 has successfully completed freeCodeCamp's
 				h1
 					strong Data Visualization Projects
-				h4 1 of 3 legacy freeCodeCamp certifications, representing approximately 400 hours of coursework
+				h4 Developer Certification, representing approximately 400 hours of coursework
 
 		footer
 			.row.signatures

--- a/server/views/certificate/legacy/front-end.jade
+++ b/server/views/certificate/legacy/front-end.jade
@@ -19,8 +19,8 @@ include ../styles
 					strong= name
 				h3 has successfully completed freeCodeCamp's
 				h1
-					strong Front End Development Projects
-				h4 1 of 3 legacy freeCodeCamp certifications, representing approximately 400 hours of coursework
+					strong Front End Development
+				h4 Certification, representing approximately 400 hours of coursework
 
 		footer
 			.row.signatures

--- a/server/views/certificate/legacy/full-stack.jade
+++ b/server/views/certificate/legacy/full-stack.jade
@@ -20,7 +20,7 @@ include ../styles
 				h3 has successfully completed freeCodeCamp's
 				h1
 					strong Legacy Full Stack Development Program
-				h4 All three of the legacy freeCodeCamp certifications, representing approximately 12000 hours of coursework
+				h4 All three of the legacy freeCodeCamp certifications, representing approximately 1,200 hours of coursework
 
 		footer
 			.row.signatures

--- a/server/views/certificate/responsive-web-design.jade
+++ b/server/views/certificate/responsive-web-design.jade
@@ -20,7 +20,7 @@ include styles
 				h3 has successfully completed freeCodeCamp's
 				h1
 					strong Responsive Web Design Projects
-				h4 1 of 6 freeCodeCamp certifications, representing approximately 300 hours of coursework
+				h4 Developer Certification, representing approximately 300 hours of coursework
 
 		footer
 			.row.signatures


### PR DESCRIPTION
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.

#### Description
Addresses a [widely-upvoted concern about the wording of the text on the certification](https://forum.freecodecamp.org/t/freecodecamps-new-certificates-heres-how-were-rolling-them-out/141618/126?u=quincylarson). I agree with this sentiment and think this will make the certifications more attractive to hiring managers while conveying the same basic information.

Note that I fixed a minor typo in the Full Stack Development cert, but that needs to be fixed on a subsequent pull request. That cert will be available to anyone who completes all 6 of the new certs.