### PR TITLE
Information correction

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/create-a-more-complex-shape-using-css-and-html.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/create-a-more-complex-shape-using-css-and-html.english.md
@@ -16,7 +16,7 @@ In the above example, the element with the class of <code>heart</code> has a <co
 ## Instructions
 <section id='instructions'>
 Transform the element on the screen to a heart. In the <code>heart::after</code> selector, change the <code>background-color</code> to pink and the <code>border-radius</code> to 50%.
-Next, target the element with the class <code>heart</code> (just <code>heart</code>) and fill in the <code>transform</code> property. Use the <code>rotate()</code> function with -45 degrees. (<code>rotate()</code> works the same way that <code>skewX()</code> and <code>skewY()</code> do).
+Next, target the element with the class <code>heart</code> (just <code>heart</code>) and fill in the <code>transform</code> property. Use the <code>rotate()</code> function with -45 degrees.
 Finally, in the <code>heart::before</code> selector, set its <code>content</code> property to an empty string.
 </section>
 


### PR DESCRIPTION
Eliminated the line  (<code>rotate()</code> works the same way that <code>skewX()</code> and <code>skewY()</code> do).
It is incorrect. SkewX and SkewY do not work the same as rotate, perhaps in the sense that they take an argument ranging from 0 to 360deg, but they do not have the same effect.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ ] My pull request targets the `master` branch of freeCodeCamp.
- [ ] None of my changes are plagiarized from another source without proper attribution.
- [ ] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
