### PR TITLE
fix(client): disable core prefetching due to scrolling performance in the map

### DIFF
--- a/client/gatsby-browser.js
+++ b/client/gatsby-browser.js
@@ -57,3 +57,5 @@ wrapPageElement.propTypes = {
   location: PropTypes.objectOf({ pathname: PropTypes.string }),
   props: PropTypes.any
 };
+
+export const disableCorePrefetching = () => true;


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.

Closes #35418

It disables only prefetching on link become visible, other prefetching strategies like prefetching on link hover still work.