### PR TITLE
C#: Async await - Fixed example 2 so that its runnable

### DIFF
--- a/guide/english/csharp/async-await/index.md
+++ b/guide/english/csharp/async-await/index.md
@@ -41,20 +41,25 @@ public async Task<int> CalcDamage(Player player)
   //   Boss based on the damage types, Boss stats (from static data),
   //   player stats, etc.
   // ...
+  await Task.Delay(1000); // extemely time consuming calculation
+  return 3;               // that calculates a very accurate damage thats not hardcoded at all
 }
 
-public static async Task<int> CalcTotalDamage(IEnumerable<Player> group)
+public async Task<int> CalcTotalDamage(IEnumerable<Player> players)
 {
-  var totalDamage = 0;
-  foreach (Player player in group)
+  var tasks = new List<Task<int>>();
+  foreach (Player player in players)
   {
     // each of the async methods are queued in the thread-pool and move on.
-    totalDamage += CalcDamage(player);
+    var t = CalcDamage(player);
+    // storing reference to the task
+    tasks.Add(t);
   }
 
   // total damage done must be calculated from all players in the group
   //   before we return the result.
-  return await Task.WhenAll(totalDamage);
+  var completeTask = await Task.WhenAll(tasks);
+  return completeTask.Sum();
 }
 ```
 


### PR DESCRIPTION
* added some some time consuming code and a return to `CalcDamage`

* removed `static` from `CalcTotalDamage` so that the compiler doesn't complain that `CalcDamage` should be static
* compiler wasn't happy with `totalDamage += CalcDamage(player);` or `return await Task.WhenAll(totalDamage)` because you are attempting to assign a Task to an int. Fixed it by using `WhenAll` correctly
* Changed parameter name of `CalcTotalDamage` from `group` to `people` as  `group` can  be confusing to read as its used with linq

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
