### PR TITLE
feature(guide): added usage of default parameters

### DIFF
--- a/client/src/pages/guide/english/javascript/es6/default-parameters/index.md
+++ b/client/src/pages/guide/english/javascript/es6/default-parameters/index.md
@@ -47,3 +47,9 @@ NotWorkingFunction(20, 30); // 50;
 ```
 
 Works fine.
+
+However, if you want to use the default first parameter, you can pass `undefined` as the first argument of the function call.
+
+```
+NotWorkingFunction(undefined, 30); // 40;
+```


### PR DESCRIPTION
When the default parameters are not in the end of the parameters list, they still can be used if you pass 'undefined' arguments.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
