### PR TITLE
fix: Improve formatting for Pascal's triangle challenge

### DIFF
--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-148-exploring-pascals-triangle.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-148-exploring-pascals-triangle.english.md
@@ -8,83 +8,21 @@ title: 'Problem 148: Exploring Pascal''s triangle'
 <section id='description'>
 We can easily verify that none of the entries in the first seven rows of Pascal's triangle are divisible by 7:
 
-
-
-
-
-
- 1
-
-
-
-
-
- 1
-
- 1
-
-
-
-
- 1
-
- 2
-
- 1
-
-
-
- 1
-
- 3
-
- 3
-
- 1
-
-
- 1
-
- 4
-
- 6
-
- 4
-
- 1
-
- 1
-
- 5
-
-10
-
-10
-
- 5
-
- 1
-1
-
- 6
-
-15
-
-20
-
-15
-
- 6
-
- 1
+<pre>
+            1
+          1   1
+        1   2   1
+      1   3   3   1
+    1   4   6   4   1
+  1   5   10  10  5   1
+1   6   15  20  15  6   1
+</pre>
 However, if we check the first one hundred rows, we will find that only 2361 of the 5050 entries are not divisible by 7.
-
-Find the number of entries which are not divisible by 7 in the first one billion (109) rows of Pascal's triangle.
 </section>
 
 ## Instructions
 <section id='instructions'>
-
+Find the number of entries which are not divisible by 7 in the first one billion (10<sup>9</sup>) rows of Pascal's triangle.
 </section>
 
 ## Tests


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The challenge https://www.freecodecamp.rocks/learn/coding-interview-prep/project-euler/problem-148-exploring-pascals-triangle is poorly formatted.  This PR just makes the instructions a bit easier to read.
