### PR TITLE
fixed typo with instructions and preview

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/css-grid/create-flexible-layouts-using-auto-fill.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-grid/create-flexible-layouts-using-auto-fill.english.md
@@ -10,7 +10,7 @@ videoUrl: 'https://scrimba.com/p/pByETK/cmzdycW'
 The repeat function comes with an option called <dfn>auto-fill</dfn>. This allows you to automatically insert as many rows or columns of your desired size as possible depending on the size of the container. You can create flexible layouts when combining <code>auto-fill</code> with <code>minmax</code>.
 In the preview, <code>grid-template-columns</code> for <code>.container2</code> is set to
 <blockquote>repeat(auto-fill, minmax(60px, 1fr));</blockquote>
-When the container changes size, this setup keeps inserting 60px columns and stretching them until it can insert another one.
+When  <code>.container2</code> changes size, this setup keeps inserting 60px columns and stretching them until it can insert another one.
 <strong>Note</strong><br>If your container can't fit all your items on one row, it will move them down to a new one.
 </section>
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-grid/create-flexible-layouts-using-auto-fill.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-grid/create-flexible-layouts-using-auto-fill.english.md
@@ -96,8 +96,54 @@ tests:
 <section id='solution'>
 
 
-```js
-var code = ".container {grid-template-columns: repeat(auto-fill, minmax(60px, 1fr));}"
+```html
+<style>
+  .item1{background:LightSkyBlue;}
+  .item2{background:LightSalmon;}
+  .item3{background:PaleTurquoise;}
+  .item4{background:LightPink;}
+  .item5{background:PaleGreen;}
+  
+  .container {
+    font-size: 40px;
+    min-height: 100px;
+    width: 100%;
+    background: LightGray;
+    display: grid;
+    /* change the code below this line */
+    
+    grid-template-columns: repeat(auto-fill, minmax(60px, 1fr));
+    
+    /* change the code above this line */
+    grid-template-rows: 1fr 1fr 1fr;
+    grid-gap: 10px;
+  }
+  
+  .container2 {
+    font-size: 40px;
+    min-height: 100px;
+    width: 100%;
+    background: Silver;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(60px, 1fr));
+    grid-template-rows: 1fr 1fr 1fr;
+    grid-gap: 10px;
+  }
+</style>
+<div class="container">
+  <div class="item1">1</div>
+  <div class="item2">2</div>
+  <div class="item3">3</div>
+  <div class="item4">4</div>
+  <div class="item5">5</div>
+</div>
+<div class="container2">
+  <div class="item1">1</div>
+  <div class="item2">2</div>
+  <div class="item3">3</div>
+  <div class="item4">4</div>
+  <div class="item5">5</div>
+</div>
 ```
 
 </section>

--- a/curriculum/challenges/english/01-responsive-web-design/css-grid/create-flexible-layouts-using-auto-fill.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-grid/create-flexible-layouts-using-auto-fill.english.md
@@ -7,10 +7,9 @@ videoUrl: 'https://scrimba.com/p/pByETK/cmzdycW'
 
 ## Description
 <section id='description'>
-The repeat function comes with an option called <dfn>auto-fill</dfn>. This allows you to automatically insert as many rows or columns of your desired size as possible depending on the size of the container. You can create flexible layouts when combining <code>auto-fill</code> with <code>minmax</code>.
-In the preview, <code>grid-template-columns</code> for <code>.container2</code> is set to
+The repeat function comes with an option called <dfn>auto-fill</dfn>. This allows you to automatically insert as many rows or columns of your desired size as possible depending on the size of the container. You can create flexible layouts when combining <code>auto-fill</code> with <code>minmax</code>, like this:
 <blockquote>repeat(auto-fill, minmax(60px, 1fr));</blockquote>
-When  <code>.container2</code> changes size, this setup keeps inserting 60px columns and stretching them until it can insert another one.
+When the container changes size, this setup keeps inserting 60px columns and stretching them until it can insert another one.
 <strong>Note</strong><br>If your container can't fit all your items on one row, it will move them down to a new one.
 </section>
 
@@ -65,7 +64,7 @@ tests:
     width: 100%;
     background: Silver;
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(60px, 1fr));
+    grid-template-columns: repeat(3, minmax(60px, 1fr));
     grid-template-rows: 1fr 1fr 1fr;
     grid-gap: 10px;
   }
@@ -125,7 +124,7 @@ tests:
     width: 100%;
     background: Silver;
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(60px, 1fr));
+    grid-template-columns: repeat(3, minmax(60px, 1fr));
     grid-template-rows: 1fr 1fr 1fr;
     grid-gap: 10px;
   }

--- a/curriculum/challenges/english/01-responsive-web-design/css-grid/create-flexible-layouts-using-auto-fill.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-grid/create-flexible-layouts-using-auto-fill.english.md
@@ -8,7 +8,7 @@ videoUrl: 'https://scrimba.com/p/pByETK/cmzdycW'
 ## Description
 <section id='description'>
 The repeat function comes with an option called <dfn>auto-fill</dfn>. This allows you to automatically insert as many rows or columns of your desired size as possible depending on the size of the container. You can create flexible layouts when combining <code>auto-fill</code> with <code>minmax</code>.
-In the preview, <code>grid-template-columns</code> is set to
+In the preview, <code>grid-template-columns</code> for <code>.container2</code> is set to
 <blockquote>repeat(auto-fill, minmax(60px, 1fr));</blockquote>
 When the container changes size, this setup keeps inserting 60px columns and stretching them until it can insert another one.
 <strong>Note</strong><br>If your container can't fit all your items on one row, it will move them down to a new one.
@@ -65,7 +65,7 @@ tests:
     width: 100%;
     background: Silver;
     display: grid;
-    grid-template-columns: repeat(3, minmax(60px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(60px, 1fr));
     grid-template-rows: 1fr 1fr 1fr;
     grid-gap: 10px;
   }


### PR DESCRIPTION
Instructions stated that grid-template-columns was set to repeat(auto-fill, minmax(60px, 1fr)); but it was not in .container or .container2
Changed .container2 to already include this as I believe was intended, leaving camper to change .container on their own
Fixes #18034

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #18034
