### PR TITLE
fix(guide) add solutions to Factorialize a Number and Reverse and String challenges

### DIFF
--- a/guide/english/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/factorialize-a-number/index.md
+++ b/guide/english/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/factorialize-a-number/index.md
@@ -3,15 +3,18 @@ title: Factorialize a Number
 ---
 ![:triangular_flag_on_post:](https://forum.freecodecamp.com/images/emoji/emoji_one/triangular_flag_on_post.png?v=3 ":triangular_flag_on_post:") Remember to use <a>**`Read-Search-Ask`**</a> if you get stuck. Try to pair program ![:busts_in_silhouette:](https://forum.freecodecamp.com/images/emoji/emoji_one/busts_in_silhouette.png?v=3 ":busts_in_silhouette:") and write your own code ![:pencil:](https://forum.freecodecamp.com/images/emoji/emoji_one/pencil.png?v=3 ":pencil:")
 
-## ![:checkered_flag:](https://forum.freecodecamp.com/images/emoji/emoji_one/checkered_flag.png?v=3 ":checkered_flag:") Problem Explanation:
+## Hints for Solution
 
-Return the factorial of the provided integer. If the integer is represented with the letter n, a factorial is the product of all positive integers less than or equal to n.
+### ![:speech_balloon:](https://forum.freecodecamp.com/images/emoji/emoji_one/speech_balloon.png?v=3 ":speech_balloon:") Hint:
 
-Factorials are often represented with the shorthand notation n!
+You know your solution should return `1` when the number passed to the function is `0` or `1`.  Also, the final value returned will be the product of all the numbers between 1 and the number (inclusive).  If you initialize the value for the product to `1`, then think how you could start at the given number and continue decrementing this number until a specific value while multiplying the product by the number at each step.
 
-For example: `5! = 1 * 2 * 3 * 4 * 5 = 120`
+> _try to solve the problem now_
 
-## ![:speech_balloon:](https://forum.freecodecamp.com/images/emoji/emoji_one/speech_balloon.png?v=3 ":speech_balloon:") Hint: 1
+
+## Hints for a Recursive Solution
+
+### ![:speech_balloon:](https://forum.freecodecamp.com/images/emoji/emoji_one/speech_balloon.png?v=3 ":speech_balloon:") Hint: 1
 
 This one starts easily since `0! = 1`, so you can go ahead and simply `return 1` there.
 
@@ -21,7 +24,7 @@ This is also why **instead** of having _"finished"_, a function is always said t
 
 > _try to solve the problem now_
 
-## ![:speech_balloon:](https://forum.freecodecamp.com/images/emoji/emoji_one/speech_balloon.png?v=3 ":speech_balloon:") Hint: 2
+### ![:speech_balloon:](https://forum.freecodecamp.com/images/emoji/emoji_one/speech_balloon.png?v=3 ":speech_balloon:") Hint: 2
 
 **Understanding recursion**
 
@@ -29,13 +32,13 @@ Recursion refers to a function repeating (calling) itself. In this case we are b
 
 > _try to solve the problem now_
 
-## ![:speech_balloon:](https://forum.freecodecamp.com/images/emoji/emoji_one/speech_balloon.png?v=3 ":speech_balloon:") Hint: 3
+### ![:speech_balloon:](https://forum.freecodecamp.com/images/emoji/emoji_one/speech_balloon.png?v=3 ":speech_balloon:") Hint: 3
 
 **Understanding the flow**
 
 The first **returned** value can be visualized better if you think about those parenthesis operations you did in secondary school where you do the math inside every parenthesis from inside out, bracket and square bracket until you get a final result (a total). This time it's the same thing, look at the program flow:
 
-### During the first execution of the function:
+#### During the first execution of the function:
 
 [**num** = 5]
 
@@ -47,7 +50,7 @@ Is 5 _equal_ to 1 or 0? **No** ---> Oki doki, let's continue...
 
 What it returns can be viewed as `(5*(4*(3*(2*1))))` or just `5 * 4 * 3 * 2 * 1`, and the function will return the result of that operation: `120`. Now, let's check what the rest of the executions do:
 
-### During the rest of the executions:
+#### During the rest of the executions:
 
 **Second Execution**: _num_ = 5-1 = **4** -> is _num_ 0 or 1? No  
 
@@ -69,7 +72,7 @@ Got it? ![:wink:](https://forum.freecodecamp.com/images/emoji/emoji_one/wink.png
 
 > _try to solve the problem now_
 
-#### Relevant Links
+### Relevant Links
 
 *   <a href='https://www.youtube.com/watch?v=R8SjM4DKK80' target='_blank' rel='nofollow'>JS Functions</a>
 *   <a href='https://www.youtube.com/watch?v=k7-N8R0-KY4' target='_blank' rel='nofollow'>Recursion in JS</a>
@@ -80,18 +83,41 @@ Got it? ![:wink:](https://forum.freecodecamp.com/images/emoji/emoji_one/wink.png
 
 **Solution ahead!**
 
-## ![:beginner:](https://forum.freecodecamp.com/images/emoji/emoji_one/beginner.png?v=3 ":beginner:") Basic Code Solution:
+## ![:beginner:](https://forum.freecodecamp.com/images/emoji/emoji_one/beginner.png?v=3 ":beginner:") Basic Code Solution #1:
 
-    function factorialize(num) {
-      if (num === 0) { return 1; }
-      return num * factorialize(num-1);
-    }
+<details><summary>Click to see solution</summary>
 
-    factorialize(5);
+```js
+function factorialize(num) {
+  for (var product = 1; num > 0; num--) {
+    product *= num;
+  }
+  return product;
+}
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":rocket:") <a href='https://repl.it/CLjU/1' target='_blank' rel='nofollow'>Run Code</a>
+factorialize(5);
+```
 
-## Code Explanation:
+#### Code Explanation:
+
+- Since the return values for the function will always be greater than or equal to 1, `product` is initialized at one.  For the case where the number is `0`, the for loop condition will be false, but since `product` is initialized as `1`, it will have the correct value when the `return` statement is executed.  
+
+- For all numbers passed to the function which are greater than one, the simple `for` loop will decrement `num` by one each iteration and recalculate `product` down to the value `1`.
+</details><br>
+
+## ![:beginner:](https://forum.freecodecamp.com/images/emoji/emoji_one/beginner.png?v=3 ":beginner:") Basic Code Solution #2 (using Recursion):
+<details><summary>Click to see solution</summary>
+
+```js
+function factorialize(num) {
+  if (num === 0) { return 1; }
+    return num * factorialize(num-1);
+  }
+
+factorialize(5);
+```
+
+#### Code Explanation:
 
 Notice at the first line we have the terminal condition, i.e a condition to check the end of the recursion. If `num == 0`, then we return 1, i.e. effectively ending the recursion and informing the stack to propagate this value to the upper levels. If we do not have this condition, the recursion would go on until the stack space gets consumed, thereby resulting in a <a href='https://en.wikipedia.org/wiki/Stack_overflow' target='_blank' rel='nofollow'>Stack Overflow</a>.
 
@@ -100,22 +126,24 @@ Notice at the first line we have the terminal condition, i.e a condition to chec
 *   <a href='https://www.codecademy.com/en/courses/javascript-lesson-205/0/1' target='_blank' rel='nofollow'>Recursion</a>
 *   <a href='https://en.wikipedia.org/wiki/Factorial' target='_blank' rel='nofollow'>Factorialization</a>
 *   <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators' target='_blank' rel='nofollow'>Arithmetic Operators</a>
+</details><br>
 
 ## ![:sunflower:](https://forum.freecodecamp.com/images/emoji/emoji_one/sunflower.png?v=3 ":sunflower:") Intermediate Code Solution:
 
-    function factorialize(num, factorial = 1) {
-      if (num == 0) {
-        return factorial;
-      } else {
-        return factorialize(num - 1, factorial * num);
-      }
-    }
+<details><summary>Click to see solution</summary>
 
-    factorialize(5);
+```js
+function factorialize(num, factorial = 1) {
+  if (num == 0) {
+    return factorial;
+  } else {
+    return factorialize(num - 1, factorial * num);
+  }
+}
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":rocket:") <a href='https://repl.it/repls/CrimsonVerifiableDownload' target='_blank' rel='nofollow'>Run Code</a>
-
-## Code Explanation:
+factorialize(5);
+```
+#### Code Explanation:
 
 In this solution, we use <a href='https://stackoverflow.com/questions/33923/what-is-tail-recursion' target='_blank' rel='nofollow'>Tail Recursion</a> to optimize the the memory use.
 
@@ -128,6 +156,7 @@ In this solution, with each evaluation of the recursive call, the factorial is u
 ### Relevant Links
 
 *   <a href='https://www.geeksforgeeks.org/tail-recursion/' target='_blank' rel='nofollow'>Tail Recursion</a>
+</details><br>
 
 ## ![:clipboard:](https://forum.freecodecamp.com/images/emoji/emoji_one/clipboard.png?v=3 ":clipboard:") NOTES FOR CONTRIBUTIONS:
 

--- a/guide/english/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/reverse-a-string/index.md
+++ b/guide/english/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/reverse-a-string/index.md
@@ -3,15 +3,6 @@ title: Reverse a String
 ---
 ![:triangular_flag_on_post:](https://forum.freecodecamp.com/images/emoji/emoji_one/triangular_flag_on_post.png?v=3 ":triangular_flag_on_post:") Remember to use <a>**`Read-Search-Ask`**</a> if you get stuck. Try to pair program ![:busts_in_silhouette:](https://forum.freecodecamp.com/images/emoji/emoji_one/busts_in_silhouette.png?v=3 ":busts_in_silhouette:") and write your own code ![:pencil:](https://forum.freecodecamp.com/images/emoji/emoji_one/pencil.png?v=3 ":pencil:")
 
-### ![:checkered_flag:](https://forum.freecodecamp.com/images/emoji/emoji_one/checkered_flag.png?v=3 ":checkered_flag:") Problem Explanation:
-
-We need to take the string and reverse it, so if it originally reads 'hello', it will now read 'olleh'. We will need to split the string, and therefore we will be working with Arrays as well.
-
-#### Relevant Links
-
-*   <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split' target='_blank' rel='nofollow'>str.split()</a>
-*   <a href='https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/reverse' target='_blank' rel='nofollow'>arr.reverse()</a>
-*   <a href='https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/join' target='_blank' rel='nofollow'>arr.join()</a>
 
 ## ![:speech_balloon:](https://forum.freecodecamp.com/images/emoji/emoji_one/speech_balloon.png?v=3 ":speech_balloon:") Hint: 1
 
@@ -37,15 +28,17 @@ Do not forget to join the characters back together after you reverse them.
 
 **Solution ahead!**
 
-## ![:beginner:](https://forum.freecodecamp.com/images/emoji/emoji_one/beginner.png?v=3 ":beginner:") Basic Code Solution:
+## ![:beginner:](https://forum.freecodecamp.com/images/emoji/emoji_one/beginner.png?v=3 ":beginner:") Basic Code Solution #1:
 
-    function reverseString(str) {
-      return str.split('').reverse().join('');
-    }
+<details><summary>Click to see solution</summary>
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":rocket:") <a href='https://repl.it/CLjU' target='_blank' rel='nofollow'>Run Code</a>
+```js
+function reverseString(str) {
+  return str.split('').reverse().join('');
+}
+```
 
-### Code Explanation:
+#### Code Explanation:
 
 *   Our goal is to take the input, `str`, and return it in reverse. Our first step is to split the string by characters using `split('')`. Notice that we don't leave anything in between the single quotes, this tells the function to split the string by each character.
 
@@ -54,6 +47,37 @@ Do not forget to join the characters back together after you reverse them.
 *   Next we _chain_ the `reverse()` function, which takes our array of characters and reverses them.
 
 *   Finally, we _chain_ `join('')` to put our characters back together into a string. Notice once again that we left no spaces in the argument for join, this makes sure that the array of characters is joined back together by each character.
+
+### Relevant Links
+
+*   <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split' target='_blank' rel='nofollow'>str.split()</a>
+*   <a href='https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/reverse' target='_blank' rel='nofollow'>arr.reverse()</a>
+*   <a href='https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/join' target='_blank' rel='nofollow'>arr.join()</a>
+</details><br>
+
+
+## ![:beginner:](https://forum.freecodecamp.com/images/emoji/emoji_one/beginner.png?v=3 ":beginner:") Basic Code Solution #2:
+
+<details><summary>Click to see solution</summary>
+
+```js
+function reverseString(str) {
+  for (var reversedStr = '', i = str.length - 1; i >= 0; i--){
+    reversedStr += str[i];
+  }
+  return reversedStr;
+};
+```
+
+#### Code Explanation:
+
+* Starting at the last character of the string passed to the function, you build a new string `reversedStr` from `str`.
+
+* During each iteration of the `for` loop, `reversedStr` gets concatenated with itself and the current character.
+
+* Finally, you return the final value of `reversedStr`.
+
+</details><br>
 
 ## ![:clipboard:](https://forum.freecodecamp.com/images/emoji/emoji_one/clipboard.png?v=3 ":clipboard:") NOTES FOR CONTRIBUTIONS:
 


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

In [a forum thread](https://www.freecodecamp.org/forum/t/javascript-cirriculum-issue/275423) I had a discussion with a camper regarding the fact that the only solution for the `Factorialize a Number` challenge used recursion and recursion is never introduced into the curriculum, except for the solution in the Guide for the challenge.  I added an iterative solution which is very basic.

Also, in the same discussion, methods like `split` and `join` are first introduced in the Functional Programming section currently, yet the only Guide solution for the `Reverse a String` challenge involves using these.  I decided to add a basic solution which shows how to solve the challenge without these methods.

I also took the liberty of shuffling things around in the same Guide articles and hid the solutions along with removing external repl.it links and the challenge problem descriptions which is just duplicated from the challenge.
