### PR TITLE
[Portugese] Fix gitter href for official chat rooms link

### DIFF
--- a/guide/portuguese/meta/free-code-camp-official-chat-rooms/index.md
+++ b/guide/portuguese/meta/free-code-camp-official-chat-rooms/index.md
@@ -8,16 +8,16 @@ localeTitle: Free Chat Camp Official Chat Rooms
 
 **Observe que todas as salas de bate-papo listadas aqui são acessíveis e indexadas publicamente pelos mecanismos de pesquisa, portanto, apenas compartilhe endereços de e-mail ou outras informações confidenciais em mensagens privadas.**
 
-[FreeCodeCamp](https://gitter.im/freecodecamp/FreeCodeCamp) nossa sala de chat principal - sair e conversar sobre a vida e aprender a codificar  
-[Ajude a](https://gitter.im/freecodecamp/Help) obter ajuda com nossos desafios de HTML, CSS e jQuery de seus colegas campistas  
-[HelpJavaScript](https://gitter.im/freecodecamp/HelpJavaScript) obtém ajuda com nossos desafios de JavaScript e algoritmo de seus colegas campistas  
-[HelpFrontEnd](https://gitter.im/freecodecamp/HelpFrontEnd) obter ajuda com nossos projetos front-end de seus colegas campistas  
-[HelpDataViz](https://gitter.im/freecodecamp/HelpDataViz) obter ajuda com nossos projetos de visualização de dados de seus colegas campistas  
-[HelpBackEnd](https://gitter.im/freecodecamp/HelpBackEnd) obter ajuda com nossos projetos de back-end de seus colegas campistas  
-[A CodeReview](https://gitter.im/freecodecamp/CodeReview) fornece e recebe feedback construtivo de seus colegas campistas em seus projetos  
-[YouCanDoThis](https://gitter.im/freecodecamp/YouCanDoThis) aprender a codificar é difícil - compartilhe seus sentimentos e obtenha apoio moral aqui  
-[LetsPair](https://gitter.im/FreeCodeCamp/LetsPair) encontrar outros campistas com quem você pode emparelhar programa  
-[CodingJobs](https://gitter.im/FreeCodeCamp/CodingJobs) conversar sobre o processo de obtenção de um trabalho de codificação, como portfólios, redes e entrevistas  
-[Casual](https://gitter.im/freecodecamp/Casual) você pode conversar sobre seus interesses não-codificadores com outros campistas aqui  
-[Os](https://gitter.im/freecodecamp/Contributors) colaboradores nos ajudam a melhorar nosso currículo de código aberto  
+[FreeCodeCamp](https://gitter.im/freecodecamp/home) nossa sala de chat principal - sair e conversar sobre a vida e aprender a codificar
+[Ajude a](https://gitter.im/freecodecamp/Help) obter ajuda com nossos desafios de HTML, CSS e jQuery de seus colegas campistas
+[HelpJavaScript](https://gitter.im/freecodecamp/HelpJavaScript) obtém ajuda com nossos desafios de JavaScript e algoritmo de seus colegas campistas
+[HelpFrontEnd](https://gitter.im/freecodecamp/HelpFrontEnd) obter ajuda com nossos projetos front-end de seus colegas campistas
+[HelpDataViz](https://gitter.im/freecodecamp/HelpDataViz) obter ajuda com nossos projetos de visualização de dados de seus colegas campistas
+[HelpBackEnd](https://gitter.im/freecodecamp/HelpBackEnd) obter ajuda com nossos projetos de back-end de seus colegas campistas
+[A CodeReview](https://gitter.im/freecodecamp/CodeReview) fornece e recebe feedback construtivo de seus colegas campistas em seus projetos
+[YouCanDoThis](https://gitter.im/freecodecamp/YouCanDoThis) aprender a codificar é difícil - compartilhe seus sentimentos e obtenha apoio moral aqui
+[LetsPair](https://gitter.im/FreeCodeCamp/LetsPair) encontrar outros campistas com quem você pode emparelhar programa
+[CodingJobs](https://gitter.im/FreeCodeCamp/CodingJobs) conversar sobre o processo de obtenção de um trabalho de codificação, como portfólios, redes e entrevistas
+[Casual](https://gitter.im/freecodecamp/Casual) você pode conversar sobre seus interesses não-codificadores com outros campistas aqui
+[Os](https://gitter.im/freecodecamp/Contributors) colaboradores nos ajudam a melhorar nosso currículo de código aberto
 [DataScience](https://gitter.im/freecodecamp/DataScience) nos ajuda a entender nossos shows e shows de dados públicos


### PR DESCRIPTION
Fix gitter href for official chat rooms home page

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
