### PR TITLE
Fixed example display error

### DIFF
--- a/guide/english/javascript/arithmetic-operation/index.md
+++ b/guide/english/javascript/arithmetic-operation/index.md
@@ -87,9 +87,13 @@ _Hint:_ There is a handy <a href='https://developer.mozilla.org/en-US/docs/Web/J
 
 **Syntax**
 
-`a++ or ++a`
+`a++ or ++a` "++" can be written on either side of the variable you want to increment
 
 **Usage**
+    
+    var num = 5;
+    num++;
+    // num will now be equal to 6
     
     // Postfix
     x = 3;  // declare a variable 
@@ -103,9 +107,13 @@ _Hint:_ There is a handy <a href='https://developer.mozilla.org/en-US/docs/Web/J
 
 **Syntax**
 
-`a-- or --a`
+`a-- or --a` Like when you are incrementing, "--" can be written on either side of the variable you want to decrement
 
 **Usage**
+    
+    var num = 5;
+    num--;
+    // num will now be equal to 4
     
     // Postfix
     x = 3;  // declare a variable 


### PR DESCRIPTION
Potentially fixed example display errors that made the bottom two examples display like normal text. I believe this was due to both of those examples starting with comments. It did display correctly here on Github, so I can't say for certain that the errors are fixed. Will double check if this pull request gets approved

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `master` branch of freeCodeCamp.
- [X] None of my changes are plagiarized from another source without proper attribution.
- [X] My article does not contain shortened URLs or affiliate links.