### PR TITLE
fix(challenge): remove child selector from name attribute test

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/create-a-set-of-radio-buttons.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/create-a-set-of-radio-buttons.english.md
@@ -30,7 +30,7 @@ tests:
   - text: Your page should have two radio button elements.
     testString: assert($('input[type="radio"]').length > 1, 'Your page should have two radio button elements.');
   - text: Give your radio buttons the <code>name</code> attribute of <code>indoor-outdoor</code>.
-    testString: assert($('label > input[type="radio"]').filter("[name='indoor-outdoor']").length > 1, 'Give your radio buttons the <code>name</code> attribute of <code>indoor-outdoor</code>.');
+    testString: assert($('input[type="radio"]').filter("[name='indoor-outdoor']").length > 1, 'Give your radio buttons the <code>name</code> attribute of <code>indoor-outdoor</code>.');
   - text: Each of your two radio button elements should be nested in its own <code>label</code> element.
     testString: assert($('label > input[type="radio"]:only-child').length > 1, 'Each of your two radio button elements should be nested in its own <code>label</code> element.');
   - text: Make sure each of your <code>label</code> elements has a closing tag.


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Remove the child selector from the radio input name attribute test. This avoids any confusion caused by triggering the name attribute assertion when not nesting the inputs inside labels.

Example:
```
<label for="indoor">Indoor</label>
<input id="indoor" type="radio" name="indoor-outdoor">
```

Test output:
```
Give your radio buttons the name attribute of indoor-outdoor.
Each of your two radio button elements should be nested in its own label element.
```


After PR test output:
`Each of your two radio button elements should be nested in its own label element.`


Note: With this change, the test will be like the test also is for the checkboxes challenge.
