### PR TITLE
Fix: Navbar Alignment in Night Mode on Curriculum Page

### DIFF
--- a/client/src/components/layouts/layout.css
+++ b/client/src/components/layouts/layout.css
@@ -623,5 +623,5 @@ pre tt:after {
   }
 }
 .default-layout {
-  margin-top: 38px;
+  margin-top: 34px;
 }


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #29296 
--
The problem wasn't actually with the navbar itself, but the alignment of the div below it. 
You can actually see this in bright mode as well, it's just that the colours happen to be matching.
The top margin was 2px too large so I shortened it. 

Also yes, despite what I commented in the issue you can't actually see this bug when you run it locally 
(I replicated the error by increasing the top margin by 2 pixels) 
So just in case, I shrunk the margin by 4px 😃 
