### PR TITLE
Update description of tests pig-latin.english.md where too vague

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/pig-latin.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/pig-latin.english.md
@@ -35,9 +35,9 @@ tests:
     testString: assert.deepEqual(translatePigLatin("algorithm"), "algorithmway", '<code>translatePigLatin("algorithm")</code> should return "algorithmway".');
   - text: <code>translatePigLatin("eight")</code> should return "eightway".
     testString: assert.deepEqual(translatePigLatin("eight"), "eightway", '<code>translatePigLatin("eight")</code> should return "eightway".');
-  - text: Should handle words where the first vowel comes in the end of the word.
+  - text: Should handle words where the first vowel comes in the middle of the word.  <code>translatePigLatin("schwartz")</code> should return "artzschway". 
     testString: assert.deepEqual(translatePigLatin("schwartz"), "artzschway", 'Should handle words where the first vowel comes in the end of the word.');
-  - text: Should handle words without vowels.
+  - text: Should handle words without vowels. <code>translatePigLatin("rhythm")</code> should return "rhythmay".
     testString: assert.deepEqual(translatePigLatin("rhythm"), "rhythmay", 'Should handle words without vowels.');
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/pig-latin.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/pig-latin.english.md
@@ -38,7 +38,7 @@ tests:
   - text: Should handle words where the first vowel comes in the middle of the word.  <code>translatePigLatin("schwartz")</code> should return "artzschway". 
     testString: assert.deepEqual(translatePigLatin("schwartz"), "artzschway", 'Should handle words where the first vowel comes in the end of the word.');
   - text: Should handle words without vowels. <code>translatePigLatin("rhythm")</code> should return "rhythmay".
-    testString: assert.deepEqual(translatePigLatin("rhythm"), "rhythmay", 'Should handle words without vowels.');
+    testString: assert.deepEqual(translatePigLatin("rhythm"), "rhythmay");
 
 ```
 


### PR DESCRIPTION
The last two tests "Should handle words where the first vowel comes in the end of the word." and "Should handle words without vowels." are too vague without examples of what is meant by that.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x ] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x ] My pull request targets the `master` branch of freeCodeCamp.
- [x ] None of my changes are plagiarized from another source without proper attribution.
- [x ] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x ] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX
