### PR TITLE
 fix: update chunky monkey code solution links

### DIFF
--- a/guide/english/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/chunky-monkey/index.md
+++ b/guide/english/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/chunky-monkey/index.md
@@ -181,7 +181,7 @@ Finally, we need a method to do the actual splitting and we can use `Array.slice
       }
     }
 ```
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":rocket:") <a href='https://repl.it/CLjU/579' target='_blank' rel='nofollow'>Run Code</a>
+![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":rocket:") <a href='https://repl.it/repls/WideBriskMining' target='_blank' rel='nofollow'>Run Code</a>
 
 ### Code Explanation:
 
@@ -191,7 +191,7 @@ Finally, we need a method to do the actual splitting and we can use `Array.slice
 #### Relevant Links
 
 *   <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Functions#Recursion' target='_blank' rel='nofollow'>Recursion</a>
-*   <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice' target='_blank' rel='nofollow'>Array.splice()</a>
+*   <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice' target='_blank' rel='nofollow'>Array.slice()</a>
 
 ## ![:clipboard:](https://forum.freecodecamp.com/images/emoji/emoji_one/clipboard.png?v=3 ":clipboard:") NOTES FOR CONTRIBUTIONS:
 


### PR DESCRIPTION
advanced code solution 3 links:
1. solution code shows 'slice' being used, but relevant link directed to 'splice'-- link now sends to 'slice'
2. 'run code' link showed adv code solution 2-- link now sends to code used in adv code solution 3

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
