### PR TITLE
Fix broken Quick Reference link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,7 @@ This directory contains all of the documentation on contributing to freeCodeCamp
 
 ## Quick references articles
 
-<a href="/how-to-work-on-guide-articles.md">1. How to work on Guide articles.</a>
+<a href="/docs/how-to-work-on-guide-articles.md">1. How to work on Guide articles.</a>
 <a href="/how-to-work-on-coding-challenges.md">2. How to work on Coding Challenges.</a>
 <a href="/how-to-setup-freecodecamp-locally.md">3. How to setup freeCodeCamp locally.</a>
 <a href="/how-to-catch-outgoing-emails-locally.md">4. How to catch outgoing emails locally.</a>


### PR DESCRIPTION
The current link for how-to-work-on-guide-articles.md is broken as it doesn't include the docs folder

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.
