### PR TITLE
Fix missing "currentNode" variable declaration in data structures linked list challenges (English)

### DIFF
--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/add-elements-at-a-specific-index-in-a-linked-list.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/add-elements-at-a-specific-index-in-a-linked-list.english.md
@@ -64,7 +64,7 @@ function LinkedList() {
     if(head === null){
         head = node;
     } else {
-        currentNode = head;
+        var currentNode = head;
 
         while(currentNode.next){
             currentNode  = currentNode.next;

--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/remove-elements-from-a-linked-list-by-index.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/remove-elements-from-a-linked-list-by-index.english.md
@@ -67,7 +67,7 @@ function LinkedList() {
     if(head === null){
         head = node;
     } else {
-        currentNode = head;
+        var currentNode = head;
 
         while(currentNode.next){
             currentNode  = currentNode.next;

--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/remove-elements-from-a-linked-list.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/remove-elements-from-a-linked-list.english.md
@@ -65,7 +65,7 @@ function LinkedList() {
     if(head === null){
         head = node;
     } else {
-        currentNode = head;
+        var currentNode = head;
 
         while(currentNode.next){
             currentNode  = currentNode.next;

--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/remove-elements-from-a-linked-list.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/remove-elements-from-a-linked-list.english.md
@@ -46,7 +46,7 @@ tests:
 function LinkedList() {
   var length = 0;
   var head = null;
-  var currentNode = null;
+
   var Node = function(element){
     this.element = element;
     this.next = null;

--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/search-within-a-linked-list.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/search-within-a-linked-list.english.md
@@ -64,7 +64,7 @@ function LinkedList() {
     if(head === null){
         head = node;
     } else {
-        currentNode = head;
+        var currentNode = head;
 
         while(currentNode.next){
             currentNode  = currentNode.next;


### PR DESCRIPTION
## Description

This PR fixes an issue where the `currentNode` variable in the following challenges is not declared before usage like it should be:

- https://learn.freecodecamp.org/coding-interview-prep/data-structures/remove-elements-from-a-linked-list/
- https://learn.freecodecamp.org/coding-interview-prep/data-structures/search-within-a-linked-list/
- https://learn.freecodecamp.org/coding-interview-prep/data-structures/remove-elements-from-a-linked-list-by-index/
- https://learn.freecodecamp.org/coding-interview-prep/data-structures/add-elements-at-a-specific-index-in-a-linked-list/
- https://learn.freecodecamp.org/coding-interview-prep/data-structures/search-within-a-linked-list

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

## Sibling PRs
- Arabic: #35636
- Chinese: #35637
- Portuguese: #35639
- Russian: #35640
- Spanish: #35641