### PR TITLE
Updated buttons page to match 4.1.3 standards.

### DIFF
--- a/guide/english/bootstrap/buttons/index.md
+++ b/guide/english/bootstrap/buttons/index.md
@@ -25,13 +25,13 @@ This is a list of the CSS classes that bootstrap provides for buttons.
 
 `<button type="button" class="btn">Basic</button>`
 
-`.btn-default` Bootstrap's default button.
-
-`<button type="button" class="btn btn-default">Default</button>`
-
 `.btn-primary` Bootstrap's primary button.
 
 `<button type="button" class="btn btn-primary">Primary</button>`
+
+`.btn-secondary` Bootstrap's secondary button.
+
+`<button type="button" class="btn btn-secondary">Secondary</button>`
 
 `.btn-success` Bootstrap's success button.
 
@@ -49,13 +49,17 @@ This is a list of the CSS classes that bootstrap provides for buttons.
 
 `<button type="button" class="btn btn-danger">Danger</button>`
 
-`.btn-link` Bootstrap's link button.
-
-`<button type="button" class="btn btn-link">Link</button>`
-
 `.btn-light` Bootstrap's light button.
 
 `<button type="button" class="btn btn-light">Light</button>`
+
+`.btn-dark` Bootstrap's dark button.
+
+`<button type="button" class="btn btn-dark">Dark</button>`
+
+`.btn-link` Bootstrap's link button.
+
+`<button type="button" class="btn btn-link">Link</button>`
 
 #### Bootstrap Button Sizes:
 This is a list of the CSS classes for different size of the buttons.
@@ -68,20 +72,34 @@ This is a list of the CSS classes for different size of the buttons.
 
 `<button type="button" class="btn btn-sm">Small</button>`
 
-`.btn-xs` This is bootstrap's extra small button.
+`.btn-block` Bootstrap's block level button, it spans the full width of a parent.
 
-`<button type="button" class="btn btn-xs">Extra Small</button>`
+`<button type="button" class="btn btn-block">Block level button</button>`
 
 #### Bootstrap Outlined Buttons:
 It is possible to also have outlined buttons rather than fully colored in ones. This is achieved by placing the mid fix `outline` between the button class you want. A sample usage would be as follows:
 
 `<button type="button" class="btn btn-outline-primary">Primary</button>`
 
+`<button type="button" class="btn btn-outline-secondary">Secondary</button>`
+
+`<button type="button" class="btn btn-outline-success">Success</button>`
+
+`<button type="button" class="btn btn-outline-danger">Danger</button>`
+
+`<button type="button" class="btn btn-outline-warning">Warning</button>`
+
+`<button type="button" class="btn btn-outline-info">Info</button>`
+
+`<button type="button" class="btn btn-outline-light">Light</button>`
+
+`<button type="button" class="btn btn-outline-dark">Dark</button>`
+
 Outlined buttons are a part of Bootstrap since version 4, please be sure that you are using the right version if you are unable to get them to work.
 
 _Note: Do not include the dot in the HTML Class Attribute, referring to the classes with a dot is only used when adjusting the classes in CSS._
 
-#### More Information: 
-* <a href='https://getbootstrap.com/docs/4.0/components/buttons/' target='_blank' rel='nofollow'>Bootstrap Buttons documentation</a>
-* <a href='http://getbootstrap.com/docs/4.0/components/button-group/' target='_blank' rel='nofollow'>Bootstrap Button Group documentation</a>
+#### More Information:
+* <a href='https://getbootstrap.com/docs/4.1/components/buttons/' target='_blank' rel='nofollow'>Bootstrap Buttons documentation</a>
+* <a href='https://getbootstrap.com/docs/4.1/components/button-group/' target='_blank' rel='nofollow'>Bootstrap Button Group documentation</a>
 * [Bootstrap Get Started](/articles/bootstrap/bootstrap-get-started)


### PR DESCRIPTION
Replaced .btn-default which is no longer in use in Bootstrap 4 with .btn-secondary in all examples.
Added info about .btn-dark.
Added additional examples for outline buttons.
Updated classes for button sizes as .btn-xs is no longer in use.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
