### PR TITLE
fix(guide): change path to correct one

### DIFF
--- a/guide/english/certifications/apis-and-microservices/basic-node-and-express/serve-static-assets/index.md
+++ b/guide/english/certifications/apis-and-microservices/basic-node-and-express/serve-static-assets/index.md
@@ -12,7 +12,7 @@ To serve a static webpage from the "views" folder you can use code such as:
 ```javascript
  const express = require("express");
  const app = express();
- app.use(express.static(__dirname + "/views"));
+ app.use(express.static(__dirname + "/public"));
 ```
 
 


### PR DESCRIPTION
Task: Basic Node and Express - Serve Static Assets
Fix: wrong argument of <express.static> function: /public" instead of /views"

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX
