### PR TITLE
Fix(curriculum) Removed unnecessary guideUrl from frontmatter block in various Arabic challenges

### DIFF
--- a/curriculum/challenges/arabic/01-responsive-web-design/applied-accessibility/add-a-text-alternative-to-images-for-visually-impaired-accessibility.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/applied-accessibility/add-a-text-alternative-to-images-for-visually-impaired-accessibility.arabic.md
@@ -3,7 +3,6 @@ id: 587d774c367417b2b2512a9c
 title: Add a Text Alternative to Images for Visually Impaired Accessibility
 challengeType: 0
 videoUrl: ''
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/add-alt-text-to-an-image-for-accessibility'
 localeTitle: إضافة نص بديل للصور لذوي ضعاف البصر
 ---
 

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-css/add-a-negative-margin-to-an-element.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-css/add-a-negative-margin-to-an-element.arabic.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08823
 title: Add a Negative Margin to an Element
 challengeType: 0
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/add-a-negative-margin-to-an-element'
 videoUrl: ''
 localeTitle: أضف هامشًا سلبيًا إلى عنصر
 ---

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-css/add-borders-around-your-elements.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-css/add-borders-around-your-elements.arabic.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9bedf08813
 title: Add Borders Around Your Elements
 challengeType: 0
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/add-borders-around-your-elements'
 videoUrl: ''
 localeTitle: أضف حدود حول عناصرك
 ---

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-css/add-different-padding-to-each-side-of-an-element.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-css/add-different-padding-to-each-side-of-an-element.arabic.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08824
 title: Add Different Padding to Each Side of an Element
 challengeType: 0
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/add-different-padding-to-each-side-of-an-element'
 videoUrl: ''
 localeTitle: ''
 ---

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-css/add-rounded-corners-with-border-radius.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-css/add-rounded-corners-with-border-radius.arabic.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08814
 title: Add Rounded Corners with border-radius
 challengeType: 0
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/add-rounded-corners-a-border-radius'
 videoUrl: ''
 localeTitle: ''
 ---

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-css/adjust-the-margin-of-an-element.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-css/adjust-the-margin-of-an-element.arabic.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08822
 title: Adjust the Margin of an Element
 challengeType: 0
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/adjust-the-margin-of-an-element'
 videoUrl: ''
 localeTitle: ضبط هامش عنصر
 ---

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-css/adjust-the-padding-of-an-element.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-css/adjust-the-padding-of-an-element.arabic.md
@@ -2,7 +2,6 @@
 id: bad88fee1348bd9aedf08825
 title: Adjust the Padding of an Element
 challengeType: 0
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/adjust-the-padding-of-an-element'
 videoUrl: ''
 localeTitle: ضبط الحشو من عنصر
 ---

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-html-and-html5/add-a-submit-button-to-a-form.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-html-and-html5/add-a-submit-button-to-a-form.arabic.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedd08830
 title: Add a Submit Button to a Form
 challengeType: 0
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/add-a-submit-button-to-a-form'
 videoUrl: ''
 localeTitle: إضافة زر إرسال إلى نموذج
 ---

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-html-and-html5/add-images-to-your-website.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-html-and-html5/add-images-to-your-website.arabic.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08812
 title: Add Images to Your Website
 challengeType: 0
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/add-images-to-your-website'
 videoUrl: ''
 localeTitle: إضافة الصور إلى موقع الويب الخاص بك
 ---

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-html-and-html5/add-placeholder-text-to-a-text-field.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-html-and-html5/add-placeholder-text-to-a-text-field.arabic.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08830
 title: Add Placeholder Text to a Text Field
 challengeType: 0
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/add-placeholder-text-to-a-text-field'
 videoUrl: ''
 localeTitle: إضافة نص العنصر النائب إلى حقل نص
 ---

--- a/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/access-array-data-with-indexes.arabic.md
+++ b/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/access-array-data-with-indexes.arabic.md
@@ -2,7 +2,6 @@
 id: 56bbb991ad1ed5201cd392ca
 title: Access Array Data with Indexes
 challengeType: 1
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/access-array-data-with-indexes'
 videoUrl: ''
 localeTitle: ''
 ---

--- a/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/access-multi-dimensional-arrays-with-indexes.arabic.md
+++ b/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/access-multi-dimensional-arrays-with-indexes.arabic.md
@@ -2,7 +2,6 @@
 id: 56592a60ddddeae28f7aa8e1
 title: Access Multi-Dimensional Arrays With Indexes
 challengeType: 1
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/access-array-data-with-indexes'
 videoUrl: ''
 localeTitle: الوصول إلى صفائف متعددة الأبعاد مع فهارس
 ---

--- a/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-arrays.arabic.md
+++ b/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-arrays.arabic.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244cd
 title: Accessing Nested Arrays
 challengeType: 1
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/access-array-data-with-indexes'
 videoUrl: ''
 localeTitle: الوصول إلى صفائف متداخلة
 ---

--- a/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-objects.arabic.md
+++ b/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-objects.arabic.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244cc
 title: Accessing Nested Objects
 challengeType: 1
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/accessing-nested-objects-in-json'
 videoUrl: ''
 localeTitle: الوصول إلى الكائنات المتداخلة
 ---

--- a/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-bracket-notation.arabic.md
+++ b/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-bracket-notation.arabic.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244c8
 title: Accessing Object Properties with Bracket Notation
 challengeType: 1
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/accessing-objects-properties-with-bracket-notation'
 videoUrl: ''
 localeTitle: الوصول إلى خصائص كائن مع تدرج قوس
 ---

--- a/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-variables.arabic.md
+++ b/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-variables.arabic.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244c9
 title: Accessing Object Properties with Variables
 challengeType: 1
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/accessing-objects-properties-with-variables'
 videoUrl: ''
 localeTitle: الوصول إلى خصائص الكائن مع المتغيرات
 ---

--- a/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/adding-a-default-option-in-switch-statements.arabic.md
+++ b/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/adding-a-default-option-in-switch-statements.arabic.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244de
 title: Adding a Default Option in Switch Statements
 challengeType: 1
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/adding-a-default-option-in-switch-statements'
 videoUrl: ''
 localeTitle: إضافة خيار افتراضي في تبديل البيانات
 ---

--- a/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/appending-variables-to-strings.arabic.md
+++ b/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/appending-variables-to-strings.arabic.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244ed
 title: Appending Variables to Strings
 challengeType: 1
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/appending-variables-to-strings'
 videoUrl: ''
 localeTitle: إلحاق المتغيرات بالسلاسل
 ---

--- a/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/assignment-with-a-returned-value.arabic.md
+++ b/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/assignment-with-a-returned-value.arabic.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244c3
 title: Assignment with a Returned Value
 challengeType: 1
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/assignment-with-a-returned-value'
 videoUrl: ''
 localeTitle: التنازل مع القيمة المرتجعة
 ---

--- a/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/arguments-optional.arabic.md
+++ b/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/arguments-optional.arabic.md
@@ -3,7 +3,6 @@ id: a97fd23d9b809dac9921074f
 title: Arguments Optional
 isRequired: true
 challengeType: 5
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/arguments-optional'
 videoUrl: ''
 localeTitle: ''
 ---

--- a/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/apply-the-default-bootstrap-button-style.arabic.md
+++ b/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/apply-the-default-bootstrap-button-style.arabic.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aec908850
 title: Apply the Default Bootstrap Button Style
 challengeType: 0
-guideUrl: 'https://arabic.freecodecamp.org/guide/certificates/apply-the-default-bootstrap-button-style'
 videoUrl: ''
 localeTitle: ''
 ---


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

This PR depends on related PR #35294 being merged first, so it should be `blocked` until that has happened.  I was able to remove the `guideUrl`s from 21 challenges which still used this old way of linking to the respective challenge Guide article when the `Get a Hint` button is clicked.

**Attention Reviewers:** When testing this PR locally, you will need to temporarily copy the `guide/arabic/certifications` folder into the `mock-guide/arabic` folder to test that all the guide links work.