### PR TITLE
Fix typos in MongoDB lessons and clarify some language

### DIFF
--- a/curriculum/challenges/english/05-apis-and-microservices/mongodb-and-mongoose/create-and-save-a-record-of-a-model.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/mongodb-and-mongoose/create-and-save-a-record-of-a-model.english.md
@@ -5,8 +5,9 @@ challengeType: 2
 ---
 
 ## Description
+
 <section id='description'>
-Create a document instance using the Person constructor you built before. Pass to the constructor an object having the fields name, age, and favoriteFoods. Their types must be conformant to the ones in the Person Schema. Then call the method document.save() on the returned document instance. Pass to it a callback using the Node convention. This is a common pattern, all the following CRUD methods take a callback function like this as the last argument.
+Create a document instance using the Person constructor you built before. Pass an object to the constructor with the fields name, age, and favoriteFoods. Their types must conform to the ones in the Person Schema. Then call the method document.save() on the returned document instance. Pass it a callback using the Node convention you saw before. This is a common pattern, all the following CRUD methods take a callback function like this as the last argument.
 <code>/* Example */</code>
 <code>// ...</code>
 <code>person.save(function(err, data) {</code>
@@ -15,31 +16,35 @@ Create a document instance using the Person constructor you built before. Pass t
 </section>
 
 ## Instructions
+
 <section id='instructions'>
 
 </section>
 
 ## Tests
+
 <section id='tests'>
 
 ```yml
 tests:
   - text: Creating and saving a db item should succeed
     testString: 'getUserInput => $.get(getUserInput(''url'') + ''/_api/create-and-save-person'').then(data => { assert.isString(data.name, ''"item.name" should be a String''); assert.isNumber(data.age, ''28'', ''"item.age" should be a Number''); assert.isArray(data.favoriteFoods, ''"item.favoriteFoods" should be an Array''); assert.equal(data.__v, 0, ''The db item should be not previously edited''); }, xhr => { throw new Error(xhr.responseText); })'
-
 ```
 
 </section>
 
 ## Challenge Seed
+
 <section id='challengeSeed'>
 
 </section>
 
 ## Solution
+
 <section id='solution'>
 
 ```js
 // solution required
 ```
+
 </section>

--- a/curriculum/challenges/english/05-apis-and-microservices/mongodb-and-mongoose/create-and-save-a-record-of-a-model.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/mongodb-and-mongoose/create-and-save-a-record-of-a-model.english.md
@@ -5,7 +5,6 @@ challengeType: 2
 ---
 
 ## Description
-
 <section id='description'>
 Create a document instance using the Person constructor you built before. Pass an object to the constructor with the fields name, age, and favoriteFoods. Their types must conform to the ones in the Person Schema. Then call the method document.save() on the returned document instance. Pass it a callback using the Node convention you saw before. This is a common pattern, all the following CRUD methods take a callback function like this as the last argument.
 <code>/* Example */</code>
@@ -16,13 +15,11 @@ Create a document instance using the Person constructor you built before. Pass a
 </section>
 
 ## Instructions
-
 <section id='instructions'>
 
 </section>
 
 ## Tests
-
 <section id='tests'>
 
 ```yml
@@ -34,13 +31,11 @@ tests:
 </section>
 
 ## Challenge Seed
-
 <section id='challengeSeed'>
 
 </section>
 
 ## Solution
-
 <section id='solution'>
 
 ```js

--- a/curriculum/challenges/english/05-apis-and-microservices/mongodb-and-mongoose/perform-classic-updates-by-running-find-edit-then-save.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/mongodb-and-mongoose/perform-classic-updates-by-running-find-edit-then-save.english.md
@@ -5,38 +5,43 @@ challengeType: 2
 ---
 
 ## Description
+
 <section id='description'>
-In the good old days this was what you needed to do if you wanted to edit a document and be able to use it somehow e.g. sending it back in a server response. Mongoose has a dedicated updating method : Model.update(). It is binded to the low-level mongo driver. It can bulk edit many documents matching certain criteria, but it doesn’t send back the updated document, only a ‘status’ message. Furthermore it makes model validations difficult, because it just directly calls the mongo driver.
+In the good old days this was what you needed to do if you wanted to edit a document and be able to use it somehow e.g. sending it back in a server response. Mongoose has a dedicated updating method : Model.update(). It is bound to the low-level mongo driver. It can bulk edit many documents matching certain criteria, but it doesn’t send back the updated document, only a ‘status’ message. Furthermore it makes model validations difficult, because it just directly calls the mongo driver.
 Find a person by _id ( use any of the above methods ) with the parameter personId as search key. Add “hamburger” to the list of her favoriteFoods (you can use Array.push()). Then - inside the find callback - save() the updated Person.
 [*] Hint: This may be tricky if in your Schema you declared favoriteFoods as an Array, without specifying the type (i.e. [String]). In that casefavoriteFoods defaults to Mixed type, and you have to manually mark it as edited using document.markModified('edited-field'). (http://mongoosejs.com/docs/schematypes.html - #Mixed )
 </section>
 
 ## Instructions
+
 <section id='instructions'>
 
 </section>
 
 ## Tests
+
 <section id='tests'>
 
 ```yml
 tests:
   - text: Find-edit-update an item should succeed
-    testString: 'getUserInput => $.post(getUserInput(''url'') + ''/_api/find-edit-save'', {name:''Poldo'', age: 40, favoriteFoods:[''spaghetti'']}).then(data => { assert.equal(data.name, ''Poldo'', ''item.name is not what expected''); assert.equal(data.age, 40, ''item.age is not what expected''); assert.deepEqual(data.favoriteFoods, [''spaghetti'', ''hamburger''], ''item.favoriteFoods is not what expected''); assert.equal(data.__v, 1, ''The item should be previously edited''); }, xhr => { throw new Error(xhr.responseText); })'
-
+    testString: "getUserInput => $.post(getUserInput('url') + '/_api/find-edit-save', {name:'Poldo', age: 40, favoriteFoods:['spaghetti']}).then(data => { assert.equal(data.name, 'Poldo', 'item.name is not what expected'); assert.equal(data.age, 40, 'item.age is not what expected'); assert.deepEqual(data.favoriteFoods, ['spaghetti', 'hamburger'], 'item.favoriteFoods is not what expected'); assert.equal(data.__v, 1, 'The item should be previously edited'); }, xhr => { throw new Error(xhr.responseText); })"
 ```
 
 </section>
 
 ## Challenge Seed
+
 <section id='challengeSeed'>
 
 </section>
 
 ## Solution
+
 <section id='solution'>
 
 ```js
 // solution required
 ```
+
 </section>

--- a/curriculum/challenges/english/05-apis-and-microservices/mongodb-and-mongoose/perform-classic-updates-by-running-find-edit-then-save.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/mongodb-and-mongoose/perform-classic-updates-by-running-find-edit-then-save.english.md
@@ -5,7 +5,6 @@ challengeType: 2
 ---
 
 ## Description
-
 <section id='description'>
 In the good old days this was what you needed to do if you wanted to edit a document and be able to use it somehow e.g. sending it back in a server response. Mongoose has a dedicated updating method : Model.update(). It is bound to the low-level mongo driver. It can bulk edit many documents matching certain criteria, but it doesn’t send back the updated document, only a ‘status’ message. Furthermore it makes model validations difficult, because it just directly calls the mongo driver.
 Find a person by _id ( use any of the above methods ) with the parameter personId as search key. Add “hamburger” to the list of her favoriteFoods (you can use Array.push()). Then - inside the find callback - save() the updated Person.
@@ -13,31 +12,27 @@ Find a person by _id ( use any of the above methods ) with the parameter personI
 </section>
 
 ## Instructions
-
 <section id='instructions'>
 
 </section>
 
 ## Tests
-
 <section id='tests'>
 
 ```yml
 tests:
   - text: Find-edit-update an item should succeed
-    testString: "getUserInput => $.post(getUserInput('url') + '/_api/find-edit-save', {name:'Poldo', age: 40, favoriteFoods:['spaghetti']}).then(data => { assert.equal(data.name, 'Poldo', 'item.name is not what expected'); assert.equal(data.age, 40, 'item.age is not what expected'); assert.deepEqual(data.favoriteFoods, ['spaghetti', 'hamburger'], 'item.favoriteFoods is not what expected'); assert.equal(data.__v, 1, 'The item should be previously edited'); }, xhr => { throw new Error(xhr.responseText); })"
+    testString: "getUserInput => $.post(getUserInput('url') + '/_api/find-edit-save', {name:'Poldo', age: 40, favoriteFoods:['spaghetti']}).then(data => { assert.equal(data.name, 'Poldo', 'item.name is not what is expected'); assert.equal(data.age, 40, 'item.age is not what expected'); assert.deepEqual(data.favoriteFoods, ['spaghetti', 'hamburger'], 'item.favoriteFoods is not what expected'); assert.equal(data.__v, 1, 'The item should be previously edited'); }, xhr => { throw new Error(xhr.responseText); })"
 ```
 
 </section>
 
 ## Challenge Seed
-
 <section id='challengeSeed'>
 
 </section>
 
 ## Solution
-
 <section id='solution'>
 
 ```js

--- a/curriculum/challenges/english/05-apis-and-microservices/mongodb-and-mongoose/use-model.findbyid-to-search-your-database-by-id.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/mongodb-and-mongoose/use-model.findbyid-to-search-your-database-by-id.english.md
@@ -7,7 +7,7 @@ challengeType: 2
 ## Description
 
 <section id='description'>
-When saving a document, mongodb automatically adds the field _id, and set it to a unique alphanumeric key. Searching by _id is an extremely frequent operation, so moongose provides a dedicated method for it. Find the (only!!) person who has the given _id using Model.findById() -> Person. Use the function argument personId as search key.
+When saving a document, mongodb automatically adds the field _id, and set it to a unique alphanumeric key. Searching by _id is an extremely frequent operation, so mongoose provides a dedicated method for it. Find the (only!!) person who has the given _id using Model.findById() -> Person. Use the function argument personId as search key.
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/05-apis-and-microservices/mongodb-and-mongoose/use-model.findbyid-to-search-your-database-by-id.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/mongodb-and-mongoose/use-model.findbyid-to-search-your-database-by-id.english.md
@@ -5,36 +5,41 @@ challengeType: 2
 ---
 
 ## Description
+
 <section id='description'>
-When saving a document, mongodb automatically adds the field _id, and set it to a unique alphanumeric key. Searching by _id is an extremely frequent operation, so mongoose provides a dedicated method for it. Find the (only!!) person having a given _id, using Model.findById() -> Person. Use the function argument personId as search key.
+When saving a document, mongodb automatically adds the field _id, and set it to a unique alphanumeric key. Searching by _id is an extremely frequent operation, so moongose provides a dedicated method for it. Find the (only!!) person who has the given _id using Model.findById() -> Person. Use the function argument personId as search key.
 </section>
 
 ## Instructions
+
 <section id='instructions'>
 
 </section>
 
 ## Tests
+
 <section id='tests'>
 
 ```yml
 tests:
   - text: Find an item by Id should succeed
-    testString: 'getUserInput => $.get(getUserInput(''url'') + ''/_api/find-by-id'').then(data => { assert.equal(data.name, ''test'', ''item.name is not what expected''); assert.equal(data.age, 0, ''item.age is not what expected''); assert.deepEqual(data.favoriteFoods, [''none''], ''item.favoriteFoods is not what expected''); assert.equal(data.__v, 0, ''The item should be not previously edited''); }, xhr => { throw new Error(xhr.responseText); })'
-
+    testString: "getUserInput => $.get(getUserInput('url') + '/_api/find-by-id').then(data => { assert.equal(data.name, 'test', 'item.name is not what expected'); assert.equal(data.age, 0, 'item.age is not what expected'); assert.deepEqual(data.favoriteFoods, ['none'], 'item.favoriteFoods is not what expected'); assert.equal(data.__v, 0, 'The item should be not previously edited'); }, xhr => { throw new Error(xhr.responseText); })"
 ```
 
 </section>
 
 ## Challenge Seed
+
 <section id='challengeSeed'>
 
 </section>
 
 ## Solution
+
 <section id='solution'>
 
 ```js
 // solution required
 ```
+
 </section>

--- a/curriculum/challenges/english/05-apis-and-microservices/mongodb-and-mongoose/use-model.findbyid-to-search-your-database-by-id.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/mongodb-and-mongoose/use-model.findbyid-to-search-your-database-by-id.english.md
@@ -5,19 +5,16 @@ challengeType: 2
 ---
 
 ## Description
-
 <section id='description'>
 When saving a document, mongodb automatically adds the field _id, and set it to a unique alphanumeric key. Searching by _id is an extremely frequent operation, so mongoose provides a dedicated method for it. Find the (only!!) person who has the given _id using Model.findById() -> Person. Use the function argument personId as search key.
 </section>
 
 ## Instructions
-
 <section id='instructions'>
 
 </section>
 
 ## Tests
-
 <section id='tests'>
 
 ```yml
@@ -29,13 +26,11 @@ tests:
 </section>
 
 ## Challenge Seed
-
 <section id='challengeSeed'>
 
 </section>
 
 ## Solution
-
 <section id='solution'>
 
 ```js


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

There were a few little typos and grammatical errors in the text of the MongoDB lessons. This PR clears up the low hanging fruit. 