### PR TITLE
Fix line for Example

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/access-array-data-with-indexes.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/access-array-data-with-indexes.english.md
@@ -9,6 +9,7 @@ guideUrl: 'https://www.freecodecamp.org/guide/certificates/access-array-data-wit
 <section id='description'>
 We can access the data inside arrays using <code>indexes</code>.
 Array indexes are written in the same bracket notation that strings use, except that instead of specifying a character, they are specifying an entry in the array. Like strings, arrays use <dfn>zero-based</dfn> indexing, so the first element in an array is element <code>0</code>.
+  
 <strong>Example</strong>
 <blockquote>var array = [50,60,70];<br>array[0]; // equals 50<br>var data = array[1];  // equals 60</blockquote>
 <strong>Note</strong><br>There shouldn't be any spaces between the array name and the square brackets, like <code>array [0]</code>. Although JavaScript is able to process this correctly, this may confuse other programmers reading your code.

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/access-array-data-with-indexes.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/access-array-data-with-indexes.english.md
@@ -9,7 +9,7 @@ guideUrl: 'https://www.freecodecamp.org/guide/certificates/access-array-data-wit
 <section id='description'>
 We can access the data inside arrays using <code>indexes</code>.
 Array indexes are written in the same bracket notation that strings use, except that instead of specifying a character, they are specifying an entry in the array. Like strings, arrays use <dfn>zero-based</dfn> indexing, so the first element in an array is element <code>0</code>.
-  
+<br />
 <strong>Example</strong>
 <blockquote>var array = [50,60,70];<br>array[0]; // equals 50<br>var data = array[1];  // equals 60</blockquote>
 <strong>Note</strong><br>There shouldn't be any spaces between the array name and the square brackets, like <code>array [0]</code>. Although JavaScript is able to process this correctly, this may confuse other programmers reading your code.


### PR DESCRIPTION
Bolded Example is inline with description. Added new line so that Example will have its own line (right before the actual example)

**Before**
<img width="931" alt="screen shot 2018-10-18 at 3 15 23 pm" src="https://user-images.githubusercontent.com/7784705/47187500-2da80880-d2e9-11e8-842d-a7db708bb422.png">

**After**
<img width="918" alt="screen shot 2018-10-18 at 3 18 03 pm" src="https://user-images.githubusercontent.com/7784705/47187499-2da80880-d2e9-11e8-9e88-311440cba23d.png">



<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
