### PR TITLE
Fix(curriculum) Removed unnecessary guideUrl from frontmatter block in various challenges

### DIFF
--- a/client/src/templates/Challenges/backend/Show.js
+++ b/client/src/templates/Challenges/backend/Show.js
@@ -227,7 +227,6 @@ export const query = graphql`
   query BackendChallenge($slug: String!) {
     challengeNode(fields: { slug: { eq: $slug } }) {
       title
-      guideUrl
       description
       instructions
       challengeType

--- a/curriculum/challenges/arabic/01-responsive-web-design/applied-accessibility/add-a-text-alternative-to-images-for-visually-impaired-accessibility.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/applied-accessibility/add-a-text-alternative-to-images-for-visually-impaired-accessibility.arabic.md
@@ -3,7 +3,6 @@ id: 587d774c367417b2b2512a9c
 title: Add a Text Alternative to Images for Visually Impaired Accessibility
 challengeType: 0
 videoUrl: ''
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/add-alt-text-to-an-image-for-accessibility'
 localeTitle: إضافة نص بديل للصور لذوي ضعاف البصر
 ---
 

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-css/add-a-negative-margin-to-an-element.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-css/add-a-negative-margin-to-an-element.arabic.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08823
 title: Add a Negative Margin to an Element
 challengeType: 0
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/add-a-negative-margin-to-an-element'
 videoUrl: ''
 localeTitle: أضف هامشًا سلبيًا إلى عنصر
 ---

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-css/add-borders-around-your-elements.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-css/add-borders-around-your-elements.arabic.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9bedf08813
 title: Add Borders Around Your Elements
 challengeType: 0
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/add-borders-around-your-elements'
 videoUrl: ''
 localeTitle: أضف حدود حول عناصرك
 ---

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-css/add-different-padding-to-each-side-of-an-element.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-css/add-different-padding-to-each-side-of-an-element.arabic.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08824
 title: Add Different Padding to Each Side of an Element
 challengeType: 0
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/add-different-padding-to-each-side-of-an-element'
 videoUrl: ''
 localeTitle: ''
 ---

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-css/add-rounded-corners-with-border-radius.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-css/add-rounded-corners-with-border-radius.arabic.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08814
 title: Add Rounded Corners with border-radius
 challengeType: 0
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/add-rounded-corners-a-border-radius'
 videoUrl: ''
 localeTitle: ''
 ---

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-css/adjust-the-margin-of-an-element.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-css/adjust-the-margin-of-an-element.arabic.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08822
 title: Adjust the Margin of an Element
 challengeType: 0
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/adjust-the-margin-of-an-element'
 videoUrl: ''
 localeTitle: ضبط هامش عنصر
 ---

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-css/adjust-the-padding-of-an-element.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-css/adjust-the-padding-of-an-element.arabic.md
@@ -2,7 +2,6 @@
 id: bad88fee1348bd9aedf08825
 title: Adjust the Padding of an Element
 challengeType: 0
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/adjust-the-padding-of-an-element'
 videoUrl: ''
 localeTitle: ضبط الحشو من عنصر
 ---

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-html-and-html5/add-a-submit-button-to-a-form.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-html-and-html5/add-a-submit-button-to-a-form.arabic.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedd08830
 title: Add a Submit Button to a Form
 challengeType: 0
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/add-a-submit-button-to-a-form'
 videoUrl: ''
 localeTitle: إضافة زر إرسال إلى نموذج
 ---

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-html-and-html5/add-images-to-your-website.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-html-and-html5/add-images-to-your-website.arabic.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08812
 title: Add Images to Your Website
 challengeType: 0
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/add-images-to-your-website'
 videoUrl: ''
 localeTitle: إضافة الصور إلى موقع الويب الخاص بك
 ---

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-html-and-html5/add-placeholder-text-to-a-text-field.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-html-and-html5/add-placeholder-text-to-a-text-field.arabic.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08830
 title: Add Placeholder Text to a Text Field
 challengeType: 0
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/add-placeholder-text-to-a-text-field'
 videoUrl: ''
 localeTitle: إضافة نص العنصر النائب إلى حقل نص
 ---

--- a/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/access-array-data-with-indexes.arabic.md
+++ b/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/access-array-data-with-indexes.arabic.md
@@ -2,7 +2,6 @@
 id: 56bbb991ad1ed5201cd392ca
 title: Access Array Data with Indexes
 challengeType: 1
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/access-array-data-with-indexes'
 videoUrl: ''
 localeTitle: ''
 ---

--- a/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/access-multi-dimensional-arrays-with-indexes.arabic.md
+++ b/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/access-multi-dimensional-arrays-with-indexes.arabic.md
@@ -2,7 +2,6 @@
 id: 56592a60ddddeae28f7aa8e1
 title: Access Multi-Dimensional Arrays With Indexes
 challengeType: 1
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/access-array-data-with-indexes'
 videoUrl: ''
 localeTitle: الوصول إلى صفائف متعددة الأبعاد مع فهارس
 ---

--- a/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-arrays.arabic.md
+++ b/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-arrays.arabic.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244cd
 title: Accessing Nested Arrays
 challengeType: 1
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/access-array-data-with-indexes'
 videoUrl: ''
 localeTitle: الوصول إلى صفائف متداخلة
 ---

--- a/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-objects.arabic.md
+++ b/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-objects.arabic.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244cc
 title: Accessing Nested Objects
 challengeType: 1
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/accessing-nested-objects-in-json'
 videoUrl: ''
 localeTitle: الوصول إلى الكائنات المتداخلة
 ---

--- a/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-bracket-notation.arabic.md
+++ b/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-bracket-notation.arabic.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244c8
 title: Accessing Object Properties with Bracket Notation
 challengeType: 1
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/accessing-objects-properties-with-bracket-notation'
 videoUrl: ''
 localeTitle: الوصول إلى خصائص كائن مع تدرج قوس
 ---

--- a/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-variables.arabic.md
+++ b/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-variables.arabic.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244c9
 title: Accessing Object Properties with Variables
 challengeType: 1
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/accessing-objects-properties-with-variables'
 videoUrl: ''
 localeTitle: الوصول إلى خصائص الكائن مع المتغيرات
 ---

--- a/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/adding-a-default-option-in-switch-statements.arabic.md
+++ b/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/adding-a-default-option-in-switch-statements.arabic.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244de
 title: Adding a Default Option in Switch Statements
 challengeType: 1
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/adding-a-default-option-in-switch-statements'
 videoUrl: ''
 localeTitle: إضافة خيار افتراضي في تبديل البيانات
 ---

--- a/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/appending-variables-to-strings.arabic.md
+++ b/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/appending-variables-to-strings.arabic.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244ed
 title: Appending Variables to Strings
 challengeType: 1
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/appending-variables-to-strings'
 videoUrl: ''
 localeTitle: إلحاق المتغيرات بالسلاسل
 ---

--- a/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/assignment-with-a-returned-value.arabic.md
+++ b/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/assignment-with-a-returned-value.arabic.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244c3
 title: Assignment with a Returned Value
 challengeType: 1
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/assignment-with-a-returned-value'
 videoUrl: ''
 localeTitle: التنازل مع القيمة المرتجعة
 ---

--- a/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/arguments-optional.arabic.md
+++ b/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/arguments-optional.arabic.md
@@ -3,7 +3,6 @@ id: a97fd23d9b809dac9921074f
 title: Arguments Optional
 isRequired: true
 challengeType: 5
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/arguments-optional'
 videoUrl: ''
 localeTitle: ''
 ---

--- a/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/apply-the-default-bootstrap-button-style.arabic.md
+++ b/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/apply-the-default-bootstrap-button-style.arabic.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aec908850
 title: Apply the Default Bootstrap Button Style
 challengeType: 0
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/apply-the-default-bootstrap-button-style'
 videoUrl: ''
 localeTitle: ''
 ---

--- a/curriculum/challenges/chinese/01-responsive-web-design/applied-accessibility/add-a-text-alternative-to-images-for-visually-impaired-accessibility.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/applied-accessibility/add-a-text-alternative-to-images-for-visually-impaired-accessibility.chinese.md
@@ -3,7 +3,6 @@ id: 587d774c367417b2b2512a9c
 title: Add a Text Alternative to Images for Visually Impaired Accessibility
 challengeType: 0
 videoUrl: ''
-guideUrl: 'https://chinese.freecodecamp.org/guide/certificates/add-alt-text-to-an-image-for-accessibility'
 localeTitle: 为视力受损的辅助功能添加图像替代文字
 ---
 

--- a/curriculum/challenges/chinese/01-responsive-web-design/basic-css/add-a-negative-margin-to-an-element.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/basic-css/add-a-negative-margin-to-an-element.chinese.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08823
 title: Add a Negative Margin to an Element
 challengeType: 0
-guideUrl: 'https://chinese.freecodecamp.org/guide/certificates/add-a-negative-margin-to-an-element'
 videoUrl: ''
 localeTitle: 向元素添加负边距
 ---

--- a/curriculum/challenges/chinese/01-responsive-web-design/basic-css/add-borders-around-your-elements.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/basic-css/add-borders-around-your-elements.chinese.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9bedf08813
 title: Add Borders Around Your Elements
 challengeType: 0
-guideUrl: 'https://chinese.freecodecamp.org/guide/certificates/add-borders-around-your-elements'
 videoUrl: ''
 localeTitle: 添加元素周围的边框
 ---

--- a/curriculum/challenges/chinese/01-responsive-web-design/basic-css/add-different-padding-to-each-side-of-an-element.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/basic-css/add-different-padding-to-each-side-of-an-element.chinese.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08824
 title: Add Different Padding to Each Side of an Element
 challengeType: 0
-guideUrl: 'https://chinese.freecodecamp.org/guide/certificates/add-different-padding-to-each-side-of-an-element'
 videoUrl: ''
 localeTitle: 在元素的每一侧添加不同的填充
 ---

--- a/curriculum/challenges/chinese/01-responsive-web-design/basic-css/add-rounded-corners-with-border-radius.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/basic-css/add-rounded-corners-with-border-radius.chinese.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08814
 title: Add Rounded Corners with border-radius
 challengeType: 0
-guideUrl: 'https://chinese.freecodecamp.org/guide/certificates/add-rounded-corners-a-border-radius'
 videoUrl: ''
 localeTitle: 添加带有border-radius的圆角
 ---

--- a/curriculum/challenges/chinese/01-responsive-web-design/basic-css/adjust-the-margin-of-an-element.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/basic-css/adjust-the-margin-of-an-element.chinese.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08822
 title: Adjust the Margin of an Element
 challengeType: 0
-guideUrl: 'https://chinese.freecodecamp.org/guide/certificates/adjust-the-margin-of-an-element'
 videoUrl: ''
 localeTitle: 调整元素的边距
 ---

--- a/curriculum/challenges/chinese/01-responsive-web-design/basic-css/adjust-the-padding-of-an-element.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/basic-css/adjust-the-padding-of-an-element.chinese.md
@@ -2,7 +2,6 @@
 id: bad88fee1348bd9aedf08825
 title: Adjust the Padding of an Element
 challengeType: 0
-guideUrl: 'https://chinese.freecodecamp.org/guide/certificates/adjust-the-padding-of-an-element'
 videoUrl: ''
 localeTitle: 调整元素的填充
 ---

--- a/curriculum/challenges/chinese/01-responsive-web-design/basic-html-and-html5/add-a-submit-button-to-a-form.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/basic-html-and-html5/add-a-submit-button-to-a-form.chinese.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedd08830
 title: Add a Submit Button to a Form
 challengeType: 0
-guideUrl: 'https://chinese.freecodecamp.org/guide/certificates/add-a-submit-button-to-a-form'
 videoUrl: ''
 localeTitle: 向表单添加提交按钮
 ---

--- a/curriculum/challenges/chinese/01-responsive-web-design/basic-html-and-html5/add-images-to-your-website.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/basic-html-and-html5/add-images-to-your-website.chinese.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08812
 title: Add Images to Your Website
 challengeType: 0
-guideUrl: 'https://chinese.freecodecamp.org/guide/certificates/add-images-to-your-website'
 videoUrl: ''
 localeTitle: 添加图片到您的网站
 ---

--- a/curriculum/challenges/chinese/01-responsive-web-design/basic-html-and-html5/add-placeholder-text-to-a-text-field.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/basic-html-and-html5/add-placeholder-text-to-a-text-field.chinese.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08830
 title: Add Placeholder Text to a Text Field
 challengeType: 0
-guideUrl: 'https://chinese.freecodecamp.org/guide/certificates/add-placeholder-text-to-a-text-field'
 videoUrl: ''
 localeTitle: 将占位符文本添加到文本字段
 ---

--- a/curriculum/challenges/chinese/02-javascript-algorithms-and-data-structures/basic-javascript/access-array-data-with-indexes.chinese.md
+++ b/curriculum/challenges/chinese/02-javascript-algorithms-and-data-structures/basic-javascript/access-array-data-with-indexes.chinese.md
@@ -2,7 +2,6 @@
 id: 56bbb991ad1ed5201cd392ca
 title: Access Array Data with Indexes
 challengeType: 1
-guideUrl: 'https://chinese.freecodecamp.org/guide/certificates/access-array-data-with-indexes'
 videoUrl: ''
 localeTitle: 使用索引访问数组数据
 ---

--- a/curriculum/challenges/chinese/02-javascript-algorithms-and-data-structures/basic-javascript/access-multi-dimensional-arrays-with-indexes.chinese.md
+++ b/curriculum/challenges/chinese/02-javascript-algorithms-and-data-structures/basic-javascript/access-multi-dimensional-arrays-with-indexes.chinese.md
@@ -2,7 +2,6 @@
 id: 56592a60ddddeae28f7aa8e1
 title: Access Multi-Dimensional Arrays With Indexes
 challengeType: 1
-guideUrl: 'https://chinese.freecodecamp.org/guide/certificates/access-array-data-with-indexes'
 videoUrl: ''
 localeTitle: 访问带索引的多维数组
 ---

--- a/curriculum/challenges/chinese/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-arrays.chinese.md
+++ b/curriculum/challenges/chinese/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-arrays.chinese.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244cd
 title: Accessing Nested Arrays
 challengeType: 1
-guideUrl: 'https://chinese.freecodecamp.org/guide/certificates/access-array-data-with-indexes'
 videoUrl: ''
 localeTitle: 访问嵌套数组
 ---

--- a/curriculum/challenges/chinese/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-objects.chinese.md
+++ b/curriculum/challenges/chinese/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-objects.chinese.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244cc
 title: Accessing Nested Objects
 challengeType: 1
-guideUrl: 'https://chinese.freecodecamp.org/guide/certificates/accessing-nested-objects-in-json'
 videoUrl: ''
 localeTitle: 访问嵌套对象
 ---

--- a/curriculum/challenges/chinese/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-bracket-notation.chinese.md
+++ b/curriculum/challenges/chinese/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-bracket-notation.chinese.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244c8
 title: Accessing Object Properties with Bracket Notation
 challengeType: 1
-guideUrl: 'https://chinese.freecodecamp.org/guide/certificates/accessing-objects-properties-with-bracket-notation'
 videoUrl: ''
 localeTitle: 使用括号表示法访问对象属性
 ---

--- a/curriculum/challenges/chinese/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-variables.chinese.md
+++ b/curriculum/challenges/chinese/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-variables.chinese.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244c9
 title: Accessing Object Properties with Variables
 challengeType: 1
-guideUrl: 'https://chinese.freecodecamp.org/guide/certificates/accessing-objects-properties-with-variables'
 videoUrl: ''
 localeTitle: 使用变量访问对象属性
 ---

--- a/curriculum/challenges/chinese/02-javascript-algorithms-and-data-structures/basic-javascript/adding-a-default-option-in-switch-statements.chinese.md
+++ b/curriculum/challenges/chinese/02-javascript-algorithms-and-data-structures/basic-javascript/adding-a-default-option-in-switch-statements.chinese.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244de
 title: Adding a Default Option in Switch Statements
 challengeType: 1
-guideUrl: 'https://chinese.freecodecamp.org/guide/certificates/adding-a-default-option-in-switch-statements'
 videoUrl: ''
 localeTitle: 在交换机语句中添加默认选项
 ---

--- a/curriculum/challenges/chinese/02-javascript-algorithms-and-data-structures/basic-javascript/appending-variables-to-strings.chinese.md
+++ b/curriculum/challenges/chinese/02-javascript-algorithms-and-data-structures/basic-javascript/appending-variables-to-strings.chinese.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244ed
 title: Appending Variables to Strings
 challengeType: 1
-guideUrl: 'https://chinese.freecodecamp.org/guide/certificates/appending-variables-to-strings'
 videoUrl: ''
 localeTitle: 将变量附加到字符串
 ---

--- a/curriculum/challenges/chinese/02-javascript-algorithms-and-data-structures/basic-javascript/assignment-with-a-returned-value.chinese.md
+++ b/curriculum/challenges/chinese/02-javascript-algorithms-and-data-structures/basic-javascript/assignment-with-a-returned-value.chinese.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244c3
 title: Assignment with a Returned Value
 challengeType: 1
-guideUrl: 'https://chinese.freecodecamp.org/guide/certificates/assignment-with-a-returned-value'
 videoUrl: ''
 localeTitle: 具有返回值的分配
 ---

--- a/curriculum/challenges/chinese/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/arguments-optional.chinese.md
+++ b/curriculum/challenges/chinese/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/arguments-optional.chinese.md
@@ -3,7 +3,6 @@ id: a97fd23d9b809dac9921074f
 title: Arguments Optional
 isRequired: true
 challengeType: 5
-guideUrl: 'https://chinese.freecodecamp.org/guide/certificates/arguments-optional'
 videoUrl: ''
 localeTitle: 参数可选
 ---

--- a/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/apply-the-default-bootstrap-button-style.chinese.md
+++ b/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/apply-the-default-bootstrap-button-style.chinese.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aec908850
 title: Apply the Default Bootstrap Button Style
 challengeType: 0
-guideUrl: 'https://chinese.freecodecamp.org/guide/certificates/apply-the-default-bootstrap-button-style'
 videoUrl: ''
 localeTitle: 应用默认引导按钮样式
 ---

--- a/curriculum/challenges/english/01-responsive-web-design/applied-accessibility/add-a-text-alternative-to-images-for-visually-impaired-accessibility.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-accessibility/add-a-text-alternative-to-images-for-visually-impaired-accessibility.english.md
@@ -3,7 +3,6 @@ id: 587d774c367417b2b2512a9c
 title: Add a Text Alternative to Images for Visually Impaired Accessibility
 challengeType: 0
 videoUrl: 'https://scrimba.com/c/cPp7VfD'
-guideUrl: 'https://www.freecodecamp.org/guide/certificates/responsive-web-design/applied-accessibility/add-a-text-alternative-to-images-for-visually-impaired-accessibility'
 ---
 
 ## Description

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/add-a-negative-margin-to-an-element.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/add-a-negative-margin-to-an-element.english.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08823
 title: Add a Negative Margin to an Element
 challengeType: 0
-guideUrl: 'https://www.freecodecamp.org/guide/certificates/add-a-negative-margin-to-an-element'
 videoUrl: 'https://scrimba.com/c/cnpyGs3'
 ---
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/add-borders-around-your-elements.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/add-borders-around-your-elements.english.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9bedf08813
 title: Add Borders Around Your Elements
 challengeType: 0
-guideUrl: 'https://www.freecodecamp.org/guide/certificates/add-borders-around-your-elements'
 videoUrl: 'https://scrimba.com/c/c2MvnHZ'
 ---
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/add-different-padding-to-each-side-of-an-element.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/add-different-padding-to-each-side-of-an-element.english.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08824
 title: Add Different Padding to Each Side of an Element
 challengeType: 0
-guideUrl: 'https://www.freecodecamp.org/guide/certificates/add-different-padding-to-each-side-of-an-element'
 videoUrl: 'https://scrimba.com/c/cB7mwUw'
 ---
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/add-rounded-corners-with-border-radius.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/add-rounded-corners-with-border-radius.english.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08814
 title: Add Rounded Corners with border-radius
 challengeType: 0
-guideUrl: 'https://www.freecodecamp.org/guide/certificates/add-rounded-corners-a-border-radius'
 videoUrl: 'https://scrimba.com/c/cbZm2hg'
 ---
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/adjust-the-margin-of-an-element.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/adjust-the-margin-of-an-element.english.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08822
 title: Adjust the Margin of an Element
 challengeType: 0
-guideUrl: 'https://www.freecodecamp.org/guide/certificates/adjust-the-margin-of-an-element'
 videoUrl: 'https://scrimba.com/c/cVJarHW'
 ---
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/adjust-the-padding-of-an-element.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/adjust-the-padding-of-an-element.english.md
@@ -2,7 +2,6 @@
 id: bad88fee1348bd9aedf08825
 title: Adjust the Padding of an Element
 challengeType: 0
-guideUrl: 'https://www.freecodecamp.org/guide/certificates/adjust-the-padding-of-an-element'
 videoUrl: 'https://scrimba.com/c/cED8ZC2'
 ---
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/add-a-submit-button-to-a-form.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/add-a-submit-button-to-a-form.english.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedd08830
 title: Add a Submit Button to a Form
 challengeType: 0
-guideUrl: 'https://www.freecodecamp.org/guide/certificates/add-a-submit-button-to-a-form'
 videoUrl: 'https://scrimba.com/p/pVMPUv/cp2Nkhz'
 ---
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/add-images-to-your-website.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/add-images-to-your-website.english.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08812
 title: Add Images to Your Website
 challengeType: 0
-guideUrl: 'https://www.freecodecamp.org/guide/certificates/add-images-to-your-website'
 videoUrl: 'https://scrimba.com/p/pVMPUv/c8EbJf2'
 ---
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/add-placeholder-text-to-a-text-field.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/add-placeholder-text-to-a-text-field.english.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08830
 title: Add Placeholder Text to a Text Field
 challengeType: 0
-guideUrl: 'https://www.freecodecamp.org/guide/certificates/add-placeholder-text-to-a-text-field'
 videoUrl: 'https://scrimba.com/p/pVMPUv/cKdJDhg'
 ---
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/access-array-data-with-indexes.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/access-array-data-with-indexes.english.md
@@ -2,7 +2,6 @@
 id: 56bbb991ad1ed5201cd392ca
 title: Access Array Data with Indexes
 challengeType: 1
-guideUrl: 'https://www.freecodecamp.org/guide/certificates/access-array-data-with-indexes'
 videoUrl: 'https://scrimba.com/c/cBZQbTz'
 ---
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/access-multi-dimensional-arrays-with-indexes.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/access-multi-dimensional-arrays-with-indexes.english.md
@@ -2,7 +2,6 @@
 id: 56592a60ddddeae28f7aa8e1
 title: Access Multi-Dimensional Arrays With Indexes
 challengeType: 1
-guideUrl: 'https://www.freecodecamp.org/guide/certificates/access-array-data-with-indexes'
 videoUrl: 'https://scrimba.com/c/ckND4Cq'
 ---
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-arrays.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-arrays.english.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244cd
 title: Accessing Nested Arrays
 challengeType: 1
-guideUrl: 'https://www.freecodecamp.org/guide/certificates/access-array-data-with-indexes'
 videoUrl: 'https://scrimba.com/c/cLeGDtZ'
 ---
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-objects.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-objects.english.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244cc
 title: Accessing Nested Objects
 challengeType: 1
-guideUrl: 'https://www.freecodecamp.org/guide/certificates/accessing-nested-objects-in-json'
 videoUrl: 'https://scrimba.com/c/cRnRnfa'
 ---
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-bracket-notation.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-bracket-notation.english.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244c8
 title: Accessing Object Properties with Bracket Notation
 challengeType: 1
-guideUrl: 'https://www.freecodecamp.org/guide/certificates/accessing-objects-properties-with-bracket-notation'
 videoUrl: 'https://scrimba.com/c/cBvmEHP'
 ---
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-variables.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-variables.english.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244c9
 title: Accessing Object Properties with Variables
 challengeType: 1
-guideUrl: 'https://www.freecodecamp.org/guide/certificates/accessing-objects-properties-with-variables'
 videoUrl: 'https://scrimba.com/c/cnQyKur'
 ---
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/adding-a-default-option-in-switch-statements.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/adding-a-default-option-in-switch-statements.english.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244de
 title: Adding a Default Option in Switch Statements
 challengeType: 1
-guideUrl: 'https://www.freecodecamp.org/guide/certificates/adding-a-default-option-in-switch-statements'
 videoUrl: 'https://scrimba.com/c/c3JvVfg'
 ---
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/appending-variables-to-strings.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/appending-variables-to-strings.english.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244ed
 title: Appending Variables to Strings
 challengeType: 1
-guideUrl: 'https://www.freecodecamp.org/guide/certificates/appending-variables-to-strings'
 videoUrl: 'https://scrimba.com/c/cbQmZfa'
 ---
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/assignment-with-a-returned-value.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/assignment-with-a-returned-value.english.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244c3
 title: Assignment with a Returned Value
 challengeType: 1
-guideUrl: 'https://www.freecodecamp.org/guide/certificates/assignment-with-a-returned-value'
 videoUrl: 'https://scrimba.com/c/ce2pEtB'
 ---
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/arguments-optional.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/arguments-optional.english.md
@@ -3,7 +3,6 @@ id: a97fd23d9b809dac9921074f
 title: Arguments Optional
 isRequired: true
 challengeType: 5
-guideUrl: 'https://www.freecodecamp.org/guide/certificates/arguments-optional'
 ---
 
 ## Description

--- a/curriculum/challenges/english/03-front-end-libraries/bootstrap/apply-the-default-bootstrap-button-style.english.md
+++ b/curriculum/challenges/english/03-front-end-libraries/bootstrap/apply-the-default-bootstrap-button-style.english.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aec908850
 title: Apply the Default Bootstrap Button Style
 challengeType: 0
-guideUrl: 'https://www.freecodecamp.org/guide/certificates/apply-the-default-bootstrap-button-style'
 ---
 
 ## Description

--- a/curriculum/challenges/portuguese/01-responsive-web-design/applied-accessibility/add-a-text-alternative-to-images-for-visually-impaired-accessibility.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/applied-accessibility/add-a-text-alternative-to-images-for-visually-impaired-accessibility.portuguese.md
@@ -3,7 +3,6 @@ id: 587d774c367417b2b2512a9c
 title: Add a Text Alternative to Images for Visually Impaired Accessibility
 challengeType: 0
 videoUrl: ''
-guideUrl: 'https://portuguese.freecodecamp.org/guide/certificates/add-alt-text-to-an-image-for-accessibility'
 localeTitle: Adicionar uma alternativa de texto a imagens para acessibilidade com deficiência visual
 ---
 

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/add-a-negative-margin-to-an-element.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/add-a-negative-margin-to-an-element.portuguese.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08823
 title: Add a Negative Margin to an Element
 challengeType: 0
-guideUrl: 'https://portuguese.freecodecamp.org/guide/certificates/add-a-negative-margin-to-an-element'
 videoUrl: ''
 localeTitle: Adicione uma margem negativa a um elemento
 ---

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/add-borders-around-your-elements.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/add-borders-around-your-elements.portuguese.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9bedf08813
 title: Add Borders Around Your Elements
 challengeType: 0
-guideUrl: 'https://portuguese.freecodecamp.org/guide/certificates/add-borders-around-your-elements'
 videoUrl: ''
 localeTitle: Adicionar bordas ao redor de seus elementos
 ---

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/add-different-padding-to-each-side-of-an-element.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/add-different-padding-to-each-side-of-an-element.portuguese.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08824
 title: Add Different Padding to Each Side of an Element
 challengeType: 0
-guideUrl: 'https://portuguese.freecodecamp.org/guide/certificates/add-different-padding-to-each-side-of-an-element'
 videoUrl: ''
 localeTitle: Adicionar preenchimento diferente a cada lado de um elemento
 ---

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/add-rounded-corners-with-border-radius.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/add-rounded-corners-with-border-radius.portuguese.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08814
 title: Add Rounded Corners with border-radius
 challengeType: 0
-guideUrl: 'https://portuguese.freecodecamp.org/guide/certificates/add-rounded-corners-a-border-radius'
 videoUrl: ''
 localeTitle: Adicionar cantos arredondados com raio de borda
 ---

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/adjust-the-margin-of-an-element.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/adjust-the-margin-of-an-element.portuguese.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08822
 title: Adjust the Margin of an Element
 challengeType: 0
-guideUrl: 'https://portuguese.freecodecamp.org/guide/certificates/adjust-the-margin-of-an-element'
 videoUrl: ''
 localeTitle: Ajustar a margem de um elemento
 ---

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/adjust-the-padding-of-an-element.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/adjust-the-padding-of-an-element.portuguese.md
@@ -2,7 +2,6 @@
 id: bad88fee1348bd9aedf08825
 title: Adjust the Padding of an Element
 challengeType: 0
-guideUrl: 'https://portuguese.freecodecamp.org/guide/certificates/adjust-the-padding-of-an-element'
 videoUrl: ''
 localeTitle: Ajustar o preenchimento de um elemento
 ---

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-html-and-html5/add-a-submit-button-to-a-form.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-html-and-html5/add-a-submit-button-to-a-form.portuguese.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedd08830
 title: Add a Submit Button to a Form
 challengeType: 0
-guideUrl: 'https://portuguese.freecodecamp.org/guide/certificates/add-a-submit-button-to-a-form'
 videoUrl: ''
 localeTitle: Adicionar um botão Enviar para um formulário
 ---

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-html-and-html5/add-images-to-your-website.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-html-and-html5/add-images-to-your-website.portuguese.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08812
 title: Add Images to Your Website
 challengeType: 0
-guideUrl: 'https://portuguese.freecodecamp.org/guide/certificates/add-images-to-your-website'
 videoUrl: ''
 localeTitle: Adicionar imagens ao seu site
 ---

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-html-and-html5/add-placeholder-text-to-a-text-field.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-html-and-html5/add-placeholder-text-to-a-text-field.portuguese.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08830
 title: Add Placeholder Text to a Text Field
 challengeType: 0
-guideUrl: 'https://portuguese.freecodecamp.org/guide/certificates/add-placeholder-text-to-a-text-field'
 videoUrl: ''
 localeTitle: Adicionar texto do marcador de posição a um campo de texto
 ---

--- a/curriculum/challenges/portuguese/02-javascript-algorithms-and-data-structures/basic-javascript/access-array-data-with-indexes.portuguese.md
+++ b/curriculum/challenges/portuguese/02-javascript-algorithms-and-data-structures/basic-javascript/access-array-data-with-indexes.portuguese.md
@@ -2,7 +2,6 @@
 id: 56bbb991ad1ed5201cd392ca
 title: Access Array Data with Indexes
 challengeType: 1
-guideUrl: 'https://portuguese.freecodecamp.org/guide/certificates/access-array-data-with-indexes'
 videoUrl: ''
 localeTitle: Dados de Matriz de Acesso com Índices
 ---

--- a/curriculum/challenges/portuguese/02-javascript-algorithms-and-data-structures/basic-javascript/access-multi-dimensional-arrays-with-indexes.portuguese.md
+++ b/curriculum/challenges/portuguese/02-javascript-algorithms-and-data-structures/basic-javascript/access-multi-dimensional-arrays-with-indexes.portuguese.md
@@ -2,7 +2,6 @@
 id: 56592a60ddddeae28f7aa8e1
 title: Access Multi-Dimensional Arrays With Indexes
 challengeType: 1
-guideUrl: 'https://portuguese.freecodecamp.org/guide/certificates/access-array-data-with-indexes'
 videoUrl: ''
 localeTitle: Acessar matrizes multi-dimensionais com índices
 ---

--- a/curriculum/challenges/portuguese/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-arrays.portuguese.md
+++ b/curriculum/challenges/portuguese/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-arrays.portuguese.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244cd
 title: Accessing Nested Arrays
 challengeType: 1
-guideUrl: 'https://portuguese.freecodecamp.org/guide/certificates/access-array-data-with-indexes'
 videoUrl: ''
 localeTitle: Acessando matrizes aninhadas
 ---

--- a/curriculum/challenges/portuguese/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-objects.portuguese.md
+++ b/curriculum/challenges/portuguese/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-objects.portuguese.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244cc
 title: Accessing Nested Objects
 challengeType: 1
-guideUrl: 'https://portuguese.freecodecamp.org/guide/certificates/accessing-nested-objects-in-json'
 videoUrl: ''
 localeTitle: Acessando Objetos Aninhados
 ---

--- a/curriculum/challenges/portuguese/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-bracket-notation.portuguese.md
+++ b/curriculum/challenges/portuguese/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-bracket-notation.portuguese.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244c8
 title: Accessing Object Properties with Bracket Notation
 challengeType: 1
-guideUrl: 'https://portuguese.freecodecamp.org/guide/certificates/accessing-objects-properties-with-bracket-notation'
 videoUrl: ''
 localeTitle: Acessando propriedades de objeto com notação de suporte
 ---

--- a/curriculum/challenges/portuguese/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-variables.portuguese.md
+++ b/curriculum/challenges/portuguese/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-variables.portuguese.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244c9
 title: Accessing Object Properties with Variables
 challengeType: 1
-guideUrl: 'https://portuguese.freecodecamp.org/guide/certificates/accessing-objects-properties-with-variables'
 videoUrl: ''
 localeTitle: Acessando propriedades de objetos com variáveis
 ---

--- a/curriculum/challenges/portuguese/02-javascript-algorithms-and-data-structures/basic-javascript/adding-a-default-option-in-switch-statements.portuguese.md
+++ b/curriculum/challenges/portuguese/02-javascript-algorithms-and-data-structures/basic-javascript/adding-a-default-option-in-switch-statements.portuguese.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244de
 title: Adding a Default Option in Switch Statements
 challengeType: 1
-guideUrl: 'https://portuguese.freecodecamp.org/guide/certificates/adding-a-default-option-in-switch-statements'
 videoUrl: ''
 localeTitle: Adicionando uma opção padrão em instruções de troca
 ---

--- a/curriculum/challenges/portuguese/02-javascript-algorithms-and-data-structures/basic-javascript/appending-variables-to-strings.portuguese.md
+++ b/curriculum/challenges/portuguese/02-javascript-algorithms-and-data-structures/basic-javascript/appending-variables-to-strings.portuguese.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244ed
 title: Appending Variables to Strings
 challengeType: 1
-guideUrl: 'https://portuguese.freecodecamp.org/guide/certificates/appending-variables-to-strings'
 videoUrl: ''
 localeTitle: Anexando variáveis ​​a seqüências de caracteres
 ---

--- a/curriculum/challenges/portuguese/02-javascript-algorithms-and-data-structures/basic-javascript/assignment-with-a-returned-value.portuguese.md
+++ b/curriculum/challenges/portuguese/02-javascript-algorithms-and-data-structures/basic-javascript/assignment-with-a-returned-value.portuguese.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244c3
 title: Assignment with a Returned Value
 challengeType: 1
-guideUrl: 'https://portuguese.freecodecamp.org/guide/certificates/assignment-with-a-returned-value'
 videoUrl: ''
 localeTitle: Atribuição com um valor retornado
 ---

--- a/curriculum/challenges/portuguese/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/arguments-optional.portuguese.md
+++ b/curriculum/challenges/portuguese/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/arguments-optional.portuguese.md
@@ -3,7 +3,6 @@ id: a97fd23d9b809dac9921074f
 title: Arguments Optional
 isRequired: true
 challengeType: 5
-guideUrl: 'https://portuguese.freecodecamp.org/guide/certificates/arguments-optional'
 videoUrl: ''
 localeTitle: Argumentos Opcional
 ---

--- a/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/apply-the-default-bootstrap-button-style.portuguese.md
+++ b/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/apply-the-default-bootstrap-button-style.portuguese.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aec908850
 title: Apply the Default Bootstrap Button Style
 challengeType: 0
-guideUrl: 'https://portuguese.freecodecamp.org/guide/certificates/apply-the-default-bootstrap-button-style'
 videoUrl: ''
 localeTitle: Aplicar o estilo padrão do botão de inicialização
 ---

--- a/curriculum/challenges/russian/01-responsive-web-design/applied-accessibility/add-a-text-alternative-to-images-for-visually-impaired-accessibility.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/applied-accessibility/add-a-text-alternative-to-images-for-visually-impaired-accessibility.russian.md
@@ -3,7 +3,6 @@ id: 587d774c367417b2b2512a9c
 title: Добавьте текстовое описание для изображений, чтобы увеличить их информативность для пользователей с нарушением зрения
 challengeType: 0
 videoUrl: ''
-guideUrl: 'https://russian.freecodecamp.org/guide/certificates/add-alt-text-to-an-image-for-accessibility'
 localeTitle: Добавьте текстовое описание для изображений, чтобы увеличить их информативность для пользователей с нарушением зрения
 ---
 ## Description (Описание)

--- a/curriculum/challenges/russian/01-responsive-web-design/basic-css/add-a-negative-margin-to-an-element.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/basic-css/add-a-negative-margin-to-an-element.russian.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08823
 title: Add a Negative Margin to an Element
 challengeType: 0
-guideUrl: 'https://russian.freecodecamp.org/guide/certificates/add-a-negative-margin-to-an-element'
 videoUrl: ''
 localeTitle: Добавить к элементу свойство margin с отрицательным значением
 ---

--- a/curriculum/challenges/russian/01-responsive-web-design/basic-css/add-borders-around-your-elements.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/basic-css/add-borders-around-your-elements.russian.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9bedf08813
 title: Add Borders Around Your Elements
 challengeType: 0
-guideUrl: 'https://russian.freecodecamp.org/guide/certificates/add-borders-around-your-elements'
 videoUrl: ''
 
 localeTitle: Добавьте рамки вокруг ваших элементов

--- a/curriculum/challenges/russian/01-responsive-web-design/basic-css/add-different-padding-to-each-side-of-an-element.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/basic-css/add-different-padding-to-each-side-of-an-element.russian.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08824
 title: Add Different Padding to Each Side of an Element
 challengeType: 0
-guideUrl: 'https://russian.freecodecamp.org/guide/certificates/add-different-padding-to-each-side-of-an-element'
 videoUrl: ''
 localeTitle: Добавьте разные внутренние отступы к каждой стороне элемента
 ---

--- a/curriculum/challenges/russian/01-responsive-web-design/basic-css/add-rounded-corners-with-border-radius.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/basic-css/add-rounded-corners-with-border-radius.russian.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08814
 title: Add Rounded Corners with border-radius
 challengeType: 0
-guideUrl: 'https://russian.freecodecamp.org/guide/certificates/add-rounded-corners-a-border-radius'
 videoUrl: ''
 localeTitle: Добавить закругленные углы при помощи свойства border-radius
 ---

--- a/curriculum/challenges/russian/01-responsive-web-design/basic-css/adjust-the-margin-of-an-element.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/basic-css/adjust-the-margin-of-an-element.russian.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08822
 title: Adjust the Margin of an Element
 challengeType: 0
-guideUrl: 'https://russian.freecodecamp.org/guide/certificates/adjust-the-margin-of-an-element'
 videoUrl: ''
 localeTitle: Отрегулируйте маржу элемента
 ---

--- a/curriculum/challenges/russian/01-responsive-web-design/basic-css/adjust-the-padding-of-an-element.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/basic-css/adjust-the-padding-of-an-element.russian.md
@@ -2,7 +2,6 @@
 id: bad88fee1348bd9aedf08825
 title: Adjust the Padding of an Element
 challengeType: 0
-guideUrl: 'https://russian.freecodecamp.org/guide/certificates/adjust-the-padding-of-an-element'
 videoUrl: ''
 localeTitle: Отрегулируйте прокладку элемента
 ---

--- a/curriculum/challenges/russian/01-responsive-web-design/basic-html-and-html5/add-a-submit-button-to-a-form.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/basic-html-and-html5/add-a-submit-button-to-a-form.russian.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedd08830
 title: Add a Submit Button to a Form
 challengeType: 0
-guideUrl: 'https://russian.freecodecamp.org/guide/certificates/add-a-submit-button-to-a-form'
 videoUrl: ''
 localeTitle: Добавить кнопку отправки в форму
 ---

--- a/curriculum/challenges/russian/01-responsive-web-design/basic-html-and-html5/add-images-to-your-website.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/basic-html-and-html5/add-images-to-your-website.russian.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08812
 title: Add Images to Your Website
 challengeType: 0
-guideUrl: 'https://russian.freecodecamp.org/guide/certificates/add-images-to-your-website'
 videoUrl: ''
 localeTitle: Добавить изображения на свой сайт
 ---

--- a/curriculum/challenges/russian/01-responsive-web-design/basic-html-and-html5/add-placeholder-text-to-a-text-field.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/basic-html-and-html5/add-placeholder-text-to-a-text-field.russian.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08830
 title: Add Placeholder Text to a Text Field
 challengeType: 0
-guideUrl: 'https://russian.freecodecamp.org/guide/certificates/add-placeholder-text-to-a-text-field'
 videoUrl: ''
 localeTitle: Добавить текст заполнителя в текстовое поле
 ---

--- a/curriculum/challenges/russian/02-javascript-algorithms-and-data-structures/basic-javascript/access-array-data-with-indexes.russian.md
+++ b/curriculum/challenges/russian/02-javascript-algorithms-and-data-structures/basic-javascript/access-array-data-with-indexes.russian.md
@@ -2,7 +2,6 @@
 id: 56bbb991ad1ed5201cd392ca
 title: Access Array Data with Indexes
 challengeType: 1
-guideUrl: 'https://russian.freecodecamp.org/guide/certificates/access-array-data-with-indexes'
 videoUrl: ''
 localeTitle: Доступ к массиву данных с индексами
 ---

--- a/curriculum/challenges/russian/02-javascript-algorithms-and-data-structures/basic-javascript/access-multi-dimensional-arrays-with-indexes.russian.md
+++ b/curriculum/challenges/russian/02-javascript-algorithms-and-data-structures/basic-javascript/access-multi-dimensional-arrays-with-indexes.russian.md
@@ -2,7 +2,6 @@
 id: 56592a60ddddeae28f7aa8e1
 title: Access Multi-Dimensional Arrays With Indexes
 challengeType: 1
-guideUrl: 'https://russian.freecodecamp.org/guide/certificates/access-array-data-with-indexes'
 videoUrl: ''
 localeTitle: Доступ к многомерным массивам с индексами
 ---

--- a/curriculum/challenges/russian/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-arrays.russian.md
+++ b/curriculum/challenges/russian/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-arrays.russian.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244cd
 title: Accessing Nested Arrays
 challengeType: 1
-guideUrl: 'https://russian.freecodecamp.org/guide/certificates/access-array-data-with-indexes'
 videoUrl: ''
 localeTitle: Доступ к вложенным массивам
 ---

--- a/curriculum/challenges/russian/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-objects.russian.md
+++ b/curriculum/challenges/russian/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-objects.russian.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244cc
 title: Accessing Nested Objects
 challengeType: 1
-guideUrl: 'https://russian.freecodecamp.org/guide/certificates/accessing-nested-objects-in-json'
 videoUrl: ''
 localeTitle: Доступ к вложенным объектам
 ---

--- a/curriculum/challenges/russian/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-bracket-notation.russian.md
+++ b/curriculum/challenges/russian/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-bracket-notation.russian.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244c8
 title: Accessing Object Properties with Bracket Notation
 challengeType: 1
-guideUrl: 'https://russian.freecodecamp.org/guide/certificates/accessing-objects-properties-with-bracket-notation'
 videoUrl: ''
 localeTitle: Доступ к объектным свойствам с помощью скобок
 ---

--- a/curriculum/challenges/russian/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-variables.russian.md
+++ b/curriculum/challenges/russian/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-variables.russian.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244c9
 title: Accessing Object Properties with Variables
 challengeType: 1
-guideUrl: 'https://russian.freecodecamp.org/guide/certificates/accessing-objects-properties-with-variables'
 videoUrl: ''
 localeTitle: Доступ к свойствам объектов с переменными
 ---

--- a/curriculum/challenges/russian/02-javascript-algorithms-and-data-structures/basic-javascript/adding-a-default-option-in-switch-statements.russian.md
+++ b/curriculum/challenges/russian/02-javascript-algorithms-and-data-structures/basic-javascript/adding-a-default-option-in-switch-statements.russian.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244de
 title: Adding a Default Option in Switch Statements
 challengeType: 1
-guideUrl: 'https://russian.freecodecamp.org/guide/certificates/adding-a-default-option-in-switch-statements'
 videoUrl: ''
 localeTitle: Добавление опции по умолчанию в операторы switch
 ---

--- a/curriculum/challenges/russian/02-javascript-algorithms-and-data-structures/basic-javascript/appending-variables-to-strings.russian.md
+++ b/curriculum/challenges/russian/02-javascript-algorithms-and-data-structures/basic-javascript/appending-variables-to-strings.russian.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244ed
 title: Appending Variables to Strings
 challengeType: 1
-guideUrl: 'https://russian.freecodecamp.org/guide/certificates/appending-variables-to-strings'
 videoUrl: ''
 localeTitle: Добавление переменных в строки
 ---

--- a/curriculum/challenges/russian/02-javascript-algorithms-and-data-structures/basic-javascript/assignment-with-a-returned-value.russian.md
+++ b/curriculum/challenges/russian/02-javascript-algorithms-and-data-structures/basic-javascript/assignment-with-a-returned-value.russian.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244c3
 title: Assignment with a Returned Value
 challengeType: 1
-guideUrl: 'https://russian.freecodecamp.org/guide/certificates/assignment-with-a-returned-value'
 videoUrl: ''
 localeTitle: Назначение с возвращенной стоимостью
 ---

--- a/curriculum/challenges/russian/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/arguments-optional.russian.md
+++ b/curriculum/challenges/russian/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/arguments-optional.russian.md
@@ -3,7 +3,6 @@ id: a97fd23d9b809dac9921074f
 title: Arguments Optional
 isRequired: true
 challengeType: 5
-guideUrl: 'https://russian.freecodecamp.org/guide/certificates/arguments-optional'
 videoUrl: ''
 localeTitle: Аргументы Дополнительно
 ---

--- a/curriculum/challenges/russian/03-front-end-libraries/bootstrap/apply-the-default-bootstrap-button-style.russian.md
+++ b/curriculum/challenges/russian/03-front-end-libraries/bootstrap/apply-the-default-bootstrap-button-style.russian.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aec908850
 title: Apply the Default Bootstrap Button Style
 challengeType: 0
-guideUrl: 'https://russian.freecodecamp.org/guide/certificates/apply-the-default-bootstrap-button-style'
 videoUrl: ''
 localeTitle: Применить стиль кнопки Bootstrap по умолчанию
 ---

--- a/curriculum/challenges/spanish/01-responsive-web-design/applied-accessibility/add-a-text-alternative-to-images-for-visually-impaired-accessibility.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/applied-accessibility/add-a-text-alternative-to-images-for-visually-impaired-accessibility.spanish.md
@@ -3,7 +3,6 @@ id: 587d774c367417b2b2512a9c
 title: Add a Text Alternative to Images for Visually Impaired Accessibility
 challengeType: 0
 videoUrl: ''
-guideUrl: 'https://spanish.freecodecamp.org/guide/certificates/add-alt-text-to-an-image-for-accessibility'
 localeTitle: Agregar un texto alternativo a las imágenes para la accesibilidad de personas con discapacidad visual
 ---
 

--- a/curriculum/challenges/spanish/01-responsive-web-design/basic-css/add-a-negative-margin-to-an-element.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/basic-css/add-a-negative-margin-to-an-element.spanish.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08823
 title: Add a Negative Margin to an Element
 challengeType: 0
-guideUrl: 'https://spanish.freecodecamp.org/guide/certificates/add-a-negative-margin-to-an-element'
 videoUrl: ''
 localeTitle: Agregar un margen negativo a un elemento
 ---

--- a/curriculum/challenges/spanish/01-responsive-web-design/basic-css/add-borders-around-your-elements.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/basic-css/add-borders-around-your-elements.spanish.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9bedf08813
 title: Add Borders Around Your Elements
 challengeType: 0
-guideUrl: 'https://spanish.freecodecamp.org/guide/certificates/add-borders-around-your-elements'
 videoUrl: ''
 localeTitle: Añadir bordes alrededor de sus elementos
 ---

--- a/curriculum/challenges/spanish/01-responsive-web-design/basic-css/add-different-padding-to-each-side-of-an-element.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/basic-css/add-different-padding-to-each-side-of-an-element.spanish.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08824
 title: Add Different Padding to Each Side of an Element
 challengeType: 0
-guideUrl: 'https://spanish.freecodecamp.org/guide/certificates/add-different-padding-to-each-side-of-an-element'
 videoUrl: ''
 localeTitle: Añadir diferente relleno a cada lado de un elemento
 ---

--- a/curriculum/challenges/spanish/01-responsive-web-design/basic-css/add-rounded-corners-with-border-radius.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/basic-css/add-rounded-corners-with-border-radius.spanish.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08814
 title: Add Rounded Corners with border-radius
 challengeType: 0
-guideUrl: 'https://spanish.freecodecamp.org/guide/certificates/add-rounded-corners-a-border-radius'
 videoUrl: ''
 localeTitle: Añadir esquinas redondeadas con radio de borde
 ---

--- a/curriculum/challenges/spanish/01-responsive-web-design/basic-css/adjust-the-margin-of-an-element.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/basic-css/adjust-the-margin-of-an-element.spanish.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08822
 title: Adjust the Margin of an Element
 challengeType: 0
-guideUrl: 'https://spanish.freecodecamp.org/guide/certificates/adjust-the-margin-of-an-element'
 videoUrl: ''
 localeTitle: Ajustar el margen de un elemento
 ---

--- a/curriculum/challenges/spanish/01-responsive-web-design/basic-css/adjust-the-padding-of-an-element.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/basic-css/adjust-the-padding-of-an-element.spanish.md
@@ -2,7 +2,6 @@
 id: bad88fee1348bd9aedf08825
 title: Adjust the Padding of an Element
 challengeType: 0
-guideUrl: 'https://spanish.freecodecamp.org/guide/certificates/adjust-the-padding-of-an-element'
 videoUrl: ''
 localeTitle: Ajustar el relleno de un elemento
 ---

--- a/curriculum/challenges/spanish/01-responsive-web-design/basic-html-and-html5/add-a-submit-button-to-a-form.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/basic-html-and-html5/add-a-submit-button-to-a-form.spanish.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedd08830
 title: Add a Submit Button to a Form
 challengeType: 0
-guideUrl: 'https://spanish.freecodecamp.org/guide/certificates/add-a-submit-button-to-a-form'
 videoUrl: ''
 localeTitle: Agregar un botón de envío a un formulario
 ---

--- a/curriculum/challenges/spanish/01-responsive-web-design/basic-html-and-html5/add-images-to-your-website.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/basic-html-and-html5/add-images-to-your-website.spanish.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08812
 title: Add Images to Your Website
 challengeType: 0
-guideUrl: 'https://spanish.freecodecamp.org/guide/certificates/add-images-to-your-website'
 videoUrl: ''
 localeTitle: Añadir imágenes a su sitio web
 ---

--- a/curriculum/challenges/spanish/01-responsive-web-design/basic-html-and-html5/add-placeholder-text-to-a-text-field.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/basic-html-and-html5/add-placeholder-text-to-a-text-field.spanish.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08830
 title: Add Placeholder Text to a Text Field
 challengeType: 0
-guideUrl: 'https://spanish.freecodecamp.org/guide/certificates/add-placeholder-text-to-a-text-field'
 videoUrl: ''
 localeTitle: Añadir texto de marcador de posición a un campo de texto
 ---

--- a/curriculum/challenges/spanish/02-javascript-algorithms-and-data-structures/basic-javascript/access-array-data-with-indexes.spanish.md
+++ b/curriculum/challenges/spanish/02-javascript-algorithms-and-data-structures/basic-javascript/access-array-data-with-indexes.spanish.md
@@ -2,7 +2,6 @@
 id: 56bbb991ad1ed5201cd392ca
 title: Access Array Data with Indexes
 challengeType: 1
-guideUrl: 'https://spanish.freecodecamp.org/guide/certificates/access-array-data-with-indexes'
 videoUrl: ''
 localeTitle: Acceso a datos de matriz con índices
 ---

--- a/curriculum/challenges/spanish/02-javascript-algorithms-and-data-structures/basic-javascript/access-multi-dimensional-arrays-with-indexes.spanish.md
+++ b/curriculum/challenges/spanish/02-javascript-algorithms-and-data-structures/basic-javascript/access-multi-dimensional-arrays-with-indexes.spanish.md
@@ -2,7 +2,6 @@
 id: 56592a60ddddeae28f7aa8e1
 title: Access Multi-Dimensional Arrays With Indexes
 challengeType: 1
-guideUrl: 'https://spanish.freecodecamp.org/guide/certificates/access-array-data-with-indexes'
 videoUrl: ''
 localeTitle: Acceder a matrices multidimensionales con índices
 ---

--- a/curriculum/challenges/spanish/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-arrays.spanish.md
+++ b/curriculum/challenges/spanish/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-arrays.spanish.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244cd
 title: Accessing Nested Arrays
 challengeType: 1
-guideUrl: 'https://spanish.freecodecamp.org/guide/certificates/access-array-data-with-indexes'
 videoUrl: ''
 localeTitle: Acceso a matrices anidadas
 ---

--- a/curriculum/challenges/spanish/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-objects.spanish.md
+++ b/curriculum/challenges/spanish/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-objects.spanish.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244cc
 title: Accessing Nested Objects
 challengeType: 1
-guideUrl: 'https://spanish.freecodecamp.org/guide/certificates/accessing-nested-objects-in-json'
 videoUrl: ''
 localeTitle: Accediendo a objetos anidados
 ---

--- a/curriculum/challenges/spanish/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-bracket-notation.spanish.md
+++ b/curriculum/challenges/spanish/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-bracket-notation.spanish.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244c8
 title: Accessing Object Properties with Bracket Notation
 challengeType: 1
-guideUrl: 'https://spanish.freecodecamp.org/guide/certificates/accessing-objects-properties-with-bracket-notation'
 videoUrl: ''
 localeTitle: Acceso a las propiedades del objeto con notación de corchete
 ---

--- a/curriculum/challenges/spanish/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-variables.spanish.md
+++ b/curriculum/challenges/spanish/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-variables.spanish.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244c9
 title: Accessing Object Properties with Variables
 challengeType: 1
-guideUrl: 'https://spanish.freecodecamp.org/guide/certificates/accessing-objects-properties-with-variables'
 videoUrl: ''
 localeTitle: Accediendo a las propiedades del objeto con variables
 ---

--- a/curriculum/challenges/spanish/02-javascript-algorithms-and-data-structures/basic-javascript/adding-a-default-option-in-switch-statements.spanish.md
+++ b/curriculum/challenges/spanish/02-javascript-algorithms-and-data-structures/basic-javascript/adding-a-default-option-in-switch-statements.spanish.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244de
 title: Adding a Default Option in Switch Statements
 challengeType: 1
-guideUrl: 'https://spanish.freecodecamp.org/guide/certificates/adding-a-default-option-in-switch-statements'
 videoUrl: ''
 localeTitle: Adición de una opción predeterminada en los estados de cambio
 ---

--- a/curriculum/challenges/spanish/02-javascript-algorithms-and-data-structures/basic-javascript/appending-variables-to-strings.spanish.md
+++ b/curriculum/challenges/spanish/02-javascript-algorithms-and-data-structures/basic-javascript/appending-variables-to-strings.spanish.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244ed
 title: Appending Variables to Strings
 challengeType: 1
-guideUrl: 'https://spanish.freecodecamp.org/guide/certificates/appending-variables-to-strings'
 videoUrl: ''
 localeTitle: Anexando Variables a las Cadenas
 ---

--- a/curriculum/challenges/spanish/02-javascript-algorithms-and-data-structures/basic-javascript/assignment-with-a-returned-value.spanish.md
+++ b/curriculum/challenges/spanish/02-javascript-algorithms-and-data-structures/basic-javascript/assignment-with-a-returned-value.spanish.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244c3
 title: Assignment with a Returned Value
 challengeType: 1
-guideUrl: 'https://spanish.freecodecamp.org/guide/certificates/assignment-with-a-returned-value'
 videoUrl: ''
 localeTitle: Asignación con un valor devuelto
 ---

--- a/curriculum/challenges/spanish/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/arguments-optional.spanish.md
+++ b/curriculum/challenges/spanish/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/arguments-optional.spanish.md
@@ -3,7 +3,6 @@ id: a97fd23d9b809dac9921074f
 title: Arguments Optional
 isRequired: true
 challengeType: 5
-guideUrl: 'https://spanish.freecodecamp.org/guide/certificates/arguments-optional'
 videoUrl: ''
 localeTitle: Argumentos Opcionales
 ---

--- a/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/apply-the-default-bootstrap-button-style.spanish.md
+++ b/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/apply-the-default-bootstrap-button-style.spanish.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aec908850
 title: Apply the Default Bootstrap Button Style
 challengeType: 0
-guideUrl: 'https://spanish.freecodecamp.org/guide/certificates/apply-the-default-bootstrap-button-style'
 videoUrl: ''
 localeTitle: Aplicar el estilo de botón predeterminado Bootstrap
 ---


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

After some help from @ValeraS regarding a line to delete from `Show.js`, I was able to remove the `guideUrl`s from 21 challenges which still used this old way of linking to the respective challenge Guide article when the `Get a Hint` button is clicked.

I have tested all 21 guide links worked after removing them.  

Closes #27778 

**Attention Reviewers:** When testing this PR locally for the English challenges, you will need to temporarily copy the `guide/english/certifications` folder into the `mock-guide/english` folder to test that all the guide links work.  There is not currently a way to test the non-English challenges, but they should work.

**Note:**  Per instruction from @Bouncey, I have put all languages in one PR, because there is no translation involved.