### PR TITLE
fix(curriculum): Made third test more flexible for the Use Destructuring Assignment with the Rest Operator to Reassign Array Elements challenge

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-with-the-rest-operator-to-reassign-array-elements.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-with-the-rest-operator-to-reassign-array-elements.english.md
@@ -24,11 +24,11 @@ Use destructuring assignment with the rest operator to perform an effective <cod
 ```yml
 tests:
   - text: <code>arr</code> should be <code>[3,4,5,6,7,8,9,10]</code>
-    testString: assert(arr.every((v, i) => v === i + 3) && arr.length === 8,'<code>arr</code> should be <code>[3,4,5,6,7,8,9,10]</code>');
+    testString: assert(arr.every((v, i) => v === i + 3) && arr.length === 8);
   - text: <code>Array.slice()</code> should not be used.
-    testString: getUserInput => assert(!getUserInput('index').match(/slice/g), '<code>Array.slice()</code> should not be used.');
+    testString: getUserInput => assert(!getUserInput('index').match(/slice/g));
   - text: Destructuring on <code>list</code> should be used.
-    testString: getUserInput => assert(getUserInput('index').match(/\s*\[\s*,\s*,\s*\.\.\.\s*arr\s*\]\s*=\s*list\s*/g), 'Destructuring on <code>list</code> should be used.');
+    testString: assert(code.replace(/\s/g, '').match(/\[(([_$a-z]\w*)?,){1,}\.\.\.arr\]=list/i));
 
 ```
 


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

While reviewing PR #35681, I discovered that a solution being added to the Guide (see below) should technically meet the requirements of the challenge.  However, the third test was only allowing a very specific solution. 
```js
const source = [1,2,3,4,5,6,7,8,9,10];
function removeFirstTwo(list) {
  "use strict";
  // change code below this line
  const [a, b, ...arr] = list; 
  // change code above this line
  return arr;
}
const arr = removeFirstTwo(source);
console.log(arr); // should be [3,4,5,6,7,8,9,10]
console.log(source); // should be [1,2,3,4,5,6,7,8,9,10];
```
This PR proposes changing the third test to the following:
```
  - text: Destructuring on <code>list</code> should be used.
    testString: assert(code.replace(/\s/g, '').match(/\[(([a-z]\w*)?,){1,}\.\.\.arr\]=list/gi));
```
This will allow the following to still pass the last test, because they are all destructuring (though some would not pass the first test which is OK).

```
const [m, d, ...arr]=list; // will pass all tests
```
```
const [, , ...arr]=list; // will past all tests
```
```
const [, ...arr]=list; // will not pass 1st test, but will correctly pass last test
```
```
const [a, b, c, ...arr]=list; // will not pass 1st test, but will correctly pass last test
```
```
const [, , , ...arr]=list; // will not pass 1st test, but will correctly pass last test
```