### PR TITLE
Fix/jfitz fcc navright

### DIFF
--- a/common/app/Nav/LargeNav.jsx
+++ b/common/app/Nav/LargeNav.jsx
@@ -19,8 +19,8 @@ function LargeNav({ clickOnLogo }) {
                 <FCCSearchBar />
               </Navbar.Header>
             </Col>
-            <Col className='nav-component bins' sm={ 3 } xs={ 6 }/>
-            <Col className='nav-component nav-links' sm={ 4 } xs={ 0 }>
+            <Col className='nav-component bins' sm={ 2 } xs={ 6 }/>
+            <Col className='nav-component nav-links' sm={ 5 } xs={ 0 }>
               <Navbar.Collapse>
                 <NavLinks />
               </Navbar.Collapse>

--- a/common/app/Nav/nav.less
+++ b/common/app/Nav/nav.less
@@ -45,9 +45,6 @@
   background-color: @brand-primary;
   text-align: center;
 
-  @media (min-width: @screen-md-min) {
-    margin-right:0;
-  }
   @media (min-width: @screen-md-max) and (max-width: 991px) {
     left: 0;
     margin-right: 0;
@@ -305,7 +302,7 @@ li.nav-avatar {
 .bins {
 
   .disabled-button {
-    color: whitesmoke; 
+    color: whitesmoke;
   }
   .enabled-button {
     color: black;


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [ ] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #18154

#### Description
<!-- Describe your changes in detail -->

Seemed to be an unnecessary media query that messed with the right margin of the UL nav-links.
Also upped the cols from 4 to 5, and the decreased the cols for the spacing dive in the center from 3 to 2.  Seems a similar fix was implemented inLargeNav.js

On a public profile page, when the window width is below 1100px, the settings link wraps under the rest of the links in the top right corner of the page.

`<li class="nav-avatar"><a href="/settings">Settings</a></li>`

wraps under the rest of the list items in nav-links

`<ul id="nav-links" class="nav navbar-nav navbar-right" data-reactid="30"> ... </ul>`

This is my first PR to this project so if I'm way off base let me know.  Just wanted to get my feet wet and help out.