### PR TITLE
fix(curriculum): Added ; to blockquote's end as it can lead to errors - (Lesson: ES6: Use * to Import Everything from a File)

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use--to-import-everything-from-a-file.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use--to-import-everything-from-a-file.english.md
@@ -10,7 +10,7 @@ Suppose you have a file and you wish to import all of its contents into the curr
 Here's an example where the contents of a file named <code>"math_functions"</code> are imported into a file in the same directory:
 <blockquote>import * as myMathModule from "math_functions";<br>myMathModule.add(2,3);<br>myMathModule.subtract(5,3);</blockquote>
 And breaking down that code:
-<blockquote>import * as object_with_name_of_your_choice from "file_path_goes_here"<br>object_with_name_of_your_choice.imported_function</blockquote>
+<blockquote>import * as object_with_name_of_your_choice from "file_path_goes_here";<br>object_with_name_of_your_choice.imported_function</blockquote>
 You may use any name following the <code>import * as </code>portion of the statement. In order to utilize this method, it requires an object that receives the imported values (i.e., you must provide a name). From here, you will use the dot notation to call your imported values.
 </section>
 


### PR DESCRIPTION
Added ; to blockquote's end of lesson "ES6: Use * to Import Everything from a File" (Javascript) as without it the student can make errors, to pass on the lesson the student MUST use ";".

- [ X ] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [ X ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ X ] My pull request targets the `master` branch of freeCodeCamp.
- [ X ] None of my changes are plagiarized from another source without proper attribution.
- [ X ] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [ X ] My changes do not use shortened URLs or affiliate links.