### PR TITLE
fix: remove stub information from a guide article

### DIFF
--- a/guide/english/mathematics/exponents-basic-rules/index.md
+++ b/guide/english/mathematics/exponents-basic-rules/index.md
@@ -3,11 +3,6 @@ title: Exponents Basic Rules
 ---
 ## Exponents Basic Rules
 
-This is a stub. <a href='https://github.com/freecodecamp/guides/tree/master/src/pages/mathematics/exponents-basic-rules/index.md' target='_blank' rel='nofollow'>Help our community expand it</a>.
-
-<a href='https://github.com/freecodecamp/guides/blob/master/README.md' target='_blank' rel='nofollow'>This quick style guide will help ensure your pull request gets accepted</a>.
-
-<!-- The article goes here, in GitHub-flavored Markdown. Feel free to add YouTube videos, images, and CodePen/JSBin embeds  -->
 ### Rules of Exponents
 The nine laws for exponents are:
 - x<sup>1</sup> = x
@@ -21,11 +16,8 @@ The nine laws for exponents are:
 
 ## 0<sup>0</sup> = ?
 
-0<sup>0</sup> has no correct answear but is generally taken as 1. More information about it can be found [here](https://en.wikipedia.org/wiki/Zero_to_the_power_of_zero)
+0<sup>0</sup> has no correct answear but is generally taken as 1. More information about it can be found [here](https://en.wikipedia.org/wiki/Zero_to_the_power_of_zero).
 
 #### More Information:
 - https://www.mathsisfun.com/algebra/exponent-laws.html
 - https://en.wikipedia.org/wiki/Zero_to_the_power_of_zero
-<!-- Please add any articles you think might be helpful to read before writing the article -->
-
-


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Remove stub information from Guide's [Exponents Basic Rules article](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/guide/english/mathematics/exponents-basic-rules/index.md).