### PR TITLE
fix: removed all &#8203; from tests verbiage

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/convert-html-entities.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/convert-html-entities.english.md
@@ -21,18 +21,18 @@ Remember to use <a href='http://forum.freecodecamp.org/t/how-to-get-help-when-yo
 
 ```yml
 tests:
-  - text: '<code>convertHTML("Dolce & Gabbana")</code> should return <code>Dolce &&#8203;amp; Gabbana</code>.'
-    testString: 'assert.match(convertHTML("Dolce & Gabbana"), /Dolce &amp; Gabbana/, "<code>convertHTML("Dolce & Gabbana")</code> should return <code>Dolce &&#8203;amp; Gabbana</code>.");'
-  - text: '<code>convertHTML("Hamburgers < Pizza < Tacos")</code> should return <code>Hamburgers &&#8203;lt; Pizza &&#8203;lt; Tacos</code>.'
-    testString: 'assert.match(convertHTML("Hamburgers < Pizza < Tacos"), /Hamburgers &lt; Pizza &lt; Tacos/, "<code>convertHTML("Hamburgers < Pizza < Tacos")</code> should return <code>Hamburgers &&#8203;lt; Pizza &&#8203;lt; Tacos</code>.");'
-  - text: '<code>convertHTML("Sixty > twelve")</code> should return <code>Sixty &&#8203;gt; twelve</code>.'
-    testString: 'assert.match(convertHTML("Sixty > twelve"), /Sixty &gt; twelve/, "<code>convertHTML("Sixty > twelve")</code> should return <code>Sixty &&#8203;gt; twelve</code>.");'
-  - text: '<code>convertHTML(&apos;Stuff in "quotation marks"&apos;)</code> should return <code>Stuff in &&#8203;quot;quotation marks&&#8203;quot;</code>.'
-    testString: 'assert.match(convertHTML("Stuff in "quotation marks""), /Stuff in &quot;quotation marks&quot;/, "<code>convertHTML(&apos;Stuff in "quotation marks"&apos;)</code> should return <code>Stuff in &&#8203;quot;quotation marks&&#8203;quot;</code>.");'
-  - text: '<code>convertHTML("Schindler&apos;s List")</code> should return <code>Schindler&&#8203;apos;s List</code>.'
-    testString: 'assert.match(convertHTML("Schindler"s List"), /Schindler&apos;s List/, "<code>convertHTML("Schindler&apos;s List")</code> should return <code>Schindler&&#8203;apos;s List</code>.");'
-  - text: '<code>convertHTML("<>")</code> should return <code>&&#8203;lt;&&#8203;gt;</code>.'
-    testString: 'assert.match(convertHTML("<>"), /&lt;&gt;/, "<code>convertHTML("<>")</code> should return <code>&&#8203;lt;&&#8203;gt;</code>.");'
+  - text: '<code>convertHTML("Dolce & Gabbana")</code> should return <code>Dolce &amp; Gabbana</code>.'
+    testString: 'assert.match(convertHTML("Dolce & Gabbana"), /Dolce &amp; Gabbana/, "<code>convertHTML("Dolce & Gabbana")</code> should return <code>Dolce &amp; Gabbana</code>.");'
+  - text: '<code>convertHTML("Hamburgers < Pizza < Tacos")</code> should return <code>Hamburgers &lt; Pizza &lt; Tacos</code>.'
+    testString: 'assert.match(convertHTML("Hamburgers < Pizza < Tacos"), /Hamburgers &lt; Pizza &lt; Tacos/, "<code>convertHTML("Hamburgers < Pizza < Tacos")</code> should return <code>Hamburgers &lt; Pizza &lt; Tacos</code>.");'
+  - text: '<code>convertHTML("Sixty > twelve")</code> should return <code>Sixty &gt; twelve</code>.'
+    testString: 'assert.match(convertHTML("Sixty > twelve"), /Sixty &gt; twelve/, "<code>convertHTML("Sixty > twelve")</code> should return <code>Sixty &gt; twelve</code>.");'
+  - text: '<code>convertHTML(&apos;Stuff in "quotation marks"&apos;)</code> should return <code>Stuff in &quot;quotation marks&quot;</code>.'
+    testString: 'assert.match(convertHTML("Stuff in "quotation marks""), /Stuff in &quot;quotation marks&quot;/, "<code>convertHTML(&apos;Stuff in "quotation marks"&apos;)</code> should return <code>Stuff in &quot;quotation marks&quot;</code>.");'
+  - text: '<code>convertHTML("Schindler&apos;s List")</code> should return <code>Schindler&apos;s List</code>.'
+    testString: 'assert.match(convertHTML("Schindler"s List"), /Schindler&apos;s List/, "<code>convertHTML("Schindler&apos;s List")</code> should return <code>Schindler&apos;s List</code>.");'
+  - text: '<code>convertHTML("<>")</code> should return <code>&lt;&gt;</code>.'
+    testString: 'assert.match(convertHTML("<>"), /&lt;&gt;/, "<code>convertHTML("<>")</code> should return <code>&lt;&gt;</code>.");'
   - text: <code>convertHTML("abc")</code> should return <code>abc</code>.
     testString: 'assert.strictEqual(convertHTML("abc"), "abc", "<code>convertHTML("abc")</code> should return <code>abc</code>.");'
 


### PR DESCRIPTION
Removed all instances of &#8203;  in the Tests section for this challenge, because campers were copying/pasting them without knowing when using the html entity codes as replacement values in their solutions.  This hidden character was causing the tests to fail without the user understanding why.  The original reason the character was present, was to handle how the tests had to be written at a certain time to escape certain characters.  This is no longer necessary.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x ] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x ] My pull request targets the `master` branch of freeCodeCamp.
- [x ] None of my changes are plagiarized from another source without proper attribution.
- [x ] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #17542
