### PR TITLE
Corrected erroneous translations of "Amazon"

### DIFF
--- a/guide/spanish/book-recommendations/javascript/index.md
+++ b/guide/spanish/book-recommendations/javascript/index.md
@@ -9,7 +9,7 @@ _JavaScript elocuente_
 Uno de los mejores libros en JavaScript. Una necesidad para los programadores principiantes e intermedios, que codifican en JavaScript. La mejor parte es que el libro electrónico está disponible de forma gratuita.
 
 *   [E-libro](https://eloquentjavascript.net/) (gratis)
-*   [Amazonas](https://www.amazon.com/gp/product/1593275846/ref=as_li_qf_sp_asin_il_tl?ie=UTF8&camp=1789&creative=9325&creativeASIN=1593275846&linkCode=as2&tag=marijhaver-20&linkId=VPXXXSRYC5COG5R5)
+*   [Versión Kindle, Amazon](https://www.amazon.com/gp/product/1593275846/ref=as_li_qf_sp_asin_il_tl?ie=UTF8&camp=1789&creative=9325&creativeASIN=1593275846&linkCode=as2&tag=marijhaver-20&linkId=VPXXXSRYC5COG5R5)
 
 _No sabes js_
 
@@ -18,11 +18,15 @@ Seis series de libros de Kyle Simpson. Serie en profundidad sobre todos los aspe
 *   [Github](https://github.com/getify/You-Dont-Know-JS) (gratis)
 *   [Versión Kindle, Amazon](https://www.amazon.com/You-Dont-Know-Js-Book/dp/B01AY9P0P6)
 
-_JavaScript: Las partes buenas_ Libro del "abuelo" de JavaScript, Douglas Crockford. Discute las partes "buenas" y "malas" de JavaScript.
+_JavaScript: Las partes buenas_ 
 
-*   [Amazonas](https://www.amazon.com/JavaScript-Good-Parts-Douglas-Crockford/dp/0596517742)
+Libro del "abuelo" de JavaScript, Douglas Crockford. Discute las partes "buenas" y "malas" de JavaScript.
 
-_JavaScript: Información_ Una colección de artículos que cubren los conceptos básicos (lenguaje central y trabajar con un navegador), así como temas avanzados con explicaciones concisas. Disponible como libro electrónico de pago y también como tutorial en línea.
+*   [Versión Kindle, Amazon](https://www.amazon.com/JavaScript-Good-Parts-Douglas-Crockford/dp/0596517742)
+
+_JavaScript: Información_ 
+
+Una colección de artículos que cubren los conceptos básicos (lenguaje central y trabajar con un navegador), así como temas avanzados con explicaciones concisas. Disponible como libro electrónico de pago y también como tutorial en línea.
 
 *   [En línea](https://javascript.info/)
 *   [Libro electronico](https://javascript.info/ebook)


### PR DESCRIPTION
Amazon was translated as "Amazonas", due it's the literal translation but, in this case being the name of a company, it souldn't be translated. The bad translationas was replaced as "Versión Kindle, Amazon" which gives more and exact info about the url.

Added 2 new lines to_Javascript: las partes buenas_ to make it coherent with previous book's descriptions
Added 2 new lines to_Javascript: Informacion_ to make it coherent with previous book's descriptions

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ ] My pull request targets the `master` branch of freeCodeCamp.
- [ ] None of my changes are plagiarized from another source without proper attribution.
- [ ] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
