### PR TITLE
Fixed broken link in guide for guide articles

### DIFF
--- a/docs/how-to-work-on-guide-articles.md
+++ b/docs/how-to-work-on-guide-articles.md
@@ -79,7 +79,7 @@ You are not required to work on your local machine, unless you would like to pre
 Here are a few guidelines the reviewers follow when reviewing PRs:
 
 - there is a relevant description and title
-- PR respects the [style guide](/docs/style-guide-for-guide-articles)
+- PR respects the [style guide](/docs/style-guide-for-guide-articles.md)
 - we follow general QA tips found in [Moderator guidelines](https://forum.freecodecamp.org/t/freecodecamp-moderator-guidelines/18295)
 - as long as a pull request improves or expands the guide, we accept it even if it contains imperfect English or partial content
 - older pull requests are reviewed first


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.