### PR TITLE
feat(client): make UX changes to be aligned for release

### DIFF
--- a/client/gatsby-browser.js
+++ b/client/gatsby-browser.js
@@ -6,7 +6,7 @@ import { createStore } from './src/redux/createStore';
 import AppMountNotifier from './src/components/AppMountNotifier';
 import GuideNavContextProvider from './src/contexts/GuideNavigationContext';
 import DefaultLayout from './src/components/layouts/Default';
-import GuideLayout from './src/components/layouts/GuideLayout';
+import GuideLayout from './src/components/layouts/Guide';
 
 const store = createStore();
 
@@ -30,15 +30,26 @@ export const wrapPageElement = ({ element, props }) => {
   } = props;
   if (pathname === '/') {
     return (
-      <DefaultLayout disableSettings={true} landingPage={true}>
+      <DefaultLayout
+        disableSettings={true}
+        landingPage={true}
+        nonLearnPage={true}
+        >
         {element}
       </DefaultLayout>
     );
   }
   if ((/^\/guide(\/.*)*/).test(pathname)) {
     return (
-      <DefaultLayout>
+      <DefaultLayout nonLearnPage={true}>
         <GuideLayout>{element}</GuideLayout>
+      </DefaultLayout>
+    );
+  }
+  if (false === (/^\/learn(\/.*)*/).test(pathname)) {
+    return (
+      <DefaultLayout nonLearnPage={true}>
+        {element}
       </DefaultLayout>
     );
   }

--- a/client/gatsby-browser.js
+++ b/client/gatsby-browser.js
@@ -30,28 +30,20 @@ export const wrapPageElement = ({ element, props }) => {
   } = props;
   if (pathname === '/') {
     return (
-      <DefaultLayout
-        disableSettings={true}
-        landingPage={true}
-        nonLearnPage={true}
-        >
+      <DefaultLayout disableSettings={true} landingPage={true}>
         {element}
       </DefaultLayout>
     );
   }
   if ((/^\/guide(\/.*)*/).test(pathname)) {
     return (
-      <DefaultLayout nonLearnPage={true}>
+      <DefaultLayout>
         <GuideLayout>{element}</GuideLayout>
       </DefaultLayout>
     );
   }
-  if (false === (/^\/learn(\/.*)*/).test(pathname)) {
-    return (
-      <DefaultLayout nonLearnPage={true}>
-        {element}
-      </DefaultLayout>
-    );
+  if ((/^\/learn(\/.*)*/).test(pathname)) {
+    return <DefaultLayout showFooter={false}>{element}</DefaultLayout>;
   }
   return <DefaultLayout>{element}</DefaultLayout>;
 };

--- a/client/gatsby-ssr.js
+++ b/client/gatsby-ssr.js
@@ -8,7 +8,7 @@ import { createStore } from './src/redux/createStore';
 
 import GuideNavContextProvider from './src/contexts/GuideNavigationContext';
 import DefaultLayout from './src/components/layouts/Default';
-import GuideLayout from './src/components/layouts/GuideLayout';
+import GuideLayout from './src/components/layouts/Guide';
 
 const store = createStore();
 
@@ -30,15 +30,26 @@ export const wrapPageElement = ({ element, props }) => {
   } = props;
   if (pathname === '/') {
     return (
-      <DefaultLayout disableSettings={true} landingPage={true}>
+      <DefaultLayout
+        disableSettings={true}
+        landingPage={true}
+        nonLearnPage={true}
+        >
         {element}
       </DefaultLayout>
     );
   }
   if ((/^\/guide(\/.*)*/).test(pathname)) {
     return (
-      <DefaultLayout>
+      <DefaultLayout nonLearnPage={true}>
         <GuideLayout>{element}</GuideLayout>
+      </DefaultLayout>
+    );
+  }
+  if (false === (/^\/learn(\/.*)*/).test(pathname)) {
+    return (
+      <DefaultLayout nonLearnPage={true}>
+        {element}
       </DefaultLayout>
     );
   }

--- a/client/gatsby-ssr.js
+++ b/client/gatsby-ssr.js
@@ -30,28 +30,20 @@ export const wrapPageElement = ({ element, props }) => {
   } = props;
   if (pathname === '/') {
     return (
-      <DefaultLayout
-        disableSettings={true}
-        landingPage={true}
-        nonLearnPage={true}
-        >
+      <DefaultLayout disableSettings={true} landingPage={true}>
         {element}
       </DefaultLayout>
     );
   }
   if ((/^\/guide(\/.*)*/).test(pathname)) {
     return (
-      <DefaultLayout nonLearnPage={true}>
+      <DefaultLayout>
         <GuideLayout>{element}</GuideLayout>
       </DefaultLayout>
     );
   }
-  if (false === (/^\/learn(\/.*)*/).test(pathname)) {
-    return (
-      <DefaultLayout nonLearnPage={true}>
-        {element}
-      </DefaultLayout>
-    );
+  if ((/^\/learn(\/.*)*/).test(pathname)) {
+    return <DefaultLayout showFooter={false}>{element}</DefaultLayout>;
   }
   return <DefaultLayout>{element}</DefaultLayout>;
 };

--- a/client/src/components/Footer/index.js
+++ b/client/src/components/Footer/index.js
@@ -87,10 +87,10 @@ function Footer() {
           </Col>
           <Col lg={3} sm={2} xs={12}>
             <ColHeader>Our Learning Resources</ColHeader>
-            <Link target='_blank' to='/learn'>
-              Curriculum
+            <Link to='/learn'>
+              Learn
             </Link>
-            <Link target='_blank' to='/guide'>
+            <Link to='/guide'>
               Guide
             </Link>
             <Link to='https://www.youtube.com/freecodecamp'>Youtube</Link>

--- a/client/src/components/Header/index.js
+++ b/client/src/components/Header/index.js
@@ -58,7 +58,7 @@ class Header extends Component {
           {disableSettings ? null : <FCCSearch />}
           <ul id='top-right-nav'>
             <li>
-              <Link to='/learn'>Curriculum</Link>
+              <Link to='/learn'>Learn</Link>
             </li>
             <li>
               <a href='/forum' rel='noopener noreferrer' target='_blank'>

--- a/client/src/components/layouts/Default.js
+++ b/client/src/components/layouts/Default.js
@@ -69,9 +69,9 @@ const propTypes = {
   isOnline: PropTypes.bool.isRequired,
   isSignedIn: PropTypes.bool,
   landingPage: PropTypes.bool,
-  nonLearnPage: PropTypes.bool,
   onlineStatusChange: PropTypes.func.isRequired,
-  removeFlashMessage: PropTypes.func.isRequired
+  removeFlashMessage: PropTypes.func.isRequired,
+  showFooter: PropTypes.bool
 };
 
 const mapStateToProps = createSelector(
@@ -139,7 +139,7 @@ class DefaultLayout extends Component {
       flashMessages = [],
       removeFlashMessage,
       landingPage,
-      nonLearnPage,
+      showFooter = true,
       isOnline,
       isSignedIn
     } = this.props;
@@ -166,7 +166,7 @@ class DefaultLayout extends Component {
           ) : null}
           {children}
         </div>
-        {nonLearnPage ? (<Footer />) : null}
+        {showFooter && (<Footer />)}
       </Fragment>
     );
   }

--- a/client/src/components/layouts/Default.js
+++ b/client/src/components/layouts/Default.js
@@ -21,7 +21,6 @@ import OfflineWarning from '../OfflineWarning';
 import Flash from '../Flash';
 import Header from '../Header';
 import Footer from '../Footer';
-import Spacer from '../helpers/Spacer';
 
 import './global.css';
 import './layout.css';
@@ -70,6 +69,7 @@ const propTypes = {
   isOnline: PropTypes.bool.isRequired,
   isSignedIn: PropTypes.bool,
   landingPage: PropTypes.bool,
+  nonLearnPage: PropTypes.bool,
   onlineStatusChange: PropTypes.func.isRequired,
   removeFlashMessage: PropTypes.func.isRequired
 };
@@ -139,6 +139,7 @@ class DefaultLayout extends Component {
       flashMessages = [],
       removeFlashMessage,
       landingPage,
+      nonLearnPage,
       isOnline,
       isSignedIn
     } = this.props;
@@ -165,9 +166,7 @@ class DefaultLayout extends Component {
           ) : null}
           {children}
         </div>
-        <hr/>
-        <Spacer size={3}/>
-        <Footer />
+        {nonLearnPage ? (<Footer />) : null}
       </Fragment>
     );
   }

--- a/client/src/components/layouts/Guide.js
+++ b/client/src/components/layouts/Guide.js
@@ -9,6 +9,7 @@ import Spacer from '../helpers/Spacer';
 
 import 'prismjs/themes/prism.css';
 import './guide.css';
+import Footer from '../Footer';
 
 const propTypes = {
   children: PropTypes.any,
@@ -29,7 +30,7 @@ const propTypes = {
   location: PropTypes.object
 };
 
-class Layout extends React.Component {
+class GuideLayout extends React.Component {
   getContentRef = ref => (this.contentRef = ref);
 
   handleNavigation = () => {
@@ -41,7 +42,7 @@ class Layout extends React.Component {
     return (
       <StaticQuery
         query={graphql`
-          query LayoutQuery {
+          query GuideLayoutQuery {
             allNavigationNode {
               edges {
                 node {
@@ -110,7 +111,7 @@ class Layout extends React.Component {
   }
 }
 
-Layout.displayName = 'Layout';
-Layout.propTypes = propTypes;
+GuideLayout.displayName = 'GuideLayout';
+GuideLayout.propTypes = propTypes;
 
-export default Layout;
+export default GuideLayout;

--- a/client/src/components/layouts/Guide.js
+++ b/client/src/components/layouts/Guide.js
@@ -9,7 +9,6 @@ import Spacer from '../helpers/Spacer';
 
 import 'prismjs/themes/prism.css';
 import './guide.css';
-import Footer from '../Footer';
 
 const propTypes = {
   children: PropTypes.any,

--- a/client/src/templates/Challenges/classic/DesktopLayout.js
+++ b/client/src/templates/Challenges/classic/DesktopLayout.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import { ReflexContainer, ReflexSplitter, ReflexElement } from 'react-reflex';
 import PropTypes from 'prop-types';
 
@@ -14,8 +14,7 @@ const propTypes = {
     onStopResize: PropTypes.func,
     onResize: PropTypes.func
   }),
-  testOutput: PropTypes.element,
-  toolPanel: PropTypes.element
+  testOutput: PropTypes.element
 };
 
 class DesktopLayout extends Component {
@@ -27,50 +26,46 @@ class DesktopLayout extends Component {
       editor,
       testOutput,
       hasPreview,
-      preview,
-      toolPanel
+      preview
     } = this.props;
     return (
-      <Fragment>
-        <ReflexContainer className='desktop-layout' orientation='vertical'>
-          <ReflexElement flex={1} {...resizeProps}>
-            {instructions}
-          </ReflexElement>
-          <ReflexSplitter propagate={true} {...resizeProps} />
-          <ReflexElement flex={1} {...resizeProps}>
-            {challengeFile && (
-              <ReflexContainer key={challengeFile.key} orientation='horizontal'>
-                <ReflexElement
-                  flex={1}
-                  propagateDimensions={true}
-                  renderOnResize={true}
-                  renderOnResizeRate={20}
-                  {...resizeProps}
-                  >
-                  {editor}
-                </ReflexElement>
-                <ReflexSplitter propagate={true} {...resizeProps} />
-                <ReflexElement
-                  flex={0.25}
-                  propagateDimensions={true}
-                  renderOnResize={true}
-                  renderOnResizeRate={20}
-                  {...resizeProps}
-                  >
-                  {testOutput}
-                </ReflexElement>
-              </ReflexContainer>
-            )}
-          </ReflexElement>
-          {hasPreview && <ReflexSplitter propagate={true} {...resizeProps} />}
-          {hasPreview && (
-            <ReflexElement flex={0.7} {...resizeProps}>
-              {preview}
-            </ReflexElement>
+      <ReflexContainer className='desktop-layout' orientation='vertical'>
+        <ReflexElement flex={1} {...resizeProps}>
+          {instructions}
+        </ReflexElement>
+        <ReflexSplitter propagate={true} {...resizeProps} />
+        <ReflexElement flex={1} {...resizeProps}>
+          {challengeFile && (
+            <ReflexContainer key={challengeFile.key} orientation='horizontal'>
+              <ReflexElement
+                flex={1}
+                propagateDimensions={true}
+                renderOnResize={true}
+                renderOnResizeRate={20}
+                {...resizeProps}
+                >
+                {editor}
+              </ReflexElement>
+              <ReflexSplitter propagate={true} {...resizeProps} />
+              <ReflexElement
+                flex={0.25}
+                propagateDimensions={true}
+                renderOnResize={true}
+                renderOnResizeRate={20}
+                {...resizeProps}
+                >
+                {testOutput}
+              </ReflexElement>
+            </ReflexContainer>
           )}
-        </ReflexContainer>
-        {toolPanel}
-      </Fragment>
+        </ReflexElement>
+        {hasPreview && <ReflexSplitter propagate={true} {...resizeProps} />}
+        {hasPreview && (
+          <ReflexElement flex={0.7} {...resizeProps}>
+            {preview}
+          </ReflexElement>
+        )}
+      </ReflexContainer>
     );
   }
 }

--- a/client/src/templates/Challenges/classic/MobileLayout.js
+++ b/client/src/templates/Challenges/classic/MobileLayout.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { TabPane, Tabs } from '@freecodecamp/react-bootstrap';
 import { connect } from 'react-redux';
 
+import ToolPanel from '../components/Tool-Panel';
 import { createStructuredSelector } from 'reselect';
 import { currentTabSelector, moveToTab } from '../redux';
 import { bindActionCreators } from 'redux';
@@ -22,12 +23,13 @@ const mapDispatchToProps = dispatch =>
 const propTypes = {
   currentTab: PropTypes.number,
   editor: PropTypes.element,
+  guideUrl: PropTypes.string,
   hasPreview: PropTypes.bool,
   instructions: PropTypes.element,
   moveToTab: PropTypes.func,
   preview: PropTypes.element,
   testOutput: PropTypes.element,
-  toolPanel: PropTypes.element
+  videoUrl: PropTypes.string
 };
 
 class MobileLayout extends Component {
@@ -40,7 +42,8 @@ class MobileLayout extends Component {
       testOutput,
       hasPreview,
       preview,
-      toolPanel
+      guideUrl,
+      videoUrl
     } = this.props;
 
     const editorTabPaneProps = {
@@ -71,7 +74,7 @@ class MobileLayout extends Component {
             </TabPane>
           )}
         </Tabs>
-        {toolPanel}
+        <ToolPanel guideUrl={guideUrl} isMobile={true} videoUrl={videoUrl} />
       </Fragment>
     );
   }

--- a/client/src/templates/Challenges/classic/Show.js
+++ b/client/src/templates/Challenges/classic/Show.js
@@ -19,7 +19,6 @@ import VideoModal from '../components/VideoModal';
 import ResetModal from '../components/ResetModal';
 import MobileLayout from './MobileLayout';
 import DesktopLayout from './DesktopLayout';
-import ToolPanel from '../components/Tool-Panel';
 
 import { createGuideUrl } from '../utils';
 import { challengeTypes } from '../../../../utils/challengeTypes';
@@ -244,17 +243,6 @@ class ShowClassic extends Component {
     );
   }
 
-  renderToolPanel(isMobile) {
-    return (
-      <ToolPanel
-        className='classic-tool-panel'
-        guideUrl={this.getGuideUrl()}
-        isMobile={isMobile}
-        videoUrl={this.getVideoUrl()}
-      />
-    );
-  }
-
   render() {
     return (
       <LearnLayout>
@@ -266,13 +254,14 @@ class ShowClassic extends Component {
             matches ? (
               <MobileLayout
                 editor={this.renderEditor()}
+                guideUrl={this.getGuideUrl()}
                 hasPreview={this.hasPreview()}
                 instructions={this.renderInstructionsPanel({
                   showToolPanel: false
                 })}
                 preview={this.renderPreview()}
                 testOutput={this.renderTestOutput()}
-                toolPanel={this.renderToolPanel(true)}
+                videoUrl={this.getVideoUrl()}
               />
             ) : (
               <DesktopLayout
@@ -280,12 +269,11 @@ class ShowClassic extends Component {
                 editor={this.renderEditor()}
                 hasPreview={this.hasPreview()}
                 instructions={this.renderInstructionsPanel({
-                  showToolPanel: false
+                  showToolPanel: true
                 })}
                 preview={this.renderPreview()}
                 resizeProps={this.resizeProps}
                 testOutput={this.renderTestOutput()}
-                toolPanel={this.renderToolPanel(false)}
               />
             )
           }

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -3,7 +3,7 @@
 }
 
 .desktop-layout {
-  height: calc(100vh - var(--header-height) - 42px);
+  height: calc(100vh - var(--header-height));
 }
 
 .monaco-menu .action-label {
@@ -33,14 +33,4 @@
 #challenge-page-tabs .tab-pane {
   height: 100%;
   overflow: hidden;
-}
-
-.classic-tool-panel.tool-panel-group {
-  display: flex;
-  flex-direction: row-reverse;
-  padding: 0 2px;
-}
-
-.classic-tool-panel.tool-panel-group .btn-block + .btn-block {
-  margin: 0 2px 0 0;
 }

--- a/client/src/templates/Challenges/components/Tool-Panel.js
+++ b/client/src/templates/Challenges/components/Tool-Panel.js
@@ -21,7 +21,6 @@ const mapDispatchToProps = dispatch =>
   );
 
 const propTypes = {
-  className: PropTypes.string,
   executeChallenge: PropTypes.func.isRequired,
   guideUrl: PropTypes.string,
   isMobile: PropTypes.bool,
@@ -32,7 +31,6 @@ const propTypes = {
 };
 
 function ToolPanel({
-  className,
   executeChallenge,
   isMobile,
   openHelpModal,
@@ -43,11 +41,9 @@ function ToolPanel({
 }) {
   return (
     <Fragment>
-      <div
-        className={`tool-panel-group ${
+      <div className={`tool-panel-group ${
           isMobile ? 'tool-panel-group-mobile' : ''
-        } ${className}`}
-        >
+        }`}>
         <Button block={true} bsStyle='primary' onClick={executeChallenge}>
           {isMobile ? 'Run' : 'Run the Tests'}
         </Button>
@@ -96,10 +92,7 @@ function ToolPanel({
 ToolPanel.displayName = 'ToolPanel';
 ToolPanel.propTypes = propTypes;
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(ToolPanel);
+export default connect(mapStateToProps, mapDispatchToProps)(ToolPanel);
 
 /*
 <Button


### PR DESCRIPTION
Hi Everyone! 

One of our goals is to make our challenge (learn) views into a single column layout.

But, we have come the conclusion that tweaking the UI every few weeks, will confuse the users. We should instead do it only once.

That said, refactoring the UX will make master's release a potential show-stopper. This will also cascade to tons of fixes that we have already done since our last major release. We want to push all those changes out with minimal friction. The most notable being hundreds of fixes to coding challenges.

To push master towards production, we are reverting some of the UX changes that we have done recently. 

Please note, we are not throwing away all the hard work that has gone into the UX. Instead we are going to branch off on a dedicated UX branch and keep moving further. 

We are planning for the second release of master while we are still finalising on the first release.

If you have worked on something related to the UX, and see this PR revert some of it, please do not feel disappointed. We are simply aligning our priorities in the best interest of the users.

We will make our best efforts, and preserve changes on a separate branch for one of the upcoming releases.

Thanks for your hard work and valued contribution.

Currently our immediate aim is to:

- Make the UX of the master same as of current production.
- Add footer views only on pages other than Learn.
- Updates the Nav and Links to Change "Curriculum" to "Learn" as a Label.
  Note: Curriculum will still be used in other verbiage like a welcome greeting.

Reverts #35209
Closes #35235
Closes #35102
