### PR TITLE
fix: remove `<code>` tags around word 'queue'

### DIFF
--- a/seed/challenges/02-javascript-algorithms-and-data-structures/basic-javascript.json
+++ b/seed/challenges/02-javascript-algorithms-and-data-structures/basic-javascript.json
@@ -3565,7 +3565,7 @@
       "id": "56533eb9ac21ba0edf2244c6",
       "title": "Stand in Line",
       "description": [
-        "In Computer Science a <dfn>queue</dfn> is an abstract <dfn>Data Structure</dfn> where items are kept in order. New items can be added at the back of the <code>queue</code> and old items are taken off from the front of the <code>queue</code>.",
+        "In Computer Science a <dfn>queue</dfn> is an abstract <dfn>Data Structure</dfn> where items are kept in order. New items can be added at the back of the queue, and old items are taken off from the front of the queue.",
         "Write a function <code>nextInLine</code> which takes an array (<code>arr</code>) and a number (<code>item</code>) as arguments.",
         "Add the number to the end of the array, then remove the first element of the array.",
         "The <code>nextInLine</code> function should then return the element that was removed."


### PR DESCRIPTION
#### Pre-Submission Checklist

- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change

- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:

- [x] Tested changes locally.
- [x] Addressed currently open issue

Closes #17655

#### Description

Trivial change, but the PR is a response to a user of the forum having issues with the _Stand in Line_ challenge. To quote:

> I have no idea how to use “queue” in JavaScript. The instructions don’t mention if it’s a variable, a function, or what. I don’t know where to put it, what to put it with, or how to use it. Internet searches offer complex examples and commands not mentioned in this assignment or those previously.

![screen shot 2018-06-20 at 10 35 18](https://user-images.githubusercontent.com/573694/41651291-2204b3e0-7478-11e8-8568-acb8e18d92e3.png)

Within challenge descriptions, `<code>` tags refer [natch] to code. The name of a data structure is not code, and marking it as such is confusing. PR just changes it to:

![screen shot 2018-06-20 at 10 36 57](https://user-images.githubusercontent.com/573694/41651319-32537b5a-7478-11e8-9a54-65d24154e7bc.png)



