### PR TITLE
Add clarity to/clean up Canvas basic usage guide

### DIFF
--- a/guide/english/canvas/basic-usage/index.md
+++ b/guide/english/canvas/basic-usage/index.md
@@ -9,20 +9,20 @@ When using canvas, first place a canvas into the document as an element.
 <canvas width="400" height="400" id="canvas"></canvas>
 ```
 
-The `width` and `height` attributes will control the size of the canvas. These attributes control the size of the drawing canvas, not the actual rendered size. See the "Canvas Dimensions" page for more.
+The `width` and `height` attributes will control the size of the canvas. These attributes control the size of the drawing canvas, not the actual rendered size. See the [Canvas Dimensions](/canvas/canvas-dimensions) page for more information.
 
 In order to use a `canvas`, we must first grab the element from the page as a DOM element, and then get a drawing context from it.
 
 ```js
-var canvas = document.getElementById("canvas");
-var ctx = canvas.getContext('2d');
+const canvas = document.getElementById('canvas');
+const ctx = canvas.getContext('2d');
 ```
 
 All drawing calls after this will be made from the `ctx` object. The `ctx` represents the drawing context of the object, and contains information about the 2D drawing space. The `canvas` object is the actual DOM element. Interacting with it allows us to access attributes like `width` and `height`.
 
 There are a few available drawing contexts, including `webgl`. WebGL is really an entirely different technology, so we will only focus on 2D drawing.
 
-Paths are the building block of drawing in `canvas`. See the '[Paths](/articles/canvas/paths)' page for more.
+Paths are the building block of drawing in `canvas`. See the [Paths](/articles/canvas/paths) page for more information.
 
 #### More Information:
 


### PR DESCRIPTION
# What?
* Add link to Canvas Dimensions guide page
* Normalize use of single vs. double quotes in code example
* Use ES6 syntax in code example

# Why?
Documentation will be easier to comprehend while providing additional context to the user in the form of links to other parts of the guide.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.
