### PR TITLE
fix(curriculum): Added test and corrected solution for Restrict Possible Usernames challenge

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/restrict-possible-usernames.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/restrict-possible-usernames.english.md
@@ -71,7 +71,7 @@ let result = userCheck.test(username);
 
 ```js
 let username = "JackOfAllTrades";
-const userCheck = /^[a-z]([a-z]|[0-9]{2,}|[a-z]+\d*)$/i;
+const userCheck = /^[a-z]([0-9]{2,}|[a-z]+\d*)$/i;
 let result = userCheck.test(username);
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/restrict-possible-usernames.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/restrict-possible-usernames.english.md
@@ -8,9 +8,10 @@ challengeType: 1
 <section id='description'>
 Usernames are used everywhere on the internet. They are what give users a unique identity on their favorite sites.
 You need to check all the usernames in a database. Here are some simple rules that users have to follow when creating their username.
-1) The only numbers in the username have to be at the end. There can be zero or more of them at the end.
-2) Username letters can be lowercase and uppercase.
-3) Usernames have to be at least two characters long. A two-letter username can only use alphabet letter characters.
+1) Usernames can only use alpha-numeric characters.
+2) The only numbers in the username have to be at the end. There can be zero or more of them at the end.
+3) Username letters can be lowercase and uppercase.
+4) Usernames have to be at least two characters long. A two-character username can only use alphabet letters as characters.
 </section>
 
 ## Instructions
@@ -24,23 +25,25 @@ Change the regex <code>userCheck</code> to fit the constraints listed above.
 ```yml
 tests:
   - text: Your regex should match <code>JACK</code>
-    testString: assert(userCheck.test("JACK"), 'Your regex should match <code>JACK</code>');
+    testString: assert(userCheck.test("JACK"));
   - text: Your regex should not match <code>J</code>
-    testString: assert(!userCheck.test("J"), 'Your regex should not match <code>J</code>');
+    testString: assert(!userCheck.test("J"));
   - text: Your regex should match <code>Jo</code>
-    testString: assert(userCheck.test("Jo"), 'Your regex should match <code>Jo</code>');
+    testString: assert(userCheck.test("Jo"));
   - text: Your regex should match <code>Oceans11</code>
-    testString: assert(userCheck.test("Oceans11"), 'Your regex should match <code>Oceans11</code>');
+    testString: assert(userCheck.test("Oceans11"));
   - text: Your regex should match <code>RegexGuru</code>
-    testString: assert(userCheck.test("RegexGuru"), 'Your regex should match <code>RegexGuru</code>');
+    testString: assert(userCheck.test("RegexGuru"));
   - text: Your regex should not match <code>007</code>
-    testString: assert(!userCheck.test("007"), 'Your regex should not match <code>007</code>');
+    testString: assert(!userCheck.test("007"));
   - text: Your regex should not match <code>9</code>
-    testString: assert(!userCheck.test("9"), 'Your regex should not match <code>9</code>');
+    testString: assert(!userCheck.test("9"));
   - text: Your regex should not match <code>A1</code>
-    testString: assert(!userCheck.test("A1"), 'Your regex should not match <code>A1</code>');
+    testString: assert(!userCheck.test("A1"));
   - text: Your regex should not match <code>BadUs3rnam3</code>
-    testString: assert(!userCheck.test("BadUs3rnam3"), 'Your regex should not match <code>BadUs3rnam3</code>');
+    testString: assert(!userCheck.test("BadUs3rnam3"));
+  - text: Your regex should match <code>Z97</code>
+    testString: assert(userCheck.test("Z97"));    
 
 ```
 
@@ -67,7 +70,9 @@ let result = userCheck.test(username);
 <section id='solution'>
 
 ```js
-const userCheck = /^[A-Za-z]{2,}\d*$/;
+let username = "JackOfAllTrades";
+const userCheck = /^[a-z]([a-z]|[0-9]{2,}|[a-z]+\d*)$/i;
+let result = userCheck.test(username);
 ```
 
 </section>


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.
 
Closes #35842

In this PR the following changes were made:
* Added a new restriction to the challenge that valid characters are alphanumeric instead of **any** character.
* Changed verbiage in one of the last restriction from "two-letter" to "two-character".
* Added a new test to test for the situation where the first character is a letter and the last two characters are numbers which should pass with the correct solution with the instructions.
* Change the solution to one which satisfies all the existing tests plus the new one added above.
