### PR TITLE
fixed translation of "Links"

### DIFF
--- a/guide/spanish/html/attributes/links/index.md
+++ b/guide/spanish/html/attributes/links/index.md
@@ -1,8 +1,8 @@
 ---
 title: Links
-localeTitle: Campo de golf
+localeTitle: Enlaces
 ---
-## Campo de golf
+## Enlaces
 
 Esto es un talón. [Ayuda a nuestra comunidad a expandirla](https://github.com/freecodecamp/guides/tree/master/src/pages/html/attributes/links/index.md) .
 


### PR DESCRIPTION
Proper translation of "Links" is "Enlaces" not "Campo de Golf" (= "golf course").

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
