### PR TITLE
Adjust translation to spread-syntax on portuguese

### DIFF
--- a/guide/portuguese/javascript/spread-syntax/index.md
+++ b/guide/portuguese/javascript/spread-syntax/index.md
@@ -2,9 +2,9 @@
 title: Spread syntax
 localeTitle: Espalhe a sintaxe
 ---
-## Espalhe a sintaxe
+## Spread Syntax
 
-A sintaxe de propagação permite que uma iterável, como uma expressão de matriz ou cadeia, seja expandida em locais onde zero ou mais argumentos (para chamadas de função) ou elementos (para literais de matriz) sejam esperados ou uma expressão de objeto seja expandida em locais onde zero é esperado .
+O conceito de spread é permitier que um iterável, como um array ou string seja expandida em locais onde zero ou mais argumentos (para chamadas de função) ou elementos (para arrays) sejam esperados ou uma expressão de objeto seja expandida em locais onde zero é esperado.
 
 ### Sintaxe
 
@@ -20,41 +20,41 @@ Para literais ou strings de array:
 
 ### Exemplos
 
-#### Espalhe em chamadas de função
+#### Spread em chamadas de função
 
 #### Substituir aplicar
 
 É comum usar o `Function.prototype.apply` nos casos em que você deseja usar os elementos de um array como argumentos para uma função.
-```
+```js
 function myFunction(x, y, z) { } 
  var args = [0, 1, 2]; 
  myFunction.apply(null, args); 
 ```
 
-Com a sintaxe de propagação, o acima pode ser escrito como:
-```
+Com a sintaxe spread, o exemplo acima pode ser escrito como:
+```js
 function myFunction(x, y, z) { } 
  var args = [0, 1, 2]; 
  myFunction(...args); 
 ```
 
-Qualquer argumento na lista de argumentos pode usar a sintaxe de propagação e pode ser usado várias vezes.
-```
+Qualquer argumento na lista de argumentos pode usar a sintaxe spread e pode ser usado várias vezes.
+```js
 function myFunction(v, w, x, y, z) { } 
  var args = [0, 1]; 
  myFunction(-1, ...args, 2, ...[3]); 
 ```
 
-### Inscreva-se para novos
+### Apply e New
 
-Ao chamar um construtor com `new` , não é possível usar **diretamente** um array e `apply` ( `apply` faz um `[[Call]]` e não um `[[Construct]]` ). No entanto, um array pode ser facilmente usado com novos agradecimentos à sintaxe de propagação:
-```
+Ao chamar um construtor com `new` , não é possível usar **diretamente** um array e `apply` ( `apply` faz um `[[Call]]` e não um `[[Construct]]` ). No entanto, um array pode ser facilmente usado com `new` graças à sintaxe spread:
+```js
 var dateFields = [1970, 0, 1];  // 1 Jan 1970 
  var d = new Date(...dateFields); 
 ```
 
-Para usar o novo com uma matriz de parâmetros sem sintaxe de propagação, você teria que fazê-lo **indiretamente** através da aplicação parcial:
-```
+Para usar `new` com um array de parâmetros sem sintaxe spread, você teria que fazê-lo **indiretamente** através da aplicação parcial:
+```js
 function applyAndNew(constructor, args) { 
    function partial () { 
       return constructor.apply(this, args); 
@@ -82,21 +82,21 @@ function applyAndNew(constructor, args) {
  // (log of "new myConstructorWithArguments"): {prop1: "val1", prop2: "val2"} 
 ```
 
-### Espalhar em literais de array
+### Spread em literais de array
 
 #### Um literal de array mais poderoso
 
-Sem a sintaxe de propagação, para criar uma nova matriz usando uma matriz existente como uma parte dela, a sintaxe literal da matriz não é mais suficiente e um código imperativo deve ser usado usando uma combinação de push, splice, concat, etc. torna-se muito mais sucinto:
-```
+Sem a sintaxe de propagação, para criar um novo array usando um array existente como uma parte dela, a sintaxe literal de array não é mais suficiente e um código imperativo deve ser usado ao invez de uma combinação de push, splice, concat, etc. torna-se muito mais sucinto:
+```js
 var parts = ['shoulders', 'knees']; 
  var lyrics = ['head', ...parts, 'and', 'toes']; 
  // ["head", "shoulders", "knees", "and", "toes"] 
 ```
 
-Assim como o spread para listas de argumentos, `...` pode ser usado em qualquer lugar no literal da matriz e pode ser usado várias vezes.
+Assim como o spread para listas de argumentos, `...` pode ser usado em qualquer lugar em um array e pode ser usado várias vezes.
 
-### Copie uma matriz
-```
+### Copie um array
+```js
 var arr = [1, 2, 3]; 
  var arr2 = [...arr]; // like arr.slice() 
  arr2.push(4); 
@@ -105,43 +105,42 @@ var arr = [1, 2, 3];
  // arr remains unaffected 
 ```
 
-> **Nota** : A sintaxe de propagação atinge um nível de profundidade enquanto copia uma matriz. Portanto, pode ser inadequado para copiar matrizes multidimensionais como mostra o exemplo a seguir (é o mesmo com Object.assign () e sintaxe de propagação).
-```
+> **Nota** : A sintaxe spread atinge um nível de profundidade enquanto copia um array. Portanto, pode ser inadequado para copiar arrays multidimensionais como mostra o exemplo a seguir (é o mesmo com Object.assign () e sintaxe spread).
+```js
 var a = [[1], [2], [3]]; 
  var b = [...a]; 
  b.shift().shift(); // 1 
  // Now array a is affected as well: [[], [2], [3]] 
 ```
 
-### Uma maneira melhor de concatenar matrizes
+### Uma maneira melhor de concatenar arrays
 
-`Array.concat` é freqüentemente usado para concatenar uma matriz ao final de uma matriz existente. Sem a sintaxe de propagação, isso é feito como:
-```
+`Array.concat` é freqüentemente usado para concatenar um array ao final de um array existente. Sem a sintaxe spread, isso é feito como:
+```js
 var arr1 = [0, 1, 2]; 
  var arr2 = [3, 4, 5]; 
  // Append all items from arr2 onto arr1 
  arr1 = arr1.concat(arr2); 
 ```
 
-Com a sintaxe de propagação, isso se torna:
-```
+Com a sintaxe spread, isso se torna:
+```js
 var arr1 = [0, 1, 2]; 
- var arr2 = [3, 4, 5]; 
- arr1 = [...arr1, ...arr2]; 
+var arr2 = [3, 4, 5]; 
+arr1 = [...arr1, ...arr2]; 
 ```
 
-`Array.unshift` é frequentemente usado para inserir uma matriz de valores no início de um array existente. Sem a sintaxe de propagação, isso é feito como:
-```
+`Array.unshift` é frequentemente usado para inserir um array de valores no início de um array existente. Sem a sintaxe spread, isso é feito como:
+```js
 var arr1 = [0, 1, 2]; 
- var arr2 = [3, 4, 5]; 
- // Prepend all items from arr2 onto arr1 
- Array.prototype.unshift.apply(arr1, arr2) // arr1 is now [3, 4, 5, 0, 1, 2] 
+var arr2 = [3, 4, 5]; 
+// Prepend all items from arr2 onto arr1 
+Array.prototype.unshift.apply(arr1, arr2) // arr1 is now [3, 4, 5, 0, 1, 2] 
 ```
 
-Com a sintaxe de propagação, isso se torna:
-```
+Com a sintaxe spread, isso se torna:
+```js
 var arr1 = [0, 1, 2]; 
- var arr2 = [3, 4, 5]; 
- arr1 = [...arr2, ...arr1]; // arr1 is now [3, 4, 5, 0, 1, 2] 
-
+var arr2 = [3, 4, 5]; 
+arr1 = [...arr2, ...arr1]; // arr1 is now [3, 4, 5, 0, 1, 2] 
 ```

--- a/guide/portuguese/javascript/spread-syntax/index.md
+++ b/guide/portuguese/javascript/spread-syntax/index.md
@@ -2,9 +2,9 @@
 title: Spread syntax
 localeTitle: Espalhe a sintaxe
 ---
-## Spread Syntax
+## Operador Spread
 
-O conceito de spread é permitier que um iterável, como um array ou string seja expandida em locais onde zero ou mais argumentos (para chamadas de função) ou elementos (para arrays) sejam esperados ou uma expressão de objeto seja expandida em locais onde zero é esperado.
+O conceito de spread é permitir que um iterável, como um array ou string seja expandida em locais onde zero ou mais argumentos (para chamadas de função) ou elementos (para arrays) sejam esperados ou uma expressão de objeto seja expandida em locais onde zero é esperado.
 
 ### Sintaxe
 
@@ -31,14 +31,14 @@ function myFunction(x, y, z) { }
  myFunction.apply(null, args); 
 ```
 
-Com a sintaxe spread, o exemplo acima pode ser escrito como:
+Com a operador spread, o exemplo acima pode ser escrito como:
 ```js
 function myFunction(x, y, z) { } 
  var args = [0, 1, 2]; 
  myFunction(...args); 
 ```
 
-Qualquer argumento na lista de argumentos pode usar a sintaxe spread e pode ser usado várias vezes.
+Qualquer argumento na lista de argumentos pode usar a operador spread e pode ser usado várias vezes.
 ```js
 function myFunction(v, w, x, y, z) { } 
  var args = [0, 1]; 
@@ -47,13 +47,13 @@ function myFunction(v, w, x, y, z) { }
 
 ### Apply e New
 
-Ao chamar um construtor com `new` , não é possível usar **diretamente** um array e `apply` ( `apply` faz um `[[Call]]` e não um `[[Construct]]` ). No entanto, um array pode ser facilmente usado com `new` graças à sintaxe spread:
+Ao chamar um construtor com `new` , não é possível usar **diretamente** um array e `apply` ( `apply` faz um `[[Call]]` e não um `[[Construct]]` ). No entanto, um array pode ser facilmente usado com `new` graças à operador spread:
 ```js
 var dateFields = [1970, 0, 1];  // 1 Jan 1970 
  var d = new Date(...dateFields); 
 ```
 
-Para usar `new` com um array de parâmetros sem sintaxe spread, você teria que fazê-lo **indiretamente** através da aplicação parcial:
+Para usar `new` com um array de parâmetros sem operador spread, você teria que fazê-lo **indiretamente** através da aplicação parcial:
 ```js
 function applyAndNew(constructor, args) { 
    function partial () { 
@@ -105,7 +105,7 @@ var arr = [1, 2, 3];
  // arr remains unaffected 
 ```
 
-> **Nota** : A sintaxe spread atinge um nível de profundidade enquanto copia um array. Portanto, pode ser inadequado para copiar arrays multidimensionais como mostra o exemplo a seguir (é o mesmo com Object.assign () e sintaxe spread).
+> **Nota** : A operador spread atinge um nível de profundidade enquanto copia um array. Portanto, pode ser inadequado para copiar arrays multidimensionais como mostra o exemplo a seguir (é o mesmo com Object.assign () e operador spread).
 ```js
 var a = [[1], [2], [3]]; 
  var b = [...a]; 
@@ -115,7 +115,7 @@ var a = [[1], [2], [3]];
 
 ### Uma maneira melhor de concatenar arrays
 
-`Array.concat` é freqüentemente usado para concatenar um array ao final de um array existente. Sem a sintaxe spread, isso é feito como:
+`Array.concat` é freqüentemente usado para concatenar um array ao final de um array existente. Sem a operador spread, isso é feito como:
 ```js
 var arr1 = [0, 1, 2]; 
  var arr2 = [3, 4, 5]; 
@@ -123,14 +123,14 @@ var arr1 = [0, 1, 2];
  arr1 = arr1.concat(arr2); 
 ```
 
-Com a sintaxe spread, isso se torna:
+Com a operador spread, isso se torna:
 ```js
 var arr1 = [0, 1, 2]; 
 var arr2 = [3, 4, 5]; 
 arr1 = [...arr1, ...arr2]; 
 ```
 
-`Array.unshift` é frequentemente usado para inserir um array de valores no início de um array existente. Sem a sintaxe spread, isso é feito como:
+`Array.unshift` é frequentemente usado para inserir um array de valores no início de um array existente. Sem a operador spread, isso é feito como:
 ```js
 var arr1 = [0, 1, 2]; 
 var arr2 = [3, 4, 5]; 
@@ -138,7 +138,7 @@ var arr2 = [3, 4, 5];
 Array.prototype.unshift.apply(arr1, arr2) // arr1 is now [3, 4, 5, 0, 1, 2] 
 ```
 
-Com a sintaxe spread, isso se torna:
+Com a operador spread, isso se torna:
 ```js
 var arr1 = [0, 1, 2]; 
 var arr2 = [3, 4, 5]; 


### PR DESCRIPTION
Adjusted some of the translations on spread-syntax on portuguese, they were missleading

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `master` branch of freeCodeCamp.
- [X] None of my changes are plagiarized from another source without proper attribution.
- [X] My article does not contain shortened URLs or affiliate links.