### PR TITLE
fix:reformat-npm-section

### DIFF
--- a/curriculum/challenges/english/05-apis-and-microservices/managing-packages-with-npm/add-a-description-to-your-package.json.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/managing-packages-with-npm/add-a-description-to-your-package.json.english.md
@@ -6,18 +6,16 @@ challengeType: 2
 
 ## Description
 <section id='description'>
-The next part of a good package.json is the description-field, where a short but informative description about your project belongs.
-If you some day plan to publish a package to npm, remember that this is the string that should sell your idea to the user when they decide whether to install your package or not. However, that’s not the only use case for the description: It’s a great way to summarize what a project does, it’s just as important for your normal Node.js-projects to help other developers, future maintainers or even your future self understand the project quickly.
-Regardless of what you plan for your project, a description is definitely recommended. Let’s add something similar to this:
-<code>"description": "A project that does something awesome",</code>
-Instructions
-Add a description to the package.json in your Glitch project.
-Remember to use double-quotes for field-names (") and commas (,) to separate fields.
+The next part of a good package.json file is the <code>description</code> field; where a short, but informative description about your project belongs.
+If you some day plan to publish a package to npm, this is the string that should sell your idea to the user when they decide whether to install your package or not. However, that’s not the only use case for the description, it’s a great way to summarize what a project does. It’s just as important in any Node.js project to help other developers, future maintainers or even your future self understand the project quickly.
+Regardless of what you plan for your project, a description is definitely recommended. Here's an example:
+<blockquote>"description": "A project that does something awesome",</blockquote>
 </section>
 
 ## Instructions
 <section id='instructions'>
-
+Add a <code>description</code> to the package.json file of your project.
+<strong>Note:</strong> Remember to use double-quotes for field-names (") and commas (,) to separate fields.
 </section>
 
 ## Tests

--- a/curriculum/challenges/english/05-apis-and-microservices/managing-packages-with-npm/add-a-license-to-your-package.json.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/managing-packages-with-npm/add-a-license-to-your-package.json.english.md
@@ -6,18 +6,14 @@ challengeType: 2
 
 ## Description
 <section id='description'>
-The license-field is where you inform users of your project what they are allowed to do with it.
-Some common licenses for open source projects include MIT and BSD. http://choosealicense.com is a great resource if you want to learn more about what license could fit your project.
-License information is not required. Copyright laws in most countries will give you ownership of what you create by default. However, it’s always a good practice to explicitly state what users can and can’t do.
-Example
-<code>"license": "MIT",</code>
-Instructions
-Fill the license-field in the package.json of your Glitch project as you find suitable.
+The <code>license</code> field is where you inform users of what they are allowed to do with your project.
+Some common licenses for open source projects include MIT and BSD. License information is not required, and copyright laws in most countries will give you ownership of what you create by default. However, it’s always a good practice to explicitly state what users can and can’t do. Here's an example of the license field:
+<blockquote>"license": "MIT",</blockquote>
 </section>
 
 ## Instructions
 <section id='instructions'>
-
+Fill the <code>license</code> field in the package.json file of your project as you find suitable.
 </section>
 
 ## Tests

--- a/curriculum/challenges/english/05-apis-and-microservices/managing-packages-with-npm/add-a-version-to-your-package.json.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/managing-packages-with-npm/add-a-version-to-your-package.json.english.md
@@ -6,16 +6,13 @@ challengeType: 2
 
 ## Description
 <section id='description'>
-The version is together with name one of the required fields in a package.json. This field describes the current version of your project.
-Example
-<code>"version": "1.2",</code>
-Instructions
-Add a version to the package.json in your Glitch project.
+A <code>version</code> is one of the required fields of your package.json file. This field describes the current version of your project. Here's an example:
+<blockquote>"version": "1.2",</blockquote>
 </section>
 
 ## Instructions
 <section id='instructions'>
-
+Add a <code>version</code> to the package.json file of your project.
 </section>
 
 ## Tests

--- a/curriculum/challenges/english/05-apis-and-microservices/managing-packages-with-npm/add-keywords-to-your-package.json.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/managing-packages-with-npm/add-keywords-to-your-package.json.english.md
@@ -6,18 +6,15 @@ challengeType: 2
 
 ## Description
 <section id='description'>
-The keywords-field is where you can describe your project using related keywords.
-Example
-<code>"keywords": [ "descriptive", "related", "words" ],</code>
+The <code>keywords</code> field is where you can describe your project using related keywords. Here's an example:
+<blockquote>"keywords": [ "descriptive", "related", "words" ],</blockquote>
 As you can see, this field is structured as an array of double-quoted strings.
-Instructions
-Add an array of suitable strings to the keywords-field in the package.json of your Glitch project.
-One of the keywords should be freecodecamp.
 </section>
 
 ## Instructions
 <section id='instructions'>
-
+Add an array of suitable strings to the <code>keywords</code> field in the package.json file of your project.
+One of the keywords should be "freecodecamp".
 </section>
 
 ## Tests

--- a/curriculum/challenges/english/05-apis-and-microservices/managing-packages-with-npm/expand-your-project-with-external-packages-from-npm.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/managing-packages-with-npm/expand-your-project-with-external-packages-from-npm.english.md
@@ -6,20 +6,20 @@ challengeType: 2
 
 ## Description
 <section id='description'>
-One of the biggest reasons to use a package manager is their powerful dependency management. Instead of manually having to make sure that you get all dependencies whenever you set up a project on a new computer, npm automatically installs everything for you. But how can npm know exactly what your project needs? Meet the dependencies-section of your package.json.
-In the dependencies-section, packages your project require are stored using the following format:
-<code>"dependencies": {</code>
-<code>  "package-name": "version",</code>
-<code>  "express": "4.14.0"</code>
-<code>}</code>
-Instructions
-Add version 2.14.0 of the package moment to the dependencies-field of your package.json
-Moment is a handy library for working with time and dates.
+One of the biggest reasons to use a package manager, is their powerful dependency management. Instead of manually having to make sure that you get all dependencies whenever you set up a project on a new computer, npm automatically installs everything for you. But how can npm know exactly what your project needs? Meet the <code>dependencies</code> section of your package.json file.
+In this section, packages your project requires are stored using the following format:
+<blockquote>
+"dependencies": {<br>
+&nbsp;&nbsp;"package-name": "version",</br>
+&nbsp;&nbsp;"express": "4.14.0"</br>
+}<br>
+</blockquote>
 </section>
 
 ## Instructions
 <section id='instructions'>
-
+Add version "2.14.0" of the "moment" package to the <code>dependencies</code> field of your package.json file.
+<strong>Note:</strong> Moment is a handy library for working with time and dates.
 </section>
 
 ## Tests

--- a/curriculum/challenges/english/05-apis-and-microservices/managing-packages-with-npm/how-to-use-package.json-the-core-of-any-node.js-project-or-npm-package.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/managing-packages-with-npm/how-to-use-package.json-the-core-of-any-node.js-project-or-npm-package.english.md
@@ -6,21 +6,16 @@ challengeType: 2
 
 ## Description
 <section id='description'>
-The file package.json is the center of any Node.js project or npm package. It stores information about your project just like the &lt;head&gt;-section in a HTML document describes the content of a webpage. The package.json consists of a single JSON-object where information is stored in "key": value-pairs. There are only two required fields in a minimal package.json - name and version - but it’s a good practice to provide additional information about your project that could be useful to future users or maintainers.
-The author-field
-If you go to the Glitch project that you set up previously and look at on the left side of your screen, you’ll find the file tree where you can see an overview of the various files in your project. Under the file tree’s back-end section, you’ll find package.json - the file that we’ll be improving in the next couple of challenges.
-One of the most common pieces of information in this file is the author-field that specifies who’s the creator of a project. It can either be a string or an object with contact details. The object is recommended for bigger projects but in our case, a simple string like the following example will do.
-<code>"author": "Jane Doe",</code>
-Instructions
-Add your name to the author-field in the package.json of your Glitch project.
-Remember that you’re writing JSON.
-All field-names must use double-quotes ("), e.g. "author"
-All fields must be separated with a comma (,)
+The <code>package.json</code> file is the center of any Node.js project or npm package. It stores information about your project, similar to how the &lt;head&gt; section of an HTML document describes the content of a webpage. It consists of a single JSON object where information is stored in key-value pairs. There are only two required fields; "name" and "version", but it’s good practice to provide additional information about your project that could be useful to future users or maintainers.
+If you look at the file tree of your project, you will find the package.json file on the top level of the tree. This is the file that you will be improving in the next couple of challenges.
+One of the most common pieces of information in this file is the <code>author</code> field. It specifies who created the project, and can consist of a string or an object with contact or other details. An object is recommended for bigger projects, but a simple string like the following example will do for this project.
+<blockquote>"author": "Jane Doe",</blockquote>
 </section>
 
 ## Instructions
 <section id='instructions'>
-
+Add your name as the <code>author</code> of the project in the package.json file.
+<strong>Note:</strong> Remember that you’re writing JSON, so all field names must use double-quotes (") and be separated with a comma (,).
 </section>
 
 ## Tests

--- a/curriculum/challenges/english/05-apis-and-microservices/managing-packages-with-npm/manage-npm-dependencies-by-understanding-semantic-versioning.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/managing-packages-with-npm/manage-npm-dependencies-by-understanding-semantic-versioning.english.md
@@ -6,25 +6,18 @@ challengeType: 2
 
 ## Description
 <section id='description'>
-Versions of the npm packages in the dependencies-section of your package.json follow what’s called Semantic Versioning (SemVer), an industry standard for software versioning aiming to make it easier to manage dependencies. Libraries, frameworks or other tools published on npm should use SemVer in order to clearly communicate what kind of changes that projects who depend on the package can expect if they update.
-SemVer doesn’t make sense in projects without public APIs - so unless your project is similar to the examples above, use another versioning format.
-So why do you need to understand SemVer?
-Knowing SemVer can be useful when you develop software that use external dependencies (which you almost always do). One day, your understanding of these numbers will save you from accidentally introducing breaking changes to your project without understanding why things “that worked yesterday” suddenly don’t.
-This is how Semantic Versioning works according to the official website:
-Given a version number MAJOR.MINOR.PATCH, increment the:
-MAJOR version when you make incompatible API changes,
-MINOR version when you add functionality in a backwards-compatible manner, and
-PATCH version when you make backwards-compatible bug fixes.
+<code>Versions</code> of the npm packages in the dependencies section of your package.json file follow what’s called Semantic Versioning (SemVer), an industry standard for software versioning aiming to make it easier to manage dependencies. Libraries, frameworks or other tools published on npm should use SemVer in order to clearly communicate what kind of changes projects can expect if they update.
+Knowing SemVer can be useful when you develop software that uses external dependencies (which you almost always do). One day, your understanding of these numbers will save you from accidentally introducing breaking changes to your project without understanding why things that worked yesterday suddenly don’t work today. This is how Semantic Versioning works according to the official website:
+<blockquote>"package": "MAJOR.MINOR.PATCH"</blockquote>
+The MAJOR version should increment when you make incompatible API changes.
+The MINOR version should increment when you add functionality in a backwards-compatible manner.
+The PATCH version should increment when you make backwards-compatible bug fixes.
 This means that PATCHes are bug fixes and MINORs add new features but neither of them break what worked before. Finally, MAJORs add changes that won’t work with earlier versions.
-Example
-A semantic version number: 1.3.8
-Instructions
-In the dependencies-section of your package.json, change the version of moment to match MAJOR version 2, MINOR version 10 and PATCH version 2
 </section>
 
 ## Instructions
 <section id='instructions'>
-
+In the dependencies section of your package.json file, change the <code>version</code> of moment to match MAJOR version 2, MINOR version 10 and PATCH version 2
 </section>
 
 ## Tests

--- a/curriculum/challenges/english/05-apis-and-microservices/managing-packages-with-npm/remove-a-package-from-your-dependencies.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/managing-packages-with-npm/remove-a-package-from-your-dependencies.english.md
@@ -6,17 +6,15 @@ challengeType: 2
 
 ## Description
 <section id='description'>
-Now you’ve tested a few ways you can manage dependencies of your project by using the package.json's dependencies-section. You’ve included external packages by adding them to the file and even told npm what types of versions you want by using special characters as the tilde (~) or the caret (^).
-But what if you want to remove an external package that you no longer need? You might already have guessed it - Just remove the corresponding "key": value-pair for that from your dependencies.
+You have now tested a few ways you can manage dependencies of your project by using the package.json's dependencies section. You have also included external packages by adding them to the file and even told npm what types of versions you want, by using special characters such as the tilde or the caret.
+But what if you want to remove an external package that you no longer need? You might already have guessed it, just remove the corresponding key-value pair for that package from your dependencies.
 This same method applies to removing other fields in your package.json as well
-Instructions
-Remove the package moment from your dependencies.
-Make sure you have the right amount of commas after removing it.
 </section>
 
 ## Instructions
 <section id='instructions'>
-
+Remove the moment package from your dependencies.
+<strong>Note:</strong> Make sure you have the right amount of commas after removing it.
 </section>
 
 ## Tests

--- a/curriculum/challenges/english/05-apis-and-microservices/managing-packages-with-npm/use-the-caret-character-to-use-the-latest-minor-version-of-a-dependency.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/managing-packages-with-npm/use-the-caret-character-to-use-the-latest-minor-version-of-a-dependency.english.md
@@ -6,18 +6,16 @@ challengeType: 2
 
 ## Description
 <section id='description'>
-Similar to how the tilde (~) we learned about in the last challenge allow npm to install the latest PATCH for a dependency, the caret (^) allows npm to install future updates as well. The difference is that the caret will allow both MINOR updates and PATCHes.
-At the moment, your current version of moment should be ~2.10.2 which allows npm to install to the latest 2.10.x-version. If we instead were to use the caret (^) as our version prefix, npm would instead be allowed to update to any 2.x.x-version.
-Example
-<code>"some-package-name": "^1.3.8" allows updates to any 1.x.x version.</code>
-Instructions
-Use the caret-character (^) to prefix the version of moment in your dependencies and allow npm to update it to any new MINOR release.
-Note that the version numbers themselves not should be changed.
+Similar to how the tilde we learned about in the last challenge allows npm to install the latest PATCH for a dependency, the caret (<code>^</code>) allows npm to install future updates as well. The difference is that the caret will allow both MINOR updates and PATCHes.
+Your current version of moment should be "~2.10.2" which allows npm to install to the latest 2.10.x version. If you were to use the caret (^) as a version prefix instead, npm would be allowed to update to any 2.x.x version.
+<blockquote>"package": "^1.3.8"</blockquote>
+This would allow updates to any 1.x.x version of the package.
 </section>
 
 ## Instructions
 <section id='instructions'>
-
+Use the caret (<code>^</code>) to prefix the version of moment in your dependencies and allow npm to update it to any new MINOR release.
+<strong>Note:</strong> The version numbers themselves not should be changed.
 </section>
 
 ## Tests

--- a/curriculum/challenges/english/05-apis-and-microservices/managing-packages-with-npm/use-the-tilde-character-to-always-use-the-latest-patch-version-of-a-dependency.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/managing-packages-with-npm/use-the-tilde-character-to-always-use-the-latest-patch-version-of-a-dependency.english.md
@@ -6,18 +6,16 @@ challengeType: 2
 
 ## Description
 <section id='description'>
-In the last challenge, we told npm to only include a specific version of a package. That’s a useful way to freeze your dependencies if you need to make sure that different parts of your project stay compatible with each other. But in most use cases you don’t want to miss bug fixes, since they often include important security patches and (hopefully) don’t break things in doing so.
-To allow a npm dependency to get updated to the latest PATCH-version, you can prefix the dependency’s version with the tilde-character (~). In package.json, our current rule for how npm may upgrade moment is to use a specific version only (2.10.2), but we want to allow the latest 2.10.x-version.
-Example
-<code>"some-package-name": "~1.3.8" allows updates to any 1.3.x version.</code>
-Instructions
-Use the tilde-character (~) to prefix the version of moment in your dependencies and allow npm to update it to any new PATCH release.
-Note that the version numbers themselves should not be changed.
+In the last challenge, you told npm to only include a specific version of a package. That’s a useful way to freeze your dependencies if you need to make sure that different parts of your project stay compatible with each other. But in most use cases, you don’t want to miss bug fixes since they often include important security patches and (hopefully) don’t break things in doing so.
+To allow an npm dependency to update to the latest PATCH version, you can prefix the dependency’s version with the tilde (<code>~</code>) character. Here's an example of how to allow updates to any 1.3.x version.
+<blockquote>"package": "~1.3.8"</blockquote>
 </section>
 
 ## Instructions
 <section id='instructions'>
-
+In the package.json file, your current rule for how npm may upgrade moment is to use a specific version (2.10.2). But now, you want to allow the latest 2.10.x version.
+Use the tilde (<code>~</code>) character to prefix the version of moment in your dependencies, and allow npm to update it to any new PATCH release.
+<strong>Note:</strong> The version numbers themselves should not be changed.
 </section>
 
 ## Tests


### PR DESCRIPTION
I have gone through the "Managing Packages with Npm" section and done the following:
Reformat code to use `blockquote` tags where needed
Move any instructions to the instructions area of the file
Add `<code>` and other tags where needed.
Slightly reword some things/fix up grammar and punctuation to make it more concise and understandable.

I have gone through these pretty thoroughly - I hope it's not too many changes. 

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Refer to https://github.com/freeCodeCamp/freeCodeCamp/issues/35413
