### PR TITLE
Fix/pt translation redux corrections

### DIFF
--- a/guide/english/redux/redux-sagas/index.md
+++ b/guide/english/redux/redux-sagas/index.md
@@ -1,15 +1,312 @@
 ---
 title: Redux Sagas
 ---
-## Redux Sagas
 
-This is a stub. <a href='https://github.com/freecodecamp/guides/tree/master/src/pages/redux/redux-sagas/index.md' target='_blank' rel='nofollow'>Help our community expand it</a>.
+## Introduction
 
-<a href='https://github.com/freecodecamp/guides/blob/master/README.md' target='_blank' rel='nofollow'>This quick style guide will help ensure your pull request gets accepted</a>.
+In this guide it will be presented to the reader the basic concept of Redux Sagas, coupled with a minimal working example.
+
+It's assumed that the reader has already grasped the basic concepts of [Redux](http://redux.js.org/) and [React](https://reactjs.org/).
+
+## Definition
+
+Ranging from fetching content from the browser local storage to fetching data from HTTP call or from GraphQL server, Redux Sagas help any Redux application to achieve this in a more organized and efficient way.
+
+A analogy that can be used to ilustrate what Redux Sagas are, is to think of a Saga like a separate process running side by side with the application and can be controlled via Redux actions.
+
+
+## Simple Example
+
+Bellow will be presented to the reader a very simple example that covers some of the key features of this library.
+
+Assuming that the [Redux Tutorial](https://guide.freecodecamp.org/redux/tutorial) was followed and a similar project structure is present.
+
+```
+project_root
+│   index.js
+|
+└───client
+|   App.jsx
+|   NotFound.jsx
+|   
+└───common
+    │
+    └───actions
+    |   │  appActions.js
+    |      
+    └───constants
+    |   │  Actiontypes.js
+    |
+    └───reducers
+    |   │   appReducer.js
+    └───store
+        │   store.js
+```
+
+## Installation
+
+Start by adding the library to the project.
+
+With npm by issuing the command:
+
+```sh
+    npm install --save redux-saga
+```
+Or with yarn:
+
+```sh
+    yarn add redux-saga
+```
+
+
+ Also for the scope of this guide it will be used the [axios](https://github.com/axios/axios) library that handles [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) based API calls, but any other is acceptable.
+
+
+## Redux Changes
+
+It will be necessary to make some changes to the tutorial to accommodate the addition of Sagas.
+
+Start by modifying the `Actiontypes.js` file located in the *constants* folder and add the following code.
+
+```javascript
+export const API_REQUEST = "API_REQUEST";
+export const API_SUCCESS = "API_SUCCESS";
+export const API_FAILURE = "API_FAILURE";
+```
+
+Modify the `appReducer.js` file located in the *reducers* folder to contain the code bellow.
+
+```javascript
+ import {
+    API_REQUEST,
+    API_SUCCESS,
+    API_FAILURE
+} from '../constants/Actiontypes';
+
+// initial state of the reducer
+const initialState = {
+  fetching: false,
+  data: null,
+  error: null
+};
+// the reducer
+export const reducer=(state = initialState, action)=>{
+  switch (action.type) {
+    case API_REQUEST:
+      return { ...state, fetching: true, error: null };
+    case API_SUCCESS:
+      return { ...state, fetching: false, data: action.data };
+    case API_FAILURE:
+      return { ...state, fetching: false, data: null, error: action.error };
+    default:
+      return state;
+  }
+};
+```
+
+
+## Saga Implementation
+
+After the changes made to the Redux part of the application, now time to move onto the Saga implementation.
+
+Inside the *common* folder create a new one named *sagas*, and inside that folder a new file named `sagas.js` with the following code.
+
+```javascript
+import { takeLatest, call, put } from "redux-saga/effects"; // helper functions imported from redux-sagas
+import axios from "axios"; // promise library used for the guide
+
+// watcher saga: the functon that watches for actions dispatched to the store and starts worker saga
+export function* watcherSaga() {
+  yield takeLatest("API_REQUEST", workerSaga);
+}
+
+// function that makes the api request and returns a Promise for response
+function fetchData() {
+  return axios({
+    method: "get",
+    url: "https://your_api_endpoint"
+  });
+}
+
+// worker saga: makes the api call when watcher saga sees the action
+function* workerSaga() {
+  try {
+    const response = yield call(fetchData);
+    const data = response.data.message;
+
+    // dispatch a success action to the store with the new data
+    yield put({ type: "API_SUCCESS", data });
+  
+  } catch (error) {
+    // dispatch a failure action to the store with the error
+    yield put({ type: "API_FAILURE", error });
+  }
+}
+```
+
+While reading the code above, the reader might notice some things that are different from standard javascript code.
+
+One is the `function*` syntax. Using this creates a special kind of function called a [generator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*).
+
+These functions have a special feature built in, and that is, they can be paused and restarted and also remember the state over time.
+
+Also another diference is the `yield` keyword inside these functions, it represents a asynchronous step in a synchronous/sequencial process.
+
+An analogy that can be applied to the `yield` keyword is to to think of it as the `await` in the await/async pattern.
+
+Breaking the saga code into smaller pieces will result in the following:
+
+ 1. The `watcherSaga` generator function is what will *watch* for any action dispatched to the store and will trigger the `workerSaga` function.
+
+ 2. [takeLatest](https://github.com/redux-saga/redux-saga/tree/master/docs/api#takelatestpattern-saga-args) is a helper function built in the library
+    that will trigger a new `workerSaga` when a `API_REQUEST` action is triggered, while cancelling any previously triggered ones still being processed.
+
+ 3. The `fetchData` function will make use of the axios library to make a request to a given API endpoint and returns a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) as a response.
+
+ 4. The `workerSaga` generator function will attempt to `fetchData`, using the other imported helper function [call](https://github.com/redux-saga/redux-saga/tree/master/docs/api#callfn-args) and will store the result.
+
+ 5. If the `fetchData` function succeed, it's result will be extracted from the response and sent as the payload of the action `API_SUCCESS`, using the `put` helper function that was imported.
+
+ 6. If there was an error with the request. The store is notified via the action `API_FAILURE` sending the error as the payload.
+
+
+
+ ## Connect React with Redux and Redux-Saga
+
+
+Now that a simple Redux Saga is implemented, now to proceed in connecting all the parts.
+
+Open the `store.js` file located inside *store*  folder, and modify it by adding the following code:
+
+```javascript
+import { createStore, applyMiddleware, compose } from "redux";
+import reducer from '../reducers/ExampleAppReducer'; // the reducer created
+
+import createSagaMiddleware from "redux-saga"; // Redux Saga middleware
+import { watcherSaga } from "../sagas/sagas"; // imports the watched saga defined earlier
+
+// create the saga middleware
+const sagaMiddleware = createSagaMiddleware();
+
+// dev tools middleware
+const reduxDevTools =
+  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__();
+
+export default createStore(
+    reducer,
+    compose(applyMiddleware(sagaMiddleware), reduxDevTools)
+);
+// run the saga
+sagaMiddleware.run(watcherSaga);
+
+```
+
+The `index.js` located at the *project_root* folder should look like this.
+
+```javascript
+import React from "react";
+import ReactDOM from "react-dom";
+import {Router,Route,browserHistory} from 'react-router';
+import store from "../common/store/store";
+import App from '../client/App';
+import NotFound from '../client/NotFound';
+import { Provider } from "react-redux";
+
+ReactDOM.render(
+  <Provider store={store}>
+    <Router history={browserHistory}>
+      <Route path="/" component={App}/>
+      <Route path="*" component={NotFound}/>
+    </Router>
+  </Provider>,
+  document.getElementById("root")
+);
+
+```
+
+The `app.js` file inside the *client* folder needs to be modified in order to reflect the changes made to the application.
+
+Bellow is a simple React Component connected to redux that will make use of what was implemented.
+
+```javascript
+import React, { Component } from "react";
+import { connect } from "react-redux";
+
+class App extends Component {
+  render() {
+    const { fetching, item, onRequestData, error } = this.props;
+    
+    return (
+      <div>
+        <header>
+          <h1>Redux Saga Guide</h1>
+        </header>
+        <h4>{item}</h4>
+
+        {fetching ? (
+          <button disabled>Fetching...</button>
+        ) : (
+          <button onClick={onRequestData}>Make a async request to your saga</button>
+        )}
+
+        {error && <p style={{ color: "red" }}>Uh oh - something went wrong!</p>}
+
+      </div>
+    );
+  }
+}
+/**
+ * es6 fat arrow function to get information from the application state
+ * @param {*} state current state of the application
+ */
+const mapStateToProps = state => {
+  return {
+    fetching: state.fetching,
+    item: state.data,
+    error: state.error
+  };
+};
+
+/**
+ * es6 fat arrow function to connect the actions declared in the saga file to the the component as if they were common react props
+ * @param {*} dispatch function send to action file to be later processed in the reducer
+ */
+const mapDispatchToProps = dispatch => {
+  return {
+    onRequestData: () => dispatch({ type: "API_REQUEST" })
+  };
+};
+
+/**
+ * this function connects the application component to be possible to interact with the store
+ * @param {*} mapStateToProps allows the retrieval of information from the state of the application
+ * @param {*} mapDispatchToProps allows the state to change via the actions defined inside
+ */
+export default connect(mapStateToProps, mapDispatchToProps)(App);
+```
+
+# In summary
+
+Now that everything is connected, what will happen every time a user interacts with the application is the following:
+
+1. An event takes place — e.g. user does something (clicks “onRequestData” button) or an update occurs (like componentDidMount).
+2. Based on the event, an action is dispatched, likely through a function declared in `mapDispatchToProps` (e.g.onRequestData)
+3. A `watcherSaga` sees the action and triggers a `workerSaga`. Use saga helpers to watch for actions differently.
+4. While the saga is starting, the action also hits a reducer and updates some piece of state to indicate that the saga has begun and is in process (e.g. fetching).
+5. The `workerSaga` performs some side-effect operation (e.g. `fetchData`).
+6. Based on the result of the `workerSaga‘s` operation, it dispatches an action to indicate that result. If it's successful then (`API_SUCCESS`), with a payload of the data recieved. If an error (`API_FAILURE`), you might send along an error object for more details on what went wrong.
+7. The reducer handles the success or failure action from the `workerSaga` and updates the store accordingly with any new data, as well as sets the “in process” indicator (e.g. fetching) to false.
+
 
 <!-- The article goes here, in GitHub-flavored Markdown. Feel free to add YouTube videos, images, and CodePen/JSBin embeds  -->
 
 #### More Information:
 <!-- Please add any articles you think might be helpful to read before writing the article -->
+[Redux Saga Docs](https://redux-saga.js.org/)
 
+[Redux Docs](https://redux.js.org/)
+
+[Redux Saga Examples](https://github.com/redux-saga/redux-saga/tree/master/examples)
+
+[Redux Tutorial](https://guide.freecodecamp.org/redux/tutorial)
 

--- a/guide/portuguese/redux/index.md
+++ b/guide/portuguese/redux/index.md
@@ -4,54 +4,53 @@ localeTitle: Redux
 ---
 ## Redux
 
-O Redux é um contêiner de estado previsível para aplicativos JavaScript.
+O Redux é um contentor de estados previsível para aplicações JavaScript.
 
-Ele ajuda você a escrever aplicativos que se comportam de maneira consistente, executados em diferentes ambientes (cliente, servidor e nativo) e são fáceis de testar. Além disso, proporciona uma ótima experiência de desenvolvedor, como edição de código ao vivo combinada com um depurador de viagem no tempo.
+Ajuda no desenvolvimento de aplicações que se comportam de forma consistente e operam em ambientes diferentes(cliente, servidor e nativo), e bastante fáceis de testar. Além disso proporciona uma experiência de desenvolvimento rica, com a possibilidade de edição de código ao vivo, combinada com um depurador com possibilidade de viagem no tempo.
 
 Princípios Básicos do Redux:
 
-1.  Redux é um contêiner do estado, armazena todo o seu estado em um só lugar
-2.  O estado é somente leitura, a única maneira de alterar o estado é despachar uma ação.
-3.  Estado só pode ser alterado por funções puras ou em outro termo: Redutores. Redux Reducers aceitam o estado anterior e um objeto de ação e retornam o próximo estado.
+1.  Redux é um contentor de estados, armazena todo a informação num só lugar.
+2.  O estado é somente leitura, a única forma de ser alterado é através de uma ação que foi desencadeada.
+3.  O estado somente pode ser alterado por funções puras, ou por outras palavras: Redutores. Redutores Redux recebem o estado anterior e um objeto que contém uma ação e retornam o próximo estado.
 
-Em termos práticos, como usamos o Redux exatamente?
+Em termos práticos, como é usado o Redux?
 
 ### REGRA 1
 
-#### Onde este estado é armazenado? Redux fornece uma função útil chamada
+#### Onde é que o estado é armazenado? O Redux fornece uma função útil chamada
 
-```js
+```javascript
 createStore() 
 ```
 
-Onde você cria a loja que armazenará todo o seu estado.
+Onde você cria a loja que armazenará todo o estado da aplicação.
 
 ### REGRA 3 (vou mostrar a regra 3 primeiro, pois fará mais sentido)
+#### O estado somente pode ser alterado por uma função pura, também conhecida como redutor, logo para criar essa conexão, passaremos o nosso redutor para createStore() da seguinte forma
 
-#### O estado só pode ser alterado por uma função pura, também conhecida como redutor, para criar essa conexão, passaremos nosso redutor para createStore () assim como
-
-```js
+```javascript
 var store = createStore(reducer) 
 ```
 
-Fica mais complicado quando você tem mais redutores, mas no centro, a loja agora tem um redutor ligado a ela
+Torna-se mais complicado quando existem mais redutores envolvidos, mas agora, a loja já contém um redutor.
 
 ### REGRA 2
 
-#### Uma vez que temos uma loja que é criada com store = createStore (redutor). A nova loja que criamos tem um método chamado despacho. Lembre-se na regra 2, a única maneira que podemos mudar o estado é despachar uma ação!
+#### Assim que existir uma loja criada da seguinte forma store = createStore(redutor). Esta nova loja tem um método chamado dispatch. Relembrando a regra 2, a única maneira que podemos alterar o estado é despachar uma ação!
 
-Você pode ver onde isso está indo.
+Você pode ver agora para onde isto está indo.
 
-```js
+```javascript
 store.dispatch(action) 
 ```
 
-Antes de entrar no que é um redutor e uma ação, acho que mostrar uma implementação muito básica e limitada do createStore () do Redux vai ajudar muito.
+Antes de se explicar o que é um redutor e uma ação, acho que ao mostrar uma implementação muito básica e limitada do `createStore()` Redux, vai ajudar em muito.
 
-```js
+```javascript
 createStore = (reducer) => { 
     let state; 
- //dispatch method 
+    //método dispatch
     dispatch = (action) => { 
         state = reducer(state, action) 
     } 
@@ -59,24 +58,24 @@ createStore = (reducer) => {
  } 
 ```
 
-Veja como passamos em um redutor para createStore e ele se torna definido em nosso método de envio; e quando chamamos o método de despacho, ele recebe uma ação e define um novo estado com base no que o redutor retornará.
+Observem agora, como o redutor foi passado para `createStore` e definido no método `dispatch` e quando invocado, recebe uma ação e define um novo estado com base no que o redutor irá retornar.
 
 ## O que é um redutor? O que é uma ação?
 
-Uma ação no nível mais básico é um objeto que possui uma propriedade chamada type. Também pode ter outras propriedades, mas, por simplicidade, só terá tipo.
+Uma ação basicamente é um objeto que possui uma propriedade chamada type.  Pode ter também outras propriedades, mas para simplicidade, somente terá o type.
 
-```js
-var someAction = {type:'doSomething'} 
+```javascript
+var someAction = {type:'fazAlgo'} 
 ```
 
-Um redutor é apenas uma função:
+Um redutor é somente uma função:
 
-```js
+```javascript
 var reducer = (state, action) => { 
  
-    if (action.type === 'doSomething'){ 
+    if (action.type === 'fazAlgo'){ 
         return changedState; 
-    } else if ( action.type === 'doSomethingElse'){ 
+    } else if ( action.type === 'fazOutraCoisa'){ 
         return changedState; 
     } else { 
         return state 
@@ -84,15 +83,14 @@ var reducer = (state, action) => {
  } 
 ```
 
-A ação que passamos em um redutor determinará como o estado será alterado dependendo do tipo. O Redux se torna mais complicado, mas se você entender esses princípios, você terá mais facilidade em navegar através dos projetos react-redux!
+A ação enviada para o redutor irá determinar como o estado irá ser alterado dependendo do tipo. O Redux torna-se cada vez mais complicado, mas se forem entendidos estes princípios, então você terá mais facilidade em navegar através de projetos react-redux!
 
 #### Mais Informações:
 
 ##### Você realmente precisa do Redux?
+[Dan Abramov](https://github.com/gaearon) , criador do Redux, escreveu há algum tempo um ótimo artigo, [You Might Not Need Redux](https://medium.com/@dan_abramov/you-might-not-need-redux-be46360cf367) . Você deve verificar primeiro porque, bem, você pode nem precisar.
 
-[Dan Abramov](https://github.com/gaearon) , criador do Redux, escreveu há algum tempo um ótimo artigo, [You Might Not Need Redux](https://medium.com/@dan_abramov/you-might-not-need-redux-be46360cf367) . Você deve verificar primeiro porque, bem, você pode não precisar.
-
-Para mais informações, acesse [http://redux.js.org/](http://redux.js.org/)
+Para mais informações [http://redux.js.org/](http://redux.js.org/)
 
 ### Recursos
 

--- a/guide/portuguese/redux/reducers/index.md
+++ b/guide/portuguese/redux/reducers/index.md
@@ -4,7 +4,8 @@ localeTitle: Redutores
 ---
 ### Quais são os redutores no Redux?
 
-Redutores são as funções puras que executam uma ação e um estado anterior e retornam um novo estado. Dada a mesma entrada, o redutor deve sempre retornar a mesma saída. 1
+Redutores são funções javascript puras que recebem como parâmetros uma ação e um estado anterior e efetuam algum tipo de transformação sobre os dados e com isto retornam um novo estado.
+Com base num determinado input, o redutor terá sempre que retornar o mesmo output.<sup>1</sup>
 
 ### Fontes
 

--- a/guide/portuguese/redux/redux-actions/index.md
+++ b/guide/portuguese/redux/redux-actions/index.md
@@ -2,15 +2,23 @@
 title: Redux Actions
 localeTitle: Ações do Redux
 ---
-## Ações do Redux
+## Ações em Redux
 
-A ação do Redux é um objeto simples que descreve o tipo de evento que aconteceu em seu aplicativo. Eles podem até conter dados que precisam ser enviados do aplicativo para a loja Redux. A ação pode conter qualquer coisa, mas deve ter um type propriedade que descreve o evento ocorrendo. Uma boa prática é usar constantes ao descrever a ação.
+A ação em Redux é um objeto simples que descreve um qualquer tipo de evento da aplicação.
+Poderão conter dados necessários á loja/store Redux.
+Mas também poderá não conter nada.
 
-Por exemplo
+Mas deverá sempre possuir uma propriedade que descreve qual é o tipo de evento.
+
+De acordo com as boas práticas em Redux, deverá usar-se uma constante para descrever a ação.
+
+Exemplo de uma ação simples, sem dados adicionais.
 
 ```javascript
 const ADD_ITEM = 'ADD_ITEM' 
 ```
+
+Exemplo de uma ação com um parâmetro extra de dados, que poderiam ser necessários á loja Redux.
 
 ```javascript
 { 
@@ -18,11 +26,13 @@ const ADD_ITEM = 'ADD_ITEM'
  text: 'This is the first item' 
  } 
 ```
+Através da invocação da função  `store.dispatch()`, podemos enviar ações para a loja/store.
 
-Podemos enviar essas ações para a loja usando `javascript store.dispatch()` Um aplicativo pode ter diferentes tipos de eventos acontecendo ao mesmo tempo e essas ações ajudam a descrever esses eventos. Sem essas ações, não há como alterar o estado do aplicativo.
+A uma qualquer altura na aplicação, poderão estar a ocorrer vários eventos ao mesmo tempo e de forma que se saiba o que está a acontecer, as ações ajudam a descrever os eventos que estão a ocorrer.
+Mais ainda, sem ações não existe forma de se alterar o estado da aplicação.
 
-Você pode tentar o projeto [redux-actions](https://github.com/redux-utilities/redux-actions) , que reduz muito o clichê, tornando suas ações mais rápidas.
+Uma biblioteca que agiliza a implementação de ações em Redux, é a seguinte [redux-actions](https://github.com/redux-utilities/redux-actions)
 
 #### Mais Informações:
 
-[Documentos oficiais do Redux de ações](https://redux.js.org/basics/actions) página do projeto github do [redux-actions](https://github.com/redux-utilities/redux-actions)
+[Documentação oficial de ações em Redux](https://redux.js.org/basics/actions) 

--- a/guide/portuguese/redux/redux-reducers/index.md
+++ b/guide/portuguese/redux/redux-reducers/index.md
@@ -4,9 +4,18 @@ localeTitle: Redux Redutores
 ---
 ## Redux Redutores
 
-Reduxores Redux permitem que você faça alterações em seu estado em sua aplicação. Ações no redux apenas informam ao aplicativo o que basicamente aconteceu. Quer tenha sido um evento de clique que ocorreu ou alguma rolagem do mouse, ele apenas informará que isso aconteceu. Agora, como você muda o estado do seu aplicativo que mora dentro da loja, você faz isso usando um redutor.
+Redutores Redux permitem que se façam alterações no estado da aplicação. 
+Ações em Redux apenas informam a aplicação sobre o que aconteceu.
 
-Agora um redutor no redux precisa ser uma função pura. Uma função pura é um tipo de função que não tem efeitos colaterais adicionais. Você passa alguns argumentos e retorna o resultado esperado. Por exemplo:
+Quer tenha sido um evento de clique, ou movimentação do rato, apenas informará que isso aconteceu. 
+
+Agora, como se altera o estado do sua aplicação que vive dentro da loja? Isto através de um redutor.
+
+Um redutor em Redux irá ser sempre uma função pura. 
+
+Uma função pura é um tipo de função que não tem efeitos colaterais adicionais. São fornecidos argumentos e esta retorna o resultado esperado. 
+
+Por exemplo:
 
 ```javascript
 function add(a,b) { 
@@ -16,9 +25,14 @@ function add(a,b) {
  const sum = add(5,4); 
 ```
 
-A função acima é pura, porque não importa o que aconteça, ela retornará 9. Uma função que tem ajax chama dentro dela ou faz algo como acessar um banco de dados não é uma função pura. Mesmo se nós mutarmos significando mudança, um valor variável pode ser considerado não uma função pura.
+A função acima é pura, independentemente do que aconteça, irá retornar 9. 
 
-Agora, para fazer alterações no estado, você usa um redutor. Aqui está um exemplo de código de um redutor:
+Uma função que contém pedidos ajax ou acede a uma base de dados não é função pura. 
+O caso de uma mutação e com isto a alteração de um valor de uma variável não irá ser considerado uma função pura.
+
+Para  alterar o estado, usa-se então um redutor. 
+
+Aqui está um exemplo de código de um redutor:
 
 ```javascript
  function todoReducer(state= [],action) { 
@@ -31,7 +45,10 @@ Agora, para fazer alterações no estado, você usa um redutor. Aqui está um ex
  } 
 ```
 
-O que este todoReducer está fazendo é que ele pega o estado atual e a ação que foi disparada e então retorna um novo estado. Aqui usamos a sintaxe do parâmetro padrão es6 para atribuir um valor padrão ao array state. O objeto de ação para o redutor acima pode ser semelhante ao seguinte:
+O que o `todoReducer` está a fazer, não é nada mais nada menos que, dado o presente estado da aplicação e uma ação despoletada este irá retornar um novo estado.
+Aqui usou-se a sintaxe es6 para parâmetros padrão, isto para atribuir ao array estado, um valor considerado por defeito.
+O objeto ação para o redutor, poderia ser por exemplo ser algo semelhante 
+ao seguinte:
 
 ```javascript
 { 
@@ -39,11 +56,11 @@ O que este todoReducer está fazendo é que ele pega o estado atual e a ação q
  data: {name: 'Learn Redux',completed:false} 
  } 
 ```
+A ação aqui tem uma propriedade do tipo 'ADD_TODO' e um objecto `data`.
+Quando a ação é despoletada, irá ser recebida pelo redutor e em seguida, com base na cláusula `switch` irá retornar um novo array com os novos dados assim como os dados já existentes.
 
-Aqui a ação tem uma propriedade type de 'ADD\_TODO' com um objeto de dados. Agora, quando esta ação é acionada, ela é recebida pelo redutor e, em seguida, com base na instrução switch, ela retornará um novo array com os dados existentes ao lado dos novos dados.
-
-Então, resumir os redutores não são nada além de funções puras que retornam um novo estado para sua aplicação.
+Resumindo os redutores não são nada mais nada menos que funções puras que retornam estados novos da aplicação.
 
 #### Mais Informações:
 
-[Redux-Reducers Official Docs](https://redux.js.org/basics/reducers)
+[Documentação oficial Redux-Reducers](https://redux.js.org/basics/reducers)

--- a/guide/portuguese/redux/redux-thunk/index.md
+++ b/guide/portuguese/redux/redux-thunk/index.md
@@ -4,9 +4,9 @@ localeTitle: Thunk Redux
 ---
 ## Thunk Redux
 
-O Redux Thunk é um middleware que permite retornar funções, ao invés de apenas ações, dentro do Redux 1 . Isso permite ações atrasadas, incluindo o trabalho com promessas.
+O Redux Thunk é um middleware que permite retornar funções, ao invés de ações, dentro do Redux <sup>1</sup> . Isso permite ações atrasadas, incluindo o uso de [promessas](https://developer.mozilla.org/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 
-O motivo pelo qual usamos este middleware é que nem todas as ações que executamos serão sincronizadas e algumas não são síncronas, como o uso de axios para enviar uma solicitação get. Isso levará um pouco de tempo e o simples redux não leva em conta esse comportamento. Então, o Redux-thunk vem para o resgate, permitindo-nos despachar ações de forma assíncrona, para que possamos permitir que essas promessas sejam resolvidas.
+O motivo pelo qual este middleware é usado, consiste no facto que nem todas as ações que executamos serão síncronas, tal como acontece quando é usado [axios](https://github.com/axios/axios) para enviar um pedido HTTP get. Isso irá levar algum tempo e o redux nativamente não tem forma de lidar com este comportamento. Logo, é aí que entra o Redux Thunk, permitindo que as ações possam ser despoletadas de forma assíncrona e possamos lidar com o resultado sob a forma de promessas.
 
 Exemplo 1:
 
@@ -32,15 +32,15 @@ const INCREMENT_COUNTER = 'INCREMENT_COUNTER';
 Exemplo 2:
 
 ```javascript
-const GET_CURRENT_USER = 'GET_CURRENT_USER'; 
+ const GET_CURRENT_USER = 'GET_CURRENT_USER'; 
  const GET_CURRENT_USER_SUCCESS = 'GET_CURRENT_USER_SUCCESS'; 
  const GET_CURRENT_USER_FAILURE = 'GET_CURRENT_USER_FAILURE'; 
  
  const getUser = () => { 
-  return (dispatch) => {     //nameless functions 
-    // Initial action dispatched 
+  return (dispatch) => {     //funções anónimas
+    //Ação inicial despoletada 
     dispatch({ type: GET_CURRENT_USER }); 
-    // Return promise with success and failure actions 
+    //Retorna uma promessa/promise com sucesso ou falha 
     return axios.get('/api/auth/user').then( 
       user => dispatch({ type: GET_CURRENT_USER_SUCCESS, user }), 
       err => dispatch({ type: GET_CURRENT_USER_FAILURE, err }) 
@@ -51,7 +51,7 @@ const GET_CURRENT_USER = 'GET_CURRENT_USER';
 
 ### Instalação e Configuração
 
-O Redux Thunk pode ser instalado usando `npm install redux-thunk --save` ou `yarn add redux-thunk` com a linha de comando. Por ser uma ferramenta do Redux, você também precisará configurar o Redux. Uma vez instalado, é ativado usando `applyMiddleware()` :
+O Redux Thunk pode ser instalado usando `npm install redux-thunk --save` ou `yarn add redux-thunk` na linha de comando. Por ser uma ferramenta do Redux, irá ser necessário configurar o Redux. Uma vez instalado, é ativado através da função `applyMiddleware()`  com o argumento, neste caso thunk, ou seja o import que foi definido:
 
 ```javascript
 import { createStore, applyMiddleware } from 'redux'; 
@@ -71,4 +71,4 @@ import { createStore, applyMiddleware } from 'redux';
 
 ### Fontes
 
-1.  [Exemplo de Contador de Incrementos citado na Documentação do Redux Thunk, 10/02/2018](#https://github.com/reduxjs/redux-thunk)
+1.  [Exemplo de Contador citado na Documentação do Redux Thunk, 10/02/2018](#https://github.com/reduxjs/redux-thunk)

--- a/guide/portuguese/redux/reselect/index.md
+++ b/guide/portuguese/redux/reselect/index.md
@@ -2,17 +2,22 @@
 title: Reselect
 localeTitle: Reselecionar
 ---
-## Reselecionar
+## Reselect
 
-Reselecionar é uma biblioteca de seletores simples para o Redux. Por que precisamos de seletores? Documentos oficiais descrevem desta forma:
+Reselect é uma biblioteca de seletores simples para o Redux. 
+
+Por que precisamos de seletores? 
+
+A documentação oficial descreve da seguinte forma:
 
 *   Os seletores podem calcular dados derivados, permitindo que o Redux armazene o estado mínimo possível.
 *   Seletores são eficientes. Um seletor não é recalculado a menos que um dos seus argumentos seja alterado.
 *   Seletores são compostos. Eles podem ser usados ​​como entrada para outros seletores.
 
-Pode parecer complicado, mas os slectors permitem que o aplicativo funcione mais rápido, reduzindo o (s) processamento (s) desnecessário (s). Normalmente `mapStateToProps` é chamado toda vez que qualquer alteração na `store` é feita. `mapStateToProps` liga valores de armazenamento para reagir. Até você usar o `PureComponents` ele pode fazer com que o componente seja renderizado `PureComponents` , embora não seja necessário.
+Pode parecer complicado, mas os selectors permitem que a aplicação funcione mais rápido, reduzindo renderizações desnecessárias. Normalmente a função `mapStateToProps` é invocada sempre que é feita qualquer alteração na `store`. A função React-Redux `connect()` usa como argumento `mapStateToProps` para especificar que valores da loja/store irão ser fornecidos ao componente React como props(propriedades).
+A não ser que sejam usados `PureComponents`, isto irá causar renderizações desnecessárias por parte do componente.
 
 #### Mais Informações:
 
-*   [selecionar novamente](https://github.com/reduxjs/reselect)
-*   [Reagir, selecionar novamente e Redux](https://medium.com/@parkerdan/react-reselect-and-redux-b34017f8194c)
+*   [Reselect](https://github.com/reduxjs/reselect)
+*   [React, Reselect e Redux](https://medium.com/@parkerdan/react-reselect-and-redux-b34017f8194c)


### PR DESCRIPTION
This pull request makes some corrections in the portuguese translation of the redux part of the guide.
Some of the changes correct some "ipsis verbis" translations that existed in the guide.
Also all of the changes were made according to the spelling agreement for all portuguese native speaking countries.
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->
