### PR TITLE
Fixed last 2 links

### DIFF
--- a/client/src/pages/guide/english/html/symbols/index.md
+++ b/client/src/pages/guide/english/html/symbols/index.md
@@ -14,5 +14,5 @@ If no entity name exists, either the entity number or hexadecimal reference can 
 
 #### More Information:
 
-* ![W3 Schools Reference](https://www.w3schools.com/html/html_symbols.asp)
-* ![Symbols Reference Chart](https://dev.w3.org/html5/html-author/charref)
+* [W3 Schools Reference](https://www.w3schools.com/html/html_symbols.asp)
+* [Symbols Reference Chart](https://dev.w3.org/html5/html-author/charref)


### PR DESCRIPTION
Incorrect markdown format had them displaying a broken image link, because the links don't lead to an image. Used normal markdown link format instead.

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.