### PR TITLE
fixed translation of "links"

### DIFF
--- a/guide/spanish/tools/image-editor/index.md
+++ b/guide/spanish/tools/image-editor/index.md
@@ -18,7 +18,7 @@ Disponible como descargas gratuitas y abierto a las contribuciones de los usuari
 
 Los editores pagados necesitan un pago único o están basados ​​en suscripciones. Pero, las versiones de prueba están disponibles para probar el software antes de comprometerse a comprar. Si resulta ser un estudiante, muchas veces, hay descuentos disponibles a través de un correo electrónico o identificación del estudiante.
 
-### Campo de golf:
+### Enlaces:
 
 *   [Pixlr Editor](https://pixlr.com/editor/) - Gratis | Navegador
 *   [Gimp](https://www.gimp.org/) - Gratis | Descargar | Fuente abierta


### PR DESCRIPTION
Proper translation of "Links" is "Enlaces" not "Campo de Golf" (= "golf course").

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
