### PR TITLE
fix(curriculum): Remove function syntax to simplify the Word Blanks challenge

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/word-blanks.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/word-blanks.english.md
@@ -10,13 +10,13 @@ videoUrl: 'https://scrimba.com/c/cP3vVsm'
 We will now use our knowledge of strings to build a "<a href='https://en.wikipedia.org/wiki/Mad_Libs' target='_blank'>Mad Libs</a>" style word game we're calling "Word Blanks". You will create an (optionally humorous) "Fill in the Blanks" style sentence.
 In a "Mad Libs" game, you are provided sentences with some missing words, like nouns, verbs, adjectives and adverbs. You then fill in the missing pieces with words of your choice in a way that the completed sentence makes sense.
 Consider this sentence - "It was really <strong>____</strong>, and we <strong>____</strong> ourselves <strong>____</strong>". This sentence has three missing pieces- an adjective, a verb and an adverb, and we can add words of our choice to complete it. We can then assign the completed sentence to a variable as follows:
-<blockquote>var sentence = "It was really" + "hot" + ", and we" + "laughed" + "ourselves" + "silly.";</blockquote>
+<blockquote>var sentence = "It was really " + "hot" + ", and we " + "laughed" + " ourselves " + "silly" + ".";</blockquote>
 </section>
 
 ## Instructions
 <section id='instructions'>
 In this challenge, we provide you with a noun, a verb, an adjective and an adverb. You need to form a complete sentence using words of your choice, along with the words we provide.
-You will need to use the string concatenation operator <code>+</code> to build a new string, using the provided variables: <code>myNoun</code>, <code>myAdjective</code>, <code>myVerb</code>, and <code>myAdverb</code>. You will then assign the formed string to the <code>result</code> variable.
+You will need to use the string concatenation operator <code>+</code> to build a new string, using the provided variables: <code>myNoun</code>, <code>myAdjective</code>, <code>myVerb</code>, and <code>myAdverb</code>. You will then assign the formed string to the <code>wordBlanks</code> variable.  You should not change the words assigned to the variables.
 You will also need to account for spaces in your string, so that the final sentence has spaces between all the words. The result should be a complete sentence.
 </section>
 
@@ -25,12 +25,14 @@ You will also need to account for spaces in your string, so that the final sente
 
 ```yml
 tests:
-  - text: <code>wordBlanks("","","","")</code> should return a string.
-    testString: assert(typeof wordBlanks("","","","") === 'string', '<code>wordBlanks("","","","")</code> should return a string.');
-  - text: <code>wordBlanks("dog", "big", "ran", "quickly")</code> should contain all of the passed in words separated by non-word characters (and any additional words in your madlib).
-    testString: assert(/\bdog\b/.test(test1) && /\bbig\b/.test(test1) && /\bran\b/.test(test1) && /\bquickly\b/.test(test1),'<code>wordBlanks("dog", "big", "ran", "quickly")</code> should contain all of the passed in words separated by non-word characters (and any additional words in your madlib).');
-  - text: <code>wordBlanks("cat", "little", "hit", "slowly")</code> should contain all of the passed in words separated by non-word characters (and any additional words in your madlib).
-    testString: assert(/\bcat\b/.test(test2) && /\blittle\b/.test(test2) && /\bhit\b/.test(test2) && /\bslowly\b/.test(test2),'<code>wordBlanks("cat", "little", "hit", "slowly")</code> should contain all of the passed in words separated by non-word characters (and any additional words in your madlib).');
+  - text: <code>wordBlanks</code> should be a string.
+    testString: assert(typeof wordBlanks === 'string');
+  - text: You should not change the values assigned to <code>myNoun</code>, <code>myVerb</code>, <code>myAdjective</code> or <code>myAdverb</code>.
+    testString: assert(myNoun === "dog" && myVerb === "ran" && myAdjective === "big" && myAdverb === "quickly");    
+  - text: You should not directly use the values "dog", "ran", "big", or "quickly" to create <code>wordBlanks</code>.    
+    testString: const newCode = removeAssignments(code); assert(!/dog/.test(newCode) && !/ran/.test(newCode) && !/big/.test(newCode) && !/quickly/.test(newCode));    
+  - text: <code>wordBlanks</code> should contain all of the words assigned to the variables <code>myNoun</code>, <code>myVerb</code>, <code>myAdjective</code> and <code>myAdverb</code> separated by non-word characters (and any additional words in your madlib).
+    testString: assert(/\bdog\b/.test(wordBlanks) && /\bbig\b/.test(wordBlanks) && /\bran\b/.test(wordBlanks) && /\bquickly\b/.test(wordBlanks));
 
 ```
 
@@ -42,27 +44,25 @@ tests:
 <div id='js-seed'>
 
 ```js
-function wordBlanks(myNoun, myAdjective, myVerb, myAdverb) {
-  // Your code below this line
-  var result = "";
+var myNoun = "dog";
+var myAdjective = "big";
+var myVerb = "ran";
+var myAdverb = "quickly";
 
-  // Your code above this line
-  return result;
-}
+var wordBlanks = ""; // Only change this line;
 
-// Change the words here to test your function
-wordBlanks("dog", "big", "ran", "quickly");
 ```
 
 </div>
 
-
-### After Test
 <div id='js-teardown'>
 
 ```js
-var test1 = wordBlanks("dog", "big", "ran", "quickly");
-var test2 = wordBlanks("cat", "little", "hit", "slowly");
+const removeAssignments = str => str
+  .replace(/myNoun\s*=\s*["']dog["']/g, '')
+  .replace(/myAdjective\s*=\s*["']big["']/g, '')
+  .replace(/myVerb\s*=\s*["']ran["']/g, '')
+  .replace(/myAdverb\s*=\s*["']quickly["']/g, '');
 ```
 
 </div>
@@ -74,14 +74,13 @@ var test2 = wordBlanks("cat", "little", "hit", "slowly");
 
 
 ```js
-function wordBlanks(myNoun, myAdjective, myVerb, myAdverb) {
-  var result = "";
+var myNoun = "dog";
+var myAdjective = "big";
+var myVerb = "ran";
+var myAdverb = "quickly";
 
-  result = "Once there was a " + myNoun + " which was very " + myAdjective + ". ";
-  result += "It " + myVerb + " " + myAdverb + " around the yard.";
-
-  return result;
-}
+var wordBlanks = "Once there was a " + myNoun + " which was very " + myAdjective + ". ";
+wordBlanks += "It " + myVerb + " " + myAdverb + " around the yard.";
 ```
 
 </section>


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Based on many complaints/confusion seen on the forum regarding the Word Blanks use of a function even though functions have not been introduced at that point in the forum, I decided to see if I could rewrite the challenge not using a function.  The purpose of the challenge is to teach the camper it is possible to create strings by concatenating variables with other strings.

@beaucarnes Would like your opinion on this rewrite, since a new video would need to be created. 
