### PR TITLE
Fix output of sample code

### DIFF
--- a/guide/english/design-patterns/functional-programming/index.md
+++ b/guide/english/design-patterns/functional-programming/index.md
@@ -55,7 +55,7 @@ Using parameters creates function-specific scope.
   function double(number) {
     return number * 2;
   }
-  console.log(count(1)); // 2
+  console.log(count(1)); // 1
   console.log(double(1)); // 2
   ```
 Using shared, global variables means that changes might be unpredictable, especially when variables are shared between multiple files.


### PR DESCRIPTION
sample code to avoid using shared or mutable state has output commented as 2 while it should be 1.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
