### PR TITLE
Add hyperlinks to the list of translated languages

### DIFF
--- a/docs/portuguese/CONTRIBUTING.md
+++ b/docs/portuguese/CONTRIBUTING.md
@@ -84,11 +84,11 @@ Entretanto, eles precisam ser constantemente refinados para melhor qualidade. Po
 
 Você pode nos ajudar a traduzir nossos Artigos de guia e Desafios de código para uma língua que você fala. Atualmente, nós temos versões traduzidas em:
 
-- Chinês (中文)
-- Russo (русский)
-- Árabe (عربى)
-- Espanhol (Español)
-- Português (Português)
+- [Chinês (中文)](https://github.com/freeCodeCamp/freeCodeCamp/tree/master/curriculum/challenges/chinese)
+- [Russo (русский)](https://github.com/freeCodeCamp/freeCodeCamp/tree/master/curriculum/challenges/russian)
+- [Árabe (عربى)](https://github.com/freeCodeCamp/freeCodeCamp/tree/master/curriculum/challenges/arabic)
+- [Espanhol (Español)](https://github.com/freeCodeCamp/freeCodeCamp/tree/master/curriculum/challenges/spanish)
+- [Português](https://github.com/freeCodeCamp/freeCodeCamp/tree/master/curriculum/challenges/portuguese)
 
 A maioria dessas versões são traduções de máquina. Nós vamos amar sua ajuda em melhorar a qualidade dessas traduções.
 


### PR DESCRIPTION
The English version of this document has hyperlinks for each language under "Traduza artigos de guia e desafios de código," I added them to this version as well.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.
