### PR TITLE
Sugestão da tradução do termo React Native

### DIFF
--- a/guide/portuguese/react-native/props/index.md
+++ b/guide/portuguese/react-native/props/index.md
@@ -1,12 +1,12 @@
 ---
 title: Props
-localeTitle: Adereços
+localeTitle: Propriedades
 ---
-## Reagir Nativo - Adereços
+## React Native - Propriedades
 
-O termo props, abreviação de 'properties', significa algum tipo de dado que é passado de um componente para outro. Adereços sempre fluem para baixo a partir do componente pai para o filho.
+O termo props, abreviação de 'properties', significa algum tipo de dado que é passado de um componente para outro. Propriedades sempre fluem para baixo a partir do componente pai para o filho.
 
-Em React, o componente filho tem acesso às informações de um pai por meio de adereços:
+Em React, o componente filho tem acesso às informações de um pai por meio do _props_:
 
 ```jsx
 // the child Header component receives the text prop and can access it via this.props.text 


### PR DESCRIPTION
Por se tratar do nome do framework não vejo a necessidade de traduzi-lo.
Além disso, na minha visão o termo props tem mais haver com propriedades do que adereços.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
