### PR TITLE
fix(about): Return empty object for no user

### DIFF
--- a/common/models/user.js
+++ b/common/models/user.js
@@ -493,9 +493,7 @@ module.exports = function(User) {
     if (!username) {
       // Zalgo!!
       return nextTick(() => {
-        cb(new TypeError(
-            `username should be a string but got ${ username }`
-        ));
+        cb(null, {});
       });
     }
     return User.findOne({ where: { username } }, (err, user) => {
@@ -503,7 +501,7 @@ module.exports = function(User) {
         return cb(err);
       }
       if (!user || user.username !== username) {
-        return cb(new Error(`no user found for ${ username }`));
+        return cb(null, {});
       }
       const aboutUser = getAboutProfile(user);
       return cb(null, aboutUser);


### PR DESCRIPTION
This commit will significantly reduce rollbar errors, hopefully bringing us back inside the free tier quota.

If the `/about` route fails to find a user, we send an empty object instead of throwing. This bring the api in line with other `GET` user endpoints we have.