### PR TITLE
Replaced translated CSS code in set-the-font-family-of-an-element.arabic.md

### DIFF
--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-css/set-the-font-family-of-an-element.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-css/set-the-font-family-of-an-element.arabic.md
@@ -7,7 +7,7 @@ localeTitle: ''
 ---
 
 ## Description
-<section id="description"> يمكنك تعيين الخط الذي يجب أن يستخدمه عنصر ما ، باستخدام خاصية <code>font-family</code> . على سبيل المثال ، إذا أردت تعيين خط عنصر <code>h2</code> على <code>sans-serif</code> ، <code>sans-serif</code> CSS التالي: <blockquote style=";text-align:right;direction:rtl"> h2 { <br> عائلة الخط: sans-serif؛ <br> } </blockquote></section>
+<section id="description"> يمكنك تعيين الخط الذي يجب أن يستخدمه عنصر ما ، باستخدام خاصية <code>font-family</code> . على سبيل المثال ، إذا أردت تعيين خط عنصر <code>h2</code> على <code>sans-serif</code> ، <code>sans-serif</code> CSS التالي: <blockquote> h2 { <br>font-family: sans-serif؛ <br> } </blockquote></section>
 
 ## Instructions
 <section id="instructions"> اجعل جميع عناصر <code>p</code> تستخدم خط <code>monospace</code> . </section>


### PR DESCRIPTION
CSS code shouldn't be translated thus translted text was replaced by original.

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
