### PR TITLE
fix(challenge): simplify and cleanup tests

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/change-the-color-of-text.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/change-the-color-of-text.english.md
@@ -25,10 +25,12 @@ Change your <code>h2</code> element's style so that its text color is red.
 
 ```yml
 tests:
+  - text: Your <code>h2</code> element should have a <code>style</code> declaration.
+    testString: assert($("h2").attr('style'));
   - text: Your <code>h2</code> element should be red.
-    testString: assert($("h2").css("color") === "rgb(255, 0, 0)", 'Your <code>h2</code> element should be red.');
+    testString: assert($("h2").css("color") === "rgb(255, 0, 0)");
   - text: Your <code>style</code> declaration should end with a <code>;</code> .
-    testString: assert(code.match(/<h2\s+style\s*=\s*(\'|")\s*color\s*:\s*(?:rgb\(\s*255\s*,\s*0\s*,\s*0\s*\)|rgb\(\s*100%\s*,\s*0%\s*,\s*0%\s*\)|red|#ff0000|#f00|hsl\(\s*0\s*,\s*100%\s*,\s*50%\s*\))\s*\;(\'|")>\s*CatPhotoApp\s*<\/h2>/),' Your <code>style</code> declaration should end with a <code>;</code> .');
+    testString: assert($("h2").attr('style') && $("h2").attr('style').endsWith(';'));
 
 ```
 


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

1. Right now the test is using a very long regex to test for a semicolon at the end. It will give the wrong assertion message if any part of it fails. It should only throw an error for a missing semicolon at the end and nothing else. I believe this code for the check should work.

2. I added a test for the style attribute declaration.

To guard against throwing an error when querying a missing style attribute, the missing semicolon test will only run if we find the style attribute. As a consequence, the missing semicolon test will technically throw the assertion message incorrectly if the style attribute is not found. So for clarity sake, I added a test for the style attribute as the first test to pass. It is mainly just for the assertion message.

I also think it makes sense to throw an assertion in the case of a missing style attribute to help guide the user.

3. I remove the assertion messages from testString. It was suggested in another PR to help clean up the tests. If this is not correct or I did it incorrectly please let me know.

Tested locally.