### PR TITLE
fix(client): catch errors on replacing a challenge

### DIFF
--- a/client/plugins/fcc-source-challenges/gatsby-node.js
+++ b/client/plugins/fcc-source-challenges/gatsby-node.js
@@ -45,6 +45,13 @@ exports.sourceNodes = function sourceChallengesSourceNodes(
               return createChallengeNode(challenge, reporter);
             })
             .then(createNode)
+            .catch(e =>
+              reporter.error(`fcc-replace-challenge
+
+  ${e.message}
+
+  `)
+            )
         : null
   );
 


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [ ] My article does not contain shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Periodically when changing a challenge file, MD parser read an empty file, which causes an error on createChallengeNode, and Gatsby shutdown.

Closes #XXXXX
