### PR TITLE
fix: spelling "vendEr" -> "vendOr"

### DIFF
--- a/curriculum/challenges/arabic/03-front-end-libraries/sass/create-reusable-css-with-mixins.arabic.md
+++ b/curriculum/challenges/arabic/03-front-end-libraries/sass/create-reusable-css-with-mixins.arabic.md
@@ -20,11 +20,11 @@ tests:
   - text: ''
     testString: 'assert(code.match(/@mixin\s+?border-radius\s*?\(\s*?\$radius\s*?\)\s*?{/gi), "Your code should declare a <code>mixin</code> named <code>border-radius</code> which has a parameter named <code>$radius</code>.");'
   - text: ''
-    testString: 'assert(code.match(/-webkit-border-radius:\s*?\$radius;/gi), "Your code should include the <code>-webkit-border-radius</code> vender prefix that uses the <code>$radius</code> parameter.");'
+    testString: 'assert(code.match(/-webkit-border-radius:\s*?\$radius;/gi), "Your code should include the <code>-webkit-border-radius</code> vendor prefix that uses the <code>$radius</code> parameter.");'
   - text: ''
-    testString: 'assert(code.match(/-moz-border-radius:\s*?\$radius;/gi), "Your code should include the <code>-moz-border-radius</code> vender prefix that uses the <code>$radius</code> parameter.");'
+    testString: 'assert(code.match(/-moz-border-radius:\s*?\$radius;/gi), "Your code should include the <code>-moz-border-radius</code> vendor prefix that uses the <code>$radius</code> parameter.");'
   - text: يجب أن تحتوي <code>-ms-border-radius</code> على <code>-ms-border-radius</code> التي تستخدم معلمة <code>$radius</code> .
-    testString: 'assert(code.match(/-ms-border-radius:\s*?\$radius;/gi), "Your code should include the <code>-ms-border-radius</code> vender prefix that uses the <code>$radius</code> parameter.");'
+    testString: 'assert(code.match(/-ms-border-radius:\s*?\$radius;/gi), "Your code should include the <code>-ms-border-radius</code> vendor prefix that uses the <code>$radius</code> parameter.");'
   - text: يجب أن تتضمن شفرتك قاعدة <code>border-radius</code> العامة التي تستخدم معلمة <code>$radius</code> .
     testString: 'assert(code.match(/border-radius:\s*?\$radius;/gi).length == 4, "Your code should include the general <code>border-radius</code> rule that uses the <code>$radius</code> parameter.");'
   - text: ''

--- a/curriculum/challenges/chinese/03-front-end-libraries/sass/create-reusable-css-with-mixins.chinese.md
+++ b/curriculum/challenges/chinese/03-front-end-libraries/sass/create-reusable-css-with-mixins.chinese.md
@@ -19,12 +19,12 @@ localeTitle: 使用Mixins创建可重用的CSS
 tests:
   - text: 你的代码应该声明一个名为<code>border-radius</code>的<code>mixin</code> ，它有一个名为<code>$radius</code>的参数。
     testString: 'assert(code.match(/@mixin\s+?border-radius\s*?\(\s*?\$radius\s*?\)\s*?{/gi), "Your code should declare a <code>mixin</code> named <code>border-radius</code> which has a parameter named <code>$radius</code>.");'
-  - text: 您的代码应包含使用<code>$radius</code>参数的<code>-webkit-border-radius</code> vender前缀。
-    testString: 'assert(code.match(/-webkit-border-radius:\s*?\$radius;/gi), "Your code should include the <code>-webkit-border-radius</code> vender prefix that uses the <code>$radius</code> parameter.");'
-  - text: 您的代码应包含使用<code>$radius</code>参数的<code>-moz-border-radius</code> vender前缀。
-    testString: 'assert(code.match(/-moz-border-radius:\s*?\$radius;/gi), "Your code should include the <code>-moz-border-radius</code> vender prefix that uses the <code>$radius</code> parameter.");'
-  - text: 您的代码应包含使用<code>$radius</code>参数的<code>-ms-border-radius</code> vender前缀。
-    testString: 'assert(code.match(/-ms-border-radius:\s*?\$radius;/gi), "Your code should include the <code>-ms-border-radius</code> vender prefix that uses the <code>$radius</code> parameter.");'
+  - text: 您的代码应包含使用<code>$radius</code>参数的<code>-webkit-border-radius</code> vendor前缀。
+    testString: 'assert(code.match(/-webkit-border-radius:\s*?\$radius;/gi), "Your code should include the <code>-webkit-border-radius</code> vendor prefix that uses the <code>$radius</code> parameter.");'
+  - text: 您的代码应包含使用<code>$radius</code>参数的<code>-moz-border-radius</code> vendor前缀。
+    testString: 'assert(code.match(/-moz-border-radius:\s*?\$radius;/gi), "Your code should include the <code>-moz-border-radius</code> vendor prefix that uses the <code>$radius</code> parameter.");'
+  - text: 您的代码应包含使用<code>$radius</code>参数的<code>-ms-border-radius</code> vendor前缀。
+    testString: 'assert(code.match(/-ms-border-radius:\s*?\$radius;/gi), "Your code should include the <code>-ms-border-radius</code> vendor prefix that uses the <code>$radius</code> parameter.");'
   - text: 您的代码应包含使用<code>$radius</code>参数的一般<code>border-radius</code>规则。
     testString: 'assert(code.match(/border-radius:\s*?\$radius;/gi).length == 4, "Your code should include the general <code>border-radius</code> rule that uses the <code>$radius</code> parameter.");'
   - text: 您的代码应使用<code>@include</code>关键字调用<code>border-radius mixin</code> ，将其设置为15px。

--- a/curriculum/challenges/english/03-front-end-libraries/sass/create-reusable-css-with-mixins.english.md
+++ b/curriculum/challenges/english/03-front-end-libraries/sass/create-reusable-css-with-mixins.english.md
@@ -29,12 +29,12 @@ Write a <code>mixin</code> for <code>border-radius</code> and give it a <code>$r
 tests:
   - text: Your code should declare a <code>mixin</code> named <code>border-radius</code> which has a parameter named <code>$radius</code>.
     testString: assert(code.match(/@mixin\s+?border-radius\s*?\(\s*?\$radius\s*?\)\s*?{/gi), 'Your code should declare a <code>mixin</code> named <code>border-radius</code> which has a parameter named <code>$radius</code>.');
-  - text: Your code should include the <code>-webkit-border-radius</code> vender prefix that uses the <code>$radius</code> parameter.
-    testString: assert(code.match(/-webkit-border-radius:\s*?\$radius;/gi), 'Your code should include the <code>-webkit-border-radius</code> vender prefix that uses the <code>$radius</code> parameter.');
-  - text: Your code should include the <code>-moz-border-radius</code> vender prefix that uses the <code>$radius</code> parameter.
-    testString: assert(code.match(/-moz-border-radius:\s*?\$radius;/gi), 'Your code should include the <code>-moz-border-radius</code> vender prefix that uses the <code>$radius</code> parameter.');
-  - text: Your code should include the <code>-ms-border-radius</code> vender prefix that uses the <code>$radius</code> parameter.
-    testString: assert(code.match(/-ms-border-radius:\s*?\$radius;/gi), 'Your code should include the <code>-ms-border-radius</code> vender prefix that uses the <code>$radius</code> parameter.');
+  - text: Your code should include the <code>-webkit-border-radius</code> vendor prefix that uses the <code>$radius</code> parameter.
+    testString: assert(code.match(/-webkit-border-radius:\s*?\$radius;/gi), 'Your code should include the <code>-webkit-border-radius</code> vendor prefix that uses the <code>$radius</code> parameter.');
+  - text: Your code should include the <code>-moz-border-radius</code> vendor prefix that uses the <code>$radius</code> parameter.
+    testString: assert(code.match(/-moz-border-radius:\s*?\$radius;/gi), 'Your code should include the <code>-moz-border-radius</code> vendor prefix that uses the <code>$radius</code> parameter.');
+  - text: Your code should include the <code>-ms-border-radius</code> vendor prefix that uses the <code>$radius</code> parameter.
+    testString: assert(code.match(/-ms-border-radius:\s*?\$radius;/gi), 'Your code should include the <code>-ms-border-radius</code> vendor prefix that uses the <code>$radius</code> parameter.');
   - text: Your code should include the general <code>border-radius</code> rule that uses the <code>$radius</code> parameter.
     testString: assert(code.match(/border-radius:\s*?\$radius;/gi).length == 4, 'Your code should include the general <code>border-radius</code> rule that uses the <code>$radius</code> parameter.');
   - text: Your code should call the <code>border-radius mixin</code> using the <code>@include</code> keyword, setting it to 15px.

--- a/curriculum/challenges/portuguese/03-front-end-libraries/sass/create-reusable-css-with-mixins.portuguese.md
+++ b/curriculum/challenges/portuguese/03-front-end-libraries/sass/create-reusable-css-with-mixins.portuguese.md
@@ -20,11 +20,11 @@ tests:
   - text: Seu código deve declarar um <code>mixin</code> chamado <code>border-radius</code> que tenha um parâmetro chamado <code>$radius</code> .
     testString: 'assert(code.match(/@mixin\s+?border-radius\s*?\(\s*?\$radius\s*?\)\s*?{/gi), "Your code should declare a <code>mixin</code> named <code>border-radius</code> which has a parameter named <code>$radius</code>.");'
   - text: Seu código deve incluir o <code>-webkit-border-radius</code> que usa o parâmetro <code>$radius</code> .
-    testString: 'assert(code.match(/-webkit-border-radius:\s*?\$radius;/gi), "Your code should include the <code>-webkit-border-radius</code> vender prefix that uses the <code>$radius</code> parameter.");'
+    testString: 'assert(code.match(/-webkit-border-radius:\s*?\$radius;/gi), "Your code should include the <code>-webkit-border-radius</code> vendor prefix that uses the <code>$radius</code> parameter.");'
   - text: Seu código deve incluir o prefixo de vendedor <code>-moz-border-radius</code> que usa o parâmetro <code>$radius</code> .
-    testString: 'assert(code.match(/-moz-border-radius:\s*?\$radius;/gi), "Your code should include the <code>-moz-border-radius</code> vender prefix that uses the <code>$radius</code> parameter.");'
+    testString: 'assert(code.match(/-moz-border-radius:\s*?\$radius;/gi), "Your code should include the <code>-moz-border-radius</code> vendor prefix that uses the <code>$radius</code> parameter.");'
   - text: Seu código deve incluir o prefixo do <code>-ms-border-radius</code> que usa o parâmetro <code>$radius</code> .
-    testString: 'assert(code.match(/-ms-border-radius:\s*?\$radius;/gi), "Your code should include the <code>-ms-border-radius</code> vender prefix that uses the <code>$radius</code> parameter.");'
+    testString: 'assert(code.match(/-ms-border-radius:\s*?\$radius;/gi), "Your code should include the <code>-ms-border-radius</code> vendor prefix that uses the <code>$radius</code> parameter.");'
   - text: 'Seu código deve incluir a regra geral <code>border-radius</code> , que usa o parâmetro <code>$radius</code> .'
     testString: 'assert(code.match(/border-radius:\s*?\$radius;/gi).length == 4, "Your code should include the general <code>border-radius</code> rule that uses the <code>$radius</code> parameter.");'
   - text: 'Seu código deve chamar o <code>@include</code> <code>border-radius mixin</code> usando a palavra-chave <code>@include</code> , configurando-a para 15px.'

--- a/curriculum/challenges/russian/03-front-end-libraries/sass/create-reusable-css-with-mixins.russian.md
+++ b/curriculum/challenges/russian/03-front-end-libraries/sass/create-reusable-css-with-mixins.russian.md
@@ -20,11 +20,11 @@ tests:
   - text: Ваш код должен объявить <code>mixin</code> именем <code>border-radius</code> который имеет параметр с именем <code>$radius</code> .
     testString: 'assert(code.match(/@mixin\s+?border-radius\s*?\(\s*?\$radius\s*?\)\s*?{/gi), "Your code should declare a <code>mixin</code> named <code>border-radius</code> which has a parameter named <code>$radius</code>.");'
   - text: Ваш код должен включать <code>-webkit-border-radius</code> который использует параметр <code>$radius</code> .
-    testString: 'assert(code.match(/-webkit-border-radius:\s*?\$radius;/gi), "Your code should include the <code>-webkit-border-radius</code> vender prefix that uses the <code>$radius</code> parameter.");'
-  - text: 'Ваш код должен включать префикс <code>-moz-border-radius</code> vender, который использует параметр <code>$radius</code> .'
-    testString: 'assert(code.match(/-moz-border-radius:\s*?\$radius;/gi), "Your code should include the <code>-moz-border-radius</code> vender prefix that uses the <code>$radius</code> parameter.");'
-  - text: 'Ваш код должен включать префикс <code>-ms-border-radius</code> vender, который использует параметр <code>$radius</code> .'
-    testString: 'assert(code.match(/-ms-border-radius:\s*?\$radius;/gi), "Your code should include the <code>-ms-border-radius</code> vender prefix that uses the <code>$radius</code> parameter.");'
+    testString: 'assert(code.match(/-webkit-border-radius:\s*?\$radius;/gi), "Your code should include the <code>-webkit-border-radius</code> vendor prefix that uses the <code>$radius</code> parameter.");'
+  - text: 'Ваш код должен включать префикс <code>-moz-border-radius</code> vendor, который использует параметр <code>$radius</code> .'
+    testString: 'assert(code.match(/-moz-border-radius:\s*?\$radius;/gi), "Your code should include the <code>-moz-border-radius</code> vendor prefix that uses the <code>$radius</code> parameter.");'
+  - text: 'Ваш код должен включать префикс <code>-ms-border-radius</code> vendor, который использует параметр <code>$radius</code> .'
+    testString: 'assert(code.match(/-ms-border-radius:\s*?\$radius;/gi), "Your code should include the <code>-ms-border-radius</code> vendor prefix that uses the <code>$radius</code> parameter.");'
   - text: Ваш код должен содержать общее правило <code>border-radius</code> которое использует параметр <code>$radius</code> .
     testString: 'assert(code.match(/border-radius:\s*?\$radius;/gi).length == 4, "Your code should include the general <code>border-radius</code> rule that uses the <code>$radius</code> parameter.");'
   - text: 'Ваш код должен вызвать <code>@include</code> <code>border-radius mixin</code> с помощью <code>@include</code> слова <code>@include</code> , установив его на 15 пикселей.'

--- a/curriculum/challenges/spanish/03-front-end-libraries/sass/create-reusable-css-with-mixins.spanish.md
+++ b/curriculum/challenges/spanish/03-front-end-libraries/sass/create-reusable-css-with-mixins.spanish.md
@@ -20,11 +20,11 @@ tests:
   - text: Su código debe declarar un <code>mixin</code> llamado <code>border-radius</code> que tiene un parámetro llamado <code>$radius</code> .
     testString: 'assert(code.match(/@mixin\s+?border-radius\s*?\(\s*?\$radius\s*?\)\s*?{/gi), "Your code should declare a <code>mixin</code> named <code>border-radius</code> which has a parameter named <code>$radius</code>.");'
   - text: Su código debe incluir el <code>-webkit-border-radius</code> que usa el parámetro <code>$radius</code> .
-    testString: 'assert(code.match(/-webkit-border-radius:\s*?\$radius;/gi), "Your code should include the <code>-webkit-border-radius</code> vender prefix that uses the <code>$radius</code> parameter.");'
+    testString: 'assert(code.match(/-webkit-border-radius:\s*?\$radius;/gi), "Your code should include the <code>-webkit-border-radius</code> vendor prefix that uses the <code>$radius</code> parameter.");'
   - text: Su código debe incluir el prefijo de vendedor <code>-moz-border-radius</code> que usa el parámetro <code>$radius</code> .
-    testString: 'assert(code.match(/-moz-border-radius:\s*?\$radius;/gi), "Your code should include the <code>-moz-border-radius</code> vender prefix that uses the <code>$radius</code> parameter.");'
+    testString: 'assert(code.match(/-moz-border-radius:\s*?\$radius;/gi), "Your code should include the <code>-moz-border-radius</code> vendor prefix that uses the <code>$radius</code> parameter.");'
   - text: Su código debe incluir el <code>-ms-border-radius</code> que usa el parámetro <code>$radius</code> .
-    testString: 'assert(code.match(/-ms-border-radius:\s*?\$radius;/gi), "Your code should include the <code>-ms-border-radius</code> vender prefix that uses the <code>$radius</code> parameter.");'
+    testString: 'assert(code.match(/-ms-border-radius:\s*?\$radius;/gi), "Your code should include the <code>-ms-border-radius</code> vendor prefix that uses the <code>$radius</code> parameter.");'
   - text: Su código debe incluir la regla general <code>border-radius</code> que usa el parámetro <code>$radius</code> .
     testString: 'assert(code.match(/border-radius:\s*?\$radius;/gi).length == 4, "Your code should include the general <code>border-radius</code> rule that uses the <code>$radius</code> parameter.");'
   - text: 'Su código debe llamar a la <code>border-radius mixin</code> usando la palabra clave <code>@include</code> , configurándolo en 15px.'


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Apparently, "vender" is used very rarely.