### PR TITLE
Modify test to allow grid-column: 2 / -1 as valid answer

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/css-grid/use-grid-column-to-control-spacing.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-grid/use-grid-column-to-control-spacing.english.md
@@ -34,7 +34,7 @@ Make the item with the class <code>item5</code> consume the last two columns of 
 ```yml
 tests:
   - text: <code>item5</code> class should have a <code>grid-column</code> property that has the value of <code>2 / 4</code> or <code>2 / -1</code>.
-    testString: assert(code.match(/.item5\s*?{[\s\S]*grid-column\s*?:\s*?2\s*?\/\s*?(4|-1)\s*?;[\s\S]*}/gi), '<code>item5</code> class should have a <code>grid-column</code> property that has the value of <code>2 / 4</code>.');
+    testString: assert(code.match(/.item5\s*?{[\s\S]*grid-column\s*?:\s*?2\s*?\/\s*?(4|-1)\s*?;[\s\S]*}/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-grid/use-grid-column-to-control-spacing.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-grid/use-grid-column-to-control-spacing.english.md
@@ -15,6 +15,12 @@ To control the amount of columns an item will consume, you can use the <code>gri
 Here's an example:
 <blockquote>grid-column: 1 / 3;</blockquote>
 This will make the item start at the first vertical line of the grid on the left and span to the 3rd line of the grid, consuming two columns.
+
+Additionally, using a ending value of <code>-1</code> will cause the item to span to the end of the grid, regardless of the number of columns.
+Here's an example:
+<blockquote>grid-column: 1 / -1;</blockquote>
+
+This will make the item start at the first vertical line of the grid on the left and span to the end of the grid, consuming all columns.
 </section>
 
 ## Instructions
@@ -27,8 +33,8 @@ Make the item with the class <code>item5</code> consume the last two columns of 
 
 ```yml
 tests:
-  - text: <code>item5</code> class should have a <code>grid-column</code> property that has the value of <code>2 / 4</code>.
-    testString: assert(code.match(/.item5\s*?{[\s\S]*grid-column\s*?:\s*?2\s*?\/\s*?4\s*?;[\s\S]*}/gi), '<code>item5</code> class should have a <code>grid-column</code> property that has the value of <code>2 / 4</code>.');
+  - text: <code>item5</code> class should have a <code>grid-column</code> property that has the value of <code>2 / 4</code> or <code>2 / -1</code>.
+    testString: assert(code.match(/.item5\s*?{[\s\S]*grid-column\s*?:\s*?2\s*?\/\s*?(4|-1)\s*?;[\s\S]*}/gi), '<code>item5</code> class should have a <code>grid-column</code> property that has the value of <code>2 / 4</code>.');
 
 ```
 


### PR DESCRIPTION
This lesson currently only allows `grid-column: 2 / 4;`, when `grid-column: 2 / -1;` would also do the trick. I think the lesson could introduce the concept here and I've modified both the lesson and test accordingly.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX
