### PR TITLE
[English] Fix gitter href for official chat rooms link

### DIFF
--- a/guide/english/meta/free-code-camp-official-chat-rooms/index.md
+++ b/guide/english/meta/free-code-camp-official-chat-rooms/index.md
@@ -7,16 +7,16 @@ title: Free Code Camp Official Chat Rooms
 
 **Please note that all chat rooms listed here are publicly accessible and indexed by search engines, so only share email addresses or other sensitive information in private messages.**
 
-<a href='https://gitter.im/freecodecamp/FreeCodeCamp' target='_blank' rel='nofollow'>FreeCodeCamp</a> our main chat room - hang out and chat about life and learning to code  
-<a href='https://gitter.im/freecodecamp/Help' target='_blank' rel='nofollow'>Help</a> get help with our HTML, CSS and jQuery challenges from your fellow campers  
-<a href='https://gitter.im/freecodecamp/HelpJavaScript' target='_blank' rel='nofollow'>HelpJavaScript</a> get help with our JavaScript and algorithm challenges from your fellow campers  
-<a href='https://gitter.im/freecodecamp/HelpFrontEnd' target='_blank' rel='nofollow'>HelpFrontEnd</a> get help with our front end projects from your fellow campers  
-<a href='https://gitter.im/freecodecamp/HelpDataViz' target='_blank' rel='nofollow'>HelpDataViz</a> get help with our data visualization projects from your fellow campers  
-<a href='https://gitter.im/freecodecamp/HelpBackEnd' target='_blank' rel='nofollow'>HelpBackEnd</a> get help with our back end projects from your fellow campers  
-<a href='https://gitter.im/freecodecamp/CodeReview' target='_blank' rel='nofollow'>CodeReview</a> give and receive constructive feedback from your fellow campers on your projects  
-<a href='https://gitter.im/freecodecamp/YouCanDoThis' target='_blank' rel='nofollow'>YouCanDoThis</a> learning to code is hard - share your feelings and get moral support here  
-<a href='https://gitter.im/FreeCodeCamp/LetsPair' target='_blank' rel='nofollow'>LetsPair</a> find other campers with whom you can pair program  
-<a href='https://gitter.im/FreeCodeCamp/CodingJobs' target='_blank' rel='nofollow'>CodingJobs</a> chat about the process of getting a coding job, such as portfolios, networking, and interviewing  
-<a href='https://gitter.im/freecodecamp/Casual' target='_blank' rel='nofollow'>Casual</a> you can chat about your non-coding interests with other campers here  
-<a href='https://gitter.im/freecodecamp/Contributors' target='_blank' rel='nofollow'>Contributors</a> help us improve our open source curriculum  
+<a href='https://gitter.im/freecodecamp/home' target='_blank' rel='nofollow'>FreeCodeCamp</a> our main chat room - hang out and chat about life and learning to code
+<a href='https://gitter.im/freecodecamp/Help' target='_blank' rel='nofollow'>Help</a> get help with our HTML, CSS and jQuery challenges from your fellow campers
+<a href='https://gitter.im/freecodecamp/HelpJavaScript' target='_blank' rel='nofollow'>HelpJavaScript</a> get help with our JavaScript and algorithm challenges from your fellow campers
+<a href='https://gitter.im/freecodecamp/HelpFrontEnd' target='_blank' rel='nofollow'>HelpFrontEnd</a> get help with our front end projects from your fellow campers
+<a href='https://gitter.im/freecodecamp/HelpDataViz' target='_blank' rel='nofollow'>HelpDataViz</a> get help with our data visualization projects from your fellow campers
+<a href='https://gitter.im/freecodecamp/HelpBackEnd' target='_blank' rel='nofollow'>HelpBackEnd</a> get help with our back end projects from your fellow campers
+<a href='https://gitter.im/freecodecamp/CodeReview' target='_blank' rel='nofollow'>CodeReview</a> give and receive constructive feedback from your fellow campers on your projects
+<a href='https://gitter.im/freecodecamp/YouCanDoThis' target='_blank' rel='nofollow'>YouCanDoThis</a> learning to code is hard - share your feelings and get moral support here
+<a href='https://gitter.im/FreeCodeCamp/LetsPair' target='_blank' rel='nofollow'>LetsPair</a> find other campers with whom you can pair program
+<a href='https://gitter.im/FreeCodeCamp/CodingJobs' target='_blank' rel='nofollow'>CodingJobs</a> chat about the process of getting a coding job, such as portfolios, networking, and interviewing
+<a href='https://gitter.im/freecodecamp/Casual' target='_blank' rel='nofollow'>Casual</a> you can chat about your non-coding interests with other campers here
+<a href='https://gitter.im/freecodecamp/Contributors' target='_blank' rel='nofollow'>Contributors</a> help us improve our open source curriculum
 <a href='https://gitter.im/freecodecamp/DataScience' target='_blank' rel='nofollow'>DataScience</a> help us understand our gigs and gigs of public data

--- a/guide/english/meta/free-code-camp-official-chat-rooms/index.md
+++ b/guide/english/meta/free-code-camp-official-chat-rooms/index.md
@@ -1,22 +1,24 @@
 ---
 title: Free Code Camp Official Chat Rooms
 ---
-### Note: if you came here because you saw a message that one of the chat rooms you're a member of is closing, please [go here](//forum.freecodecamp.com/t/simplifying-fccs-gitter-chatrooms/37621).
+
+### Note: if you came here because you saw a message that one of the chat rooms you're a member of is closing, please [see this post on our forum](//forum.freecodecamp.com/t/simplifying-fccs-gitter-chatrooms/37621).
 
 # The following are our official chat rooms.
 
 **Please note that all chat rooms listed here are publicly accessible and indexed by search engines, so only share email addresses or other sensitive information in private messages.**
 
-<a href='https://gitter.im/freecodecamp/home' target='_blank' rel='nofollow'>FreeCodeCamp</a> our main chat room - hang out and chat about life and learning to code
-<a href='https://gitter.im/freecodecamp/Help' target='_blank' rel='nofollow'>Help</a> get help with our HTML, CSS and jQuery challenges from your fellow campers
-<a href='https://gitter.im/freecodecamp/HelpJavaScript' target='_blank' rel='nofollow'>HelpJavaScript</a> get help with our JavaScript and algorithm challenges from your fellow campers
-<a href='https://gitter.im/freecodecamp/HelpFrontEnd' target='_blank' rel='nofollow'>HelpFrontEnd</a> get help with our front end projects from your fellow campers
-<a href='https://gitter.im/freecodecamp/HelpDataViz' target='_blank' rel='nofollow'>HelpDataViz</a> get help with our data visualization projects from your fellow campers
-<a href='https://gitter.im/freecodecamp/HelpBackEnd' target='_blank' rel='nofollow'>HelpBackEnd</a> get help with our back end projects from your fellow campers
-<a href='https://gitter.im/freecodecamp/CodeReview' target='_blank' rel='nofollow'>CodeReview</a> give and receive constructive feedback from your fellow campers on your projects
-<a href='https://gitter.im/freecodecamp/YouCanDoThis' target='_blank' rel='nofollow'>YouCanDoThis</a> learning to code is hard - share your feelings and get moral support here
-<a href='https://gitter.im/FreeCodeCamp/LetsPair' target='_blank' rel='nofollow'>LetsPair</a> find other campers with whom you can pair program
-<a href='https://gitter.im/FreeCodeCamp/CodingJobs' target='_blank' rel='nofollow'>CodingJobs</a> chat about the process of getting a coding job, such as portfolios, networking, and interviewing
-<a href='https://gitter.im/freecodecamp/Casual' target='_blank' rel='nofollow'>Casual</a> you can chat about your non-coding interests with other campers here
-<a href='https://gitter.im/freecodecamp/Contributors' target='_blank' rel='nofollow'>Contributors</a> help us improve our open source curriculum
-<a href='https://gitter.im/freecodecamp/DataScience' target='_blank' rel='nofollow'>DataScience</a> help us understand our gigs and gigs of public data
+- [FreeCodeCamp](https://gitter.im/freecodecamp/home) - our list of chat room
+- [Help](https://gitter.im/freecodecamp/Help) - get help with our HTML, CSS and jQuery challenges from your fellow campers
+- [HelpJavaScript](https://gitter.im/freecodecamp/HelpJavaScript) - get help with our JavaScript and algorithm challenges from your fellow campers
+- [HelpFrontEnd](https://gitter.im/freecodecamp/HelpFrontEnd) - get help with our front end projects from your fellow campers
+- [HelpDataViz](https://gitter.im/freecodecamp/HelpDataViz) - get help with our data visualization projects from your fellow campers
+- [HelpBackEnd](https://gitter.im/freecodecamp/HelpBackEnd) - get help with our back end projects from your fellow campers
+- [CodeReview](https://gitter.im/freecodecamp/CodeReview) - give and receive constructive feedback from your fellow campers on your projects
+- [YouCanDoThis](https://gitter.im/freecodecamp/YouCanDoThis) - learning to code is hard - share your feelings and get moral support here
+- [LetsPair](https://gitter.im/FreeCodeCamp/LetsPair) - find other campers with whom you can pair program
+- [PairProgrammingWomen](https://gitter.im/FreeCodeCamp/PairProgrammingWomen) - This room is for women looking to pair program
+- [DataScience](https://gitter.im/freecodecamp/DataScience) - help us understand our gigs and gigs of public data
+- [Python](https://gitter.im/FreeCodeCamp/python) - Discuss Python and related coding tools and get help 
+- [Linux](https://gitter.im/FreeCodeCamp/linux) - This is the best place to discuss Linux and get help with Linux 
+- [Contributors](https://gitter.im/freecodecamp/Contributors) - help us improve our open source curriculum


### PR DESCRIPTION
Fix href for gitter chat rooms home page.

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
