### PR TITLE
fix: add missing style-to-object in tools/challenge-md-parser/package…

### DIFF
--- a/tools/challenge-md-parser/package.json
+++ b/tools/challenge-md-parser/package.json
@@ -25,6 +25,7 @@
     "remark-frontmatter": "^1.3.0",
     "remark-parse": "^5.0.0",
     "remark-rehype": "^3.0.1",
+    "style-to-object": "^0.2.2",
     "to-vfile": "^5.0.1",
     "unified": "^7.0.0",
     "unist-util-visit": "^1.4.0"


### PR DESCRIPTION
Fix error when I run FreeCodeCamp locally
```bash
module.js:549
    throw err;
    ^
Error: Cannot find module 'style-to-object'
    at Function.Module._resolveFilename (module.js:547:15)
    at Function.Module._load (module.js:474:25)
    at Module.require (module.js:596:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/home/gossard/Dev/freeCodeCamp/tools/challenge-md-parser/node_modules/hast-to-hyperscript/index.js:8:13)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
```


- [X] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `master` branch of freeCodeCamp.
- [ ] None of my changes are plagiarized from another source without proper attribution.
- [ ] My article does not contain shortened URLs or affiliate links.

