### PR TITLE
fixed spelling of 'knowledge' in the guides (agile backlog-item-effort article)

### DIFF
--- a/guide/english/agile/backlog-item-effort/index.md
+++ b/guide/english/agile/backlog-item-effort/index.md
@@ -2,7 +2,7 @@
 title: Backlog Item Effort
 ---
 ## Backlog Item Effort
-Backlog item effort is a rough estimate of the effort required to complete the item in the product backlog.  It is not an estimate of duration.  This effort can be expressed in ideal engineering days or vague alternative units like story points or function points.<sup>[1]</sup>  Estimating the effort should be done by the team.  Each team member can contribute to the estimate based on their perspective and knowlege of the backlog item which may have an effect on the effort involved.<sup>[2]</sup>
+Backlog item effort is a rough estimate of the effort required to complete the item in the product backlog.  It is not an estimate of duration.  This effort can be expressed in ideal engineering days or vague alternative units like story points or function points.<sup>[1]</sup>  Estimating the effort should be done by the team.  Each team member can contribute to the estimate based on their perspective and knowledge of the backlog item which may have an effect on the effort involved.<sup>[2]</sup>
 
 #### More Information:
 [1]: https://www.solutionsiq.com/agile-glossary/backlog-item-effort/


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This is just a spelling error fix from 'knowlege' to 'knowledge' in the article on Backlog Item Effort in the Agile Dev directory.