### PR TITLE
Add source name in content for a tags at footer of index.md

### DIFF
--- a/guide/english/javascript/booleans/index.md
+++ b/guide/english/javascript/booleans/index.md
@@ -97,7 +97,7 @@ Do not use a Boolean object in place of a Boolean primitive.
 
 ### Resources
 
-- <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean' target='_blank' rel='nofollow'>Boolean Object</a>
-- <a href='https://docs.oracle.com/javase/7/docs/api/java/lang/Boolean.html' target='_blank' rel='nofollow'>Boolean Object</a>
+- <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean' target='_blank' rel='nofollow'>Boolean Object - Mozilla MDN</a>
+- <a href='https://docs.oracle.com/javase/7/docs/api/java/lang/Boolean.html' target='_blank' rel='nofollow'>Boolean Object - Oracle Docs</a>
 
 


### PR DESCRIPTION
Specify which resource the a tag links to. Previously, both list items were just `Boolean Object`. Makes it more specific

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.
