### PR TITLE
Fix the no convenient translation of return

### DIFF
--- a/curriculum/challenges/spanish/02-javascript-algorithms-and-data-structures/basic-javascript/introducing-else-statements.spanish.md
+++ b/curriculum/challenges/spanish/02-javascript-algorithms-and-data-structures/basic-javascript/introducing-else-statements.spanish.md
@@ -7,7 +7,7 @@ localeTitle: Introduciendo otras declaraciones
 ---
 
 ## Description
-<section id="description"> Cuando una condición para una sentencia <code>if</code> es verdadera, se ejecuta el bloque de código siguiente. ¿Qué pasa cuando esa condición es falsa? Normalmente no pasaría nada. Con una sentencia <code>else</code> , se puede ejecutar un bloque de código alternativo. <blockquote> if (num&gt; 10) { <br> devuelve &quot;Más grande que 10&quot;; <br> } else { <br> devuelve &quot;10 o menos&quot;; <br> } </blockquote></section>
+<section id="description"> Cuando una condición para una sentencia <code>if</code> es verdadera, se ejecuta el bloque de código siguiente. ¿Qué pasa cuando esa condición es falsa? Normalmente no pasaría nada. Con una sentencia <code>else</code> , se puede ejecutar un bloque de código alternativo. <blockquote> if (num&gt; 10) { <br> return &quot;Más grande que 10&quot;; <br> } else { <br> return &quot;10 o menos&quot;; <br> } </blockquote></section>
 
 ## Instructions
 <section id="instructions"> Combine las declaraciones <code>if</code> en una sola instrucción <code>if/else</code> . </section>


### PR DESCRIPTION
The return statement in the code inside the description should not be translated.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
