### PR TITLE
Fix first paragraph of index.html

### DIFF
--- a/guide/spanish/computer-hardware/power-supply/index.md
+++ b/guide/spanish/computer-hardware/power-supply/index.md
@@ -4,7 +4,7 @@ localeTitle: Fuente de alimentación
 ---
 ## Fuente de alimentación
 
-Una unidad de fuente de alimentación (PSU) suministra energía a una computadora. Convierte la alimentación de CA en una alimentación continua de baja tensión de CC para los componentes internos.
+Una unidad de fuente de alimentación (PSU) suministra energía a una computadora. Convierte la alimentación electrica de Corriente Alterna (CA) en una alimentación electrica continua de baja tensión de Corriente Continua (CC) para los componentes internos.
 
 Una fuente de alimentación no suele ser reparable por el usuario. Para su seguridad, es aconsejable nunca abrir una unidad de fuente de alimentación.
 


### PR DESCRIPTION
I added some clarification regarding the first paragraph for the Power Supply (PSU) description. I understand the translation is more of a Spaniard translation than Latinoamerica translation.  However, this clarification should comfort to all spanish speakers.

Trivia:
In Latinoamerica, a Power Supply Units are called a Fuentes de Poder, only in Spain these are called Fuentes de Alimentación. This PSU translation depends on what audience you want to target.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x ] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x ] My pull request targets the `master` branch of freeCodeCamp.
- [x ] None of my changes are plagiarized from another source without proper attribution.
- [x ] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
