### PR TITLE
CSS: Add ::before pseudo-element document

### DIFF
--- a/client/src/pages/guide/english/css/selectors/pseudo/before/index.md
+++ b/client/src/pages/guide/english/css/selectors/pseudo/before/index.md
@@ -1,0 +1,42 @@
+---
+title: After
+---
+## Before
+
+The ```::before``` CSS pseudo-element inserts a custom HTML element before the content of the selected HTML element. This selector is most commonly used to add visual content using the CSS ```content``` property.
+
+General Syntax:
+
+```css
+::before
+```
+
+## Example
+
+```css
+/* "Text to insert" is placed before the content of each <div> element */
+div::before {
+  content: "Text to insert";
+}
+```
+
+## More Examples
+
+A great example of a practical use case is if you wanted to display a copyright icon before your copyright info.
+
+```html
+<p>2018 freeCodeCamp. All rights Reserved</a>
+```
+
+```css
+a::before {
+  content: "©";
+}
+```
+
+The ```::before``` CSS pseudo-element can be used in many creative ways, especially when combined with it's sibling ```::after```.
+
+#### More Information:
+* [MDN Web Docs](https://www.w3schools.com/cssref/sel_before.asp)
+* [W3 Schools](https://developer.mozilla.org/en-US/docs/Web/CSS/::before)
+* [CSS Tricks - A Whole Bunch of Amazing Stuff Pseudo Elements Can Do](https://css-tricks.com/pseudo-element-roundup/)


### PR DESCRIPTION
This is a follow up to my ::after pseudo-element pull-request. I figured it would be easy to convert it over to ::before since they are so similar. As before this is meant to be just a foundation for the concept and should be added/expounded on.

Let me know if anything else should be done to this.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ ] My pull request targets the `master` branch of freeCodeCamp.
- [ ] None of my changes are plagiarized from another source without proper attribution.
- [ ] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
