### PR TITLE
[fix] Use * to Import Everything from a File - Updated test regex to allow single quotes for file name among other corrections

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use--to-import-everything-from-a-file.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use--to-import-everything-from-a-file.english.md
@@ -25,7 +25,7 @@ The code below requires the contents of a file, <code>"capitalize_strings"</code
 ```yml
 tests:
   - text: Properly uses <code>import * as</code> syntax.
-    testString: assert(code.match(/import\s+\*\s+as\s+[a-zA-Z0-9_$]+\s+from\s*"\s*capitalize_strings\s*"\s*;/gi), 'Properly uses <code>import * as</code> syntax.');
+    testString: assert(code.match(/import\s+\*\s+as\s+[\w$]+\s+from\s*("|')(\.\/)*capitalize_strings\1\s*;*/g), 'Properly uses <code>import * as</code> syntax.');
 
 ```
 


### PR DESCRIPTION
### Challenge: Use * to Import Everything from a File challenge

I changed the regular expression for the assert in the following test:
```
testString: assert(code.match(/import\s+\*\s+as\s+[\w$]+\s+from\s*("|')(\.\/)*capitalize_strings\1\s*;*/g), 'Properly uses <code>import * as</code> syntax.');
```
This change resolves the issues referenced in issue #17665:
* Allows double or single quotes surrounding the file name
* Makes the semi-colon at the end of statement optional
* Allows the option of using of "./" before the file name

In addition, this corrected test fixes the following previously unreported issues:
* No longer allows key words `import`, `as`, `from` or the file name **capital_strings** to be uppercase
* No longer allows white space at the beginning or ending of the file name string

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes issue #17665
 
**Upon approval, I will create a separate PR for each of the other languages for this challenge.**