### PR TITLE
added example to make description clear

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/responsive-web-design-principles/make-typography-responsive.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/responsive-web-design-principles/make-typography-responsive.english.md
@@ -10,6 +10,8 @@ videoUrl: 'https://scrimba.com/p/pzrPu4/crzN7T8'
 Instead of using <code>em</code> or <code>px</code> to size text, you can use viewport units for responsive typography. Viewport units, like percentages, are relative units, but they are based off different items. Viewport units are relative to the viewport dimensions (width or height) of a device, and percentages are relative to the size of the parent container element.
 The four different viewport units are:
 <ul><li><code>vw: 10vw</code> would be 10% of the viewport's width.</li><li><code>vh: 3vh</code> would be 3% of the viewport's height.</li><li><code>vmin: 70vmin</code> would be 70% of the viewport's smaller dimension (height vs. width).</li><li><code>vmax: 100vmax</code> would be 100% of the viewport's bigger dimension (height vs. width).</li></ul>
+Here is an example that sets a body tag to 30% of the viewport's width.
+<code>body { width: 30vw; }</code>
 </section>
 
 ## Instructions


### PR DESCRIPTION
Added example in the description for understanding that the width of the element is still set using the width property in CSS.
fixes issue #17617

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #17617
