### PR TITLE
Removed .btn-md and .btn-xs classes

### DIFF
--- a/guide/english/bootstrap/buttons/index.md
+++ b/guide/english/bootstrap/buttons/index.md
@@ -68,21 +68,13 @@ This is a list of the CSS classes for different size of the buttons.
 
 `<button type="button" class="btn btn-lg">Large</button>`
 
-`.btn-md` This is bootstrap's medium button.
-
-`<button type="button" class="btn btn-md">Medium</button>`
-
 `.btn-sm` Bootstrap's small button.
 
 `<button type="button" class="btn btn-sm">Small</button>`
 
-`.btn-xs` This is bootstrap's extra small button.
+`.btn-block` Bootstrap's block level button, it spans the full width of a parent element.
 
-`<button type="button" class="btn btn-xs">Extra Small</button>`
-
-`.btn-block` This is bootstrap's full width button.
-
-<button type="button" class="btn btn-block">Block</button>
+`<button type="button" class="btn btn-block">Block button</button>`
 
 #### Bootstrap Outlined Buttons:
 It is possible to also have outlined buttons rather than fully colored in ones. This is achieved by placing the mid fix `outline` between the button class you want. A sample usage would be as follows:


### PR DESCRIPTION
* Removed .btn-md class examples, it is no longer used in Bootstrap 4
* Removed .btn-xs class examples, it is no longer used in Bootstrap 4
* Fixed .btn-block example and updated definition to be more understandable

_.btn-md and .btn-xs are no longer used because .btn-sm and .btn-lg have different sizes compared to Bootstrap 3._


- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.