### PR TITLE
[fix] Data Structures: Create a Circular Queue challenge example

### DIFF
--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/create-a-circular-queue.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/create-a-circular-queue.english.md
@@ -6,24 +6,46 @@ challengeType: 1
 
 ## Description
 <section id='description'>
-In this challenge you will be creating a Circular Queue. A circular queue is basically a queue that writes to the end of a collection then begins over writing itself at the beginning of the collection. This is type of data structure has some useful applications in certain situations. For example, a circular queue can be used for streaming media. Once the queue is full, new media data simply begins to overwrite old data.
+In this challenge you will be creating a Circular Queue. A circular queue is a queue that writes to the end of a collection then begins overwriting itself at the beginning of the collection. This type of data structure is useful in certain situations.  For example, a circular queue can be used for streaming media. Once the queue is full, new media data will overwrite old data.
+
 A good way to illustrate this concept is with an array of length `5`:
   
-<blockquote>[null, null, null, null, null]<br> ^Read @ 0<br> ^Write @ 0</blockquote>
-Here the read and write are both at position <code>0</code>. Now the queue gets 3 new records <code>a</code>, <code>b</code>, and <code>c</code>. Our queue now looks like:
-<blockquote>[a, b, c, null, null]<br> ^Read @ 0<br>       ^Write @ 3</blockquote>
+```output
+[null, null, null, null, null]
+ ^Read @ 0
+ ^Write @ 0
+```
+
+Here the read and write are both at position `0`. Now the queue gets 3 new records `a`, `b`, and `c`. Our queue now looks like:
+
+```output
+[a, b, c, null, null]
+ ^Read @ 0
+          ^Write @ 3
+```
+
 As the read head reads, it can remove values or keep them:
-<blockquote>[null, null, null, null, null]<br>                   ^Read @ 3<br>                   ^Write @ 3</blockquote>
-Once the write reaches the end of the array it loops back to the beginning:
-<blockquote>[f, null, null, d, e]<br>                ^Read @ 3<br> ^Write @ 1</blockquote>
+```output
+[null, null, null, null, null]
+                   ^Read @ 3
+                   ^Write @ 3
+```
+
+Now we write the values `d`, `e`, and `f` to the queue.  Once the write reaches the end of the array it loops back to the beginning:
+```output
+[f, null, null, d, e]
+                ^Read @ 3
+    ^Write @ 1
+```
+
 This approach requires a constant amount of memory but allows files of a much larger size to be processed.
-Instructions:
-In this challenge we will implement a circular queue. The circular queue should provide <code>enqueue</code> and <code>dequeue</code> methods which allow you to read from and write to the queue. The class itself should also accept an integer which you can use to specify the size of the queue when you create it. We've written the starting version of this class for you in the code editor. When you enqueue items to the queue, the write pointer should advance forward and loop back to the beginning once it reaches the end of the queue. Likewise, the read pointer should advance forward as you dequeue items. The write pointer should not be allowed to move past the read pointer (our class won't let you overwrite data you haven't read yet) and the read pointer should not be able to advance past data you have written.
-In addition, the <code>enqueue</code> method should return the item you enqueued if it is successfully and otherwise return <code>null</code>. Similarly, when you dequeue an item it should be returned and if you cannot dequeue you should return <code>null</code>.
 </section>
 
 ## Instructions
 <section id='instructions'>
+
+In this challenge we will implement a circular queue. The circular queue should provide `enqueue` and `dequeue` methods which allow you to read from and write to the queue. The class itself should also accept an integer argument which you can use to specify the size of the queue when created. We've written the starting version of this class for you in the code editor. When you enqueue items to the queue, the write pointer should advance forward and loop back to the beginning once it reaches the end of the queue. Likewise, the read pointer should advance forward as you dequeue items. The write pointer should not be allowed to move past the read pointer (our class won't let you overwrite data you haven't read yet) and the read pointer should not be able to advance past data you have written.
+In addition, the `enqueue` method should return the item you enqueued if it is successful; otherwise it will return `null`. Similarly, when you dequeue an item, that item should be returned and if you cannot dequeue an item you should return `null`.
 
 </section>
 

--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/create-a-circular-queue.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/create-a-circular-queue.english.md
@@ -7,12 +7,13 @@ challengeType: 1
 ## Description
 <section id='description'>
 In this challenge you will be creating a Circular Queue. A circular queue is basically a queue that writes to the end of a collection then begins over writing itself at the beginning of the collection. This is type of data structure has some useful applications in certain situations. For example, a circular queue can be used for streaming media. Once the queue is full, new media data simply begins to overwrite old data.
-A good way to illustrate this concept is with an array:
-<blockquote>[1, 2, 3, 4, 5]<br> ^Read @ 0<br> ^Write @ 0</blockquote>
+A good way to illustrate this concept is with an array of length `5`:
+  
+<blockquote>[null, null, null, null, null]<br> ^Read @ 0<br> ^Write @ 0</blockquote>
 Here the read and write are both at position <code>0</code>. Now the queue gets 3 new records <code>a</code>, <code>b</code>, and <code>c</code>. Our queue now looks like:
-<blockquote>[a, b, c, 4, 5]<br> ^Read @ 0<br>       ^Write @ 3</blockquote>
+<blockquote>[a, b, c, null, null]<br> ^Read @ 0<br>       ^Write @ 3</blockquote>
 As the read head reads, it can remove values or keep them:
-<blockquote>[null, null, null, 4, 5]<br>                   ^Read @ 3<br>                   ^Write @ 3</blockquote>
+<blockquote>[null, null, null, null, null]<br>                   ^Read @ 3<br>                   ^Write @ 3</blockquote>
 Once the write reaches the end of the array it loops back to the beginning:
 <blockquote>[f, null, null, d, e]<br>                ^Read @ 3<br> ^Write @ 1</blockquote>
 This approach requires a constant amount of memory but allows files of a much larger size to be processed.
@@ -64,13 +65,11 @@ class CircularQueue {
         this.queue.push(null);
         size--;
      }
-
    }
 
    print() {
      return this.queue;
    }
-
 
    enqueue(item) {
     // Only change code below this line
@@ -98,46 +97,51 @@ class CircularQueue {
 
 ```js
 class CircularQueue {
- constructor(size) {
- this.queue = [];
- this.read = 0;
- this.write = 0;
- this.max = size - 1;
- while (size > 0) {
- this.queue.push(null);
- size--;
- }
- }
- print() {
- return this.queue;
- }
- enqueue(item) {
- if (this.queue[this.write] === null) {
- this.queue[this.write] = item;
- if (this.write === this.max) {
- this.write = 0;
- } else {
- this.write++;
- }
- return item;
- }
- return null;
- }
- dequeue() {
- if (this.queue[this.read] !== null) {
- var item = this.queue[this.read];
- this.queue[this.read] = null;
- if (this.read === this.max) {
- this.read = 0;
- } else {
- this.read++;
- }
- return item;
- } else {
- return null;
- }
- }
- }
+  constructor(size) {
+    this.queue = [];
+    this.read = 0;
+    this.write = 0;
+    this.max = size - 1;
+
+    while (size > 0) {
+      this.queue.push(null);
+      size--;
+    }
+  }
+
+  print() {
+    return this.queue;
+  }
+
+  enqueue(item) {
+    // Only change code below this line
+    console.log(this.write, this.max);
+    if (this.queue[this.write] === null) {
+      this.queue[this.write++] = item;
+
+      if (this.write > this.max) {
+        this.write = 0;
+      }
+      return item;
+    }
+    return null;
+    // Only change code above this line
+  }
+
+  dequeue() {
+    // Only change code below this line
+    if (this.queue[this.read] !== null) {
+      let item = this.queue[this.read];
+      this.queue[this.read++] = null;
+      if (this.read > this.max) {
+        this.read = 0;
+      }
+      return item;
+    }
+    return null;
+    // Only change code above this line
+  }
+}
 ```
 
 </section>


### PR DESCRIPTION
The current example shown in the [challenge](https://learn.freecodecamp.org/coding-interview-prep/data-structures/create-a-circular-queue) suggests that the `^Write` pointer can overwrite the existing queue values bypassing `^Read` pointer. Example:
```
[1, 2, 3, 4, 5]
^Read @ 0
^Write @ 0
```
To:
```
[a, b, c, 4, 5]
^Read @ 0
^Write @ 3
```
The elements in the first example are suppose to show the nth term of the array but it comes off as the value instead.
From the text challenge:
> **The write pointer should not be allowed to move past the read pointer** (our class won't let you overwrite data you haven't read yet) and the read pointer should not be able to advance past data you have written.

This PR improves this example so theres no ambiguity in the text and improves the current solution.

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
