### PR TITLE
Test / Error message gives away the solution

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/css-grid/use-grid-area-without-creating-an-areas-template.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-grid/use-grid-area-without-creating-an-areas-template.english.md
@@ -25,7 +25,7 @@ Using the <code>grid-area</code> property, place the element with <code>item5</c
 ```yml
 tests:
   - text: <code>item5</code> class should have a <code>grid-area</code> property that places it between the third and fourth horizontal lines and between the first and fourth vertical lines.
-    testString: assert(code.match(/.item5\s*?{[\s\S]*grid-area\s*?:\s*?3\s*?\/\s*?1\s*?\/\s*?4\s*?\/\s*?4\s*?;[\s\S]*}/gi), '<code>item5</code> class should have a <code>grid-area</code> property that has the value of <code>3/1/4/4</code>.');
+    testString: assert(code.match(/.item5\s*?{[\s\S]*grid-area\s*?:\s*?3\s*?\/\s*?1\s*?\/\s*?4\s*?\/\s*?4\s*?;[\s\S]*}/gi), '<code>item5</code> class should have a <code>grid-area</code> property that places it between the third and fourth horizontal lines and between the first and fourth vertical lines.');
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-grid/use-grid-area-without-creating-an-areas-template.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-grid/use-grid-area-without-creating-an-areas-template.english.md
@@ -24,7 +24,7 @@ Using the <code>grid-area</code> property, place the element with <code>item5</c
 
 ```yml
 tests:
-  - text: <code>item5</code> class should have a <code>grid-area</code> property that has the value of <code>3/1/4/4</code>.
+  - text: <code>item5</code> class should have a <code>grid-area</code> property that places it between the third and fourth horizontal lines and between the first and fourth vertical lines.
     testString: assert(code.match(/.item5\s*?{[\s\S]*grid-area\s*?:\s*?3\s*?\/\s*?1\s*?\/\s*?4\s*?\/\s*?4\s*?;[\s\S]*}/gi), '<code>item5</code> class should have a <code>grid-area</code> property that has the value of <code>3/1/4/4</code>.');
 
 ```


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

The test text in the Coding Challenge [CSS Grid: Use grid-area Without Creating an Areas Template](https://learn.freecodecamp.org/responsive-web-design/css-grid/use-grid-area-without-creating-an-areas-template) states the solution.

![solution in test](https://user-images.githubusercontent.com/45669613/52112660-d3208700-260f-11e9-89d4-9c235bb0ef27.png)


The proposed change uses a part of the text given in the challenge instructions instead of stating the explicit solution.
