### PR TITLE
Update challenge descriptions with code tags

### DIFF
--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/information-security-with-helmetjs/ask-browsers-to-access-your-site-via-https-only-with-helmet.hsts.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/information-security-with-helmetjs/ask-browsers-to-access-your-site-via-https-only-with-helmet.hsts.english.md
@@ -12,7 +12,7 @@ HTTP Strict Transport Security (HSTS) is a web security policy which helps to pr
 
 ## Instructions
 <section id='instructions'>
-Configure helmet.hsts() to use HTTPS for the next 90 days. Pass the config object {maxAge: timeInMilliseconds, force: true}. Glitch already has hsts enabled. To override its settings you need to set the field "force" to true in the config object. We will intercept and restore the Glitch header, after inspecting it for testing.
+Configure <code>helmet.hsts()</code> to use HTTPS for the next 90 days. Pass the config object <code>{maxAge: timeInMilliseconds, force: true}</code>. Glitch already has hsts enabled. To override its settings you need to set the field "force" to true in the config object. We will intercept and restore the Glitch header, after inspecting it for testing.
 Note: Configuring HTTPS on a custom website requires the acquisition of a domain, and a SSL/TSL Certificate.
 </section>
 

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/information-security-with-helmetjs/configure-helmet-using-the-parent-helmet-middleware.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/information-security-with-helmetjs/configure-helmet-using-the-parent-helmet-middleware.english.md
@@ -23,7 +23,7 @@ app.use(helmet({<br>
 &nbsp;&nbsp;dnsPrefetchControl: false     // disable<br>
 }))
 </blockquote>
-We introduced each middleware separately for teaching purpose, and for ease of testing. Using the ‘parent’ <code>helmet()</code> middleware is easiest, and cleaner, for a real project.
+We introduced each middleware separately for teaching purposes and for ease of testing. Using the ‘parent’ <code>helmet()</code> middleware is easy to implement in a real project.
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/information-security-with-helmetjs/configure-helmet-using-the-parent-helmet-middleware.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/information-security-with-helmetjs/configure-helmet-using-the-parent-helmet-middleware.english.md
@@ -7,7 +7,7 @@ challengeType: 2
 ## Description
 <section id='description'>
 As a reminder, this project is being built upon the following starter project on <a href='https://glitch.com/#!/import/github/freeCodeCamp/boilerplate-infosec/'>Glitch</a>, or cloned from <a href='https://github.com/freeCodeCamp/boilerplate-infosec/'>GitHub</a>.
-app.use(helmet()) will automatically include all the middleware introduced above, except noCache(), and contentSecurityPolicy(), but these can be enabled if necessary. You can also disable or configure any other middleware individually, using a configuration object.
+<code>app.use(helmet())</code> will automatically include all the middleware introduced above, except <code>noCache()</code>, and <code>contentSecurityPolicy()</code>, but these can be enabled if necessary. You can also disable or configure any other middleware individually, using a configuration object.
 <h3>Example:</h3>
 <blockquote>
 app.use(helmet({<br>
@@ -23,7 +23,7 @@ app.use(helmet({<br>
 &nbsp;&nbsp;dnsPrefetchControl: false     // disable<br>
 }))
 </blockquote>
-We introduced each middleware separately for teaching purpose, and for ease of testing. Using the ‘parent’ helmet() middleware is easiest, and cleaner, for a real project.
+We introduced each middleware separately for teaching purpose, and for ease of testing. Using the ‘parent’ <code>helmet()</code> middleware is easiest, and cleaner, for a real project.
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/information-security-with-helmetjs/hide-potentially-dangerous-information-using-helmet.hidepoweredby.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/information-security-with-helmetjs/hide-potentially-dangerous-information-using-helmet.hidepoweredby.english.md
@@ -7,7 +7,7 @@ challengeType: 2
 ## Description
 <section id='description'>
 As a reminder, this project is being built upon the following starter project on <a href='https://glitch.com/#!/import/github/freeCodeCamp/boilerplate-infosec/'>Glitch</a>, or cloned from <a href='https://github.com/freeCodeCamp/boilerplate-infosec/'>GitHub</a>.
-Hackers can exploit known vulnerabilities in Express/Node if they see that your site is powered by Express. X-Powered-By: Express is sent in every request coming from Express by default. The helmet.hidePoweredBy() middleware will remove the X-Powered-By header. You can also explicitly set the header to something else, to throw people off. e.g. app.use(helmet.hidePoweredBy({ setTo: 'PHP 4.2.0' }))
+Hackers can exploit known vulnerabilities in Express/Node if they see that your site is powered by Express. X-Powered-By: Express is sent in every request coming from Express by default. The <code>helmet.hidePoweredBy()</code> middleware will remove the X-Powered-By header. You can also explicitly set the header to something else, to throw people off. e.g. <code>app.use(helmet.hidePoweredBy({ setTo: 'PHP 4.2.0' }))</code>
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/information-security-with-helmetjs/set-a-content-security-policy-with-helmet.contentsecuritypolicy.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/information-security-with-helmetjs/set-a-content-security-policy-with-helmet.contentsecuritypolicy.english.md
@@ -13,7 +13,7 @@ By default, directives are wide open, so it’s important to set the defaultSrc 
 
 ## Instructions
 <section id='instructions'>
-In this exercise, use helmet.contentSecurityPolicy(), and configure it setting the defaultSrc directive to ["self"] (the list of allowed sources must be in an array), in order to trust only your website address by default. Set also the scriptSrc directive so that you will allow scripts to be downloaded from your website, and from the domain 'trusted-cdn.com'.
+In this exercise, use <code>helmet.contentSecurityPolicy()</code>, and configure it setting the <code>defaultSrc directive</code> to <code>["self"]</code> (the list of allowed sources must be in an array), in order to trust only your website address by default. Set also the <code>scriptSrc</code> directive so that you will allow scripts to be downloaded from your website, and from the domain 'trusted-cdn.com'.
 Hint: in the <code>self</code> keyword, the single quotes are part of the keyword itself, so it needs to be enclosed in double quotes to be working.
 </section>
 


### PR DESCRIPTION
Reopening of #34900

Adds missing code tags to multiple challanges in the category "Information Security with HelmetJS"