### PR TITLE
Improved translation to Spanish. Await promises

### DIFF
--- a/guide/spanish/javascript/await-promises/index.md
+++ b/guide/spanish/javascript/await-promises/index.md
@@ -1,8 +1,8 @@
 ---
 title: Await Promises
-localeTitle: Aguarda promesas
+localeTitle: Promesas await
 ---
-## Aguarda promesas
+## Promesas `await`
 
 Los [operadores](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators) `async` / `await` facilitan la implementación de muchas promesas async. También permiten que los ingenieros escriban códigos más claros, concisos y verificables.
 
@@ -12,77 +12,100 @@ Para comprender este tema, debe tener una comprensión sólida de cómo funciona
 
 ## Sintaxis basica
 
-\`\` \`javascript function slowlyResolvedPromiseFunc (cadena) { devolver nueva Promesa (resolver => { setTimeout (() => { resolver (cadena); }, 5000); }); }
-
-función asíncrona doIt () { const myPromise = aguardan slowResolvedPromiseFunc ("foo"); console.log (myPromise); // "foo" }
-
-hazlo();
-```
-There are a few things to note: 
- 
- * The function that encompasses the `await` declaration must include the `async` operator. This will tell the JS interpreter that it must wait until the Promise is resolved or rejected. 
- * The `await` operator must be inline, during the const declaration. 
- * This works for `reject` as well as `resolve`. 
- 
- --- 
- 
- ## Nested Promises vs. `Async` / `Await` 
- 
- Implementing a single Promise is pretty straightforward. In contrast, Chained Promises or the creation of a dependency pattern may produce "spaghetti code". 
- 
- The following examples assume that the <a href='https://github.com/request/request-promise' target='_blank' rel='nofollow'>`request-promise`</a> library is available as `rp`. 
- 
- ### Chained/Nested Promises 
-```
-
-javascript // Primera promesa const fooPromise = rp ("http://domain.com/foo");
-
-fooPromise.then (resultFoo => { // Debe esperar a que "foo" se resuelva console.log (resultFoo);
-```
-const barPromise = rp("http://domain.com/bar"); 
- const bazPromise = rp("http://domain.com/baz"); 
- 
- return Promise.all([barPromise, bazPromise]); 
-```
-
-}). entonces (resultArr => { // Manejar resoluciones "bar" y "baz" aquí console.log (resultArr \[0\]); console.log (resultArr \[1\]); });
-```
-### `async` and `await` Promises 
-```
-
-javascript // Envolver todo en una función asíncrona función asíncrona doItAll () { // Agarra los datos del punto final "foo", pero espera la resolución console.log (aguarda rp ("http://domain.com/foo"));
-```
-// Concurrently kick off the next two async calls, 
- // don't wait for "bar" to kick off "baz" 
- const barPromise = rp("http://domain.com/bar"); 
- const bazPromise = rp("http://domain.com/baz"); 
- 
- // After both are concurrently kicked off, wait for both 
- const barResponse = await barPromise; 
- const bazResponse = await bazPromise; 
- 
- console.log(barResponse); 
- console.log(bazResponse); 
-```
-
+```javascript
+function slowlyResolvedPromiseFunc(string) {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve(string);
+    }, 5000);
+  });
 }
 
-// Finalmente, invocar la función asíncrona. doItAll (). then (() => console.log ('Done!'));
-```
-The advantages of using `async` and `await` should be clear. This code is more readable, modular, and testable. 
- 
- It's fair to note that even though there is an added sense of concurrency, the underlying computational process is the same as the previous example. 
- 
- --- 
- 
- ## Handling Errors / Rejection 
- 
- A basic try-catch block handles a rejected Promise. 
+async function doIt() {
+  const myPromise = await slowResolvedPromiseFunc("foo");
+  console.log(myPromise); // "foo"
+}
+
+doIt();
 ```
 
-javascript función asíncrona errorExample () { tratar { const rejectedPromise = aguarda Promise.reject ("Oh-oh!"); } captura (error) { console.log (error); // "¡UH oh!" } }
+Hay algunas cosas que observar: 
+ 
+* La función que engloba la declaración `await` debe incluir el operador `async`. Esto le dirá al intérprete de JS que debe esperar hasta que la Promesa se resuelva o se rechace. 
+* El operador `await` debe estar en la misma línea, durante la declaración `const`. 
+* Funciona tanto para `reject` como para `resolve`. 
+ 
+--- 
+ 
+## Promesas anidadas vs. `Async` / `Await` 
+ 
+Implementar una sola Promesa es bastante sencillo. Por el contrario, las Promesas encadenadas o la creación de un patrón de dependencia puede producir "código espagueti". 
+ 
+Los siguientes ejemplos asumen que la biblioteca <a href='https://github.com/request/request-promise' target='_blank' rel='nofollow'>`request-promise`</a> está disponible como `rp`. 
+ 
+### Promesas encadenadas/anidadas 
+```javascript
+// Primera promesa
+const fooPromise = rp("http://domain.com/foo");
 
-errorExample (); \`\` \`
+fooPromise.then(resultFoo => {
+  // Debe esperar a que "foo" se resuelva
+  console.log (resultFoo);
+  
+  const barPromise = rp("http://domain.com/bar"); 
+  const bazPromise = rp("http://domain.com/baz"); 
+ 
+  return Promise.all([barPromise, bazPromise]);
+}).then(resultArr => {
+  // Manejar resoluciones "bar" y "baz" aquí
+  console.log(resultArr[0]);
+  console.log(resultArr[1]);
+});
+```
+### `async` y promesas `await` 
+```javascript
+// Envolver todo en una función asíncrona
+async function doItAll() {
+  // Agarra los datos del punto final "foo", pero espera la resolución
+  console.log(await rp("http://domain.com/foo"));
+
+  // Concurrentemente ejecuta las siguientes dos llamadas asíncronas, 
+  // no esperes a "bar" para ejecutar "baz" 
+  const barPromise = rp("http://domain.com/bar"); 
+  const bazPromise = rp("http://domain.com/baz"); 
+ 
+  // Después de que ambas hayan sido llamadas concurrentemente, espéralas 
+  const barResponse = await barPromise; 
+  const bazResponse = await bazPromise; 
+ 
+  console.log(barResponse); 
+  console.log(bazResponse);
+}
+
+// Finalmente, invoca la función asíncrona.
+doItAll().then(() => console.log ('Done!'));
+```
+
+Las ventajas de usar `async` y `await` son claras. Este código es más comprensible, modula y verificable. 
+ 
+Es justo decir que aunque se ha añadido un cierto sentido de concurrencia, el proceso computacional subyacente es el mismo que el del ejemplo anterior. 
+ 
+--- 
+ 
+## Handling Errors / Rejection 
+
+Un bloque try-catch básico se encarga de una Promesa rechazada. 
+```javascript
+async function errorExample () {
+  try {
+    const rejectedPromise = await Promise.reject("Oh-oh!");
+  } catch(error) {
+    console.log (error); // "¡UH oh!"
+  }
+}
+
+errorExample (); 
+```
 
 * * *
 


### PR DESCRIPTION
The markdown left by the Google Translator was messy and now is similar to the original article. Also, parts of the text were untranslated and now they are in spanish.

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.