### PR TITLE
Fixed language names on index.md

### DIFF
--- a/guide/spanish/book-recommendations/index.md
+++ b/guide/spanish/book-recommendations/index.md
@@ -73,7 +73,7 @@ _Cracking the Coding Interview: 150 Preguntas y soluciones de programación_ por
 *   [Sonrisa de amazon](https://smile.amazon.com/Cracking-Coding-Interview-Programming-Questions/dp/098478280X)
 *   ISBN-13: 978-0984782802
 
-## Sonido metálico
+## C
 
 _El lenguaje de programación C_ por Brian W. Kernighan y Dennis M. Ritchie
 
@@ -85,7 +85,7 @@ _Un libro sobre C: Programación en C_
 *   [Amazonas](https://www.amazon.com/Book-Programming-4th-Al-Kelley/dp/0201183994/ref=cm_cr_arp_d_bdcrb_top?ie=UTF8)
 *   ISBN-13: 978-0201183993
 
-## Entrevista de codificación
+## Entrevista de programación
 
 _Cracking the Coding Interview: 150 Preguntas y soluciones de programación_
 
@@ -131,7 +131,7 @@ _JavaScript y JQuery: desarrollo web front-end interactivo_
 *   [Sonrisa de amazon](https://smile.amazon.com/JavaScript-JQuery-Interactive-Front-End-Development/dp/1118531647/?pldnSite=1)
 *   ISBN-13: 978-1118531648
 
-## Pitón
+## Python
 
 _Automatiza las cosas aburridas con Python_
 


### PR DESCRIPTION
C-lang was translated as "metallic sound" (clang! maybe?, lol)
I just put C for consistency with other programming language names.
Also Python name was translated, when it shouldn't be.
It is not translated in official resources so it shouldn't be here.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
