### PR TITLE
fix: update intermediate solution

### DIFF
--- a/guide/english/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/sum-all-odd-fibonacci-numbers/index.md
+++ b/guide/english/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/sum-all-odd-fibonacci-numbers/index.md
@@ -89,7 +89,8 @@ As you get the next odd one, don't forget to add it to a global variable that ca
         }
 
         // Sum only the odd numbers and return the value
-        return arrFib.reduce((acc, curr) => {
+        // First, reverse the array to avoid starting acc with the first/greater number when it's even
+        return arrFib.reverse().reduce((acc, curr) => {
             return acc + curr * (curr % 2);
         });
     }


### PR DESCRIPTION
Intermediate code solution doesn't pass tests when the greater number is even because it's the starting acc without passing the reducer function that avoids even number.
Proposed solution: reverse the array before reduce.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
