### PR TITLE
Fixed capitalization and unclear example

### DIFF
--- a/guide/english/html/symbols/index.md
+++ b/guide/english/html/symbols/index.md
@@ -6,7 +6,7 @@ title: Symbols
 
 HTML symbol entities are characters that are not represented on a user's keyboards. Many mathematical, scientific, and currency symbols
 are not present on a normal keyboard; therefore, to add such symbols to a page using HTML, the HTML entity name can be used.
-It is important to note that these will not effect the HTML code themselves, and will always be interpreted as text. For example, if we wanted to type `<div>' as text on a webpage, we may need to use these symbol entities: `&lt;div&gt`.
+It is important to note that these will not effect the HTML code themselves, and will always be interpreted as text. For example, if we wanted to type `<div>` as text on a webpage, we may need to use these symbol entities: `&lt;div&gt`.
 
 If no entity name exists, either the entity number or hexadecimal reference can be used.
 

--- a/guide/english/html/symbols/index.md
+++ b/guide/english/html/symbols/index.md
@@ -17,3 +17,4 @@ If no entity name exists, either the entity number or hexadecimal reference can 
 * [W3 Schools Reference](https://www.w3schools.com/html/html_symbols.asp)
 * [Symbols Reference Chart](https://dev.w3.org/html5/html-author/charref)
 * [Toptal Reference](https://www.toptal.com/designers/htmlarrows/symbols/)
+

--- a/guide/english/html/symbols/index.md
+++ b/guide/english/html/symbols/index.md
@@ -6,7 +6,7 @@ title: Symbols
 
 HTML symbol entities are characters that are not represented on a user's keyboards. Many mathematical, scientific, and currency symbols
 are not present on a normal keyboard; therefore, to add such symbols to a page using HTML, the HTML entity name can be used.
-It is important to note that these will not effect the HTML code themselves, and will always be interpreted as text. For example, if we wanted to type &lt;div&gt; as text on a webpage, we may need to use these symbol entities: `&lt;` and `&gt;`.
+It is important to note that these will not effect the HTML code themselves, and will always be interpreted as text. For example, if we wanted to type `<div>' as text on a webpage, we may need to use these symbol entities: `&lt;div&gt`.
 
 If no entity name exists, either the entity number or hexadecimal reference can be used.
 

--- a/guide/english/html/symbols/index.md
+++ b/guide/english/html/symbols/index.md
@@ -6,7 +6,7 @@ title: Symbols
 
 HTML symbol entities are characters that are not represented on a user's keyboards. Many mathematical, scientific, and currency symbols
 are not present on a normal keyboard; therefore, to add such symbols to a page using HTML, the HTML entity name can be used.
-It is important to note that these will not effect the html code themselves, and will always be interpreted as text. For example, if we wanted to type &lt;div&gt; as text on a webpage, we may need to use these symbol entities.
+It is important to note that these will not effect the HTML code themselves, and will always be interpreted as text. For example, if we wanted to type &lt;div&gt; as text on a webpage, we may need to use these symbol entities: `&lt;` and `&gt;`.
 
 If no entity name exists, either the entity number or hexadecimal reference can be used.
 


### PR DESCRIPTION
I capitalized HTML in order to be consistent with the rest of the paragraph. I also added the less than sign and greater than sign symbol entity names to the example sentence, in order to make it more clear what symbol entity names you would actual need to use in that example.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.
