### PR TITLE
Fixed props typo for the example to make sense and work (prop.title -> prop.text)

### DIFF
--- a/guide/english/react-native/props/index.md
+++ b/guide/english/react-native/props/index.md
@@ -34,7 +34,7 @@ This also works the same way in functional components:
 // in functional components, props will be received as a parameter 'props'
 const Header = (props) => {
   return (
-    <Text>{props.title}</Text>
+    <Text>{props.text}</Text>
   );
 };
 


### PR DESCRIPTION
Properties should be having the same name for the example to work.
Either line 37 and line 45 are {props.text} and text="Welcome"  OR {props.title} and title="Welcome"

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `master` branch of freeCodeCamp.
- [X] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
