### PR TITLE
Fix problem euler 19 tests and solution

### DIFF
--- a/curriculum/challenges/en/08-coding-interview-prep/project-euler.json
+++ b/curriculum/challenges/en/08-coding-interview-prep/project-euler.json
@@ -1267,9 +1267,9 @@
             "assert.strictEqual(countingSundays(1943, 1946), 6, '<code>countingSundays(1943, 1946)</code> should return 6.');"
         },
         {
-          "text": "<code>countingSundays(1995, 2000)</code> should return 9.",
+          "text": "<code>countingSundays(1995, 2000)</code> should return 10.",
           "testString":
-            "assert.strictEqual(countingSundays(1995, 2000), 9, '<code>countingSundays(1995, 2000)</code> should return 9.');"
+            "assert.strictEqual(countingSundays(1995, 2000), 10, '<code>countingSundays(1995, 2000)</code> should return 10.');"
         },
         {
           "text": "<code>countingSundays(1901, 2000)</code> should return 171.",
@@ -1278,7 +1278,7 @@
         }
       ],
       "solutions": [
-        "function countingSundays(firstYear, lastYear) {\n  let sundays = 0;\n\n  for (let year = firstYear; year <= lastYear; year++) {\n    for (let month = 1; month <= 12; month++) {\n      const thisDate = new Date(year, month, 1);\n      if (thisDate.getDay() === 0) {\n        sundays++;\n      }\n    }\n  }\n  return sundays;\n}"
+        "function countingSundays(firstYear, lastYear) {\n  let sundays = 0;\n\n  for (let year = firstYear; year <= lastYear; year++) {\n    for (let month = 0; month < 12; month++) {\n      const thisDate = new Date(year, month, 1);\n      if (thisDate.getDay() === 0) {\n        sundays++;\n      }\n    }\n  }\n  return sundays;\n}"
       ],
       "translations": {},
       "description": [

--- a/curriculum/challenges/en/08-coding-interview-prep/project-euler/problem-19-counting-sundays.en.md
+++ b/curriculum/challenges/en/08-coding-interview-prep/project-euler/problem-19-counting-sundays.en.md
@@ -22,8 +22,8 @@ How many Sundays fell on the first of the month during the twentieth century (1 
 ```yml
 - text: '<code>countingSundays(1943, 1946)</code> should return 6.'
   testString: 'assert.strictEqual(countingSundays(1943, 1946), 6, ''<code>countingSundays(1943, 1946)</code> should return 6.'');'
-- text: '<code>countingSundays(1995, 2000)</code> should return 9.'
-  testString: 'assert.strictEqual(countingSundays(1995, 2000), 9, ''<code>countingSundays(1995, 2000)</code> should return 9.'');'
+- text: '<code>countingSundays(1995, 2000)</code> should return 10.'
+  testString: 'assert.strictEqual(countingSundays(1995, 2000), 10, ''<code>countingSundays(1995, 2000)</code> should return 10.'');'
 - text: '<code>countingSundays(1901, 2000)</code> should return 171.'
   testString: 'assert.strictEqual(countingSundays(1901, 2000), 171, ''<code>countingSundays(1901, 2000)</code> should return 171.'');'
 
@@ -60,7 +60,7 @@ function countingSundays(firstYear, lastYear) {
   let sundays = 0;
 
   for (let year = firstYear; year <= lastYear; year++) {
-    for (let month = 1; month <= 12; month++) {
+    for (let month = 0; month < 12; month++) {
       const thisDate = new Date(year, month, 1);
       if (thisDate.getDay() === 0) {
         sundays++;


### PR DESCRIPTION

#### Pre-Submission Checklist
- [ ] Your pull request targets the `staging` branch of freeCodeCamp.
- [X] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [X] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [ ] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
- [ ] Tested changes locally.
- [ ] Addressed currently open issue 


#### Description
In this challenge you have to return the number of Sundays that fell the first of the month in a given period.

I fixed an off-by-one error in the proposed solution, which didn't count the first Sunday of 1995 (01/01/1995).
Date.getMonth returns the month from 0 to 11 and not 1 to 12.
There are indeed 10 Sundays as first day of the month between 01/01/1995 and 31/12/2000, I checked manually.