### PR TITLE
Change order of regex lesson according to previous content

### DIFF
--- a/curriculum/challenges/_meta/regular-expressions/meta.json
+++ b/curriculum/challenges/_meta/regular-expressions/meta.json
@@ -93,10 +93,6 @@
       "Match All Non-Numbers"
     ],
     [
-      "587d7db8367417b2b2512ba2",
-      "Restrict Possible Usernames"
-    ],
-    [
       "587d7db8367417b2b2512ba3",
       "Match Whitespace"
     ],
@@ -115,6 +111,10 @@
     [
       "587d7db9367417b2b2512ba7",
       "Specify Exact Number of Matches"
+    ],
+    [
+      "587d7db8367417b2b2512ba2",
+      "Restrict Possible Usernames"
     ],
     [
       "587d7dba367417b2b2512ba8",


### PR DESCRIPTION
Lesson 'restrict possible username' uses quantity specifiers which are not introduced yet. Change order to after quantity specifier lessons

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Lesson 'Restrict possible username' uses quantity specifiers which are introduced in later lessons.
Change order to make it solvable. 
