### PR TITLE
Fixed broken img link

### DIFF
--- a/client/src/pages/guide/english/html/layouts/index.md
+++ b/client/src/pages/guide/english/html/layouts/index.md
@@ -29,7 +29,7 @@ If you are to design a 2-column based page with left navigation pane and center 
 #### CSS Frameworks
 This is where CSS Frameworks such as [Bootstrap](http://getbootstrap.com/) and [Materialize](http://materializecss.com/) come in. These frameworks provide a grid functionality that lets to divide each section of your webpage into 12 columns, which you can order to design. 
 
-![Grid Example](http://blog.gridbox.io/wp-content/uploads/2018/01/download-1-1024x271.png)
+![Grid Example](https://blog.gridbox.io/wp-content/uploads/2018/01/download-1-1024x271.png)
 > Sample Bootstrap Grid
 
 ### HTML Semantic Elements


### PR DESCRIPTION
Just changed URL from http to https. Before this, the image link did not work.

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.