### PR TITLE
Agreando encabezado H2

### DIFF
--- a/guide/spanish/html/html-forms/index.md
+++ b/guide/spanish/html/html-forms/index.md
@@ -52,7 +52,7 @@ Otros elementos que forman pueden contener:
 *   `select` etiqueta `select` - junto con la etiqueta `<option></option>` crea un menú de selección desplegable.
 *   `button` : el elemento botón se puede utilizar para definir un botón en el que se puede hacer clic.
 
-MÁS INFORMACIÓN SOBRE FORMAS HTML.
+## MÁS INFORMACIÓN SOBRE FORMAS HTML.
 
 Los formularios HTML son necesarios cuando desea recopilar algunos datos del visitante del sitio. Por ejemplo, durante el registro de un usuario, le gustaría recopilar información como nombre, dirección de correo electrónico, tarjeta de crédito, etc.
 


### PR DESCRIPTION
En el cuerpo del texto el título "MÁS INFORMACIÓN SOBRE FORMAS HTML" era fácil confundirlo y pasarlo por alto porque no había nada que indicara que era una sección diferente a lo que se venía hablando en el párrafo anterior. Se agregó la etiqueta h2 para diferenciarla como título.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
