### PR TITLE
fix(docs): Add note about error banner on sign in

### DIFF
--- a/docs/how-to-setup-freecodecamp-locally.md
+++ b/docs/how-to-setup-freecodecamp-locally.md
@@ -453,3 +453,5 @@ npm run seed
 # Restart the application
 npm run develop
 ```
+
+If you can't sign in, and instead, you see a banner with an error message saying that it'll be reported to freeCodeCamp, please double-check that your local port 3000 is not in use by a different program.


### PR DESCRIPTION
I was trying to test some changes to the user portfolio page for accessibility. I wasn't able to log in. Later I realized that I had my 9-to-5 Vagrant instance still running, taking port 3000 for a Rails app, and I had to shut it down.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `master` branch of freeCodeCamp.
- [X] None of my changes are plagiarized from another source without proper attribution.
- [X] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [X] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->
