### PR TITLE
Reformat a11y resources guide and add a resource

### DIFF
--- a/client/src/pages/guide/english/accessibility/accessibility-tools-for-web-developers/index.md
+++ b/client/src/pages/guide/english/accessibility/accessibility-tools-for-web-developers/index.md
@@ -1,43 +1,51 @@
 ---
 title: Accessibility Tools for Web Developers
 ---
-## Accessibility Tools for Web Developers
+# Accessibility Tools for Web Developers
 
 There are many tools and online resources that can help you to ensure that your web application meets all of the accessibility requirements.
 
-1. **<a href='https://chrome.google.com/webstore/detail/accessibility-developer-t/fpkknkljclfencbdbgkenhalefipecmb?hl=en' target='_blank' rel='nofollow'>Accessibility Developer Tools</a>**
+## General 
+
+- **<a href='https://chrome.google.com/webstore/detail/accessibility-developer-t/fpkknkljclfencbdbgkenhalefipecmb?hl=en' target='_blank' rel='nofollow'>Accessibility Developer Tools</a>**
 
    This is a Google Chrome extension that will add a new Accessibility sidebar pane in the Elements tab to the Chrome Developer tools. This new pane will display any properties that are relevant to the accessibility aspect of the element that you are currently inspecting. This extension also adds an accessibility audit that can be used to check whether the current web page violates any accessibility rules. 
 
 
-2. **<a href='https://chrome.google.com/webstore/detail/axe/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US' target='_blank' rel='nofollow'>aXe</a>**
+- **<a href='https://chrome.google.com/webstore/detail/axe/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US' target='_blank' rel='nofollow'>aXe</a>**
    
    This Google Chrome extension can find accessibility defects on your web page.
 
-
-3. **<a href='http://colorsafe.co' target='_blank' rel='nofollow'>Color Safe Palette Generator</a>**
-
-   This website can help you to create a color palette that is based on the WCAG guidelines for text and background contrast ratios.
-
-
-4. **<a href='http://www.checkmycolours.com' target='_blank' rel='nofollow'>Check My Colours</a>**
-
-   A website for checking if your existing website meets the accessibility requirements for color and contrast.
-
-
-5. **<a href='http://colororacle.org' target='_blank' rel='nofollow'>Color Oracle</a>**
-
-   An application that simulates color blindness. It is available on Windows, Mac and Linux.
-
-
-6. **<a href='http://khan.github.io/tota11y/' target='_blank' rel='nofollow'>tota11y</a>**
+- **<a href='http://khan.github.io/tota11y/' target='_blank' rel='nofollow'>tota11y</a>**
 
    An accessibility visualization toolkit that checks how your website performs with assistive technologies.
 
 
-7. **<a href='https://www.accesslint.com' target='_blank' rel='nofollow'>AccessLint</a>**
+- **<a href='https://www.accesslint.com' target='_blank' rel='nofollow'>AccessLint</a>**
 
    A GitHub app that checks your pull requests for accessibility issues.
+
+
+## Color Contrast
+
+- **<a href='http://colorsafe.co' target='_blank' rel='nofollow'>Color Safe Palette Generator</a>**
+
+   This website can help you to create a color palette that is based on the WCAG guidelines for text and background contrast ratios.
+
+
+- **<a href='http://www.checkmycolours.com' target='_blank' rel='nofollow'>Check My Colours</a>**
+
+   A website for checking if your existing website meets the accessibility requirements for color and contrast.
+
+
+- **<a href='http://colororacle.org' target='_blank' rel='nofollow'>Color Oracle</a>**
+
+   An application that simulates color blindness. It is available on Windows, Mac and Linux.
+
+
+- **<a href='https://toolness.github.io/accessible-color-matrix/' target='_blank' rel='nofollow'>Accessible Color Palette Builder</a>**
+
+   This website allows you to edit a color palette and will create a table showing all of the possible color combinations, telling you which ones are accessible and which combinations to avoid using.
 
 
 ***

--- a/client/src/pages/guide/english/accessibility/accessibility-tools-for-web-developers/index.md
+++ b/client/src/pages/guide/english/accessibility/accessibility-tools-for-web-developers/index.md
@@ -1,11 +1,11 @@
 ---
 title: Accessibility Tools for Web Developers
 ---
-# Accessibility Tools for Web Developers
+## Accessibility Tools for Web Developers
 
 There are many tools and online resources that can help you to ensure that your web application meets all of the accessibility requirements.
 
-## General 
+### General 
 
 - **<a href='https://chrome.google.com/webstore/detail/accessibility-developer-t/fpkknkljclfencbdbgkenhalefipecmb?hl=en' target='_blank' rel='nofollow'>Accessibility Developer Tools</a>**
 
@@ -26,7 +26,7 @@ There are many tools and online resources that can help you to ensure that your 
    A GitHub app that checks your pull requests for accessibility issues.
 
 
-## Color Contrast
+### Color Contrast
 
 - **<a href='http://colorsafe.co' target='_blank' rel='nofollow'>Color Safe Palette Generator</a>**
 


### PR DESCRIPTION
I added a resource to an accessible color palette builder, as well as did some reformatting.

Color tools are under their own heading for easy perusable. General section could be broken down as well, I believe, but for now I think it should be ok as-is. 

Since the order of these resources is not important, I turned the lists into `ul`s, which makes more sense as well as making this guide easier to maintain. Now if someone wants to change the order around or add or remove something, there is no need to go and change all of the list item numbers.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
