### PR TITLE
Fix: changed can to can't

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/css-grid/create-flexible-layouts-using-auto-fill.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-grid/create-flexible-layouts-using-auto-fill.english.md
@@ -10,7 +10,7 @@ videoUrl: 'https://scrimba.com/p/pByETK/cmzdycW'
 The repeat function comes with an option called <dfn>auto-fill</dfn>. This allows you to automatically insert as many rows or columns of your desired size as possible depending on the size of the container. You can create flexible layouts when combining <code>auto-fill</code> with <code>minmax</code>.
 In the preview, <code>grid-template-columns</code> is set to
 <blockquote>repeat(auto-fill, minmax(60px, 1fr));</blockquote>
-When the container changes size, this setup keeps inserting 60px columns and stretching them until it can insert another one.
+When the container changes size, this setup keeps inserting 60px columns and stretching them until it can't insert another one.
 <strong>Note</strong><br>If your container can't fit all your items on one row, it will move them down to a new one.
 </section>
 


### PR DESCRIPTION
Corrected can to can't, as grid auto-fills while there is space to do so. When it can't it wraps to create a new row.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX
