### PR TITLE
Add option for Developer tools inside browsers

### DIFF
--- a/guide/spanish/developer-tools/index.md
+++ b/guide/spanish/developer-tools/index.md
@@ -12,3 +12,4 @@ Algunos ejemplos de estas herramientas:
 *   Herramientas devOps
 *   Construir herramientas
 *   Gestores de paquetes
+*   Herramientas de desarrollador en los navegadores


### PR DESCRIPTION
As developer tools are used extensively by front-end developers, it's nice to hint readers that this guide also contains information about developer tools of browsers such as chrome, firefox and edge.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.
