### PR TITLE
Added difference in range() between Python 2 and 3

### DIFF
--- a/guide/english/python/range-function/index.md
+++ b/guide/english/python/range-function/index.md
@@ -39,3 +39,11 @@ for i in range(3, 12, 2):
 9
 11
  ```
+ 
+ #### Notes
+ In Python 2, there are 2 functions for going through a range of numbers: range() and xrange().
+ Out of these functions, xrange() is the "lazy" function, meaning it generates numbers as necessary instead of actually creating
+ a list of numbers and iterating through them. range(), on the other hand, makes an entire list of numbers and iterates through
+ this list. This makes it a strain on the memory in the case of really long lists.
+ 
+ In Python 3, the range() function mimics xrange() as the "lazy" variant, and xrange() itself has been removed.


### PR DESCRIPTION
Added the differences between the working methods of the range() function in Python 2 and 3, including the explanation of the "lazy" method of generating a list of numbers.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
