### PR TITLE
added the text-Use not only in 'not in' code, otherwise its usage wil…

### DIFF
--- a/guide/english/python/basic-operators/index.md
+++ b/guide/english/python/basic-operators/index.md
@@ -261,7 +261,7 @@ A membership operator is used to identify membership in any sequence (e.g. lists
 <br>`in` and `not in` are membership operators
 
 <br>`in` returns True if the specified value is found in the sequence. Returns False otherwise.
-<br>`not in` returns True if the specified value is not found in the sequence. Returns False otherwise.
+<br>`not in` returns True if the specified value is not found in the sequence. Returns False otherwise. Use not only in 'not in' code, otherwise its usage will confuse people reading your code.
 
 ###### Example Usage
 


### PR DESCRIPTION
…l confuse people reading your code.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
