### PR TITLE
fix(pageDir): solve the error--can't read property 'split' of undefined

### DIFF
--- a/client/plugins/fcc-create-nav-data/create-navigation-node.js
+++ b/client/plugins/fcc-create-nav-data/create-navigation-node.js
@@ -5,7 +5,7 @@ const commonREs = require('../../utils/regEx');
 const readDir = require('../../utils/readDir');
 
 const { isAStubRE } = commonREs;
-const pagesDir = path.resolve(__dirname, '../../../guide/english/');
+const pagesDir = path.resolve(__dirname, '/src/pages/guide/english/');
 
 function withGuidePrefix(str) {
   return `/guide${str}`;


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

Today I deploy freeCodeCamp on my local computer.
When i do the action: `npm run develop` in the last step.
I meet a error--can't read property 'split' of undefined.
I review the code very carefully.
Finally, I find the bug and fixed it.
Just one line code, it's simple but works.

