### PR TITLE
Removed duplicate link

### DIFF
--- a/client/src/pages/guide/english/product-design/index.md
+++ b/client/src/pages/guide/english/product-design/index.md
@@ -24,9 +24,6 @@ User Research, Data Analysis, UX and Interaction Design, Graphic and UI Design, 
  <a href='https://www.youtube.com/watch?v=v-XDF57OOQQ' target='_blank' rel='nofollow'>How to be a Freelance Product Designer — Jared Erondu</a>
 [Dann Petty Youtube Channel] (https://www.youtube.com/channel/UCTOwGti_mRb2J1JfTdIkg_w)
 
- <a href='https://www.youtube.com/watch?v=v-XDF57OOQQ' target='_blank' rel='nofollow'>How to be a Freelance Product Designer — Jared Erondu</a>
-[Dann Petty Youtube Channel] (https://www.youtube.com/channel/UCTOwGti_mRb2J1JfTdIkg_w)
-
 
  ###### Resources:
 <a href='https://medium.com/@jeanniehuang/product-design-resources-ive-found-helpful-5dadad58dcff' target='_blank' rel='nofollow'>Product Design Resources I’ve Found Helpful</a>


### PR DESCRIPTION
the link to this freelance video is duplicated, removed one of them.
 <a href='https://www.youtube.com/watch?v=v-XDF57OOQQ' target='_blank' rel='nofollow'>How to be a Freelance Product Designer — Jared Erondu</a>
[Dann Petty Youtube Channel] (https://www.youtube.com/channel/UCTOwGti_mRb2J1JfTdIkg_w)

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
