### PR TITLE
Added fall-through documentation & return notation

### DIFF
--- a/client/src/pages/guide/english/php/switch/index.md
+++ b/client/src/pages/guide/english/php/switch/index.md
@@ -85,4 +85,4 @@ While break can be omitted without causing fall-through in some instances (see b
 ```
 
 #### More Information:
-* <a href="https://secure.php.net/manual/en/control-structures.switch.php" rel="nofollow">php.net docs Switch</a>
+* [php.net docs Switch](https://secure.php.net/manual/en/control-structures.switch.php")

--- a/client/src/pages/guide/english/php/switch/index.md
+++ b/client/src/pages/guide/english/php/switch/index.md
@@ -19,13 +19,68 @@ In PHP, the `Switch` statement is very similar to the Javascript `Switch` statem
     	    echo "i is camp";
     	    break;
     	default:
-    		echo "i is freecodecamp";
+    	    echo "i is freecodecamp";
+            break;
 	}
 
 ```
 
 ### Break
 The `break;` statement exits the switch and goes on to run the rest of the application's code. If you do not use the `break;` statement you may end up running mulitple cases and statements, sometimes this may be desired in which case you should not include the `break;` statement.
+
+An example of this behavior can be seen below:
+
+```
+<?php
+    $j = 0
+
+    switch ($i) {
+        case '2':
+            $j++;
+        case '1':
+            $j++;
+            break;
+        default:
+            break;
+    }
+```
+
+If $i = 1, the value of $j would be:
+
+```
+1
+```
+
+If $i = 2, the value of $j would be:
+
+```
+2
+```
+
+While break can be omitted without causing fall-through in some instances (see below), it is generally best practice to include it for legibility and safety (see below):
+
+```
+<?php
+    switch ($i) {
+        case '1':
+            return 1;
+        case '2':
+            return 2;
+        default:
+            break;
+```
+```
+<?php
+    switch ($i) {
+        case '1':
+            return 1;
+            break;
+        case '2':
+            return 2;
+            break;
+        default:
+            break;
+```
 
 #### More Information:
 * <a href="https://secure.php.net/manual/en/control-structures.switch.php" rel="nofollow">php.net docs Switch</a>

--- a/client/src/pages/guide/english/php/switch/index.md
+++ b/client/src/pages/guide/english/php/switch/index.md
@@ -68,6 +68,7 @@ While break can be omitted without causing fall-through in some instances (see b
             return 2;
         default:
             break;
+     }
 ```
 ```
 <?php
@@ -80,6 +81,7 @@ While break can be omitted without causing fall-through in some instances (see b
             break;
         default:
             break;
+     }
 ```
 
 #### More Information:


### PR DESCRIPTION
Fall-through is an important feature of switch statements. In addition, best practices with break-usage have been included.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
