### PR TITLE
fix: add meta for invalid merge

### DIFF
--- a/guide/russian/react/context-api/index.md
+++ b/guide/russian/react/context-api/index.md
@@ -1,3 +1,7 @@
+---
+title: Context API
+---
+
 # Context API
 
 Новый Context API был реализован в версии React 16.3. 


### PR DESCRIPTION
This adds meta-data for a invalid merge from #20267

/cc @freeCodeCamp/moderators 