### PR TITLE
Add constants to blockNameify.js

### DIFF
--- a/client/utils/blockNameify.js
+++ b/client/utils/blockNameify.js
@@ -1,4 +1,6 @@
 const preFormattedBlockNames = {
+  'apis-and-microservices-certification': 'APIs and Microservices Certification',
+  'apis-and-microservices-projects': 'APIs and Microservices Projects',
   'api-projects': 'API Projects',
   'basic-css': 'Basic CSS',
   'basic-html-and-html5': 'Basic HTML and HTML5',


### PR DESCRIPTION
Added the constants, 'apis-and-microservices-certification': 'APIs and Microservices Certification',  'apis-and-microservices-projects': 'APIs and Microservices Projects', to preFormattedBLockNames as suggested by [erictleung](https://github.com/erictleung) in order to address the capitalization of the word APIs issue #28446.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #28446
