### PR TITLE
Fix incorrect proper name translation and phrases with wrong meaning

### DIFF
--- a/guide/portuguese/react/state/index.md
+++ b/guide/portuguese/react/state/index.md
@@ -126,6 +126,6 @@ Quando apenas um número limitado de campos no objeto de estado é necessário, 
 
 ### Mais Informações
 
-*   [Reagir - Estado e ciclo de vida](https://reactjs.org/docs/state-and-lifecycle.html)
-*   [Reagir - levantando o estado acima](https://reactjs.org/docs/lifting-state-up.html)
-*   [Reagir Nativo - Estado Acima](https://facebook.github.io/react-native/docs/state.html)
+*   [React - Estado e ciclo de vida](https://reactjs.org/docs/state-and-lifecycle.html)
+*   [React - Movendo o estado para cima](https://reactjs.org/docs/lifting-state-up.html)
+*   [React Native - Estado](https://facebook.github.io/react-native/docs/state.html)


### PR DESCRIPTION
Some occurrences of proper names, like "React" and "React Native" were wrongly translated to Portuguese.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.