### PR TITLE
Associativity of operators

### DIFF
--- a/guide/english/c/operators/index.md
+++ b/guide/english/c/operators/index.md
@@ -199,9 +199,13 @@ sizeof()	               Returns the size of a variable.	                    size
 ? :	                    Conditional Expression.	                              If Condition is true ? then value X : otherwise value Y
 
 
-## 6. Operator precedence in C
+## 6. Operator precedence and associativity in C
 Operators with the highest precedence appear at the top of the list. Within an expression, operators
-with higher precedence will be evaluated first.
+with higher precedence will be evaluated first. When two or more operators of the same precedence is
+present in an expression, then the associativity of the operator tells us the order in which the operators
+must be evaluated. The associativity in the given list is from left to right i.e, operators in the left are
+evaluated first. 
+
 - Postfix `() [] -> . ++ --`
 - Unary `+ - ! ~ ++ -- (type)* & sizeof`
 - Multiplicative `* / %`


### PR DESCRIPTION
When two or more operators of the same precedence occur in an expression, associativity determines the order in which they must be evaluated.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [ x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ x] My pull request targets the `master` branch of freeCodeCamp.
- [ x] None of my changes are plagiarized from another source without proper attribution.
- [ x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
