### PR TITLE
removed \\s* in line 31

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/quoting-strings-with-single-quotes.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/quoting-strings-with-single-quotes.english.md
@@ -28,7 +28,7 @@ Right now, the <code>&#60;a&#62;</code> tag in the string uses double quotes eve
 ```yml
 tests:
   - text: Remove all the <code>backslashes</code> (<code>\</code>)
-    testString: assert(!/\\/g.test(code) && myStr.match('\\s*<a href\\s*=\\s*"http://www.example.com"\\s*target\\s*=\\s*"_blank">\\s*Link\\s*</a>\\s*'), 'Remove all the <code>backslashes</code> (<code>\</code>)');
+    testString: assert(!/\\/g.test(code) && myStr.match('<a href\\s*=\\s*"http://www.example.com"\\s*target\\s*=\\s*"_blank">\\s*Link\\s*</a>\\s*'), 'Remove all the <code>backslashes</code> (<code>\</code>)');
   - text: You should have two single quotes <code>&#39;</code> and four double quotes <code>&quot;</code>
     testString: assert(code.match(/"/g).length === 4 && code.match(/'/g).length === 2, 'You should have two single quotes <code>&#39;</code> and four double quotes <code>&quot;</code>');
 


### PR DESCRIPTION
when i did the exercise i had to delete the first whitespace before the <a></a> tag (which i think is represented by the regex pattern \\\s*) to get the code to pass all the tests, even when i changed the double quotes at the two ends to single quotes and deleted all the backslashes . 
so i just deleted the first \\\s* pattern of line 31. 
i hope this is the right pattern and place to delete!

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
