### PR TITLE
Revert "fix: landing page image css fix"

### DIFF
--- a/client/src/pages/sponsors.css
+++ b/client/src/pages/sponsors.css
@@ -3,6 +3,7 @@
   max-width: 100%;
   height: auto;
   padding: 0;
+  margin: 0;
 }
 
 .sls {


### PR DESCRIPTION
Reverts freeCodeCamp/freeCodeCamp#35551
The fix break the layout of the sponsor's page, a more comprehensive solution is needed.