### PR TITLE
fix:removed bug in front end lib random quote project (#35459)

### DIFF
--- a/curriculum/challenges/english/03-front-end-libraries/front-end-libraries-projects/build-a-random-quote-machine.english.md
+++ b/curriculum/challenges/english/03-front-end-libraries/front-end-libraries-projects/build-a-random-quote-machine.english.md
@@ -14,12 +14,12 @@ You can use any mix of HTML, JavaScript, CSS, Bootstrap, SASS, React, Redux, and
 <strong>User Story #2:</strong> Within <code>#quote-box</code>, I can see an element with a corresponding <code>id="text"</code>.
 <strong>User Story #3:</strong> Within <code>#quote-box</code>, I can see an element with a corresponding <code>id="author"</code>.
 <strong>User Story #4:</strong> Within <code>#quote-box</code>, I can see a clickable element with a corresponding <code>id="new-quote"</code>.
-<strong>User Story #5:</strong> Within <code>#quote-box</code>, I can see a clickable <codea</code> element with a corresponding <code>id="tweet-quote"</code>.
+<strong>User Story #5:</strong> Within <code>#quote-box</code>, I can see a clickable <code>a</code> element with a corresponding <code>id="tweet-quote"</code>.
 <strong>User Story #6:</strong> On first load, my quote machine displays a random quote in the element with <code>id="text"</code>.
 <strong>User Story #7:</strong> On first load, my quote machine displays the random quote's author in the element with <code>id="author"</code>.
 <strong>User Story #8:</strong> When the <code>#new-quote</code> button is clicked, my quote machine should fetch a new quote and display it in the <code>#text</code> element.
 <strong>User Story #9:</strong> My quote machine should fetch the new quote's author when the <code>#new-quote</code> button is clicked and display it in the <code>#author</code> element.
-<strong>User Story #10:</strong> I can tweet the current quote by clicking on the <code>#tweet-quote</code> <code>a</code> element. This <code>a</code> element should include the <code>"twitter.com/intent/tweet"</code> path in its <code>href</code> attribute to tweet the current quote.
+<strong>User Story #10:</strong> I can tweet the current quote by clicking on the <code>#tweet-quote</code><code>a</code> element. This <code>a</code> element should include the <code>"twitter.com/intent/tweet"</code> path in its <code>href</code> attribute to tweet the current quote.
 <strong>User Story #11:</strong> The <code>#quote-box</code> wrapper element should be horizontally centered. Please run tests with browser's zoom level at 100% and page maximized.
 You can build your project by forking <a href='http://codepen.io/freeCodeCamp/pen/MJjpwO' target='_blank'>this CodePen pen</a>. Or you can use this CDN link to run the tests in any environment you like: <code>https://cdn.freecodecamp.org/testable-projects-fcc/v1/bundle.js</code>
 Once you're done, submit the URL to your working project with all its tests passing.


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #35459

- Changed `<codea></code>` int line #17 to `<code>a</code>`
- Removed the extra space between `#tweet-quote` and  `a` in line #22 as @RandellDawson did.

These were responsible for issue #35459 and have been resolved.
