### PR TITLE
chore: Pay down some tech-debt

### DIFF
--- a/client/src/redux/index.js
+++ b/client/src/redux/index.js
@@ -14,10 +14,7 @@ import failedUpdatesEpic from './failed-updates-epic';
 import updateCompleteEpic from './update-complete-epic';
 
 import { types as settingsTypes } from './settings';
-
-/** ***********************************/
-const challengeReduxTypes = {};
-/** ***********************************/
+import { types as challengeReduxTypes } from '../templates/Challenges/redux';
 
 export const ns = 'app';
 


### PR DESCRIPTION
I think this was to get the app store working before `learn` was ported over. I remember commenting it like that so I would do it correctly when possible.

It didn't break anything as we only use it here to track session challenge completions for the donation modal logic.
