### PR TITLE
Changed grid-column-gap to column-gap

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/css-grid/create-a-column-gap-using-grid-column-gap.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-grid/create-a-column-gap-using-grid-column-gap.english.md
@@ -1,14 +1,14 @@
 ---
 id: 5a9036ee38fddaf9a66b5d35
-title: Create a Column Gap Using grid-column-gap
+title: Create a Column Gap Using column-gap
 challengeType: 0
 videoUrl: 'https://scrimba.com/p/pByETK/cVZ8vfD'
 ---
 
 ## Description
 <section id='description'>
-So far in the grids you have created, the columns have all been tight up against each other. Sometimes you want a gap in between the columns. To add a gap between the columns, use the <code>grid-column-gap</code> property like this:
-<blockquote>grid-column-gap: 10px;</blockquote>
+So far in the grids you have created, the columns have all been tight up against each other. Sometimes you want a gap in between the columns. To add a gap between the columns, use the <code>column-gap</code> property like this:
+<blockquote>column-gap: 10px;</blockquote>
 This creates 10px of empty space between all of our columns.
 </section>
 
@@ -22,8 +22,8 @@ Give the columns in the grid a <code>20px</code> gap.
 
 ```yml
 tests:
-  - text: <code>container</code> class should have a <code>grid-column-gap</code> property that has the value of <code>20px</code>.
-    testString: assert(code.match(/.container\s*?{[\s\S]*grid-column-gap\s*?:\s*?20px\s*?;[\s\S]*}/gi), '<code>container</code> class should have a <code>grid-column-gap</code> property that has the value of <code>20px</code>.');
+  - text: <code>container</code> class should have a <code>column-gap</code> property that has the value of <code>20px</code>.
+    testString: assert(code.match(/.container\s*?{[\s\S]*column-gap\s*?:\s*?20px\s*?;[\s\S]*}/gi), '<code>container</code> class should have a <code>column-gap</code> property that has the value of <code>20px</code>.');
 
 ```
 
@@ -77,7 +77,7 @@ tests:
 
 
 ```js
-var code = ".container {grid-column-gap: 20px;}"
+var code = ".container {column-gap: 20px;}"
 ```
 
 </section>


### PR DESCRIPTION
grid-column-gap is obsolete and should be replaced with column-gap. column-gap is already implemented in all the major browsers except for IE and Edge Mobile.

The file name should also be renamed to "create-a-column-gap-using-column-gap.english.md", IMHO, but I wasn't sure about that out of inexperience.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->
