### PR TITLE
Add missing closing quotation mark to term

### DIFF
--- a/docs/portuguese/CONTRIBUTING.md
+++ b/docs/portuguese/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Olá 👋!
 
 freeCodeCamp.org é possível graças a milhares de voluntários gentis como você. Somos gratos por suas contribuições e estamos felizes em te receber.
 
-Nós seguimos as diretrizes do nosso ["Código de Conduta](https://www.freecodecamp.org/code-of-conduct). Dedique um tempo para lê-lo. Ele não é muito longo.
+Nós seguimos as diretrizes do nosso ["Código de Conduta"](https://www.freecodecamp.org/code-of-conduct). Dedique um tempo para lê-lo. Ele não é muito longo.
 
 Divirta-se contribuindo 🎉!
 


### PR DESCRIPTION
Added a missing closing quotation mark in PT-BR's `CONTRIBUTING.md`.

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.