### PR TITLE
Remove ternary operator in React component

### DIFF
--- a/client/src/templates/News/components/ArticleMeta.js
+++ b/client/src/templates/News/components/ArticleMeta.js
@@ -74,11 +74,11 @@ function ArticleMeta({
         <span className='meta-item'>
           <FontAwesomeIcon icon={faClock} /> {`${meta.readTime} minute read`}
         </span>
-        {viewCount >= 100 ? (
+        {viewCount >= 100 && (
           <span className='meta-item'>
             <FontAwesomeIcon icon={faFreeCodeCamp} /> {`${viewCount} views`}
           </span>
-        ) : null}
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
Remove ternary operator in React component, unnecessary operator to render null

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
