### PR TITLE
fix(curriculum): Improved the tests for Find the length of a String challenge

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/find-the-length-of-a-string.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/find-the-length-of-a-string.english.md
@@ -58,16 +58,6 @@ lastNameLength = lastName;
 
 </div>
 
-
-### After Test
-<div id='js-teardown'>
-
-```js
-if(typeof lastNameLength !== "undefined"){(function(){return lastNameLength;})();}
-```
-
-</div>
-
 </section>
 
 ## Solution

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/find-the-length-of-a-string.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/find-the-length-of-a-string.english.md
@@ -22,10 +22,12 @@ Use the <code>.length</code> property to count the number of characters in the <
 
 ```yml
 tests:
+  - text: 'You should not change the variable declarations in the <code>// Setup</code> section.'
+    testString: assert(code.match(/var lastNameLength = 0;/) && code.match(/var lastName = "Lovelace";/));   
   - text: <code>lastNameLength</code> should be equal to eight.
-    testString: assert((function(){if(typeof lastNameLength !== "undefined" && typeof lastNameLength === "number" && lastNameLength === 8){return true;}else{return false;}})(), '<code>lastNameLength</code> should be equal to eight.');
+    testString: assert(typeof lastNameLength !== 'undefined' && typeof lastNameLength === 'number' && lastNameLength === 8); 
   - text: 'You should be getting the length of <code>lastName</code> by using <code>.length</code> like this: <code>lastName.length</code>.'
-    testString: 'assert((function(){if(code.match(/\.length/gi) && code.match(/\.length/gi).length >= 2 && code.match(/var lastNameLength \= 0;/gi) && code.match(/var lastNameLength \= 0;/gi).length >= 1){return true;}else{return false;}})(), ''You should be getting the length of <code>lastName</code> by using <code>.length</code> like this: <code>lastName.length</code>.'');'
+    testString: assert(code.match(/=\s*lastName\.length/g) && !code.match(/lastName\s*=\s*8/));
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/find-the-length-of-a-string.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/find-the-length-of-a-string.english.md
@@ -25,7 +25,7 @@ tests:
   - text: 'You should not change the variable declarations in the <code>// Setup</code> section.'
     testString: assert(code.match(/var lastNameLength = 0;/) && code.match(/var lastName = "Lovelace";/));   
   - text: <code>lastNameLength</code> should be equal to eight.
-    testString: assert(typeof lastNameLength !== 'undefined' && typeof lastNameLength === 'number' && lastNameLength === 8); 
+    testString: assert(typeof lastNameLength !== 'undefined' && lastNameLength === 8); 
   - text: 'You should be getting the length of <code>lastName</code> by using <code>.length</code> like this: <code>lastName.length</code>.'
     testString: assert(code.match(/=\s*lastName\.length/g) && !code.match(/lastName\s*=\s*8/));
 


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

I have noticed a few campers get confused regarding the test messages for this challenge.  The reason for the confusion is if the user changes the original setup code, but the code would still technically result in the correct solution, the test message would fail but the reason given would not match the reason stated because the test combines the following checks but displays "You should be getting the length of lastName by using .length like this: lastName.length." if either fail.
1. Check that the original setup code is not changed
2. Check the the user gets the length of lastName by using .length like this: lastName.length

See https://www.freecodecamp.org/forum/t/help-w-js-challenge-suspected-bug/274365 for the full discussion.

This PR creates an additional test to make sure the user does not change the original setup code which the tests use.