### PR TITLE
Corrected syntax for interface.

### DIFF
--- a/guide/english/csharp/interface/index.md
+++ b/guide/english/csharp/interface/index.md
@@ -31,7 +31,7 @@ and only have to change the one place where the object is created.
 
 Interface Example:
 ```csharp
-public Interface IUserFavoriteFood
+public interface IUserFavoriteFood
 {
   void AddFood();
   Task<User> EatFavoriteFood(int id);


### PR DESCRIPTION
Corrected syntax of interface. From Interface to interface (lowercase on first letter). 
If the first letter on the word interface is uppercase, this will produce an error on Visual Studio stating that: 

The type or namespace name 'Interface' could not be found (are you missing a using directive or an assembly reference?)

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
