### PR TITLE
fix: add missing header for HTML guide article

### DIFF
--- a/guide/english/certifications/responsive-web-design/basic-html-and-html5/inform-with-the-paragraph-element/index.md
+++ b/guide/english/certifications/responsive-web-design/basic-html-and-html5/inform-with-the-paragraph-element/index.md
@@ -1,6 +1,7 @@
 ---
 title: Inform with the Paragraph Element
 ---
+## Inform with the Paragraph Element
 
 You are asked to create another HTML element. A brief recap on how to achieve that:
  - Create an opening tag.


### PR DESCRIPTION
'Inform with the Paragraph Element' html guide was missing an appropriate header.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX
