### PR TITLE
fix(curriculum) Prevent 5th test from allowing invalid solution in Escape Sequences in Strings challenge

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/escape-sequences-in-strings.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/escape-sequences-in-strings.english.md
@@ -27,17 +27,17 @@ Here is the text with the escape sequences written out.
 ```yml
 tests:
   - text: <code>myStr</code> should not contain any spaces
-    testString: assert(!/ /.test(myStr), '<code>myStr</code> should not contain any spaces');
+    testString: assert(!/ /.test(myStr));
   - text: <code>myStr</code> should contain the strings <code>FirstLine</code>, <code>SecondLine</code> and <code>ThirdLine</code> (remember case sensitivity)
-    testString: assert(/FirstLine/.test(myStr) && /SecondLine/.test(myStr) && /ThirdLine/.test(myStr), '<code>myStr</code> should contain the strings <code>FirstLine</code>, <code>SecondLine</code> and <code>ThirdLine</code> (remember case sensitivity)');
+    testString: assert(/FirstLine/.test(myStr) && /SecondLine/.test(myStr) && /ThirdLine/.test(myStr));
   - text: <code>FirstLine</code> should be followed by the newline character <code>\n</code>
-    testString: assert(/FirstLine\n/.test(myStr), '<code>FirstLine</code> should be followed by the newline character <code>\n</code>');
+    testString: assert(/FirstLine\n/.test(myStr));
   - text: <code>myStr</code> should contain a tab character <code>\t</code> which follows a newline character
-    testString: assert(/\n\t/.test(myStr), '<code>myStr</code> should contain a tab character <code>\t</code> which follows a newline character');
-  - text: <code>SecondLine</code> should be preceded by the backslash character <code>\\</code>
-    testString: assert(/\SecondLine/.test(myStr), '<code>SecondLine</code> should be preceded by the backslash character <code>\\</code>');
+    testString: assert(/\n\t/.test(myStr));
+  - text: <code>SecondLine</code> should be preceded by the backslash character <code>\</code>
+    testString: assert(/\\SecondLine/.test(myStr));
   - text: There should be a newline character between <code>SecondLine</code> and <code>ThirdLine</code>
-    testString: assert(/SecondLine\nThirdLine/.test(myStr), 'There should be a newline character between <code>SecondLine</code> and <code>ThirdLine</code>');
+    testString: assert(/SecondLine\nThirdLine/.test(myStr));
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/escape-sequences-in-strings.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/escape-sequences-in-strings.english.md
@@ -38,6 +38,8 @@ tests:
     testString: assert(/\\SecondLine/.test(myStr));
   - text: There should be a newline character between <code>SecondLine</code> and <code>ThirdLine</code>
     testString: assert(/SecondLine\nThirdLine/.test(myStr));
+  - text: <code>myStr</code> should only contain characters shown in the instructions
+    testString: assert(myStr === 'FirstLine\n\t\\SecondLine\nThirdLine');    
 
 ```
 


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Closes #17712

This PR fixes the issue referenced above and also corrects the `text` to correct display a single `\` instead of `\\` which was displaying before the fix.  Also, I took the opportunity to remove `message` from the assert which is no longer needed in all assert tests.
