### PR TITLE
fix(challenge): fix broken regex

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/improve-compatibility-with-browser-fallbacks.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/improve-compatibility-with-browser-fallbacks.english.md
@@ -59,8 +59,19 @@ tests:
 <section id='solution'>
 
 
-```js
-var code=".red-box {background: red; background: var(--red-color);}"
+```html
+<style>
+  :root {
+    --red-color: red;
+  }
+  .red-box {
+    background: red;
+    background: var(--red-color);
+    height: 200px;
+    width:200px;
+  }
+</style>
+<div class="red-box"></div>
 ```
 
 </section>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/improve-compatibility-with-browser-fallbacks.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/improve-compatibility-with-browser-fallbacks.english.md
@@ -23,7 +23,7 @@ It looks like a variable is being used to set the background color of the <code>
 ```yml
 tests:
   - text: Your <code>.red-box</code> rule should include a fallback with the <code>background</code> set to red immediately before the existing <code>background</code> declaration.
-    testString: assert(code.match(/.red-box\s*{[^}]*background:\s*(red|#ff0000|#f00|rgb\(\s*255\s*,\s*0\s*,\s*0\s*\)|rgb\(\s*100%\s*,\s*0%\s*,\s*0%\s*\)|hsl\(\s*0\s*,\s*100%\s*,\s*50%\s*\))\s*;\s*background:\s*var\(\s*--red-color\s*\);/gi), 'Your <code>.red-box</code> rule should include a fallback with the <code>background</code> set to red immediately before the existing <code>background</code> declaration.');
+    testString: assert(code.replace(/\s/g, "").match(/\.red-box{background:(red|#ff0000|#f00|rgb\(255,0,0\)|rgb\(100%,0%,0%\)|hsl\(0,100%,50%\));background:var\(--red-color\);height:200px;width:200px;}/gi));
 
 ```
 


### PR DESCRIPTION
Fix for this challenge: https://learn.freecodecamp.org/responsive-web-design/basic-css/improve-compatibility-with-browser-fallbacks/

Right now this very wrong CSS passes the test

```
.___red-box {
  --background: red;
  background: var(--red-color);
```


1. Escape the . in the class name.

2. Fix the match to only allow for the background property. Not sure why the regex was like it was, so if I missed anything about this please let me know.

3. Include a check for the closing brace }

4. Trim the code string of whitespace before running the regex.

5. Remove second assertion text.


Last I have a question about the solution part of the challenge, does it need to be updated? It looks different from the other solutions I have seen.