### PR TITLE
fix(client): replace react-responsive with media queries for menu

### DIFF
--- a/client/gatsby-browser.js
+++ b/client/gatsby-browser.js
@@ -41,7 +41,7 @@ export const wrapPageElement = ({ element, props }) => {
   }
   if (/^\/guide(\/.*)*/.test(pathname)) {
     return (
-      <DefaultLayout disableMenuButtonBehavior={true} guide={true}>
+      <DefaultLayout disableMenuButtonBehavior={true}>
         <GuideLayout>{element}</GuideLayout>
       </DefaultLayout>
     );

--- a/client/gatsby-browser.js
+++ b/client/gatsby-browser.js
@@ -10,6 +10,7 @@ import {
   DefaultLayout,
   GuideLayout
 } from './src/components/layouts';
+import GuideNavMenu from './src/components/layouts/components/guide/NavMenu';
 
 const store = createStore();
 
@@ -41,7 +42,7 @@ export const wrapPageElement = ({ element, props }) => {
   }
   if (/^\/guide(\/.*)*/.test(pathname)) {
     return (
-      <DefaultLayout disableMenuButtonBehavior={true}>
+      <DefaultLayout navigationMenu={<GuideNavMenu />}>
         <GuideLayout>{element}</GuideLayout>
       </DefaultLayout>
     );

--- a/client/gatsby-browser.js
+++ b/client/gatsby-browser.js
@@ -11,7 +11,6 @@ import {
   GuideLayout
 } from './src/components/layouts';
 import GuideNavMenu from './src/components/layouts/components/guide/NavMenu';
-import DefaultNavMenu from './src/components/Header/components/NavMenu';
 
 const store = createStore();
 
@@ -33,10 +32,7 @@ export const wrapPageElement = ({ element, props }) => {
   } = props;
   if (pathname === '/') {
     return (
-      <DefaultLayout
-        disableSettings={true}
-        navigationMenu={<DefaultNavMenu disableSettings={true} />}
-      >
+      <DefaultLayout disableSettings={true} landingPage={true}>
         {element}
       </DefaultLayout>
     );
@@ -52,15 +48,9 @@ export const wrapPageElement = ({ element, props }) => {
     );
   }
   if (/^\/learn(\/.*)*/.test(pathname)) {
-    return (
-      <DefaultLayout navigationMenu={<DefaultNavMenu />} showFooter={false}>
-        {element}
-      </DefaultLayout>
-    );
+    return <DefaultLayout showFooter={false}>{element}</DefaultLayout>;
   }
-  return (
-    <DefaultLayout navigationMenu={<DefaultNavMenu />}>{element}</DefaultLayout>
-  );
+  return <DefaultLayout>{element}</DefaultLayout>;
 };
 
 wrapPageElement.propTypes = {

--- a/client/gatsby-browser.js
+++ b/client/gatsby-browser.js
@@ -11,6 +11,7 @@ import {
   GuideLayout
 } from './src/components/layouts';
 import GuideNavMenu from './src/components/layouts/components/guide/NavMenu';
+import DefaultNavMenu from './src/components/Header/components/NavMenu';
 
 const store = createStore();
 
@@ -32,7 +33,10 @@ export const wrapPageElement = ({ element, props }) => {
   } = props;
   if (pathname === '/') {
     return (
-      <DefaultLayout disableSettings={true} landingPage={true}>
+      <DefaultLayout
+        disableSettings={true}
+        navigationMenu={<DefaultNavMenu disableSettings={true} />}
+      >
         {element}
       </DefaultLayout>
     );
@@ -48,9 +52,15 @@ export const wrapPageElement = ({ element, props }) => {
     );
   }
   if (/^\/learn(\/.*)*/.test(pathname)) {
-    return <DefaultLayout showFooter={false}>{element}</DefaultLayout>;
+    return (
+      <DefaultLayout navigationMenu={<DefaultNavMenu />} showFooter={false}>
+        {element}
+      </DefaultLayout>
+    );
   }
-  return <DefaultLayout>{element}</DefaultLayout>;
+  return (
+    <DefaultLayout navigationMenu={<DefaultNavMenu />}>{element}</DefaultLayout>
+  );
 };
 
 wrapPageElement.propTypes = {

--- a/client/gatsby-browser.js
+++ b/client/gatsby-browser.js
@@ -41,7 +41,7 @@ export const wrapPageElement = ({ element, props }) => {
   }
   if (/^\/guide(\/.*)*/.test(pathname)) {
     return (
-      <DefaultLayout disableMenuButtonBehavior={true} mediaBreakpoint='991px'>
+      <DefaultLayout disableMenuButtonBehavior={true} guide={true}>
         <GuideLayout>{element}</GuideLayout>
       </DefaultLayout>
     );

--- a/client/gatsby-ssr.js
+++ b/client/gatsby-ssr.js
@@ -38,7 +38,7 @@ export const wrapPageElement = ({ element, props }) => {
   }
   if (/^\/guide(\/.*)*/.test(pathname)) {
     return (
-      <DefaultLayout onGuide={true}>
+      <DefaultLayout disableMenuButtonBehavior={true} guide={true}>
         <GuideLayout>{element}</GuideLayout>
       </DefaultLayout>
     );

--- a/client/gatsby-ssr.js
+++ b/client/gatsby-ssr.js
@@ -5,12 +5,9 @@ import { Provider } from 'react-redux';
 
 import headComponents from './src/head';
 import { createStore } from './src/redux/createStore';
+import { wrapPageElement } from './gatsby-browser';
 
-import {
-  CertificationLayout,
-  DefaultLayout,
-  GuideLayout
-} from './src/components/layouts';
+export { wrapPageElement };
 
 const store = createStore();
 
@@ -20,39 +17,6 @@ export const wrapRootElement = ({ element }) => {
 
 wrapRootElement.propTypes = {
   element: PropTypes.any
-};
-
-export const wrapPageElement = ({ element, props }) => {
-  const {
-    location: { pathname }
-  } = props;
-  if (pathname === '/') {
-    return (
-      <DefaultLayout disableSettings={true} landingPage={true}>
-        {element}
-      </DefaultLayout>
-    );
-  }
-  if (/^\/certification(\/.*)*/.test(pathname)) {
-    return <CertificationLayout>{element}</CertificationLayout>;
-  }
-  if (/^\/guide(\/.*)*/.test(pathname)) {
-    return (
-      <DefaultLayout disableMenuButtonBehavior={true} guide={true}>
-        <GuideLayout>{element}</GuideLayout>
-      </DefaultLayout>
-    );
-  }
-  if (/^\/learn(\/.*)*/.test(pathname)) {
-    return <DefaultLayout showFooter={false}>{element}</DefaultLayout>;
-  }
-  return <DefaultLayout>{element}</DefaultLayout>;
-};
-
-wrapPageElement.propTypes = {
-  element: PropTypes.any,
-  location: PropTypes.objectOf({ pathname: PropTypes.string }),
-  props: PropTypes.any
 };
 
 export const onRenderBody = ({ setHeadComponents, setPostBodyComponents }) => {

--- a/client/src/components/Header/components/MenuButton.js
+++ b/client/src/components/Header/components/MenuButton.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+function MenuButton(props) {
+  return (
+    <button
+      aria-expanded={props.displayMenu}
+      className={`menu-button${props.displayMenu ? ' menu-button-open' : ''}${
+        props.disableMenuButtonBehavior ? ' menu-button-guide' : ''
+      }`}
+      onClick={props.toggleDisplayMenu}
+      ref={props.menuButtonRef}
+    >
+      Menu
+    </button>
+  );
+}
+
+MenuButton.displayName = 'MenuButton';
+MenuButton.propTypes = {
+  disableMenuButtonBehavior: PropTypes.bool.isRequired,
+  displayMenu: PropTypes.bool.isRequired,
+  menuButtonRef: PropTypes.object.isRequired,
+  toggleDisplayMenu: PropTypes.func.isRequired
+};
+
+export default MenuButton;

--- a/client/src/components/Header/components/MenuButton.js
+++ b/client/src/components/Header/components/MenuButton.js
@@ -1,27 +1,29 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-function MenuButton(props) {
-  return (
-    <button
-      aria-expanded={props.displayMenu}
-      className={`menu-button${props.displayMenu ? ' menu-button-open' : ''}${
-        props.disableMenuButtonBehavior ? ' menu-button-guide' : ''
-      }`}
-      onClick={props.toggleDisplayMenu}
-      ref={props.menuButtonRef}
-    >
-      Menu
-    </button>
-  );
-}
+import './menuButton.css';
+
+const MenuButton = React.forwardRef((props, ref) => (
+  <button
+    aria-expanded={props.displayMenu}
+    className={
+      'menu-button' +
+      (props.displayMenu ? ' menu-button-open' : '') +
+      ' ' +
+      (props.className ? props.className : 'top-menu-button')
+    }
+    onClick={props.onClick}
+    ref={ref}
+  >
+    Menu
+  </button>
+));
 
 MenuButton.displayName = 'MenuButton';
 MenuButton.propTypes = {
-  disableMenuButtonBehavior: PropTypes.bool.isRequired,
+  className: PropTypes.string,
   displayMenu: PropTypes.bool.isRequired,
-  menuButtonRef: PropTypes.object.isRequired,
-  toggleDisplayMenu: PropTypes.func.isRequired
+  onClick: PropTypes.func.isRequired
 };
 
 export default MenuButton;

--- a/client/src/components/Header/components/MenuLinks.js
+++ b/client/src/components/Header/components/MenuLinks.js
@@ -4,14 +4,11 @@ import PropTypes from 'prop-types';
 import { Link } from '../../helpers';
 import UserState from '../components/UserState';
 
+import './menuLinks.css';
+
 function MenuLinks(props) {
   return (
-    <ul
-      className={`${props.displayMenu ? ' nav-expanded' : ''}${
-        props.disableMenuButtonBehavior ? ' nav-guide' : ''
-      }`}
-      id='top-right-nav'
-    >
+    <ul className={props.className} id='top-right-nav'>
       <li>
         <Link className='top-right-nav-link' to='/learn'>
           Learn
@@ -36,9 +33,8 @@ function MenuLinks(props) {
 
 MenuLinks.displayName = 'MenuLinks';
 MenuLinks.propTypes = {
-  disableMenuButtonBehavior: PropTypes.bool.isRequired,
-  disableSettings: PropTypes.bool.isRequired,
-  displayMenu: PropTypes.bool.isRequired
+  className: PropTypes.string,
+  disableSettings: PropTypes.bool
 };
 
 export default MenuLinks;

--- a/client/src/components/Header/components/MenuLinks.js
+++ b/client/src/components/Header/components/MenuLinks.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Link } from '../../helpers';
+import UserState from '../components/UserState';
+
+function MenuLinks(props) {
+  return (
+    <ul
+      className={`${props.displayMenu ? ' nav-expanded' : ''}${
+        props.disableMenuButtonBehavior ? ' nav-guide' : ''
+      }`}
+      id='top-right-nav'
+    >
+      <li>
+        <Link className='top-right-nav-link' to='/learn'>
+          Learn
+        </Link>
+      </li>
+      <li>
+        <Link className='top-right-nav-link' external={true} to='/forum'>
+          Forum
+        </Link>
+      </li>
+      <li>
+        <Link className='top-right-nav-link' external={true} to='/news'>
+          News
+        </Link>
+      </li>
+      <li>
+        <UserState disableSettings={props.disableSettings} />
+      </li>
+    </ul>
+  );
+}
+
+MenuLinks.displayName = 'MenuLinks';
+MenuLinks.propTypes = {
+  disableMenuButtonBehavior: PropTypes.bool.isRequired,
+  disableSettings: PropTypes.bool.isRequired,
+  displayMenu: PropTypes.bool.isRequired
+};
+
+export default MenuLinks;

--- a/client/src/components/Header/components/NavMenu.js
+++ b/client/src/components/Header/components/NavMenu.js
@@ -1,0 +1,65 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import MenuButton from './MenuButton';
+import MenuLinks from './MenuLinks';
+
+class NavigationMenu extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      displayMenu: false
+    };
+    this.menuButtonRef = React.createRef();
+
+    this.handleClickOutside = this.handleClickOutside.bind(this);
+    this.toggleDisplayMenu = this.toggleDisplayMenu.bind(this);
+  }
+
+  componentDidMount() {
+    document.addEventListener('click', this.handleClickOutside);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('click', this.handleClickOutside);
+  }
+
+  handleClickOutside(event) {
+    if (
+      this.state.displayMenu &&
+      this.menuButtonRef.current &&
+      !this.menuButtonRef.current.contains(event.target)
+    ) {
+      this.toggleDisplayMenu();
+    }
+  }
+
+  toggleDisplayMenu() {
+    this.setState(({ displayMenu }) => ({ displayMenu: !displayMenu }));
+  }
+
+  render() {
+    const { disableSettings } = this.props;
+    const { displayMenu } = this.state;
+    return (
+      <>
+        <MenuButton
+          displayMenu={displayMenu}
+          onClick={this.toggleDisplayMenu}
+          ref={this.menuButtonRef}
+        />
+        <MenuLinks
+          className={'top-nav' + (displayMenu ? ' top-nav-expanded' : '')}
+          disableSettings={disableSettings}
+        />
+      </>
+    );
+  }
+}
+
+NavigationMenu.displayName = 'NavigationMenu';
+NavigationMenu.propTypes = {
+  disableSettings: PropTypes.bool
+};
+
+export default NavigationMenu;

--- a/client/src/components/Header/components/menuButton.css
+++ b/client/src/components/Header/components/menuButton.css
@@ -1,0 +1,26 @@
+
+#top-nav .menu-button {
+  color: white;
+  background-color: transparent;
+  margin: 0 20px 0 12px;
+  padding: 2px 14px;
+  border: 1px solid #fff;
+  border-radius: 3px;
+}
+
+#top-nav .menu-button-open {
+  background: white;
+  color: #006400;
+}
+
+@media (min-width: 735px) {
+  #top-nav .top-menu-button {
+    display: none;
+  }
+}
+
+@media (max-width: 420px) {
+  #top-nav .menu-button {
+    margin: 0 10px 0 4px;
+  }
+}

--- a/client/src/components/Header/components/menuLinks.css
+++ b/client/src/components/Header/components/menuLinks.css
@@ -1,0 +1,62 @@
+#top-right-nav {
+  display: flex;
+  margin: 0;
+  list-style: none;
+  justify-content: space-between;
+  align-items: center;
+  background-color: #006400;
+}
+
+#top-right-nav li {
+  margin: 0;
+}
+
+.top-right-nav-link {
+  max-height: var(--header-height);
+  color: #fff;
+  font-size: 18px;
+  padding: 8px 15px;
+}
+
+.top-right-nav-link:hover,
+.top-right-nav-link:focus,
+.top-right-nav-link:active {
+  background-color: #fff;
+  color: #006400;
+  text-decoration: none;
+}
+
+.user-state-spinner {
+  height: var(--header-height);
+  padding: 0 12px;
+}
+
+.user-state-spinner > div {
+  animation-duration: 1.5s !important;
+}
+
+#top-right-nav .signup-btn,
+#top-right-nav .settings-link {
+  margin: 0 15px;
+}
+
+#top-right-nav .user-avatar {
+  max-height: calc(var(--header-height) - 4px);
+}
+
+@media (max-width: 734px) {
+  #top-right-nav {
+    position: absolute;
+    top: var(--header-height);
+    flex-direction: column;
+    width: 100vw;
+    height: min-content;
+    min-height: 160px;
+    padding: 10px 0;
+    display: none;
+  }
+
+  #top-right-nav.top-nav-expanded {
+    display: flex;
+  }
+}

--- a/client/src/components/Header/header.css
+++ b/client/src/components/Header/header.css
@@ -26,49 +26,6 @@ header {
   align-items: center;
 }
 
-#top-nav .nav-logo {
-  max-height: 25px;
-  min-width: 35px;
-  margin: 0 5px;
-}
-
-#top-right-nav {
-  display: flex;
-  margin: 0;
-  list-style: none;
-  justify-content: space-between;
-  align-items: center;
-  background-color: #006400;
-}
-
-#top-right-nav li {
-  margin: 0;
-}
-
-.top-right-nav-link {
-  max-height: var(--header-height);
-  color: #fff;
-  font-size: 18px;
-  padding: 8px 15px;
-}
-
-.top-right-nav-link:hover,
-.top-right-nav-link:focus,
-.top-right-nav-link:active {
-  background-color: #fff;
-  color: #006400;
-  text-decoration: none;
-}
-
-.user-state-spinner {
-  height: var(--header-height);
-  padding: 0 12px;
-}
-
-.user-state-spinner > div {
-  animation-duration: 1.5s !important;
-}
-
 /* Search bar */
 .fcc_searchBar {
   flex-grow: 1;
@@ -127,22 +84,14 @@ header {
 
 /* Navbar logo */
 
-.logoContainer {
-  margin-right: 10px;
+#top-nav .nav-logo {
+  max-height: 25px;
+  min-width: 35px;
+  margin: 0 5px;
 }
 
-@media (max-width: 992px) {
-  #top-nav .menu-button.menu-button-guide {
-    display: block;
-  }
-
-  #top-right-nav.nav-guide {
-    display: none;
-  }
-
-  #top-right-nav.nav-expanded.nav-guide {
-    display: none;
-  }
+.logoContainer {
+  margin-right: 10px;
 }
 
 @media (min-width: 735px) {
@@ -150,55 +99,11 @@ header {
     margin-right: 50px;
     width: 25%;
   }
-  #top-nav .menu-button {
-    display: none;
-  }
-  #top-right-nav {
-    display: flex;
-  }
-}
-
-#top-nav .menu-button {
-  color: white;
-  background-color: transparent;
-  margin: 0 20px 0 12px;
-  padding: 2px 14px;
-  border: 1px solid #fff;
-  border-radius: 3px;
-}
-
-#top-nav .menu-button-open {
-  background: white;
-  color: #006400;
-}
-
-#top-right-nav .signup-btn,
-#top-right-nav .settings-link {
-  margin: 0 15px;
-}
-
-#top-right-nav .user-avatar {
-  max-height: calc(var(--header-height) - 4px);
 }
 
 @media (max-width: 734px) {
   #top-nav {
     padding: 0;
-  }
-
-  #top-right-nav {
-    position: absolute;
-    top: var(--header-height);
-    flex-direction: column;
-    width: 100vw;
-    height: min-content;
-    min-height: 160px;
-    padding: 10px 0;
-    display: none;
-  }
-
-  #top-right-nav.nav-expanded {
-    display: flex;
   }
 
   #top-nav .nav-logo {
@@ -209,15 +114,5 @@ header {
 @media (max-width: 420px) {
   #top-nav .nav-logo {
     margin: 0 0 0 5px;
-  }
-
-  #top-nav .menu-button {
-    margin: 0 10px 0 4px;
-  }
-
-  .ais-Hits {
-    background-color: #fff;
-    left: 0.5em;
-    top: 2.4em;
   }
 }

--- a/client/src/components/Header/header.css
+++ b/client/src/components/Header/header.css
@@ -131,6 +131,12 @@ header {
   margin-right: 10px;
 }
 
+@media (max-width: 992px) {
+  #top-nav .menu-button.menu-button-guide {
+    display: block;
+  }
+}
+
 @media (min-width: 735px) {
   .logoContainer {
     margin-right: 50px;

--- a/client/src/components/Header/header.css
+++ b/client/src/components/Header/header.css
@@ -135,6 +135,14 @@ header {
   #top-nav .menu-button.menu-button-guide {
     display: block;
   }
+
+  #top-right-nav.nav-guide {
+    display: none;
+  }
+
+  #top-right-nav.nav-expanded.nav-guide {
+    display: none;
+  }
 }
 
 @media (min-width: 735px) {

--- a/client/src/components/Header/header.css
+++ b/client/src/components/Header/header.css
@@ -136,6 +136,12 @@ header {
     margin-right: 50px;
     width: 25%;
   }
+  #top-nav .menu-button {
+    display: none;
+  }
+  #top-right-nav {
+    display: flex;
+  }
 }
 
 #top-nav .menu-button {
@@ -174,6 +180,11 @@ header {
     height: min-content;
     min-height: 160px;
     padding: 10px 0;
+    display: none;
+  }
+
+  #top-right-nav.nav-expanded {
+    display: flex;
   }
 
   #top-nav .nav-logo {

--- a/client/src/components/Header/index.js
+++ b/client/src/components/Header/index.js
@@ -94,7 +94,6 @@ class Header extends Component {
             className={`menu-button${displayMenu ? ' menu-button-open' : ''}${
               disableMenuButtonBehavior ? ' menu-button-guide' : ''
             }`}
-            key='menu-button'
             onClick={toggleDisplayMenu}
             ref={this.menuButtonRef}
           >

--- a/client/src/components/Header/index.js
+++ b/client/src/components/Header/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import FCCSearch from 'react-freecodecamp-search';
 
+import NavigationMenu from './components/NavMenu';
 import NavLogo from './components/NavLogo';
 import { Link } from '../helpers';
 
@@ -21,7 +22,11 @@ function Header(props) {
           <NavLogo />
         </Link>
         {disableSettings ? null : <FCCSearch />}
-        {navigationMenu}
+        {navigationMenu ? (
+          navigationMenu
+        ) : (
+          <NavigationMenu disableSettings={disableSettings} />
+        )}
       </nav>
     </header>
   );

--- a/client/src/components/Header/index.js
+++ b/client/src/components/Header/index.js
@@ -86,36 +86,32 @@ class Header extends Component {
           >
             Menu
           </button>
-          {!disableMenuButtonBehavior && (
-            <ul
-              className={displayMenu ? 'nav-expanded' : ''}
-              id='top-right-nav'
-              key='top-right-nav'
-            >
-              <li>
-                <Link className='top-right-nav-link' to='/learn'>
-                  Learn
-                </Link>
-              </li>
-              <li>
-                <Link
-                  className='top-right-nav-link'
-                  external={true}
-                  to='/forum'
-                >
-                  Forum
-                </Link>
-              </li>
-              <li>
-                <Link className='top-right-nav-link' external={true} to='/news'>
-                  News
-                </Link>
-              </li>
-              <li>
-                <UserState disableSettings={disableSettings} />
-              </li>
-            </ul>
-          )}
+          <ul
+            className={`${displayMenu ? ' nav-expanded' : ''}${
+              disableMenuButtonBehavior ? ' nav-guide' : ''
+            }`}
+            id='top-right-nav'
+            key='top-right-nav'
+          >
+            <li>
+              <Link className='top-right-nav-link' to='/learn'>
+                Learn
+              </Link>
+            </li>
+            <li>
+              <Link className='top-right-nav-link' external={true} to='/forum'>
+                Forum
+              </Link>
+            </li>
+            <li>
+              <Link className='top-right-nav-link' external={true} to='/news'>
+                News
+              </Link>
+            </li>
+            <li>
+              <UserState disableSettings={disableSettings} />
+            </li>
+          </ul>
         </nav>
       </header>
     );

--- a/client/src/components/Header/index.js
+++ b/client/src/components/Header/index.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import FCCSearch from 'react-freecodecamp-search';
 
-import NavigationMenu from './components/NavMenu';
 import NavLogo from './components/NavLogo';
 import { Link } from '../helpers';
 
@@ -22,11 +21,7 @@ function Header(props) {
           <NavLogo />
         </Link>
         {disableSettings ? null : <FCCSearch />}
-        {navigationMenu ? (
-          navigationMenu
-        ) : (
-          <NavigationMenu disableSettings={disableSettings} />
-        )}
+        {navigationMenu}
       </nav>
     </header>
   );

--- a/client/src/components/Header/index.js
+++ b/client/src/components/Header/index.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { createSelector } from 'reselect';
-import Media from 'react-responsive';
 import FCCSearch from 'react-freecodecamp-search';
 
 import NavLogo from './components/NavLogo';
@@ -31,7 +30,6 @@ const propTypes = {
   disableMenuButtonBehavior: PropTypes.bool,
   disableSettings: PropTypes.bool,
   displayMenu: PropTypes.bool,
-  mediaBreakpoint: PropTypes.string.isRequired,
   toggleDisplayMenu: PropTypes.func.isRequired
 };
 
@@ -60,18 +58,11 @@ class Header extends Component {
     }
   };
 
-  handleMediaChange = matches => {
-    if (!matches && this.props.displayMenu) {
-      this.props.toggleDisplayMenu();
-    }
-  };
-
   render() {
     const {
       disableMenuButtonBehavior,
       disableSettings,
       displayMenu,
-      mediaBreakpoint,
       toggleDisplayMenu
     } = this.props;
     return (
@@ -81,53 +72,45 @@ class Header extends Component {
             <NavLogo />
           </Link>
           {disableSettings ? null : <FCCSearch />}
-          <Media maxWidth={mediaBreakpoint} onChange={this.handleMediaChange}>
-            {matches => [
-              matches && (
-                <button
-                  aria-expanded={displayMenu}
-                  className={
-                    'menu-button' + (displayMenu ? ' menu-button-open' : '')
-                  }
-                  key='menu-button'
-                  onClick={toggleDisplayMenu}
-                  ref={this.menuButtonRef}
+          <button
+            aria-expanded={displayMenu}
+            className={'menu-button' + (displayMenu ? ' menu-button-open' : '')}
+            key='menu-button'
+            onClick={toggleDisplayMenu}
+            ref={this.menuButtonRef}
+          >
+            Menu
+          </button>
+          {!disableMenuButtonBehavior && (
+            <ul
+              className={displayMenu ? 'nav-expanded' : ''}
+              id='top-right-nav'
+              key='top-right-nav'
+            >
+              <li>
+                <Link className='top-right-nav-link' to='/learn'>
+                  Learn
+                </Link>
+              </li>
+              <li>
+                <Link
+                  className='top-right-nav-link'
+                  external={true}
+                  to='/forum'
                 >
-                  Menu
-                </button>
-              ),
-              (!matches || (displayMenu && !disableMenuButtonBehavior)) && (
-                <ul id='top-right-nav' key='top-right-nav'>
-                  <li>
-                    <Link className='top-right-nav-link' to='/learn'>
-                      Learn
-                    </Link>
-                  </li>
-                  <li>
-                    <Link
-                      className='top-right-nav-link'
-                      external={true}
-                      to='/forum'
-                    >
-                      Forum
-                    </Link>
-                  </li>
-                  <li>
-                    <Link
-                      className='top-right-nav-link'
-                      external={true}
-                      to='/news'
-                    >
-                      News
-                    </Link>
-                  </li>
-                  <li>
-                    <UserState disableSettings={disableSettings} />
-                  </li>
-                </ul>
-              )
-            ]}
-          </Media>
+                  Forum
+                </Link>
+              </li>
+              <li>
+                <Link className='top-right-nav-link' external={true} to='/news'>
+                  News
+                </Link>
+              </li>
+              <li>
+                <UserState disableSettings={disableSettings} />
+              </li>
+            </ul>
+          )}
         </nav>
       </header>
     );
@@ -135,9 +118,6 @@ class Header extends Component {
 }
 
 Header.propTypes = propTypes;
-Header.defaultProps = {
-  mediaBreakpoint: '734px'
-};
 
 export default connect(
   mapStateToProps,

--- a/client/src/components/Header/index.js
+++ b/client/src/components/Header/index.js
@@ -30,7 +30,6 @@ const propTypes = {
   disableMenuButtonBehavior: PropTypes.bool,
   disableSettings: PropTypes.bool,
   displayMenu: PropTypes.bool,
-  guide: PropTypes.bool,
   toggleDisplayMenu: PropTypes.func.isRequired
 };
 
@@ -64,9 +63,11 @@ class Header extends Component {
       disableMenuButtonBehavior,
       disableSettings,
       displayMenu,
-      guide,
       toggleDisplayMenu
     } = this.props;
+    // On the guide, the menu button behaves differently from the rest of the
+    // site. disableMenuButtonBehavior=true is used for guide pages to make sure
+    // that only menu button clicks toggle between side nav and article.
     return (
       <header>
         <nav id='top-nav'>
@@ -77,7 +78,7 @@ class Header extends Component {
           <button
             aria-expanded={displayMenu}
             className={`menu-button${displayMenu ? ' menu-button-open' : ''}${
-              guide ? ' menu-button-guide' : ''
+              disableMenuButtonBehavior ? ' menu-button-guide' : ''
             }`}
             key='menu-button'
             onClick={toggleDisplayMenu}

--- a/client/src/components/Header/index.js
+++ b/client/src/components/Header/index.js
@@ -52,7 +52,6 @@ class Header extends Component {
 
   handleClickOutside = event => {
     if (
-      !this.props.disableMenuButtonBehavior &&
       this.state.displayTopMenu &&
       this.menuButtonRef.current &&
       !this.menuButtonRef.current.contains(event.target)

--- a/client/src/components/Header/index.js
+++ b/client/src/components/Header/index.js
@@ -30,6 +30,7 @@ const propTypes = {
   disableMenuButtonBehavior: PropTypes.bool,
   disableSettings: PropTypes.bool,
   displayMenu: PropTypes.bool,
+  guide: PropTypes.bool,
   toggleDisplayMenu: PropTypes.func.isRequired
 };
 
@@ -63,6 +64,7 @@ class Header extends Component {
       disableMenuButtonBehavior,
       disableSettings,
       displayMenu,
+      guide,
       toggleDisplayMenu
     } = this.props;
     return (
@@ -74,7 +76,9 @@ class Header extends Component {
           {disableSettings ? null : <FCCSearch />}
           <button
             aria-expanded={displayMenu}
-            className={'menu-button' + (displayMenu ? ' menu-button-open' : '')}
+            className={`menu-button${displayMenu ? ' menu-button-open' : ''}${
+              guide ? ' menu-button-guide' : ''
+            }`}
             key='menu-button'
             onClick={toggleDisplayMenu}
             ref={this.menuButtonRef}

--- a/client/src/components/Header/index.js
+++ b/client/src/components/Header/index.js
@@ -62,7 +62,7 @@ class Header extends Component {
   };
 
   toggleTopMenu = () => {
-    this.setState({ displayTopMenu: !this.state.displayTopMenu });
+    this.setState(state => ({ displayTopMenu: !state.displayTopMenu }));
   };
 
   render() {

--- a/client/src/components/Header/index.js
+++ b/client/src/components/Header/index.js
@@ -12,31 +12,34 @@ import { Link } from '../helpers';
 import './header.css';
 
 import {
-  toggleDisplayMenu,
+  toggleDisplayMenu as toggleGuideMenu,
   displayMenuSelector
 } from '../layouts/components/guide/redux';
 
 const mapStateToProps = createSelector(
   displayMenuSelector,
-  displayMenu => ({
-    displayMenu
+  displayGuideMenu => ({
+    displayGuideMenu
   })
 );
 
 const mapDispatchToProps = dispatch =>
-  bindActionCreators({ toggleDisplayMenu }, dispatch);
+  bindActionCreators({ toggleGuideMenu }, dispatch);
 
 const propTypes = {
   disableMenuButtonBehavior: PropTypes.bool,
   disableSettings: PropTypes.bool,
-  displayMenu: PropTypes.bool,
-  toggleDisplayMenu: PropTypes.func.isRequired
+  displayGuideMenu: PropTypes.bool,
+  toggleGuideMenu: PropTypes.func.isRequired
 };
 
 class Header extends Component {
   constructor(props) {
     super(props);
     this.menuButtonRef = React.createRef();
+    this.state = {
+      displayTopMenu: false
+    };
   }
 
   componentDidMount() {
@@ -50,24 +53,35 @@ class Header extends Component {
   handleClickOutside = event => {
     if (
       !this.props.disableMenuButtonBehavior &&
-      this.props.displayMenu &&
+      this.state.displayTopMenu &&
       this.menuButtonRef.current &&
       !this.menuButtonRef.current.contains(event.target)
     ) {
-      this.props.toggleDisplayMenu();
+      this.toggleTopMenu();
     }
+  };
+
+  toggleTopMenu = () => {
+    this.setState({ displayTopMenu: !this.state.displayTopMenu });
   };
 
   render() {
     const {
       disableMenuButtonBehavior,
       disableSettings,
-      displayMenu,
-      toggleDisplayMenu
+      displayGuideMenu,
+      toggleGuideMenu
     } = this.props;
     // On the guide, the menu button behaves differently from the rest of the
     // site. disableMenuButtonBehavior=true is used for guide pages to make sure
     // that only menu button clicks toggle between side nav and article.
+    const displayMenu = disableMenuButtonBehavior
+      ? displayGuideMenu
+      : this.state.displayTopMenu;
+
+    const toggleDisplayMenu = disableMenuButtonBehavior
+      ? toggleGuideMenu
+      : this.toggleTopMenu;
     return (
       <header>
         <nav id='top-nav'>

--- a/client/src/components/Header/index.js
+++ b/client/src/components/Header/index.js
@@ -5,8 +5,9 @@ import { bindActionCreators } from 'redux';
 import { createSelector } from 'reselect';
 import FCCSearch from 'react-freecodecamp-search';
 
+import MenuButton from './components/MenuButton';
+import MenuLinks from './components/MenuLinks';
 import NavLogo from './components/NavLogo';
-import UserState from './components/UserState';
 import { Link } from '../helpers';
 
 import './header.css';
@@ -88,41 +89,17 @@ class Header extends Component {
             <NavLogo />
           </Link>
           {disableSettings ? null : <FCCSearch />}
-          <button
-            aria-expanded={displayMenu}
-            className={`menu-button${displayMenu ? ' menu-button-open' : ''}${
-              disableMenuButtonBehavior ? ' menu-button-guide' : ''
-            }`}
-            onClick={toggleDisplayMenu}
-            ref={this.menuButtonRef}
-          >
-            Menu
-          </button>
-          <ul
-            className={`${displayMenu ? ' nav-expanded' : ''}${
-              disableMenuButtonBehavior ? ' nav-guide' : ''
-            }`}
-            id='top-right-nav'
-          >
-            <li>
-              <Link className='top-right-nav-link' to='/learn'>
-                Learn
-              </Link>
-            </li>
-            <li>
-              <Link className='top-right-nav-link' external={true} to='/forum'>
-                Forum
-              </Link>
-            </li>
-            <li>
-              <Link className='top-right-nav-link' external={true} to='/news'>
-                News
-              </Link>
-            </li>
-            <li>
-              <UserState disableSettings={disableSettings} />
-            </li>
-          </ul>
+          <MenuButton
+            disableMenuButtonBehavior={disableMenuButtonBehavior}
+            displayMenu={displayMenu}
+            menuButtonRef={this.menuButtonRef}
+            toggleDisplayMenu={toggleDisplayMenu}
+          />
+          <MenuLinks
+            disableMenuButtonBehavior={disableMenuButtonBehavior}
+            disableSettings={disableSettings}
+            displayMenu={displayMenu}
+          />
         </nav>
       </header>
     );

--- a/client/src/components/Header/index.js
+++ b/client/src/components/Header/index.js
@@ -105,7 +105,6 @@ class Header extends Component {
               disableMenuButtonBehavior ? ' nav-guide' : ''
             }`}
             id='top-right-nav'
-            key='top-right-nav'
           >
             <li>
               <Link className='top-right-nav-link' to='/learn'>

--- a/client/src/components/Header/index.js
+++ b/client/src/components/Header/index.js
@@ -1,114 +1,37 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
-import { createSelector } from 'reselect';
 import FCCSearch from 'react-freecodecamp-search';
 
-import MenuButton from './components/MenuButton';
-import MenuLinks from './components/MenuLinks';
+import NavigationMenu from './components/NavMenu';
 import NavLogo from './components/NavLogo';
 import { Link } from '../helpers';
 
 import './header.css';
 
-import {
-  toggleDisplayMenu as toggleGuideMenu,
-  displayMenuSelector
-} from '../layouts/components/guide/redux';
-
-const mapStateToProps = createSelector(
-  displayMenuSelector,
-  displayGuideMenu => ({
-    displayGuideMenu
-  })
-);
-
-const mapDispatchToProps = dispatch =>
-  bindActionCreators({ toggleGuideMenu }, dispatch);
-
 const propTypes = {
-  disableMenuButtonBehavior: PropTypes.bool,
   disableSettings: PropTypes.bool,
-  displayGuideMenu: PropTypes.bool,
-  toggleGuideMenu: PropTypes.func.isRequired
+  navigationMenu: PropTypes.element
 };
 
-class Header extends Component {
-  constructor(props) {
-    super(props);
-    this.menuButtonRef = React.createRef();
-    this.state = {
-      displayTopMenu: false
-    };
-  }
-
-  componentDidMount() {
-    document.addEventListener('click', this.handleClickOutside);
-  }
-
-  componentWillUnmount() {
-    document.removeEventListener('click', this.handleClickOutside);
-  }
-
-  handleClickOutside = event => {
-    if (
-      this.state.displayTopMenu &&
-      this.menuButtonRef.current &&
-      !this.menuButtonRef.current.contains(event.target)
-    ) {
-      this.toggleTopMenu();
-    }
-  };
-
-  toggleTopMenu = () => {
-    this.setState(state => ({ displayTopMenu: !state.displayTopMenu }));
-  };
-
-  render() {
-    const {
-      disableMenuButtonBehavior,
-      disableSettings,
-      displayGuideMenu,
-      toggleGuideMenu
-    } = this.props;
-    // On the guide, the menu button behaves differently from the rest of the
-    // site. disableMenuButtonBehavior=true is used for guide pages to make sure
-    // that only menu button clicks toggle between side nav and article.
-    const displayMenu = disableMenuButtonBehavior
-      ? displayGuideMenu
-      : this.state.displayTopMenu;
-
-    const toggleDisplayMenu = disableMenuButtonBehavior
-      ? toggleGuideMenu
-      : this.toggleTopMenu;
-    return (
-      <header>
-        <nav id='top-nav'>
-          <Link className='home-link' to='/'>
-            <NavLogo />
-          </Link>
-          {disableSettings ? null : <FCCSearch />}
-          <MenuButton
-            disableMenuButtonBehavior={disableMenuButtonBehavior}
-            displayMenu={displayMenu}
-            menuButtonRef={this.menuButtonRef}
-            toggleDisplayMenu={toggleDisplayMenu}
-          />
-          <MenuLinks
-            disableMenuButtonBehavior={disableMenuButtonBehavior}
-            disableSettings={disableSettings}
-            displayMenu={displayMenu}
-          />
-        </nav>
-      </header>
-    );
-  }
+function Header(props) {
+  const { disableSettings, navigationMenu } = props;
+  return (
+    <header>
+      <nav id='top-nav'>
+        <Link className='home-link' to='/'>
+          <NavLogo />
+        </Link>
+        {disableSettings ? null : <FCCSearch />}
+        {navigationMenu ? (
+          navigationMenu
+        ) : (
+          <NavigationMenu disableSettings={disableSettings} />
+        )}
+      </nav>
+    </header>
+  );
 }
 
 Header.propTypes = propTypes;
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Header);
+export default Header;

--- a/client/src/components/layouts/Default.js
+++ b/client/src/components/layouts/Default.js
@@ -56,7 +56,6 @@ const metaKeywords = [
 
 const propTypes = {
   children: PropTypes.node.isRequired,
-  disableSettings: PropTypes.bool,
   fetchUser: PropTypes.func.isRequired,
   flashMessages: PropTypes.arrayOf(
     PropTypes.shape({
@@ -68,6 +67,7 @@ const propTypes = {
   hasMessages: PropTypes.bool,
   isOnline: PropTypes.bool.isRequired,
   isSignedIn: PropTypes.bool,
+  landingPage: PropTypes.bool,
   navigationMenu: PropTypes.element.isRequired,
   onlineStatusChange: PropTypes.func.isRequired,
   removeFlashMessage: PropTypes.func.isRequired,
@@ -134,10 +134,10 @@ class DefaultLayout extends Component {
   render() {
     const {
       children,
-      disableSettings,
       hasMessages,
       flashMessages = [],
       removeFlashMessage,
+      landingPage,
       showFooter = true,
       navigationMenu,
       isOnline,
@@ -158,13 +158,8 @@ class DefaultLayout extends Component {
         >
           <style>{fontawesome.dom.css()}</style>
         </Helmet>
-        <Header
-          disableSettings={disableSettings}
-          navigationMenu={navigationMenu}
-        />
-        <div
-          className={`default-layout ${disableSettings ? 'landing-page' : ''}`}
-        >
+        <Header disableSettings={landingPage} navigationMenu={navigationMenu} />
+        <div className={`default-layout ${landingPage ? 'landing-page' : ''}`}>
           <OfflineWarning isOnline={isOnline} isSignedIn={isSignedIn} />
           {hasMessages ? (
             <Flash messages={flashMessages} onClose={removeFlashMessage} />

--- a/client/src/components/layouts/Default.js
+++ b/client/src/components/layouts/Default.js
@@ -56,7 +56,6 @@ const metaKeywords = [
 
 const propTypes = {
   children: PropTypes.node.isRequired,
-  disableMenuButtonBehavior: PropTypes.bool,
   disableSettings: PropTypes.bool,
   fetchUser: PropTypes.func.isRequired,
   flashMessages: PropTypes.arrayOf(
@@ -70,6 +69,7 @@ const propTypes = {
   isOnline: PropTypes.bool.isRequired,
   isSignedIn: PropTypes.bool,
   landingPage: PropTypes.bool,
+  navigationMenu: PropTypes.element,
   onlineStatusChange: PropTypes.func.isRequired,
   removeFlashMessage: PropTypes.func.isRequired,
   showFooter: PropTypes.bool
@@ -141,7 +141,7 @@ class DefaultLayout extends Component {
       removeFlashMessage,
       landingPage,
       showFooter = true,
-      disableMenuButtonBehavior,
+      navigationMenu,
       isOnline,
       isSignedIn
     } = this.props;
@@ -161,8 +161,8 @@ class DefaultLayout extends Component {
           <style>{fontawesome.dom.css()}</style>
         </Helmet>
         <Header
-          disableMenuButtonBehavior={disableMenuButtonBehavior}
           disableSettings={disableSettings}
+          navigationMenu={navigationMenu}
         />
         <div className={`default-layout ${landingPage ? 'landing-page' : ''}`}>
           <OfflineWarning isOnline={isOnline} isSignedIn={isSignedIn} />

--- a/client/src/components/layouts/Default.js
+++ b/client/src/components/layouts/Default.js
@@ -68,8 +68,7 @@ const propTypes = {
   hasMessages: PropTypes.bool,
   isOnline: PropTypes.bool.isRequired,
   isSignedIn: PropTypes.bool,
-  landingPage: PropTypes.bool,
-  navigationMenu: PropTypes.element,
+  navigationMenu: PropTypes.element.isRequired,
   onlineStatusChange: PropTypes.func.isRequired,
   removeFlashMessage: PropTypes.func.isRequired,
   showFooter: PropTypes.bool
@@ -139,7 +138,6 @@ class DefaultLayout extends Component {
       hasMessages,
       flashMessages = [],
       removeFlashMessage,
-      landingPage,
       showFooter = true,
       navigationMenu,
       isOnline,
@@ -164,7 +162,9 @@ class DefaultLayout extends Component {
           disableSettings={disableSettings}
           navigationMenu={navigationMenu}
         />
-        <div className={`default-layout ${landingPage ? 'landing-page' : ''}`}>
+        <div
+          className={`default-layout ${disableSettings ? 'landing-page' : ''}`}
+        >
           <OfflineWarning isOnline={isOnline} isSignedIn={isSignedIn} />
           {hasMessages ? (
             <Flash messages={flashMessages} onClose={removeFlashMessage} />

--- a/client/src/components/layouts/Default.js
+++ b/client/src/components/layouts/Default.js
@@ -66,11 +66,11 @@ const propTypes = {
       message: PropTypes.string
     })
   ),
+  guide: PropTypes.bool,
   hasMessages: PropTypes.bool,
   isOnline: PropTypes.bool.isRequired,
   isSignedIn: PropTypes.bool,
   landingPage: PropTypes.bool,
-  mediaBreakpoint: PropTypes.string,
   onlineStatusChange: PropTypes.func.isRequired,
   removeFlashMessage: PropTypes.func.isRequired,
   showFooter: PropTypes.bool
@@ -137,12 +137,12 @@ class DefaultLayout extends Component {
     const {
       children,
       disableSettings,
+      guide,
       hasMessages,
       flashMessages = [],
       removeFlashMessage,
       landingPage,
       showFooter = true,
-      mediaBreakpoint,
       disableMenuButtonBehavior,
       isOnline,
       isSignedIn
@@ -165,7 +165,7 @@ class DefaultLayout extends Component {
         <Header
           disableMenuButtonBehavior={disableMenuButtonBehavior}
           disableSettings={disableSettings}
-          mediaBreakpoint={mediaBreakpoint}
+          guide={guide}
         />
         <div className={`default-layout ${landingPage ? 'landing-page' : ''}`}>
           <OfflineWarning isOnline={isOnline} isSignedIn={isSignedIn} />

--- a/client/src/components/layouts/Default.js
+++ b/client/src/components/layouts/Default.js
@@ -66,7 +66,6 @@ const propTypes = {
       message: PropTypes.string
     })
   ),
-  guide: PropTypes.bool,
   hasMessages: PropTypes.bool,
   isOnline: PropTypes.bool.isRequired,
   isSignedIn: PropTypes.bool,
@@ -137,7 +136,6 @@ class DefaultLayout extends Component {
     const {
       children,
       disableSettings,
-      guide,
       hasMessages,
       flashMessages = [],
       removeFlashMessage,
@@ -165,7 +163,6 @@ class DefaultLayout extends Component {
         <Header
           disableMenuButtonBehavior={disableMenuButtonBehavior}
           disableSettings={disableSettings}
-          guide={guide}
         />
         <div className={`default-layout ${landingPage ? 'landing-page' : ''}`}>
           <OfflineWarning isOnline={isOnline} isSignedIn={isSignedIn} />

--- a/client/src/components/layouts/components/guide/NavMenu.js
+++ b/client/src/components/layouts/components/guide/NavMenu.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { createSelector } from 'reselect';
+
+import MenuButton from '../../../../components/Header/components/MenuButton';
+import MenuLinks from '../../../../components/Header/components/MenuLinks';
+
+import { toggleDisplayMenu, displayMenuSelector } from './redux';
+
+const mapStateToProps = createSelector(
+  displayMenuSelector,
+  displayMenu => ({
+    displayMenu
+  })
+);
+
+const mapDispatchToProps = dispatch =>
+  bindActionCreators({ toggleDisplayMenu }, dispatch);
+
+function GuideNavigationMenu(props) {
+  const { displayMenu, toggleDisplayMenu } = props;
+  return (
+    <>
+      <MenuButton
+        className={'guide-menu-button'}
+        displayMenu={displayMenu}
+        onClick={toggleDisplayMenu}
+      />
+      <MenuLinks className={'guide-top-nav'} />
+    </>
+  );
+}
+
+GuideNavigationMenu.displayName = 'GuideNavigationMenu';
+GuideNavigationMenu.propTypes = {
+  displayMenu: PropTypes.bool.isRequired,
+  toggleDisplayMenu: PropTypes.func.isRequired
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(GuideNavigationMenu);

--- a/client/src/components/layouts/guide.css
+++ b/client/src/components/layouts/guide.css
@@ -124,6 +124,15 @@
   .content {
     height: auto;
   }
+  #top-right-nav.guide-top-nav {
+    display: none;
+  }
+}
+
+@media (min-width: 993px) {
+  #top-nav .guide-menu-button {
+    display: none;
+  }
 }
 
 .content,


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This is related to #35931, it specifically fixes the problem during page load on small screens. Namely that the menu briefly displays as expanded when the page is reloaded:
![Menu](https://user-images.githubusercontent.com/15801806/56983584-43de2d80-6b84-11e9-9e5c-e92db29ea321.gif)

It touches the code for the menu button, removing the wrapping `Media` element, so it could affect that part of the issue.  However, that would need to be verified by someone with a Mac.

Finally, I was not sure if the nav menu should appear on the guide pages.  I opted not to display it at all, to be consistent with smaller screens and how it currently works in production.  That's part of why this is a draft PR.