### PR TITLE
Docs: Fix link to style guide for best practices

### DIFF
--- a/docs/how-to-work-on-guide-articles.md
+++ b/docs/how-to-work-on-guide-articles.md
@@ -12,7 +12,7 @@ You can:
 1. 🍴 [Fork this repo](https://github.com/freeCodeCamp/freeCodeCamp#fork-destination-box)
 2. 👀️ Follow the contributing guidelines outlined below.
 3. 🔧 Make some awesome changes!
-4. 📖 Read this [style guide for best practices](/docs/style-guide-for-guide-articles).
+4. 📖 Read this [style guide for best practices](/docs/style-guide-for-guide-articles.md).
 5. 👉 [Make a pull request](https://github.com/freeCodeCamp/freeCodeCamp/compare)
 6. 🎉 Get your pull request approved - success!
 


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->
## Change the broken styleguide link to match the one that works

Changelog:
/docs/how-to-work-on-guide-articles - add missing .md extension so that link works

Broken link:
![broken_styleguide_link](https://user-images.githubusercontent.com/12958190/46901709-24dcb000-ce6d-11e8-8f5d-a7ab6f64d716.gif)


- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes # N/A
