### PR TITLE
Fixed the code block for student table display

### DIFF
--- a/guide/english/sql/sql-left-join-keyword/index.md
+++ b/guide/english/sql/sql-left-join-keyword/index.md
@@ -60,6 +60,7 @@ student or LEFT table data
 |         9 | Raymond F. Boyce       |      2400 | Computer Science | Raymond@someSchool.edu |
 +-----------+------------------------+-----------+------------------+------------------------+
 9 rows in set (0.00 sec)
+```
 
 student contact or RIGHT table SQL	
 ```sql


### PR DESCRIPTION
Added a code block end quote after the student table so that the student-contact-info sql command is properly displayed in a code block.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
