### PR TITLE
Make a comparison in the test more accurately

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-arrow-functions-to-write-concise-anonymous-functions.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-arrow-functions-to-write-concise-anonymous-functions.english.md
@@ -33,7 +33,7 @@ tests:
   - text: <code>magic</code> is a <code>function</code>.
     testString: assert(typeof magic === 'function', '<code>magic</code> is a <code>function</code>.');
   - text: <code>magic()</code> returns correct date.
-    testString: assert(magic().getDate() == new Date().getDate(), '<code>magic()</code> returns correct date.');
+    testString: assert(magic().getTime() === new Date().getTime(), '<code>magic()</code> returns correct date.');
   - text: <code>function</code> keyword was not used.
     testString: getUserInput => assert(!getUserInput('index').match(/function/g), '<code>function</code> keyword was not used.');
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-arrow-functions-to-write-concise-anonymous-functions.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-arrow-functions-to-write-concise-anonymous-functions.english.md
@@ -26,15 +26,15 @@ Rewrite the function assigned to the variable <code>magic</code> which returns a
 
 ```yml
 tests:
-  - text: User did replace <code>var</code> keyword.
+  - text: User should replace <code>var</code> keyword.
     testString: getUserInput => assert(!getUserInput('index').match(/var/g));
   - text: <code>magic</code> should be a constant variable (by using <code>const</code>).
     testString: getUserInput => assert(getUserInput('index').match(/const\s+magic/g));
-  - text: <code>magic</code> is a <code>function</code>.
+  - text: <code>magic</code> should be a <code>function</code>.
     testString: assert(typeof magic === 'function');
-  - text: <code>magic()</code> returns correct date.
+  - text: <code>magic()</code> should return correct date.
     testString: assert(magic().setHours(0,0,0,0) === new Date().setHours(0,0,0,0));
-  - text: <code>function</code> keyword was not used.
+  - text: <code>function</code> keyword should not be used.
     testString: getUserInput => assert(!getUserInput('index').match(/function/g));
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-arrow-functions-to-write-concise-anonymous-functions.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-arrow-functions-to-write-concise-anonymous-functions.english.md
@@ -27,15 +27,15 @@ Rewrite the function assigned to the variable <code>magic</code> which returns a
 ```yml
 tests:
   - text: User did replace <code>var</code> keyword.
-    testString: getUserInput => assert(!getUserInput('index').match(/var/g), 'User did replace <code>var</code> keyword.');
+    testString: getUserInput => assert(!getUserInput('index').match(/var/g));
   - text: <code>magic</code> should be a constant variable (by using <code>const</code>).
-    testString: getUserInput => assert(getUserInput('index').match(/const\s+magic/g), '<code>magic</code> should be a constant variable (by using <code>const</code>).');
+    testString: getUserInput => assert(getUserInput('index').match(/const\s+magic/g));
   - text: <code>magic</code> is a <code>function</code>.
-    testString: assert(typeof magic === 'function', '<code>magic</code> is a <code>function</code>.');
+    testString: assert(typeof magic === 'function');
   - text: <code>magic()</code> returns correct date.
-    testString: assert(magic().getTime() === new Date().getTime(), '<code>magic()</code> returns correct date.');
+    testString: assert(magic().setHours(0,0,0,0) === new Date().setHours(0,0,0,0));
   - text: <code>function</code> keyword was not used.
-    testString: getUserInput => assert(!getUserInput('index').match(/function/g), '<code>function</code> keyword was not used.');
+    testString: getUserInput => assert(!getUserInput('index').match(/function/g));
 
 ```
 


### PR DESCRIPTION
Before that, if the month coincided, then the test passed.

An example of an incorrect code, but tests passed:
```
const magic = () => new Date("2022-03-03T21:18:23.040Z")
```

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.


