### PR TITLE
Fix gitter link for setting-up-python-web-framework-django-and-flask article

### DIFF
--- a/client/src/pages/guide/english/python/setting-up-python-web-framework-django-and-flask/index.md
+++ b/client/src/pages/guide/english/python/setting-up-python-web-framework-django-and-flask/index.md
@@ -39,4 +39,4 @@ In next article, we would be discussing how to install PostgreSQL and use it wit
 
 A point to ponder - we have been using `pip` heavily, but we have barely said anything about it. Well, for now, it's just a package manager like `npm`. It has some differences with `npm`; but, you don't need to worry about that now. If you are interested, do check out the <a href='http://pip-python3.readthedocs.org/en/latest/index.html' target='_blank' rel='nofollow'>official `pip` documentation</a>.
 
-_If you have suggestions or questions, come join us on <a href='https://gitter.im/FreeCodeCamp/FreeCodeCamp' target='_blank' rel='nofollow'>gitter</a>_.
+_If you have suggestions or questions, come join us on <a href='https://gitter.im/FreeCodeCamp/home' target='_blank' rel='nofollow'>gitter</a>_.


### PR DESCRIPTION
 - Fix broken gitter href on the [setting-up-python-web-framework-django-and-flask](https://github.com/freeCodeCamp/freeCodeCamp/tree/master/client/src/pages/guide/english/python/setting-up-python-web-framework-django-and-flask) article

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
