### PR TITLE
Typos and removing scripts from <head> section.

### DIFF
--- a/client/src/pages/guide/english/html/page-structure/index.md
+++ b/client/src/pages/guide/english/html/page-structure/index.md
@@ -3,7 +3,7 @@ title: Page Structure
 ---
 ## Page Structure
 
-To create your pages in `HTML`, you need to know how to structure a page in `HTML`. Usually, the website structure follows the order below:
+To create your pages in `HTML`, you need to know how to structure a page in `HTML`. Usually, the page structure follows the example below:
 
 ```HTML
 <!DOCTYPE html>
@@ -16,15 +16,15 @@ To create your pages in `HTML`, you need to know how to structure a page in `HTM
   </body>
 </html>
 ```
-1º - The `<!DOCTYPE html>` statement must always be the first to appear on an `HTML` page and tell the browser which version of the language is being used. In this case, we are working with `HTML5`.
+1. The `<!DOCTYPE html>` statement must always be the first to appear on an `HTML` page and tell the browser which version of the language is being used. In this case, we are working with `HTML5`.
 
-2º - The `<html>` and `</html>` tags tell the web browser where the `HTML` code starts and ends.
+1. The `<html>` and `</html>` tags tell the web browser where the `HTML` code starts and ends.
 
-3º - The `<head>` and `</head>` tags contains information about the website, e.g. style, meta-tags, etc.
+1. The `<head>` and `</head>` tags contains information about the website, e.g. style, meta-tags, etc.
 
-4º - The `<title>` and `</title>` tags tell the browser what the page title is. The title can be seen by identifying the tab in your internet browser. The text that is defined between these tags is also the text that is used as title by the search engines when they present the pages in the results of a search.
+1. The `<title>` and `</title>` tags tell the browser what the page title is. The title can be seen by identifying the tab in your internet browser. The text that is defined between these tags is also the text that is used as title by the search engines when they present the pages in the results of a search.
 
-5º - Between the `<body>` and `</ body>` tags the page content is placed, which is what is displayed in the browser.
+1. Between the `<body>` and `</ body>` tags the page content is placed, which is what is displayed in the browser.
 
 ### Changes in HTML5
 

--- a/client/src/pages/guide/english/html/page-structure/index.md
+++ b/client/src/pages/guide/english/html/page-structure/index.md
@@ -3,7 +3,7 @@ title: Page Structure
 ---
 ## Page Structure
 
-To create your pages in `HTML`, you need to know how to structure a page in `HTML`, basically, the structuring a page follows the order below:
+To create your pages in `HTML`, you need to know how to structure a page in `HTML`. Usually, the structuring a page follows the order below:
 
 ```HTML
 <!DOCTYPE html>
@@ -20,7 +20,7 @@ To create your pages in `HTML`, you need to know how to structure a page in `HTM
 
 2º - The `<html>` and `</html>` tags tell the web browser where the `HTML` code starts and ends.
 
-3º - The `<head>` and `</head>` tags contains informations about the web site, exemple: style, meta-tags, scripts, etc...
+3º - The `<head>` and `</head>` tags contains informations about the website, e.g. style, meta-tags, etc.
 
 4º - The `<title>` and `</title>` tags tell the browser what the page title is. The title can be seen by identifying the tab in your internet browser. The text that is defined between these tags is also the text that is used as title by the search engines when they present the pages in the results of a search.
 
@@ -30,7 +30,7 @@ To create your pages in `HTML`, you need to know how to structure a page in `HTM
 
 #### Introduction of semantic tags
 Instead of using `<div>` for every other container several semantic(these tags help screenreaders which are used by visually
-impaired) tags such as `<header>` `<footer>` . So it is advisable to use these tags instead of generic `<div>`. 
+impaired) tags such as `<header>` `<footer>`. So it is advisable to use these tags instead of generic `<div>`. 
 
 #### More Information:
 [HTML: Introduction](https://www.w3schools.com/html/html_intro.asp)

--- a/client/src/pages/guide/english/html/page-structure/index.md
+++ b/client/src/pages/guide/english/html/page-structure/index.md
@@ -3,7 +3,7 @@ title: Page Structure
 ---
 ## Page Structure
 
-To create your pages in `HTML`, you need to know how to structure a page in `HTML`. Usually, the structuring a page follows the order below:
+To create your pages in `HTML`, you need to know how to structure a page in `HTML`. Usually, the website structure follows the order below:
 
 ```HTML
 <!DOCTYPE html>
@@ -20,7 +20,7 @@ To create your pages in `HTML`, you need to know how to structure a page in `HTM
 
 2º - The `<html>` and `</html>` tags tell the web browser where the `HTML` code starts and ends.
 
-3º - The `<head>` and `</head>` tags contains informations about the website, e.g. style, meta-tags, etc.
+3º - The `<head>` and `</head>` tags contains information about the website, e.g. style, meta-tags, etc.
 
 4º - The `<title>` and `</title>` tags tell the browser what the page title is. The title can be seen by identifying the tab in your internet browser. The text that is defined between these tags is also the text that is used as title by the search engines when they present the pages in the results of a search.
 


### PR DESCRIPTION
Removed scripts from <head> section description. "contains informations about the web site, exemple: style, meta-tags, scripts, etc..." (exemple on its own have typo), scripts doesn't containt informations about website.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
