### PR TITLE
Remove duplicate sections from 'react/state'

### DIFF
--- a/client/src/pages/guide/english/react/state/index.md
+++ b/client/src/pages/guide/english/react/state/index.md
@@ -78,26 +78,26 @@ this.setState({value: 1});
 
 Keep in mind that `setState` may be asynchronous so you should be careful when using the current state to set a new state. A good example of this would be if you want to increment a value in your state. 
 
-### The Wrong Way
+#### The Wrong Way
 ```js
 this.setState({value: this.state.value + 1});
 ```
 
 This can lead to unexpected behavior in your app if the code above is called multiple times in the same update cycle. To avoid this you can pass an updater callback function to `setState` instead of an object. 
 
-### The Right Way
+#### The Right Way
 ```js
 this.setState(prevState => ({value: prevState.value + 1}));
 ```
 
-### The Cleaner Way
+#### The Cleaner Way
 ```
 this.setState(({ value }) => ({ value: value + 1 }));
 ```
 
 When only a limited number of fields in the state object is required, object destructing can be used for cleaner code.
 
-### More Information
+#### More Information
 
 - [React - State and Lifecycle](https://reactjs.org/docs/state-and-lifecycle.html)
 - [React - Lifting State Up](https://reactjs.org/docs/lifting-state-up.html)

--- a/client/src/pages/guide/english/react/state/index.md
+++ b/client/src/pages/guide/english/react/state/index.md
@@ -73,45 +73,24 @@ export default App;
 You can change the data stored in the state of your application using the `setState` method on your component.
 
 ```js
-this.setState({ value: 1 });
-```
-
-Keep in mind that `setState` is asynchronous so you should be careful when using the current state to set a new state. A good example of this would be if you want to increment a value in your state. 
-
-#### The Wrong Way
-```js
-this.setState({ value: this.state.value + 1 });
-```
-
-This can lead to unexpected behavior in your app if the code above is called multiple times in the same update cycle. To avoid this you can pass an updater callback function to `setState` instead of an object. 
-
-#### The Right Way
-```js
-this.setState(prevState => ({ value: prevState.value + 1 }));
-```
-
-## Updating State
-You can change the data stored in the state of your application using the `setState` method on your component.
-
-```js
 this.setState({value: 1});
 ```
 
 Keep in mind that `setState` may be asynchronous so you should be careful when using the current state to set a new state. A good example of this would be if you want to increment a value in your state. 
 
-##### The Wrong Way
+### The Wrong Way
 ```js
 this.setState({value: this.state.value + 1});
 ```
 
 This can lead to unexpected behavior in your app if the code above is called multiple times in the same update cycle. To avoid this you can pass an updater callback function to `setState` instead of an object. 
 
-##### The Right Way
+### The Right Way
 ```js
 this.setState(prevState => ({value: prevState.value + 1}));
 ```
 
-##### The Cleaner Way
+### The Cleaner Way
 ```
 this.setState(({ value }) => ({ value: value + 1 }));
 ```


### PR DESCRIPTION
The "updating state" section was duplicated, so I removed one of them.

I also corrected the heading levels for the subheadings below "updating state". It went from h2 to h5 and now goes properly from h2 to h3.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
