### PR TITLE
fix (guide): Improve Java Lambda Expressions

### DIFF
--- a/client/src/pages/guide/english/java/lambda-expressions/index.md
+++ b/client/src/pages/guide/english/java/lambda-expressions/index.md
@@ -3,17 +3,34 @@ title: Lambda Expressions
 ---
 ## Lambda Expressions
 
-This is a stub. <a href='https://github.com/freecodecamp/guides/tree/master/src/pages/mathematics/quadratic-equations/index.md' target='_blank' rel='nofollow'>Help our community expand it</a>.
-
-<a href='https://github.com/freecodecamp/guides/blob/master/README.md' target='_blank' rel='nofollow'>This quick style guide will help ensure your pull request gets accepted</a>.
-
 <!-- The article goes here, in GitHub-flavored Markdown. Feel free to add YouTube videos, images, and CodePen/JSBin embeds  -->
 
-The Stream Api is used in java to allow chaining of sequential and aggregate operations. Stream operations are either intermediate or terminal in nature.
+Lambda Expressions were introduced in Java 8 and it marks Java's foray to the Functional Programming paradigm. It helps produce readable and concise code and can tremendously simplify your Java applications.
+
+Lambdas are essentially functions - independent units of code that you can use anywhere you would normally use an object, like passing an argument to a method. In this case, instead of creating a class and then creating an object from the class, or directly using an anonymous class, you write your lambda expression and just pass it to the method instead of a class object.
+
+A Lambda Expression is composed of three parts - the function parameters, the `->` symbol, and the function body.
+
+- The first part, function parameters, indicate what arguments you expect your lambda function to take. For instance, if you are iterating over a list of `Person` objects, you can write the function parameter of the Lambda expression as `(Person p)`. If you expect to get two (or more) `Person` objects as arguments, you would separate them with a comma, `(Person p1, Person p2)`. If you don't expect any argument, you just use empty paranthesis `()`. The rule is you can omit the paranthesis in case your Lambda expression accepts only 1 argument. In all other cases, the paranthesis are mandatory.
+
+- The function parameters are followed by the `->` symbol (dash followed by a greater-than/arrow symbol).
+
+- The third component of the Lambda expression is the function body, which performs the actual work. You write the function body within braces `{ }`. However, if your function body is just one line, you can omit the `{ }` and write it directly after the `->`, like so: 
+
+  ```java
+   Person p -> System.out.println(p.getName());
+  ```
+  This is a complete Lambda Expression. It accepts a `Person` object as argument and prints it's name using the `getName()` getter.
+
+### Stream API
+
+The `Stream` API was also introduced in Java 8, and can be used to allow chaining of sequential and aggregate operations. Stream operations are either intermediate or terminal in nature.
+
+Normally, the Stream API is used in conjuction with Lambda Expressions to produce concise code.
 
 In this small example you can see that one of the utilities of a stream is to receive a certain property of all objects in a list and return it in another list using intermediate and terminal operations.
 
-Assume you have an object class of Student.
+Assume you have a `Student` class like so:
 ```java
 public class Student {
   int studentId;
@@ -30,32 +47,33 @@ public class Student {
 }
 ```
 
-Now assume in some method you have a list of all the students and want to get a list of all the student names. 
+Now assume you're writing a method which has a list of all the students and you want to get a list of all the student names. 
 Traditionally this can looks something like this.
 
 ```java
-List<Student> students = some list of student objects
+List<Student> students = /* some list of student objects */;
 
 List<String> studentNames = new ArrayList<>();
 for(Student student: students) {
   studentNames.add(student.getStudentName());
 }
 ```
-While this isn't terrible it can be simplified.
-Using streams this is possible with one line of code.
+While this isn't a bad idea, it can be simplified using streams into just one line of code.
 
 ```java
-List<Student> students = some list of student objects
+List<Student> students = /* some list of student objects */;
 
 List<String> studentNames = students.stream().map(String::getStudentName).collect(Collectors.toList());
 ```
 
-The students stream api goes over the list of students and uses the intermediate map function to return a new list of streams using whatever method is on the right of the ::
+The `Stream` API goes over the list of students and uses the intermediate `map` function to return a new Stream using whatever method is on the right of the `::`. 
 
-The terminal collect operation collects the stream as a list of strings.
+The terminal `collect` operation collects the stream as a list of strings.
 
-This is only one use of the Streams Api used in java 8. There are many other applications of streams utilizing the other operations as seen here in the documentation.
- [Streams api doc](https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html)
+This is only one use of the Streams API used in Java 8. There are many other applications of streams utilizing other operations as seen here in the [documentation](https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html).
 
 #### More Information:
 <!-- Please add any articles you think might be helpful to read before writing the article -->
+- [Lambda Expressions](https://docs.oracle.com/javase/tutorial/java/javaOO/lambdaexpressions.html)
+- [Java 8 Stream API](https://docs.oracle.com/javase/8/docs/api/java/util/stream/package-summary.html)
+- [Java 8 Double Colon Operator](https://www.baeldung.com/java-8-double-colon-operator)

--- a/client/src/pages/guide/english/java/lambda-expressions/index.md
+++ b/client/src/pages/guide/english/java/lambda-expressions/index.md
@@ -3,34 +3,33 @@ title: Lambda Expressions
 ---
 ## Lambda Expressions
 
-<!-- The article goes here, in GitHub-flavored Markdown. Feel free to add YouTube videos, images, and CodePen/JSBin embeds  -->
+Lambda expressions were introduced in Java 8 and it marks Java's foray to the functional programming paradigm. It helps produce readable and concise code and can tremendously simplify your Java applications.
 
-Lambda Expressions were introduced in Java 8 and it marks Java's foray to the Functional Programming paradigm. It helps produce readable and concise code and can tremendously simplify your Java applications.
+Lambda functions are essentially functions — independent units of code that you can use anywhere you would normally use an object, like passing an argument to a method. In this case, instead of creating a class and then creating an object from the class, or directly using an anonymous class, you write your lambda expression and just pass it to the method instead of a class object.
 
-Lambdas are essentially functions - independent units of code that you can use anywhere you would normally use an object, like passing an argument to a method. In this case, instead of creating a class and then creating an object from the class, or directly using an anonymous class, you write your lambda expression and just pass it to the method instead of a class object.
+A lambda expression is composed of three parts — function parameters, the `->` symbol, and a function body.
 
-A Lambda Expression is composed of three parts - the function parameters, the `->` symbol, and the function body.
+- The first part, function parameters, indicates what arguments you expect your lambda function to take. For instance, if you are iterating over a list of `Person` objects, you can write the function parameter of the lambda expression as `(Person p)`. If you expect to get two (or more) `Person` objects as arguments, you would separate them with a comma, `(Person p1, Person p2)`. If you don't expect any arguments, you simply use empty parentheses `()`. The rule is that you can omit the parentheses in case your Lambda expression accepts only 1 argument. In all other cases, the parentheses are mandatory.
 
-- The first part, function parameters, indicate what arguments you expect your lambda function to take. For instance, if you are iterating over a list of `Person` objects, you can write the function parameter of the Lambda expression as `(Person p)`. If you expect to get two (or more) `Person` objects as arguments, you would separate them with a comma, `(Person p1, Person p2)`. If you don't expect any argument, you just use empty paranthesis `()`. The rule is you can omit the paranthesis in case your Lambda expression accepts only 1 argument. In all other cases, the paranthesis are mandatory.
+- Function parameters are followed by the `->` symbol (dash followed by a greater-than symbol).
 
-- The function parameters are followed by the `->` symbol (dash followed by a greater-than/arrow symbol).
-
-- The third component of the Lambda expression is the function body, which performs the actual work. You write the function body within braces `{ }`. However, if your function body is just one line, you can omit the `{ }` and write it directly after the `->`, like so: 
+- The third component of a lambda expression is a function body, which performs the actual work. You write the function body within curly braces `{}`. However, if your function body is just one line, you can omit the `{}` and write it directly after the `->`, like so: 
 
   ```java
    Person p -> System.out.println(p.getName());
   ```
-  This is a complete Lambda Expression. It accepts a `Person` object as argument and prints it's name using the `getName()` getter.
+  This is a complete lambda expression. It accepts a `Person` object as argument and prints its name using the `getName()` getter.
 
 ### Stream API
 
 The `Stream` API was also introduced in Java 8, and can be used to allow chaining of sequential and aggregate operations. Stream operations are either intermediate or terminal in nature.
 
-Normally, the Stream API is used in conjuction with Lambda Expressions to produce concise code.
+Normally, the Stream API is used in conjunction with lambda expressions to produce concise code.
 
 In this small example you can see that one of the utilities of a stream is to receive a certain property of all objects in a list and return it in another list using intermediate and terminal operations.
 
 Assume you have a `Student` class like so:
+
 ```java
 public class Student {
   int studentId;
@@ -47,22 +46,21 @@ public class Student {
 }
 ```
 
-Now assume you're writing a method which has a list of all the students and you want to get a list of all the student names. 
-Traditionally this can looks something like this.
+Now assume you're writing a method which has a list of all the students and you want to get a list of all the student names, which may look something like this:
 
 ```java
 List<Student> students = /* some list of student objects */;
-
 List<String> studentNames = new ArrayList<>();
+
 for(Student student: students) {
   studentNames.add(student.getStudentName());
 }
 ```
-While this isn't a bad idea, it can be simplified using streams into just one line of code.
+
+While this isn't a bad idea, it can be simplified using streams into just one line of code:
 
 ```java
 List<Student> students = /* some list of student objects */;
-
 List<String> studentNames = students.stream().map(String::getStudentName).collect(Collectors.toList());
 ```
 
@@ -70,7 +68,8 @@ The `Stream` API goes over the list of students and uses the intermediate `map` 
 
 The terminal `collect` operation collects the stream as a list of strings.
 
-This is only one use of the Streams API used in Java 8. There are many other applications of streams utilizing other operations as seen here in the [documentation](https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html).
+This is only one use of the Streams API used in Java 8. There are many other applications of streams utilizing other operations as seen here in the
+ [documentation](https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html).
 
 #### More Information:
 <!-- Please add any articles you think might be helpful to read before writing the article -->


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

Introduced several changes to the guide on Java Lambda Expressions. Currently, the guide is titled "Lambda Expressions" while it talks about the Stream API, which is an entirely different topic. It introduces code using Lambda expressions without even explaining what lambda expressions are.

Added content about Lambda Expressions - what they are, how they are written, etc. The new content would be helpful when reading about the subsequent content on Stream API.

The code introduced in Stream API also uses 'Method References' without any explanation of what they are. Added a link to an article about Method References for now, and will add more content about it soon.

Also fixed several style and formatting errors, like `List<Student> students = some list of student objects` - which isn't really a thing in Java.
