### PR TITLE
Updated "More Information" Links at Bootstrap Buttons

### DIFF
--- a/guide/english/bootstrap/buttons/index.md
+++ b/guide/english/bootstrap/buttons/index.md
@@ -88,6 +88,6 @@ Outlined buttons are a part of Bootstrap since version 4, please be sure that yo
 _Note: Do not include the dot in the HTML Class Attribute, referring to the classes with a dot is only used when adjusting the classes in CSS._
 
 #### More Information: 
-* <a href='https://getbootstrap.com/docs/4.0/components/buttons/' target='_blank' rel='nofollow'>Bootstrap Buttons documentation</a>
-* <a href='http://getbootstrap.com/docs/4.0/components/button-group/' target='_blank' rel='nofollow'>Bootstrap Button Group documentation</a>
-* [Bootstrap Get Started](/articles/bootstrap/bootstrap-get-started)
+* <a href='https://getbootstrap.com/docs/4.1/components/buttons/' target='_blank' rel='nofollow'>Bootstrap Buttons documentation</a>
+* <a href='https://getbootstrap.com/docs/4.1/components/button-group/' target='_blank' rel='nofollow'>Bootstrap Button Group documentation</a>
+* [Bootstrap Get Started](https://guide.freecodecamp.org/bootstrap/get-started)

--- a/guide/english/bootstrap/buttons/index.md
+++ b/guide/english/bootstrap/buttons/index.md
@@ -90,4 +90,4 @@ _Note: Do not include the dot in the HTML Class Attribute, referring to the clas
 #### More Information: 
 * <a href='https://getbootstrap.com/docs/4.1/components/buttons/' target='_blank' rel='nofollow'>Bootstrap Buttons documentation</a>
 * <a href='https://getbootstrap.com/docs/4.1/components/button-group/' target='_blank' rel='nofollow'>Bootstrap Button Group documentation</a>
-* [Bootstrap Get Started](https://guide.freecodecamp.org/bootstrap/get-started)
+* [Bootstrap Get Started](/bootstrap/get-started)

--- a/guide/english/bootstrap/buttons/index.md
+++ b/guide/english/bootstrap/buttons/index.md
@@ -90,4 +90,3 @@ _Note: Do not include the dot in the HTML Class Attribute, referring to the clas
 #### More Information: 
 * <a href='https://getbootstrap.com/docs/4.1/components/buttons/' target='_blank' rel='nofollow'>Bootstrap Buttons documentation</a>
 * <a href='https://getbootstrap.com/docs/4.1/components/button-group/' target='_blank' rel='nofollow'>Bootstrap Button Group documentation</a>
-* [Bootstrap Get Started](/bootstrap/get-started)


### PR DESCRIPTION
Updated bootstrap links from 4.0 to 4.1 version
"Bootstrap Get Started" link was broken (404 error). Changed to https://guide.freecodecamp.org/bootstrap/get-started/

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
