### PR TITLE
Fix incorrect proper name translation and phrases with wrong meaning

### DIFF
--- a/guide/portuguese/react/what-are-react-props/index.md
+++ b/guide/portuguese/react/what-are-react-props/index.md
@@ -1,25 +1,26 @@
 ---
 title: React TypeChecking with PropTypes
-localeTitle: Tipo de ReaçãoChecendo com PropTypes
----## Reagir PropTypes
+localeTitle: Validação de Tipo em React com PropTypes
+---
+## React PropTypes
 
-Estes servem como um método de typechecking à medida que um aplicativo tende a crescer, com isso uma base muito grande de bugs tende a ser corrigida com o uso desse recurso.
+Estes servem como um método de validação de tipo (type checking) à medida que um aplicativo tende a crescer, com isso uma base muito grande de bugs tende a ser corrigida com o uso desse recurso.
 
 ## Como obter PropTypes
 
 Começando com o React versão 15.5, esse recurso foi movido para um pacote separado chamado prop-types.
 
-Para usá-lo, é necessário que ele seja adicionado ao projeto como uma dependência, emitindo o seguinte comando em um console.
+Para usá-lo, é necessário que ele seja adicionado ao projeto como uma dependência, emitindo o seguinte comando em um terminal:
 
 ```sh
 npm install --save prop-types 
 ```
 
-Depois disso, toda uma gama de validadores que podem ser usados ​​para garantir que os dados que o desenvolvedor receberá realmente sejam válidos. Quando um valor inválido é fornecido, haverá um aviso aparecendo no console do JavaScript.
+Depois disso, toda uma gama de validadores de tipo podem ser usados para garantir que os dados que o desenvolvedor receberá realmente sejam válidos. Quando um valor inválido é fornecido, haverá um aviso aparecendo no console do JavaScript.
 
 Observe que, por motivos de desempenho, os propTypes definidos são verificados apenas no modo de desenvolvimento.
 
-Também, ao contrário do estado do componente, que pode ser manipulado conforme necessário, esses suportes são somente leitura.
+Também, ao contrário do estado do componente, que pode ser manipulado conforme necessário, essas propriedades (props) são somente leitura.
 
 Seu valor não pode ser alterado pelo componente.
 


### PR DESCRIPTION
Some occurrences of proper names, like "React" and "propTypes" were wrongly translated to Portuguese.

Also fixed mixed line endings (CF by LF).

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.
