### PR TITLE
Removed duplicate text and corrected formatting

### DIFF
--- a/guide/english/html/elements/label-tag/index.md
+++ b/guide/english/html/elements/label-tag/index.md
@@ -3,23 +3,23 @@ title: Label Tag
 ---
 
 # Label Tag
-<***label***> defines a label for an <input> type element/tag.
+<***label***> defines a label for an `<input>` type element/tag.
 
 ### Usage
 ```
 <label for="id">Label</label>
 <input type="text" name="text" id="id" value="yourvalue"><br>
 ```
-As you can see, the *for* attribute of the <label> tag should be equal to the id attribute of the related element to bind them together.
+As you can see, the *for* attribute of the `<label>` tag should be equal to the id attribute of the related element to bind them together.
 
 ### Platform Support
 |Browser|Element Support|
 |:-----:|:-------------:|
-|Internet Explorer|:white_check_mark:|
-|Mozilla Firefox|:white_check_mark:|
-|Google Chrome|:white_check_mark:|
-|Opera|:white_check_mark:|
-|Safari|:white_check_mark:|
+|Internet Explorer|Yes|
+|Mozilla Firefox|Yes|
+|Google Chrome|Yes|
+|Opera|Yes|
+|Safari|Yes|
 
 ### Attributes
 |Attribute|	Value|Description|
@@ -36,30 +36,6 @@ The <**label**> tag supports the Event Attributes in HTML.
 
 > The <**label**> element does not render as anything special for the user. However, it provides a usability improvement for mouse users, because if the user clicks on the text within the <label> element, it toggles the control.
 
-
-
 #### More Information:
-[https://www.w3schools.com/jsref/dom_obj_label.asp](https://www.w3schools.com/jsref/dom_obj_label.asp)
-=======
-
-## Label
-The `<label>` tag defines a label for an `<input>` element.
-
-A label can be bound to an element either by using the "for" attribute, or by placing the element inside the <label> element.
-```html
-<label for="peas">Do you like peas?
-  <input type="checkbox" name="peas" id="peas">
-</label>
-```
-
-```html
-<label>Do you like peas?
-  <input type="checkbox" name="peas">
-</label>
-```
-
-#### More Information:
-
-
-<a href='https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label' target='_blank' rel='nofollow'>MDN - Tabel Tag</a>  
-<a href='https://www.w3schools.com/tags/tag_label.asp' target='_blank' rel='nofollow'>W3School - Label Tag</a>
+[MDN - Label Tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label)  
+[W3School - Label Tag](https://www.w3schools.com/tags/tag_label.asp)


### PR DESCRIPTION
There were two descriptions of what a <label> is.
Markdown formatting was incorrectly rendering in https://guide.freecodecamp.org/html/elements/label-tag.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
