### PR TITLE
Fixed bug allowing versions of Object.keys method and hard coding of ownProps array

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/understand-own-properties.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/understand-own-properties.english.md
@@ -25,11 +25,11 @@ Add the <code>own</code> properties of <code>canary</code> to the array <code>ow
 ```yml
 tests:
   - text: <code>ownProps</code> should include the values <code>"numLegs"</code> and <code>"name"</code>.
-    testString: assert(ownProps.indexOf('name') !== -1 && ownProps.indexOf('numLegs') !== -1, '<code>ownProps</code> should include the values <code>"numLegs"</code> and <code>"name"</code>.');
+    testString: assert(ownProps.indexOf('name') !== -1 && ownProps.indexOf('numLegs') !== -1);
   - text: Solve this challenge without using the built in method <code>Object.keys()</code>.
-    testString: assert(!/Object(\.(keys)|\[('|"|\`).+\2\3\])/.test(code), 'Solve this challenge without using the built in method <code>Object.keys()</code>.');
+    testString: assert(!/Object(\.keys|\[(['"`])keys\2\])/.test(code));
   - text: Solve this challenge without hardcoding the <code>ownProps</code> array.
-    testString: assert(!/\[\s*(?:'|")(?:name|numLegs)|(?:push|concat)\(\s*(?:'|")(?:name|numLegs)/.test(code), 'Solve this challenge without hardcoding <code>ownProps</code>.');
+    testString: assert(!/\[\s*(?:'|")(?:name|numLegs)|(?:push|concat)\(\s*(?:'|")(?:name|numLegs)/.test(code));
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/understand-own-properties.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/understand-own-properties.english.md
@@ -27,7 +27,7 @@ tests:
   - text: <code>ownProps</code> should include the values <code>"numLegs"</code> and <code>"name"</code>.
     testString: assert(ownProps.indexOf('name') !== -1 && ownProps.indexOf('numLegs') !== -1, '<code>ownProps</code> should include the values <code>"numLegs"</code> and <code>"name"</code>.');
   - text: Solve this challenge without using the built in method <code>Object.keys()</code>.
-    testString: assert(!/\Object.keys/.test(code), 'Solve this challenge without using the built in method <code>Object.keys()</code>.');
+    testString: assert(!/Object(\.(keys)|\[('|"|\`).+\2\3\])/.test(code), 'Solve this challenge without using the built in method <code>Object.keys()</code>.');
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/understand-own-properties.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/understand-own-properties.english.md
@@ -28,6 +28,8 @@ tests:
     testString: assert(ownProps.indexOf('name') !== -1 && ownProps.indexOf('numLegs') !== -1, '<code>ownProps</code> should include the values <code>"numLegs"</code> and <code>"name"</code>.');
   - text: Solve this challenge without using the built in method <code>Object.keys()</code>.
     testString: assert(!/Object(\.(keys)|\[('|"|\`).+\2\3\])/.test(code), 'Solve this challenge without using the built in method <code>Object.keys()</code>.');
+  - text: Solve this challenge without hardcoding the <code>ownProps</code> array.
+    testString: assert(!/\[\s*(?:'|")(?:name|numLegs)|(?:push|concat)\(\s*(?:'|")(?:name|numLegs)/.test(code), 'Solve this challenge without hardcoding <code>ownProps</code>.');
 
 ```
 


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Closes #17427 

This PR fixes the bug pointed out in issue #17427 by correcting the testString for the second test.  Also, 
 it "attempts" to prevent a user from just hard coding the `ownProps` array.  It does not cover every hard coding case, but it covers the base cases and a few variants of these:
```
ownProps = ['name', 'numLegs'];
```
```
ownProps.push('name');
ownProps.push('numLegs');
```
```
ownProps.push('name', 'numLegs');
```
```
ownProps = ownProps.concat('name');
ownProps = ownProps.concat('numLegs');
```
```
ownProps = ownProps.concat('name','numLegs');
```
I tested the changes locally with no problems that I can detect.

**NOTE:**  After reviewing all the tests for this challenge, I noticed it is missing an additional test where if the `Bird` function had a prototype property added such as `Bird.prototype.color = 'brown'`.   code like I just mentioned should be a part of the challenge seed code.  Then, there would need to be a test to validate that `ownProps` only contains the two `own` properties (`name` and `numLegs`) and **not** the `color` property available via the prototype.  However, since the current challenge order is placed before prototypes are introduced, this would not make sense in the current challenge.  I plan to created a separate issue to deal with changing the order of these two challenges along with adding/modifying the tests of this current challenge as I describe above, so others can share their opinions about how best to approach this separate issue.