### PR TITLE
feat(curriculum): Allow use of triple backticks for code in description and instructions sections of challenges

### DIFF
--- a/client/src/components/layouts/night.css
+++ b/client/src/components/layouts/night.css
@@ -36,19 +36,12 @@
   background: #2a2a2a;
 }
 
+.night .challenge-instructions pre,
+.night .challenge-instructions pre code,
 .night .challenge-instructions blockquote,
 .night blockquote,
+.night code,
 .night pre {
-  background: #222;
-}
-
-.night .challenge-instructions pre,
-.night .challenge-instructions pre code {
-  background-color: #242424;
-  color: #02a902;
-}
-
-.night code {
   background-color: #242424;
   color: #02a902;
 }

--- a/client/src/components/layouts/night.css
+++ b/client/src/components/layouts/night.css
@@ -44,8 +44,8 @@
 
 .night .challenge-instructions pre,
 .night .challenge-instructions pre code {
-  color: #c7254e;
-  background: #222;
+  background-color: #242424;
+  color: #02a902;
 }
 
 .night code {

--- a/client/src/components/layouts/night.css
+++ b/client/src/components/layouts/night.css
@@ -42,6 +42,12 @@
   background: #222;
 }
 
+.night .challenge-instructions pre,
+.night .challenge-instructions pre code {
+  color: #c7254e;
+  background: #222;
+}
+
 .night code {
   background-color: #242424;
   color: #02a902;

--- a/client/src/templates/Challenges/components/challenge-description.css
+++ b/client/src/templates/Challenges/components/challenge-description.css
@@ -2,19 +2,23 @@
   font-size: 16px;
 }
 
-.challenge-instructions blockquote, .challenge-instructions pre {
+ .challenge-instructions blockquote, .challenge-instructions pre, .challenge-instructions pre[class*="language-"] {
   background-color: #eee;
   color: #c7254e;
-  padding: 10px;
+  padding: 10px 10px 10px 15px;
   width: 100%;
   margin: 0;
   margin-bottom: 1.45rem;
-  font-family: monospace;
+  font-family: 'SFMono-Regular', Consolas, 'Roboto Mono', 'Droid Sans Mono', 'Liberation Mono', Menlo, Courier, monospace;
   font-size: 16px;
+  word-spacing: normal;
+  word-break: normal;
+  word-wrap: normal;
+  border: unset;
 }
 
-.challenge-instructions pre {
-  border: 0;
-  border-radius: 0%;
-  word-break: normal;
+.challenge-instructions code {
+  text-shadow: initial;
+  font-family: 'SFMono-Regular', Consolas, 'Roboto Mono', 'Droid Sans Mono', 'Liberation Mono', Menlo, Courier, monospace;
+  color: #c7254e;
 }

--- a/client/src/templates/Challenges/components/challenge-description.css
+++ b/client/src/templates/Challenges/components/challenge-description.css
@@ -2,7 +2,7 @@
   font-size: 16px;
 }
 
-.challenge-instructions blockquote {
+.challenge-instructions blockquote, .challenge-instructions pre {
   background-color: #eee;
   color: #c7254e;
   padding: 10px;
@@ -11,4 +11,10 @@
   margin-bottom: 1.45rem;
   font-family: monospace;
   font-size: 16px;
+}
+
+.challenge-instructions pre {
+  border: 0;
+  border-radius: 0%;
+  word-break: normal;
 }

--- a/client/src/templates/Challenges/components/challenge-description.css
+++ b/client/src/templates/Challenges/components/challenge-description.css
@@ -22,3 +22,8 @@
   font-family: 'SFMono-Regular', Consolas, 'Roboto Mono', 'Droid Sans Mono', 'Liberation Mono', Menlo, Courier, monospace;
   color: #c7254e;
 }
+
+.challenge-instructions pre code {
+  white-space: pre-wrap;
+  line-height: 1.42;
+}

--- a/client/src/templates/Challenges/components/challenge-description.css
+++ b/client/src/templates/Challenges/components/challenge-description.css
@@ -2,28 +2,26 @@
   font-size: 16px;
 }
 
- .challenge-instructions blockquote, .challenge-instructions pre, .challenge-instructions pre[class*="language-"] {
+ .challenge-instructions blockquote, .challenge-instructions pre {
   background-color: #eee;
   color: #c7254e;
   padding: 10px 10px 10px 15px;
   width: 100%;
   margin: 0;
   margin-bottom: 1.45rem;
-  font-family: 'SFMono-Regular', Consolas, 'Roboto Mono', 'Droid Sans Mono', 'Liberation Mono', Menlo, Courier, monospace;
+  font-family: monospace;
   font-size: 16px;
   word-spacing: normal;
   word-break: normal;
-  word-wrap: normal;
+  word-wrap: break-word;
   border: unset;
-}
-
-.challenge-instructions code {
-  text-shadow: initial;
-  font-family: 'SFMono-Regular', Consolas, 'Roboto Mono', 'Droid Sans Mono', 'Liberation Mono', Menlo, Courier, monospace;
-  color: #c7254e;
 }
 
 .challenge-instructions pre code {
   white-space: pre-wrap;
-  line-height: 1.42;
+  word-wrap: break-word;
+  line-height: 1.42857143;
+  text-shadow: initial;
+  font-family: monospace;
+  color: #c7254e;
 }

--- a/client/src/templates/Challenges/components/challenge-description.css
+++ b/client/src/templates/Challenges/components/challenge-description.css
@@ -2,7 +2,8 @@
   font-size: 16px;
 }
 
- .challenge-instructions blockquote, .challenge-instructions pre {
+ .challenge-instructions blockquote,
+ .challenge-instructions pre {
   background-color: #eee;
   color: #c7254e;
   padding: 10px 10px 10px 15px;
@@ -11,17 +12,12 @@
   margin-bottom: 1.45rem;
   font-family: monospace;
   font-size: 16px;
-  word-spacing: normal;
-  word-break: normal;
-  word-wrap: break-word;
-  border: unset;
+  border: none;
 }
 
 .challenge-instructions pre code {
-  white-space: pre-wrap;
-  word-wrap: break-word;
-  line-height: 1.42857143;
-  text-shadow: initial;
-  font-family: monospace;
+  line-height: 1.42;
+  text-shadow: none;
+  font-family: 'SFMono-Regular', Consolas, 'Roboto Mono', 'Droid Sans Mono', 'Liberation Mono', Menlo, Courier, monospace;
   color: #c7254e;
 }

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/-iterate-through-the-keys-of-an-object-with-a-for...in-statement.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/-iterate-through-the-keys-of-an-object-with-a-for...in-statement.english.md
@@ -19,7 +19,6 @@ Jeff
 Sarah
 Ryan
 ```
-
 In this statement, we defined a variable <code>user</code>, and as you can see, this variable was reset during each iteration to each of the object's keys as the statement looped through the object, resulting in each user's name being printed to the console.
 <strong>NOTE:</strong> Objects do not maintain an ordering to stored keys like arrays do; thus a key's position on an object, or the relative order in which it appears, is irrelevant when referencing or accessing that key.
 </section>
@@ -28,18 +27,20 @@ In this statement, we defined a variable <code>user</code>, and as you can see, 
 <section id='instructions'>
 We've defined a function <code>countOnline</code> which accepts one argument (a users object). Use a <dfn>for...in</dfn> statement within this function to loop through the users object passed into the function and return the number of users whose <code>online</code> property is set to <code>true</code>.  An example of a users object which could be passed to <code>countOnline</code> is shown below.  Each user will have an <code>online</code> property with either a <code>true</code> or <code>false</code> value.
 
-<blockquote>
-{<br>
-&nbsp;&nbsp;Alan: {<br>
-&nbsp;&nbsp;&nbsp;&nbsp;online: false<br>
-&nbsp;&nbsp;},<br>
-&nbsp;&nbsp;Jeff: {<br>
-&nbsp;&nbsp;&nbsp;&nbsp;online: true<br>
-&nbsp;&nbsp;},<br>
-&nbsp;&nbsp;Sarah: {<br>
-&nbsp;&nbsp;&nbsp;&nbsp;online: false<br>
-&nbsp;&nbsp;}<br>
-}</blockquote>
+
+```js
+{
+  Alan: {
+    online: false
+  },
+  Jeff: {
+    online: true
+  },
+  Sarah: {
+    online: false
+  }
+}
+```
 </section>
 
 ## Tests

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/-iterate-through-the-keys-of-an-object-with-a-for...in-statement.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/-iterate-through-the-keys-of-an-object-with-a-for...in-statement.english.md
@@ -6,27 +6,20 @@ challengeType: 1
 
 ## Description
 <section id='description'>
-Sometimes you may need to iterate through all the keys within an object. This requires a specific syntax in JavaScript called a <dfn>for...in</dfn> statement. In the example below, there is a <code>users</code> object and the loop iterates through it to display the user's name to the console.
-<blockquote>
-const users = {<br>
-&nbsp;&nbsp;Alan: {<br>
-&nbsp;&nbsp;&nbsp;&nbsp;age: 30<br>
-&nbsp;&nbsp;},<br>
-&nbsp;&nbsp;Jeff: {<br>
-&nbsp;&nbsp;&nbsp;&nbsp;age: 45<br>
-&nbsp;&nbsp;},<br>
-&nbsp;&nbsp;Sarah: {<br>
-&nbsp;&nbsp;&nbsp;&nbsp;age: 18<br>
-&nbsp;&nbsp;}<br>
-&nbsp;&nbsp;Ryan: {<br>
-&nbsp;&nbsp;&nbsp;&nbsp;age: 24<br>
-&nbsp;&nbsp;}<br>
-};<br><br>
-for (let user in users) {<br>
-&nbsp;&nbsp;console.log(user);<br>
-}<br><br>
-// logs:<br>Alan<br>Jeff<br>Sarah<br>Ryan
-</blockquote>
+Sometimes you may need to iterate through all the keys within an object. This requires a specific syntax in JavaScript called a <dfn>for...in</dfn> statement. For our <code>users</code> object, this could look like:
+
+```js
+for (let user in users) {
+  console.log(user);
+}
+
+// logs:
+Alan
+Jeff
+Sarah
+Ryan
+```
+
 In this statement, we defined a variable <code>user</code>, and as you can see, this variable was reset during each iteration to each of the object's keys as the statement looped through the object, resulting in each user's name being printed to the console.
 <strong>NOTE:</strong> Objects do not maintain an ordering to stored keys like arrays do; thus a key's position on an object, or the relative order in which it appears, is irrelevant when referencing or accessing that key.
 </section>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/access-an-arrays-contents-using-bracket-notation.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/access-an-arrays-contents-using-bracket-notation.english.md
@@ -8,13 +8,27 @@ challengeType: 1
 <section id='description'>
 The fundamental feature of any data structure is, of course, the ability to not only store data, but to be able to retrieve that data on command. So, now that we've learned how to create an array, let's begin to think about how we can access that array's information.
 When we define a simple array as seen below, there are 3 items in it:
-<blockquote>let ourArray = ["a", "b", "c"];</blockquote>
+
+```
+let ourArray = ["a", "b", "c"];
+```
+
 In an array, each array item has an <dfn>index</dfn>.  This index doubles as the position of that item in the array, and how you reference it. However, it is important to note, that JavaScript arrays are <dfn>zero-indexed</dfn>, meaning that the first element of an array is actually at the <em><strong>zeroth</strong></em> position, not the first.
 In order to retrieve an element from an array we can enclose an index in brackets and append it to the end of an array, or more commonly, to a variable which references an array object. This is known as <dfn>bracket notation</dfn>.
 For example, if we want to retrieve the <code>"a"</code> from <code>ourArray</code> and assign it to a variable, we can do so with the following code:
-<blockquote>let ourVariable = ourArray[0];<br>// ourVariable equals "a"</blockquote>
+
+```
+let ourVariable = ourArray[0];
+// ourVariable equals "a"
+```
+
 In addition to accessing the value associated with an index, you can also <em>set</em> an index to a value using the same notation:
-<blockquote>ourArray[1] = "not b anymore";<br>// ourArray now equals ["a", "not b anymore", "c"];</blockquote>
+
+```
+ourArray[1] = "not b anymore";
+// ourArray now equals ["a", "not b anymore", "c"];
+```
+
 Using bracket notation, we have now reset the item at index 1 from <code>"b"</code>, to <code>"not b anymore"</code>.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/access-an-arrays-contents-using-bracket-notation.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/access-an-arrays-contents-using-bracket-notation.english.md
@@ -9,7 +9,7 @@ challengeType: 1
 The fundamental feature of any data structure is, of course, the ability to not only store data, but to be able to retrieve that data on command. So, now that we've learned how to create an array, let's begin to think about how we can access that array's information.
 When we define a simple array as seen below, there are 3 items in it:
 
-```
+```js
 let ourArray = ["a", "b", "c"];
 ```
 
@@ -17,7 +17,7 @@ In an array, each array item has an <dfn>index</dfn>.  This index doubles as the
 In order to retrieve an element from an array we can enclose an index in brackets and append it to the end of an array, or more commonly, to a variable which references an array object. This is known as <dfn>bracket notation</dfn>.
 For example, if we want to retrieve the <code>"a"</code> from <code>ourArray</code> and assign it to a variable, we can do so with the following code:
 
-```
+```js
 let ourVariable = ourArray[0];
 // ourVariable equals "a"
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/access-an-arrays-contents-using-bracket-notation.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/access-an-arrays-contents-using-bracket-notation.english.md
@@ -24,7 +24,7 @@ let ourVariable = ourArray[0];
 
 In addition to accessing the value associated with an index, you can also <em>set</em> an index to a value using the same notation:
 
-```
+```js
 ourArray[1] = "not b anymore";
 // ourArray now equals ["a", "not b anymore", "c"];
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/access-property-names-with-bracket-notation.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/access-property-names-with-bracket-notation.english.md
@@ -7,7 +7,12 @@ challengeType: 1
 ## Description
 <section id='description'>
 In the first object challenge we mentioned the use of bracket notation as a way to access property values using the evaluation of a variable. For instance, imagine that our <code>foods</code> object is being used in a program for a supermarket cash register. We have some function that sets the <code>selectedFood</code> and we want to check our <code>foods</code> object for the presence of that food. This might look like:
-<blockquote>let selectedFood = getCurrentFood(scannedItem);<br>let inventory = foods[selectedFood];</blockquote>
+
+```
+let selectedFood = getCurrentFood(scannedItem);
+let inventory = foods[selectedFood];
+```
+
 This code will evaluate the value stored in the <code>selectedFood</code> variable and return the value of that key in the <code>foods</code> object, or <code>undefined</code> if it is not present. Bracket notation is very useful because sometimes object properties are not known before runtime or we need to access them in a more dynamic way.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/access-property-names-with-bracket-notation.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/access-property-names-with-bracket-notation.english.md
@@ -8,7 +8,7 @@ challengeType: 1
 <section id='description'>
 In the first object challenge we mentioned the use of bracket notation as a way to access property values using the evaluation of a variable. For instance, imagine that our <code>foods</code> object is being used in a program for a supermarket cash register. We have some function that sets the <code>selectedFood</code> and we want to check our <code>foods</code> object for the presence of that food. This might look like:
 
-```
+```js
 let selectedFood = getCurrentFood(scannedItem);
 let inventory = foods[selectedFood];
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/add-items-to-an-array-with-push-and-unshift.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/add-items-to-an-array-with-push-and-unshift.english.md
@@ -9,7 +9,7 @@ challengeType: 1
 An array's length, like the data types it can contain, is not fixed. Arrays can be defined with a length of any number of elements, and elements can be added or removed over time; in other words, arrays are <dfn>mutable</dfn>. In this challenge, we will look at two methods with which we can programmatically modify an array: <code>Array.push()</code> and <code>Array.unshift()</code>.
 Both methods take one or more elements as parameters and add those elements to the array the method is being called on; the <code>push()</code> method adds elements to the end of an array, and <code>unshift()</code> adds elements to the beginning. Consider the following:
 
-```
+```js
 let twentyThree = 'XXIII';
 let romanNumerals = ['XXI', 'XXII'];
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/add-items-to-an-array-with-push-and-unshift.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/add-items-to-an-array-with-push-and-unshift.english.md
@@ -8,8 +8,18 @@ challengeType: 1
 <section id='description'>
 An array's length, like the data types it can contain, is not fixed. Arrays can be defined with a length of any number of elements, and elements can be added or removed over time; in other words, arrays are <dfn>mutable</dfn>. In this challenge, we will look at two methods with which we can programmatically modify an array: <code>Array.push()</code> and <code>Array.unshift()</code>.
 Both methods take one or more elements as parameters and add those elements to the array the method is being called on; the <code>push()</code> method adds elements to the end of an array, and <code>unshift()</code> adds elements to the beginning. Consider the following:
-<blockquote>let twentyThree = 'XXIII';<br>let romanNumerals = ['XXI', 'XXII'];<br><br>romanNumerals.unshift('XIX', 'XX');<br>// now equals ['XIX', 'XX', 'XXI', 'XXII']<br><br>romanNumerals.push(twentyThree);<br>// now equals ['XIX', 'XX', 'XXI', 'XXII', 'XXIII']
-Notice that we can also pass variables, which allows us even greater flexibility in dynamically modifying our array's data.
+
+```
+let twentyThree = 'XXIII';
+let romanNumerals = ['XXI', 'XXII'];
+
+romanNumerals.unshift('XIX', 'XX');
+// now equals ['XIX', 'XX', 'XXI', 'XXII']
+
+romanNumerals.push(twentyThree);
+// now equals ['XIX', 'XX', 'XXI', 'XXII', 'XXIII']Notice that we can also pass variables, which allows us even greater flexibility in dynamically modifying our array's data.
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/add-items-using-splice.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/add-items-using-splice.english.md
@@ -8,7 +8,7 @@ challengeType: 1
 <section id='description'>
 Remember in the last challenge we mentioned that <code>splice()</code> can take up to three parameters? Well, we can go one step further with <code>splice()</code> &mdash; in addition to removing elements, we can use that third parameter, which represents one or more elements, to <em>add</em> them as well. This can be incredibly useful for quickly switching out an element, or a set of elements, for another. For instance, let's say you're storing a color scheme for a set of DOM elements in an array, and want to dynamically change a color based on some action:
 
-```
+```js
 function colorChange(arr, index, newColor) {
   arr.splice(index, 1, newColor);
   return arr;

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/add-items-using-splice.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/add-items-using-splice.english.md
@@ -7,7 +7,20 @@ challengeType: 1
 ## Description
 <section id='description'>
 Remember in the last challenge we mentioned that <code>splice()</code> can take up to three parameters? Well, we can go one step further with <code>splice()</code> &mdash; in addition to removing elements, we can use that third parameter, which represents one or more elements, to <em>add</em> them as well. This can be incredibly useful for quickly switching out an element, or a set of elements, for another. For instance, let's say you're storing a color scheme for a set of DOM elements in an array, and want to dynamically change a color based on some action:
-<blockquote>function colorChange(arr, index, newColor) {<br>&nbsp;&nbsp;arr.splice(index, 1, newColor);<br>&nbsp;&nbsp;return arr;<br>}<br><br>let colorScheme = ['#878787', '#a08794', '#bb7e8c', '#c9b6be', '#d1becf'];<br><br>colorScheme = colorChange(colorScheme, 2, '#332327');<br>// we have removed '#bb7e8c' and added '#332327' in its place<br>// colorScheme now equals ['#878787', '#a08794', '#332327', '#c9b6be', '#d1becf']</blockquote>
+
+```
+function colorChange(arr, index, newColor) {
+  arr.splice(index, 1, newColor);
+  return arr;
+}
+
+let colorScheme = ['#878787', '#a08794', '#bb7e8c', '#c9b6be', '#d1becf'];
+
+colorScheme = colorChange(colorScheme, 2, '#332327');
+// we have removed '#bb7e8c' and added '#332327' in its place
+// colorScheme now equals ['#878787', '#a08794', '#332327', '#c9b6be', '#d1becf']
+```
+
 This function takes an array of hex values, an index at which to remove an element, and the new color to replace the removed element with. The return value is an array containing a newly modified color scheme! While this example is a bit oversimplified, we can see the value that utilizing <code>splice()</code> to its maximum potential can have.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/add-key-value-pairs-to-javascript-objects.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/add-key-value-pairs-to-javascript-objects.english.md
@@ -27,7 +27,7 @@ let userData = FCC_User.followers;
 This is called <dfn>dot notation</dfn>. Alternatively, we can also access the property with brackets, like so:
 
 ```js
-let userData = FCC_User['followers']
+let userData = FCC_User['followers'];
 // userData equals 572
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/add-key-value-pairs-to-javascript-objects.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/add-key-value-pairs-to-javascript-objects.english.md
@@ -8,7 +8,7 @@ challengeType: 1
 <section id='description'>
 At their most basic, objects are just collections of <dfn>key-value pairs</dfn>, or in other words, pieces of data mapped to unique identifiers that we call <dfn>properties</dfn> or <dfn>keys</dfn>. Let's take a look at a very simple example:
 
-```
+```js
 let FCC_User = {
   username: 'awesome_coder',
   followers: 572,
@@ -19,14 +19,14 @@ let FCC_User = {
 
 The above code defines an object called <code>FCC_User</code> that has four <dfn>properties</dfn>, each of which map to a specific value. If we wanted to know the number of <code>followers</code> <code>FCC_User</code> has, we can access that property by writing:
 
-```
+```js
 let userData = FCC_User.followers;
 // userData equals 572
 ```
 
 This is called <dfn>dot notation</dfn>. Alternatively, we can also access the property with brackets, like so:
 
-```
+```js
 let userData = FCC_User['followers']
 // userData equals 572
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/add-key-value-pairs-to-javascript-objects.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/add-key-value-pairs-to-javascript-objects.english.md
@@ -7,11 +7,30 @@ challengeType: 1
 ## Description
 <section id='description'>
 At their most basic, objects are just collections of <dfn>key-value pairs</dfn>, or in other words, pieces of data mapped to unique identifiers that we call <dfn>properties</dfn> or <dfn>keys</dfn>. Let's take a look at a very simple example:
-<blockquote>let FCC_User = {<br>&nbsp;&nbsp;username: 'awesome_coder',<br>&nbsp;&nbsp;followers: 572,<br>&nbsp;&nbsp;points: 1741,<br>&nbsp;&nbsp;completedProjects: 15<br>};</blockquote>
+
+```
+let FCC_User = {
+  username: 'awesome_coder',
+  followers: 572,
+  points: 1741,
+  completedProjects: 15
+};
+```
+
 The above code defines an object called <code>FCC_User</code> that has four <dfn>properties</dfn>, each of which map to a specific value. If we wanted to know the number of <code>followers</code> <code>FCC_User</code> has, we can access that property by writing:
-<blockquote>let userData = FCC_User.followers;<br>// userData equals 572</blockquote>
+
+```
+let userData = FCC_User.followers;
+// userData equals 572
+```
+
 This is called <dfn>dot notation</dfn>. Alternatively, we can also access the property with brackets, like so:
-<blockquote>let userData = FCC_User['followers']<br>// userData equals 572</blockquote>
+
+```
+let userData = FCC_User['followers']
+// userData equals 572
+```
+
 Notice that with <dfn>bracket notation</dfn>, we enclosed <code>followers</code> in quotes. This is because the brackets actually allow us to pass a variable in to be evaluated as a property name (hint: keep this in mind for later!). Had we passed <code>followers</code> in without the quotes, the JavaScript engine would have attempted to evaluate it as a variable, and a <code>ReferenceError: followers is not defined</code> would have been thrown.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/check-for-the-presence-of-an-element-with-indexof.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/check-for-the-presence-of-an-element-with-indexof.english.md
@@ -8,7 +8,15 @@ challengeType: 1
 <section id='description'>
 Since arrays can be changed, or <em>mutated</em>, at any time, there's no guarantee about where a particular piece of data will be on a given array, or if that element even still exists. Luckily, JavaScript provides us with another built-in method, <code>indexOf()</code>, that allows us to quickly and easily check for the presence of an element on an array. <code>indexOf()</code> takes an element as a parameter, and when called, it returns the position, or index, of that element, or <code>-1</code> if the element does not exist on the array.
 For example:
-<blockquote>let fruits = ['apples', 'pears', 'oranges', 'peaches', 'pears'];<br><br>fruits.indexOf('dates') // returns -1<br>fruits.indexOf('oranges') // returns 2<br>fruits.indexOf('pears') // returns 1, the first index at which the element exists</blockquote>
+
+```
+let fruits = ['apples', 'pears', 'oranges', 'peaches', 'pears'];
+
+fruits.indexOf('dates') // returns -1
+fruits.indexOf('oranges') // returns 2
+fruits.indexOf('pears') // returns 1, the first index at which the element exists
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/check-for-the-presence-of-an-element-with-indexof.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/check-for-the-presence-of-an-element-with-indexof.english.md
@@ -12,9 +12,9 @@ For example:
 ```js
 let fruits = ['apples', 'pears', 'oranges', 'peaches', 'pears'];
 
-fruits.indexOf('dates') // returns -1
-fruits.indexOf('oranges') // returns 2
-fruits.indexOf('pears') // returns 1, the first index at which the element exists
+fruits.indexOf('dates'); // returns -1
+fruits.indexOf('oranges'); // returns 2
+fruits.indexOf('pears'); // returns 1, the first index at which the element exists
 ```
 
 </section>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/check-for-the-presence-of-an-element-with-indexof.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/check-for-the-presence-of-an-element-with-indexof.english.md
@@ -9,7 +9,7 @@ challengeType: 1
 Since arrays can be changed, or <em>mutated</em>, at any time, there's no guarantee about where a particular piece of data will be on a given array, or if that element even still exists. Luckily, JavaScript provides us with another built-in method, <code>indexOf()</code>, that allows us to quickly and easily check for the presence of an element on an array. <code>indexOf()</code> takes an element as a parameter, and when called, it returns the position, or index, of that element, or <code>-1</code> if the element does not exist on the array.
 For example:
 
-```
+```js
 let fruits = ['apples', 'pears', 'oranges', 'peaches', 'pears'];
 
 fruits.indexOf('dates') // returns -1

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/check-if-an-object-has-a-property.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/check-if-an-object-has-a-property.english.md
@@ -8,7 +8,7 @@ challengeType: 1
 <section id='description'>
 Now we can add, modify, and remove keys from objects. But what if we just wanted to know if an object has a specific property? JavaScript provides us with two different ways to do this. One uses the <code>hasOwnProperty()</code> method and the other uses the <code>in</code> keyword. If we have an object <code>users</code> with a property of <code>Alan</code>, we could check for its presence in either of the following ways:
 
-```
+```js
 users.hasOwnProperty('Alan');
 'Alan' in users;
 // both return true

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/check-if-an-object-has-a-property.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/check-if-an-object-has-a-property.english.md
@@ -7,7 +7,13 @@ challengeType: 1
 ## Description
 <section id='description'>
 Now we can add, modify, and remove keys from objects. But what if we just wanted to know if an object has a specific property? JavaScript provides us with two different ways to do this. One uses the <code>hasOwnProperty()</code> method and the other uses the <code>in</code> keyword. If we have an object <code>users</code> with a property of <code>Alan</code>, we could check for its presence in either of the following ways:
-<blockquote>users.hasOwnProperty('Alan');<br>'Alan' in users;<br>// both return true</blockquote>
+
+```
+users.hasOwnProperty('Alan');
+'Alan' in users;
+// both return true
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/combine-arrays-with-the-spread-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/combine-arrays-with-the-spread-operator.english.md
@@ -7,7 +7,14 @@ challengeType: 1
 ## Description
 <section id='description'>
 Another huge advantage of the <dfn>spread</dfn> operator, is the ability to combine arrays, or to insert all the elements of one array into another, at any index. With more traditional syntaxes, we can concatenate arrays, but this only allows us to combine arrays at the end of one, and at the start of another. Spread syntax makes the following operation extremely simple:
-<blockquote>let thisArray = ['sage', 'rosemary', 'parsley', 'thyme'];<br><br>let thatArray = ['basil', 'cilantro', ...thisArray, 'coriander'];<br>// thatArray now equals ['basil', 'cilantro', 'sage', 'rosemary', 'parsley', 'thyme', 'coriander']</blockquote>
+
+```
+let thisArray = ['sage', 'rosemary', 'parsley', 'thyme'];
+
+let thatArray = ['basil', 'cilantro', ...thisArray, 'coriander'];
+// thatArray now equals ['basil', 'cilantro', 'sage', 'rosemary', 'parsley', 'thyme', 'coriander']
+```
+
 Using spread syntax, we have just achieved an operation that would have been more complex and more verbose had we used traditional methods.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/combine-arrays-with-the-spread-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/combine-arrays-with-the-spread-operator.english.md
@@ -8,7 +8,7 @@ challengeType: 1
 <section id='description'>
 Another huge advantage of the <dfn>spread</dfn> operator, is the ability to combine arrays, or to insert all the elements of one array into another, at any index. With more traditional syntaxes, we can concatenate arrays, but this only allows us to combine arrays at the end of one, and at the start of another. Spread syntax makes the following operation extremely simple:
 
-```
+```js
 let thisArray = ['sage', 'rosemary', 'parsley', 'thyme'];
 
 let thatArray = ['basil', 'cilantro', ...thisArray, 'coriander'];

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/copy-an-array-with-the-spread-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/copy-an-array-with-the-spread-operator.english.md
@@ -9,7 +9,7 @@ challengeType: 1
 While <code>slice()</code> allows us to be selective about what elements of an array to copy, among several other useful tasks, ES6's new <dfn>spread operator</dfn> allows us to easily copy <em>all</em> of an array's elements, in order, with a simple and highly readable syntax. The spread syntax simply looks like this: <code>...</code>
 In practice, we can use the spread operator to copy an array like so:
 
-```
+```js
 let thisArray = [true, true, undefined, false, null];
 let thatArray = [...thisArray];
 // thatArray equals [true, true, undefined, false, null]

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/copy-an-array-with-the-spread-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/copy-an-array-with-the-spread-operator.english.md
@@ -8,7 +8,14 @@ challengeType: 1
 <section id='description'>
 While <code>slice()</code> allows us to be selective about what elements of an array to copy, among several other useful tasks, ES6's new <dfn>spread operator</dfn> allows us to easily copy <em>all</em> of an array's elements, in order, with a simple and highly readable syntax. The spread syntax simply looks like this: <code>...</code>
 In practice, we can use the spread operator to copy an array like so:
-<blockquote>let thisArray = [true, true, undefined, false, null];<br>let thatArray = [...thisArray];<br>// thatArray equals [true, true, undefined, false, null]<br>// thisArray remains unchanged, and is identical to thatArray</blockquote>
+
+```
+let thisArray = [true, true, undefined, false, null];
+let thatArray = [...thisArray];
+// thatArray equals [true, true, undefined, false, null]
+// thisArray remains unchanged, and is identical to thatArray
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/copy-array-items-using-slice.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/copy-array-items-using-slice.english.md
@@ -14,7 +14,6 @@ let weatherConditions = ['rain', 'snow', 'sleet', 'hail', 'clear'];
 let todaysWeather = weatherConditions.slice(1, 3);
 // todaysWeather equals ['snow', 'sleet'];
 // weatherConditions still equals ['rain', 'snow', 'sleet', 'hail', 'clear']
-
 ```
 
 In effect, we have created a new array by extracting elements from an existing array.

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/copy-array-items-using-slice.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/copy-array-items-using-slice.english.md
@@ -7,7 +7,16 @@ challengeType: 1
 ## Description
 <section id='description'>
 The next method we will cover is <code>slice()</code>. <code>slice()</code>, rather than modifying an array, copies, or <em>extracts</em>, a given number of elements to a new array, leaving the array it is called upon untouched. <code>slice()</code> takes only 2 parameters &mdash; the first is the index at which to begin extraction, and the second is the index at which to stop extraction (extraction will occur up to, but not including the element at this index). Consider this:
-<blockquote>let weatherConditions = ['rain', 'snow', 'sleet', 'hail', 'clear'];<br><br>let todaysWeather = weatherConditions.slice(1, 3);<br>// todaysWeather equals ['snow', 'sleet'];<br>// weatherConditions still equals ['rain', 'snow', 'sleet', 'hail', 'clear']<br></blockquote>
+
+```
+let weatherConditions = ['rain', 'snow', 'sleet', 'hail', 'clear'];
+
+let todaysWeather = weatherConditions.slice(1, 3);
+// todaysWeather equals ['snow', 'sleet'];
+// weatherConditions still equals ['rain', 'snow', 'sleet', 'hail', 'clear']
+
+```
+
 In effect, we have created a new array by extracting elements from an existing array.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/copy-array-items-using-slice.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/copy-array-items-using-slice.english.md
@@ -8,7 +8,7 @@ challengeType: 1
 <section id='description'>
 The next method we will cover is <code>slice()</code>. <code>slice()</code>, rather than modifying an array, copies, or <em>extracts</em>, a given number of elements to a new array, leaving the array it is called upon untouched. <code>slice()</code> takes only 2 parameters &mdash; the first is the index at which to begin extraction, and the second is the index at which to stop extraction (extraction will occur up to, but not including the element at this index). Consider this:
 
-```
+```js
 let weatherConditions = ['rain', 'snow', 'sleet', 'hail', 'clear'];
 
 let todaysWeather = weatherConditions.slice(1, 3);

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/create-complex-multi-dimensional-arrays.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/create-complex-multi-dimensional-arrays.english.md
@@ -8,12 +8,43 @@ challengeType: 1
 <section id='description'>
 Awesome! You have just learned a ton about arrays! This has been a fairly high level overview, and there is plenty more to learn about working with arrays, much of which you will see in later sections. But before moving on to looking at <dfn>Objects</dfn>, lets take one more look, and see how arrays can become a bit more complex than what we have seen in previous challenges.
 One of the most powerful features when thinking of arrays as data structures, is that arrays can contain, or even be completely made up of other arrays. We have seen arrays that contain arrays in previous challenges, but fairly simple ones. However, arrays can contain an infinite depth of arrays that can contain other arrays, each with their own arbitrary levels of depth, and so on. In this way, an array can very quickly become very complex data structure, known as a <dfn>multi-dimensional</dfn>, or nested array. Consider the following example:
-<blockquote>let nestedArray = [ // top, or first level - the outer most array<br>&nbsp;&nbsp;['deep'], // an array within an array, 2 levels of depth<br>&nbsp;&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;['deeper'], ['deeper'] // 2 arrays nested 3 levels deep<br>&nbsp;&nbsp;],<br>&nbsp;&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;['deepest'], ['deepest'] // 2 arrays nested 4 levels deep<br>&nbsp;&nbsp;&nbsp;&nbsp;],<br>&nbsp;&nbsp;&nbsp;&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;['deepest-est?'] // an array nested 5 levels deep<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;]<br>];</blockquote>
+
+```
+let nestedArray = [ // top, or first level - the outer most array
+  ['deep'], // an array within an array, 2 levels of depth
+  [
+    ['deeper'], ['deeper'] // 2 arrays nested 3 levels deep
+  ],
+  [
+    [
+      ['deepest'], ['deepest'] // 2 arrays nested 4 levels deep
+    ],
+    [
+      [
+        ['deepest-est?'] // an array nested 5 levels deep
+      ]
+    ]
+  ]
+];
+```
+
 While this example may seem convoluted, this level of complexity is not unheard of, or even unusual, when dealing with large amounts of data.
 However, we can still very easily access the deepest levels of an array this complex with bracket notation:
-<blockquote>console.log(nestedArray[2][1][0][0][0]);<br>// logs: deepest-est?</blockquote>
+
+```
+console.log(nestedArray[2][1][0][0][0]);
+// logs: deepest-est?
+```
+
 And now that we know where that piece of data is, we can reset it if we need to:
-<blockquote>nestedArray[2][1][0][0][0] = 'deeper still';<br><br>console.log(nestedArray[2][1][0][0][0]);<br>// now logs: deeper still</blockquote>
+
+```
+nestedArray[2][1][0][0][0] = 'deeper still';
+
+console.log(nestedArray[2][1][0][0][0]);
+// now logs: deeper still
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/create-complex-multi-dimensional-arrays.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/create-complex-multi-dimensional-arrays.english.md
@@ -9,7 +9,7 @@ challengeType: 1
 Awesome! You have just learned a ton about arrays! This has been a fairly high level overview, and there is plenty more to learn about working with arrays, much of which you will see in later sections. But before moving on to looking at <dfn>Objects</dfn>, lets take one more look, and see how arrays can become a bit more complex than what we have seen in previous challenges.
 One of the most powerful features when thinking of arrays as data structures, is that arrays can contain, or even be completely made up of other arrays. We have seen arrays that contain arrays in previous challenges, but fairly simple ones. However, arrays can contain an infinite depth of arrays that can contain other arrays, each with their own arbitrary levels of depth, and so on. In this way, an array can very quickly become very complex data structure, known as a <dfn>multi-dimensional</dfn>, or nested array. Consider the following example:
 
-```
+```js
 let nestedArray = [ // top, or first level - the outer most array
   ['deep'], // an array within an array, 2 levels of depth
   [
@@ -31,14 +31,14 @@ let nestedArray = [ // top, or first level - the outer most array
 While this example may seem convoluted, this level of complexity is not unheard of, or even unusual, when dealing with large amounts of data.
 However, we can still very easily access the deepest levels of an array this complex with bracket notation:
 
-```
+```js
 console.log(nestedArray[2][1][0][0][0]);
 // logs: deepest-est?
 ```
 
 And now that we know where that piece of data is, we can reset it if we need to:
 
-```
+```js
 nestedArray[2][1][0][0][0] = 'deeper still';
 
 console.log(nestedArray[2][1][0][0][0]);

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/iterate-through-all-an-arrays-items-using-for-loops.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/iterate-through-all-an-arrays-items-using-for-loops.english.md
@@ -8,7 +8,22 @@ challengeType: 1
 <section id='description'>
 Sometimes when working with arrays, it is very handy to be able to iterate through each item to find one or more elements that we might need, or to manipulate an array based on which data items meet a certain set of criteria. JavaScript offers several built in methods that each iterate over arrays in slightly different ways to achieve different results (such as <code>every()</code>, <code>forEach()</code>, <code>map()</code>, etc.), however the technique which is most flexible and offers us the greatest amount of control is a simple <code>for</code> loop.
 Consider the following:
-<blockquote>function greaterThanTen(arr) {<br>&nbsp;&nbsp;let newArr = [];<br>&nbsp;&nbsp;for (let i = 0; i < arr.length; i++) {<br>&nbsp;&nbsp;&nbsp;&nbsp;if (arr[i] > 10) {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;newArr.push(arr[i]);<br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>&nbsp;&nbsp;}<br>&nbsp;&nbsp;return newArr;<br>}<br><br>greaterThanTen([2, 12, 8, 14, 80, 0, 1]);<br>// returns [12, 14, 80]</blockquote>
+
+```
+function greaterThanTen(arr) {
+  let newArr = [];
+  for (let i = 0; i < arr.length; i++) {
+    if (arr[i] > 10) {
+      newArr.push(arr[i]);
+    }
+  }
+  return newArr;
+}
+
+greaterThanTen([2, 12, 8, 14, 80, 0, 1]);
+// returns [12, 14, 80]
+```
+
 Using a <code>for</code> loop, this function iterates through and accesses each element of the array, and subjects it to a simple test that we have created. In this way, we have easily and programmatically determined which data items are greater than <code>10</code>, and returned a new array containing those items.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/iterate-through-all-an-arrays-items-using-for-loops.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/iterate-through-all-an-arrays-items-using-for-loops.english.md
@@ -9,7 +9,7 @@ challengeType: 1
 Sometimes when working with arrays, it is very handy to be able to iterate through each item to find one or more elements that we might need, or to manipulate an array based on which data items meet a certain set of criteria. JavaScript offers several built in methods that each iterate over arrays in slightly different ways to achieve different results (such as <code>every()</code>, <code>forEach()</code>, <code>map()</code>, etc.), however the technique which is most flexible and offers us the greatest amount of control is a simple <code>for</code> loop.
 Consider the following:
 
-```
+```js
 function greaterThanTen(arr) {
   let newArr = [];
   for (let i = 0; i < arr.length; i++) {

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/modify-an-object-nested-within-an-object.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/modify-an-object-nested-within-an-object.english.md
@@ -8,7 +8,7 @@ challengeType: 1
 <section id='description'>
 Now let's take a look at a slightly more complex object. Object properties can be nested to an arbitrary depth, and their values can be any type of data supported by JavaScript, including arrays and even other objects. Consider the following:
 
-```
+```js
 let nestedObject = {
   id: 28802695164,
   date: 'December 31, 2016',

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/modify-an-object-nested-within-an-object.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/modify-an-object-nested-within-an-object.english.md
@@ -7,7 +7,22 @@ challengeType: 1
 ## Description
 <section id='description'>
 Now let's take a look at a slightly more complex object. Object properties can be nested to an arbitrary depth, and their values can be any type of data supported by JavaScript, including arrays and even other objects. Consider the following:
-<blockquote>let nestedObject = {<br>&nbsp;&nbsp;id: 28802695164,<br>&nbsp;&nbsp;date: 'December 31, 2016',<br>&nbsp;&nbsp;data: {<br>&nbsp;&nbsp;&nbsp;&nbsp;totalUsers: 99,<br>&nbsp;&nbsp;&nbsp;&nbsp;online: 80,<br>&nbsp;&nbsp;&nbsp;&nbsp;onlineStatus: {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;active: 67,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;away: 13<br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>&nbsp;&nbsp;}<br>};</blockquote>
+
+```
+let nestedObject = {
+  id: 28802695164,
+  date: 'December 31, 2016',
+  data: {
+    totalUsers: 99,
+    online: 80,
+    onlineStatus: {
+      active: 67,
+      away: 13
+    }
+  }
+};
+```
+
 <code>nestedObject</code> has three unique keys: <code>id</code>, whose value is a number, <code>date</code> whose value is a string, and <code>data</code>, whose value is an object which has yet another object nested within it. While structures can quickly become complex, we can still use the same notations to access the information we need.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/remove-items-from-an-array-with-pop-and-shift.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/remove-items-from-an-array-with-pop-and-shift.english.md
@@ -9,7 +9,7 @@ challengeType: 1
 Both <code>push()</code> and <code>unshift()</code> have corresponding methods that are nearly functional opposites: <code>pop()</code> and <code>shift()</code>. As you may have guessed by now, instead of adding, <code>pop()</code> <em>removes</em> an element from the end of an array, while <code>shift()</code> removes an element from the beginning. The key difference between <code>pop()</code> and <code>shift()</code> and their cousins <code>push()</code> and <code>unshift()</code>, is that neither method takes parameters, and each only allows an array to be modified by a single element at a time.
 Let's take a look:
 
-```
+```js
 let greetings = ['whats up?', 'hello', 'see ya!'];
 
 greetings.pop();
@@ -21,7 +21,7 @@ greetings.shift();
 
 We can also return the value of the removed element with either method like this:
 
-```
+```js
 let popped = greetings.pop();
 // returns 'hello'
 // greetings now equals []

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/remove-items-from-an-array-with-pop-and-shift.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/remove-items-from-an-array-with-pop-and-shift.english.md
@@ -8,9 +8,25 @@ challengeType: 1
 <section id='description'>
 Both <code>push()</code> and <code>unshift()</code> have corresponding methods that are nearly functional opposites: <code>pop()</code> and <code>shift()</code>. As you may have guessed by now, instead of adding, <code>pop()</code> <em>removes</em> an element from the end of an array, while <code>shift()</code> removes an element from the beginning. The key difference between <code>pop()</code> and <code>shift()</code> and their cousins <code>push()</code> and <code>unshift()</code>, is that neither method takes parameters, and each only allows an array to be modified by a single element at a time.
 Let's take a look:
-<blockquote>let greetings = ['whats up?', 'hello', 'see ya!'];<br><br>greetings.pop();<br>// now equals ['whats up?', 'hello']<br><br>greetings.shift();<br>// now equals ['hello']</blockquote>
+
+```
+let greetings = ['whats up?', 'hello', 'see ya!'];
+
+greetings.pop();
+// now equals ['whats up?', 'hello']
+
+greetings.shift();
+// now equals ['hello']
+```
+
 We can also return the value of the removed element with either method like this:
-<blockquote>let popped = greetings.pop();<br>// returns 'hello'<br>// greetings now equals []</blockquote>
+
+```
+let popped = greetings.pop();
+// returns 'hello'
+// greetings now equals []
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/remove-items-using-splice.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/remove-items-using-splice.english.md
@@ -9,7 +9,7 @@ challengeType: 1
 Ok, so we've learned how to remove elements from the beginning and end of arrays using <code>shift()</code> and <code>pop()</code>, but what if we want to remove an element from somewhere in the middle? Or remove more than one element at once? Well, that's where <code>splice()</code> comes in. <code>splice()</code> allows us to do just that: <strong>remove any number of consecutive elements</strong> from anywhere in an array.
 <code>splice()</code> can take up to 3 parameters, but for now, we'll focus on just the first 2. The first two parameters of <code>splice()</code> are integers which represent indexes, or positions, of the array that <code>splice()</code> is being called upon. And remember, arrays are <em>zero-indexed</em>, so to indicate the first element of an array, we would use <code>0</code>. <code>splice()</code>'s first parameter represents the index on the array from which to begin removing elements, while the second parameter indicates the number of elements to delete. For example:
 
-```
+```js
 let array = ['today', 'was', 'not', 'so', 'great'];
 
 array.splice(2, 2);
@@ -19,7 +19,7 @@ array.splice(2, 2);
 
 <code>splice()</code> not only modifies the array it's being called on, but it also returns a new array containing the value of the removed elements:
 
-```
+```js
 let array = ['I', 'am', 'feeling', 'really', 'happy'];
 
 let newArray = array.splice(3, 2);

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/remove-items-using-splice.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/remove-items-using-splice.english.md
@@ -8,9 +8,24 @@ challengeType: 1
 <section id='description'>
 Ok, so we've learned how to remove elements from the beginning and end of arrays using <code>shift()</code> and <code>pop()</code>, but what if we want to remove an element from somewhere in the middle? Or remove more than one element at once? Well, that's where <code>splice()</code> comes in. <code>splice()</code> allows us to do just that: <strong>remove any number of consecutive elements</strong> from anywhere in an array.
 <code>splice()</code> can take up to 3 parameters, but for now, we'll focus on just the first 2. The first two parameters of <code>splice()</code> are integers which represent indexes, or positions, of the array that <code>splice()</code> is being called upon. And remember, arrays are <em>zero-indexed</em>, so to indicate the first element of an array, we would use <code>0</code>. <code>splice()</code>'s first parameter represents the index on the array from which to begin removing elements, while the second parameter indicates the number of elements to delete. For example:
-<blockquote>let array = ['today', 'was', 'not', 'so', 'great'];<br><br>array.splice(2, 2);<br>// remove 2 elements beginning with the 3rd element<br>// array now equals ['today', 'was', 'great']</blockquote>
+
+```
+let array = ['today', 'was', 'not', 'so', 'great'];
+
+array.splice(2, 2);
+// remove 2 elements beginning with the 3rd element
+// array now equals ['today', 'was', 'great']
+```
+
 <code>splice()</code> not only modifies the array it's being called on, but it also returns a new array containing the value of the removed elements:
-<blockquote>let array = ['I', 'am', 'feeling', 'really', 'happy'];<br><br>let newArray = array.splice(3, 2);<br>// newArray equals ['really', 'happy']</blockquote>
+
+```
+let array = ['I', 'am', 'feeling', 'really', 'happy'];
+
+let newArray = array.splice(3, 2);
+// newArray equals ['really', 'happy']
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/use-an-array-to-store-a-collection-of-data.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/use-an-array-to-store-a-collection-of-data.english.md
@@ -7,10 +7,41 @@ challengeType: 1
 ## Description
 <section id='description'>
 The below is an example of the simplest implementation of an array data structure. This is known as a <dfn>one-dimensional array</dfn>, meaning it only has one level, or that it does not have any other arrays nested within it. Notice it contains <dfn>booleans</dfn>, <dfn>strings</dfn>, and <dfn>numbers</dfn>, among other valid JavaScript data types:
-<blockquote>let simpleArray = ['one', 2, 'three’, true, false, undefined, null];<br>console.log(simpleArray.length);<br>// logs 7</blockquote>
+
+```
+let simpleArray = ['one', 2, 'three', true, false, undefined, null];
+console.log(simpleArray.length);
+// logs 7
+```
+
 All arrays have a length property, which as shown above, can be very easily accessed with the syntax <code>Array.length</code>.
 A more complex implementation of an array can be seen below. This is known as a <dfn>multi-dimensional array</dfn>, or an array that contains other arrays. Notice that this array also contains JavaScript <dfn>objects</dfn>, which we will examine very closely in our next section, but for now, all you need to know is that arrays are also capable of storing complex objects.
-<blockquote>let complexArray = [<br>&nbsp;&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;one: 1,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;two: 2<br>&nbsp;&nbsp;&nbsp;&nbsp;},<br>&nbsp;&nbsp;&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;three: 3,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;four: 4<br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>&nbsp;&nbsp;],<br>&nbsp;&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;a: "a",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;b: "b"<br>&nbsp;&nbsp;&nbsp;&nbsp;},<br>&nbsp;&nbsp;&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;c: "c",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;d: “d”<br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>&nbsp;&nbsp;]<br>];</blockquote>
+
+```
+let complexArray = [
+  [
+    {
+      one: 1,
+      two: 2
+    },
+    {
+      three: 3,
+      four: 4
+    }
+  ],
+  [
+    {
+      a: "a",
+      b: "b"
+    },
+    {
+      c: "c",
+      d: "d"
+    }
+  ]
+];
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/use-an-array-to-store-a-collection-of-data.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/use-an-array-to-store-a-collection-of-data.english.md
@@ -8,7 +8,7 @@ challengeType: 1
 <section id='description'>
 The below is an example of the simplest implementation of an array data structure. This is known as a <dfn>one-dimensional array</dfn>, meaning it only has one level, or that it does not have any other arrays nested within it. Notice it contains <dfn>booleans</dfn>, <dfn>strings</dfn>, and <dfn>numbers</dfn>, among other valid JavaScript data types:
 
-```
+```js
 let simpleArray = ['one', 2, 'three', true, false, undefined, null];
 console.log(simpleArray.length);
 // logs 7
@@ -17,7 +17,7 @@ console.log(simpleArray.length);
 All arrays have a length property, which as shown above, can be very easily accessed with the syntax <code>Array.length</code>.
 A more complex implementation of an array can be seen below. This is known as a <dfn>multi-dimensional array</dfn>, or an array that contains other arrays. Notice that this array also contains JavaScript <dfn>objects</dfn>, which we will examine very closely in our next section, but for now, all you need to know is that arrays are also capable of storing complex objects.
 
-```
+```js
 let complexArray = [
   [
     {

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/use-the-delete-keyword-to-remove-object-properties.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/use-the-delete-keyword-to-remove-object-properties.english.md
@@ -9,7 +9,11 @@ challengeType: 1
 Now you know what objects are and their basic features and advantages. In short, they are key-value stores which provide a flexible, intuitive way to structure data, <strong><em>and</em></strong>, they provide very fast lookup time. Throughout the rest of these challenges, we will describe several common operations you can perform on objects so you can become comfortable applying these useful data structures in your programs.
 In earlier challenges, we have both added to and modified an object's key-value pairs. Here we will see how we can <em>remove</em> a key-value pair from an object.
 Let's revisit our <code>foods</code> object example one last time. If we wanted to remove the <code>apples</code> key, we can remove it by using the <code>delete</code> keyword like this:
-<blockquote>delete foods.apples;</blockquote>
+
+```
+delete foods.apples;
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/use-the-delete-keyword-to-remove-object-properties.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/use-the-delete-keyword-to-remove-object-properties.english.md
@@ -10,7 +10,7 @@ Now you know what objects are and their basic features and advantages. In short,
 In earlier challenges, we have both added to and modified an object's key-value pairs. Here we will see how we can <em>remove</em> a key-value pair from an object.
 Let's revisit our <code>foods</code> object example one last time. If we wanted to remove the <code>apples</code> key, we can remove it by using the <code>delete</code> keyword like this:
 
-```
+```js
 delete foods.apples;
 ```
 


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Closes #35913

This PR is an attempt to allow markdown code sections in the `Description` and  `Instructions` sections of the curriculum challenge files.  Currently, you must use `&nbsp;` and `<br>` tags inside `blockquote` to make the code sections look indented and appear on new lines.   With the changes made the following CSS files, I was able to almost duplicate the look and feel of the current blockquote CSS.  I say "almost", because in Nite-mode, I can not figure out how to get the left white line on blockquote elements in the description and instructions sections.  Honestly, I am not even sure if the left white line should even show in the current blockquote as it does locally and in current production.

* client/src/components/layouts/night.css
* client/src/templates/Challenges/components/challenge-description.css

For this first attempt, I only converted the 18 challenges in the `Basic Data Structures` section which had `blockquote` elements in the description and instructions sections.  I used a custom script locally to make the conversions.  If we agree this PR looks good and is merge-able, then I can either run the script on the other challenges or create separate PRs for each section, to keep the number of files changed smaller and make them easier to review.