### PR TITLE
Fix missing "currentNode" variable declaration in data structures linked list challenges (Chinese)

### DIFF
--- a/curriculum/challenges/chinese/08-coding-interview-prep/data-structures/add-elements-at-a-specific-index-in-a-linked-list.chinese.md
+++ b/curriculum/challenges/chinese/08-coding-interview-prep/data-structures/add-elements-at-a-specific-index-in-a-linked-list.chinese.md
@@ -57,7 +57,7 @@ function LinkedList() {
     if(head === null){
         head = node;
     } else {
-        currentNode = head;
+        var currentNode = head;
 
         while(currentNode.next){
             currentNode  = currentNode.next;

--- a/curriculum/challenges/chinese/08-coding-interview-prep/data-structures/remove-elements-from-a-linked-list-by-index.chinese.md
+++ b/curriculum/challenges/chinese/08-coding-interview-prep/data-structures/remove-elements-from-a-linked-list-by-index.chinese.md
@@ -60,7 +60,7 @@ function LinkedList() {
     if(head === null){
         head = node;
     } else {
-        currentNode = head;
+        var currentNode = head;
 
         while(currentNode.next){
             currentNode  = currentNode.next;

--- a/curriculum/challenges/chinese/08-coding-interview-prep/data-structures/remove-elements-from-a-linked-list.chinese.md
+++ b/curriculum/challenges/chinese/08-coding-interview-prep/data-structures/remove-elements-from-a-linked-list.chinese.md
@@ -58,7 +58,7 @@ function LinkedList() {
     if(head === null){
         head = node;
     } else {
-        currentNode = head;
+        var currentNode = head;
 
         while(currentNode.next){
             currentNode  = currentNode.next;

--- a/curriculum/challenges/chinese/08-coding-interview-prep/data-structures/search-within-a-linked-list.chinese.md
+++ b/curriculum/challenges/chinese/08-coding-interview-prep/data-structures/search-within-a-linked-list.chinese.md
@@ -60,7 +60,7 @@ function LinkedList() {
     if(head === null){
         head = node;
     } else {
-        currentNode = head;
+        var currentNode = head;
 
         while(currentNode.next){
             currentNode  = currentNode.next;


### PR DESCRIPTION
## Description

This PR fixes an issue where the `currentNode` variable in the following challenges is not declared before usage like it should be:

- https://learn.freecodecamp.org/coding-interview-prep/data-structures/remove-elements-from-a-linked-list/
- https://learn.freecodecamp.org/coding-interview-prep/data-structures/search-within-a-linked-list/
- https://learn.freecodecamp.org/coding-interview-prep/data-structures/remove-elements-from-a-linked-list-by-index/
- https://learn.freecodecamp.org/coding-interview-prep/data-structures/add-elements-at-a-specific-index-in-a-linked-list/
- https://learn.freecodecamp.org/coding-interview-prep/data-structures/search-within-a-linked-list

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

## Sibling PRs
- Arabic: #35636
- English: #35638
- Portuguese: #35639
- Russian: #35640
- Spanish: #35641