### PR TITLE
Fix weird word order in chaining-if-else-statements Spanish translation

### DIFF
--- a/curriculum/challenges/spanish/02-javascript-algorithms-and-data-structures/basic-javascript/chaining-if-else-statements.spanish.md
+++ b/curriculum/challenges/spanish/02-javascript-algorithms-and-data-structures/basic-javascript/chaining-if-else-statements.spanish.md
@@ -7,7 +7,7 @@ localeTitle: Encadenamiento en caso contrario
 ---
 
 ## Description
-<section id="description"> <code>if/else</code> declaraciones <code>if/else</code> se pueden encadenar para una lógica compleja. Aquí está el <dfn>pseudocódigo</dfn> de múltiples encadenadas <code>if</code> / <code>else if</code> sentencias: <blockquote> if ( <em>condición1</em> ) { <br> <em>declaración1</em> <br> } else if ( <em>condition2</em> ) { <br> <em>declaración2</em> <br> } else if ( <em>condition3</em> ) { <br> <em>declaración3</em> <br> . . . <br> } else { <br> <em>declaraciónN</em> <br> } </blockquote></section>
+<section id="description"> <code>if/else</code> declaraciones <code>if/else</code> se pueden encadenar para una lógica compleja. Aquí está el <dfn>pseudocódigo</dfn> de múltiples sentencias <code>if</code> / <code>else if</code> encadenadas: <blockquote> if ( <em>condición1</em> ) { <br> <em>declaración1</em> <br> } else if ( <em>condition2</em> ) { <br> <em>declaración2</em> <br> } else if ( <em>condition3</em> ) { <br> <em>declaración3</em> <br> . . . <br> } else { <br> <em>declaraciónN</em> <br> } </blockquote></section>
 
 ## Instructions
 <section id="instructions"> Escriba en cadena las sentencias <code>if</code> / <code>else if</code> para cumplir las siguientes condiciones: <code>num &lt; 5</code> - return &quot;Tiny&quot; <br> <code>num &lt; 10</code> - devuelve &quot;Small&quot; <br> <code>num &lt; 15</code> - devuelve &quot;Medio&quot; <br> <code>num &lt; 20</code> - devuelve &quot;Large&quot; <br> <code>num &gt;= 20</code> - devuelve &quot;Enorme&quot; </section>


### PR DESCRIPTION
Fix order of name/adjective in Spanish translation of chaining-if-else-statements

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.
