### PR TITLE
fix(flient): Moved the Mathjax config in SidePanel.js from constructor to componentDidMount

### DIFF
--- a/client/src/templates/Challenges/components/Side-Panel.js
+++ b/client/src/templates/Challenges/components/Side-Panel.js
@@ -44,6 +44,9 @@ export class SidePanel extends Component {
   constructor(props) {
     super(props);
     this.bindTopDiv = this.bindTopDiv.bind(this);
+  }
+
+  componentDidMount() {
     MathJax.Hub.Config({
       tex2jax: {
         inlineMath: [['$', '$'], ['\\(', '\\)']],
@@ -51,9 +54,6 @@ export class SidePanel extends Component {
         processClass: 'rosetta-code'
       }
     });
-  }
-
-  componentDidMount() {
     MathJax.Hub.Queue([
       'Typeset',
       MathJax.Hub,


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The Mathjax config had to be moved from the constructor because it was causing build errors. Moved it into componentDidMount with the rest of the Mathjax settings. Hopefully this will fix the errors. I went through the Sass and other challenges that feature $ characters to ensure that Mathjax doesn't render anything besides the mathematical formulas in the Rosetta Code section.

Cc @ValeraS! Please take a look at this and let me know if there's anything else that I can do.

Closes #XXXXX
