### PR TITLE
Removed btn-default. added btn-secondary

### DIFF
--- a/guide/english/bootstrap/buttons/index.md
+++ b/guide/english/bootstrap/buttons/index.md
@@ -25,13 +25,13 @@ This is a list of the CSS classes that bootstrap provides for buttons.
 
 `<button type="button" class="btn">Basic</button>`
 
-`.btn-default` Bootstrap's default button.
-
-`<button type="button" class="btn btn-default">Default</button>`
-
 `.btn-primary` Bootstrap's primary button.
 
 `<button type="button" class="btn btn-primary">Primary</button>`
+
+`.btn-secondary` Bootstrap's secondary button.
+
+`<button type="button" class="btn btn-secondary">Secondary</button>`
 
 `.btn-success` Bootstrap's success button.
 


### PR DESCRIPTION
btn-default class has been renamed to btn-secondary in 4.0 verson and is no longer used.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x ] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [ x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x ] My pull request targets the `master` branch of freeCodeCamp.
- [ x] None of my changes are plagiarized from another source without proper attribution.
- [x ] My article does not contain shortened URLs or affiliate links.