### PR TITLE
[Arabic] Fix official chat rooms link

### DIFF
--- a/guide/arabic/meta/free-code-camp-official-chat-rooms/index.md
+++ b/guide/arabic/meta/free-code-camp-official-chat-rooms/index.md
@@ -8,16 +8,16 @@ localeTitle: معسكر كود الرسمي غرف الدردشة
 
 **يرجى ملاحظة أن جميع غرف الدردشة المذكورة هنا يمكن الوصول إليها بشكل عام وفهرستها بواسطة محركات البحث ، لذلك لا تشارك سوى عناوين البريد الإلكتروني أو غيرها من المعلومات الحساسة في الرسائل الخاصة.**
 
-[FreeCodeCamp](https://gitter.im/freecodecamp/FreeCodeCamp) غرفة الدردشة الرئيسية لدينا - شنق ودردشة حول الحياة وتعلم رمز  
-[المساعدة في](https://gitter.im/freecodecamp/Help) الحصول على مساعدة بشأن HTML ، و CSS ، وتحديات jQuery من زملائك في المعسكر  
-[HelpJavaScript](https://gitter.im/freecodecamp/HelpJavaScript) للحصول على المساعدة في [حل مشاكل](https://gitter.im/freecodecamp/HelpJavaScript) جافا سكريبت وخوارزمية من زملائك من المعسكر  
-[HelpFront](https://gitter.im/freecodecamp/HelpFrontEnd) احصل على مساعدة في مشاريعنا الأمامية من زملائك في المعسكر  
-[HelpDataViz](https://gitter.im/freecodecamp/HelpDataViz) الحصول على مساعدة في مشاريع التصور البيانات من زملائك المعسكر  
-[HelpBackEnd](https://gitter.im/freecodecamp/HelpBackEnd) الحصول على المساعدة في مشاريعنا الخلفية من زملائك المعسكر  
-[CodeReview](https://gitter.im/freecodecamp/CodeReview) إعطاء وتلقي ردود الفعل البناءة من زملائك المعسكر الآخرين في مشاريعك  
-[YouCanDo إن](https://gitter.im/freecodecamp/YouCanDoThis) تعلم التعليمة أمر صعب - مشاركة مشاعرك والحصول على الدعم المعنوي هنا  
-[LetsPair](https://gitter.im/FreeCodeCamp/LetsPair) العثور على المعسكرين الآخرين الذين يمكنك الاقتران مع البرنامج  
-[يتحدث CodingJobs](https://gitter.im/FreeCodeCamp/CodingJobs) عن عملية الحصول على وظيفة ترميز ، مثل المحافظ ، والشبكات ، والمقابلات  
-[عارضة](https://gitter.im/freecodecamp/Casual) يمكنك الدردشة حول اهتماماتك غير المشفرة مع غيرها من المعسكر هنا  
-يساعدنا [المساهمون في](https://gitter.im/freecodecamp/Contributors) تحسين منهجنا المصدر المفتوح  
+[FreeCodeCamp](https://gitter.im/freecodecamp/home) غرفة الدردشة الرئيسية لدينا - شنق ودردشة حول الحياة وتعلم رمز
+[المساعدة في](https://gitter.im/freecodecamp/Help) الحصول على مساعدة بشأن HTML ، و CSS ، وتحديات jQuery من زملائك في المعسكر
+[HelpJavaScript](https://gitter.im/freecodecamp/HelpJavaScript) للحصول على المساعدة في [حل مشاكل](https://gitter.im/freecodecamp/HelpJavaScript) جافا سكريبت وخوارزمية من زملائك من المعسكر
+[HelpFront](https://gitter.im/freecodecamp/HelpFrontEnd) احصل على مساعدة في مشاريعنا الأمامية من زملائك في المعسكر
+[HelpDataViz](https://gitter.im/freecodecamp/HelpDataViz) الحصول على مساعدة في مشاريع التصور البيانات من زملائك المعسكر
+[HelpBackEnd](https://gitter.im/freecodecamp/HelpBackEnd) الحصول على المساعدة في مشاريعنا الخلفية من زملائك المعسكر
+[CodeReview](https://gitter.im/freecodecamp/CodeReview) إعطاء وتلقي ردود الفعل البناءة من زملائك المعسكر الآخرين في مشاريعك
+[YouCanDo إن](https://gitter.im/freecodecamp/YouCanDoThis) تعلم التعليمة أمر صعب - مشاركة مشاعرك والحصول على الدعم المعنوي هنا
+[LetsPair](https://gitter.im/FreeCodeCamp/LetsPair) العثور على المعسكرين الآخرين الذين يمكنك الاقتران مع البرنامج
+[يتحدث CodingJobs](https://gitter.im/FreeCodeCamp/CodingJobs) عن عملية الحصول على وظيفة ترميز ، مثل المحافظ ، والشبكات ، والمقابلات
+[عارضة](https://gitter.im/freecodecamp/Casual) يمكنك الدردشة حول اهتماماتك غير المشفرة مع غيرها من المعسكر هنا
+يساعدنا [المساهمون في](https://gitter.im/freecodecamp/Contributors) تحسين منهجنا المصدر المفتوح
 [يساعدنا DataScience في](https://gitter.im/freecodecamp/DataScience) فهم بياناتنا [ومحفوظاتنا](https://gitter.im/freecodecamp/DataScience) من البيانات العامة


### PR DESCRIPTION
Fix gitter href for the chat rooms home page

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
