### PR TITLE
Fix links/formatting in Documentation Quick Reference

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,15 +23,15 @@ This directory contains all of the documentation on contributing to freeCodeCamp
 
 ## Quick references articles
 
-1. [How to work on Guide articles](./how-to-work-on-guide-articles.md)
-2. [How to work on Coding Challenges](./how-to-work-on-coding-challenges.md)
-3. [How to setup freeCodeCamp locally](./how-to-setup-freecodecamp-locally.md)
-4. [How to catch outgoing emails locally](./how-to-catch-outgoing-emails-locally.md)
+1. [How to work on Guide articles](/docs/how-to-work-on-guide-articles.md)
+2. [How to work on Coding Challenges](/docs/how-to-work-on-coding-challenges.md)
+3. [How to setup freeCodeCamp locally](/docs/how-to-setup-freecodecamp-locally.md)
+4. [How to catch outgoing emails locally](/docs/how-to-catch-outgoing-emails-locally.md)
 
 ## Style guides
 
-1. [Style guide for creating guide articles](./style-guide-for-guide-articles.md)
-2. [Style guide for creating coding challenges](./style-guide-for-curriculum-challenges.md)
+1. [Style guide for creating guide articles](/docs/style-guide-for-guide-articles.md)
+2. [Style guide for creating coding challenges](/docs/style-guide-for-curriculum-challenges.md)
 
 ## Quick commands reference when working locally
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,15 +23,15 @@ This directory contains all of the documentation on contributing to freeCodeCamp
 
 ## Quick references articles
 
-<a href="/how-to-work-on-guide-articles.md">1. How to work on Guide articles.</a>
-<a href="/how-to-work-on-coding-challenges.md">2. How to work on Coding Challenges.</a>
-<a href="/how-to-setup-freecodecamp-locally.md">3. How to setup freeCodeCamp locally.</a>
-<a href="/how-to-catch-outgoing-emails-locally.md">4. How to catch outgoing emails locally.</a>
+1. [How to work on Guide articles](./how-to-work-on-guide-articles.md)
+2. [How to work on Coding Challenges](./how-to-work-on-coding-challenges.md)
+3. [How to setup freeCodeCamp locally](./how-to-setup-freecodecamp-locally.md)
+4. [How to catch outgoing emails locally](./how-to-catch-outgoing-emails-locally.md)
 
 ## Style guides
 
-1. Style guide for creating guide articles.
-2. Style guide for creating coding challenges.
+1. [Style guide for creating guide articles](./style-guide-for-guide-articles.md)
+2. [Style guide for creating coding challenges](./style-guide-for-curriculum-challenges.md)
 
 ## Quick commands reference when working locally
 


### PR DESCRIPTION
- Fixes formatting of links in  **Quick reference articles** section (were displaying inline)
- Adds missing links to **Style guides** section

---
## Before

> ![screen shot 2018-10-24 at 10 04 31 pm](https://user-images.githubusercontent.com/6694167/47471568-dcac7e80-d7d8-11e8-8f9f-1d6843ae90b4.png)

## After

> ![screen shot 2018-10-24 at 10 04 14 pm](https://user-images.githubusercontent.com/6694167/47471571-e0400580-d7d8-11e8-95b1-fd17434622df.png)

---
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
