### PR TITLE
Fixed <link> tag not being escaped

### DIFF
--- a/guide/english/react/react-router/index.md
+++ b/guide/english/react/react-router/index.md
@@ -33,7 +33,7 @@ To do this, we will be using the `<Link>` component. `<Link>` is similar to usin
 
 From the docs:
 
-The primary way to allow users to navigate around your application. <Link> will render a fully accessible anchor tag with the proper href.
+The primary way to allow users to navigate around your application. `<Link>` will render a fully accessible anchor tag with the proper href.
 To do this, let’s first create a Nav component. Our Nav component will contain `<Link>` components, and will look like this:
 
 ```javascript


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

I fixed a <link> tag not being properly escaped in index.md. It shows up correctly now.
