### PR TITLE
fix: Change test output formatting from code to html

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -61,6 +61,7 @@
     "redux-saga": "^0.16.0",
     "reselect": "^3.0.1",
     "rxjs": "^6.4.0",
+    "sanitize-html": "^1.20.0",
     "sass.js": "^0.10.13",
     "store": "^2.0.12",
     "validator": "^10.11.0",

--- a/client/src/templates/Challenges/components/Output.js
+++ b/client/src/templates/Challenges/components/Output.js
@@ -1,60 +1,25 @@
-import React, { Fragment, Component } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import MonacoEditor from 'react-monaco-editor';
-import { decodeHTML } from 'entities';
+import sanitizeHtml from 'sanitize-html';
+
+import './output.css';
 
 const propTypes = {
   defaultOutput: PropTypes.string,
-  dimensions: PropTypes.object,
-  height: PropTypes.number,
   output: PropTypes.string
 };
 
-const options = {
-  lineNumbers: false,
-  minimap: {
-    enabled: false
-  },
-  readOnly: true,
-  wordWrap: 'on',
-  scrollBeyondLastLine: false,
-  scrollbar: {
-    horizontal: 'hidden',
-    vertical: 'visible',
-    verticalHasArrows: true
-  }
-};
-
 class Output extends Component {
-  constructor() {
-    super();
-
-    this._editor = null;
-  }
-
-  editorDidMount(editor) {
-    this._editor = editor;
-  }
-
-  componentDidUpdate(prevProps) {
-    if (this.props.dimensions !== prevProps.dimensions && this._editor) {
-      this._editor.layout();
-    }
-  }
-
   render() {
-    const { output, defaultOutput, height } = this.props;
+    const { output, defaultOutput } = this.props;
+    const message = sanitizeHtml(output ? output : defaultOutput, {
+      allowedTags: ['b', 'i', 'em', 'strong', 'code', 'wbr']
+    });
     return (
-      <Fragment>
-        <base href='/' />
-        <MonacoEditor
-          className='challenge-output'
-          editorDidMount={::this.editorDidMount}
-          height={height}
-          options={options}
-          value={decodeHTML(output ? output : defaultOutput)}
-        />
-      </Fragment>
+      <pre
+        className='output-text'
+        dangerouslySetInnerHTML={{ __html: message }}
+      />
     );
   }
 }

--- a/client/src/templates/Challenges/components/output.css
+++ b/client/src/templates/Challenges/components/output.css
@@ -1,0 +1,12 @@
+.output-text {
+  white-space: pre-line;
+  word-break: normal;
+  padding-top: 0;
+  height: 100%;
+  width: 100%;
+  overflow-y: auto;
+}
+
+pre.output-text code {
+  color: #c7254e;
+}

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -93,9 +93,7 @@ function* executeTests(testRunner) {
         throw err;
       }
     } catch (err) {
-      newTest.message = text
-        .replace(/<code>(.*?)<\/code>/g, '$1')
-        .replace(/<wbr>/g, '');
+      newTest.message = text;
       if (err === 'timeout') {
         newTest.err = 'Test timed out';
         newTest.message = `${newTest.message} (${newTest.err})`;


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This replaces the `Output` Monaco editor with a `pre` element and adds a little css.  The idea being to highlight the output the same way as the `TestSuite` in the `SidePanel`, rather than treating it as JavaScript. 

I thought it would be best to sanitize the output, because arbitrary output is possible via console logs.  Finally, I removed `<base href='/' />` because it did not seem to be doing anything!

Closes #35800 , closes #17925 and closes #35811 