### PR TITLE
ADD: transform affects DIV child contents

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/use-the-css-transform-scale-property-to-scale-an-element-on-hover.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/use-the-css-transform-scale-property-to-scale-an-element-on-hover.english.md
@@ -11,7 +11,7 @@ The <code>transform</code> property has a variety of functions that lets you sca
 Here's an example to scale the paragraph elements to 2.1 times their original size when a user hovers over them:
 <blockquote>p:hover {<br>&nbsp;&nbsp;transform: scale(2.1);<br>}</blockquote>
    
-  **NOTE:** Applying a transform to a <code>div</div> element will also affect any child elements contained in the div.
+  **NOTE:** Applying a transform to a <code>div</code> element will also affect any child elements contained in the div.
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/use-the-css-transform-scale-property-to-scale-an-element-on-hover.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/use-the-css-transform-scale-property-to-scale-an-element-on-hover.english.md
@@ -15,6 +15,8 @@ Here's an example to scale the paragraph elements to 2.1 times their original si
 ## Instructions
 <section id='instructions'>
 Add a CSS rule for the <code>hover</code> state of the <code>div</code> and use the <code>transform</code> property to scale the <code>div</code> element to 1.1 times its original size when a user hovers over it.
+  
+  **NOTE:** Applying a transform to a <code>div</div> element will also affect any child elements contained in the div.
 </section>
 
 ## Tests

--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/use-the-css-transform-scale-property-to-scale-an-element-on-hover.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/use-the-css-transform-scale-property-to-scale-an-element-on-hover.english.md
@@ -11,7 +11,7 @@ The <code>transform</code> property has a variety of functions that lets you sca
 Here's an example to scale the paragraph elements to 2.1 times their original size when a user hovers over them:
 <blockquote>p:hover {<br>&nbsp;&nbsp;transform: scale(2.1);<br>}</blockquote>
    
-  **NOTE:** Applying a transform to a <code>div</code> element will also affect any child elements contained in the div.
+  <strong>NOTE:</strong> Applying a transform to a <code>div</code> element will also affect any child elements contained in the div.
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/use-the-css-transform-scale-property-to-scale-an-element-on-hover.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/use-the-css-transform-scale-property-to-scale-an-element-on-hover.english.md
@@ -10,13 +10,13 @@ videoUrl: 'https://scrimba.com/c/cyLPJuM'
 The <code>transform</code> property has a variety of functions that lets you scale, move, rotate, skew, etc., your elements. When used with pseudo-classes such as <code>:hover</code> that specify a certain state of an element, the <code>transform</code> property can easily add interactivity to your elements.
 Here's an example to scale the paragraph elements to 2.1 times their original size when a user hovers over them:
 <blockquote>p:hover {<br>&nbsp;&nbsp;transform: scale(2.1);<br>}</blockquote>
+   
+  **NOTE:** Applying a transform to a <code>div</div> element will also affect any child elements contained in the div.
 </section>
 
 ## Instructions
 <section id='instructions'>
 Add a CSS rule for the <code>hover</code> state of the <code>div</code> and use the <code>transform</code> property to scale the <code>div</code> element to 1.1 times its original size when a user hovers over it.
-  
-  **NOTE:** Applying a transform to a <code>div</div> element will also affect any child elements contained in the div.
 </section>
 
 ## Tests


### PR DESCRIPTION
After spending some time figuring out how to prevent text in a div being skewed as well as the div, I think it is worth mentioning that applying a transform to a div element will also affect elements contained inside of it. Perhaps the transform challenge pages could include how to negate the effects of the transform on child elements of divs.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX
