### PR TITLE
Change the statement for OR operator

### DIFF
--- a/guide/english/logic/truth-tables/index.md
+++ b/guide/english/logic/truth-tables/index.md
@@ -109,7 +109,7 @@ Here is the truth table for the OR operator
 | T  | F  | T  |
 | T  | T  | F  |
 
-Just like above the OR operator operates on two variables, notice that the only time the OR operator evaluates to True is when `x` & `y` negate eachother.
+Just like above the OR operator operates on two variables, notice that the only time the OR operator evaluates to False is when both `x` & `y` are False.
 
 Let's do one more, let's do the table for the Negation, this operates on one value instead of two
 


### PR DESCRIPTION
The statement 'Just like above the OR operator operates on two variables, notice that the only time the OR operator evaluates to True is when `x` & `y` negate each other' is ambiguous change it to 'Just like above the OR operator operates on two variables, notice that the only time the OR operator evaluates to False is when both `x` & `y` are False'.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ ] My pull request targets the `master` branch of freeCodeCamp.
- [ ] None of my changes are plagiarized from another source without proper attribution.
- [ ] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
