### PR TITLE
Fix Webstorm href

### DIFF
--- a/guide/english/tools/source-code-editors/index.md
+++ b/guide/english/tools/source-code-editors/index.md
@@ -62,7 +62,7 @@ Its main features are:
 *   Build-in Git - Review diffs, stage files, make commits, push and pull, all available in the editor.
 *   Extensions - Install extensions to add new languages, themes, debuggers, and connect additional services.
 
-## <a href='https://atom.io/' target='_blank' rel='nofollow'>WebStorm</a>
+## <a href='https://www.jetbrains.com/webstorm/' target='_blank' rel='nofollow'>WebStorm</a>
 
 DON'T COMPROMISE ON DEVELOPMENT EXPERIENCE
 The smartest editor


### PR DESCRIPTION
Webstorm link was pointing to atom.io, fixed to point to Jetbrains Webstorm page.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
