### PR TITLE
Modified statement comparing FA usage to Glyphicon

### DIFF
--- a/guide/english/bootstrap/fontawesome-icons/index.md
+++ b/guide/english/bootstrap/fontawesome-icons/index.md
@@ -12,7 +12,7 @@ In the `<head>` of your html include a reference to Font Awesome.
 ```html
 <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
 ```
-Using fontawesome is same as using Glyphicon. 
+Fontawesome usage is the same as that of Glyphicon. 
 
 Simply create `<i>` or `<span>` tag and apply the CSS Prefix `fa` and the icon's name.  A code example has been provided below.
 


### PR DESCRIPTION
The original statement seemed confusing to me- it could be understood to mean that FA and Glyphicon were the same library, whereas the intent of the statement was just to explain that the implementation was the same.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
