### PR TITLE
fix(curriculum): Modified testString to match literal spaces as well as \s for Using Capture Groups challenge

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/reuse-patterns-using-capture-groups.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/reuse-patterns-using-capture-groups.english.md
@@ -29,7 +29,7 @@ tests:
   - text: Your regex should reuse the capture group twice.
     testString: assert(reRegex.source.match(/\\\d/g).length === 2, 'Your regex should reuse the capture group twice.');
   - text: Your regex should have two spaces separating the three numbers.
-    testString: assert(reRegex.source.match(/\\s/g).length === 2, 'Your regex should have two spaces separating the three numbers.');
+    testString: assert(reRegex.source.match(/ |\\s/g).length === 2, 'Your regex should have two spaces separating the three numbers.');
   - text: Your regex should match <code>"42 42 42"</code>.
     testString: assert(reRegex.test("42 42 42"), 'Your regex should match <code>"42 42 42"</code>.');
   - text: Your regex should match <code>"100 100 100"</code>.


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Closes #18138

This PR aims to address a bug in one the test which validates that the regular expression uses two spaces separating the three numbers.  The problem was, that if the camper's regular expression used literal space characters (like the regular expression below), this test failed incorrectly.  
```
/^(\d+) \1 \1$/
```
