### PR TITLE
Fix match single unspecified characters hint page

### DIFF
--- a/guide/english/certifications/javascript-algorithms-and-data-structures/regular-expressions/match-single-characters-not-specified/index.md
+++ b/guide/english/certifications/javascript-algorithms-and-data-structures/regular-expressions/match-single-characters-not-specified/index.md
@@ -5,7 +5,7 @@ title: Match Single Characters Not Specified
 In this challenge, we are asked to return a collection of matches that are not exactly specified. Whereas previous regexp challenges would have you match within the character case [a-z], this challenge instead asks us to negate these matches using the caret character [^a-z]. Our goal then is to return a negated collection (non-matches) of letters that are not vowels nor numbers.
 
 ## Hint 1:
-Did you remember to surround your regexp in both brackets and slashes? 
+Did you remember to surround your regexp in both brackets and slashes?
 ```javascript
 let exampleRegExp = /[^a-z]/;
 ```

--- a/guide/english/certifications/javascript-algorithms-and-data-structures/regular-expressions/match-single-characters-not-specified/index.md
+++ b/guide/english/certifications/javascript-algorithms-and-data-structures/regular-expressions/match-single-characters-not-specified/index.md
@@ -15,9 +15,9 @@ If so, then double check you're adding the appropriate flags:
 * ^  : Negates the matches following this flag
 
 ### Hint 2:
-Be sure to check whether your number range is correct -- the challenge asks us to negate all numbers from 0-99. This can be done using the negate caret placed immediately after the first opening bracket of your regexp. 
+Be sure to check whether your number range is correct -- the challenge asks us to negate all numbers from 0 to 9. This can be done using the negate caret placed immediately after the first opening bracket of your regexp.
 ```javacsript
-let numbersRegExp = /[^0-99]/ig; 
+let numbersRegExp = /[^0-9]/ig;
 ```
 
 ### Spoiler Alert - Solution Ahead
@@ -25,6 +25,6 @@ let numbersRegExp = /[^0-99]/ig;
 ## Solution
 ```javascript
 let quoteSample = "3 blind mice.";
-let myRegex = /[^aeiou^0-99]/ig; // Change this line
+let myRegex = /[^aeiou^0-9]/ig; // Change this line
 let result = quoteSample.match(myRegex); // Change this line
 ```


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

before this commit explaining explanation mistakenly claimed that challenge does not require handling numbers above 99

also, 0-9 already matches all numbers in egexp and 0-99 is confusing, as repeating 9 is completely unnecessary
