### PR TITLE
adding text to correct the sentence

### DIFF
--- a/guide/english/python/ord-function/index.md
+++ b/guide/english/python/ord-function/index.md
@@ -4,7 +4,7 @@ title: Python Ord Function
 
 ## Ord function
 
-`ord()` is a built-in function in Python 3, to convert the string representing one Unicode character into integer 
+`ord()` is a built-in function in Python 2.7 & 3, to convert the string representing one Unicode character into integer 
 representing the Unicode code of the character.
 
 #### Examples:
@@ -17,7 +17,7 @@ representing the Unicode code of the character.
 
 ## chr function
 
-`chr()` is a built-in function in Python 3, to convert the integer 
+`chr()` is a built-in function in Python 2.7 & 3, to convert the integer 
 representing the Unicode code into a string representing a corresponding character.
 
 #### Examples:


### PR DESCRIPTION
Ord() and Chr() exists in both python 2.7 as well as python 3. The sentence was incorrect to state its only available in Python 3

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.
