### PR TITLE
Fixed markdown syntax

### DIFF
--- a/client/src/pages/guide/english/html/attributes/font-color-attribute/index.md
+++ b/client/src/pages/guide/english/html/attributes/font-color-attribute/index.md
@@ -6,7 +6,7 @@ title: Font Color Attribute
 This attribute is used to set a color to the text enclosed in a ```<font>``` tag.
 
 ### Syntax:
- ``html
+ ```html
  <font color= "color">
  ```
  


### PR DESCRIPTION
One backtick was missing from the starting tag of a code block, which had downstream effects.

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.