### PR TITLE
added jQuery Plugins section

### DIFF
--- a/client/src/pages/learn/front-end-libraries/jquery/index.md
+++ b/client/src/pages/learn/front-end-libraries/jquery/index.md
@@ -8,3 +8,11 @@ superBlock: Front End Libraries
 jQuery is one of the many libraries for JavaScript. It is designed to simplify scripting done on the client side.
 jQuery's most recognizable characteristic is its dollar sign (<code>$</code>) syntax. With it, you can easily manipulate elements, create animations and handle input events.
 
+## jQuery Plugins
+
+jQuery is also expandable through plugins. You can create your own plugin. You check out their [plugin registry](in read-only mode) to see some of it for your inspiration and reference. You can also use any of those plugins for your projects for free. If you are planning to create and publish your own plugin they are suggesting to publish it on [npm] with a "jquery-plugin" keyword on your package.json. npm has a [blog post] for the instructions on publishing your jquery plugin to their registry.
+
+[plugin registry]: https://plugins.jquery.com/
+[npm]: https://www.npmjs.com/
+[blog post]: https://blog.npmjs.org/post/111475741445/publishing-your-jquery-plugin-to-npm-the-quick
+


### PR DESCRIPTION
jQuery plugins are widely used. Their are still a lot of websites uses jQuery plugins to extend the functionality of jQuery. I believe WordPress is one them.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x ] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [ x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x ] My pull request targets the `master` branch of freeCodeCamp.
- [x ] None of my changes are plagiarized from another source without proper attribution.
- [x ] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
