### PR TITLE
Update meta.json

### DIFF
--- a/curriculum/challenges/_meta/basic-data-structures/meta.json
+++ b/curriculum/challenges/_meta/basic-data-structures/meta.json
@@ -78,7 +78,7 @@
     ],
     [
       "587d7b7d367417b2b2512b1d",
-      " Iterate Through the Keys of an Object with a for...in Statement"
+      "Iterate Through the Keys of an Object with a for...in Statement"
     ],
     [
       "587d7b7d367417b2b2512b1e",


### PR DESCRIPTION
Remove leading space in the title of "Iterate through the keys of an object with a for...in Statement". 
Actually what I'm trying to do is fix broken link for this challenge "get hint" link. I open issue and someone commented that there is a leading space in the title and then told that actual link is different. Now I'm going to find the location where I can replace the link.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ ] My pull request targets the `master` branch of freeCodeCamp.
- [ ] None of my changes are plagiarized from another source without proper attribution.
- [ ] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
