### PR TITLE
fix(challenge): check for li and specify elements accepting text

### DIFF
--- a/curriculum/challenges/english/03-front-end-libraries/react/create-a-complex-jsx-element.english.md
+++ b/curriculum/challenges/english/03-front-end-libraries/react/create-a-complex-jsx-element.english.md
@@ -21,7 +21,7 @@ Here's an example:
 ## Instructions
 <section id='instructions'>
 Define a new constant <code>JSX</code> that renders a <code>div</code> which contains the following elements in order:
-An <code>h1</code>, a <code>p</code>, and an unordered list that contains three <code>li</code> items. You can include any text you want within each element.
+An <code>h1</code>, a <code>p</code>, and an unordered list that contains three <code>li</code> items. You can include any text you want within the <code>h1</code>, <code>p</code> and <code>li</code> elements.
 <strong>Note:</strong>&nbsp;When rendering multiple elements like this, you can wrap them all in parentheses, but it's not strictly required. Also notice this challenge uses a <code>div</code> tag to wrap all the child elements within a single parent element. If you remove the <code>div</code>, the JSX will no longer transpile. Keep this in mind, since it will also apply when you return JSX elements in React components.
 </section>
 
@@ -32,14 +32,14 @@ An <code>h1</code>, a <code>p</code>, and an unordered list that contains three 
 tests:
   - text: The constant <code>JSX</code> should return a <code>div</code> element.
     testString: assert(JSX.type === 'div', 'The constant <code>JSX</code> should return a <code>div</code> element.');
+  - text: The <code>div</code> should contain an <code>h1</code> tag as the first element.
+    testString: assert(JSX.props.children[0].type === 'h1', 'The <code>div</code> should contain an <code>h1</code> tag as the first element.');
   - text: The <code>div</code> should contain a <code>p</code> tag as the second element.
     testString: assert(JSX.props.children[1].type === 'p', 'The <code>div</code> should contain a <code>p</code> tag as the second element.');
   - text: The <code>div</code> should contain a <code>ul</code> tag as the third element.
     testString: assert(JSX.props.children[2].type === 'ul', 'The <code>div</code> should contain a <code>ul</code> tag as the third element.');
-  - text: The <code>div</code> should contain an <code>h1</code> tag as the first element.
-    testString: assert(JSX.props.children[0].type === 'h1', 'The <code>div</code> should contain an <code>h1</code> tag as the first element.');
   - text: The <code>ul</code> should contain three <code>li</code> elements.
-    testString: assert(JSX.props.children[2].props.children.length === 3, 'The <code>ul</code> should contain three <code>li</code> elements.');
+    testString: assert(JSX.props.children[2].props.children.filter( (ele, idx, arr) => arr.every(ele => ele.type === 'li')).length === 3, 'The <code>ul</code> should contain three <code>li</code> elements.');
 
 ```
 

--- a/curriculum/challenges/english/03-front-end-libraries/react/create-a-complex-jsx-element.english.md
+++ b/curriculum/challenges/english/03-front-end-libraries/react/create-a-complex-jsx-element.english.md
@@ -21,7 +21,7 @@ Here's an example:
 ## Instructions
 <section id='instructions'>
 Define a new constant <code>JSX</code> that renders a <code>div</code> which contains the following elements in order:
-An <code>h1</code>, a <code>p</code>, and an unordered list that contains three <code>li</code> items. You can include any text you want within the each element.
+An <code>h1</code>, a <code>p</code>, and an unordered list that contains three <code>li</code> items. You can include any text you want within each element.
 <strong>Note:</strong>&nbsp;When rendering multiple elements like this, you can wrap them all in parentheses, but it's not strictly required. Also notice this challenge uses a <code>div</code> tag to wrap all the child elements within a single parent element. If you remove the <code>div</code>, the JSX will no longer transpile. Keep this in mind, since it will also apply when you return JSX elements in React components.
 </section>
 

--- a/curriculum/challenges/english/03-front-end-libraries/react/create-a-complex-jsx-element.english.md
+++ b/curriculum/challenges/english/03-front-end-libraries/react/create-a-complex-jsx-element.english.md
@@ -31,15 +31,15 @@ An <code>h1</code>, a <code>p</code>, and an unordered list that contains three 
 ```yml
 tests:
   - text: The constant <code>JSX</code> should return a <code>div</code> element.
-    testString: assert(JSX.type === 'div', 'The constant <code>JSX</code> should return a <code>div</code> element.');
+    testString: assert(JSX.type === 'div');
   - text: The <code>div</code> should contain an <code>h1</code> tag as the first element.
-    testString: assert(JSX.props.children[0].type === 'h1', 'The <code>div</code> should contain an <code>h1</code> tag as the first element.');
+    testString: assert(JSX.props.children[0].type === 'h1');
   - text: The <code>div</code> should contain a <code>p</code> tag as the second element.
-    testString: assert(JSX.props.children[1].type === 'p', 'The <code>div</code> should contain a <code>p</code> tag as the second element.');
+    testString: assert(JSX.props.children[1].type === 'p');
   - text: The <code>div</code> should contain a <code>ul</code> tag as the third element.
-    testString: assert(JSX.props.children[2].type === 'ul', 'The <code>div</code> should contain a <code>ul</code> tag as the third element.');
+    testString: assert(JSX.props.children[2].type === 'ul');
   - text: The <code>ul</code> should contain three <code>li</code> elements.
-    testString: assert(JSX.props.children[2].props.children.filter( (ele, idx, arr) => arr.every(ele => ele.type === 'li')).length === 3, 'The <code>ul</code> should contain three <code>li</code> elements.');
+    testString: assert(JSX.props.children.filter(ele => ele.type === 'ul')[0].props.children.filter(ele => ele.type === 'li').length === 3);
 
 ```
 

--- a/curriculum/challenges/english/03-front-end-libraries/react/create-a-complex-jsx-element.english.md
+++ b/curriculum/challenges/english/03-front-end-libraries/react/create-a-complex-jsx-element.english.md
@@ -21,7 +21,7 @@ Here's an example:
 ## Instructions
 <section id='instructions'>
 Define a new constant <code>JSX</code> that renders a <code>div</code> which contains the following elements in order:
-An <code>h1</code>, a <code>p</code>, and an unordered list that contains three <code>li</code> items. You can include any text you want within the <code>h1</code>, <code>p</code> and <code>li</code> elements.
+An <code>h1</code>, a <code>p</code>, and an unordered list that contains three <code>li</code> items. You can include any text you want within the each element.
 <strong>Note:</strong>&nbsp;When rendering multiple elements like this, you can wrap them all in parentheses, but it's not strictly required. Also notice this challenge uses a <code>div</code> tag to wrap all the child elements within a single parent element. If you remove the <code>div</code>, the JSX will no longer transpile. Keep this in mind, since it will also apply when you return JSX elements in React components.
 </section>
 


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Fixes for the challenge: https://learn.freecodecamp.org/front-end-libraries/react/create-a-complex-jsx-element/

1. The assertion test does not check for the type of ul children. You can pass using the wrong elements.

2. Right now the challenge text says "You can include any text you want within each element". However, text is not permitted content for the ul element. I changed the text to specify what elements accept text.

3. I switched the order of the tests to be first element, second element, third element. Instead of before where it was second element, third element, first element. Not sure why it was like that, but I didn't see a reason for it.

@RandellDawson If you have the time at some point can you test this locally?

Note: The test still uses hard-coded positions for the elements. The last test will fail with an incorrect assertion text if you mess up the order of the element because it depends on the location of the UL.

```
// This will fail with the assertion for the last test "The ul should contain three li elements."
const JSX = <div>
  <h1>Start</h1>
  <ul>
    <li>2</li>
    <li>2</li>
    <li>2</li>
  </ul>
  <p>Paragraph Two</p>
</div>
```
