### PR TITLE
Changed "Excluir" to "`delete`" and "desalocá-lo"por "desalocá-la"

### DIFF
--- a/guide/portuguese/cplusplus/dynamic-memory-allocation/index.md
+++ b/guide/portuguese/cplusplus/dynamic-memory-allocation/index.md
@@ -37,4 +37,4 @@ localeTitle: Alocação Dinâmica de Memória
     
     ### Perdas de memória
     
-    Os vazamentos são causados ​​quando você não consegue desalocar a memória dinâmica alocada por meio do operador `New` no final do programa. Se você não desalocá-lo com o operador Excluir, seu computador continuará criando nova memória no heap toda vez que o programa for executado. Isso faz com que o computador fique lento porque a memória não é excluída e a memória disponível diminui.
+    Os vazamentos são causados ​​quando você não consegue desalocar a memória dinâmica alocada por meio do operador `New` no final do programa. Se você não desalocá-la com o operador `delete`, seu computador continuará criando nova memória no heap toda vez que o programa for executado. Isso faz com que o computador fique lento porque a memória não é excluída e a memória disponível diminui.


### PR DESCRIPTION
Os vazamentos são causados ​​quando você não consegue desalocar a memória dinâmica alocada por meio do operador `New` no final do programa. Se você não desalocá-lo com o operador Excluir,

to: 

Os vazamentos são causados ​​quando você não consegue desalocar a memória dinâmica alocada por meio do operador `New` no final do programa. Se você não desalocá-la com o operador `delete`,

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
