### PR TITLE
fix(client): SideNav, if more than 1 child is expanded, only the firs…

### DIFF
--- a/client/src/components/layouts/components/guide/NavPanel.js
+++ b/client/src/components/layouts/components/guide/NavPanel.js
@@ -75,17 +75,10 @@ class NavPanel extends Component {
 
   renderBody() {
     const { hasChildren, children, isExpanded } = this.props;
-    const childrenWithChildren = children.filter(child => child.props.children);
-    const uniqueChildren = children.filter(
-      child =>
-        !childrenWithChildren.some(
-          (potentialDupe, index) => index > 0 && potentialDupe.key === child.key
-        )
-    );
     return (
       <div className={isExpanded ? 'body' : ''}>
         <ul className='navPanelUl'>
-          {hasChildren ? uniqueChildren : <NoArticles />}
+          {hasChildren ? children : <NoArticles />}
         </ul>
       </div>
     );


### PR DESCRIPTION
…t is shown, the rest disappear

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.

Closes #34962
