### PR TITLE
[Fix] Try to fix Legacy Full Stack Cert not displaying

### DIFF
--- a/client/src/components/profile/components/Certifications.js
+++ b/client/src/components/profile/components/Certifications.js
@@ -23,6 +23,7 @@ const mapStateToProps = (state, props) =>
       isFrontEndCert,
       isBackEndCert,
       isDataVisCert,
+      is2018FullStackCert,
       isFullStackCert
     }) => ({
       hasModernCert:
@@ -32,11 +33,11 @@ const mapStateToProps = (state, props) =>
         isJsAlgoDataStructCert ||
         isApisMicroservicesCert ||
         isInfosecQaCert ||
-        isFullStackCert,
-      hasLegacyCert: isFrontEndCert || isBackEndCert || isDataVisCert,
+        is2018FullStackCert,
+      hasLegacyCert: isFrontEndCert || isBackEndCert || isDataVisCert || isFullStackCert,
       currentCerts: [
         {
-          show: isFullStackCert,
+          show: is2018FullStackCert,
           title: 'Full Stack Certification',
           showURL: 'full-stack'
         },


### PR DESCRIPTION
This PR aims to fix the issue with Legacy Full Stack Certification not displaying, the only thing which I think of can be wrong with my changes is that the order in which the boolean variables to which whether the user has the certificate or not is assigned.

I request someone from the team who has worked on this before maybe @Bouncey can guide me to whether the order is correct or not and if not, what is the correct order.

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #18253 
