### PR TITLE
remove link to google cert

### DIFF
--- a/guide/english/certifications/index.md
+++ b/guide/english/certifications/index.md
@@ -23,8 +23,3 @@ Upon completion of all six certificates, the freeCodeCamp [Full Stack Developmen
 For more information about freeCodeCamp, visit [about.freecodecamp.org](https://about.freecodecamp.org/).
 
 For more information about the new certification program, see the forum post [here](https://www.freecodecamp.org/forum/t/freecodecamps-new-certificates-heres-how-were-rolling-them-out/141618).
-
-### Associate Android Developer Certification
-
-A great way to test one's Android skills and certify that by none other than Google.
-The link to the certification and its details are [here](https://developers.google.com/training/certification/).


### PR DESCRIPTION
Why would there be a link to a single google certification on this page?

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
