### PR TITLE
Corrected grammatical mistake

### DIFF
--- a/curriculum/challenges/english/05-apis-and-microservices/managing-packages-with-npm/use-the-caret-character-to-use-the-latest-minor-version-of-a-dependency.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/managing-packages-with-npm/use-the-caret-character-to-use-the-latest-minor-version-of-a-dependency.english.md
@@ -15,7 +15,7 @@ This would allow updates to any 1.x.x version of the package.
 ## Instructions
 <section id='instructions'>
 Use the caret (<code>^</code>) to prefix the version of moment in your dependencies and allow npm to update it to any new MINOR release.
-<strong>Note:</strong> The version numbers themselves not should be changed.
+<strong>Note:</strong> The version numbers themselves should not be changed.
 </section>
 
 ## Tests


### PR DESCRIPTION
From: "The version numbers themselves not should be changed"
To: "The version numbers themselves should not be changed"

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX
