### PR TITLE
docs(local): update sync instructions

### DIFF
--- a/docs/how-to-setup-freecodecamp-locally.md
+++ b/docs/how-to-setup-freecodecamp-locally.md
@@ -114,7 +114,7 @@ Start by installing these prerequisite software.
 | Prerequisite                                | Version | Notes |
 | ------------------------------------------- | ------- | ----- |
 | [MongoDB Community Server](https://docs.mongodb.com/manual/administration/install-community/) | `3.6`   | [Release Notes](https://docs.mongodb.com/manual/release-notes/), Note: We currently on `3.6`, an [upgrade is planned](https://github.com/freeCodeCamp/freeCodeCamp/issues/18275).
-| [Node.js](http://nodejs.org)                | `8.x`   | [LTS Schedule](https://github.com/nodejs/Release#release-schedule) |
+| [Node.js](http://nodejs.org)                | `8.x`   | [LTS Schedule](https://github.com/nodejs/Release#release-schedule), Note: We currently on `8.x`, an upgrade is planned to 10.x |
 | npm (comes bundled with Node)               | `6.x`   | Does not have LTS releases, we use the version bundled with Node LTS |
 
 **Important:**
@@ -259,9 +259,11 @@ Follow these steps:
     git checkout master
     ```
 
-2. Next, you would want to **sync the lastest changes** from the main repository of freeCodeCamp.
+2. Next, you would want to **sync the lastest changes for `master` branch** from the main repository of freeCodeCamp.
 
-    Its important that you do this as often as possible, to avoid conflicts later:
+    **Note:** If you have any outstanding pull-request that you made from the `master` branch of your fork previously, you will lose them. You should get it merged by a moderator, prior following this. To avoid this, you should always work on a branch.
+
+    Its recommended that you do this as often as possible, to avoid conflicts later:
 
     ```shell
     git fetch upstream
@@ -272,12 +274,6 @@ Follow these steps:
     ```shell
     git reset --hard upstream/master
     ```
-
-    **Important:**
-
-    If you have any outstanding PRs that you made from the `master` branch, you will lose them.
-
-    Get them, merged by a moderator, in such a case. And to avoid this, you should always work on a branch.
 
     Push this branch back to your origin, to have a clean history on your fork on GitHub:
 
@@ -444,10 +440,6 @@ Follow these steps:
 5. Indicate if you have tested on a local copy of the site or not.
 
     This is very important when you are making changes that are not copy editing markdown files. For example, changes to CSS or JavaScript code, etc.
-
-## Get your PR accepted
-
-
 
 ## Getting Help
 

--- a/docs/how-to-setup-freecodecamp-locally.md
+++ b/docs/how-to-setup-freecodecamp-locally.md
@@ -259,15 +259,27 @@ Follow these steps:
     git checkout master
     ```
 
-2. Next, you would want to `rebase` from the `upstream`.
+2. Next, you would want to **sync the lastest changes** from the main repository of freeCodeCamp.
 
-    This step **will sync the lastest changes** from the main repository of freeCodeCamp. Its important that you rebase as often as possible, to avoid conflicts later.
+    Its important that you do this as often as possible, to avoid conflicts later:
 
     ```shell
-    git pull --rebase upstream master
+    git fetch upstream
     ```
 
-    You can optionally push this branch back to your origin, to have a clean history on your fork on GitHub.
+    Now, you want to do a hard reset with the copy on the freeCodeCamp master:
+
+    ```shell
+    git reset --hard upstream/master
+    ```
+
+    **Important:**
+
+    If you have any outstanding PRs that you made from the `master` branch, you will lose them.
+
+    Get them, merged by a moderator, in such a case. And to avoid this, you should always work on a branch.
+
+    Push this branch back to your origin, to have a clean history on your fork on GitHub:
 
     ```shell
     git push origin master --force
@@ -390,7 +402,7 @@ Follow these steps:
 
     You can learn more about why you should use conventional commits [here](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#why-use-conventional-commits).
 
-9. If you realise that you need to edit a file or, update the commit message after making a commit you can do so after editing the files with:
+9.  If you realise that you need to edit a file or, update the commit message after making a commit you can do so after editing the files with:
 
     ```shell
     git commit --amend

--- a/docs/how-to-setup-freecodecamp-locally.md
+++ b/docs/how-to-setup-freecodecamp-locally.md
@@ -398,7 +398,7 @@ Follow these steps:
 
     You can learn more about why you should use conventional commits [here](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#why-use-conventional-commits).
 
-9.  If you realise that you need to edit a file or, update the commit message after making a commit you can do so after editing the files with:
+9. If you realise that you need to edit a file or update the commit message after making a commit you can do so after editing the files with:
 
     ```shell
     git commit --amend


### PR DESCRIPTION
Since we have an extremely fast moving repo with a huge no of contributors, the usual *recommended* method of keeping repo up to date is not good enough.

Usual method:

```shell
# check the remotes are correct
git remote -v

    origin  git@github.com:raisedadead/freeCodeCamp.git (fetch)
    origin  git@github.com:raisedadead/freeCodeCamp.git (push)
    upstream        https://github.com/freeCodeCamp/freeCodeCamp/.git (fetch)
    upstream        https://github.com/freeCodeCamp/freeCodeCamp/.git (push)

# checkout the master
git checkout master

# make a rebase
git pull --rebase upstream master

# push changes on fork
git push origin master --force
```

This is a rebase and update flow, but when we have 300+ commits going in each day. It gets horribly messy because of conflicts. 

I propose rather doing this:

```shell
git checkout master

git fetch upstream

git reset --hard upstream/master

git push origin master --force
```

This is a better way for our scenario, avoiding conflicts, because we are simply telling Git: "Hey, just reset my `master` with the main, please."

**But**, This does some with its own dangers. That is if you had PR's made from your forks `master` You would lose them. Firstly you should never edit files on master, but if you did then this would be the side effect that would come with it.