### PR TITLE
Improve copy for screenreaders (Accessibility)

### DIFF
--- a/guide/english/certifications/index.md
+++ b/guide/english/certifications/index.md
@@ -22,4 +22,4 @@ Upon completion of all six certificates, the freeCodeCamp [Full Stack Developmen
 
 For more information about freeCodeCamp, visit [about.freecodecamp.org](https://about.freecodecamp.org/).
 
-For more information about the new certification program, see the forum post [here](https://www.freecodecamp.org/forum/t/freecodecamps-new-certificates-heres-how-were-rolling-them-out/141618).
+For more information about the new certification program, see [this forum post](https://www.freecodecamp.org/forum/t/freecodecamps-new-certificates-heres-how-were-rolling-them-out/141618).


### PR DESCRIPTION
Linking just the word "here" can make it difficult for people accessing your page using a screenreader or other accessibility technology. Some screenreaders present a list of links available on a page and "here" doesn't give any context to the user.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
