### PR TITLE
Changed to package.json to resolve build errors for jest on Travis CI

### DIFF
--- a/client/jest.config.js
+++ b/client/jest.config.js
@@ -13,6 +13,7 @@ module.exports = {
     __PATH_PREFIX__: ''
   },
   verbose: true,
+  testURL: "http://localhost/",
   transform: {
     '^.+\\.js$': '<rootDir>/jest.transform.js'
   },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "test:server": "echo 'Warning: TODO - Define Testing.'",
     "test:tools": "jest ./tools"
   },
+  "jest": {
+    "testURL": "http://localhost/"
+  },
   "devDependencies": {
     "cross-env": "^5.2.0",
     "debug": "^4.0.1",


### PR DESCRIPTION
Trying to resolve build errors in Travis CI.

![image](https://user-images.githubusercontent.com/602422/47734869-a429fc00-dc41-11e8-8eaf-288a39bb62ba.png)

Solution referenced Jest needs localhost.

ref:https://github.com/jsdom/jsdom/issues/2304

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #32724 - Travis CI Builds: SecurityError: localStorage is not available for opaque origins
