### PR TITLE
curriculum: Fix tests in Positive and Negative lookahead challenge for Regular Expressions

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/positive-and-negative-lookahead.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/positive-and-negative-lookahead.english.md
@@ -34,6 +34,8 @@ tests:
     testString: assert(!pwRegex.test("ast12"));
   - text: Your regex should not match the string <code>banan1</code>
     testString: assert(!pwRegex.test("banan1"));
+  - text: Your regex should not match the string if it starts with a number
+    testString: assert(!pwRegex.test("0ban12")||!pwRegex.test("1ban12")||!pwRegex.test("2ban12")||!pwRegex.test("3ban12")||!pwRegex.test("4ban12")||!pwRegex.test("5ban12")||!pwRegex.test("6ban12")||!pwRegex.test("7ban12")||!pwRegex.test("8ban12")||!pwRegex.test("9ban12")||);
   - text: Your regex should match the string <code>bana12</code>
     testString: assert(pwRegex.test("bana12"));
   - text: Your regex should match the string <code>abc123</code>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/positive-and-negative-lookahead.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/positive-and-negative-lookahead.english.md
@@ -26,22 +26,22 @@ Use <code>lookaheads</code> in the <code>pwRegex</code> to match passwords that 
 
 ```yml
 tests:
-  - text: Your regex should use two positive <code>lookaheads</code>.
-    testString: assert(pwRegex.source.match(/\(\?=.*?\)\(\?=.*?\)/) !== null, 'Your regex should use two positive <code>lookaheads</code>.');
-  - text: Your regex should not match <code>"astronaut"</code>
-    testString: assert(!pwRegex.test("astronaut"), 'Your regex should not match <code>"astronaut"</code>');
-  - text: Your regex should not match <code>"airplanes"</code>
-    testString: assert(!pwRegex.test("airplanes"), 'Your regex should not match <code>"airplanes"</code>');
-  - text: Your regex should not match <code>"banan1"</code>
-    testString: assert(!pwRegex.test("banan1"), 'Your regex should not match <code>"banan1"</code>');
-  - text: Your regex should match <code>"bana12"</code>
-    testString: assert(pwRegex.test("bana12"), 'Your regex should match <code>"bana12"</code>');
-  - text: Your regex should match <code>"abc123"</code>
-    testString: assert(pwRegex.test("abc123"), 'Your regex should match <code>"abc123"</code>');
-  - text: Your regex should not match <code>"123"</code>
-    testString: assert(!pwRegex.test("123"), 'Your regex should not match <code>"123"</code>');
-  - text: Your regex should not match <code>"1234"</code>
-    testString: assert(!pwRegex.test("1234"), 'Your regex should not match <code>"1234"</code>');
+  - text: Your regex should use two positive <code>lookaheads</code>
+    testString: assert(pwRegex.source.match(/\(\?=.*?\)\(\?=.*?\)/) !== null);
+  - text: Your regex should not match the string <code>astronaut</code>
+    testString: assert(!pwRegex.test("astronaut"));
+  - text: Your regex should not match the string <code>ast12</code>
+    testString: assert(!pwRegex.test("ast12"));
+  - text: Your regex should not match the string <code>banan1</code>
+    testString: assert(!pwRegex.test("banan1"));
+  - text: Your regex should match the string <code>bana12</code>
+    testString: assert(pwRegex.test("bana12"));
+  - text: Your regex should match the string <code>abc123</code>
+    testString: assert(pwRegex.test("abc123"));
+  - text: Your regex should not match the string <code>123</code>
+    testString: assert(!pwRegex.test("123"));
+  - text: Your regex should not match the string <code>1234</code>
+    testString: assert(!pwRegex.test("1234"));
 
 ```
 


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Refer to the discussion on PR #34582 

The following incorrect case was passing, this PR fixes that
![image](https://user-images.githubusercontent.com/34807532/55144367-b2376680-5166-11e9-946d-d37f76f5c794.png)