### PR TITLE
Fix the order wording(Second to first )

### DIFF
--- a/guide/english/html/attributes/input-checked-attribute/index.md
+++ b/guide/english/html/attributes/input-checked-attribute/index.md
@@ -20,4 +20,4 @@ The checked attribute can also be set after the page load, through JavaScript.
 </form>
 ```
 
-In the example above when the web page is loaded by default the first checkbox will come automatically selected due to the checked attribute.
+In the example above when the web page is loaded by default the second checkbox will come automatically selected due to the checked attribute.


### PR DESCRIPTION
Before modifying this, line 23 quote, "by default the first checkbox will come automatically" even though the checked attribute is in the second input element, not the first.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
