### PR TITLE
Fix markdown hyperlink

### DIFF
--- a/guide/english/react/components/index.md
+++ b/guide/english/react/components/index.md
@@ -84,4 +84,4 @@ const Cat = props =>
 
 ### More Information:
 
-[https://reactjs.org/docs/components-and-props.html](Components and Props)
+[Components and Props](https://reactjs.org/docs/components-and-props.html)


### PR DESCRIPTION
Markdown formatting for a hyperlink was incorrect so the hyperlink wasn't showing up as expected.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.
