### PR TITLE
Fixed misspelling and capitalization in C Variables and Basic Data Types

### DIFF
--- a/guide/english/c/variables-and-basic-datatypes/index.md
+++ b/guide/english/c/variables-and-basic-datatypes/index.md
@@ -34,7 +34,7 @@ int main(void){
 }
 ```
 
-Let's break down what we did under the `Some shingy things`:
+Let's break down what we did under the `Some shiny things`:
 ```C
 printf("%d \n", c); 
 ```
@@ -46,7 +46,7 @@ You can print out several integers in the order given after the comma.
 
 Note that when you try to store a decimal value in an `int`, you will only get the whole part of it, because they will be truncated.
 
-we can also write the program in the manner below:
+We can also write the program in the manner below:
 ```
 #include <stdio.h>
 int main(void){


### PR DESCRIPTION
This commit fixes a misspelling in the reference to 'Some shiny things' and capitalizes the 'W in 'We can also write the program in the manner below:'

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Does not close an issue.
