### PR TITLE
Some Sentences in Spanish are incorrect

### DIFF
--- a/curriculum/challenges/spanish/01-responsive-web-design/basic-html-and-html5/add-a-submit-button-to-a-form.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/basic-html-and-html5/add-a-submit-button-to-a-form.spanish.md
@@ -8,17 +8,17 @@ localeTitle: Agregar un botón de envío a un formulario
 ---
 
 ## Description
-<section id="description"> Agreguemos un botón de <code>submit</code> a su formulario. Al hacer clic en este botón, los datos de su formulario se enviarán a la URL que especificó con el atributo de <code>action</code> su formulario. Aquí hay un ejemplo de botón de envío: <code>&lt;button type=&quot;submit&quot;&gt;this button submits the form&lt;/button&gt;</code> </section>
+<section id="description"> Agreguemos un botón de <code>submit</code> a su formulario. Al hacer clic en este botón, los datos de su formulario se estaran enviando a la dirección Web-URL que se ha especificado con el atributo de <code>action</code> su formulario. Aquí hay un ejemplo de botón de envío: <code>&lt;button type=&quot;submit&quot;&gt;this button submits the form&lt;/button&gt;</code> </section>
 
 ## Instructions
-<section id="instructions"> Agregue un botón como el último elemento de su elemento de <code>form</code> con un tipo de <code>submit</code> y &quot;Enviar&quot; como texto. </section>
+<section id="instructions"> Agregue un botón como el ejemplo anterior elemento de su elemento de <code>form</code> con un tipo de <code>submit</code> y &quot;Enviar&quot; como texto. </section>
 
 ## Tests
 <section id='tests'>
 
 ```yml
 tests:
-  - text: Su formulario debe tener un botón en su interior.
+  - text: Su formulario debe tener un botón en el interior.
     testString: 'assert($("form").children("button").length > 0, "Your form should have a button inside it.");'
   - text: Su botón de envío debe tener el <code>type</code> atributo establecido para <code>submit</code> .
     testString: 'assert($("button").attr("type") === "submit", "Your submit button should have the attribute <code>type</code> set to <code>submit</code>.");'


### PR DESCRIPTION
I corrected some words in Spanish "Al hacer clic en este botón, los datos de su formulario se estaran enviando a la dirección Web-URL que se ha especificado con el atributo de"

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
