### PR TITLE
Remove beta marker for Google Cloud Functions

### DIFF
--- a/guide/english/cloud-development/google-cloud-platform/index.md
+++ b/guide/english/cloud-development/google-cloud-platform/index.md
@@ -3,16 +3,16 @@ title: Google Cloud Platform
 ---
 ## Google Cloud Platform
 
-Google Cloud Platform, offered by Google, is a suite of cloud computing services that runs on the same infrastructure that Google uses internally for its end-user products, such as Google Search and YouTube. Alongside a set of management tools,
-it provides a series of modular cloud services including computing, data storage, data analytics and machine learning.
+Google Cloud Platform (GCP), offered by Google, is a suite of cloud computing services that runs on the same infrastructure that Google uses internally for its end-user products, such as Google Search and YouTube. Alongside a set of management tools,
+GCP provides a series of modular cloud services including computing, data storage, data analytics and machine learning.
 
-Some famous web services include
+Some famous web services include:
 
 * Google Compute Engine – IaaS providing virtual machines.
 * Google App Engine – PaaS for application hosting.
 * Bigtable – IaaS massively scalable NoSQL database.
 * BigQuery – SaaS large scale database analytics.
-* Google Cloud Functions – As of August 2017 is in beta testing. FaaS providing serverless functions to be triggered by cloud events.
+* Google Cloud Functions – FaaS providing serverless functions to be triggered by cloud events.
 * Google Cloud Datastore - DBaaS providing a document-oriented database.
 * Cloud Pub/Sub - a service for publishing and subscribing to data streams and messages. Applications can communicate via Pub/Sub, without direct integration between the applications themselves.
 * Google Storage - IaaS providing RESTful online file and object storage.


### PR DESCRIPTION
Google Cloud Functions was moved to General Availability [last July 24](https://cloud.google.com/functions/docs/release-notes). Article has been updated to reflect that, alongside some very minor edits.

- [X] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `master` branch of freeCodeCamp.
- [X] None of my changes are plagiarized from another source without proper attribution.
- [X] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
