### PR TITLE
fix: save and restore guide scroll

### DIFF
--- a/client/src/components/layouts/GuideLayout.js
+++ b/client/src/components/layouts/GuideLayout.js
@@ -57,7 +57,9 @@ const Layout = ({ children }) => (
             toggleDisplaySideNav,
             displaySideNav,
             expandedState,
-            toggleExpandedState
+            sidebarScroll,
+            toggleExpandedState,
+            saveSidebarScroll
           }) => (
             <DefaultLayout>
               <Spacer size={2} />
@@ -72,6 +74,8 @@ const Layout = ({ children }) => (
                     pages={pages}
                     toggleDisplaySideNav={toggleDisplaySideNav}
                     toggleExpandedState={toggleExpandedState}
+                    saveSidebarScroll={saveSidebarScroll}
+                    sidebarScroll={sidebarScroll}
                   />
                 </Col>
                 <Col

--- a/client/src/components/layouts/components/guide/NavItem.js
+++ b/client/src/components/layouts/components/guide/NavItem.js
@@ -7,14 +7,22 @@ const propTypes = {
   path: PropTypes.string,
   router: PropTypes.object,
   title: PropTypes.string,
-  toggleDisplaySideNav: PropTypes.func.isRequired
+  toggleDisplaySideNav: PropTypes.func.isRequired,
+  saveSidebarScroll: PropTypes.func.isRequired
 };
+
+function handleClick() {
+  const { toggleDisplaySideNav, saveSidebarScroll } = this.props
+  toggleDisplaySideNav()
+  saveSidebarScroll()
+}
 
 function NavItem(props) {
   const { isStubbed, path, title } = props;
+
   return (
     <li>
-      <Link data-navitem='true' onClick={props.toggleDisplaySideNav} to={path}>
+      <Link data-navitem='true' onClick={handleClick} to={path}>
         <span className={'navItemTitle' + (isStubbed ? ' stubbed' : '')}>
           {title}
         </span>

--- a/client/src/components/layouts/components/guide/NavPanel.js
+++ b/client/src/components/layouts/components/guide/NavPanel.js
@@ -11,7 +11,8 @@ const propTypes = {
   isExpanded: PropTypes.bool,
   path: PropTypes.string,
   title: PropTypes.string,
-  toggleDisplaySideNav: PropTypes.func.isRequired
+  toggleDisplaySideNav: PropTypes.func.isRequired,
+  saveSidebarScroll: PropTypes.func.isRequired
 };
 
 function NoArticles() {
@@ -46,9 +47,10 @@ class NavPanel extends Component {
   }
 
   handleHeaderClick() {
-    const { path, handleClick } = this.props;
+    const { path, handleClick, saveSidebarScroll } = this.props;
     handleClick(path);
-    navigate(path);
+    saveSidebarScroll();
+    navigate(path)
   }
 
   renderHeader() {

--- a/client/src/components/layouts/components/guide/SideNav.js
+++ b/client/src/components/layouts/components/guide/SideNav.js
@@ -10,7 +10,9 @@ const propTypes = {
   pages: PropTypes.arrayOf(PropTypes.object),
   parents: PropTypes.arrayOf(PropTypes.object),
   toggleDisplaySideNav: PropTypes.func.isRequired,
-  toggleExpandedState: PropTypes.func.isRequired
+  toggleExpandedState: PropTypes.func.isRequired,
+  sidebarScroll: PropTypes.number,
+  saveSidebarScroll: PropTypes.func.isRequired
 };
 
 function parentFilter(node) {
@@ -24,6 +26,12 @@ class SideNav extends Component {
     this.renderChildren = this.renderChildren.bind(this);
     this.renderPanels = this.renderPanels.bind(this);
     this.renderParent = this.renderParent.bind(this);
+  }
+
+  componentDidMount() {
+    const el = document.getElementById('side-nav');
+    if (el === undefined) { return; }
+    el.scrollTop = this.props.sidebarScroll
   }
 
   renderPanels(parents, pages) {
@@ -53,6 +61,7 @@ class SideNav extends Component {
         path={parent.path}
         title={title}
         toggleDisplaySideNav={this.props.toggleDisplaySideNav}
+        saveSidebarScroll={this.props.saveSidebarScroll}
         >
         {isExpanded ? children : null}
       </NavPanel>
@@ -71,6 +80,7 @@ class SideNav extends Component {
           path={child.path}
           title={child.title}
           toggleDisplaySideNav={this.props.toggleDisplaySideNav}
+          saveSidebarScroll={this.props.saveSidebarScroll}
         />
       );
     });

--- a/client/src/contexts/GuideNavigationContext.js
+++ b/client/src/contexts/GuideNavigationContext.js
@@ -2,17 +2,21 @@ import React, { Component, createContext } from 'react';
 import PropTypes from 'prop-types';
 
 const noop = () => {};
+const warnNoMethod = () => {
+  console.warn('no method from provider');
+}
 
-const initialState = { displaySideNav: false, expandedState: {} };
+const initialState = { 
+  displaySideNav: false, 
+  expandedState: {},
+  sidebarScroll: 0
+};
 
 const { Provider, Consumer } = createContext({
   ...initialState,
-  toggleDisplaySideNav: () => {
-    console.warn('no method from provider');
-  },
-  toggleExpandedState: () => {
-    console.warn('no method from provider');
-  }
+  toggleDisplaySideNav: warnNoMethod,
+  toggleExpandedState: warnNoMethod,
+  sidebarScroll: warnNoMethod
 });
 
 const propTypes = {
@@ -27,6 +31,7 @@ class NavigationContextProvider extends Component {
 
     this.toggleSideNav = this.toggleSideNav.bind(this);
     this.toggleExpandedState = this.toggleExpandedState.bind(this);
+    this.saveSidebarScroll = this.saveSidebarScroll.bind(this)
   }
 
   componentDidMount() {
@@ -70,16 +75,27 @@ class NavigationContextProvider extends Component {
     }));
   }
 
+  saveSidebarScroll() {
+    const el = document.getElementById('side-nav')
+    if (!el) { return noop; }
+    return this.setState(state => ({
+      ...state,
+      sidebarScroll: el.scrollTop
+    }))
+  }
+
   render() {
     const { children } = this.props;
-    const { displaySideNav, expandedState } = this.state;
+    const { displaySideNav, expandedState, sidebarScroll } = this.state;
     return (
       <Provider
         value={{
           displaySideNav,
           expandedState,
+          sidebarScroll,
           toggleDisplaySideNav: noop,
-          toggleExpandedState: this.toggleExpandedState
+          toggleExpandedState: this.toggleExpandedState,
+          saveSidebarScroll: this.saveSidebarScroll
         }}
         >
         {children}


### PR DESCRIPTION
When expanding a panel in the guide, save the scroll state
when mounting a new side nav component,
check whether there's a scroll state we should restore
refactor reused log message fn

- [X] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `master` branch of freeCodeCamp.
- [X] None of my changes are plagiarized from another source without proper attribution.
- [X] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [X] My changes do not use shortened URLs or affiliate links.

Closes #34285
Note: I'm not sure I would fully say this closes 34285.  There are two situations: you click on an expandable header w/in the guide (e.g. accessibility) or you click on an endpoint (e.g. accessibility basics).  The current state of the site forces the sidebar to navigate to the top for both of these cases.

This PR only fixes when you expand a header, however, I think this is the worse case because when you expand a header the next action you (probably) want to take is to click on one of the children, which you'll be jump scrolled away from on the live site.  When you click on an individual article, you probably want to read it, so it's worth it IMO to fix the first w/o the second.

For the second, I think there's a higher level issue that the entire page is re-rendered (which is completely unnecessary).  This may be related to [gatsby#4260](https://github.com/gatsbyjs/gatsby/issues/4260) but this was supposed to be fixed in our version.  This PR is already a bit of a hack, and we could do more with some pushState type of stuff, but I suspect there's something wrong about the way we're using Gatsby / the location provider.  It's worth investigating, but I think we should fix the primary issue first.

Another issue caused by the re-render (besides wasting time) is that if I can a tree of guide sections expanded (e.g. accessibility and agile) and then click on a endpoint link (e.g. accessibility basics) we lose the tree.  We restore it based on the current article (so accessibility will be expanded) but it's not actually saving the tree.