### PR TITLE
Adding Docstring convention section in Python Convention Standards within Guide

### DIFF
--- a/guide/english/python/python-coding-standards/index.md
+++ b/guide/english/python/python-coding-standards/index.md
@@ -25,3 +25,8 @@ Here's how you check if your python code meets he standards.
 ```
 
 This will give all those lines which violate the standards, along with a short description of the fixes.
+
+### Docstring Conventions - PEP 257
+In addition to PEP 8, there is another set of conventions created by the python community for docstrings. It's important to know these conventions because, as described in the [docstring section](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/guide/english/python/docstring/index.md) of FCC's Python Guide, it is a way for developers to communicate the purpose, parameters, requirements, and usage of a function in Python to other developers. It allows for ease of code maintenance and understanding. 
+
+[Take a look at PEP-257 -- Docstring Conventions for more information](https://www.python.org/dev/peps/pep-0257/ "PEP 257 -- Docstring Conventions")


### PR DESCRIPTION
Adding docstring conventions as part of the coding standards.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X ] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [X ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X ] My pull request targets the `master` branch of freeCodeCamp.
- [X ] None of my changes are plagiarized from another source without proper attribution.
- [X ] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
