### PR TITLE
fix: replace hard-code learn URL with .env value

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -18,3 +18,6 @@ PEER=stuff
 DEBUG=true
 
 IMAGE_BASE_URL='https://s3.amazonaws.com/freecodecamp/images/'
+
+LEARN_URL='https://learn.freecodecamp.org'
+

--- a/server/boot/challenge.js
+++ b/server/boot/challenge.js
@@ -19,7 +19,7 @@ import { fixCompletedChallengeItem } from '../../common/utils';
 
 const log = debug('fcc:boot:challenges');
 
-const learnURL = 'https://learn.freecodecamp.org';
+const learnURL = process.env.LEARN_URL || 'https://learn.freecodecamp.org';
 
 const jsProjects = [
 'aaa48de84e1ecc7c742e1124',


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [ ] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #XXXXX

#### Description
The learn URL is currently hard-coded. This PR first checks if the LEARN_URL value has been provided by the `.env` file, and if not it reverts to the hard-coded value. This allows easy configuration of the learn URL for testing or for use with a custom learn platform.