### PR TITLE
[Chinese] Fix gitter href for free-code-camp-official-chat-rooms article

### DIFF
--- a/guide/chinese/meta/free-code-camp-official-chat-rooms/index.md
+++ b/guide/chinese/meta/free-code-camp-official-chat-rooms/index.md
@@ -8,16 +8,16 @@ localeTitle: 免费密码营官方聊天室
 
 **请注意，此处列出的所有聊天室均可公开访问并由搜索引擎编制索引，因此仅在私人消息中共享电子邮件地址或其他敏感信息。**
 
-[FreeCodeCamp](https://gitter.im/freecodecamp/FreeCodeCamp)我们的主要聊天室 - 闲逛和聊天生活和学习代码  
-[帮助](https://gitter.im/freecodecamp/Help)您解决来自同伴的HTML，CSS和jQuery挑战  
-[HelpJavaScript](https://gitter.im/freecodecamp/HelpJavaScript)可以帮助您解决来自同行的JavaScript和算法挑战  
-[HelpFrontEnd](https://gitter.im/freecodecamp/HelpFrontEnd)从您的同伴露营者[那里](https://gitter.im/freecodecamp/HelpFrontEnd)获得我们前端项目的帮助  
-[HelpDataViz](https://gitter.im/freecodecamp/HelpDataViz)从您的同伴露营者[那里](https://gitter.im/freecodecamp/HelpDataViz)获得我们的数据可视化项目的帮助  
-[HelpBackEnd](https://gitter.im/freecodecamp/HelpBackEnd)从您的同伴露营者[那里](https://gitter.im/freecodecamp/HelpBackEnd)获得我们后端项目的帮助  
-[CodeReview](https://gitter.im/freecodecamp/CodeReview)提供并接收您的同伴露营者对您项目的建设性反馈  
-[你可以](https://gitter.im/freecodecamp/YouCanDoThis)学习编码很难 - 在这里分享你的感受并获得道义上的支持  
-[LetsPair](https://gitter.im/FreeCodeCamp/LetsPair)找到其他可以与之配对的露营者  
-[CodingJobs](https://gitter.im/FreeCodeCamp/CodingJobs)聊聊了获取编码工作的过程，例如投资组合，网络和面试  
-[随便](https://gitter.im/freecodecamp/Casual)您可以在这里与其他露营者聊聊您的非编码兴趣  
-[贡献者](https://gitter.im/freecodecamp/Contributors)帮助我们改进开源课程  
+[FreeCodeCamp](https://gitter.im/freecodecamp/home)我们的主要聊天室 - 闲逛和聊天生活和学习代码
+[帮助](https://gitter.im/freecodecamp/Help)您解决来自同伴的HTML，CSS和jQuery挑战
+[HelpJavaScript](https://gitter.im/freecodecamp/HelpJavaScript)可以帮助您解决来自同行的JavaScript和算法挑战
+[HelpFrontEnd](https://gitter.im/freecodecamp/HelpFrontEnd)从您的同伴露营者[那里](https://gitter.im/freecodecamp/HelpFrontEnd)获得我们前端项目的帮助
+[HelpDataViz](https://gitter.im/freecodecamp/HelpDataViz)从您的同伴露营者[那里](https://gitter.im/freecodecamp/HelpDataViz)获得我们的数据可视化项目的帮助
+[HelpBackEnd](https://gitter.im/freecodecamp/HelpBackEnd)从您的同伴露营者[那里](https://gitter.im/freecodecamp/HelpBackEnd)获得我们后端项目的帮助
+[CodeReview](https://gitter.im/freecodecamp/CodeReview)提供并接收您的同伴露营者对您项目的建设性反馈
+[你可以](https://gitter.im/freecodecamp/YouCanDoThis)学习编码很难 - 在这里分享你的感受并获得道义上的支持
+[LetsPair](https://gitter.im/FreeCodeCamp/LetsPair)找到其他可以与之配对的露营者
+[CodingJobs](https://gitter.im/FreeCodeCamp/CodingJobs)聊聊了获取编码工作的过程，例如投资组合，网络和面试
+[随便](https://gitter.im/freecodecamp/Casual)您可以在这里与其他露营者聊聊您的非编码兴趣
+[贡献者](https://gitter.im/freecodecamp/Contributors)帮助我们改进开源课程
 [DataScience](https://gitter.im/freecodecamp/DataScience)帮助我们理解公共数据的演出和演出


### PR DESCRIPTION
Fix gitter href for chat rooms link for the chinese article.

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
