### PR TITLE
Fixed translation errors for the Portuguese language

### DIFF
--- a/guide/portuguese/javascript/await-promises/index.md
+++ b/guide/portuguese/javascript/await-promises/index.md
@@ -1,100 +1,98 @@
 ---
 title: Await Promises
-localeTitle: Aguardar Promessas
+localeTitle: Await Promises
 ---
-## Aguardar Promessas
+## Await Promises
 
-Os [operadores](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators) `async` / `await` facilitam a implementação de muitas promessas assíncronas. Eles também permitem que os engenheiros escrevam códigos mais claros, mais sucintos e testáveis.
+Os [operadores](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators) `async` / `await` facilitam a implementação de muitas `Promises` assíncronas. Eles também permitem que os engenheiros escrevam códigos mais claros, mais sucintos e testáveis.
 
-Para entender esse assunto, você deve ter uma compreensão sólida de como as [Promessas](https://guide.freecodecamp.org/javascript/promises) funcionam.
+Para entender esse assunto, você deve ter uma compreensão sólida de como as [Promises](https://guide.freecodecamp.org/javascript/promises) funcionam.
 
 * * *
 
 ## Sintaxe Básica
 
-```javascript 
-function slowlyResolvedPromiseFunc (string) { 
-   return new Promise (resolve => { 
-     setTimeout (() => { resolver (string); }, 5000); 
-   }); 
+``` javascript
+function slowlyResolvedPromiseFunc(string) { 
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve(string);
+    }, 5000);
+  });
 }
 
-função assíncrona doIt () { 
-  const myPromise = aguardar lentamenteResolvedPromiseFunc ("foo"); 
-  console.log (myPromise); // "foo" 
+async function doIt() {
+  const myPromise = await slowlyResolvedPromiseFunc("foo");
+  console.log(myPromise); // "foo"
 }
 
-faça();
+doIt();
 ```
 
 Há outras coisas para se prestar atenção:
 
 * A função que contém alguma declaração de `await` precisa incluir o operador `async` em sua declaração. Isso irá dizer ao interpretador JS para que ele espere até que a `Promise` seja resolvida ou rejeitada.
- * O operador `await` precisa ser declarado inline.
-   * `const something = await thisReturnsAPromise()`
+ * O operador `await` precisa ser declarado inline, durante a declaração da `const`.
  * Isso funciona tanto para a rejeição ou a resolução de uma `Promise`.
  
  --- 
  
  ## Promises aninhadas vs. `Async` / `Await` 
  
- Implementar uma unica promise é muito facil. Por outro lado promises aninhadas ou a criação de uma "dependency pattern" pode produzir um código spagetti.
+ Implementar uma unica Promise é muito fácil. Por outro lado Promises aninhadas ou a criação de uma "dependency pattern" pode produzir um "código spagetti".
  
  Os exemplos a seguir assumem que <a href='https://github.com/request/request-promise' target='_blank' rel='nofollow'>`request-promise`</a> está disponível como `rp`. 
  
  ### Promises encadeadas/aninhadas
-```js 
-
-// Primeira Promisse
+ 
+ 
+``` javascript
+// Primeira Promise
 const fooPromise = rp("http://domain.com/foo");
 
-fooPromise.then(resultFoo => { 
-// deve esperar por "foo" para resolver 
-  console.log (resultFoo);
-})
-```
-```js
-const barPromise = rp("http://domain.com/bar"); 
-const bazPromise = rp("http://domain.com/baz"); 
- 
-Promise.all([barPromise, bazPromise])
-.then(resultArr => {
-   // Lidar com as resoluções "bar" e "baz" aqui 
-   console.log(resultArr [0]); 
-   console.log(resultArr [1]); 
+fooPromise.then(resultFoo => {
+    // Deve aguardar por "foo" para resolver
+    console.log(resultFoo);
+
+    const barPromise = rp("http://domain.com/bar");
+    const bazPromise = rp("http://domain.com/baz");
+
+    return Promise.all([barPromise, bazPromise]);
+}).then(resultArr => {
+    // Lidar com as resoluções "bar" e "baz" aqui 
+    console.log(resultArr[0]);
+    console.log(resultArr[1]);
 });
 ```
-### `async` and `await` Promises 
-
-```js
-
-// Enrole tudo em uma função assíncrona função assíncrona 
-async doItAll () { 
- // Pega dados do ponto de extremidade "foo", mas aguarde a resolução 
- console.log (await rp("http://domain.com/foo"));
-
- // Concorrência aconteceConcurrently kick off the next two async calls, 
- // não espere por "bar" para disparar "baz"
- const barPromise = rp("http://domain.com/bar"); 
- const bazPromise = rp("http://domain.com/baz"); 
  
- // Depois que as duas foram disparadas, espere pelas duas
- const barResponse = await barPromise; 
- const bazResponse = await bazPromise; 
- 
- console.log(barResponse); 
- console.log(bazResponse); 
+### `async` e `await` Promises
+
+``` javascript
+// Envolva tudo em uma função assíncrona (async)
+async function doItAll() {
+   // Pega os dados do ponto final "foo", mas aguarda a resolução
+   console.log(await rp("http://domain.com/foo"));
+   
+   // Ao mesmo tempo, inicie as próximas duas chamadas assíncronas,
+   // Não espera por "bar" para disparar "baz"
+   const barPromise = rp("http://domain.com/bar");
+   const bazPromise = rp("http://domain.com/baz");
+   
+   // Depois que as duas foram disparadas, espere pelas duas
+   const barResponse = await barPromise;
+   const bazResponse = await bazPromise;
+   
+   console.log(barResponse);
+   console.log(bazResponse);
 }
+
+// Finalmente, chame a função assíncrona
+doItAll().then(() => console.log('Done!'));
 ```
 
-```js
-// Finalmente, invoque a função assíncrona 
-doItAll().then(() => console.log ('Feito!'));
-```
-
-As vantagens de usar `async` e `await` deve estar claro. O codigo é mais modular, testavel e legível. 
+As vantagens de usar `async` e `await` devem estar bem claras. O código é mais modular, testavel e legível. 
  
-Entretanto há um senso de concorrencia, os processos computacionais que ocorrem são os mesmos do exemplo anterior.
+É justo notar que, embora exista uma sensação adicional de simultaneidade, os processos computacionais que ocorrem são os mesmos do exemplo anterior.
  
  --- 
  
@@ -102,20 +100,21 @@ Entretanto há um senso de concorrencia, os processos computacionais que ocorrem
  
 Um bloco `try-catch` consegue lidar com rejeição de promises.
 
-```js 
-async errorExample () { 
-  try { 
-    const rejectedPromise = await Promise.reject ("Oh-oh!"); 
-  } catch (erro) { 
-    console.log (erro);
+``` javascript
+async function errorExample() {
+  try {
+    const rejectedPromise = await Promise.reject("Oh-oh!");
+  } catch (error) {
+    console.log(error); // "Uh-oh!"
   }
+}
 
-errorExample ();
+errorExample();
 ```
 
-* * *
+---
 
-#### Mais Informações:
+### Mais informação:
 
-*   `await` Operador [MDN Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await)
-*   [Documentos do MDN do](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/async_function) operador de funções `async`
+* Operador `await` <a href='https://developer.mozilla.org/pt-BR/docs/Web/JavaScript/Reference/Operators/await' target='_blank' rel='nofollow'>MDN Docs</a>
+* Função `async` <a href='https://developer.mozilla.org/pt-BR/docs/Web/JavaScript/Reference/Operators/async_function' target='_blank' rel=''nofollow'>MDN Docs</a>


### PR DESCRIPTION
The name of "Promise" was translated to portuguese, "Promessa", but since it's a name, it should reamin the original name.
Some code examples had been changed. I returned to the original, and only translated the comments.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
