### PR TITLE
Applied consistent commas in numbers in C Guide, "Data Types in C" article

### DIFF
--- a/guide/english/c/data-types/index.md
+++ b/guide/english/c/data-types/index.md
@@ -4,11 +4,11 @@ title: Data Types in C
 # Data Types in C
 There are several different ways to store data in C, and they are all unique from each other. The types of data that information can be stored as are called data types. C is much less forgiving about data types than other languages. As a result, it's important to make sure that you understand the existing data types, their abilities, and their limitations.
 
-One quirk of C's data types is that they depend entirely on the hardware that you're running your code on. An `int` on your laptop will be smaller than an `int` on a supercomputer, so knowing the limitations of the hardware you're working on is important. This is also why the data types are defined as being minimums- an `int` value, as you will learn, is at minimum -32767 to 32767: on certain machines, it will be able to store even more values that this.
+One quirk of C's data types is that they depend entirely on the hardware that you're running your code on. An `int` on your laptop will be smaller than an `int` on a supercomputer, so knowing the limitations of the hardware you're working on is important. This is also why the data types are defined as being minimums- an `int` value, as you will learn, is at minimum -32,768 to 32,767: on certain machines, it will be able to store even more values that this.
 
-There are two categories that we can break this into: integers, and floating point numbers. Integers are whole numbers. They can be positive, negative, or zero. Numbers like -321, 497, 19345, and -976812 are all perfectly valid integers, but 4.5 is not because 4.5 is not a whole number.
+There are two categories that we can break this into: integers, and floating point numbers. Integers are whole numbers. They can be positive, negative, or zero. Numbers like -321, 497, 19,345, and -976,812 are all perfectly valid integers, but 4.5 is not because 4.5 is not a whole number.
 
-Floating point numbers are numbers with a decimal. Like integers, -321, 497, 19345, and -976812 are all valid, but now 4.5, 0.0004, -324.984, and other non-whole numbers are valid too.
+Floating point numbers are numbers with a decimal. Like integers, -321, 497, 19,345, and -976,812 are all valid, but now 4.5, 0.0004, -324.984, and other non-whole numbers are valid too.
 
 C allows us to choose between several different options with our data types because they are all stored in different ways on the computer. As a result, it is important to be aware of the abilities and limitations of each data type to choose the most appropriate one.
 
@@ -25,7 +25,7 @@ The amount of memory that a single `int` takes depends on the hardware. However,
 Like all of these other data types, there is an `unsigned` variant that can be used. The `unsigned int` can be positive and zero but not negative, so it can store values from 0 to 65,535, or more depending on hardware.
 
 #### Short integers: `short`
-This doesn't get used often, but it's good to know that it exists. Like int, it can store -32768 to 32767. Unlike int, however, this is the extent of its ability. Anywhere you can use `short`, you can use `int`.
+This doesn't get used often, but it's good to know that it exists. Like int, it can store -32,768 to 32,767. Unlike int, however, this is the extent of its ability. Anywhere you can use `short`, you can use `int`.
 
 #### Longer integers: `long`
 The `long` data type stores integers like `int`, but gives a wider range of values at the cost of taking more memory. Long stores at least 32 bits, giving it a range of -2,147,483,648 to 2,147,483,647. Alternatively, use `unsigned long` for a range of 0 to 4,294,967,295.
@@ -41,7 +41,7 @@ The `long long` data type is overkill for just about every application, but C wi
 `double` takes double the memory of float (so at least 64 bits). In return, double can provide 15 decimal place from 2.3E-308 to 1.7E+308.
 
 #### Getting a wider range of doubles: `long double`
-`long double` takes at least 80 bits. As a result, we can get 19 decimal places from 3.4E-4932 to 1.1E+4932.
+`long double` takes at least 80 bits. As a result, we can get 19 decimal places from 3.4E-4,932 to 1.1E+4,932.
 
 ## Picking the right data type
 C makes pick the data type, and makes us be very specific and intentional about the way that we do this. This gives you a lot of power over your code, but it's important to pick the right one.


### PR DESCRIPTION
In the article "Data Types in C" under the C Guide, commas were added to all numbers greater than three digits for consistency.  Note the minimum value for an int was changed from -32767 to -32,768 per pull request #24692.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Does not close an issue.
