### PR TITLE
Added missing link for JS regex resources

### DIFF
--- a/guide/english/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/search-and-replace/index.md
+++ b/guide/english/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/search-and-replace/index.md
@@ -102,7 +102,7 @@ You will create a program that takes a sentence, then search for a word in it an
 
 #### Relevant Links
 
-*   <a>JS Regex Resources</a>
+*   <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions' target='_blank' rel='nofollow'>JS Regex Resources</a>
 
 ## ![:rotating_light:](https://forum.freecodecamp.com/images/emoji/emoji_one/rotating_light.png?v=3 ":rotating_light:") Advanced Code Solution:
 


### PR DESCRIPTION
JS regex resources link above advanced solution wasn't referencing any webpage. Updated it to link to MDN's regular expressions guide.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x ] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x ] My pull request targets the `master` branch of freeCodeCamp.
- [x ] None of my changes are plagiarized from another source without proper attribution.
- [x ] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
