### PR TITLE
Correct order of FCC local setup

### DIFF
--- a/docs/how-to-setup-freecodecamp-locally.md
+++ b/docs/how-to-setup-freecodecamp-locally.md
@@ -140,14 +140,7 @@ Please avoid creating GitHub issues for pre-requisite issues. They are out of th
 
 ### Installing dependencies
 
-Start by installing the dependencies required for the application to startup.
-
-```shell
-# Install NPM dependencies
-npm install
-```
-
-Then you need to add the private environment variables (API Keys):
+First you need to add the private environment variables (API Keys):
 
 ```shell
 # Create a copy of the "sample.env" and name it as ".env".
@@ -158,6 +151,13 @@ cp sample.env .env
 
 # Windows
 copy sample.env .env
+```
+
+Then you have to install the dependencies required for the application to startup.
+
+```shell
+# Install NPM dependencies
+npm install
 ```
 
 The keys are not required to be changed, to run the app locally. You can leave the default values from the `sample.env` as it is.


### PR DESCRIPTION
Before the `sample.env` copying file part was after `npm install` which also executes the command `npm run ensure-env`. But `ensure-env` requires the `HOME_LOCATION, API_LOCATION, FORUM_LOCATION, FORUM_PROXY_LOCATION and LOCALE` which is given by the `.env` file and creates issues later on when seeding the database as the values were never passed before it was executed. So the copying part has been moved to before the installation of the dependencies.

**cc** - @cmccormack @raisedadead  

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
