### PR TITLE
[Spanish] Fix gitter href for official chat rooms link

### DIFF
--- a/guide/spanish/meta/free-code-camp-official-chat-rooms/index.md
+++ b/guide/spanish/meta/free-code-camp-official-chat-rooms/index.md
@@ -8,16 +8,16 @@ localeTitle: Salas de chat oficiales de Code gratis
 
 **Tenga en cuenta que todas las salas de chat aquí enumeradas son de acceso público e indexadas por los motores de búsqueda, por lo que solo comparten direcciones de correo electrónico u otra información confidencial en mensajes privados.**
 
-[FreeCodeCampa](https://gitter.im/freecodecamp/FreeCodeCamp) nuestra sala de chat principal: [pasa](https://gitter.im/freecodecamp/FreeCodeCamp) el rato y charla sobre la vida y aprende a codificar  
-[Ayuda a](https://gitter.im/freecodecamp/Help) obtener ayuda con nuestros desafíos de HTML, CSS y jQuery de tus compañeros de trabajo  
-[HelpJavaScript](https://gitter.im/freecodecamp/HelpJavaScript) obtenga ayuda con nuestros desafíos de algoritmos y JavaScript de sus compañeros de trabajo  
-[HelpFrontEnd](https://gitter.im/freecodecamp/HelpFrontEnd) obtenga ayuda de nuestros compañeros de trabajo con nuestros proyectos front-end  
-[HelpDataViz](https://gitter.im/freecodecamp/HelpDataViz) recibe ayuda de nuestros compañeros de trabajo con nuestros proyectos de visualización de datos  
-[HelpBackEnd](https://gitter.im/freecodecamp/HelpBackEnd) obtener ayuda con nuestros proyectos de back-end de sus compañeros de campamento  
-[CodeReview](https://gitter.im/freecodecamp/CodeReview) ofrece y recibe comentarios constructivos de tus compañeros de trabajo sobre tus proyectos  
-[Puede hacer esto:](https://gitter.im/freecodecamp/YouCanDoThis) aprender a codificar es difícil: comparta sus sentimientos y obtenga apoyo moral aquí  
-[LetsPair](https://gitter.im/FreeCodeCamp/LetsPair) encuentra otros campistas con los que puedes emparejar el programa  
-[CodingJobs](https://gitter.im/FreeCodeCamp/CodingJobs) conversa sobre el proceso de obtención de un trabajo de codificación, como carteras, redes y entrevistas.  
-[Casual](https://gitter.im/freecodecamp/Casual) , puedes conversar sobre tus intereses no codificantes con otros campistas aquí  
-[Los](https://gitter.im/freecodecamp/Contributors) colaboradores nos ayudan a mejorar nuestro currículum de código abierto.  
+[FreeCodeCampa](https://gitter.im/freecodecamp/home) nuestra sala de chat principal: [pasa](https://gitter.im/freecodecamp/FreeCodeCamp) el rato y charla sobre la vida y aprende a codificar
+[Ayuda a](https://gitter.im/freecodecamp/Help) obtener ayuda con nuestros desafíos de HTML, CSS y jQuery de tus compañeros de trabajo
+[HelpJavaScript](https://gitter.im/freecodecamp/HelpJavaScript) obtenga ayuda con nuestros desafíos de algoritmos y JavaScript de sus compañeros de trabajo
+[HelpFrontEnd](https://gitter.im/freecodecamp/HelpFrontEnd) obtenga ayuda de nuestros compañeros de trabajo con nuestros proyectos front-end
+[HelpDataViz](https://gitter.im/freecodecamp/HelpDataViz) recibe ayuda de nuestros compañeros de trabajo con nuestros proyectos de visualización de datos
+[HelpBackEnd](https://gitter.im/freecodecamp/HelpBackEnd) obtener ayuda con nuestros proyectos de back-end de sus compañeros de campamento
+[CodeReview](https://gitter.im/freecodecamp/CodeReview) ofrece y recibe comentarios constructivos de tus compañeros de trabajo sobre tus proyectos
+[Puede hacer esto:](https://gitter.im/freecodecamp/YouCanDoThis) aprender a codificar es difícil: comparta sus sentimientos y obtenga apoyo moral aquí
+[LetsPair](https://gitter.im/FreeCodeCamp/LetsPair) encuentra otros campistas con los que puedes emparejar el programa
+[CodingJobs](https://gitter.im/FreeCodeCamp/CodingJobs) conversa sobre el proceso de obtención de un trabajo de codificación, como carteras, redes y entrevistas.
+[Casual](https://gitter.im/freecodecamp/Casual) , puedes conversar sobre tus intereses no codificantes con otros campistas aquí
+[Los](https://gitter.im/freecodecamp/Contributors) colaboradores nos ayudan a mejorar nuestro currículum de código abierto.
 [DataScience](https://gitter.im/freecodecamp/DataScience) nos ayuda a comprender nuestros conciertos y conciertos de datos públicos


### PR DESCRIPTION
Fix gitter href for chat rooms home page.

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
