### PR TITLE
Fix Title section links on Article Guide

### DIFF
--- a/docs/style-guide-for-guide-articles.md
+++ b/docs/style-guide-for-guide-articles.md
@@ -14,7 +14,7 @@ However, you can include special characters in the article title.
 
 Here are some examples of properly named titles:
 
-> [`src/pages/html/tables/index.md`](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/src/pages/html/tables/index.md)
+> [`src/pages/html/tables/index.md`](https://github.com/freeCodeCamp/guide/blob/master/src/pages/html/tables/index.md)
 
 ```markdown
 ---
@@ -22,7 +22,7 @@ title: Tables
 ---
 ```
 
-> [`src/pages/css/borders/index.md`](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/src/pages/css/borders/index.md)
+> [`src/pages/css/borders/index.md`](https://github.com/freeCodeCamp/guide/blob/master/src/pages/css/borders/index.md)
 
 ```markdown
 ---
@@ -30,7 +30,7 @@ title: Borders
 ---
 ```
 
-> [`src/pages/javascript/loops/for-loop/index.md`](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/src/pages/javascript/loops/for-loop/index.md)
+> [`src/pages/javascript/loops/for-loop/index.md`](https://github.com/freeCodeCamp/guide/blob/master/src/pages/javascript/loops/for-loop/index.md)
 
 ```markdown
 ---


### PR DESCRIPTION
Links on Title section of Style guide for creating and editing Guide Articles were broken.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #30592 
