### PR TITLE
fix(Learn): Search bar height on retina displays

### DIFF
--- a/client/src/components/Header/header.css
+++ b/client/src/components/Header/header.css
@@ -97,6 +97,7 @@ li.user-state-link > a:focus {
 .fcc_searchBar {
   flex-grow: 1;
   padding: 0 10px;
+  max-height: 33px;
 }
 
 .fcc_searchBar .ais-SearchBox-input,


### PR DESCRIPTION
Gives the search bar a defined height to prevent it from overflowing on Retina devices.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #34887
