### PR TITLE
Fix partial Spanish translations

### DIFF
--- a/curriculum/challenges/spanish/02-javascript-algorithms-and-data-structures/basic-javascript/count-backwards-with-a-for-loop.spanish.md
+++ b/curriculum/challenges/spanish/02-javascript-algorithms-and-data-structures/basic-javascript/count-backwards-with-a-for-loop.spanish.md
@@ -7,7 +7,7 @@ localeTitle: Contar hacia atrás con un bucle for
 ---
 
 ## Description
-<section id="description"> Un bucle for también puede contar hacia atrás, siempre que podamos definir las condiciones correctas. Para contar hacia atrás de dos en dos, necesitaremos cambiar nuestra <code>initialization</code> , <code>condition</code> y <code>final-expression</code> . Comenzaremos en <code>i = 10</code> y haremos un bucle mientras <code>i &gt; 0</code> . Disminuiremos <code>i</code> en 2 cada bucle con <code>i -= 2</code> . <blockquote> var ourArray = []; <br> para (var i = 10; i&gt; 0; i- = 2) { <br> nuestroArray.push (i); <br> } </blockquote> <code>ourArray</code> ahora contendrá <code>[10,8,6,4,2]</code> . Cambiemos nuestra <code>initialization</code> y <code>final-expression</code> para que podamos contar hacia atrás de dos en dos por números impares. </section>
+<section id="description"> Un bucle for también puede contar hacia atrás, siempre que podamos definir las condiciones correctas. Para contar hacia atrás de dos en dos, necesitaremos cambiar nuestra <code>initialization</code> , <code>condition</code> y <code>final-expression</code> . Comenzaremos en <code>i = 10</code> y haremos un bucle mientras <code>i &gt; 0</code> . Disminuiremos <code>i</code> en 2 cada bucle con <code>i -= 2</code> . <blockquote> var ourArray = []; <br> for (var i = 10; i&gt; 0; i- = 2) { <br> ourArray.push (i); <br> } </blockquote> <code>ourArray</code> ahora contendrá <code>[10,8,6,4,2]</code> . Cambiemos nuestra <code>initialization</code> y <code>final-expression</code> para que podamos contar hacia atrás de dos en dos por números impares. </section>
 
 ## Instructions
 <section id="instructions"> Empuje los números impares del 9 al 1 a <code>myArray</code> usando un bucle <code>for</code> . </section>
@@ -17,12 +17,12 @@ localeTitle: Contar hacia atrás con un bucle for
 
 ```yml
 tests:
-  - text: Usted debe estar usando una <code>for</code> bucle para esto.
-    testString: 'assert(code.match(/for\s*\(/g).length > 1, "You should be using a <code>for</code> loop for this.");'
-  - text: Deberías estar usando el método de matriz <code>push</code> .
-    testString: 'assert(code.match(/myArray.push/), "You should be using the array method <code>push</code>.");'
-  - text: '<code>myArray</code> debe ser igual a <code>[9,7,5,3,1]</code> .'
-    testString: 'assert.deepEqual(myArray, [9,7,5,3,1], "<code>myArray</code> should equal <code>[9,7,5,3,1]</code>.");'
+  - text: Usted debe estar usando un bucle <code>for</code> para esto.
+    testString: 'assert(code.match(/for\s*\(/g).length > 1, "Usted debe estar usando un bucle <code>for</code> para esto.");'
+  - text: Deberías estar usando el método de matriz <code>push</code>.
+    testString: 'assert(code.match(/myArray.push/), "Deberías estar usando el método de matriz <code>push</code>.");'
+  - text: '<code>myArray</code> debe ser igual a <code>[9,7,5,3,1]</code>.'
+    testString: 'assert.deepEqual(myArray, [9,7,5,3,1], "<code>myArray</code> debe ser igual a <code>[9,7,5,3,1]</code>.");'
 
 ```
 


### PR DESCRIPTION
The description and test in count-backwards-with-a-for-loop Spanish translation contains incoherent translations of reserved words (for / para), variable declarations (ourArray) and tests literals.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
