### PR TITLE
fix: prevent focus when using find/replace

### DIFF
--- a/client/src/templates/Challenges/classic/Editor.js
+++ b/client/src/templates/Challenges/classic/Editor.js
@@ -109,6 +109,9 @@ class Editor extends PureComponent {
   };
 
   focusEditor = e => {
+    if (document.activeElement.className === 'input') {
+      return;
+    }
     // e key to focus editor
     if (e.keyCode === 69) {
       this._editor.focus();

--- a/client/src/templates/Challenges/classic/Editor.js
+++ b/client/src/templates/Challenges/classic/Editor.js
@@ -85,10 +85,6 @@ class Editor extends PureComponent {
     this._editor = null;
   }
 
-  componentWillUnmount() {
-    document.removeEventListener('keyup', this.focusEditor);
-  }
-
   editorWillMount = monaco => {
     defineMonacoThemes(monaco);
   };
@@ -96,7 +92,6 @@ class Editor extends PureComponent {
   editorDidMount = (editor, monaco) => {
     this._editor = editor;
     this._editor.focus();
-    document.addEventListener('keyup', this.focusEditor);
     this._editor.addAction({
       id: 'execute-challenge',
       label: 'Run tests',
@@ -106,16 +101,6 @@ class Editor extends PureComponent {
       ],
       run: this.props.executeChallenge
     });
-  };
-
-  focusEditor = e => {
-    if (document.activeElement.className === 'input') {
-      return;
-    }
-    // e key to focus editor
-    if (e.keyCode === 69) {
-      this._editor.focus();
-    }
   };
 
   onChange = editorValue => {


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

I apologize that this is hacky. I'm not sure of any way to check if MonacoEditor is currently in the find/replace state. I checked their github and docs. If anyone has a better idea, let me know, but the issue lies in the hot key event.

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #19695
