### PR TITLE
Problem with example description

### DIFF
--- a/guide/english/jquery/index.md
+++ b/guide/english/jquery/index.md
@@ -14,7 +14,7 @@ jQuery adds a global variable with all of the libraries methods attached. The na
 
 ## Example
 
-When a user clicks on a button, all <p> elements will be hidden:
+When a user clicks on a button, all \<p> elements will be hidden:
 
 ```javascript
 $(document).ready(function(){


### PR DESCRIPTION
"When a user clicks on a button, all \<p> elements will be hidden:" - here the "\<p>" is taken as html tag due to which text is moving to next line. The intention of author is to say that all paragraph (\<p>) tags will be hidden. The "\<p>" itself is not showing in the explanation as it's considered an HTML tag. I have added an escape character in front.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
