### PR TITLE
Fixed typos and spacing concerns for breakpoints

### DIFF
--- a/guide/english/css/breakpoints/index.md
+++ b/guide/english/css/breakpoints/index.md
@@ -24,7 +24,7 @@ Breakpoints are broadly set on basis of either of the following.
 
 ### Breakpoints based on device width
 
-It's quite apparent that all of our devices donot have same screen widths/ sizes. It is now a design decision to include a set of particular devices and code the css rules accordingly. We already have enough devices to worry about, and when a new one comes out with a different width, going back to your CSS and adding a new breakpoint all over again is time-consuming.
+It's quite apparent that all of our devices do not have same screen widths/sizes. It is now a design decision to include a set of particular devices and code the css rules accordingly. We already have enough devices to worry about, and when a new one comes out with a different width, going back to your CSS and adding a new breakpoint all over again is time-consuming.
 
 Here's an example 
 
@@ -102,7 +102,7 @@ This is the most preferred choice while making or writing the breakpoint rules. 
 > This breakpoint means the CSS will apply when the device width is 768px and above.
 
 
-#### You can also set a range with breakpoints,  so the CSS will only apply within those limits.
+#### You can also set a range with breakpoints, so the CSS will only apply within those limits.
 ```
 @media only screen and (min-width: 768px) and (max-width: 959px){
 
@@ -178,7 +178,7 @@ Breakpoints that are based on content as opposed to device are less complicated.
 }
 ```
 
-You can also set a minimum and maximum width, which let's you experiments with differnt ranges. This one roughly triggers between smar-phone and larger desktop and monitor sizes
+You can also set a minimum and maximum width, which lets you experiments with differnt ranges. This one roughly triggers between smar-phone and larger desktop and monitor sizes
 
 ```code
 @media only screen and (min-width: 700px) and (max-width: 1500px) {


### PR DESCRIPTION
Corrected a couple of typos and altered some spacing to clean up text in article on CSS/breakpoints

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x ] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x ] My pull request targets the `master` branch of freeCodeCamp.
- [x ] None of my changes are plagiarized from another source without proper attribution.
- [x ] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
