### PR TITLE
Fix typo on CRA's package name

### DIFF
--- a/guide/english/react/your-first-app/index.md
+++ b/guide/english/react/your-first-app/index.md
@@ -7,7 +7,7 @@ title: Your first React App
 As specified in the previous artice (Installation), run the `Create React App` tool. After everything has finished, `cd` into the folder of your application and run `npm start`.
 This will start a development server and you are all set to start developing your app!
 ```bash
-npm install -g react-create-app
+npm install -g create-react-app
 create-react-app my-first-app
 
 cd my-first-app


### PR DESCRIPTION
The create-react-app installation npm command has a typo: 
```npm install -g react-create-app```
Instead of 
```npm install -g create-react-app```

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.
