### PR TITLE
Typos y errores de traducción - typos and translation errors

### DIFF
--- a/guide/spanish/nodejs/socket.io/index.md
+++ b/guide/spanish/nodejs/socket.io/index.md
@@ -1,12 +1,11 @@
 ---
 title: Socket.io
-localeTitle: Zócalo.io
 ---
-## Zócalo.io
+## Socket.io
 
-[Socket.io](https://socket.io/) es una biblioteca Node.js creada para ayudar a hacer posible la comunicación en tiempo real entre computadoras. Para garantizar que Socket.io utiliza WebSockets para establecer una conexión entre el navegador del cliente y el servidor. Esta biblioteca usa [Engine.IO](https://github.com/socketio/engine.io) para construir la conexión.
+[Socket.io](https://socket.io/) es una biblioteca Node.js creada para ayudar a hacer posible la comunicación en tiempo real entre computadoras. Para lograrlo, Socket.io utiliza una combinación de WebSockets y polling para establecer una conexión entre el navegador del cliente y el servidor. Esta biblioteca usa [Engine.IO](https://github.com/socketio/engine.io) para construir la conexión.
 
-### Población
+### Demostraciones
 
 Para obtener una idea de lo que es posible, Socket.io ofrece dos demostraciones para mostrar sus posibles casos de uso. Puede encontrar las demostraciones en [https://socket.io/demos/chat/](https://socket.io/demos/chat/) y encontrar el enlace a la demostración de la pizarra a la izquierda.
 

--- a/guide/spanish/nodejs/socket.io/index.md
+++ b/guide/spanish/nodejs/socket.io/index.md
@@ -1,5 +1,6 @@
 ---
 title: Socket.io
+localeTitle: Socket.io
 ---
 ## Socket.io
 


### PR DESCRIPTION
Socket.io is not known as Zócalo.io, so I changed it back. Also fixed some small translation errors.

Socket.io no se conoce como Zócalo.io en español, así que lo volví a cambiar. También corregí otros errores de traducción pequeños.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
