### PR TITLE
Added a space after css property colon

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/use-the-css-transform-scale-property-to-change-the-size-of-an-element.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/use-the-css-transform-scale-property-to-change-the-size-of-an-element.english.md
@@ -8,7 +8,7 @@ videoUrl: 'https://scrimba.com/c/c2MZVSg'
 ## Description
 <section id='description'>
 To change the scale of an element, CSS has the <code>transform</code> property, along with its <code>scale()</code> function. The following code example doubles the size of all the paragraph elements on the page:
-<blockquote>p {<br>&nbsp;&nbsp;transform:scale(2);<br>}</blockquote>
+<blockquote>p {<br>&nbsp;&nbsp;transform: scale(2);<br>}</blockquote>
 </section>
 
 ## Instructions


### PR DESCRIPTION
I was doing this challenge and noticed that there wasn't a space after "transform:scale(2)" in the description which is inconsistent with the other challenges so I changed it to "transform: scale(2)"

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ ] My pull request targets the `master` branch of freeCodeCamp.
- [ ] None of my changes are plagiarized from another source without proper attribution.
- [ ] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
