### PR TITLE
fix(bootstrap): uses OS-specific filepath separators to split file paths

### DIFF
--- a/curriculum/getChallenges.js
+++ b/curriculum/getChallenges.js
@@ -64,7 +64,7 @@ async function buildCurriculum(file, curriculum) {
 }
 
 function superBlockInfoFromPath(filePath) {
-  const [maybeSuper] = filePath.split('/');
+  const [maybeSuper] = filePath.split(path.sep);
   return superBlockInfo(maybeSuper);
 }
 
@@ -82,6 +82,6 @@ function superBlockInfo(fileName) {
 }
 
 function getBlockNameFromPath(filePath) {
-  const [, block] = filePath.split('/');
+  const [, block] = filePath.split(path.sep);
   return block;
 }


### PR DESCRIPTION
* uses OS-specific path separator via node's `path` module

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #19019
