### PR TITLE
fix(challenge): add support for IIFE arrow function

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/understand-the-immediately-invoked-function-expression-iife.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/understand-the-immediately-invoked-function-expression-iife.english.md
@@ -22,9 +22,9 @@ Rewrite the function <code>makeNest</code> and remove its call so instead it's a
 ```yml
 tests:
   - text: The function should be anonymous.
-    testString: assert(/\(\s*?function\s*?\(\s*?\)\s*?{/.test(code), 'The function should be anonymous.');
+    testString: assert(/\(\s*?(?:function|\(\s*?\))\s*?(?:=>|\(\s*?\)\s*?)\s*?{/.test(code));
   - text: Your function should have parentheses at the end of the expression to call it immediately.
-    testString: assert(/}\s*?\)\s*?\(\s*?\)/.test(code), 'Your function should have parentheses at the end of the expression to call it immediately.');
+    testString: assert(/}\s*?\)\s*?\(\s*?\)/.test(code));
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/understand-the-immediately-invoked-function-expression-iife.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/understand-the-immediately-invoked-function-expression-iife.english.md
@@ -22,9 +22,9 @@ Rewrite the function <code>makeNest</code> and remove its call so instead it's a
 ```yml
 tests:
   - text: The function should be anonymous.
-    testString: assert(/\(\s*?(?:function|\(\s*?\))\s*?(?:=>|\(\s*?\)\s*?)\s*?{/.test(code));
+    testString: assert(/\((function|\(\))(=>|\(\)){/.test(code.replace(/\s/g, "")));
   - text: Your function should have parentheses at the end of the expression to call it immediately.
-    testString: assert(/}\s*?\)\s*?\(\s*?\)/.test(code));
+    testString: assert(/}\)\(\)/.test(code.replace(/\s/g, "")));
 
 ```
 


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

1. Add support for arrow function.

2. Remove secondary assert messages.

Tested locally.

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/18193

There is a PR https://github.com/freeCodeCamp/freeCodeCamp/pull/18223 for this but it looks stale.


If anyone has an opinion on the regex, or see a problem, I'm all for some feedback.

This is the regex from the old PR

`assert(/\(\s*function\s*\(\s*\)\s*{|\(.*\(\s*\)\s*=>\s*{/.test(code))`

This is the regex in this PR

`assert(/\(\s*?(?:function|\(\s*?\))\s*?(?:=>|\(\s*?\)\s*?)\s*?{/.test(code))`


I think the regex from the old PR is more legible. Also, I'm not sure if the non-greedy matching and non-capturing groups are really needed. I'm more than happy to change the regex to whatever is considered best, including any other versions.

BTW, there is no test for the removal of the makeNest() function call and I didn't add one. Not sure if it should be tested for?
