### PR TITLE
fix(curriculum): Fixed issue with & not displaying properly in test text of Convert HTML Entities challenge

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/convert-html-entities.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/convert-html-entities.english.md
@@ -21,20 +21,20 @@ Remember to use <a href='http://forum.freecodecamp.org/t/how-to-get-help-when-yo
 
 ```yml
 tests:
-  - text: <code>convertHTML("Dolce & Gabbana")</code> should return <code>Dolce &amp; Gabbana</code>.
-    testString: assert.match(convertHTML("Dolce & Gabbana"), /Dolce &amp; Gabbana/, '<code>convertHTML("Dolce & Gabbana")</code> should return <code>Dolce &amp; Gabbana</code>.');
-  - text: <code>convertHTML("Hamburgers < Pizza < Tacos")</code> should return <code>Hamburgers &lt; Pizza &lt; Tacos</code>.
-    testString: assert.match(convertHTML("Hamburgers < Pizza < Tacos"), /Hamburgers &lt; Pizza &lt; Tacos/, '<code>convertHTML("Hamburgers < Pizza < Tacos")</code> should return <code>Hamburgers &lt; Pizza &lt; Tacos</code>.');
-  - text: <code>convertHTML("Sixty > twelve")</code> should return <code>Sixty &gt; twelve</code>.
-    testString: assert.match(convertHTML("Sixty > twelve"), /Sixty &gt; twelve/, '<code>convertHTML("Sixty > twelve")</code> should return <code>Sixty &gt; twelve</code>.');
-  - text: <code>convertHTML(&apos;Stuff in "quotation marks"&apos;)</code> should return <code>Stuff in &quot;quotation marks&quot;</code>.
-    testString: assert.match(convertHTML('Stuff in "quotation marks"'), /Stuff in &quot;quotation marks&quot;/, '<code>convertHTML(&apos;Stuff in "quotation marks"&apos;)</code> should return <code>Stuff in &quot;quotation marks&quot;</code>.');
-  - text: <code>convertHTML("Schindler&apos;s List")</code> should return <code>Schindler&apos;s List</code>.
-    testString: assert.match(convertHTML("Schindler's List"), /Schindler&apos;s List/, '<code>convertHTML("Schindler&apos;s List")</code> should return <code>Schindler&apos;s List</code>.');
-  - text: <code>convertHTML("<>")</code> should return <code>&lt;&gt;</code>.
-    testString: assert.match(convertHTML('<>'), /&lt;&gt;/, '<code>convertHTML("<>")</code> should return <code>&lt;&gt;</code>.');
+  - text: <code>convertHTML("Dolce & Gabbana")</code> should return <code>Dolce &amp;amp; Gabbana</code>.
+    testString: assert.match(convertHTML("Dolce & Gabbana"), /Dolce &amp; Gabbana/);
+  - text: <code>convertHTML("Hamburgers < Pizza < Tacos")</code> should return <code>Hamburgers &amp;lt; Pizza &amp;lt; Tacos</code>.
+    testString: assert.match(convertHTML("Hamburgers < Pizza < Tacos"), /Hamburgers &lt; Pizza &lt; Tacos/);
+  - text: <code>convertHTML("Sixty > twelve")</code> should return <code>Sixty &amp;gt; twelve</code>.
+    testString: assert.match(convertHTML("Sixty > twelve"), /Sixty &gt; twelve/);
+  - text: <code>convertHTML(&apos;Stuff in "quotation marks"&apos;)</code> should return <code>Stuff in &amp;quot;quotation marks&amp;quot;</code>.
+    testString: assert.match(convertHTML('Stuff in "quotation marks"'), /Stuff in &quot;quotation marks&quot;/);
+  - text: <code>convertHTML("Schindler&apos;s List")</code> should return <code>Schindler&amp;apos;s List</code>.
+    testString: assert.match(convertHTML("Schindler's List"), /Schindler&apos;s List/);
+  - text: <code>convertHTML("<>")</code> should return <code>&amp;lt;&amp;gt;</code>.
+    testString: assert.match(convertHTML('<>'), /&lt;&gt;/);
   - text: <code>convertHTML("abc")</code> should return <code>abc</code>.
-    testString: assert.strictEqual(convertHTML('abc'), 'abc', '<code>convertHTML("abc")</code> should return <code>abc</code>.');
+    testString: assert.strictEqual(convertHTML('abc'), 'abc');
 
 ```
 


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Not sure if we just missed this issue back when PR #19674 was merged (to resolve an unrelated issue) or if something changed in the way html entities are displayed in test `text`, but this PR resolves it.

I noticed the issue while reviewing the beta site.  We should get this merged and moved to the beta site quickly, because without this fix, the challenge test messages will confuse campers.

**Note:**  Once this PR is approved/merged, I will create a separate PR to correct the non-English versions of this challenge.