### PR TITLE
fix(settings): Fix for Button clickable Overflow

### DIFF
--- a/common/app/routes/Settings/Settings.jsx
+++ b/common/app/routes/Settings/Settings.jsx
@@ -2,12 +2,9 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
-
 import { Button } from 'react-bootstrap';
-
 import ns from './ns.json';
 import { FullWidthRow, Spacer, Loader } from '../../helperComponents';
-import { Link } from '../../Router';
 import AboutSettings from './components/About-Settings.jsx';
 import InternetSettings from './components/Internet-Settings.jsx';
 import EmailSettings from './components/Email-Settings.jsx';
@@ -77,16 +74,15 @@ export class Settings extends React.Component {
     return (
       <div className={ `${ns}-container` }>
         <FullWidthRow>
-          <Link to={ `/${username}` }>
             <Button
               block={ true }
               bsSize='lg'
               bsStyle='primary'
               className='btn-link-social'
+              href={ `/${username}`}
               >
               Show me my public portfolio
             </Button>
-          </Link>
           <Button
             block={ true }
             bsSize='lg'

--- a/common/app/routes/Settings/Settings.jsx
+++ b/common/app/routes/Settings/Settings.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 import { Button } from 'react-bootstrap';
+
 import ns from './ns.json';
 import { FullWidthRow, Spacer, Loader } from '../../helperComponents';
 import AboutSettings from './components/About-Settings.jsx';


### PR DESCRIPTION
The first button in the settings page no longer has a link tag so that
the clickable area doesn't overflow outside of the button boundaries

Small Bug Fix

BREAKING CHANGE: none AFAIK

Closes #17867
