### PR TITLE
Added points to note when using git force push

### DIFF
--- a/guide/english/git/git-push/index.md
+++ b/guide/english/git/git-push/index.md
@@ -57,6 +57,12 @@ By default `git push` will trigger the `--verify` toggle.  This means that git w
 git push --no-verify
 ```
 
+### Points to Note
+
+`git push --force` should be used very carefully. This command basically overrides the remote repository with any code that you have in the local. In the meanwhile if anyone else had commited to the remote repository then their code will be completely overwritten. 
+
+In some cases it makes sense to use force push to get the job done. But always evaluate the risks before running a force push command.
+
 
 ### More Information:
 - [Git documentation - push](https://git-scm.com/docs/git-push)


### PR DESCRIPTION
git force push is very powerful but equally dangerous. Added a quick warning note for using git force push

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
