### PR TITLE
fix: update tests for difference on two sets

### DIFF
--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/perform-a-difference-on-two-sets-of-data.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/perform-a-difference-on-two-sets-of-data.english.md
@@ -23,7 +23,7 @@ tests:
   - text: Your <code>Set</code> class should have a <code>difference</code> method.
     testString: 'assert((function(){var test = new Set(); return (typeof test.difference === "function")})(), "Your <code>Set</code> class should have a <code>difference</code> method.");'
   - text: The proper collection was returned
-    testString: 'assert((function(){var setA = new Set(); var setB = new Set(); setA.add("a"); setA.add("b"); setA.add("c"); setB.add("c"); setB.add("d"); var differenceSetAB = setA.difference(setB); return (differenceSetAB.size() === 2) && DeepEqual(differenceSetAB.values(), [ 'a', 'b' ])})(), "The expected collection was not returned");'
+    testString: 'assert((function(){var setA = new Set(); var setB = new Set(); setA.add("a"); setA.add("b"); setA.add("c"); setB.add("c"); setB.add("d"); var differenceSetAB = setA.difference(setB); return (differenceSetAB.size() === 2) && DeepEqual(differenceSetAB.values(), [ "a", "b" ])})(), "The expected collection was not returned");'
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/perform-a-difference-on-two-sets-of-data.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/perform-a-difference-on-two-sets-of-data.english.md
@@ -21,9 +21,9 @@ For example, if <code>setA = ['a','b','c']</code> and <code>setB = ['a','b','d',
 ```yml
 tests:
   - text: Your <code>Set</code> class should have a <code>difference</code> method.
-    testString: assert((function(){var test = new Set(); return (typeof test.difference === 'function')})(), 'Your <code>Set</code> class should have a <code>difference</code> method.');
+    testString: 'assert((function(){var test = new Set(); return (typeof test.difference === "function")})(), "Your <code>Set</code> class should have a <code>difference</code> method.");'
   - text: The proper collection was returned
-    testString: assert((function(){var setA = new Set(); var setB = new Set(); setA.add('a'); setA.add('b'); setA.add('c'); setB.add('c'); setB.add('d'); var differenceSetAB = setA.difference(setB); return (differenceSetAB.size() === 2) && DeepEqual(differenceSetAB.values(), [ 'a', 'b' ])})(), 'The proper collection was returned');
+    testString: 'assert((function(){var setA = new Set(); var setB = new Set(); setA.add("a"); setA.add("b"); setA.add("c"); setB.add("c"); setB.add("d"); var differenceSetAB = setA.difference(setB); return (differenceSetAB.size() === 2) && DeepEqual(differenceSetAB.values(), [ 'a', 'b' ])})(), "The expected collection was not returned");'
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/perform-a-difference-on-two-sets-of-data.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/perform-a-difference-on-two-sets-of-data.english.md
@@ -21,9 +21,9 @@ For example, if <code>setA = ['a','b','c']</code> and <code>setB = ['a','b','d',
 ```yml
 tests:
   - text: Your <code>Set</code> class should have a <code>difference</code> method.
-    testString: 'assert((function(){var test = new Set(); return (typeof test.difference === "function")})(), "Your <code>Set</code> class should have a <code>difference</code> method.");'
-  - text: The proper collection was returned
-    testString: 'assert((function(){var setA = new Set(); var setB = new Set(); setA.add("a"); setA.add("b"); setA.add("c"); setB.add("c"); setB.add("d"); var differenceSetAB = setA.difference(setB); return (differenceSetAB.size() === 2) && DeepEqual(differenceSetAB.values(), [ "a", "b" ])})(), "The expected collection was not returned");'
+    testString: assert((function(){var test = new Set(); return (typeof test.difference === 'function')})());
+  - text: Your <code>difference</code> method should return the proper collection.
+    testString: assert((function(){var setA = new Set(); var setB = new Set(); setA.add('a'); setA.add('b'); setA.add('c'); setB.add('c'); setB.add('d'); var differenceSetAB = setA.difference(setB); return (differenceSetAB.size() === 2) && DeepEqual(differenceSetAB.values(), [ 'a', 'b' ])})());
 
 ```
 


### PR DESCRIPTION
For Data Structures: Perform a Subset Check on Two Sets of Data:
Updates the test assertions as currently the tests pass without any code changes

- [X] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `master` branch of freeCodeCamp.
- [X] None of my changes are plagiarized from another source without proper attribution.
- [X] My article does not contain shortened URLs or affiliate links.

Closes #17815 and is related to https://github.com/freeCodeCamp/freeCodeCamp/pull/18698