### PR TITLE
Fixed typos in spanish docs

### DIFF
--- a/docs/spanish/how-to-catch-outgoing-emails-locally.md
+++ b/docs/spanish/how-to-catch-outgoing-emails-locally.md
@@ -94,7 +94,7 @@ Siguiente, puedes ir a [usando MailHog](#usando-mailhog).
 
 ## Usando MailHog
 
-Una vez que hayas instalado MailHog y lo hayas iniciado, debes abrir tu bandeja de entrada de MailHog en tu navegador, abriendo una nueva pestaña o ventana y navegar a [http://localhost:8025] (http://localhost:8025). Ahora deberías ver una pantalla como la siguiente:
+Una vez que hayas instalado MailHog y lo hayas iniciado, debes abrir tu bandeja de entrada de MailHog en tu navegador, abriendo una nueva pestaña o ventana y navegar a [http://localhost:8025](http://localhost:8025). Ahora deberías ver una pantalla como la siguiente:
 
 ![Captura de pantalla MailHog 1](../images/mailhog/1.jpg)
 

--- a/docs/spanish/how-to-setup-freecodecamp-locally.md
+++ b/docs/spanish/how-to-setup-freecodecamp-locally.md
@@ -8,4 +8,4 @@ El flujo de trabajo de las contribuciones puede desear y mostrar vistas previas 
 
 ['Forking'](https://help.github.com/articles/about-forks/) es un paso en donde obtienes tu propia copia del repositorio principal de freeCodeCamp (también conocido como _repo_) en GitHub.
 
-Esto es esencial, por que de esta manera puedes trabajar en tu propia copia de freeCodeCamp en GitHub, o descargarla para trabajar con ella de manera local. Despues, podrias solicitar que los cambios sean extraídos al repositorio principal al realizar un _pull request_ o solicitud de cambio.
+Esto es esencial, porque de esta manera puedes trabajar en tu propia copia de freeCodeCamp en GitHub, o descargarla para trabajar con ella de manera local. Después, podrías solicitar que los cambios sean extraídos al repositorio principal al realizar un _pull request_ o solicitud de cambio.


### PR DESCRIPTION
Fixed typos in spanish docs.

Also fixed a link that was displaying markdown brackets.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.
