### PR TITLE
fix(curriculum) Fixed test to only allow valid JSX comments for Add Comments In JSX challenge

### DIFF
--- a/curriculum/challenges/english/03-front-end-libraries/react/add-comments-in-jsx.english.md
+++ b/curriculum/challenges/english/03-front-end-libraries/react/add-comments-in-jsx.english.md
@@ -22,15 +22,15 @@ The code editor has a JSX element similar to what you created in the last challe
 ```yml
 tests:
   - text: The constant <code>JSX</code> should return a <code>div</code> element.
-    testString: assert(JSX.type === 'div', 'The constant <code>JSX</code> should return a <code>div</code> element.');
+    testString: assert(JSX.type === 'div');
   - text: The <code>div</code> should contain an <code>h1</code> tag as the first element.
-    testString: assert(JSX.props.children[0].type === 'h1', 'The <code>div</code> should contain an <code>h1</code> tag as the first element.');
+    testString: assert(JSX.props.children[0].type === 'h1');
   - text: The <code>div</code> should contain a <code>p</code> tag as the second element.
-    testString: assert(JSX.props.children[1].type === 'p', 'The <code>div</code> should contain a <code>p</code> tag as the second element.');
+    testString: assert(JSX.props.children[1].type === 'p');
   - text: The existing <code>h1</code> and <code>p</code> elements should not be modified.
-    testString: assert(JSX.props.children[0].props.children === 'This is a block of JSX' && JSX.props.children[1].props.children === 'Here\'s a subtitle', 'The existing <code>h1</code> and <code>p</code> elements should not be modified.');     
-  - text: The <code>JSX</code> should include a comment.
-    testString: assert(/<div>[\s\S]*{\s*\/\*\s*\S[\s\S]*\*\/\s*}[\s\S]*<\/div>/.test(code), 'The <code>JSX</code> should include a comment.');
+    testString: assert(JSX.props.children[0].props.children === 'This is a block of JSX' && JSX.props.children[1].props.children === 'Here\'s a subtitle');     
+  - text: The <code>JSX</code> should use valid comment syntax.
+    testString: assert(/<div>[\s\S]*{\s*\/\*[\s\S]*\*\/\s*}[\s\S]*<\/div>/.test(code));
 ```
 
 </section>

--- a/curriculum/challenges/english/03-front-end-libraries/react/add-comments-in-jsx.english.md
+++ b/curriculum/challenges/english/03-front-end-libraries/react/add-comments-in-jsx.english.md
@@ -27,9 +27,10 @@ tests:
     testString: assert(JSX.props.children[0].type === 'h1', 'The <code>div</code> should contain an <code>h1</code> tag as the first element.');
   - text: The <code>div</code> should contain a <code>p</code> tag as the second element.
     testString: assert(JSX.props.children[1].type === 'p', 'The <code>div</code> should contain a <code>p</code> tag as the second element.');
+  - text: The existing <code>h1</code> and <code>p</code> elements should not be modified.
+    testString: assert(JSX.props.children[0].props.children === 'This is a block of JSX' && JSX.props.children[1].props.children === 'Here\'s a subtitle', 'The existing <code>h1</code> and <code>p</code> elements should not be modified.');     
   - text: The <code>JSX</code> should include a comment.
-    testString: getUserInput => assert(getUserInput('index').includes('/*') && getUserInput('index').includes('*/'), 'The <code>JSX</code> should include a comment.');
-
+    testString: assert(/<div>[\s\S]*{\s*\/\*\s*\S[\s\S]*\*\/\s*}[\s\S]*<\/div>/.test(code), 'The <code>JSX</code> should include a comment.');
 ```
 
 </section>


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Closes #34697

I fixed the main issue discussed in #34697 which allow a user to write the comment on the same line as the opening `div` tag.  I went a little further and validate that a comment appears inside the `div` element somewhere, but still not affect the existing `h1` and `p` elements.  I also created another test and made it the 3rd to make sure the `h1` and `p` elements original content does not change, which was part of the challenge instructions' requirements.