### PR TITLE
fix: improve mobile views for settings

### DIFF
--- a/client/less/main.less
+++ b/client/less/main.less
@@ -337,6 +337,9 @@ p.stats {
   max-width: 400px;
   margin: auto;
   margin-bottom: 10px;
+  @media (max-width: 450px) {
+    max-width: 90vw;
+  }
 }
 
 a {

--- a/common/app/routes/Settings/Settings.jsx
+++ b/common/app/routes/Settings/Settings.jsx
@@ -98,6 +98,7 @@ export class Settings extends React.Component {
           </Button>
         </FullWidthRow>
         <h1 className='text-center'>{ `Account Settings for ${username}` }</h1>
+        <div className='offset-negative-row'>
         <AboutSettings />
         <Spacer />
         <PrivacySettings />
@@ -113,6 +114,7 @@ export class Settings extends React.Component {
         <CertificationSettings />
         <Spacer />
         <DangerZone />
+        </div>
       </div>
     );
   }

--- a/common/app/routes/Settings/Toggle-Button/toggle.less
+++ b/common/app/routes/Settings/Toggle-Button/toggle.less
@@ -1,6 +1,7 @@
 @ns: toggle;
 
 .@{ns}-container > .btn-group {
+  min-width: 180px;
   float: right;
   .btn {
     margin-top: 20px;

--- a/common/app/routes/Settings/settings.less
+++ b/common/app/routes/Settings/settings.less
@@ -28,6 +28,11 @@
   }
 }
 
+.offset-negative-row{
+  margin-right: 15px;
+  margin-left: 15px;
+}
+
 .@{ns}-container {
   .center(@value: @container-xl, @padding: @grid-gutter-width);
 
@@ -81,6 +86,10 @@
     .btn-group > label {
       margin: 10px 0;
     }
+    @media (max-width: 450px){
+      flex-wrap: wrap;
+      border-bottom: 1px solid #e0e0e0;
+    }
   }
 
   label {
@@ -104,6 +113,10 @@
 
   input, textarea {
     background-color: #fff;
+    margin: 5px 0;
+  }
+  @media (max-width: 450px) {
+    flex-wrap: wrap;
   }
 }
 .edit-preview-tabs {


### PR DESCRIPTION


#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [ ] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [ ] Addressed currently open issue (replace XXXXX with an issue no in next line)


#### Description

These changes improve the mobile responsiveness of the settings page mainly by allowing flex items to wrap and by offsetting the -15px horizontal margin added by React Bootstrap's class '.row'.  Offsetting this negative margin creates space between the edge of the page and the text. A similar change was made by editing the max-width of certain buttons so that the edges would not touch on mobile.

Also, added a min-width to the btn-group on the settings page to prevent the buttons from collapsing on top of one another which previously began happening around 700px-900px

Almost all changes involve media queries as to avoid negatively effecting the desktop version.
<!-- Describe your changes in detail -->
