### PR TITLE
[Russian] Fix gitter href for free-code-camp-official-chat-rooms article

### DIFF
--- a/client/src/guide/russian/meta/free-code-camp-official-chat-rooms/index.md
+++ b/client/src/guide/russian/meta/free-code-camp-official-chat-rooms/index.md
@@ -8,16 +8,16 @@ localeTitle: Официальные чаты
 
 **Обратите внимание, что все перечисленные в этом списке чаты общедоступны и индексируются поисковыми системами, поэтому обменивайтесь адресами электронной почты или другой конфиденциальной информацией в частных сообщениях.**
 
-[FreeCodeCamp](https://gitter.im/freecodecamp/FreeCodeCamp) наша главная чат-чат - пообщаться и пообщаться о жизни и научиться коду  
-[Помогите](https://gitter.im/freecodecamp/Help) справиться с нашими проблемами в HTML, CSS и jQuery у ваших товарищей по туристам  
-[HelpJavaScript](https://gitter.im/freecodecamp/HelpJavaScript) получить помощь с нашими проблемами JavaScript и алгоритмов от ваших товарищей по туристам  
-[HelpFrontEnd](https://gitter.im/freecodecamp/HelpFrontEnd) получить помощь в наших проектах переднего конца от ваших товарищей по туристам  
-[HelpDataViz](https://gitter.im/freecodecamp/HelpDataViz) получить помощь в наших проектах визуализации данных от ваших товарищей по туристам  
-[HelpBackEnd](https://gitter.im/freecodecamp/HelpBackEnd) получить помощь в наших проектах на заднем [плане](https://gitter.im/freecodecamp/HelpBackEnd) от ваших товарищей по туристам  
-[CodeReview](https://gitter.im/freecodecamp/CodeReview) дает и получает конструктивные отзывы от ваших коллег по вашим проектам  
-[YouCanDoThis](https://gitter.im/freecodecamp/YouCanDoThis) обучение коду трудно - поделиться своими чувствами и получить моральную поддержку здесь  
-[LetsPair](https://gitter.im/FreeCodeCamp/LetsPair) найти других кемперов, с которыми вы можете [сочетать](https://gitter.im/FreeCodeCamp/LetsPair) программы  
-[CodingJobs](https://gitter.im/FreeCodeCamp/CodingJobs) рассказывает о процессе получения заданий кодирования, таких как портфели, сетевое взаимодействие и интервью  
-[В обычном режиме](https://gitter.im/freecodecamp/Casual) вы можете общаться с вашими некодирующими интересами с другими кемпингами здесь  
-[Авторы](https://gitter.im/freecodecamp/Contributors) помогают нам улучшить нашу учебную программу с открытым исходным кодом  
+[FreeCodeCamp](https://gitter.im/freecodecamp/home) наша главная чат-чат - пообщаться и пообщаться о жизни и научиться коду
+[Помогите](https://gitter.im/freecodecamp/Help) справиться с нашими проблемами в HTML, CSS и jQuery у ваших товарищей по туристам
+[HelpJavaScript](https://gitter.im/freecodecamp/HelpJavaScript) получить помощь с нашими проблемами JavaScript и алгоритмов от ваших товарищей по туристам
+[HelpFrontEnd](https://gitter.im/freecodecamp/HelpFrontEnd) получить помощь в наших проектах переднего конца от ваших товарищей по туристам
+[HelpDataViz](https://gitter.im/freecodecamp/HelpDataViz) получить помощь в наших проектах визуализации данных от ваших товарищей по туристам
+[HelpBackEnd](https://gitter.im/freecodecamp/HelpBackEnd) получить помощь в наших проектах на заднем [плане](https://gitter.im/freecodecamp/HelpBackEnd) от ваших товарищей по туристам
+[CodeReview](https://gitter.im/freecodecamp/CodeReview) дает и получает конструктивные отзывы от ваших коллег по вашим проектам
+[YouCanDoThis](https://gitter.im/freecodecamp/YouCanDoThis) обучение коду трудно - поделиться своими чувствами и получить моральную поддержку здесь
+[LetsPair](https://gitter.im/FreeCodeCamp/LetsPair) найти других кемперов, с которыми вы можете [сочетать](https://gitter.im/FreeCodeCamp/LetsPair) программы
+[CodingJobs](https://gitter.im/FreeCodeCamp/CodingJobs) рассказывает о процессе получения заданий кодирования, таких как портфели, сетевое взаимодействие и интервью
+[В обычном режиме](https://gitter.im/freecodecamp/Casual) вы можете общаться с вашими некодирующими интересами с другими кемпингами здесь
+[Авторы](https://gitter.im/freecodecamp/Contributors) помогают нам улучшить нашу учебную программу с открытым исходным кодом
 [DataScience](https://gitter.im/freecodecamp/DataScience) помогает нам понять наши концерты и концерты публичных данных


### PR DESCRIPTION
 - Fix broken gitter href on the russian [free-code-camp-official-chat-rooms article](https://github.com/freeCodeCamp/freeCodeCamp/blob/303ff4eea0fa7c7d085db4e1efa229c6279796a4/client/src/guide/russian/meta/free-code-camp-official-chat-rooms/index.md) article

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
