### PR TITLE
fix(challenge): allow new line in linear-gradient formatting

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/create-a-gradual-css-linear-gradient.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/create-a-gradual-css-linear-gradient.english.md
@@ -26,7 +26,7 @@ Use a <code>linear-gradient()</code> for the <code>div</code> element's <code>ba
 ```yml
 tests:
   - text: The <code>div</code> element should have a <code>linear-gradient</code> <code>background</code> with the specified direction and colors.
-    testString: assert($('style').text().replace(/\s/g, '').match(/background:linear-gradient\(35deg,(#CCFFFF|#CFF),(#FFCCCC|#FCC)\);/gi));
+    testString: assert($('div').css('background-image').match(/linear-gradient\(35deg, rgb\(204, 255, 255\), rgb\(255, 204, 204\)\)/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/create-a-gradual-css-linear-gradient.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/create-a-gradual-css-linear-gradient.english.md
@@ -26,7 +26,7 @@ Use a <code>linear-gradient()</code> for the <code>div</code> element's <code>ba
 ```yml
 tests:
   - text: The <code>div</code> element should have a <code>linear-gradient</code> <code>background</code> with the specified direction and colors.
-    testString: assert(code.match(/background:\s*?linear-gradient\(\s*?35deg,\s*?(#CCFFFF|#CFF),\s*?(#FFCCCC|#FCC)\s*?\);/gi), 'The <code>div</code> element should have a <code>linear-gradient</code> <code>background</code> with the specified direction and colors.');
+    testString: assert($('style').text().replace(/\s/g, '').match(/background:linear-gradient\(35deg,(#CCFFFF|#CFF),(#FFCCCC|#FCC)\);/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/create-a-gradual-css-linear-gradient.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/create-a-gradual-css-linear-gradient.english.md
@@ -26,7 +26,7 @@ Use a <code>linear-gradient()</code> for the <code>div</code> element's <code>ba
 ```yml
 tests:
   - text: The <code>div</code> element should have a <code>linear-gradient</code> <code>background</code> with the specified direction and colors.
-    testString: assert(code.match(/background:\s*?linear-gradient\(35deg,\s*?(#CCFFFF|#CFF),\s*?(#FFCCCC|#FCC)\);/gi), 'The <code>div</code> element should have a <code>linear-gradient</code> <code>background</code> with the specified direction and colors.');
+    testString: assert(code.match(/background:\s*?linear-gradient\(\s*?35deg,\s*?(#CCFFFF|#CFF),\s*?(#FFCCCC|#FCC)\s*?\);/gi), 'The <code>div</code> element should have a <code>linear-gradient</code> <code>background</code> with the specified direction and colors.');
 
 ```
 


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

This PR makes it so the below formatting of the linear-gradient passes the test.


```
background: linear-gradient(
  35deg,
  #ccffff,
  #ffcccc
);
```

It will still not pass with the below formatting though.

```
background: linear-gradient(
  35deg
  ,#ccffff
  ,#ffcccc
);
```


It is obviously possible to change the regex to match for this as well. I just think then the regex gets a little nasty and this formating is not very likely to be seen. However if needed I can change it to accept it as well.
