### PR TITLE
update directions on guide files location

### DIFF
--- a/docs/how-to-work-on-guide-articles.md
+++ b/docs/how-to-work-on-guide-articles.md
@@ -35,7 +35,7 @@ Watch the video demonstration or follow the steps below it:
 
 ![GIF showing the GitHub interface steps](#)
 
-1. Go into the **"pages"** folder (located in [`guide`](/guide)) and find the article stub you'd like to write or edit.
+1. Go into the [**"guide"**](/guide) folder (located in freeCodeCamp repository), select the language you want to contribute to, and find the article stub you'd like to write or edit.
 
     > All stubs will be in an index.md file
 

--- a/docs/how-to-work-on-guide-articles.md
+++ b/docs/how-to-work-on-guide-articles.md
@@ -31,9 +31,7 @@ There are two ways you can propose a change to the repository, after you edit or
 
 Watch the video demonstration or follow the steps below it:
 
-**[TODO]** Update the GIF recording.
-
-![GIF showing the GitHub interface steps](#)
+![GIF showing the GitHub interface steps](https://cdn-images-1.medium.com/max/1395/1*qnFS6ITMwcpsiZvF5b1pHw.gif)
 
 1. Go into the [**"guide"**](/guide) folder (located in freeCodeCamp repository), select the language you want to contribute to, and find the article stub you'd like to write or edit.
 


### PR DESCRIPTION
changed 'pages' folder to the 'guide' folder within the repo per the guide index restructure. Also including gif in PR comment.

![how-to-edit-guides-github-web-interface](https://user-images.githubusercontent.com/24554274/47116186-82cf1600-d226-11e8-90b1-a26d3ded404d.gif)

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
