### PR TITLE
add arr.slice() as valid array clone/copy method

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/return-a-sorted-array-without-changing-the-original-array.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/return-a-sorted-array-without-changing-the-original-array.english.md
@@ -22,7 +22,7 @@ tests:
   - text: Your code should use the <code>sort</code> method.
     testString: assert(code.match(/\.sort/g), 'Your code should use the <code>sort</code> method.');
   - text: Your code should use the <code>concat</code> method.
-    testString: assert(code.match(/\.concat/g), 'Your code should use the <code>concat</code> method.');
+    testString: assert(code.match(/\.concat|\.slice/g), 'Your code should use the <code>concat</code> method.');
   - text: The <code>globalArray</code> variable should not change.
     testString: assert(JSON.stringify(globalArray) === JSON.stringify([5, 6, 3, 2, 9]), 'The <code>globalArray</code> variable should not change.');
   - text: <code>nonMutatingSort(globalArray)</code> should return <code>[2, 3, 5, 6, 9]</code>.


### PR DESCRIPTION
Propose adding .slice to regex test expression, instead of forcing .concat as only solution.

MDN encourages using slice over concat to clone arrays in their documentation.
In my personal opinion slice is more readable as well.
cloneArr = arr.slice(0);
cloneArr = [].concat(arr)

source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX
