### PR TITLE
Moved the Instructions text into correct place, added Caution text

### DIFF
--- a/curriculum/challenges/english/05-apis-and-microservices/managing-packages-with-npm/how-to-use-package.json-the-core-of-any-node.js-project-or-npm-package.en.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/managing-packages-with-npm/how-to-use-package.json-the-core-of-any-node.js-project-or-npm-package.en.md
@@ -20,6 +20,17 @@ All fields must be separated with a comma (,)
 
 ## Instructions
 <section id='instructions'>
+Add your name to the author-field in the package.json of your Glitch project.
+
+Remember that you’re writing JSON.
+
+All field-names must use double-quotes ("), e.g. "author"
+
+All fields must be separated with a comma (,)
+___
+Caution:
+---
+Glitch has an issue where the boilerplate code written by FreeCodeCamp does not get properly imported, which causes the tests to fail. If you are failing the test repeatedly, try to create a new Glitch app using <a href='https://glitch.com/#!/import/github/freeCodeCamp/boilerplate-npm' target='_blank' rel='nofollow'>this link</a>, and complete the challenge again.
 
 </section>
 


### PR DESCRIPTION
I moved the Instructions text into the proper section. Added a cautionary text since the import issue with Glitch persists, and there is no alert to the user when that happens.

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.
