### PR TITLE
Fix: Using correct variables for 'ES6: Use Destructuring Assignment to Assign Variables from Nested Objects'

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-assign-variables-from-nested-objects.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-assign-variables-from-nested-objects.english.md
@@ -9,7 +9,7 @@ challengeType: 1
 We can similarly destructure <em>nested</em> objects into variables.
 Consider the following code:
 <blockquote>const a = {<br>&nbsp;&nbsp;start: { x: 5, y: 6},<br>&nbsp;&nbsp;end: { x: 6, y: -9 }<br>};<br>const { start : { x: startX, y: startY }} = a;<br>console.log(startX, startY); // 5, 6</blockquote>
-In the example above, the variable <code>start</code> is assigned the value of <code>a.start</code>, which is also an object.
+In the example above, the variable <code>startX</code> is assigned the value of <code>a.start.x</code>, which is also an object.
 </section>
 
 ## Instructions


### PR DESCRIPTION
For challenge 'ES6: Use Destructuring Assignment to Assign Variables from Nested Objects', the variable 'start' is changed to 'startX' and 'a.start' to 'a.start.x'

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX
Fixes one aspect mentioned under #17764
