### PR TITLE
Normalizing React Native as a product name

### DIFF
--- a/guide/portuguese/react-native/index.md
+++ b/guide/portuguese/react-native/index.md
@@ -1,8 +1,8 @@
 ---
 title: React Native
-localeTitle: Reagir Nativo
+localeTitle: React Native
 ---
-## Reagir Nativo
+## React Native
 
 O React Native é uma estrutura de plataforma cruzada para a criação de aplicativos móveis que podem ser executados fora do navegador - mais comumente aplicativos iOS e Android
 
@@ -10,13 +10,13 @@ Ele também pode ser usado para criar aplicativos em dispositivos Windows, siste
 
 **Índice**
 
-*   [O que é Reagir Nativo?](#what-is-react-native)
-*   [Razões para escolher Reagir Nativa](#reasons-to-choose-react-native)
-*   [Como começar com o Reagir Nativo](#how-to-get-started-with-react-native)
+*   [O que é React Native?](#what-is-react-native)
+*   [Razões para escolher React Native](#reasons-to-choose-react-native)
+*   [Como começar com o React Native](#how-to-get-started-with-react-native)
 
-### O que é Reagir Nativa
+### O que é React Native
 
-Reagir Nativo cai entre aplicativos nativos e híbridos no espectro de aplicativos para dispositivos móveis. A interface do usuário que você cria é totalmente nativa e o desempenho geral do aplicativo é quase tão bom quanto gravar um aplicativo nativo. Também oferece a flexibilidade de incorporar exibições da Web (páginas da Web) ou código nativo (Java / Kotlin para Android, Objective C / Swift para iOS) dentro de seus aplicativos onde você desejar.
+React Native cai entre aplicativos nativos e híbridos no espectro de aplicativos para dispositivos móveis. A interface do usuário que você cria é totalmente nativa e o desempenho geral do aplicativo é quase tão bom quanto gravar um aplicativo nativo. Também oferece a flexibilidade de incorporar exibições da Web (páginas da Web) ou código nativo (Java / Kotlin para Android, Objective C / Swift para iOS) dentro de seus aplicativos onde você desejar.
 
 Ele segue o mesmo padrão do React, em que as visualizações (o que você vê na tela) são renderizadas a partir dos arquivos JavaScript. A diferença é que ele fornece sua própria API para lidar com exibições de celular nativas em comparação ao DOM na Web. Se você está confuso sobre como isso funciona, siga este guia no freeCodeCamp e ele irá levá-lo passo a passo através destes conceitos.
 
@@ -28,12 +28,12 @@ Ele segue o mesmo padrão do React, em que as visualizações (o que você vê n
 4.  **Desempenho** - Funciona melhor que estruturas de aplicativos híbridos, como Ionic e Cordova, já que não está usando visualizações da Web.
 5.  Apoio **corporativo** - Muitas empresas apoiam e contribuem para o React Native, incluindo o Walmart, o Airbnb, o Wix e, é claro, o Facebook.
 6.  **Comunidade** - A React Native tem uma comunidade grande (e crescente) com mais de 1500 colaboradores para o projeto principal e milhares de pessoas que contribuem para várias bibliotecas.
-7.  **Melhor experiência do usuário** - o Reagir Nativo usa o código JavaScript para renderizar componentes nativos do sistema operacional do seu telefone. Em outras palavras, a interface do usuário do aplicativo é totalmente nativa!
+7.  **Melhor experiência do usuário** - o React Native usa o código JavaScript para renderizar componentes nativos do sistema operacional do seu telefone. Em outras palavras, a interface do usuário do aplicativo é totalmente nativa!
 8.  **Cross-Platform** - Uma ótima maneira de criar protótipos e economizar tempo ao criar um aplicativo universal de interface de usuário ou aplicativo móvel específico da plataforma que pode ser executado em dispositivos iOS e Android.
 
-### Como começar com o Reagir Nativo
+### Como começar com o React Native
 
 Existem duas maneiras fáceis e rápidas de começar a usar o React Native. Dependendo da sua situação, pode ser uma opção melhor para você.
 
-1.  [Criar Reagir App Nativo](https://www.npmjs.com/package/create-react-native-app) - Semelhante ao Create React App ele se levanta em execução usando o terminal.
+1.  [Create React Native App](https://www.npmjs.com/package/create-react-native-app) - Semelhante ao Create React App ele se levanta em execução usando o terminal.
 2.  [Expo](https://expo.io) - Melhor para prototipagem de um aplicativo ou se é estágio anterior. Usando a Expo você pode até mesmo criar um aplicativo rápido usando recursos de arrastar e soltar do snack.expo.io no broswer.


### PR DESCRIPTION
React Native doesn't change the name in portuguese

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.
