### PR TITLE
Fix multiples broken translations, with "Reagir" being used instead of "React"

### DIFF
--- a/guide/portuguese/react/why-react/index.md
+++ b/guide/portuguese/react/why-react/index.md
@@ -1,6 +1,6 @@
 ---
 title: Why React
-localeTitle: Por que reagir
+localeTitle: Por que React
 ---
 ## Por que o React.js?
 
@@ -8,7 +8,7 @@ localeTitle: Por que reagir
 
 O React.js não é um framework Javascript completo como o Angular.js ou outras estruturas de frontend populares. Em vez disso, o React.js atua como o 'V' no MVC (Model View Controller). É simplesmente um mecanismo de visualização que pode ser incluído e usado com uma infinidade de outras ferramentas para os dados e parte de modelo do MVC (mais popularmente Redux e Node.js).
 
-### atuação
+### Atuação
 
 Como o React usa um _DOM virtual_ , ele pode atualizar seletivamente partes da página conforme necessário, em vez de sempre precisar concluir uma recarga de página inteira. Em muitos casos, não atualizar o DOM inteiro economizará consideravelmente no desempenho. Além disso, muitas das funções integradas (como as funções do ciclo de vida) também têm benefícios de desempenho, já que geralmente ajudam a verificar se uma nova renderização é necessária para começar.
 
@@ -24,7 +24,7 @@ As ferramentas e os softwares comumente utilizados com o React são incrivelment
 
 React é criado e mantido pelo pessoal do Facebook e é usado por indivíduos e empresas em todo o mundo em grande volume. Isso significa que o React está em constante aprimoramento e provavelmente já foi perguntado sobre algum problema que você já tenha recebido no Stack Overflow.
 
-Além do que foi dito acima, podemos usar nosso conhecimento de reação para desenvolver aplicativos nativos móveis usando o reagente nativo e também tomar nosso conhecimento e expandi-lo para VR usando react-vr. Basicamente, aprender reagir nos abre para várias outras oportunidades, como usá-lo para Web, RV, PWA (Progressive Web App) e muitos outros.
+Além do que foi dito acima, podemos usar nosso conhecimento de React para desenvolver aplicativos nativos móveis usando o react-native e também tomar nosso conhecimento e expandi-lo para VR usando react-vr. Basicamente, aprender React nos abre para várias outras oportunidades, como usá-lo para Web, RV, PWA (Progressive Web App) e muitos outros.
 
 #### Mais Informações
 


### PR DESCRIPTION
There were some occurrences of proper nouns being translated to Portuguese, making the word "React" to be translated to "Reagir". Additionally, the react-native package name was wrongly translated to Portuguese.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.
