### PR TITLE
fix(curriculum): Added test to validate clockwise notation is used for the Use Clockwise Notation to Specify the Margin of an Element challenge

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-clockwise-notation-to-specify-the-margin-of-an-element.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-clockwise-notation-to-specify-the-margin-of-an-element.english.md
@@ -24,15 +24,15 @@ Use <code>Clockwise Notation</code> to give the element with the <code>blue-box<
 ```yml
 tests:
   - text: Your <code>blue-box</code> class should give the top of elements <code>40px</code> of <code>margin</code>.
-    testString: assert($(".blue-box").css("margin-top") === "40px", 'Your <code>blue-box</code> class should give the top of elements <code>40px</code> of <code>margin</code>.');
+    testString: assert($(".blue-box").css("margin-top") === "40px");
   - text: Your <code>blue-box</code> class should give the right of elements <code>20px</code> of <code>margin</code>.
-    testString: assert($(".blue-box").css("margin-right") === "20px", 'Your <code>blue-box</code> class should give the right of elements <code>20px</code> of <code>margin</code>.');
+    testString: assert($(".blue-box").css("margin-right") === "20px");
   - text: Your <code>blue-box</code> class should give the bottom of elements <code>20px</code> of <code>margin</code>.
-    testString: assert($(".blue-box").css("margin-bottom") === "20px", 'Your <code>blue-box</code> class should give the bottom of elements <code>20px</code> of <code>margin</code>.');
+    testString: assert($(".blue-box").css("margin-bottom") === "20px");
   - text: Your <code>blue-box</code> class should give the left of elements <code>40px</code> of <code>margin</code>.
-    testString: assert($(".blue-box").css("margin-left") === "40px", 'Your <code>blue-box</code> class should give the left of elements <code>40px</code> of <code>margin</code>.');
+    testString: assert($(".blue-box").css("margin-left") === "40px");
   - text: You should use the clockwise notation to set the margin of <code>blue-box</code> class.
-    testString: assert(!/.blue-box\s*{[\s\S]*margin:\s*40px\s*20px\s*20px\s*40px;?[\s\S]*}.test(removeCssComments(code))); 
+    testString: const removeCssComments = str => str.replace(/<style>|<\/style>/g, '').replace(/\/\\*[\s\S]+?\*\//g, '');assert(/\.blue-box\s*{[\s\S]*margin:\s*\d+px\s+\d+px\s+\d+px\s+\d+px(;[\s\S]*}|\s*)/.test(removeCssComments(code)));
 
 ```
 
@@ -83,18 +83,6 @@ tests:
 
 </div>
 
-<div id="js-teardown">
-
-```js
-const removeCssComments = str => {
-  return str
-    .replace(/<style>|<\/style>/g,'')
-    .replace(/\/\\*[\s\S]+?\*\//g,'');
-};
-```
-
-</div>
-
 </section>
 
 ## Solution
@@ -138,4 +126,5 @@ const removeCssComments = str => {
   <h5 class="box blue-box">padding</h5>
 </div>
 ```
+
 </section>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-clockwise-notation-to-specify-the-margin-of-an-element.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-clockwise-notation-to-specify-the-margin-of-an-element.english.md
@@ -31,6 +31,8 @@ tests:
     testString: assert($(".blue-box").css("margin-bottom") === "20px", 'Your <code>blue-box</code> class should give the bottom of elements <code>20px</code> of <code>margin</code>.');
   - text: Your <code>blue-box</code> class should give the left of elements <code>40px</code> of <code>margin</code>.
     testString: assert($(".blue-box").css("margin-left") === "40px", 'Your <code>blue-box</code> class should give the left of elements <code>40px</code> of <code>margin</code>.');
+  - text: You should use the clockwise notation to set the margin of <code>blue-box</code> class.
+    testString: assert(!/.blue-box\s*{[\s\S]*margin:\s*40px\s*20px\s*20px\s*40px;?[\s\S]*}.test(removeCssComments(code))); 
 
 ```
 
@@ -81,14 +83,59 @@ tests:
 
 </div>
 
+<div id="js-teardown">
 
+```js
+const removeCssComments = str => {
+  return str
+    .replace(/<style>|<\/style>/g,'')
+    .replace(/\/\\*[\s\S]+?\*\//g,'');
+};
+```
+
+</div>
 
 </section>
 
 ## Solution
 <section id='solution'>
 
-```js
-// solution required
+```html
+<style>
+  .injected-text {
+    margin-bottom: -25px;
+    text-align: center;
+  }
+
+  .box {
+    border-style: solid;
+    border-color: black;
+    border-width: 5px;
+    text-align: center;
+  }
+
+  .yellow-box {
+    background-color: yellow;
+    padding: 20px 40px 20px 40px;
+  }
+
+  .red-box {
+    background-color: crimson;
+    color: #fff;
+    margin: 20px 40px 20px 40px;
+  }
+
+  .blue-box {
+    background-color: blue;
+    color: #fff;
+    margin: 40px 20px 20px 40px;
+  }
+</style>
+<h5 class="injected-text">margin</h5>
+
+<div class="box yellow-box">
+  <h5 class="box red-box">padding</h5>
+  <h5 class="box blue-box">padding</h5>
+</div>
 ```
 </section>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-clockwise-notation-to-specify-the-margin-of-an-element.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-clockwise-notation-to-specify-the-margin-of-an-element.english.md
@@ -32,7 +32,7 @@ tests:
   - text: Your <code>blue-box</code> class should give the left of elements <code>40px</code> of <code>margin</code>.
     testString: assert($(".blue-box").css("margin-left") === "40px");
   - text: You should use the clockwise notation to set the margin of <code>blue-box</code> class.
-    testString: const removeCssComments = str => str.replace(/<style>|<\/style>/g, '').replace(/\/\\*[\s\S]+?\*\//g, '');assert(/\.blue-box\s*{[\s\S]*margin:\s*\d+px\s+\d+px\s+\d+px\s+\d+px(;[\s\S]*}|\s*)/.test(removeCssComments(code)));
+    testString: const removeCssComments = str => str.replace(/\/\*[\s\S]+?\*\//g, '');assert(/\.blue-box\s*{[\s\S]*margin:\s*\d+px\s+\d+px\s+\d+px\s+\d+px(;[\s\S]*}|\s*)/.test(removeCssComments($('style').text())));
 
 ```
 


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

While reviewing and making suggestions to a PR (#35079), I noticed this challenge was missing a test which validates that clockwise notation is even used for the `blue-box` class's `margin` property.  Before this addition, a user could have still passed using `margin-top`, `margin-right`, `margin-bottom`, and `margin-left` properties.

As the other PR was attempting to still allow the `margin-xxxx` syntax in a comment in the `style` element, I went ahead and made a helper function for this challenge that strips all CSS comments out before testing the code for the clockwise notation.  The same helper function should be used on the other PR also.  

The one thing I did not address in this PR is testing if the user used the `margin-xxxx` syntax outside of a comment, but I figured as long as the user still used the clockwise notation, it seems the point of the challenge would have been learned and executed.  