### PR TITLE
fix: Add '/unauthenticated' route for donations

### DIFF
--- a/server/boot/donate.js
+++ b/server/boot/donate.js
@@ -1,8 +1,10 @@
 import Stripe from 'stripe';
 import keys from '../../config/secrets';
+import debug from 'debug';
+
+const log = debug('fcc:boot:donate');
 
 export default function donateBoot(app, done) {
-
   let stripe = false;
   const { User } = app.models;
   const api = app.loopback.Router();
@@ -17,11 +19,12 @@ export default function donateBoot(app, done) {
           name:
             'Monthly Donation to freeCodeCamp.org - ' +
             `Thank you ($${current / 100})`
-          },
-          currency: 'usd',
-          id: `monthly-donation-${current}`
+        },
+        currency: 'usd',
+        id: `monthly-donation-${current}`
       }
-    }), {}
+    }),
+    {}
   );
 
   function connectToStripe() {
@@ -55,22 +58,38 @@ export default function donateBoot(app, done) {
         throw err;
       }
       console.log(`${plan.id} created`);
-        return;
-      });
+      return;
+    });
   }
 
-  function createStripeDonation(req, res) {
-    const { user, body } = req;
+  function createStripeDonation(req, res, next) {
+    const { body } = req;
 
     if (!body || !body.amount) {
       return res.status(400).send({ error: 'Amount Required' });
     }
 
-    const { amount, token: {email, id} } = body;
+    const {
+      amount,
+      // `token` is generated client-side by the stripe package
+      token: { email, id }
+    } = body;
 
-    const fccUser = user ?
-            Promise.resolve(user) :
-            User.create$({ email }).toPromise();
+    log(amount);
+    log(email);
+    const fccUserPromise = new Promise((resolve, reject) =>
+      User.findOrCreate(
+        { where: { email } },
+        { email },
+        (err, userInstance, createdNewUser) => {
+          if (err) {
+            return reject(err);
+          }
+          log('created a new user', createdNewUser);
+          return resolve(userInstance);
+        }
+      )
+    );
 
     let donatingUser = {};
     let donation = {
@@ -80,42 +99,46 @@ export default function donateBoot(app, done) {
       startDate: new Date(Date.now()).toISOString()
     };
 
-    return fccUser.then(
-      user => {
+    return fccUserPromise
+      .then(user => {
         donatingUser = user;
-        return stripe.customers
-          .create({
-            email,
-            card: id
-          });
-    })
-    .then(customer => {
-      donation.customerId = customer.id;
-      return stripe.subscriptions.create({
-        customer: customer.id,
-        items: [
-          {
-            plan: `monthly-donation-${amount}`
-          }
-        ]
-      });
-    })
-    .then(subscription => {
-      donation.subscriptionId = subscription.id;
-      return res.send(subscription);
-    })
-    .then(() => {
-      donatingUser.createDonation(donation).toPromise()
-        .catch(err => {
-          throw new Error(err);
+        return stripe.customers.create({
+          email,
+          card: id
         });
-    })
-    .catch(err => {
-      if (err.type === 'StripeCardError') {
-        return res.status(402).send({ error: err.message });
-      }
-      return res.status(500).send({ error: 'Donation Failed' });
-    });
+      })
+      .then(customer => {
+        donation.customerId = customer.id;
+        return stripe.subscriptions.create({
+          customer: customer.id,
+          items: [
+            {
+              plan: `monthly-donation-${amount}`
+            }
+          ]
+        });
+      })
+      .then(subscription => {
+        donation.subscriptionId = subscription.id;
+        return res.send(subscription);
+      })
+      .then(() => {
+        donatingUser
+          .createDonation(donation)
+          .toPromise()
+          .catch(err => {
+            throw new Error(err);
+          });
+      })
+      .catch(err => {
+        if (err.type === 'StripeCardError') {
+          return res.status(402).send({ error: err.message });
+        }
+        log(err);
+        // we care about these errors, as they are more likely to be
+        // concerned with our implementation
+        return next(err);
+      });
   }
 
   const pubKey = keys.stripe.public;
@@ -127,13 +150,14 @@ export default function donateBoot(app, done) {
     if (process.env.NODE_ENV === 'production') {
       throw new Error('Stripe API keys are required to boot the server!');
     }
-    console.info('No Stripe API keys were found, moving on...');
+    log('No Stripe API keys were found, moving on...');
     done();
   } else {
     api.post('/charge-stripe', createStripeDonation);
     donateRouter.use('/donate', api);
     app.use(donateRouter);
     app.use('/external', donateRouter);
+    app.use('/unauthenticated', donateRouter);
     connectToStripe().then(done);
   }
 }

--- a/server/middlewares/csurf.js
+++ b/server/middlewares/csurf.js
@@ -11,7 +11,7 @@ export default function() {
   return function csrf(req, res, next) {
 
     const path = req.path.split('/')[1];
-    if (/(api|external|^p$)/.test(path)) {
+    if (/(api|external|^p$|unauthenticated)/.test(path)) {
       return next();
     }
     return protection(req, res, next);


### PR DESCRIPTION
⚠️ 🚨 🚨 ⚠️ ⚠️ 🚨 🚨 ⚠️ ⚠️ 🚨 🚨 ⚠️ ⚠️ 🚨 🚨 ⚠️ ⚠️ 🚨 🚨 ⚠️ ⚠️ 🚨 🚨 ⚠️ ⚠️ 🚨 🚨 ⚠️

## This PR is against the production branch

⚠️ 🚨 🚨 ⚠️ ⚠️ 🚨 🚨 ⚠️ ⚠️ 🚨 🚨 ⚠️ ⚠️ 🚨 🚨 ⚠️ ⚠️ 🚨 🚨 ⚠️ ⚠️ 🚨 🚨 ⚠️ ⚠️ 🚨 🚨 ⚠️ 

This PR fixes issues related to unauthenticated user trying to donate:

1. It adds an `/unauthenticated` endpoint that bypasses all csurf and jwt protections. This removes `403` errors for unauthenticated users.
1. It makes use of the native loopback API of `findOrCreate`
1. Calls `next` for unexpected errors that are possibly due to our implementation