### PR TITLE
Fixes tets in "Equilibrium index" challenge

### DIFF
--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/equilibrium-index.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/equilibrium-index.english.md
@@ -30,17 +30,17 @@ tests:
   - text: <code>equilibrium</code> is a function.
     testString: 'assert(typeof equilibrium === "function", "<code>equilibrium</code> is a function.");'
   - text: '<code>equilibrium([-7, 1, 5, 2, -4, 3, 0])</code> should return <code>[3,6]</code>.'
-    testString: 'assert.deepEqual(equilibrium(tests[0]), ans[0], "<code>equilibrium([-7, 1, 5, 2, -4, 3, 0])</code> should return <code>[3,6]</code>.");'
+    testString: 'assert.deepEqual(equilibrium([-7, 1, 5, 2, -4, 3, 0]), [3,6], "<code>equilibrium([-7, 1, 5, 2, -4, 3, 0])</code> should return <code>[3,6]</code>.");'
   - text: '<code>equilibrium([2, 4, 6])</code> should return <code>[]</code>.'
-    testString: 'assert.deepEqual(equilibrium(tests[1]), ans[1], "<code>equilibrium([2, 4, 6])</code> should return <code>[]</code>.");'
+    testString: 'assert.deepEqual(equilibrium([2, 4, 6]), [], "<code>equilibrium([2, 4, 6])</code> should return <code>[]</code>.");'
   - text: '<code>equilibrium([2, 9, 2])</code> should return <code>[1]</code>.'
-    testString: 'assert.deepEqual(equilibrium(tests[2]), ans[2], "<code>equilibrium([2, 9, 2])</code> should return <code>[1]</code>.");'
+    testString: 'assert.deepEqual(equilibrium([2, 9, 2]), [1], "<code>equilibrium([2, 9, 2])</code> should return <code>[1]</code>.");'
   - text: '<code>equilibrium([1, -1, 1, -1, 1, -1, 1])</code> should return <code>[0,1,2,3,4,5,6]</code>.'
-    testString: 'assert.deepEqual(equilibrium(tests[3]), ans[3], "<code>equilibrium([1, -1, 1, -1, 1, -1, 1])</code> should return <code>[0,1,2,3,4,5,6]</code>.");'
+    testString: 'assert.deepEqual(equilibrium([1, -1, 1, -1, 1, -1, 1])), [0,1,2,3,4,5,6]<, "<code>equilibrium([1, -1, 1, -1, 1, -1, 1])</code> should return <code>[0,1,2,3,4,5,6]</code>.");'
   - text: '<code>equilibrium([1])</code> should return <code>[0]</code>.'
-    testString: 'assert.deepEqual(equilibrium(tests[4]), ans[4], "<code>equilibrium([1])</code> should return <code>[0]</code>.");'
+    testString: 'assert.deepEqual(equilibrium([1]), [0], "<code>equilibrium([1])</code> should return <code>[0]</code>.");'
   - text: '<code>equilibrium([])</code> should return <code>[]</code>.'
-    testString: 'assert.deepEqual(equilibrium(tests[5]), ans[5], "<code>equilibrium([])</code> should return <code>[]</code>.");'
+    testString: 'assert.deepEqual(equilibrium([]), [], "<code>equilibrium([])</code> should return <code>[]</code>.");'
 
 ```
 


### PR DESCRIPTION
Tests were failing because the array of tests itself was referenced for inputs. Based on the examples of other challenges, I hard-coded the assert values rather than constructing test input and output collections.


- [x ] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.


Closes #19693
