### PR TITLE
fix(heat-map): Show last 8 months of activity

### DIFF
--- a/common/app/routes/Profile/components/HeatMap.jsx
+++ b/common/app/routes/Profile/components/HeatMap.jsx
@@ -57,7 +57,10 @@ class HeatMap extends Component {
     const rectSelector = '#cal-heatmap > svg > svg.graph-legend > g > rect.r';
     const calLegendTitles = ['0 items', '1 item', '2 items', '3 or more items'];
     const firstTS = Object.keys(calendar)[0];
-    let start = new Date(firstTS * 1000);
+    // start should not be earlier than 7 months before now:
+    let start = (firstTS * 1000 + 1000 * 60 * 60 * 24 * 210 < Date.now())
+      ? new Date(Date.now() - 1000 * 60 * 60 * 24 * 210)
+      : new Date(firstTS * 1000);
     const monthsSinceFirstActive = differenceInCalendarMonths(
       today,
       start


### PR DESCRIPTION
#### Description
Fixed issue with HeatMap showing only the first 8 months of user's activity:
https://github.com/freeCodeCamp/freeCodeCamp/issues/17320

All unit tests passed:
  total:     1481
  passing:   1481
  duration:  17s

Tested the fix locally using test heat map data instead of calendar data coming via props to HeatMap.jsx. Test heat map data contains dates starting from Jul 17 2016 till Jul 17 2018 (2 years range), and there is up to 8 last months of activity is displayed on a heat map. 
```
{1468704955: 2,
1497216955: 4,
1500240955: 3,
1504128955: 1,
1505856955: 1,
1507584955: 4,
1508448955: 4,
1509312955: 4,
1509744955: 4,
1511040955: 4,
1512682555: 4,
1512768955: 4,
1513200955: 4,
1514928955: 4,
1515792955: 1,
1517520955: 2,
1519248955: 1,
1519335355: 2,
1519421755: 3,
1519508155: 4,
1519594555: 5,
1523136955: 1,
1524000955: 1,
1524087355: 1,
1527456955: 2,
1527888955: 1,
1528752955: 3,
1529184955: 1,
1529616955: 4,
1530480955: 1,
1531344955: 5,
1531690555: 1}
```

Closes #17320 

