### PR TITLE
fix: update tests for data structures challenges

### DIFF
--- a/curriculum/challenges/arabic/08-coding-interview-prep/data-structures/use-.has-and-.size-on-an-es6-set.arabic.md
+++ b/curriculum/challenges/arabic/08-coding-interview-prep/data-structures/use-.has-and-.size-on-an-es6-set.arabic.md
@@ -18,7 +18,7 @@ undefined
 ```yml
 tests:
   - text: ''
-    testString: 'assert(function(){var test = checkSet([4,5,6], 3); test === [ false, 3 ]}, "<code>checkSet([4, 5, 6], 3)</code> should return [ false, 3 ]");'
+    testString: 'assert((function(){var test = checkSet([4,5,6], 3); test === [ false, 3 ]})(), "<code>checkSet([4, 5, 6], 3)</code> should return [ false, 3 ]");'
 
 ```
 

--- a/curriculum/challenges/arabic/08-coding-interview-prep/data-structures/use-spread-and-notes-for-es5-set-integration.arabic.md
+++ b/curriculum/challenges/arabic/08-coding-interview-prep/data-structures/use-spread-and-notes-for-es5-set-integration.arabic.md
@@ -18,7 +18,7 @@ undefined
 ```yml
 tests:
   - text: ''
-    testString: 'assert(function(){var test = checkSet(new Set([1,2,3,4,5,6,7])); test === [ 1, 2, 3, 4, 5, 6, 7 ]}, "Your Set was returned correctly!");'
+    testString: 'assert((function(){var test = checkSet(new Set([1,2,3,4,5,6,7])); test === [ 1, 2, 3, 4, 5, 6, 7 ]})(), "Your Set was returned correctly!");'
 
 ```
 

--- a/curriculum/challenges/chinese/08-coding-interview-prep/data-structures/use-.has-and-.size-on-an-es6-set.chinese.md
+++ b/curriculum/challenges/chinese/08-coding-interview-prep/data-structures/use-.has-and-.size-on-an-es6-set.chinese.md
@@ -18,7 +18,7 @@ localeTitle: 在ES6集上使用.has和.size
 ```yml
 tests:
   - text: '<code>checkSet([4, 5, 6], 3)</code>应该返回[false，3]'
-    testString: 'assert(function(){var test = checkSet([4,5,6], 3); test === [ false, 3 ]}, "<code>checkSet([4, 5, 6], 3)</code> should return [ false, 3 ]");'
+    testString: 'assert((function(){var test = checkSet([4,5,6], 3); test === [ false, 3 ]})(), "<code>checkSet([4, 5, 6], 3)</code> should return [ false, 3 ]");'
 
 ```
 

--- a/curriculum/challenges/chinese/08-coding-interview-prep/data-structures/use-spread-and-notes-for-es5-set-integration.chinese.md
+++ b/curriculum/challenges/chinese/08-coding-interview-prep/data-structures/use-spread-and-notes-for-es5-set-integration.chinese.md
@@ -18,7 +18,7 @@ localeTitle: 使用Spread和Notes进行ES5 Set（）集成
 ```yml
 tests:
   - text: 您的套装已正确退回！
-    testString: 'assert(function(){var test = checkSet(new Set([1,2,3,4,5,6,7])); test === [ 1, 2, 3, 4, 5, 6, 7 ]}, "Your Set was returned correctly!");'
+    testString: 'assert((function(){var test = checkSet(new Set([1,2,3,4,5,6,7])); test === [ 1, 2, 3, 4, 5, 6, 7 ]})(), "Your Set was returned correctly!");'
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/use-.has-and-.size-on-an-es6-set.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/use-.has-and-.size-on-an-es6-set.english.md
@@ -26,7 +26,7 @@ In this exercise we will pass an array and a value to the checkSet() function. Y
 ```yml
 tests:
   - text: <code>checkSet([4, 5, 6], 3)</code> should return [ false, 3 ]
-    testString: assert(function(){var test = checkSet([4,5,6], 3); test === [ false, 3 ]}, '<code>checkSet([4, 5, 6], 3)</code> should return [ false, 3 ]');
+    testString: 'assert((function(){var test = checkSet([4,5,6], 3); test === [ false, 3 ]})(), "<code>checkSet([4, 5, 6], 3)</code> should return [ false, 3 ]");'
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/use-spread-and-notes-for-es5-set-integration.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/use-spread-and-notes-for-es5-set-integration.english.md
@@ -24,7 +24,7 @@ Now you've successfully learned how to use the ES6 <code>Set()</code> object, go
 ```yml
 tests:
   - text: Your Set was returned correctly!
-    testString: assert(function(){var test = checkSet(new Set([1,2,3,4,5,6,7])); test === [ 1, 2, 3, 4, 5, 6, 7 ]}, 'Your Set was returned correctly!');
+    testString: 'assert((function(){var test = checkSet(new Set([1,2,3,4,5,6,7])); test === [ 1, 2, 3, 4, 5, 6, 7 ]})(), "Your Set was returned correctly!");'
 
 ```
 

--- a/curriculum/challenges/portuguese/08-coding-interview-prep/data-structures/use-.has-and-.size-on-an-es6-set.portuguese.md
+++ b/curriculum/challenges/portuguese/08-coding-interview-prep/data-structures/use-.has-and-.size-on-an-es6-set.portuguese.md
@@ -18,7 +18,7 @@ localeTitle: Use .has e .size em um conjunto ES6
 ```yml
 tests:
   - text: '<code>checkSet([4, 5, 6], 3)</code> deve retornar [false, 3]'
-    testString: 'assert(function(){var test = checkSet([4,5,6], 3); test === [ false, 3 ]}, "<code>checkSet([4, 5, 6], 3)</code> should return [ false, 3 ]");'
+    testString: 'assert((function(){var test = checkSet([4,5,6], 3); test === [ false, 3 ]})(), "<code>checkSet([4, 5, 6], 3)</code> should return [ false, 3 ]");'
 
 ```
 

--- a/curriculum/challenges/portuguese/08-coding-interview-prep/data-structures/use-spread-and-notes-for-es5-set-integration.portuguese.md
+++ b/curriculum/challenges/portuguese/08-coding-interview-prep/data-structures/use-spread-and-notes-for-es5-set-integration.portuguese.md
@@ -18,7 +18,7 @@ localeTitle: Use Spread e Notes para Integração do Conjunto ES5 ()
 ```yml
 tests:
   - text: Seu conjunto foi devolvido corretamente!
-    testString: 'assert(function(){var test = checkSet(new Set([1,2,3,4,5,6,7])); test === [ 1, 2, 3, 4, 5, 6, 7 ]}, "Your Set was returned correctly!");'
+    testString: 'assert((function(){var test = checkSet(new Set([1,2,3,4,5,6,7])); test === [ 1, 2, 3, 4, 5, 6, 7 ]})(), "Your Set was returned correctly!");'
 
 ```
 

--- a/curriculum/challenges/russian/08-coding-interview-prep/data-structures/use-.has-and-.size-on-an-es6-set.russian.md
+++ b/curriculum/challenges/russian/08-coding-interview-prep/data-structures/use-.has-and-.size-on-an-es6-set.russian.md
@@ -18,7 +18,7 @@ localeTitle: Используйте .has и .size в наборе ES6.
 ```yml
 tests:
   - text: '<code>checkSet([4, 5, 6], 3)</code> должен возвращать [false, 3]'
-    testString: 'assert(function(){var test = checkSet([4,5,6], 3); test === [ false, 3 ]}, "<code>checkSet([4, 5, 6], 3)</code> should return [ false, 3 ]");'
+    testString: 'assert((function(){var test = checkSet([4,5,6], 3); test === [ false, 3 ]})(), "<code>checkSet([4, 5, 6], 3)</code> should return [ false, 3 ]");'
 
 ```
 

--- a/curriculum/challenges/russian/08-coding-interview-prep/data-structures/use-spread-and-notes-for-es5-set-integration.russian.md
+++ b/curriculum/challenges/russian/08-coding-interview-prep/data-structures/use-spread-and-notes-for-es5-set-integration.russian.md
@@ -18,7 +18,7 @@ localeTitle: Использование Spread и Notes для интеграц�
 ```yml
 tests:
   - text: Ваш набор был возвращен правильно!
-    testString: 'assert(function(){var test = checkSet(new Set([1,2,3,4,5,6,7])); test === [ 1, 2, 3, 4, 5, 6, 7 ]}, "Your Set was returned correctly!");'
+    testString: 'assert((function(){var test = checkSet(new Set([1,2,3,4,5,6,7])); test === [ 1, 2, 3, 4, 5, 6, 7 ]})(), "Your Set was returned correctly!");'
 
 ```
 

--- a/curriculum/challenges/spanish/08-coding-interview-prep/data-structures/use-.has-and-.size-on-an-es6-set.spanish.md
+++ b/curriculum/challenges/spanish/08-coding-interview-prep/data-structures/use-.has-and-.size-on-an-es6-set.spanish.md
@@ -18,7 +18,7 @@ localeTitle: Utilice .has y .size en un conjunto ES6
 ```yml
 tests:
   - text: '<code>checkSet([4, 5, 6], 3)</code> debe devolver [false, 3]'
-    testString: 'assert(function(){var test = checkSet([4,5,6], 3); test === [ false, 3 ]}, "<code>checkSet([4, 5, 6], 3)</code> should return [ false, 3 ]");'
+    testString: 'assert((function(){var test = checkSet([4,5,6], 3); test === [ false, 3 ]})(), "<code>checkSet([4, 5, 6], 3)</code> should return [ false, 3 ]");'
 
 ```
 

--- a/curriculum/challenges/spanish/08-coding-interview-prep/data-structures/use-spread-and-notes-for-es5-set-integration.spanish.md
+++ b/curriculum/challenges/spanish/08-coding-interview-prep/data-structures/use-spread-and-notes-for-es5-set-integration.spanish.md
@@ -18,7 +18,7 @@ localeTitle: Use Spread and Notes para la integración de ES5 Set ()
 ```yml
 tests:
   - text: ¡Tu Set fue devuelto correctamente!
-    testString: 'assert(function(){var test = checkSet(new Set([1,2,3,4,5,6,7])); test === [ 1, 2, 3, 4, 5, 6, 7 ]}, "Your Set was returned correctly!");'
+    testString: 'assert((function(){var test = checkSet(new Set([1,2,3,4,5,6,7])); test === [ 1, 2, 3, 4, 5, 6, 7 ]})(), "Your Set was returned correctly!");'
 
 ```
 


### PR DESCRIPTION
Fix the test strings to run the functions as the challenge currently passes without any code changes (all languages)
- Data Structures: Use .has and .size on an ES6 Set
- Data Structures: Use Spread and Notes for ES5 Set() Integration

- [X] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `master` branch of freeCodeCamp.
- [X] None of my changes are plagiarized from another source without proper attribution.
- [X] My article does not contain shortened URLs or affiliate links.

Is related to #17856
