### PR TITLE
fix: Change 404 wrapper for Gatsby build

### DIFF
--- a/client/src/components/FourOhFour/404.css
+++ b/client/src/components/FourOhFour/404.css
@@ -9,7 +9,7 @@
 }
 
 .notfound-page-wrapper img {
-  max-width: 380px;
+  width: 380px;
   margin-bottom: 1rem;
 }
 

--- a/client/src/components/FourOhFour/index.js
+++ b/client/src/components/FourOhFour/index.js
@@ -28,7 +28,7 @@ class NotFoundPage extends Component {
 
   render() {
     return (
-      <div className='notfound-page-wrapper'>
+      <main className='notfound-page-wrapper'>
         <Helmet title='Page Not Found | freeCodeCamp' />
         <img alt='404 Not Found' src={notFoundLogo} />
         <h1>NOT FOUND</h1>
@@ -52,7 +52,7 @@ class NotFoundPage extends Component {
         <Link className='btn-curriculum' to='/learn'>
           View the Curriculum
         </Link>
-      </div>
+      </main>
     );
   }
 }


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR swaps the `div` wrapping `NotFoundPage` for `main` so that Gatsby fully replaces the `Loader` with `NotFoundPage` when rendering a 404 page.

The problem in #35972 comes from how Gatsby builds the 404 page.  The html it generates is
```html
<div class="full-screen-wrapper">
  <div class="sk-fade-in sk-spinner line-scale-pulse-out">
     ...
  </div>
</div>
```
for all 404 pages, despite the fact that only potential user pages should use the spinner.  On potential user pages it then fully replaces all of this with the contents of the `NotFoundPage` component if the user is not found.  On any other page it does not replace `<div class="full-screen-wrapper">`, but instead puts `<img alt='404 Not Found' src=...` inside of it.  Presumably Gatsby is trying to do as little work as possible and does not replace the `div` as both `NotFoundPage` and `Loader` have one as their root element.

Changing the `div` to `main` is enough to make Gatsby replace the component entirely and solve the problem.  In addition, I changed the css because the 404 image was not being centered correctly in Chrome.

Closes #35972
