### PR TITLE
Responsive Web Design: Added hint to Set the id of an Element

### DIFF
--- a/guide/english/certifications/responsive-web-design/basic-css/set-the-id-of-an-element/index.md
+++ b/guide/english/certifications/responsive-web-design/basic-css/set-the-id-of-an-element/index.md
@@ -3,8 +3,27 @@ title: Set the id of an Element
 ---
 ## Set the id of an Element
 
-This is a stub. <a href='https://github.com/freecodecamp/guides/tree/master/src/pages/certifications/responsive-web-design/basic-css/set-the-id-of-an-element/index.md' target='_blank' rel='nofollow'>Help our community expand it</a>.
-
-<a href='https://github.com/freecodecamp/guides/blob/master/README.md' target='_blank' rel='nofollow'>This quick style guide will help ensure your pull request gets accepted</a>.
-
 <!-- The article goes here, in GitHub-flavored Markdown. Feel free to add YouTube videos, images, and CodePen/JSBin embeds  -->
+We need to give our ```form``` element the id ```cat-photo-form```.
+
+### Example
+
+```css
+<h2 id="cat-photo-app">
+```
+
+### Solution
+
+In the opening tag ```form``` we need add id with value ```cat-photo-form```:
+
+```css
+<form id="cat-photo-form" action="/submit-cat-photo">
+    <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
+    <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
+    <label><input type="checkbox" name="personality" checked> Loving</label>
+    <label><input type="checkbox" name="personality"> Lazy</label>
+    <label><input type="checkbox" name="personality"> Energetic</label><br>
+    <input type="text" placeholder="cat photo URL" required>
+    <button type="submit">Submit</button>
+  </form>
+  ```


### PR DESCRIPTION
Added hint to Set the id of an Element (https://learn.freecodecamp.org/responsive-web-design/basic-css/set-the-id-of-an-element and https://guide.freecodecamp.org/certifications/responsive-web-design/basic-css/set-the-id-of-an-element)

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
