### PR TITLE
Fix README on the Spanish version to point to the right

### DIFF
--- a/docs/spanish/README.md
+++ b/docs/spanish/README.md
@@ -17,7 +17,7 @@
 Este directorio contiene toda la documentación sobre cómo contribuir a freeCodeCamp.org
 
 
-## [Si estás empezando, comienza por leer esto primero.](/CONTRIBUTING.md)
+## [Si estás empezando, comienza por leer esto primero.](/docs/spanish/CONTRIBUTING.md)
 
 ---
 


### PR DESCRIPTION
In the Spanish version, the URL that leads to the first steps or CONTRIBUTING.md file, takes you to the English version.

If the user is reading the Spanish guide, I feel that the right thing should be to keep him/her in the same language. This behavior might be happening with other languages as well.

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
