### PR TITLE
travis: container based builds have been deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ env:
     - NO_UPDATE_NOTIFIER=1
     - NODE_NO_WARNINGS=1
 
-sudo: false
-
 before_install:
   - npm config set loglevel warn
 

--- a/curriculum/.travis.yml
+++ b/curriculum/.travis.yml
@@ -27,5 +27,3 @@ deploy:
 branches:
   except:
     - /^v\d+\.\d+\.\d+$/
-
-sudo: false


### PR DESCRIPTION
We were not using sudo, but now the main images should be similarly fast. More at:
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.
