### PR TITLE
Adding accent to the word "icono"

### DIFF
--- a/guide/spanish/bootstrap/icons/index.md
+++ b/guide/spanish/bootstrap/icons/index.md
@@ -2,13 +2,13 @@
 title: Icons
 localeTitle: Iconos
 ---
-## Iconos
+## Íconos
 
-El marco de Bootstrap le proporciona Glyphicons para el icono. Bootstrap no incluye una biblioteca de iconos de forma predeterminada, pero tiene una serie de recomendaciones para que elijas. Si bien la mayoría de los conjuntos de iconos incluyen múltiples formatos de archivo, preferimos las implementaciones SVG por su mejor accesibilidad y compatibilidad con vectores.
+El marco de Bootstrap le proporciona Glyphicons para el ícono. Bootstrap no incluye una biblioteca de íconos de forma predeterminada, pero tiene una serie de recomendaciones para que elijas. Si bien la mayoría de los conjuntos de íconos incluyen múltiples formatos de archivo, preferimos las implementaciones SVG por su mejor accesibilidad y compatibilidad con vectores.
 
 ### Cómo utilizar
 
-Para usar el icono de Bootstrap, cree una etiqueta de intervalo con `glyphicon` clase base y una clase de icono individual. Úselo solo en elementos que no contengan contenido de texto y no tengan elementos secundarios.
+Para usar el ícono de Bootstrap, cree una etiqueta de intervalo con `glyphicon` clase base y una clase de ícono individual. Úselo solo en elementos que no contengan contenido de texto y no tengan elementos secundarios.
 
 **Ejemplo de código:**
 
@@ -16,11 +16,11 @@ Para usar el icono de Bootstrap, cree una etiqueta de intervalo con `glyphicon` 
 
 `<span class="glyphicon glyphicon-cog"></span>`
 
-El marco de Bootstrap le proporciona más de 250 iconos llamados glifos. Vienen en formato de fuente del conjunto Glyphicon Halflings.
+El marco de Bootstrap le proporciona más de 250 íconos llamados glifos. Vienen en formato de fuente del conjunto Glyphicon Halflings.
 
 ### Cómo utilizar
 
-Para usar los iconos de arranque, simplemente cree la etiqueta `<span>` y aplique la clase CSS correspondiente al icono. A continuación se proporciona un ejemplo de código.
+Para usar los íconos de arranque, simplemente cree la etiqueta `<span>` y aplique la clase CSS correspondiente al ícono. A continuación se proporciona un ejemplo de código.
 
 **Ejemplo de código:**
 
@@ -30,7 +30,7 @@ Para usar los iconos de arranque, simplemente cree la etiqueta `<span>` y apliqu
 
 Este es un ejemplo de las clases CSS que bootstrap proporciona para los glifos. Más de ellos están disponibles [aquí.](https://getbootstrap.com/docs/3.3/components/#glyphicons)
 
-`.glyphicon glyphicon-plus` Este es el icono más / agregar de bootstrap.
+`.glyphicon glyphicon-plus` Este es el ícono más / agregar de bootstrap.
 
 `.glyphicon glyphicon-trash` Este es el ícono trash / delete de bootstrap.
 
@@ -45,7 +45,7 @@ _Nota: No incluya el punto en el atributo de clase HTML, ya que las clases con u
   </button> 
 ```
 
-_Nota: el icono de Glyphicons de Bootstrap no está disponible en bootstrap V4_
+_Nota: el ícono de Glyphicons de Bootstrap no está disponible en bootstrap V4_
 
 ### Más información:
 


### PR DESCRIPTION
The word icono should have an accent and read as ícono. This word was not accentuated across the whole article.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
