### PR TITLE
Readme language link table

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,16 +1,18 @@
 <table>
     <tr>
-        <!-- Do not translate this table -->
         <td> Read these guidelines in </td>
-        <td><a href="/CONTRIBUTING.md"> English </a></td>
-        <td><a href="/docs/arabic/README.md"> عربى </a></td>
-        <td><a href="/docs/chinese/README.md"> 中文 </a></td>
-        <td><a href="/docs/russian/README.md"> русский </a></td>
-        <td><a href="/docs/portuguese/README.md"> Português </a></td>
-        <td><a href="/docs/spanish/README.md"> Español </a></td>
-        <td><a href="/docs/german/README.md"> Deutsch </a></td>
+        <td><a href="README.md"> English </a></td>
+        <td><a href="chinese/README.md"> 中文 </a></td>
+        <td><a href="russian/README.md"> русский </a></td>
+        <td><a href="arabic/README.md"> عربى </a></td>
+        <td><a href="spanish/README.md"> Español </a></td>
+        <td><a href="romanian/README.md"> Română </a></td>
+        <td><a href="portuguese/README.md"> Português </a></td>
+        <td><a href="italian/CONTRIBUTING.md"> Italiano </a></td>
+        <td><a href="german/README.md"> Deutsch </a></td>
     </tr>
 </table>
+
 
 # Documentation Quick Reference
 

--- a/docs/arabic/README.md
+++ b/docs/arabic/README.md
@@ -1,13 +1,14 @@
-
 <table>
     <tr>
         <td> Read these guidelines in </td>
-        <td><a href="/CONTRIBUTING.md"> English </a></td>
+        <td><a href="/docs/README.md"> English </a></td>
         <td><a href="/docs/chinese/README.md"> 中文 </a></td>
         <td><a href="/docs/russian/README.md"> русский </a></td>
-        <td><a href="/docs/arabic/README.md"> عربى </a></td>
+        <td><a href="README.md"> عربى </a></td>
         <td><a href="/docs/spanish/README.md"> Español </a></td>
+        <td><a href="/docs/romanian/README.md"> Română </a></td>
         <td><a href="/docs/portuguese/README.md"> Português </a></td>
+        <td><a href="/docs/italian/CONTRIBUTING.md"> Italiano </a></td>
         <td><a href="/docs/german/README.md"> Deutsch </a></td>
     </tr>
 </table>

--- a/docs/chinese/README.md
+++ b/docs/chinese/README.md
@@ -10,6 +10,20 @@
         <td><a href="/docs/german/README.md"> Deutsch </a></td>
     </tr>
 </table>
+<table>
+    <tr>
+        <td> Read these guidelines in </td>
+        <td><a href="/docs/README.md"> English </a></td>
+        <td><a href="README.md"> 中文 </a></td>
+        <td><a href="/docs/russian/README.md"> русский </a></td>
+        <td><a href="/docs/arabic/README.md"> عربى </a></td>
+        <td><a href="/docs/spanish/README.md"> Español </a></td>
+        <td><a href="/docs/romanian/README.md"> Română </a></td>
+        <td><a href="/docs/portuguese/README.md"> Português </a></td>
+        <td><a href="/docs/italian/CONTRIBUTING.md"> Italiano </a></td>
+        <td><a href="/docs/german/README.md"> Deutsch </a></td>
+    </tr>
+</table>
 
 # Documentation快速参考
 

--- a/docs/chinese/README.md
+++ b/docs/chinese/README.md
@@ -1,18 +1,6 @@
 <table>
     <tr>
         <td> Read these guidelines in </td>
-        <td><a href="/CONTRIBUTING.md"> English </a></td>
-        <td><a href="/docs/chinese/README.md"> 中文 </a></td>
-        <td><a href="/docs/russian/README.md"> русский </a></td>
-        <td><a href="/docs/arabic/README.md"> عربى </a></td>
-        <td><a href="/docs/spanish/README.md"> Español </a></td>
-        <td><a href="/docs/portuguese/README.md"> Português </a></td>
-        <td><a href="/docs/german/README.md"> Deutsch </a></td>
-    </tr>
-</table>
-<table>
-    <tr>
-        <td> Read these guidelines in </td>
         <td><a href="/docs/README.md"> English </a></td>
         <td><a href="README.md"> 中文 </a></td>
         <td><a href="/docs/russian/README.md"> русский </a></td>

--- a/docs/german/README.md
+++ b/docs/german/README.md
@@ -1,14 +1,15 @@
 <table>
     <tr>
-        <!-- Do not translate this table -->
         <td> Read these guidelines in </td>
-        <td><a href="/CONTRIBUTING.md"> English </a></td>
-        <td><a href="/docs/arabic/README.md"> عربى </a></td>
+        <td><a href="/docs/README.md"> English </a></td>
         <td><a href="/docs/chinese/README.md"> 中文 </a></td>
         <td><a href="/docs/russian/README.md"> русский </a></td>
-        <td><a href="/docs/portuguese/README.md"> Português </a></td>
+        <td><a href="/docs/arabic/README.md"> عربى </a></td>
         <td><a href="/docs/spanish/README.md"> Español </a></td>
-        <td><a href="/docs/german/README.md"> Deutsch </a></td>
+        <td><a href="/docs/romanian/README.md"> Română </a></td>
+        <td><a href="/docs/portuguese/README.md"> Português </a></td>
+        <td><a href="/docs/italian/CONTRIBUTING.md"> Italiano </a></td>
+        <td><a href="README.md"> Deutsch </a></td>
     </tr>
 </table>
 

--- a/docs/italian/CONTRIBUTING.md
+++ b/docs/italian/CONTRIBUTING.md
@@ -1,14 +1,15 @@
 <table>
     <tr>
-        <!-- Do not translate this table -->
         <td> Read these guidelines in </td>
-        <td><a href="/CONTRIBUTING.md"> English </a></td>
-        <td><a href="/docs/arabic/CONTRIBUTING.md"> عربى </a></td>
+        <td><a href="/docs/CONTRIBUTING.md"> English </a></td>
         <td><a href="/docs/chinese/CONTRIBUTING.md"> 中文 </a></td>
-        <td><a href="/docs/portuguese/CONTRIBUTING.md"> Português </a></td>
         <td><a href="/docs/russian/CONTRIBUTING.md"> русский </a></td>
+        <td><a href="/docs/arabic/CONTRIBUTING.md"> عربى </a></td>
         <td><a href="/docs/spanish/CONTRIBUTING.md"> Español </a></td>
+        <td><a href="/docs/romanian/CONTRIBUTING.md"> Română </a></td>
+        <td><a href="/docs/portuguese/CONTRIBUTING.md"> Português </a></td>
         <td><a href="/docs/italian/CONTRIBUTING.md"> Italiano </a></td>
+        <td><a href="/docs/german/CONTRIBUTING.md"> Deutsch </a></td>
     </tr>
 </table>
 

--- a/docs/portuguese/README.md
+++ b/docs/portuguese/README.md
@@ -1,12 +1,14 @@
 <table>
     <tr>
         <td> Read these guidelines in </td>
-        <td><a href="/CONTRIBUTING.md"> English </a></td>
+        <td><a href="/docs/README.md"> English </a></td>
         <td><a href="/docs/chinese/README.md"> 中文 </a></td>
         <td><a href="/docs/russian/README.md"> русский </a></td>
         <td><a href="/docs/arabic/README.md"> عربى </a></td>
         <td><a href="/docs/spanish/README.md"> Español </a></td>
-        <td><a href="/docs/portuguese/README.md"> Português </a></td>
+        <td><a href="/docs/romanian/README.md"> Română </a></td>
+        <td><a href="README.md"> Português </a></td>
+        <td><a href="/docs/italian/CONTRIBUTING.md"> Italiano </a></td>
         <td><a href="/docs/german/README.md"> Deutsch </a></td>
     </tr>
 </table>

--- a/docs/romanian/README.md
+++ b/docs/romanian/README.md
@@ -1,15 +1,14 @@
-
 <table>
     <tr>
-        <!-- Do not translate this table -->
         <td> Read these guidelines in </td>
-        <td><a href="/CONTRIBUTING.md"> English </a></td>
-        <td><a href="/docs/arabic/CONTRIBUTING.md"> عربى </a></td>
-        <td><a href="/docs/chinese/CONTRIBUTING.md"> 中文 </a></td>
-        <td><a href="/docs/portuguese/CONTRIBUTING.md"> Português </a></td>
-        <td><a href="/docs/russian/CONTRIBUTING.md"> русский </a></td>
-        <td><a href="/docs/spanish/CONTRIBUTING.md"> Español </a></td>
-        <td><a href="/docs/romanian/CONTRIBUTING.md"> Română </a></td>
+        <td><a href="/docs/README.md"> English </a></td>
+        <td><a href="/docs/chinese/README.md"> 中文 </a></td>
+        <td><a href="/docs/russian/README.md"> русский </a></td>
+        <td><a href="/docs/arabic/README.md"> عربى </a></td>
+        <td><a href="/docs/spanish/README.md"> Español </a></td>
+        <td><a href="README.md"> Română </a></td>
+        <td><a href="/docs/portuguese/README.md"> Português </a></td>
+        <td><a href="/docs/italian/CONTRIBUTING.md"> Italiano </a></td>
         <td><a href="/docs/german/README.md"> Deutsch </a></td>
     </tr>
 </table>

--- a/docs/russian/README.md
+++ b/docs/russian/README.md
@@ -1,13 +1,15 @@
+
 <table>
     <tr>
-        <!-- Do not translate this table -->
         <td> Read these guidelines in </td>
-        <td><a href="/CONTRIBUTING.md"> English </a></td>
+        <td><a href="/docs/README.md"> English </a></td>
         <td><a href="/docs/chinese/README.md"> 中文 </a></td>
-        <td><a href="/docs/russian/README.md"> русский </a></td>
+        <td><a href="README.md"> русский </a></td>
         <td><a href="/docs/arabic/README.md"> عربى </a></td>
         <td><a href="/docs/spanish/README.md"> Español </a></td>
+        <td><a href="/docs/romanian/README.md"> Română </a></td>
         <td><a href="/docs/portuguese/README.md"> Português </a></td>
+        <td><a href="/docs/italian/CONTRIBUTING.md"> Italiano </a></td>
         <td><a href="/docs/german/README.md"> Deutsch </a></td>
     </tr>
 </table>

--- a/docs/spanish/README.md
+++ b/docs/spanish/README.md
@@ -1,12 +1,14 @@
 <table>
     <tr>
         <td> Read these guidelines in </td>
-        <td><a href="/CONTRIBUTING.md"> English </a></td>
+        <td><a href="/docs/README.md"> English </a></td>
         <td><a href="/docs/chinese/README.md"> 中文 </a></td>
         <td><a href="/docs/russian/README.md"> русский </a></td>
         <td><a href="/docs/arabic/README.md"> عربى </a></td>
-        <td><a href="/docs/spanish/README.md"> Español </a></td>
+        <td><a href="README.md"> Español </a></td>
+        <td><a href="/docs/romanian/README.md"> Română </a></td>
         <td><a href="/docs/portuguese/README.md"> Português </a></td>
+        <td><a href="/docs/italian/CONTRIBUTING.md"> Italiano </a></td>
         <td><a href="/docs/german/README.md"> Deutsch </a></td>
     </tr>
 </table>


### PR DESCRIPTION
Updated all language tables in the docs>language folders to have the same order and correct links to their specified languages. This keeps the table looking consistent no matter which language for the README.md file you are in. 

Takes over for pull request #28207 where I didn't know what I was doing and added too many edits onto the same branch. This breaks that pull request into one action instead of several.

Relates to these issue numbers:
Translations: #18312
Arabic: #18311
Chinese: #18310
Portuguese: #18309
Russian: #18308
Spanish: #18307

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
