### PR TITLE
Use Number.isInteger() to identify integers

### DIFF
--- a/guide/english/certifications/javascript-algorithms-and-data-structures/es6/write-higher-order-arrow-functions/index.md
+++ b/guide/english/certifications/javascript-algorithms-and-data-structures/es6/write-higher-order-arrow-functions/index.md
@@ -37,7 +37,7 @@ We need to compute and square values from the `realNumberArray` and store them i
 ```javascript
     const squareList = (arr) => {
       "use strict";
-      const squaredIntegers = arr.filter( (num) => num > 0 && num % parseInt(num) === 0 ).map( (num) => Math.pow(num, 2) );
+      const squaredIntegers = arr.filter( (num) => num > 0 && Number.isInteger(num) ).map( (num) => Math.pow(num, 2) );
       return squaredIntegers;
     };
 


### PR DESCRIPTION
Instead of using `num % parseInt(num) === 0` to tell whether or not a number is an integer, use the built-in `Number.isInteger()` method for simplicity and ease of understanding.

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.
