### PR TITLE
Fix README on docs for different languages

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,10 +24,10 @@ This directory contains all of the documentation on contributing to freeCodeCamp
 
 ## Quick references articles
 
-<a href="/how-to-work-on-guide-articles.md">1. How to work on Guide articles.</a>
-<a href="/how-to-work-on-coding-challenges.md">2. How to work on Coding Challenges.</a>
-<a href="/how-to-setup-freecodecamp-locally.md">3. How to setup freeCodeCamp locally.</a>
-<a href="/how-to-catch-outgoing-emails-locally.md">4. How to catch outgoing emails locally.</a>
+1. [How to work on Guide articles](/docs/how-to-work-on-guide-articles.md)
+2. [How to work on Coding Challenges](/docs/how-to-work-on-coding-challenges.md)
+3. [How to setup freeCodeCamp locally](/docs/how-to-setup-freecodecamp-locally.md)
+4. [How to catch outgoing emails locally](/docs/how-to-catch-outgoing-emails-locally.md)
 
 ## Style guides
 

--- a/docs/arabic/README.md
+++ b/docs/arabic/README.md
@@ -23,7 +23,7 @@
 freecodecamp.org
 
 
-## [إذا كنت مبتدأ, قم بقراءة هذا المستند أولا](/CONTRIBUTING.md)
+## [إذا كنت مبتدأ, قم بقراءة هذا المستند أولا](/docs/arabic/CONTRIBUTING.md)
 
 ---
 

--- a/docs/portuguese/README.md
+++ b/docs/portuguese/README.md
@@ -17,7 +17,7 @@ Olá 👋!
 
 Este directório contem toda a documentação sobre como contribuir para o freeCodeCamp.org
 
-## [Se estás agora a começar, lê isto primeiro.](/CONTRIBUTING.md)
+## [Se estás agora a começar, lê isto primeiro.](/docs/portuguese/CONTRIBUTING.md)
 
 ---
 


### PR DESCRIPTION
This is a follow up from pull request #19393, this time targetting the same fixes but for Portuguese and Arabic documentation, to keep those readers going to CONTRIBUTING.md file that correspond to their language.

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
