### PR TITLE
Fix English method examples for Ruby's guide

### DIFF
--- a/guide/english/ruby/ruby-arrays/index.md
+++ b/guide/english/ruby/ruby-arrays/index.md
@@ -27,21 +27,21 @@ mixed_array[2] # true
 You can check how many elements an array has with the `length` method:
 
 ```ruby
-mixed_array.length # 3
+mixed_array.length # 4
 [].length # 0
 ```
 
 You can check the first element of an array with the `first` method:
+
 ```ruby
 mixed_array.first # 5
 ```
 
 You can check the last element of an array with the `last` method:
+
 ```ruby
-mixed_array.last # true
+mixed_array.last # [1,2,3]
 ```
 
-
-
 #### More Information:
-<a href='https://ruby-doc.org/core-2.4.2/Array.html' target='_blank' rel='nofollow'>Ruby array documentation</a>
+[Ruby array documentation](https://ruby-doc.org/core-2.4.2/Array.html)


### PR DESCRIPTION
Fix English method examples for Ruby's guide: `guide/english/ruby/ruby-arrays/index.md`

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.