### PR TITLE
fix(curriculum): Rewrite of challenge seed and tests for Iterate Through the Keys of an Object with a for...in Statement challenge

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/-iterate-through-the-keys-of-an-object-with-a-for...in-statement.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/-iterate-through-the-keys-of-an-object-with-a-for...in-statement.english.md
@@ -6,15 +6,47 @@ challengeType: 1
 
 ## Description
 <section id='description'>
-Sometimes you may need to iterate through all the keys within an object. This requires a specific syntax in JavaScript called a <dfn>for...in</dfn> statement. For our <code>users</code> object, this could look like:
-<blockquote>for (let user in users) {<br>&nbsp;&nbsp;console.log(user);<br>}<br><br>// logs:<br>Alan<br>Jeff<br>Sarah<br>Ryan</blockquote>
+Sometimes you may need to iterate through all the keys within an object. This requires a specific syntax in JavaScript called a <dfn>for...in</dfn> statement. In the example below, there is a <code>users</code> object and the loop iterates through it to display the user's name to the console.
+<blockquote>
+const users = {<br>
+&nbsp;&nbsp;Alan: {<br>
+&nbsp;&nbsp;&nbsp;&nbsp;age: 30<br>
+&nbsp;&nbsp;},<br>
+&nbsp;&nbsp;Jeff: {<br>
+&nbsp;&nbsp;&nbsp;&nbsp;age: 45<br>
+&nbsp;&nbsp;},<br>
+&nbsp;&nbsp;Sarah: {<br>
+&nbsp;&nbsp;&nbsp;&nbsp;age: 18<br>
+&nbsp;&nbsp;}<br>
+&nbsp;&nbsp;Ryan: {<br>
+&nbsp;&nbsp;&nbsp;&nbsp;age: 24<br>
+&nbsp;&nbsp;}<br>
+};<br><br>
+for (let user in users) {<br>
+&nbsp;&nbsp;console.log(user);<br>
+}<br><br>
+// logs:<br>Alan<br>Jeff<br>Sarah<br>Ryan
+</blockquote>
 In this statement, we defined a variable <code>user</code>, and as you can see, this variable was reset during each iteration to each of the object's keys as the statement looped through the object, resulting in each user's name being printed to the console.
-<strong>NOTE:</strong><br>Objects do not maintain an ordering to stored keys like arrays do; thus a key's position on an object, or the relative order in which it appears, is irrelevant when referencing or accessing that key.
+<strong>NOTE:</strong> Objects do not maintain an ordering to stored keys like arrays do; thus a key's position on an object, or the relative order in which it appears, is irrelevant when referencing or accessing that key.
 </section>
 
 ## Instructions
 <section id='instructions'>
-We've defined a function, <code>countOnline</code>; use a <dfn>for...in</dfn> statement within this function to loop through the users in the <code>users</code> object and return the number of users whose <code>online</code> property is set to <code>true</code>.
+We've defined a function <code>countOnline</code> which accepts one argument (a users object). Use a <dfn>for...in</dfn> statement within this function to loop through the users object passed into the function and return the number of users whose <code>online</code> property is set to <code>true</code>.  An example of a users object which could be passed to <code>countOnline</code> is shown below.  Each user will have an <code>online</code> property with either a <code>true</code> or <code>false</code> value.
+
+<blockquote>
+{<br>
+&nbsp;&nbsp;Alan: {<br>
+&nbsp;&nbsp;&nbsp;&nbsp;online: false<br>
+&nbsp;&nbsp;},<br>
+&nbsp;&nbsp;Jeff: {<br>
+&nbsp;&nbsp;&nbsp;&nbsp;online: true<br>
+&nbsp;&nbsp;},<br>
+&nbsp;&nbsp;Sarah: {<br>
+&nbsp;&nbsp;&nbsp;&nbsp;online: false<br>
+&nbsp;&nbsp;}<br>
+}</blockquote>
 </section>
 
 ## Tests
@@ -22,11 +54,14 @@ We've defined a function, <code>countOnline</code>; use a <dfn>for...in</dfn> st
 
 ```yml
 tests:
-  - text: The <code>users</code> object contains users <code>Jeff</code> and <code>Ryan</code> with <code>online</code> set to <code>true</code> and users <code>Alan</code> and <code>Sarah</code> with <code>online</code> set to <code>false</code>
-    testString: assert(users.Alan.online === false && users.Jeff.online === true &&  users.Sarah.online === false &&  users.Ryan.online === true, 'The <code>users</code> object contains users <code>Jeff</code> and <code>Ryan</code> with <code>online</code> set to <code>true</code> and users <code>Alan</code> and <code>Sarah</code> with <code>online</code> set to <code>false</code>');
-  - text: The function <code>countOnline</code> returns the number of users with the <code>online</code> property set to <code>true</code>
-    testString: 'assert((function() { users.Harry = {online: true}; users.Sam = {online: true}; users.Carl = {online: true}; return countOnline(users) })() === 5, ''The function <code>countOnline</code> returns the number of users with the <code>online</code> property set to <code>true</code>'');'
-
+  - text: The function <code>countOnline</code> should use a `for in` statement to iterate through the object keys of the object passed to it.
+    testString: assert(code.match(/for\s*\(\s*(var|let)\s+[a-zA-Z_$]\w*\s+in\s+[a-zA-Z_$]\w*\s*\)\s*{/));
+  - text: 'The function <code>countOnline</code> should return <code>1</code> when the object <code>{ Alan: { online: false }, Jeff: { online: true }, Sarah: { online: false } }</code> is passed to it'
+    testString: assert(countOnline(usersObj1) === 1);
+  - text: 'The function <code>countOnline</code> should return <code>2</code> when the object <code>{ Alan: { online: true }, Jeff: { online: false }, Sarah: { online: true } }</code> is passed to it'
+    testString: assert(countOnline(usersObj2) === 2);
+  - text: 'The function <code>countOnline</code> should return <code>0</code> when the object <code>{ Alan: { online: false }, Jeff: { online: false }, Sarah: { online: false } }</code> is passed to it'
+    testString: assert(countOnline(usersObj3) === 0);
 ```
 
 </section>
@@ -37,36 +72,58 @@ tests:
 <div id='js-seed'>
 
 ```js
-let users = {
-  Alan: {
-    age: 27,
-    online: false
-  },
-  Jeff: {
-    age: 32,
-    online: true
-  },
-  Sarah: {
-    age: 48,
-    online: false
-  },
-  Ryan: {
-    age: 19,
-    online: true
-  }
-};
-
-function countOnline(obj) {
+function countOnline(usersObj) {
   // change code below this line
 
   // change code above this line
 }
-
-console.log(countOnline(users));
 ```
 
 </div>
 
+### After Test
+<div id='js-teardown'>
+
+```js
+const usersObj1 = {
+  Alan: {
+    online: false
+  },
+  Jeff: {
+    online: true
+  },
+  Sarah: {
+    online: false
+  }
+}
+
+const usersObj2 = {
+  Alan: {
+    online: true
+  },
+  Jeff: {
+    online: false
+  },
+  Sarah: {
+    online: true
+  }
+}
+
+
+const usersObj3 = {
+  Alan: {
+    online: false
+  },
+  Jeff: {
+    online: false
+  },
+  Sarah: {
+    online: false
+  }
+}
+```
+
+</div>
 
 
 </section>
@@ -75,35 +132,16 @@ console.log(countOnline(users));
 <section id='solution'>
 
 ```js
-let users = {
-  Alan: {
-    age: 27,
-    online: false
-  },
-  Jeff: {
-    age: 32,
-    online: true
-  },
-  Sarah: {
-    age: 48,
-    online: false
-  },
-  Ryan: {
-    age: 19,
-    online: true
-  }
-};
 
-function countOnline(obj) {
+function countOnline(usersObj) {
   let online = 0;
-  for(let user in obj){
-    if(obj[user].online == true) {
-      online += 1;
+  for(let user in usersObj){
+    if(usersObj[user].online) {
+      online++;
     }
   }
   return online;
 }
 
-console.log(countOnline(users));
 ```
 </section>


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x]  My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Closes #35874

This PR modifies the Instructions section to show an example of a users object that could be passed to the function. This allows us to generate objects to pass to the tests with various outcomes for the count of users with online property being `true`.  This makes the tests resistant to someone hard coding the answers or modifying an object (as the previous challenge seed started with) to allow tests to pass. 