### PR TITLE
fix(curriculum): add new test to use calculated space for Use grid-column to Control Spacing challenge

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/css-grid/use-grid-column-to-control-spacing.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-grid/use-grid-column-to-control-spacing.english.md
@@ -88,7 +88,7 @@ const hasCorrectSpacing = () => {
   const contTwoPlusThreePlusGapWidth = $('.item2').width() * 2 + 10;
   const item5Width = $('.item5').width();
   const diff = Math.abs(contTwoPlusThreePlusGapWidth - item5Width);
-  /* max expected diff assumes browser width increments of 0.01px */
+  /* To avoid rounding errors the largest allowed diff is set at 0.01px */
   return diff <= 0.01; 
 };
 </script>

--- a/curriculum/challenges/english/01-responsive-web-design/css-grid/use-grid-column-to-control-spacing.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-grid/use-grid-column-to-control-spacing.english.md
@@ -27,8 +27,10 @@ Make the item with the class <code>item5</code> consume the last two columns of 
 
 ```yml
 tests:
-  - text: <code>item5</code> class should have a <code>grid-column</code> property that has the value of <code>2 / 4</code>.
-    testString: assert(code.match(/.item5\s*?{[\s\S]*grid-column\s*?:\s*?2\s*?\/\s*?4\s*?;[\s\S]*}/gi), '<code>item5</code> class should have a <code>grid-column</code> property that has the value of <code>2 / 4</code>.');
+  - text: <code>item5</code> class should have a <code>grid-column</code> property.
+    testString: assert($('style').text().replace(/\s/g, '').match(/\.item5{.*grid-column:.*}/g));
+  - text: <code>item5</code> class should have a <code>grid-column</code> property which results in the <code>div</code> with the <code>item5</code> consuming the last two columns of the grid.
+    testString: assert(hasCorrectSpacing());
 
 ```
 
@@ -77,7 +79,22 @@ tests:
 
 </div>
 
+### After Test
+<div id='html-setup'>
 
+```html
+<script>
+const hasCorrectSpacing = () => {
+  const contTwoPlusThreePlusGapWidth = $('.item2').width() * 2 + 10;
+  const item5Width = $('.item5').width();
+  const diff = Math.abs(contTwoPlusThreePlusGapWidth - item5Width);
+  /* max expected diff assumes browser width increments of 0.01px */
+  return diff <= 0.01; 
+};
+</script>
+```
+
+</div> 
 
 </section>
 
@@ -85,8 +102,37 @@ tests:
 <section id='solution'>
 
 
-```js
-var code = ".item5 {grid-column: 2 / 4;}"
+```html
+<style>
+  .item1{background:LightSkyBlue;}
+  .item2{background:LightSalmon;}
+  .item3{background:PaleTurquoise;}
+  .item4{background:LightPink;}
+
+  .item5 {
+    background: PaleGreen;
+    grid-column: 2 / 4;
+  }
+
+  .container {
+    font-size: 40px;
+    min-height: 300px;
+    width: 100%;
+    background: LightGray;
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    grid-template-rows: 1fr 1fr 1fr;
+    grid-gap: 10px;
+  }
+</style>
+
+<div class="container">
+  <div class="item1">1</div>
+  <div class="item2">2</div>
+  <div class="item3">3</div>
+  <div class="item4">4</div>
+  <div class="item5">5</div>
+</div>
 ```
 
 </section>

--- a/curriculum/challenges/english/01-responsive-web-design/css-grid/use-grid-column-to-control-spacing.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-grid/use-grid-column-to-control-spacing.english.md
@@ -79,7 +79,7 @@ tests:
 
 </div>
 
-### After Test
+### Before Test
 <div id='html-setup'>
 
 ```html


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Closes #35786

This PR originates from a discussion on another PR (#35786) which attempted to add an alternate solutions and a lot of extra verbiage in the challenge.  The issue was that the challenge did not accept another valid way using `grid-column` to achieve the same results.  There may even be other valid solutions, so I decided to change the original test to just check that `grid-column` property was used for the `item5` class and then created another test which validates the space taken up by the `div` with class="item5" is the same space as two of the existing divs (plus the gap between them).  There can be sum rounding error based on the width calculation, but based on my simulation (see below), when the correct solution is used, the error is less than 0.005px, so I used 0.01 to be conservative.

```js
let largestDiff = 0;
let wInc = 0.1;
const maxW = 2000;
const cont = document.querySelector(".container");
for (let w = 100; w < maxW; w += wInc) {
  $(".container").width(w);
  const item2Width = $(".item2").width();
  const contTwoPlusThreePlusGapWidth = item2Width * 2 + 10;
  const item5Width = $(".item5").width();
  const diff = Math.abs(contTwoPlusThreePlusGapWidth - item5Width);
  if (diff > largestDiff) {
    largestDiff = diff;
  }
}
console.log(`largest diff = ${largestDiff}`);
```

