### PR TITLE
fix: Redux lesson guide article stub

### DIFF
--- a/guide/english/certifications/front-end-libraries/redux/use-the-spread-operator-on-arrays/index.md
+++ b/guide/english/certifications/front-end-libraries/redux/use-the-spread-operator-on-arrays/index.md
@@ -3,8 +3,16 @@ title: Use the Spread Operator on Arrays
 ---
 ## Use the Spread Operator on Arrays
 
-This is a stub. <a href='https://github.com/freecodecamp/guides/tree/master/src/pages/certifications/front-end-libraries/redux/use-the-spread-operator-on-arrays/index.md' target='_blank' rel='nofollow'>Help our community expand it</a>.
-
-<a href='https://github.com/freecodecamp/guides/blob/master/README.md' target='_blank' rel='nofollow'>This quick style guide will help ensure your pull request gets accepted</a>.
-
 <!-- The article goes here, in GitHub-flavored Markdown. Feel free to add YouTube videos, images, and CodePen/JSBin embeds  -->
+This lesson is about immutably updating a to-do list stored in <i>state</i>.  
+
+To that end, the action creator "addToDo" passes an item stored in the property "todo" to the action reducer "immutableReducer". A switch statement decides on whether the correct action.type is triggered before updating <i>state</i> immutably.
+
+What's missing is a spread operator in "case 'ADD_TO_DO'". Complete it as follows:
+````javascript
+case 'ADD_TO_DO': 
+  // don't mutate state here or the tests will fail 
+  return [ 
+    ...state, action.todo 
+  ];
+````


### PR DESCRIPTION
This fix is for the Redux lesson titled "Redux: Use the Spread Operator on Arrays". I described the problem outlined by the code and added the solution (return [ ...state, action.todo];)

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `master` branch of freeCodeCamp.
- [X] None of my changes are plagiarized from another source without proper attribution.
- [X] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [X] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX
