### PR TITLE
fix: Stop pairs of tags from getting put into paragraphs

### DIFF
--- a/tools/challenge-md-parser/fixtures/adjacent-tags-ast.json
+++ b/tools/challenge-md-parser/fixtures/adjacent-tags-ast.json
@@ -1,0 +1,284 @@
+{
+  "type": "root",
+  "children": [{
+    "type": "element",
+    "tagName": "h2",
+    "properties": {},
+    "children": [{
+      "type": "text",
+      "value": "Description",
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 4,
+          "offset": 3
+        },
+        "end": {
+          "line": 1,
+          "column": 15,
+          "offset": 14
+        }
+      }
+    }],
+    "position": {
+      "start": {
+        "line": 1,
+        "column": 1,
+        "offset": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 15,
+        "offset": 14
+      }
+    }
+  }, {
+    "type": "text",
+    "value": "\n"
+  }, {
+    "type": "element",
+    "tagName": "section",
+    "properties": {
+      "id": "description"
+    },
+    "children": [{
+      "type": "text",
+      "value": "\n",
+      "position": {
+        "start": {
+          "line": 3,
+          "column": 27,
+          "offset": 42
+        },
+        "end": {
+          "line": 4,
+          "column": 1,
+          "offset": 43
+        }
+      }
+    }, {
+      "type": "element",
+      "tagName": "code",
+      "properties": {},
+      "children": [{
+        "type": "text",
+        "value": "code",
+        "position": {
+          "start": {
+            "line": 4,
+            "column": 7,
+            "offset": 49
+          },
+          "end": {
+            "line": 4,
+            "column": 11,
+            "offset": 53
+          }
+        }
+      }],
+      "position": {
+        "start": {
+          "line": 4,
+          "column": 1,
+          "offset": 43
+        },
+        "end": {
+          "line": 4,
+          "column": 18,
+          "offset": 60
+        }
+      }
+    }, {
+      "type": "text",
+      "value": " ",
+      "position": {
+        "start": {
+          "line": 4,
+          "column": 18,
+          "offset": 60
+        },
+        "end": {
+          "line": 4,
+          "column": 19,
+          "offset": 61
+        }
+      }
+    }, {
+      "type": "element",
+      "tagName": "tag",
+      "properties": {},
+      "children": [{
+        "type": "text",
+        "value": "with more after a space",
+        "position": {
+          "start": {
+            "line": 4,
+            "column": 24,
+            "offset": 66
+          },
+          "end": {
+            "line": 4,
+            "column": 47,
+            "offset": 89
+          }
+        }
+      }],
+      "position": {
+        "start": {
+          "line": 4,
+          "column": 19,
+          "offset": 61
+        },
+        "end": {
+          "line": 4,
+          "column": 53,
+          "offset": 95
+        }
+      }
+    }, {
+      "type": "text",
+      "value": "\n"
+    }, {
+      "type": "element",
+      "tagName": "p",
+      "properties": {},
+      "children": [{
+        "type": "text",
+        "value": "after many new lines another pair of ",
+        "position": {
+          "start": {
+            "line": 9,
+            "column": 1,
+            "offset": 100
+          },
+          "end": {
+            "line": 9,
+            "column": 38,
+            "offset": 137
+          }
+        }
+      }, {
+        "type": "element",
+        "tagName": "strong",
+        "properties": {},
+        "children": [{
+          "type": "text",
+          "value": "elements",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 46,
+              "offset": 145
+            },
+            "end": {
+              "line": 9,
+              "column": 54,
+              "offset": 153
+            }
+          }
+        }],
+        "position": {
+          "start": {
+            "line": 9,
+            "column": 38,
+            "offset": 137
+          },
+          "end": {
+            "line": 9,
+            "column": 63,
+            "offset": 162
+          }
+        }
+      }, {
+        "type": "text",
+        "value": " ",
+        "position": {
+          "start": {
+            "line": 9,
+            "column": 63,
+            "offset": 162
+          },
+          "end": {
+            "line": 9,
+            "column": 64,
+            "offset": 163
+          }
+        }
+      }, {
+        "type": "element",
+        "tagName": "em",
+        "properties": {},
+        "children": [{
+          "type": "text",
+          "value": "with a space",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 68,
+              "offset": 167
+            },
+            "end": {
+              "line": 9,
+              "column": 80,
+              "offset": 179
+            }
+          }
+        }],
+        "position": {
+          "start": {
+            "line": 9,
+            "column": 64,
+            "offset": 163
+          },
+          "end": {
+            "line": 9,
+            "column": 85,
+            "offset": 184
+          }
+        }
+      }],
+      "position": {
+        "start": {
+          "line": 9,
+          "column": 1,
+          "offset": 100
+        },
+        "end": {
+          "line": 9,
+          "column": 85,
+          "offset": 184
+        }
+      }
+    }, {
+      "type": "text",
+      "value": "\n"
+    }],
+    "position": {
+      "start": {
+        "line": 3,
+        "column": 1,
+        "offset": 16
+      },
+      "end": {
+        "line": 10,
+        "column": 11,
+        "offset": 195
+      }
+    }
+  }],
+  "data": {
+    "quirksMode": false
+  },
+  "position": {
+    "start": {
+      "line": 1,
+      "column": 1,
+      "offset": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 1,
+      "offset": 0
+    }
+  }
+}

--- a/tools/challenge-md-parser/text-to-data.js
+++ b/tools/challenge-md-parser/text-to-data.js
@@ -45,7 +45,7 @@ function textToData(sectionIds) {
               const lines = child.value.split('\n');
               if (lines.filter(Boolean).length > 0) {
                 lines.forEach((line, index) => {
-                  if (/^\s*$/.test(line)) {
+                  if (line === '') {
                     currentParagraph = null;
                   } else {
                     if (!currentParagraph || index > 0) {

--- a/tools/challenge-md-parser/text-to-data.test.js
+++ b/tools/challenge-md-parser/text-to-data.test.js
@@ -1,5 +1,6 @@
 /* global describe it expect */
 const mockAST = require('./fixtures/challenge-html-ast.json');
+const adjacentTagsAST = require('./fixtures/adjacent-tags-ast.json');
 const textToData = require('./text-to-data');
 
 describe('text-to-data', () => {
@@ -69,6 +70,16 @@ describe('text-to-data', () => {
 <p>Some text in a blockquote, with <code>code</code></p>
 </blockquote>`;
     expect(file.data[expectedField].includes(expectedText)).toBe(true);
+  });
+
+  // eslint-disable-next-line max-len
+  it('should not add paragraphs when html elements are separated by whitespace', () => {
+    const plugin = textToData([expectedField]);
+    plugin(adjacentTagsAST, file);
+    const expectedText1 = `<code>code</code> <tag>with more after a space</tag>`;
+    const expectedText2 = `another pair of <strong>elements</strong> <em>with a space</em>`;
+    expect(file.data[expectedField].includes(expectedText1)).toBe(true);
+    expect(file.data[expectedField].includes(expectedText2)).toBe(true);
   });
 
   it('should have an output to match the snapshot', () => {


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #35727, which is a specific case of a problem that appears throughout the challenges.  As @RandellDawson pointed out in https://github.com/freeCodeCamp/freeCodeCamp/issues/35727#issuecomment-478433879, if you have a space between any two tags, the second tag will appear in a new paragraph.

With this PR if the parser encounters a line which is just whitespace, it will leave it alone and not try to wrap it into a paragraph.  As far as I can see, this should only appear when some text is nestled between two tags.  In that case we don't want it to get its own paragraph.
