### PR TITLE
Wrong name method

### DIFF
--- a/guide/portuguese/ruby/common-array-methods/index.md
+++ b/guide/portuguese/ruby/common-array-methods/index.md
@@ -103,7 +103,7 @@ rubi array = \[1, 2, 3, 4, 5, 6, 7, 8, 9, 10\] array.select {| number | número>
 
 rubi array = \[1, 2, 3, 4, 5\] => \[1, 2, 3, 4, 5\] array.include? (3) = verdadeiro
 
-#### .aplainar
+ruby array.flatten
 
 O método flatten pode ser usado para obter uma matriz que contém matrizes aninhadas e criar uma matriz unidimensional:
 


### PR DESCRIPTION
The flatten method was translated by the automatic translation. I adjust the method call to the correct name

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ ] My pull request targets the `master` branch of freeCodeCamp.
- [ ] None of my changes are plagiarized from another source without proper attribution.
- [ ] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
