### PR TITLE
Fixed typo ad also added three back-ticks

### DIFF
--- a/guide/english/css/comments-in-css/index.md
+++ b/guide/english/css/comments-in-css/index.md
@@ -22,7 +22,7 @@ The comment syntax in CSS works for both single and multi-line comments. You can
     }
 ```
 
-By using CSS comments to make your stylesheets more readable, the CSS will be easier to maintain in the future for you or another developper. 
+By using CSS comments to make your stylesheets more readable, the CSS will be easier to maintain in the future for you or another developer. 
 It’s good practice to use CSS comments to help identify parts of any stylesheet that might be difficult to understand for someone who didn't write the code. 
 
 You can also make your comments more readable by stylizing it.  
@@ -38,6 +38,7 @@ You can also make your comments more readable by stylizing it.
 * The asterisk around the paragraph make it more readable.
 ***
 */
+```
 
 You can add as many comments to your stylesheet as you like. It’s good practice to use CSS comments to help identify parts of any stylesheet that might be difficult to understand from a cursory glance. Comments are especially important when working in a team, when your code must be understood by others. By using CSS comments to make your stylesheets more readable, the CSS will be easier to maintain in the future.
 


### PR DESCRIPTION
Fixed typo on line 25, 'developer' was spelt 'developper'. Three back-ticks to indicate end of code highlighting was missing on line 41, so i added it.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
