### PR TITLE
componentWillReceiveProps is deprecated

### DIFF
--- a/curriculum/challenges/english/03-front-end-libraries/react/manage-updates-with-lifecycle-methods.english.md
+++ b/curriculum/challenges/english/03-front-end-libraries/react/manage-updates-with-lifecycle-methods.english.md
@@ -8,7 +8,7 @@ forumTopicId: 301397
 
 ## Description
 <section id='description'>
-<strong>Warning:</strong>&nbsp;This lifecycle method is deprecated since its usage can lead to bugs and inconsistencies.
+  <strong>Warning:</strong>&nbsp;<code>componentWillReceiveProps()</code> and <code>componentWillUpdate()</code> are deprecated since their usage can lead to bugs and inconsistencies. They were replaced to, respectively, <code>UNSAFE_componentWillReceiveProps()</code> and <code>UNSAFE_componentWillUpdate()</code> and they should be avoided in new code.
 Another lifecycle method is <code>UNSAFE_componentWillReceiveProps()</code> which is called whenever a component is receiving new props. This method receives the new props as an argument, which is usually written as <code>nextProps</code>. You can use this argument and compare with <code>this.props</code> and perform actions before the component updates. For example, you may call <code>setState()</code> locally before the update is processed.
 Another method is <code>componentDidUpdate()</code>, and is called immediately after a component re-renders. Note that rendering and mounting are considered different things in the component lifecycle. When a page first loads, all components are mounted and this is where methods like <code>componentWillMount()</code> and <code>componentDidMount()</code> are called. After this, as state changes, components re-render themselves. The next challenge covers this in more detail.
 </section>
@@ -16,7 +16,7 @@ Another method is <code>componentDidUpdate()</code>, and is called immediately a
 ## Instructions
 <section id='instructions'>
 The child component <code>Dialog</code> receives <code>message</code> props from its parent, the <code>Controller</code> component. Write the <code>UNSAFE_componentWillReceiveProps()</code> method in the <code>Dialog</code> component and have it log <code>this.props</code> and <code>nextProps</code> to the console. You'll need to pass <code>nextProps</code> as an argument to this method and although it's possible to name it anything, name it <code>nextProps</code> here.
-Next, add <code>componentDidUpdate()</code> in the <code>Dialog</code> component, and log a statement that says the component has updated. This method works similar to <code>componentWillUpdate()</code>, which is provided for you. Now click the button to change the message and watch your browser console. The order of the console statements show the order the methods are called.
+Next, add <code>componentDidUpdate()</code> in the <code>Dialog</code> component, and log a statement that says the component has updated. This method works similar to <code>UNSAFE_componentWillUpdate()</code>, which is provided for you. Now click the button to change the message and watch your browser console. The order of the console statements show the order the methods are called.
 <strong>Note:</strong>&nbsp;You'll need to write the lifecycle methods as normal functions and not as arrow functions to pass the tests (there is also no advantage to writing lifecycle methods as arrow functions).
 </section>
 
@@ -48,7 +48,7 @@ class Dialog extends React.Component {
   constructor(props) {
     super(props);
   }
-  componentWillUpdate() {
+  UNSAFE_componentWillUpdate() {
     console.log('Component is about to update...');
   }
   // change code below this line
@@ -106,7 +106,7 @@ class Dialog extends React.Component {
   constructor(props) {
     super(props);
   }
-  componentWillUpdate() {
+  UNSAFE_componentWillUpdate() {
     console.log('Component is about to update...');
   }
   // change code below this line

--- a/curriculum/challenges/english/03-front-end-libraries/react/manage-updates-with-lifecycle-methods.english.md
+++ b/curriculum/challenges/english/03-front-end-libraries/react/manage-updates-with-lifecycle-methods.english.md
@@ -8,13 +8,14 @@ forumTopicId: 301397
 
 ## Description
 <section id='description'>
-Another lifecycle method is <code>componentWillReceiveProps()</code> which is called whenever a component is receiving new props. This method receives the new props as an argument, which is usually written as <code>nextProps</code>. You can use this argument and compare with <code>this.props</code> and perform actions before the component updates. For example, you may call <code>setState()</code> locally before the update is processed.
+<strong>Warning:</strong>&nbsp;This lifecycle method is deprecated since its usage can lead to bugs and inconsistencies.
+Another lifecycle method is <code>UNSAFE_componentWillReceiveProps()</code> which is called whenever a component is receiving new props. This method receives the new props as an argument, which is usually written as <code>nextProps</code>. You can use this argument and compare with <code>this.props</code> and perform actions before the component updates. For example, you may call <code>setState()</code> locally before the update is processed.
 Another method is <code>componentDidUpdate()</code>, and is called immediately after a component re-renders. Note that rendering and mounting are considered different things in the component lifecycle. When a page first loads, all components are mounted and this is where methods like <code>componentWillMount()</code> and <code>componentDidMount()</code> are called. After this, as state changes, components re-render themselves. The next challenge covers this in more detail.
 </section>
 
 ## Instructions
 <section id='instructions'>
-The child component <code>Dialog</code> receives <code>message</code> props from its parent, the <code>Controller</code> component. Write the <code>componentWillReceiveProps()</code> method in the <code>Dialog</code> component and have it log <code>this.props</code> and <code>nextProps</code> to the console. You'll need to pass <code>nextProps</code> as an argument to this method and although it's possible to name it anything, name it <code>nextProps</code> here.
+The child component <code>Dialog</code> receives <code>message</code> props from its parent, the <code>Controller</code> component. Write the <code>UNSAFE_componentWillReceiveProps()</code> method in the <code>Dialog</code> component and have it log <code>this.props</code> and <code>nextProps</code> to the console. You'll need to pass <code>nextProps</code> as an argument to this method and although it's possible to name it anything, name it <code>nextProps</code> here.
 Next, add <code>componentDidUpdate()</code> in the <code>Dialog</code> component, and log a statement that says the component has updated. This method works similar to <code>componentWillUpdate()</code>, which is provided for you. Now click the button to change the message and watch your browser console. The order of the console statements show the order the methods are called.
 <strong>Note:</strong>&nbsp;You'll need to write the lifecycle methods as normal functions and not as arrow functions to pass the tests (there is also no advantage to writing lifecycle methods as arrow functions).
 </section>
@@ -25,11 +26,11 @@ Next, add <code>componentDidUpdate()</code> in the <code>Dialog</code> component
 ```yml
 tests:
   - text: The <code>Controller</code> component should render the <code>Dialog</code> component as a child.
-    testString: assert((function() { const mockedComponent = Enzyme.mount(React.createElement(Controller)); return mockedComponent.find('Controller').length === 1 && mockedComponent.find('Dialog').length === 1; })());
-  - text: The <code>componentWillReceiveProps</code> method in the <code>Dialog</code> component should log <code>this.props</code> to the console.
-    testString: assert((function() { const lifecycleChild = React.createElement(Dialog).type.prototype.componentWillReceiveProps.toString().replace(/ /g,''); return lifecycleChild.includes('console.log') && lifecycleChild.includes('this.props') })());
-  - text: The <code>componentWillReceiveProps</code> method in the <code>Dialog</code> component should log <code>nextProps</code> to the console.
-    testString: assert((function() { const lifecycleChild = React.createElement(Dialog).type.prototype.componentWillReceiveProps.toString().replace(/ /g,''); const nextPropsAsParameterTest = /componentWillReceiveProps(| *?= *?)(\(|)nextProps(\)|)( *?=> *?{| *?{|{)/; const nextPropsInConsoleLogTest = /console\.log\(.*?nextProps\b.*?\)/; return ( lifecycleChild.includes('console.log') && nextPropsInConsoleLogTest.test(lifecycleChild) && nextPropsAsParameterTest.test(lifecycleChild) ); })());
+    testString: assert((function() { const mockedComponent = Enzyme.mount(React.createElement(Controller)); return mockedComponent.find('Controller').length === 1 && mockedComponent.find('Dialog').length === 1; })(), 'The <code>Controller</code> component should render the <code>Dialog</code> component as a child.');
+  - text: The <code>UNSAFE_componentWillReceiveProps</code> method in the <code>Dialog</code> component should log <code>this.props</code> to the console.
+    testString: assert((function() { const lifecycleChild = React.createElement(Dialog).type.prototype.UNSAFE_componentWillReceiveProps.toString().replace(/ /g,''); return lifecycleChild.includes('console.log') && lifecycleChild.includes('this.props') })(), 'The <code>UNSAFE_componentWillReceiveProps</code> method in the <code>Dialog</code> component should log <code>this.props</code> to the console.');
+  - text: The <code>UNSAFE_componentWillReceiveProps</code> method in the <code>Dialog</code> component should log <code>nextProps</code> to the console.
+    testString: assert((function() { const lifecycleChild = React.createElement(Dialog).type.prototype.UNSAFE_componentWillReceiveProps.toString().replace(/ /g,''); const nextPropsAsParameterTest = /UNSAFE_componentWillReceiveProps(| *?= *?)(\(|)nextProps(\)|)( *?=> *?{| *?{|{)/; const nextPropsInConsoleLogTest = /console\.log\(.*?nextProps\b.*?\)/; return ( lifecycleChild.includes('console.log') && nextPropsInConsoleLogTest.test(lifecycleChild) && nextPropsAsParameterTest.test(lifecycleChild) ); })(), 'The <code>UNSAFE_componentWillReceiveProps</code> method in the <code>Dialog</code> component should log <code>nextProps</code> to the console.');
   - text: The <code>Dialog</code> component should call the <code>componentDidUpdate</code> method and log a message to the console.
     testString: assert((function() { const lifecycleChild = React.createElement(Dialog).type.prototype.componentDidUpdate.toString().replace(/ /g,''); return lifecycleChild.length !== 'undefined' && lifecycleChild.includes('console.log'); })());
 
@@ -109,7 +110,7 @@ class Dialog extends React.Component {
     console.log('Component is about to update...');
   }
   // change code below this line
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     console.log(this.props, nextProps);
   }
   componentDidUpdate() {


### PR DESCRIPTION
Consider removing this lesson from the React tutorial, once this lifecycle method is now deprecated.
In case it isn't, a warning in the beginning should be displayed

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX
