### PR TITLE
fix: turn non CTA buttons to ghost

### DIFF
--- a/client/src/templates/Challenges/components/CompletionModal.js
+++ b/client/src/templates/Challenges/components/CompletionModal.js
@@ -147,7 +147,7 @@ export class CompletionModal extends Component {
               block={true}
               bsSize='lg'
               bsStyle='primary'
-              className='btn-primary-invert'
+              className='btn-invert'
               download={`${dashedName}.json`}
               href={this.state.downloadURL}
               >

--- a/client/src/templates/Challenges/components/Tool-Panel.js
+++ b/client/src/templates/Challenges/components/Tool-Panel.js
@@ -50,7 +50,7 @@ function ToolPanel({
         <Button
           block={true}
           bsStyle='primary'
-          className='btn-primary-invert'
+          className='btn-invert'
           onClick={openResetModal}
           >
           {isMobile ? 'Reset' : 'Reset All Code'}
@@ -59,7 +59,7 @@ function ToolPanel({
           <Button
             block={true}
             bsStyle='primary'
-            className='btn-primary-invert'
+            className='btn-invert'
             href={guideUrl}
             target='_blank'
             >
@@ -70,7 +70,7 @@ function ToolPanel({
           <Button
             block={true}
             bsStyle='primary'
-            className='btn-primary-invert'
+            className='btn-invert'
             onClick={openVideoModal}
             >
             {isMobile ? 'Video' : 'Watch a video'}
@@ -79,7 +79,7 @@ function ToolPanel({
         <Button
           block={true}
           bsStyle='primary'
-          className='btn-primary-invert'
+          className='btn-invert'
           onClick={openHelpModal}
           >
           {isMobile ? 'Help' : 'Ask for help'}

--- a/client/src/templates/Challenges/project/Tool-Panel.js
+++ b/client/src/templates/Challenges/project/Tool-Panel.js
@@ -32,7 +32,7 @@ export class ToolPanel extends Component {
           <Button
             block={true}
             bsStyle='primary'
-            className='btn-primary-invert'
+            className='btn-invert'
             href={guideUrl}
             target='_blank'
             >
@@ -42,7 +42,7 @@ export class ToolPanel extends Component {
         <Button
           block={true}
           bsStyle='primary'
-          className='btn-primary-invert'
+          className='btn-invert'
           onClick={openHelpModal}
           >
           Ask for help

--- a/client/src/templates/Introduction/Intro.js
+++ b/client/src/templates/Introduction/Intro.js
@@ -57,7 +57,7 @@ function IntroductionPage({ data: { markdownRemark, allChallengeNode } }) {
           </Link>
           <ButtonSpacer />
           <Link to='/learn'>
-            <Button block={true} bsSize='lg' className='btn-primary-invert'>
+            <Button block={true} bsSize='lg' className='btn-invert'>
               View the curriculum
             </Button>
           </Link>


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

buttons that are non 'call to action' need to be ghost.
the codebase hase two classes for dealing with this.
btn-primary-invert, and btn-invert
however there are no CSS rules for btn-primary-invert.
so they have all been changed to btn-invert.

here are the after screenshots:
<img width="1440" alt="screen shot 2019-02-15 at 7 22 44 pm" src="https://user-images.githubusercontent.com/4591597/52871641-900bfb00-315b-11e9-8089-3e942f75e462.png">
