### PR TITLE
fix(curriculum): Add more valid triples to the test

### DIFF
--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-9-special-pythagorean-triplet.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-9-special-pythagorean-triplet.english.md
@@ -23,11 +23,11 @@ There exists exactly one Pythagorean triplet for which <var>a</var> + <var>b</va
 ```yml
 tests:
   - text: <code>specialPythagoreanTriplet(1000)</code> should return 31875000.
-    testString: assert.strictEqual(specialPythagoreanTriplet(1000), 31875000, '<code>specialPythagoreanTriplet(1000)</code> should return 31875000.');
+    testString: assert.strictEqual(specialPythagoreanTriplet(1000), 31875000);
   - text: <code>specialPythagoreanTriplet(24)</code> should return 480.
-    testString: assert.strictEqual(specialPythagoreanTriplet(24), 480, '<code>specialPythagoreanTriplet(24)</code> should return 480.');
-  - text: <code>specialPythagoreanTriplet(120)</code> should return 49920.
-    testString: assert.strictEqual(specialPythagoreanTriplet(120), 49920, '<code>specialPythagoreanTriplet(120)</code> should return 49920.');
+    testString: assert.strictEqual(specialPythagoreanTriplet(24), 480);
+  - text: <code>specialPythagoreanTriplet(120)</code> should return 49920, 55080 or 60000
+    testString: assert([49920, 55080, 60000].includes(specialPythagoreanTriplet(120)));
 
 ```
 


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

There are three Pythagorean triples that sum to 120.  This changes the test to allow all three and cleans up all the tests.

Closes #35070
