### PR TITLE
Fix broken markdown for Youtube links with plain HTML

### DIFF
--- a/guide/portuguese/react/index.md
+++ b/guide/portuguese/react/index.md
@@ -209,15 +209,17 @@ Se você clicar na tag head, poderemos ver nossas bibliotecas de scripts incluí
 
 ou
 
-[!["Assista](http://img.youtube.com/vi/YOUTUBE_VIDEO_ID_HERE/0.jpg)](http://www.youtube.com/watch?feature=player_embedded&v=100pKUE3OPI)
-
-[
+<a href="http://www.youtube.com/watch?feature=player_embedded&v=100pKUE3OPI" target="_blank">
+  <img src="http://img.youtube.com/vi/100pKUE3OPI/0.jpg" alt="Assista ao vídeo" width="500" height="375" border="10" />
+</a>
 
 ### Recapitular
 
 Então, vamos fazer uma rápida recapitulação. Na nossa tag head pegamos as tags de script para React, ReactDOM e Babel. Estas são as ferramentas que nosso navegador precisa em seus metadados para ler nosso código React e JSX em específico. Em seguida, localizamos a posição no DOM em que desejamos inserir nosso React, criando um elemento div com o ID de "app". Em seguida, criamos uma tag de script para inserir nosso código React. Usamos o método ReactDOM.render () que leva dois argumentos. O "o quê" do conteúdo do React, neste caso o nosso JSX, e o segundo argumento é o "where" em que você deseja inserir o conteúdo do React no DOM. Neste caso, é o local com o id de "app".
 
-](http://www.youtube.com/watch?feature=player_embedded&v=100pKUE3OPI)
+<a href="http://www.youtube.com/watch?feature=player_embedded&v=100pKUE3OPI" target="_blank">
+  <img src="http://img.youtube.com/vi/100pKUE3OPI/0.jpg" alt="Assista ao vídeo" width="500" height="375" border="10" />
+</a>
 
 [Como alternativa ao JSX, você pode usar o compilador ES6 e Javascript como o Babel.](http://www.youtube.com/watch?feature=player_embedded&v=100pKUE3OPI) [https://babeljs.io/](https://babeljs.io/)
 


### PR DESCRIPTION
The Youtube links for the referred tutorial were broken, displaying some wrong chars in the rendered page, as well as not displaying the video cover.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.