### PR TITLE
docs(angular): translate angular resources to pt-BR

### DIFF
--- a/guide/portuguese/angular/angular-resources/index.md
+++ b/guide/portuguese/angular/angular-resources/index.md
@@ -1,44 +1,44 @@
 ---
 title: Angular Resources
-localeTitle: Recursos angulares
+localeTitle: Recursos para Angular
 ---
-Uma coleção de recursos angulares úteis
+Uma coleção de recursos úteis para Angular
 
 ## Angular 1.x
 
-### Páginas gerais
+### Geral
 
-*   [Angular JS](https://angularjs.org/) - The Angular JS Homepage
-*   [AngularJS Style Guide](https://github.com/johnpapa/angular-styleguide/tree/master/a1) - Boas Práticas Detalhadas para o Desenvolvimento Angular
+*   [Angular JS](https://angularjs.org/) - Página Inicial do Angular JS
+*   [AngularJS Style Guide](https://github.com/johnpapa/angular-styleguide/tree/master/a1) - Boas Práticas para o Desenvolvimento Angular
 
 ### Vídeos
 
-*   [Roteamento no Angular JS](https://www.youtube.com/watch?v=5uhZCc0j9RY) - Roteamento do Cliente em 15 minutos
-*   [Angular ToDo App](https://www.youtube.com/watch?v=WuiHuZq_cg4) - Um aplicativo Angular ToDo em 12 minutos
+*   [Rotas no Angular JS](https://www.youtube.com/watch?v=5uhZCc0j9RY) - Rotas Client-Side em 15 minutos
+*   [App ToDo Angular](https://www.youtube.com/watch?v=WuiHuZq_cg4) - Um aplicativo To-Do em Angular em 12 minutos
 
 ### Cursos
 
-*   [Cursos de Egghead.io AngularJS ($)](https://egghead.io/browse/frameworks/angularjs)
+*   [Cursos de AngularJS do Egghead.io ($)](https://egghead.io/browse/frameworks/angularjs)
 
 ## Angular 2.x +
 
-### Páginas gerais
+### Geral
 
-*   [Angular](https://angular.io/) - a página inicial angular
-*   [Guia de Estilo Angular](https://angular.io/guide/styleguide) - Melhores Práticas Detalhadas para o Desenvolvimento Angular
+*   [Angular](https://angular.io/) - Página Inicial do Angular
+*   [Guia de Estilo Angular](https://angular.io/guide/styleguide) - Melhores Práticas para o Desenvolvimento com Angular
 
-### Páginas de tópicos específicos
+### Páginas de Tópicos Específicos
 
-*   [Diretivas](http://www.sitepoint.com/practical-guide-angularjs-directives/) - Excelente guia em detalhes sobre diretivas angulares (parte 1)
+*   [Diretivas](http://www.sitepoint.com/practical-guide-angularjs-directives/) - Excelente guia que explica em detalhes as Diretivas Angular (parte 1)
 
 ### Cursos
 
-*   [Cursos Angulares Egghead.io ($)](https://egghead.io/browse/frameworks/angular)
-*   [FrontendMasters - Criando Aplicativos Awesomer com Angular](https://frontendmasters.com/courses/building-apps-angular)
-*   [Angular final - lema de Todd](https://ultimateangular.com/)
+*   [Cursos de Angular do Egghead.io ($)](https://egghead.io/browse/frameworks/angular)
+*   [FrontendMasters - Criando Aplicativos Incríveis com Angular](https://frontendmasters.com/courses/building-apps-angular)
+*   [Ultimate Angular - Todd Motto](https://ultimateangular.com/)
 *   [Angular 6 (anteriormente Angular 2) - O Guia Completo ($) Maximilian Schwarzmüller](https://www.udemy.com/the-complete-guide-to-angular-2/)
 
 ## Blogs
 
 *   [Alligator.io](https://alligator.io/angular/)
-*   [Angular em Profundidade](https://blog.angularindepth.com/tagged/angular)
+*   [Angular in Depth](https://blog.angularindepth.com/tagged/angular)


### PR DESCRIPTION
This PR translates the angular resources page to PT-BR, in order to have a natural translation.

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.