### PR TITLE
log set as Array.from(set)

### DIFF
--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/create-and-add-to-sets-in-es6.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/create-and-add-to-sets-in-es6.english.md
@@ -47,7 +47,7 @@ function checkSet() {
   // change code below this line
 
   // change code above this line
-  console.log(set);
+  console.log(Array.from(set));
   return set;
 }
 


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X ] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [X ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X ] My pull request targets the `master` branch of freeCodeCamp.
- [X ] None of my changes are plagiarized from another source without proper attribution.
- [X ] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [ X] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Currently the `console.log(set)` call always logs an empty object due to JSON stringification.  This fix was suggested on Gitter, to convert the set to an array before logging it.
