### PR TITLE
Capitalize JS acronym

### DIFF
--- a/guide/spanish/book-recommendations/javascript/index.md
+++ b/guide/spanish/book-recommendations/javascript/index.md
@@ -11,7 +11,7 @@ Uno de los mejores libros en JavaScript. Una necesidad para los programadores pr
 *   [E-libro](https://eloquentjavascript.net/) (gratis)
 *   [Amazonas](https://www.amazon.com/gp/product/1593275846/ref=as_li_qf_sp_asin_il_tl?ie=UTF8&camp=1789&creative=9325&creativeASIN=1593275846&linkCode=as2&tag=marijhaver-20&linkId=VPXXXSRYC5COG5R5)
 
-_No sabes js_
+_No sabes JS_
 
 Seis series de libros de Kyle Simpson. Serie en profundidad sobre todos los aspectos de JavaScript.
 


### PR DESCRIPTION
Changed "js" for "JS".
The English name is You Don't Know JS. I believe it should be capitalized.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
