### PR TITLE
Default img display type

### DIFF
--- a/client/src/pages/guide/english/css/css-images/index.md
+++ b/client/src/pages/guide/english/css/css-images/index.md
@@ -14,6 +14,14 @@ title: CSS Images
 * **width:** This specifies a width for the image(can be percent or px or auto)</li>
 * **height:** This specifies a height for the image(can be percent or px or auto)</li>
 
+####CSS DEFAULTS
+<p>The IMG element will be rendered by default in most browsers to be displayed as an inline-block display type unless specified otherwise.</p>
+
+```
+img {
+     display: inline-block;
+     }
+```
 
 #### More Information:
 <!-- Please add any articles you think might be helpful to read before writing the article -->

--- a/client/src/pages/guide/english/css/css-images/index.md
+++ b/client/src/pages/guide/english/css/css-images/index.md
@@ -2,10 +2,9 @@
 title: CSS Images
 ---
 ## CSS Images
-<p>This helps in adding an image to a website.</p>
+This helps in adding an image to a website.
 
-
-####Code Sample</h4>
+#### Code Sample
 
 ```<img src="picture.jpg" alt="Picture" width="100" height="100">```
 
@@ -14,8 +13,8 @@ title: CSS Images
 * **width:** This specifies a width for the image(can be percent or px or auto)</li>
 * **height:** This specifies a height for the image(can be percent or px or auto)</li>
 
-####CSS DEFAULTS
-<p>The IMG element will be rendered by default in most browsers to be displayed as an inline-block display type unless specified otherwise.</p>
+#### CSS Defaults
+The `img` element will be rendered by default in most browsers to be displayed as an inline-block display type unless specified otherwise.
 
 ```
 img {


### PR DESCRIPTION
Added info about how img elements are rendered for display type by default.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x ] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [ x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ x] My pull request targets the `master` branch of freeCodeCamp.
- [ x] None of my changes are plagiarized from another source without proper attribution.
- [ x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
