### PR TITLE
Redudancy Mistake

### DIFF
--- a/docs/spanish/README.md
+++ b/docs/spanish/README.md
@@ -17,7 +17,7 @@
 Este directorio contiene toda la documentación sobre cómo contribuir a freeCodeCamp.org
 
 
-## [Si estás empezando, comienza por leer esto primero.](/CONTRIBUTING.md)
+## [Si estás empezando, lee esto.](/CONTRIBUTING.md)
 
 ---
 


### PR DESCRIPTION
The sentence already states that the person is starting to code.  The words: starting, commencing, and first were used in the same sentence, causing redundancy and the formation of an illogical sentence

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ ] My pull request targets the `master` branch of freeCodeCamp.
- [ ] None of my changes are plagiarized from another source without proper attribution.
- [ ] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
