### PR TITLE
 Fix typo "SVM" to "SVN" in Version Control System guide article

### DIFF
--- a/guide/english/software-engineering/version-control-system/index.md
+++ b/guide/english/software-engineering/version-control-system/index.md
@@ -35,7 +35,7 @@ The most used modern VCS (Git, Mercurial...) are Distributed Version Control Sys
 
 - SVN/Subversion
 
-*SVM* is an old SCM that succeeded *CVS*.
+*SVN* is an old SCM that succeeded *CVS*.
 Eventually *SVN* was deprecated by the wide adoption of Distributed Version Control System like *Git* and *Mercurial*
 
 ### More Information:


### PR DESCRIPTION
Fix typo "SVM" to "SVN" in article in index.md of Version Control System guide article

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
