### PR TITLE
fix(client): use picture and source to display correct logo

### DIFF
--- a/client/src/components/Header/components/NavLogo.js
+++ b/client/src/components/Header/components/NavLogo.js
@@ -5,18 +5,15 @@ const fCCglyph = 'https://s3.amazonaws.com/freecodecamp/FFCFire.png';
 
 function NavLogo() {
   return (
-    <>
+    <picture>
+      <source media='(max-width: 734px)' srcSet={fCCglyph} />
+      <source media='(min-width: 735px)' srcSet={fCClogo} />
       <img
         alt='learn to code at freeCodeCamp logo'
-        className='nav-logo logo'
-        src={fCClogo}
-      />
-      <img
-        alt='learn to code at freeCodeCamp logo'
-        className='nav-logo logo-glyph'
+        className='nav-logo'
         src={fCCglyph}
       />
-    </>
+    </picture>
   );
 }
 

--- a/client/src/components/Header/components/NavLogo.js
+++ b/client/src/components/Header/components/NavLogo.js
@@ -1,27 +1,14 @@
 import React from 'react';
-import Media from 'react-responsive';
 
 const fCClogo = 'https://s3.amazonaws.com/freecodecamp/freecodecamp_logo.svg';
-const fCCglyph = 'https://s3.amazonaws.com/freecodecamp/FFCFire.png';
 
 function NavLogo() {
   return (
-    <>
-      <Media minWidth={735}>
-        <img
-          alt='learn to code at freeCodeCamp logo'
-          className='nav-logo logo'
-          src={fCClogo}
-        />
-      </Media>
-      <Media maxWidth={734}>
-        <img
-          alt='learn to code at freeCodeCamp logo'
-          className='nav-logo logo-glyph'
-          src={fCCglyph}
-        />
-      </Media>
-    </>
+    <img
+      alt='learn to code at freeCodeCamp logo'
+      className='nav-logo logo'
+      src={fCClogo}
+    />
   );
 }
 

--- a/client/src/components/Header/components/NavLogo.js
+++ b/client/src/components/Header/components/NavLogo.js
@@ -6,23 +6,22 @@ const fCCglyph = 'https://s3.amazonaws.com/freecodecamp/FFCFire.png';
 
 function NavLogo() {
   return (
-    <Media query='(min-width: 735px)'>
-      {matches =>
-        matches ? (
-          <img
-            alt='learn to code at freeCodeCamp logo'
-            className='nav-logo logo'
-            src={fCClogo}
-          />
-        ) : (
-          <img
-            alt='learn to code at freeCodeCamp logo'
-            className='nav-logo logo-glyph'
-            src={fCCglyph}
-          />
-        )
-      }
-    </Media>
+    <>
+      <Media minWidth={735}>
+        <img
+          alt='learn to code at freeCodeCamp logo'
+          className='nav-logo logo'
+          src={fCClogo}
+        />
+      </Media>
+      <Media maxWidth={734}>
+        <img
+          alt='learn to code at freeCodeCamp logo'
+          className='nav-logo logo-glyph'
+          src={fCCglyph}
+        />
+      </Media>
+    </>
   );
 }
 

--- a/client/src/components/Header/components/NavLogo.js
+++ b/client/src/components/Header/components/NavLogo.js
@@ -1,14 +1,22 @@
 import React from 'react';
 
 const fCClogo = 'https://s3.amazonaws.com/freecodecamp/freecodecamp_logo.svg';
+const fCCglyph = 'https://s3.amazonaws.com/freecodecamp/FFCFire.png';
 
 function NavLogo() {
   return (
-    <img
-      alt='learn to code at freeCodeCamp logo'
-      className='nav-logo logo'
-      src={fCClogo}
-    />
+    <>
+      <img
+        alt='learn to code at freeCodeCamp logo'
+        className='nav-logo logo'
+        src={fCClogo}
+      />
+      <img
+        alt='learn to code at freeCodeCamp logo'
+        className='nav-logo logo-glyph'
+        src={fCCglyph}
+      />
+    </>
   );
 }
 

--- a/client/src/components/Header/header.css
+++ b/client/src/components/Header/header.css
@@ -127,28 +127,11 @@ header {
 
 /* Navbar logo */
 
-.logo-glyph {
-  height: 30px;
-  width: auto;
-}
-
-.logo {
-  display: none;
-}
-
 .logoContainer {
   margin-right: 10px;
 }
 
 @media (min-width: 735px) {
-  .logo-glyph {
-    display: none;
-  }
-
-  .logo {
-    display: block;
-  }
-
   .logoContainer {
     margin-right: 50px;
     width: 25%;

--- a/client/src/components/Header/header.css
+++ b/client/src/components/Header/header.css
@@ -127,13 +127,9 @@ header {
 
 /* Navbar logo */
 
-.logo-glyph {
-  height: 30px;
-  width: auto;
-}
 
 .logo {
-  display: none;
+  display: block;
 }
 
 .logoContainer {
@@ -141,14 +137,6 @@ header {
 }
 
 @media (min-width: 735px) {
-  .logo-glyph {
-    display: none;
-  }
-
-  .logo {
-    display: block;
-  }
-
   .logoContainer {
     margin-right: 50px;
     width: 25%;

--- a/client/src/components/Header/header.css
+++ b/client/src/components/Header/header.css
@@ -127,9 +127,13 @@ header {
 
 /* Navbar logo */
 
+.logo-glyph {
+  height: 30px;
+  width: auto;
+}
 
 .logo {
-  display: block;
+  display: none;
 }
 
 .logoContainer {
@@ -137,6 +141,14 @@ header {
 }
 
 @media (min-width: 735px) {
+  .logo-glyph {
+    display: none;
+  }
+
+  .logo {
+    display: block;
+  }
+
   .logoContainer {
     margin-right: 50px;
     width: 25%;


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #35934

Possibly due to a bug with `react-responsive`, the second `img` in the conditional was being returned for wide viewports.  This meant nothing was displayed in that case, since `.logo-glyph` is hidden below 735px.