### PR TITLE
fix(settings): Change challenge/portfolio label and input

### DIFF
--- a/common/app/routes/Settings/formHelpers/Form.jsx
+++ b/common/app/routes/Settings/formHelpers/Form.jsx
@@ -48,6 +48,7 @@ function DynamicForm({
       <FormFields
         errors={ errors }
         fields={ fields }
+        formId={ id }
         options={ options }
       />
       {

--- a/common/app/routes/Settings/formHelpers/FormFields.jsx
+++ b/common/app/routes/Settings/formHelpers/FormFields.jsx
@@ -19,6 +19,7 @@ const propTypes = {
       value: PropTypes.string.isRequired
     })
   ).isRequired,
+  formId: PropTypes.string,
   options: PropTypes.shape({
     errors: PropTypes.objectOf(
       PropTypes.oneOfType([
@@ -34,7 +35,7 @@ const propTypes = {
 };
 
 function FormFields(props) {
-  const { errors = {}, fields, options = {} } = props;
+  const { errors = {}, fields, formId, options = {} } = props;
   const {
     ignored = [],
     placeholder = true,
@@ -48,7 +49,9 @@ function FormFields(props) {
         .filter(field => !ignored.includes(field))
         .map(key => fields[key])
         .map(({ name, onChange, value, pristine }) => {
-          const key = _.kebabCase(name);
+          const key = formId ?
+            `${formId}_${_.kebabCase(name)}` :
+            _.kebabCase(name);
           const type = name in types ? types[name] : 'text';
           return (
           <Row className='inline-form-field' key={ key }>


### PR DESCRIPTION
Closes #17318

<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #17318

#### Description
<!-- Describe your changes in detail -->
This change prefixes the form's `id` to all label `for` and input `id` attributes for Challenges and Portfolio forms. 

This creates extra uniqueness for labels to identify their associated input. Previously, these attributes were associated by their field's name, which caused duplicate names due to legacy and modern challenge being both present on the Settings page.

There was also an unreported issue for the Portfolio form. If more than one portfolio item was listed, it would also share duplicate field names.

_**Before:**_
```<label for="build-a-pomodoro-clock" class="control-label">Build A Pomodoro Clock</label>```
_**After:**_
```<label for="legacy-front-end_build-a-pomodoro-clock" class="control-label">Build A Pomodoro Clock</label>```
