### PR TITLE
feat: execute js challenges saga

### DIFF
--- a/client/src/client/frame-runner.js
+++ b/client/src/client/frame-runner.js
@@ -109,15 +109,12 @@ document.addEventListener('DOMContentLoaded', function() {
             const { message, stack } = err;
             // we catch the error here to prevent the error from bubbling up
             // and collapsing the pipe
-            let errMessage = message.slice(0) || '';
-            const assertIndex = errMessage.indexOf(': expected');
-            if (assertIndex !== -1) {
-              errMessage = errMessage.slice(0, assertIndex);
-            }
-            errMessage = errMessage.replace(/<code>(.*?)<\/code>/g, '$1');
-            newTest.err = errMessage + '\n' + stack;
+            newTest.err = message + '\n' + stack;
             newTest.stack = stack;
-            newTest.message = errMessage;
+            newTest.message = text.replace(/<code>(.*?)<\/code>/g, '$1');
+            if (!(err instanceof chai.AssertionError)) {
+              console.error(err);
+            }
             // RxJS catch expects an observable as a return
             return of(newTest);
           })

--- a/client/src/client/workers/test-evaluator.js
+++ b/client/src/client/workers/test-evaluator.js
@@ -26,10 +26,12 @@ onmessage = async e => {
     self.postMessage({
       err: {
         message: err.message,
-        stack: err.stack,
-        isAssertionError: err instanceof chai.AssertionError
+        stack: err.stack
       },
       logs: self.__logs.map(String)
     });
+    if (!(err instanceof chai.AssertionError)) {
+      console.error(err);
+    }
   }
 };

--- a/client/src/client/workers/test-evaluator.js
+++ b/client/src/client/workers/test-evaluator.js
@@ -1,0 +1,35 @@
+/* global chai, importScripts */
+importScripts('https://cdnjs.cloudflare.com/ajax/libs/chai/4.2.0/chai.min.js');
+
+const oldLog = self.console.log.bind(self.console);
+self.console.log = function proxyConsole(...args) {
+  self.__logs = [...self.__logs, ...args];
+  return oldLog(...args);
+};
+
+onmessage = async e => {
+  self.__logs = [];
+  const { script: __test, code } = e.data;
+  /* eslint-disable no-unused-vars */
+  const assert = chai.assert;
+  // Fake Deep Equal dependency
+  const DeepEqual = (a, b) => JSON.stringify(a) === JSON.stringify(b);
+  /* eslint-enable no-unused-vars */
+  try {
+    // eslint-disable-next-line no-eval
+    const testResult = eval(__test);
+    if (typeof testResult === 'function') {
+      await testResult(() => code);
+    }
+    self.postMessage({ pass: true, logs: self.__logs.map(String) });
+  } catch (err) {
+    self.postMessage({
+      err: {
+        message: err.message,
+        stack: err.stack,
+        isAssertionError: err instanceof chai.AssertionError
+      },
+      logs: self.__logs.map(String)
+    });
+  }
+};

--- a/client/src/templates/Challenges/redux/execute-challenge-epic.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-epic.js
@@ -44,6 +44,13 @@ const executeDebounceTimeout = 750;
 function updateMainEpic(action$, state$, { document }) {
   return action$.pipe(
     ofType(types.updateFile, types.challengeMounted),
+    filter(() => {
+      const { challengeType } = challengeMetaSelector(state$.value);
+      return (
+        challengeType !== challengeTypes.js &&
+        challengeType !== challengeTypes.bonfire
+      );
+    }),
     debounceTime(executeDebounceTimeout),
     switchMap(() => {
       const frameMain = createMainFramer(document, state$);
@@ -77,6 +84,8 @@ function executeChallengeEpic(action$, state$, { document }) {
         consoleProxy
       );
       const challengeResults = frameReady.pipe(
+        // Delay for jQuery ready code, in jQuery challenges
+        delay(250),
         pluck('checkChallengePayload'),
         map(checkChallengePayload => ({
           checkChallengePayload,
@@ -103,6 +112,13 @@ function executeChallengeEpic(action$, state$, { document }) {
       );
       const buildAndFrameChallenge = action$.pipe(
         ofType(types.executeChallenge),
+        filter(() => {
+          const { challengeType } = challengeMetaSelector(state$.value);
+          return (
+            challengeType !== challengeTypes.js &&
+            challengeType !== challengeTypes.bonfire
+          );
+        }),
         debounceTime(executeDebounceTimeout),
         filter(() => isJSEnabledSelector(state$.value)),
         switchMap(() => {

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -1,0 +1,81 @@
+import { takeEvery, put, select, call } from 'redux-saga/effects';
+
+import {
+  challengeMetaSelector,
+  challengeTestsSelector,
+  initConsole,
+  updateConsole,
+  initLogs,
+  updateLogs,
+  logsToConsole,
+  checkChallenge,
+  updateTests,
+  challengeFilesSelector
+} from './';
+
+import { buildJSFromFiles } from '../utils/build';
+
+import { challengeTypes } from '../../../../utils/challengeTypes';
+
+import WorkerExecutor from '../utils/worker-executor';
+
+const testWorker = new WorkerExecutor('test-evaluator');
+const testTimeout = 5000;
+
+function* ExecuteJSChallengeSaga() {
+  const { challengeType } = yield select(challengeMetaSelector);
+  const { js, bonfire } = challengeTypes;
+  if (challengeType !== js && challengeType !== bonfire) {
+    return;
+  }
+  yield put(initLogs());
+  yield put(initConsole('// running tests'));
+  try {
+    const files = yield select(challengeFilesSelector);
+    const { code, solution } = yield call(buildJSFromFiles, files);
+    const tests = yield select(challengeTestsSelector);
+    const testResults = [];
+    for (const { text, testString } of tests) {
+      const newTest = { text, testString };
+      const { pass, err, logs } = yield call(
+        testWorker.execute,
+        { script: solution + '\n' + testString, code },
+        testTimeout
+      );
+      if (pass) {
+        newTest.pass = true;
+      } else {
+        const { message, stack, isAssertionError } = err;
+        newTest.err = message + '\n' + stack;
+        newTest.stack = stack;
+        newTest.message = text.replace(/<code>(.*?)<\/code>/g, '$1');
+        yield put(updateConsole(newTest.message));
+        if (!isAssertionError) {
+          console.warn(message);
+        }
+      }
+      testResults.push(newTest);
+      for (const log of logs) {
+        yield put(updateLogs(log));
+      }
+      // kill worker for independent tests
+      yield call(testWorker.killWorker);
+    }
+    yield put(updateTests(testResults));
+    yield put(updateConsole('// tests completed'));
+    yield put(logsToConsole('// console output'));
+    yield put(checkChallenge());
+  } catch (e) {
+    if (e === 'timeout') {
+      yield put(updateConsole('Test timed out'));
+    } else {
+      yield put(updateConsole(e));
+    }
+  } finally {
+    yield call(testWorker.killWorker);
+  }
+}
+
+export function createExecuteChallengeSaga(types) {
+  return [takeEvery(types.executeChallenge, ExecuteJSChallengeSaga)];
+}

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -1,4 +1,4 @@
-import { takeEvery, put, select, call } from 'redux-saga/effects';
+import { put, select, call, takeLatest } from 'redux-saga/effects';
 
 import {
   challengeMetaSelector,
@@ -27,13 +27,13 @@ function* ExecuteChallengeSaga() {
   switch (challengeType) {
     case js:
     case bonfire:
-      yield ExecuteJSChallengeSaga();
+      yield* ExecuteJSChallengeSaga();
       break;
     case backend:
-      // yield ExecuteBackendChallengeSaga();
+      // yield* ExecuteBackendChallengeSaga();
       break;
     default:
-    // yield ExecuteDOMChallengeSaga();
+    // yield* ExecuteDOMChallengeSaga();
   }
 }
 
@@ -83,5 +83,5 @@ function* ExecuteJSChallengeSaga() {
 }
 
 export function createExecuteChallengeSaga(types) {
-  return [takeEvery(types.executeChallenge, ExecuteChallengeSaga)];
+  return [takeLatest(types.executeChallenge, ExecuteChallengeSaga)];
 }

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -22,64 +22,78 @@ const testWorker = new WorkerExecutor('test-evaluator');
 const testTimeout = 5000;
 
 function* ExecuteChallengeSaga() {
-  const { js, bonfire, backend } = challengeTypes;
-  const { challengeType } = yield select(challengeMetaSelector);
-  switch (challengeType) {
-    case js:
-    case bonfire:
-      yield* ExecuteJSChallengeSaga();
-      break;
-    case backend:
-      // yield* ExecuteBackendChallengeSaga();
-      break;
-    default:
-    // yield* ExecuteDOMChallengeSaga();
+  try {
+    const { js, bonfire, backend } = challengeTypes;
+    const { challengeType } = yield select(challengeMetaSelector);
+
+    // TODO: ExecuteBackendChallengeSaga and ExecuteDOMChallengeSaga
+    if (challengeType !== js && challengeType !== bonfire) {
+      return;
+    }
+
+    yield put(initLogs());
+    yield put(initConsole('// running tests'));
+
+    const tests = yield select(challengeTestsSelector);
+    let testResults;
+    switch (challengeType) {
+      case js:
+      case bonfire:
+        testResults = yield ExecuteJSChallengeSaga(tests);
+        break;
+      case backend:
+        // yield ExecuteBackendChallengeSaga();
+        break;
+      default:
+      // yield ExecuteDOMChallengeSaga();
+    }
+
+    yield put(updateTests(testResults));
+    yield put(updateConsole('// tests completed'));
+    yield put(logsToConsole('// console output'));
+  } catch (e) {
+    yield put(updateConsole(e));
   }
 }
 
-function* ExecuteJSChallengeSaga() {
-  yield put(initLogs());
-  yield put(initConsole('// running tests'));
-  try {
-    const files = yield select(challengeFilesSelector);
-    const { code, solution } = yield call(buildJSFromFiles, files);
-    const tests = yield select(challengeTestsSelector);
-    const testResults = [];
-    for (const { text, testString } of tests) {
-      const newTest = { text, testString };
+function* ExecuteJSChallengeSaga(tests) {
+  const testResults = [];
+  const files = yield select(challengeFilesSelector);
+  const { code, solution } = yield call(buildJSFromFiles, files);
+
+  for (const { text, testString } of tests) {
+    const newTest = { text, testString };
+    try {
       const { pass, err, logs } = yield call(
         testWorker.execute,
         { script: solution + '\n' + testString, code },
         testTimeout
       );
+      for (const log of logs) {
+        yield put(updateLogs(log));
+      }
       if (pass) {
         newTest.pass = true;
+      } else {
+        throw err;
+      }
+    } catch (err) {
+      newTest.message = text.replace(/<code>(.*?)<\/code>/g, '$1');
+      if (err === 'timeout') {
+        newTest.err = 'Test timed out';
+        newTest.message = `${newTest.message} (${newTest.err})`;
       } else {
         const { message, stack } = err;
         newTest.err = message + '\n' + stack;
         newTest.stack = stack;
-        newTest.message = text.replace(/<code>(.*?)<\/code>/g, '$1');
-        yield put(updateConsole(newTest.message));
       }
+      yield put(updateConsole(newTest.message));
+    } finally {
       testResults.push(newTest);
-      for (const log of logs) {
-        yield put(updateLogs(log));
-      }
-      // kill worker for independent tests
       yield call(testWorker.killWorker);
     }
-    yield put(updateTests(testResults));
-    yield put(updateConsole('// tests completed'));
-    yield put(logsToConsole('// console output'));
-  } catch (e) {
-    if (e === 'timeout') {
-      yield put(updateConsole('Test timed out'));
-    } else {
-      yield put(updateConsole(e));
-    }
-  } finally {
-    yield call(testWorker.killWorker);
   }
+  return testResults;
 }
 
 export function createExecuteChallengeSaga(types) {

--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -14,6 +14,7 @@ import codeStorageEpic from './code-storage-epic';
 import currentChallengeEpic from './current-challenge-epic';
 
 import { createIdToNameMapSaga } from './id-to-name-map-saga';
+import { createExecuteChallengeSaga } from './execute-challenge-saga';
 
 export const ns = 'challenge';
 export const backendNS = 'backendChallenge';
@@ -88,7 +89,10 @@ export const epics = [
   currentChallengeEpic
 ];
 
-export const sagas = [...createIdToNameMapSaga(types)];
+export const sagas = [
+  ...createIdToNameMapSaga(types),
+  ...createExecuteChallengeSaga(types)
+];
 
 export const createFiles = createAction(types.createFiles, challengeFiles =>
   Object.keys(challengeFiles)

--- a/client/src/templates/Challenges/utils/worker-executor.js
+++ b/client/src/templates/Challenges/utils/worker-executor.js
@@ -2,6 +2,10 @@ export default class WorkerExecutor {
   constructor(workerName) {
     this.workerName = workerName;
     this.worker = null;
+
+    this.execute = this.execute.bind(this);
+    this.killWorker = this.killWorker.bind(this);
+    this.getWorker = this.getWorker.bind(this);
   }
 
   getWorker() {

--- a/client/webpack-frame-runner.js
+++ b/client/webpack-frame-runner.js
@@ -6,7 +6,8 @@ module.exports = (env = {}) => {
     mode: __DEV__ ? 'development' : 'production',
     entry: {
       'frame-runner': './src/client/frame-runner.js',
-      'sass-compile': './src/client/workers/sass-compile.js'
+      'sass-compile': './src/client/workers/sass-compile.js',
+      'test-evaluator': './src/client/workers/test-evaluator.js'
     },
     devtool: __DEV__ ? 'inline-source-map' : 'source-map',
     output: {


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [ ] My article does not contain shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

Before run JS challenges we transform them by babel with a loop protect plugin. For some challenges, it prevents pass the tests. As an example for https://learn.freecodecamp.org/coding-interview-prep/project-euler/problem-10-summation-of-primes, a correct solution does not pass the tests.

This PR proposes run JS challenges without loop protect in a worker with a timeout.
