### PR TITLE
fix(guide): Change typeof keyword to operator

### DIFF
--- a/client/src/pages/guide/english/javascript/typeof/index.md
+++ b/client/src/pages/guide/english/javascript/typeof/index.md
@@ -3,7 +3,7 @@ title: Typeof
 ---
 ## Typeof
 
-`typeof` is a JavaScript keyword that will return the type of a variable when you call it. You can use this to validate function parameters or check if variables are defined. There are other uses as well.
+`typeof` is a JavaScript operator that will return the type of the operand on its right hand side. You can use this to validate function parameters or check if variables are defined. There are other uses as well.
 
 The `typeof` operator is useful because it is an easy way to check the type of a variable in your code. This is important because JavaScript is a is a <a href='https://stackoverflow.com/questions/2690544/what-is-the-difference-between-a-strongly-typed-language-and-a-statically-typed' target='_blank' rel='nofollow'>dynamically typed language</a>. This means that you aren't required to assign types to variables when you create them. Because a variable is not restricted in this way, its type can change during the runtime of a program.
 

--- a/client/src/pages/guide/english/javascript/typeof/index.md
+++ b/client/src/pages/guide/english/javascript/typeof/index.md
@@ -3,7 +3,7 @@ title: Typeof
 ---
 ## Typeof
 
-`typeof` is a JavaScript operator that will return the type of the operand on its right hand side. You can use this to validate function parameters or check if variables are defined. There are other uses as well.
+`typeof` is a JavaScript operator that will return the type of the operand on its right hand side as a string. You can use this to validate function parameters or check if variables are defined. There are other uses as well.
 
 The `typeof` operator is useful because it is an easy way to check the type of a variable in your code. This is important because JavaScript is a is a <a href='https://stackoverflow.com/questions/2690544/what-is-the-difference-between-a-strongly-typed-language-and-a-statically-typed' target='_blank' rel='nofollow'>dynamically typed language</a>. This means that you aren't required to assign types to variables when you create them. Because a variable is not restricted in this way, its type can change during the runtime of a program.
 


### PR DESCRIPTION
In Javascript, 'typeof' is a unary operator, and it works with values other than variables as well.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
