### PR TITLE
add more specific tests for username regex challenge

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/restrict-possible-usernames.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/restrict-possible-usernames.english.md
@@ -27,6 +27,10 @@ tests:
     testString: assert(userCheck.test("JACK"), 'Your regex should match <code>JACK</code>');
   - text: Your regex should not match <code>J</code>
     testString: assert(!userCheck.test("J"), 'Your regex should not match <code>J</code>');
+  - text: Your regex should not match <code>J6</code>
+    testString: assert(!userCheck.test("J6"), 'Your regex should not match <code>J6</code>');
+  - text: Your regex should match <code>Jo</code>
+    testString: assert(userCheck.test("Jo"), 'Your regex should match <code>Jo</code>');
   - text: Your regex should match <code>Oceans11</code>
     testString: assert(userCheck.test("Oceans11"), 'Your regex should match <code>Oceans11</code>');
   - text: Your regex should match <code>RegexGuru</code>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/restrict-possible-usernames.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/restrict-possible-usernames.english.md
@@ -27,8 +27,6 @@ tests:
     testString: assert(userCheck.test("JACK"), 'Your regex should match <code>JACK</code>');
   - text: Your regex should not match <code>J</code>
     testString: assert(!userCheck.test("J"), 'Your regex should not match <code>J</code>');
-  - text: Your regex should not match <code>J6</code>
-    testString: assert(!userCheck.test("J6"), 'Your regex should not match <code>J6</code>');
   - text: Your regex should match <code>Jo</code>
     testString: assert(userCheck.test("Jo"), 'Your regex should match <code>Jo</code>');
   - text: Your regex should match <code>Oceans11</code>


### PR DESCRIPTION
Since the instructions state that usernames can be two characters long, but if
so it must be alphabetic, we should test for these conditions.

These new tests should also be added to the translated versions, but I don't
have the knowledge for that.

This replaces my previous PR #19503

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

Closes #17733

