### PR TITLE
fix: Update the standard email sent upon completing all certifications

### DIFF
--- a/api-server/server/boot/certificate.js
+++ b/api-server/server/boot/certificate.js
@@ -181,7 +181,7 @@ function sendCertifiedEmail(
   const notifyUser = {
     type: 'email',
     to: email,
-    from: 'team@freeCodeCamp.org',
+    from: 'quincy@freecodecamp.org',
     subject: dedent`
       Congratulations on completing all of the
       freeCodeCamp certifications!


### PR DESCRIPTION
The issue was to change the email account that is **team@freecodecamp.org** to **quincy@freecodecamp.org**. And that the email is sent when the Fullstack certificate is claimed, but this is already implemented.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #34380 
