### PR TITLE
clarify instruction in capture group

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/reuse-patterns-using-capture-groups.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/reuse-patterns-using-capture-groups.english.md
@@ -16,7 +16,7 @@ Using the <code>.match()</code> method on a string will return an array with the
 
 ## Instructions
 <section id='instructions'>
-Use <code>capture groups</code> in <code>reRegex</code> to match numbers that are repeated only three times in a string, each separated by a space.
+Use <code>capture groups</code> in <code>reRegex</code> to match string with number repeated three times, separated by a space.
 </section>
 
 ## Tests


### PR DESCRIPTION
original instruction would require match for example 'prefix 1 1 1 suffix'
new instructions are intended to make clear that string contains solely three numbers

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

