### PR TITLE
fixed typo on bash-ls - removed master

### DIFF
--- a/guide/english/bash/bash-ls/index.md
+++ b/guide/english/bash/bash-ls/index.md
@@ -32,7 +32,7 @@ Most used options:
 List files in `freeCodeCamp/guide/`
 
 ```bash
-ls                                                                ⚬ master
+ls
 CODE_OF_CONDUCT.md bin                package.json       utils
 CONTRIBUTING.md    gatsby-browser.js  plugins            yarn.lock
 LICENSE.md         gatsby-config.js   src


### PR DESCRIPTION
I fixed a typo where the usage showed cat rather than ls.
I removed a reference to *master on someones command line example that included a fancy shell hook that shows which git branch you are in (most people won't have that).

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
