### PR TITLE
fix(curriculum): Convert blockquote elements to triple backtick syntax for JavaScript Algorithms and Data Structures

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/access-array-data-with-indexes.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/access-array-data-with-indexes.english.md
@@ -11,7 +11,13 @@ We can access the data inside arrays using <code>indexes</code>.
 Array indexes are written in the same bracket notation that strings use, except that instead of specifying a character, they are specifying an entry in the array. Like strings, arrays use <dfn>zero-based</dfn> indexing, so the first element in an array is element <code>0</code>.
 <br />
 <strong>Example</strong>
-<blockquote>var array = [50,60,70];<br>array[0]; // equals 50<br>var data = array[1];  // equals 60</blockquote>
+
+```js
+var array = [50,60,70];
+array[0]; // equals 50
+var data = array[1];  // equals 60
+```
+
 <strong>Note</strong><br>There shouldn't be any spaces between the array name and the square brackets, like <code>array [0]</code>. Although JavaScript is able to process this correctly, this may confuse other programmers reading your code.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/access-multi-dimensional-arrays-with-indexes.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/access-multi-dimensional-arrays-with-indexes.english.md
@@ -9,7 +9,19 @@ videoUrl: 'https://scrimba.com/c/ckND4Cq'
 <section id='description'>
 One way to think of a <dfn>multi-dimensional</dfn> array, is as an <em>array of arrays</em>. When you use brackets to access your array, the first set of brackets refers to the entries in the outer-most (the first level) array, and each additional pair of brackets refers to the next level of entries inside.
 <strong>Example</strong>
-<blockquote>var arr = [<br>&nbsp;&nbsp;[1,2,3],<br>&nbsp;&nbsp;[4,5,6],<br>&nbsp;&nbsp;[7,8,9],<br>&nbsp;&nbsp;[[10,11,12], 13, 14]<br>];<br>arr[3]; // equals [[10,11,12], 13, 14]<br>arr[3][0]; // equals [10,11,12]<br>arr[3][0][1]; // equals 11</blockquote>
+
+```js
+var arr = [
+  [1,2,3],
+  [4,5,6],
+  [7,8,9],
+  [[10,11,12], 13, 14]
+];
+arr[3]; // equals [[10,11,12], 13, 14]
+arr[3][0]; // equals [10,11,12]
+arr[3][0][1]; // equals 11
+```
+
 <strong>Note</strong><br>There shouldn't be any spaces between the array name and the square brackets, like <code>array [0][0]</code> and even this <code>array [0] [0]</code> is not allowed. Although JavaScript is able to process this correctly, this may confuse other programmers reading your code.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-arrays.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-arrays.english.md
@@ -9,7 +9,30 @@ videoUrl: 'https://scrimba.com/c/cLeGDtZ'
 <section id='description'>
 As we have seen in earlier examples, objects can contain both nested objects and nested arrays. Similar to accessing nested objects, Array bracket notation can be chained to access nested arrays.
 Here is an example of how to access a nested array:
-<blockquote>var ourPets = [<br>&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;animalType: "cat",<br>&nbsp;&nbsp;&nbsp;&nbsp;names: [<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"Meowzer",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"Fluffy",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"Kit-Cat"<br>&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;},<br>&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;animalType: "dog",<br>&nbsp;&nbsp;&nbsp;&nbsp;names: [<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"Spot",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"Bowser",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"Frankie"<br>&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;}<br>];<br>ourPets[0].names[1]; // "Fluffy"<br>ourPets[1].names[0]; // "Spot"</blockquote>
+
+```js
+var ourPets = [
+  {
+    animalType: "cat",
+    names: [
+      "Meowzer",
+      "Fluffy",
+      "Kit-Cat"
+    ]
+  },
+  {
+    animalType: "dog",
+    names: [
+      "Spot",
+      "Bowser",
+      "Frankie"
+    ]
+  }
+];
+ourPets[0].names[1]; // "Fluffy"
+ourPets[1].names[0]; // "Spot"
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-objects.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-objects.english.md
@@ -9,7 +9,24 @@ videoUrl: 'https://scrimba.com/c/cRnRnfa'
 <section id='description'>
 The sub-properties of objects can be accessed by chaining together the dot or bracket notation.
 Here is a nested object:
-<blockquote>var ourStorage = {<br>&nbsp;&nbsp;"desk": {<br>&nbsp;&nbsp;&nbsp;&nbsp;"drawer": "stapler"<br>&nbsp;&nbsp;},<br>&nbsp;&nbsp;"cabinet": {<br>&nbsp;&nbsp;&nbsp;&nbsp;"top drawer": { <br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"folder1": "a file",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"folder2": "secrets"<br>&nbsp;&nbsp;&nbsp;&nbsp;},<br>&nbsp;&nbsp;&nbsp;&nbsp;"bottom drawer": "soda"<br>&nbsp;&nbsp;}<br>};<br>ourStorage.cabinet["top drawer"].folder2;  // "secrets"<br>ourStorage.desk.drawer; // "stapler"</blockquote>
+
+```js
+var ourStorage = {
+  "desk": {
+    "drawer": "stapler"
+  },
+  "cabinet": {
+    "top drawer": { 
+      "folder1": "a file",
+      "folder2": "secrets"
+    },
+    "bottom drawer": "soda"
+  }
+};
+ourStorage.cabinet["top drawer"].folder2;  // "secrets"
+ourStorage.desk.drawer; // "stapler"
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-bracket-notation.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-bracket-notation.english.md
@@ -10,7 +10,18 @@ videoUrl: 'https://scrimba.com/c/cBvmEHP'
 The second way to access the properties of an object is bracket notation (<code>[]</code>). If the property of the object you are trying to access has a space in its name, you will need to use bracket notation.
 However, you can still use bracket notation on object properties without spaces.
 Here is a sample of using bracket notation to read an object's property:
-<blockquote>var myObj = {<br>&nbsp;&nbsp;"Space Name": "Kirk",<br>&nbsp;&nbsp;"More Space": "Spock",<br>&nbsp;&nbsp;"NoSpace": "USS Enterprise"<br>};<br>myObj["Space Name"]; // Kirk<br>myObj['More Space']; // Spock<br>myObj["NoSpace"];    // USS Enterprise</blockquote>
+
+```js
+var myObj = {
+  "Space Name": "Kirk",
+  "More Space": "Spock",
+  "NoSpace": "USS Enterprise"
+};
+myObj["Space Name"]; // Kirk
+myObj['More Space']; // Spock
+myObj["NoSpace"];    // USS Enterprise
+```
+
 Note that property names with spaces in them must be in quotes (single or double).
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-dot-notation.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-dot-notation.english.md
@@ -10,7 +10,16 @@ videoUrl: 'https://scrimba.com/c/cGryJs8'
 There are two ways to access the properties of an object: dot notation (<code>.</code>) and bracket notation (<code>[]</code>), similar to an array.
 Dot notation is what you use when you know the name of the property you're trying to access ahead of time.
 Here is a sample of using dot notation (<code>.</code>) to read an object's property:
-<blockquote>var myObj = {<br>&nbsp;&nbsp;prop1: "val1",<br>&nbsp;&nbsp;prop2: "val2"<br>};<br>var prop1val = myObj.prop1; // val1<br>var prop2val = myObj.prop2; // val2</blockquote>
+
+```js
+var myObj = {
+  prop1: "val1",
+  prop2: "val2"
+};
+var prop1val = myObj.prop1; // val1
+var prop2val = myObj.prop2; // val2
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-variables.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-variables.english.md
@@ -9,11 +9,30 @@ videoUrl: 'https://scrimba.com/c/cnQyKur'
 <section id='description'>
 Another use of bracket notation on objects is to access a property which is stored as the value of a variable. This can be very useful for iterating through an object's properties or when accessing a lookup table.
 Here is an example of using a variable to access a property:
-<blockquote>var dogs = {<br>&nbsp;&nbsp;Fido: "Mutt",
-  Hunter: "Doberman",
-  Snoopie: "Beagle"<br>};<br>var myDog = "Hunter";<br>var myBreed = dogs[myDog];<br>console.log(myBreed); // "Doberman"</blockquote>
+
+```js
+var dogs = {
+  Fido: "Mutt",  Hunter: "Doberman",  Snoopie: "Beagle"
+};
+var myDog = "Hunter";
+var myBreed = dogs[myDog];
+console.log(myBreed); // "Doberman"
+```
+
 Another way you can use this concept is when the property's name is collected dynamically during the program execution, as follows:
-<blockquote>var someObj = {<br>&nbsp;&nbsp;propName: "John"<br>};<br>function propPrefix(str) {<br>&nbsp;&nbsp;var s = "prop";<br>&nbsp;&nbsp;return s + str;<br>}<br>var someProp = propPrefix("Name"); // someProp now holds the value 'propName'<br>console.log(someObj[someProp]); // "John"</blockquote>
+
+```js
+var someObj = {
+  propName: "John"
+};
+function propPrefix(str) {
+  var s = "prop";
+  return s + str;
+}
+var someProp = propPrefix("Name"); // someProp now holds the value 'propName'
+console.log(someObj[someProp]); // "John"
+```
+
 Note that we do <em>not</em> use quotes around the variable name when using it to access the property because we are using the <em>value</em> of the variable, not the <em>name</em>.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/add-two-numbers-with-javascript.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/add-two-numbers-with-javascript.english.md
@@ -11,7 +11,11 @@ videoUrl: 'https://scrimba.com/c/cM2KBAG'
 Now let's try to add two numbers using JavaScript.
 JavaScript uses the <code>+</code> symbol as an addition operator when placed between two numbers.
 <strong>Example:</strong>
-<blockquote>myVar = 5 + 10; // assigned 15</blockquote>
+
+```js
+myVar = 5 + 10; // assigned 15
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/adding-a-default-option-in-switch-statements.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/adding-a-default-option-in-switch-statements.english.md
@@ -9,7 +9,22 @@ videoUrl: 'https://scrimba.com/c/c3JvVfg'
 <section id='description'>
 In a <code>switch</code> statement you may not be able to specify all possible values as <code>case</code> statements. Instead, you can add the <code>default</code> statement which will be executed if no matching <code>case</code> statements are found. Think of it like the final <code>else</code> statement in an <code>if/else</code> chain.
 A <code>default</code> statement should be the last case.
-<blockquote>switch (num) {<br>&nbsp;&nbsp;case value1:<br>&nbsp;&nbsp;&nbsp;&nbsp;statement1;<br>&nbsp;&nbsp;&nbsp;&nbsp;break;<br>&nbsp;&nbsp;case value2:<br>&nbsp;&nbsp;&nbsp;&nbsp;statement2;<br>&nbsp;&nbsp;&nbsp;&nbsp;break;<br>...<br>&nbsp;&nbsp;default:<br>&nbsp;&nbsp;&nbsp;&nbsp;defaultStatement;<br>&nbsp;&nbsp;&nbsp;&nbsp;break;<br>}</blockquote>
+
+```js
+switch (num) {
+  case value1:
+    statement1;
+    break;
+  case value2:
+    statement2;
+    break;
+...
+  default:
+    defaultStatement;
+    break;
+}
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/build-javascript-objects.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/build-javascript-objects.english.md
@@ -11,9 +11,26 @@ You may have heard the term <code>object</code> before.
 Objects are similar to <code>arrays</code>, except that instead of using indexes to access and modify their data, you access the data in objects through what are called <code>properties</code>.
 Objects are useful for storing data in a structured way, and can represent real world objects, like a cat.
 Here's a sample cat object:
-<blockquote>var cat = {<br>&nbsp;&nbsp;"name": "Whiskers",<br>&nbsp;&nbsp;"legs": 4,<br>&nbsp;&nbsp;"tails": 1,<br>&nbsp;&nbsp;"enemies": ["Water", "Dogs"]<br>};</blockquote>
+
+```js
+var cat = {
+  "name": "Whiskers",
+  "legs": 4,
+  "tails": 1,
+  "enemies": ["Water", "Dogs"]
+};
+```
+
 In this example, all the properties are stored as strings, such as - <code>"name"</code>, <code>"legs"</code>, and <code>"tails"</code>. However, you can also use numbers as properties. You can even omit the quotes for single-word string properties, as follows:
-<blockquote>var anotherObject = {<br>&nbsp;&nbsp;make: "Ford",<br>&nbsp;&nbsp;5: "five",<br>&nbsp;&nbsp;"model": "focus"<br>};</blockquote>
+
+```js
+var anotherObject = {
+  make: "Ford",
+  5: "five",
+  "model": "focus"
+};
+```
+
 However, if your object has any non-string properties, JavaScript will automatically typecast them as strings.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/chaining-if-else-statements.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/chaining-if-else-statements.english.md
@@ -8,7 +8,20 @@ videoUrl: 'https://scrimba.com/c/caeJgsw'
 ## Description
 <section id='description'>
 <code>if/else</code> statements can be chained together for complex logic. Here is <dfn>pseudocode</dfn> of multiple chained <code>if</code> / <code>else if</code> statements:
-<blockquote>if (<em>condition1</em>) {<br>&nbsp;&nbsp;<em>statement1</em><br>} else if (<em>condition2</em>) {<br>&nbsp;&nbsp;<em>statement2</em><br>} else if (<em>condition3</em>) {<br>&nbsp;&nbsp;<em>statement3</em><br>. . .<br>} else {<br>&nbsp;&nbsp;<em>statementN</em><br>}</blockquote>
+
+```js
+if (condition1) {
+  statement1
+} else if (condition2) {
+  statement2
+} else if (condition3) {
+  statement3
+. . .
+} else {
+  statementN
+}
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comment-your-javascript-code.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comment-your-javascript-code.english.md
@@ -10,9 +10,18 @@ videoUrl: 'https://scrimba.com/c/c7ynnTp'
 Comments are lines of code that JavaScript will intentionally ignore. Comments are a great way to leave notes to yourself and to other people who will later need to figure out what that code does.
 There are two ways to write comments in JavaScript:
 Using <code>//</code> will tell JavaScript to ignore the remainder of the text on the current line:
-<blockquote>// This is an in-line comment.</blockquote>
+
+```js
+// This is an in-line comment.
+```
+
 You can make a multi-line comment beginning with <code>/*</code> and ending with <code>*/</code>:
-<blockquote>/* This is a<br>multi-line comment */</blockquote>
+
+```js
+/* This is a
+multi-line comment */
+```
+
 <strong>Best Practice</strong><br>As you write code, you should regularly add comments to clarify the function of parts of your code. Good commenting can help communicate the intent of your code&mdash;both for others <em>and</em> for your future self.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-equality-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-equality-operator.english.md
@@ -9,10 +9,26 @@ videoUrl: 'https://scrimba.com/c/cKyVMAL'
 <section id='description'>
 There are many <dfn>Comparison Operators</dfn> in JavaScript. All of these operators return a boolean <code>true</code> or <code>false</code> value.
 The most basic operator is the equality operator <code>==</code>. The equality operator compares two values and returns <code>true</code> if they're equivalent or <code>false</code> if they are not. Note that equality is different from assignment (<code>=</code>), which assigns the value at the right of the operator to a variable in the left.
-<blockquote>function equalityTest(myVal) {<br>&nbsp;&nbsp;if (myVal == 10) {<br>&nbsp;&nbsp;&nbsp;&nbsp; return "Equal";<br>&nbsp;&nbsp;}<br>&nbsp;&nbsp;return "Not Equal";<br>}</blockquote>
+
+```js
+function equalityTest(myVal) {
+  if (myVal == 10) {
+     return "Equal";
+  }
+  return "Not Equal";
+}
+```
+
 If <code>myVal</code> is equal to <code>10</code>, the equality operator returns <code>true</code>, so the code in the curly braces will execute, and the function will return <code>"Equal"</code>. Otherwise, the function will return <code>"Not Equal"</code>.
 In order for JavaScript to compare two different <code>data types</code> (for example, <code>numbers</code> and <code>strings</code>), it must convert one type to another. This is known as "Type Coercion". Once it does, however, it can compare terms as follows:
-<blockquote>1   ==  1    // true<br>1   ==  2    // false<br>1   == '1'   // true<br>"3"  ==  3    // true</blockquote>
+
+```js
+1   ==  1    // true
+1   ==  2    // false
+1   == '1'   // true
+"3"  ==  3    // true
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-equality-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-equality-operator.english.md
@@ -23,10 +23,10 @@ If <code>myVal</code> is equal to <code>10</code>, the equality operator returns
 In order for JavaScript to compare two different <code>data types</code> (for example, <code>numbers</code> and <code>strings</code>), it must convert one type to another. This is known as "Type Coercion". Once it does, however, it can compare terms as follows:
 
 ```js
-1   ==  1    // true
-1   ==  2    // false
-1   == '1'   // true
-"3"  ==  3    // true
+1   ==  1   // true
+1   ==  2   // false
+1   == '1'  // true
+"3" ==  3   // true
 ```
 
 </section>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-equality-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-equality-operator.english.md
@@ -9,26 +9,10 @@ videoUrl: 'https://scrimba.com/c/cKyVMAL'
 <section id='description'>
 There are many <dfn>Comparison Operators</dfn> in JavaScript. All of these operators return a boolean <code>true</code> or <code>false</code> value.
 The most basic operator is the equality operator <code>==</code>. The equality operator compares two values and returns <code>true</code> if they're equivalent or <code>false</code> if they are not. Note that equality is different from assignment (<code>=</code>), which assigns the value at the right of the operator to a variable in the left.
-
-```js
-function equalityTest(myVal) {
-  if (myVal == 10) {
-     return "Equal";
-  }
-  return "Not Equal";
-}
-```
-
+<blockquote>function equalityTest(myVal) {<br>&nbsp;&nbsp;if (myVal == 10) {<br>&nbsp;&nbsp;&nbsp;&nbsp; return "Equal";<br>&nbsp;&nbsp;}<br>&nbsp;&nbsp;return "Not Equal";<br>}</blockquote>
 If <code>myVal</code> is equal to <code>10</code>, the equality operator returns <code>true</code>, so the code in the curly braces will execute, and the function will return <code>"Equal"</code>. Otherwise, the function will return <code>"Not Equal"</code>.
 In order for JavaScript to compare two different <code>data types</code> (for example, <code>numbers</code> and <code>strings</code>), it must convert one type to another. This is known as "Type Coercion". Once it does, however, it can compare terms as follows:
-
-```js
-1   ==  1    // true
-1   ==  2    // false
-1   == '1'   // true
-"3"  ==  3    // true
-```
-
+<blockquote>1   ==  1    // true<br>1   ==  2    // false<br>1   == '1'   // true<br>"3"  ==  3    // true</blockquote>
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-greater-than-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-greater-than-operator.english.md
@@ -10,7 +10,14 @@ videoUrl: 'https://scrimba.com/c/cp6GbH4'
 The greater than operator (<code>&gt;</code>) compares the values of two numbers. If the number to the left is greater than the number to the right, it returns <code>true</code>. Otherwise, it returns <code>false</code>.
 Like the equality operator, greater than operator will convert data types of values while comparing.
 <strong>Examples</strong>
-<blockquote>5 > 3   // true<br>7 > '3' // true<br>2 > 3   // false<br>'1' > 9  // false</blockquote>
+
+```js
+5 > 3   // true
+7 > '3' // true
+2 > 3   // false
+'1' > 9  // false
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-greater-than-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-greater-than-operator.english.md
@@ -12,10 +12,10 @@ Like the equality operator, greater than operator will convert data types of val
 <strong>Examples</strong>
 
 ```js
-5 > 3   // true
-7 > '3' // true
-2 > 3   // false
-'1' > 9  // false
+5   >  3   // true
+7   > '3'  // true
+2   >  3   // false
+'1' >  9   // false
 ```
 
 </section>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-greater-than-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-greater-than-operator.english.md
@@ -10,14 +10,7 @@ videoUrl: 'https://scrimba.com/c/cp6GbH4'
 The greater than operator (<code>&gt;</code>) compares the values of two numbers. If the number to the left is greater than the number to the right, it returns <code>true</code>. Otherwise, it returns <code>false</code>.
 Like the equality operator, greater than operator will convert data types of values while comparing.
 <strong>Examples</strong>
-
-```js
-5 > 3   // true
- 7 > '3' // true
- 2 > 3   // false
-'1' > 9  // false
-```
-
+<blockquote>5 > 3   // true<br>7 > '3' // true<br>2 > 3   // false<br>'1' > 9  // false</blockquote>
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-greater-than-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-greater-than-operator.english.md
@@ -10,7 +10,14 @@ videoUrl: 'https://scrimba.com/c/cp6GbH4'
 The greater than operator (<code>&gt;</code>) compares the values of two numbers. If the number to the left is greater than the number to the right, it returns <code>true</code>. Otherwise, it returns <code>false</code>.
 Like the equality operator, greater than operator will convert data types of values while comparing.
 <strong>Examples</strong>
-<blockquote> 5 > 3   // true<br> 7 > '3' // true<br> 2 > 3   // false<br>'1' > 9  // false</blockquote>
+
+```js
+5 > 3   // true
+ 7 > '3' // true
+ 2 > 3   // false
+'1' > 9  // false
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-greater-than-or-equal-to-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-greater-than-or-equal-to-operator.english.md
@@ -10,7 +10,14 @@ videoUrl: 'https://scrimba.com/c/c6KBqtV'
 The <code>greater than or equal to</code> operator (<code>&gt;=</code>) compares the values of two numbers. If the number to the left is greater than or equal to the number to the right, it returns <code>true</code>. Otherwise, it returns <code>false</code>.
 Like the equality operator, <code>greater than or equal to</code> operator will convert data types while comparing.
 <strong>Examples</strong>
-<blockquote> 6  >=  6  // true<br> 7  >= '3' // true<br> 2  >=  3  // false<br>'7' >=  9  // false</blockquote>
+
+```js
+6  >=  6  // true
+ 7  >= '3' // true
+ 2  >=  3  // false
+'7' >=  9  // false
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-greater-than-or-equal-to-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-greater-than-or-equal-to-operator.english.md
@@ -10,7 +10,14 @@ videoUrl: 'https://scrimba.com/c/c6KBqtV'
 The <code>greater than or equal to</code> operator (<code>&gt;=</code>) compares the values of two numbers. If the number to the left is greater than or equal to the number to the right, it returns <code>true</code>. Otherwise, it returns <code>false</code>.
 Like the equality operator, <code>greater than or equal to</code> operator will convert data types while comparing.
 <strong>Examples</strong>
-<blockquote>6  >=  6  // true<br>7  >= '3' // true<br>2  >=  3  // false<br>'7' >=  9  // false</blockquote>
+
+```js
+6  >=  6  // true
+7  >= '3' // true
+2  >=  3  // false
+'7' >=  9  // false
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-greater-than-or-equal-to-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-greater-than-or-equal-to-operator.english.md
@@ -12,10 +12,10 @@ Like the equality operator, <code>greater than or equal to</code> operator will 
 <strong>Examples</strong>
 
 ```js
-6  >=  6  // true
-7  >= '3' // true
-2  >=  3  // false
-'7' >=  9  // false
+6   >=  6   // true
+7   >= '3'  // true
+2   >=  3   // false
+'7' >=  9   // false
 ```
 
 </section>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-greater-than-or-equal-to-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-greater-than-or-equal-to-operator.english.md
@@ -10,14 +10,7 @@ videoUrl: 'https://scrimba.com/c/c6KBqtV'
 The <code>greater than or equal to</code> operator (<code>&gt;=</code>) compares the values of two numbers. If the number to the left is greater than or equal to the number to the right, it returns <code>true</code>. Otherwise, it returns <code>false</code>.
 Like the equality operator, <code>greater than or equal to</code> operator will convert data types while comparing.
 <strong>Examples</strong>
-
-```js
-6  >=  6  // true
- 7  >= '3' // true
- 2  >=  3  // false
-'7' >=  9  // false
-```
-
+<blockquote>6  >=  6  // true<br>7  >= '3' // true<br>2  >=  3  // false<br>'7' >=  9  // false</blockquote>
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-inequality-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-inequality-operator.english.md
@@ -9,7 +9,15 @@ videoUrl: 'https://scrimba.com/c/cdBm9Sr'
 <section id='description'>
 The inequality operator (<code>!=</code>) is the opposite of the equality operator. It means "Not Equal" and returns <code>false</code> where equality would return <code>true</code> and <em>vice versa</em>. Like the equality operator, the inequality operator will convert data types of values while comparing.
 <strong>Examples</strong>
-<blockquote>1 != 2      // true<br>1 != "1"    // false<br>1 != '1'    // false<br>1 != true   // false<br>0 != false  // false</blockquote>
+
+```js
+1 != 2      // true
+1 != "1"    // false
+1 != '1'    // false
+1 != true   // false
+0 != false  // false
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-inequality-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-inequality-operator.english.md
@@ -9,15 +9,7 @@ videoUrl: 'https://scrimba.com/c/cdBm9Sr'
 <section id='description'>
 The inequality operator (<code>!=</code>) is the opposite of the equality operator. It means "Not Equal" and returns <code>false</code> where equality would return <code>true</code> and <em>vice versa</em>. Like the equality operator, the inequality operator will convert data types of values while comparing.
 <strong>Examples</strong>
-
-```js
-1 != 2      // true
-1 != "1"    // false
-1 != '1'    // false
-1 != true   // false
-0 != false  // false
-```
-
+<blockquote>1 != 2      // true<br>1 != "1"    // false<br>1 != '1'    // false<br>1 != true   // false<br>0 != false  // false</blockquote>
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-inequality-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-inequality-operator.english.md
@@ -11,7 +11,7 @@ The inequality operator (<code>!=</code>) is the opposite of the equality operat
 <strong>Examples</strong>
 
 ```js
-1 != 2      // true
+1 !=  2     // true
 1 != "1"    // false
 1 != '1'    // false
 1 != true   // false

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-less-than-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-less-than-operator.english.md
@@ -11,10 +11,10 @@ The <dfn>less than</dfn> operator (<code>&lt;</code>) compares the values of two
 <strong>Examples</strong>
 
 ```js
-2 < 5  // true
+2   < 5  // true
 '3' < 7  // true
-5 < 5  // false
-3 < 2  // false
+5   < 5  // false
+3   < 2  // false
 '8' < 4  // false
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-less-than-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-less-than-operator.english.md
@@ -9,7 +9,15 @@ videoUrl: 'https://scrimba.com/c/cNVRWtB'
 <section id='description'>
 The <dfn>less than</dfn> operator (<code>&lt;</code>) compares the values of two numbers. If the number to the left is less than the number to the right, it returns <code>true</code>. Otherwise, it returns <code>false</code>. Like the equality operator, <dfn>less than</dfn> operator converts data types while comparing.
 <strong>Examples</strong>
-<blockquote>2 &lt; 5  // true<br>'3' &lt; 7  // true<br>5 &lt; 5  // false<br>3 &lt; 2  // false<br>'8' &lt; 4  // false</blockquote>
+
+```js
+2 < 5  // true
+'3' < 7  // true
+5 < 5  // false
+3 < 2  // false
+'8' < 4  // false
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-less-than-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-less-than-operator.english.md
@@ -9,15 +9,7 @@ videoUrl: 'https://scrimba.com/c/cNVRWtB'
 <section id='description'>
 The <dfn>less than</dfn> operator (<code>&lt;</code>) compares the values of two numbers. If the number to the left is less than the number to the right, it returns <code>true</code>. Otherwise, it returns <code>false</code>. Like the equality operator, <dfn>less than</dfn> operator converts data types while comparing.
 <strong>Examples</strong>
-
-```js
-2 < 5  // true
-'3' < 7  // true
-5 < 5  // false
-3 < 2  // false
-'8' < 4  // false
-```
-
+<blockquote>2 &lt; 5  // true<br>'3' &lt; 7  // true<br>5 &lt; 5  // false<br>3 &lt; 2  // false<br>'8' &lt; 4  // false</blockquote>
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-less-than-or-equal-to-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-less-than-or-equal-to-operator.english.md
@@ -9,15 +9,7 @@ videoUrl: 'https://scrimba.com/c/cNVR7Am'
 <section id='description'>
 The <code>less than or equal to</code> operator (<code>&lt;=</code>) compares the values of two numbers. If the number to the left is less than or equal to the number to the right, it returns <code>true</code>. If the number on the left is greater than the number on the right, it returns <code>false</code>. Like the equality operator, <code>less than or equal to</code> converts data types.
 <strong>Examples</strong>
-
-```js
-4 <= 5  // true
-'7' <= 7  // true
-5 <= 5  // true
-3 <= 2  // false
-'8' <= 4  // false
-```
-
+<blockquote>4 &lt;= 5  // true<br>'7' &lt;= 7  // true<br>5 &lt;= 5  // true<br>3 &lt;= 2  // false<br>'8' &lt;= 4  // false</blockquote>
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-less-than-or-equal-to-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-less-than-or-equal-to-operator.english.md
@@ -11,10 +11,10 @@ The <code>less than or equal to</code> operator (<code>&lt;=</code>) compares th
 <strong>Examples</strong>
 
 ```js
-4 <= 5  // true
+4   <= 5  // true
 '7' <= 7  // true
-5 <= 5  // true
-3 <= 2  // false
+5   <= 5  // true
+3   <= 2  // false
 '8' <= 4  // false
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-less-than-or-equal-to-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-less-than-or-equal-to-operator.english.md
@@ -9,7 +9,15 @@ videoUrl: 'https://scrimba.com/c/cNVR7Am'
 <section id='description'>
 The <code>less than or equal to</code> operator (<code>&lt;=</code>) compares the values of two numbers. If the number to the left is less than or equal to the number to the right, it returns <code>true</code>. If the number on the left is greater than the number on the right, it returns <code>false</code>. Like the equality operator, <code>less than or equal to</code> converts data types.
 <strong>Examples</strong>
-<blockquote>4 &lt;= 5  // true<br>'7' &lt;= 7  // true<br>5 &lt;= 5  // true<br>3 &lt;= 2  // false<br>'8' &lt;= 4  // false</blockquote>
+
+```js
+4 <= 5  // true
+'7' <= 7  // true
+5 <= 5  // true
+3 <= 2  // false
+'8' <= 4  // false
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-strict-equality-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-strict-equality-operator.english.md
@@ -12,8 +12,8 @@ If the values being compared have different types, they are considered unequal, 
 <strong>Examples</strong>
 
 ```js
-3 === 3   // true
-3 === '3' // false
+3 ===  3   // true
+3 === '3'  // false
 ```
 
 In the second example, <code>3</code> is a <code>Number</code> type and <code>'3'</code> is a <code>String</code> type.

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-strict-equality-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-strict-equality-operator.english.md
@@ -10,7 +10,12 @@ videoUrl: 'https://scrimba.com/c/cy87atr'
 Strict equality (<code>===</code>) is the counterpart to the equality operator (<code>==</code>). However, unlike the equality operator, which attempts to convert both values being compared to a common type, the strict equality operator does not perform a type conversion.
 If the values being compared have different types, they are considered unequal, and the strict equality operator will return false.
 <strong>Examples</strong>
-<blockquote>3 === 3   // true<br>3 === '3' // false</blockquote>
+
+```js
+3 === 3   // true
+3 === '3' // false
+```
+
 In the second example, <code>3</code> is a <code>Number</code> type and <code>'3'</code> is a <code>String</code> type.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-strict-equality-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-strict-equality-operator.english.md
@@ -10,12 +10,7 @@ videoUrl: 'https://scrimba.com/c/cy87atr'
 Strict equality (<code>===</code>) is the counterpart to the equality operator (<code>==</code>). However, unlike the equality operator, which attempts to convert both values being compared to a common type, the strict equality operator does not perform a type conversion.
 If the values being compared have different types, they are considered unequal, and the strict equality operator will return false.
 <strong>Examples</strong>
-
-```js
-3 === 3   // true
-3 === '3' // false
-```
-
+<blockquote>3 === 3   // true<br>3 === '3' // false</blockquote>
 In the second example, <code>3</code> is a <code>Number</code> type and <code>'3'</code> is a <code>String</code> type.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-strict-inequality-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-strict-inequality-operator.english.md
@@ -9,13 +9,7 @@ videoUrl: 'https://scrimba.com/c/cKekkUy'
 <section id='description'>
 The strict inequality operator (<code>!==</code>) is the logical opposite of the strict equality operator. It means "Strictly Not Equal" and returns <code>false</code> where strict equality would return <code>true</code> and <em>vice versa</em>. Strict inequality will not convert data types.
 <strong>Examples</strong>
-
-```js
-3 !== 3   // false
-3 !== '3' // true
-4 !== 3   // true
-```
-
+<blockquote>3 !== 3   // false<br>3 !== '3' // true<br>4 !== 3   // true</blockquote>
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-strict-inequality-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-strict-inequality-operator.english.md
@@ -9,7 +9,13 @@ videoUrl: 'https://scrimba.com/c/cKekkUy'
 <section id='description'>
 The strict inequality operator (<code>!==</code>) is the logical opposite of the strict equality operator. It means "Strictly Not Equal" and returns <code>false</code> where strict equality would return <code>true</code> and <em>vice versa</em>. Strict inequality will not convert data types.
 <strong>Examples</strong>
-<blockquote>3 !== 3   // false<br>3 !== '3' // true<br>4 !== 3   // true</blockquote>
+
+```js
+3 !== 3   // false
+3 !== '3' // true
+4 !== 3   // true
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-strict-inequality-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-strict-inequality-operator.english.md
@@ -11,9 +11,9 @@ The strict inequality operator (<code>!==</code>) is the logical opposite of the
 <strong>Examples</strong>
 
 ```js
-3 !== 3   // false
-3 !== '3' // true
-4 !== 3   // true
+3 !==  3   // false
+3 !== '3'  // true
+4 !==  3   // true
 ```
 
 </section>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparisons-with-the-logical-and-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparisons-with-the-logical-and-operator.english.md
@@ -9,9 +9,25 @@ videoUrl: 'https://scrimba.com/c/cvbRVtr'
 <section id='description'>
 Sometimes you will need to test more than one thing at a time. The <dfn>logical and</dfn> operator (<code>&&</code>) returns <code>true</code> if and only if the <dfn>operands</dfn> to the left and right of it are true.
 The same effect could be achieved by nesting an if statement inside another if:
-<blockquote>if (num > 5) {<br>&nbsp;&nbsp;if (num < 10) {<br>&nbsp;&nbsp;&nbsp;&nbsp;return "Yes";<br>&nbsp;&nbsp;}<br>}<br>return "No";</blockquote>
+
+```js
+if (num > 5) {
+  if (num < 10) {
+    return "Yes";
+  }
+}
+return "No";
+```
+
 will only return "Yes" if <code>num</code> is greater than <code>5</code> and less than <code>10</code>. The same logic can be written as:
-<blockquote>if (num > 5 && num < 10) {<br>&nbsp;&nbsp;return "Yes";<br>}<br>return "No";</blockquote>
+
+```js
+if (num > 5 && num < 10) {
+  return "Yes";
+}
+return "No";
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparisons-with-the-logical-or-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparisons-with-the-logical-or-operator.english.md
@@ -10,9 +10,26 @@ videoUrl: 'https://scrimba.com/c/cEPrGTN'
 The <dfn>logical or</dfn> operator (<code>||</code>) returns <code>true</code> if either of the <dfn>operands</dfn> is <code>true</code>. Otherwise, it returns <code>false</code>.
 The <dfn>logical or</dfn> operator is composed of two pipe symbols (<code>|</code>). This can typically be found between your Backspace and Enter keys.
 The pattern below should look familiar from prior waypoints:
-<blockquote>if (num > 10) {<br>&nbsp;&nbsp;return "No";<br>}<br>if (num < 5) {<br>&nbsp;&nbsp;return "No";<br>}<br>return "Yes";</blockquote>
+
+```js
+if (num > 10) {
+  return "No";
+}
+if (num < 5) {
+  return "No";
+}
+return "Yes";
+```
+
 will return "Yes" only if <code>num</code> is between <code>5</code> and <code>10</code> (5 and 10 included). The same logic can be written as:
-<blockquote>if (num > 10 || num < 5) {<br>&nbsp;&nbsp;return "No";<br>}<br>return "Yes";</blockquote>
+
+```js
+if (num > 10 || num < 5) {
+  return "No";
+}
+return "Yes";
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/compound-assignment-with-augmented-addition.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/compound-assignment-with-augmented-addition.english.md
@@ -11,7 +11,13 @@ In programming, it is common to use assignments to modify the contents of a vari
 <code>myVar = myVar + 5;</code>
 to add <code>5</code> to <code>myVar</code>. Since this is such a common pattern, there are operators which do both a mathematical operation and assignment in one step.
 One such operator is the <code>+=</code> operator.
-<blockquote>var myVar = 1;<br>myVar += 5;<br>console.log(myVar); // Returns 6</blockquote>
+
+```js
+var myVar = 1;
+myVar += 5;
+console.log(myVar); // Returns 6
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/concatenating-strings-with-plus-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/concatenating-strings-with-plus-operator.english.md
@@ -9,7 +9,11 @@ videoUrl: 'https://scrimba.com/c/cNpM8AN'
 <section id='description'>
 In JavaScript, when the <code>+</code> operator is used with a <code>String</code> value, it is called the <dfn>concatenation</dfn> operator. You can build a new string out of other strings by <dfn>concatenating</dfn> them together.
 <strong>Example</strong>
-<blockquote>'My name is Alan,' + ' I concatenate.'</blockquote>
+
+```js
+'My name is Alan,' + ' I concatenate.'
+```
+
 <strong>Note</strong><br>Watch out for spaces. Concatenation does not add spaces between concatenated strings, so you'll need to add them yourself.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/count-backwards-with-a-for-loop.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/count-backwards-with-a-for-loop.english.md
@@ -10,7 +10,14 @@ videoUrl: 'https://scrimba.com/c/c2R6BHa'
 A for loop can also count backwards, so long as we can define the right conditions.
 In order to count backwards by twos, we'll need to change our <code>initialization</code>, <code>condition</code>, and <code>final-expression</code>.
 We'll start at <code>i = 10</code> and loop while <code>i &#62; 0</code>. We'll decrement <code>i</code> by 2 each loop with <code>i -= 2</code>.
-<blockquote>var ourArray = [];<br>for (var i=10; i &#62; 0; i-=2) {<br>&nbsp;&nbsp;ourArray.push(i);<br>}</blockquote>
+
+```js
+var ourArray = [];
+for (var i=10; i > 0; i-=2) {
+  ourArray.push(i);
+}
+```
+
 <code>ourArray</code> will now contain <code>[10,8,6,4,2]</code>.
 Let's change our <code>initialization</code> and <code>final-expression</code> so we can count backward by twos by odd numbers.
 </section>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/declare-javascript-variables.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/declare-javascript-variables.english.md
@@ -12,7 +12,11 @@ For example, computers distinguish between numbers, such as the number <code>12<
 <dfn>Variables</dfn> allow computers to store and manipulate data in a dynamic fashion. They do this by using a "label" to point to the data rather than using the data itself. Any of the seven data types may be stored in a variable.
 <code>Variables</code> are similar to the x and y variables you use in mathematics, which means they're a simple name to represent the data we want to refer to. Computer <code>variables</code> differ from mathematical variables in that they can store different values at different times.
 We tell JavaScript to create or <dfn>declare</dfn> a variable by putting the keyword <code>var</code> in front of it, like so:
-<blockquote>var ourName;</blockquote>
+
+```js
+var ourName;
+```
+
 creates a <code>variable</code> called <code>ourName</code>. In JavaScript we end statements with semicolons.
 <code>Variable</code> names can be made up of numbers, letters, and <code>$</code> or <code>_</code>, but may not contain spaces or start with a number.
 </section>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/divide-one-number-by-another-with-javascript.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/divide-one-number-by-another-with-javascript.english.md
@@ -11,7 +11,11 @@ We can also divide one number by another.
 JavaScript uses the <code>/</code> symbol for division.
 
 <strong>Example</strong>
-<blockquote>myVar = 16 / 2; // assigned 8</blockquote>
+
+```js
+myVar = 16 / 2; // assigned 8
+```
+
 
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/escape-sequences-in-strings.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/escape-sequences-in-strings.english.md
@@ -15,13 +15,7 @@ Quotes are not the only characters that can be <dfn>escaped</dfn> inside a strin
 ## Instructions
 <section id='instructions'>
 Assign the following three lines of text into the single variable <code>myStr</code> using escape sequences.
-
-```js
-FirstLine
-    \SecondLine
-ThirdLine
-```
-
+<blockquote>FirstLine<br/>&nbsp;&nbsp;&nbsp;&nbsp;\SecondLine<br/>ThirdLine</blockquote>
 You will need to use escape sequences to insert special characters correctly. You will also need to follow the spacing as it looks above, with no spaces between escape sequences or words.
 Here is the text with the escape sequences written out.
 <q>FirstLine<code>newline</code><code>tab</code><code>backslash</code>SecondLine<code>newline</code>ThirdLine</q>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/escape-sequences-in-strings.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/escape-sequences-in-strings.english.md
@@ -15,7 +15,13 @@ Quotes are not the only characters that can be <dfn>escaped</dfn> inside a strin
 ## Instructions
 <section id='instructions'>
 Assign the following three lines of text into the single variable <code>myStr</code> using escape sequences.
-<blockquote>FirstLine<br/>&nbsp;&nbsp;&nbsp;&nbsp;\SecondLine<br/>ThirdLine</blockquote>
+
+```js
+FirstLine
+    \SecondLine
+ThirdLine
+```
+
 You will need to use escape sequences to insert special characters correctly. You will also need to follow the spacing as it looks above, with no spaces between escape sequences or words.
 Here is the text with the escape sequences written out.
 <q>FirstLine<code>newline</code><code>tab</code><code>backslash</code>SecondLine<code>newline</code>ThirdLine</q>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/finding-a-remainder-in-javascript.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/finding-a-remainder-in-javascript.english.md
@@ -9,9 +9,21 @@ videoUrl: 'https://scrimba.com/c/cWP24Ub'
 <section id='description'>
 The <dfn>remainder</dfn> operator <code>%</code> gives the remainder of the division of two numbers.
 <strong>Example</strong>
-<blockquote>5 % 2 = 1 because<br>Math.floor(5 / 2) = 2 (Quotient)<br>2 * 2 = 4<br>5 - 4 = 1 (Remainder)</blockquote>
+
+```js
+5 % 2 = 1 because
+Math.floor(5 / 2) = 2 (Quotient)
+2 * 2 = 4
+5 - 4 = 1 (Remainder)
+```
+
 <strong>Usage</strong><br>In mathematics, a number can be checked to be even or odd by checking the remainder of the division of the number by <code>2</code>.
-<blockquote>17 % 2 = 1 (17 is Odd)<br>48 % 2 = 0 (48 is Even)</blockquote>
+
+```js
+17 % 2 = 1 (17 is Odd)
+48 % 2 = 0 (48 is Even)
+```
+
 <strong>Note</strong><br>The <dfn>remainder</dfn> operator is sometimes incorrectly referred to as  the "modulus" operator. It is very similar to modulus, but does not work properly with negative numbers.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/finding-a-remainder-in-javascript.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/finding-a-remainder-in-javascript.english.md
@@ -9,21 +9,9 @@ videoUrl: 'https://scrimba.com/c/cWP24Ub'
 <section id='description'>
 The <dfn>remainder</dfn> operator <code>%</code> gives the remainder of the division of two numbers.
 <strong>Example</strong>
-
-```js
-5 % 2 = 1 because
-Math.floor(5 / 2) = 2 (Quotient)
-2 * 2 = 4
-5 - 4 = 1 (Remainder)
-```
-
+<blockquote>5 % 2 = 1 because<br>Math.floor(5 / 2) = 2 (Quotient)<br>2 * 2 = 4<br>5 - 4 = 1 (Remainder)</blockquote>
 <strong>Usage</strong><br>In mathematics, a number can be checked to be even or odd by checking the remainder of the division of the number by <code>2</code>.
-
-```js
-17 % 2 = 1 (17 is Odd)
-48 % 2 = 0 (48 is Even)
-```
-
+<blockquote>17 % 2 = 1 (17 is Odd)<br>48 % 2 = 0 (48 is Even)</blockquote>
 <strong>Note</strong><br>The <dfn>remainder</dfn> operator is sometimes incorrectly referred to as  the "modulus" operator. It is very similar to modulus, but does not work properly with negative numbers.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/global-vs.-local-scope-in-functions.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/global-vs.-local-scope-in-functions.english.md
@@ -9,7 +9,15 @@ videoUrl: 'https://scrimba.com/c/c2QwKH2'
 <section id='description'>
 It is possible to have both <dfn>local</dfn> and <dfn>global</dfn> variables with the same name. When you do this, the <code>local</code> variable takes precedence over the <code>global</code> variable.
 In this example:
-<blockquote>var someVar = "Hat";<br>function myFun() {<br>&nbsp;&nbsp;var someVar = "Head";<br>&nbsp;&nbsp;return someVar;<br>}</blockquote>
+
+```js
+var someVar = "Hat";
+function myFun() {
+  var someVar = "Head";
+  return someVar;
+}
+```
+
 The function <code>myFun</code> will return <code>"Head"</code> because the <code>local</code> version of the variable is present.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/introducing-else-if-statements.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/introducing-else-if-statements.english.md
@@ -8,7 +8,17 @@ videoUrl: 'https://scrimba.com/c/caeJ2hm'
 ## Description
 <section id='description'>
 If you have multiple conditions that need to be addressed, you can chain <code>if</code> statements together with <code>else if</code> statements.
-<blockquote>if (num > 15) {<br>&nbsp;&nbsp;return "Bigger than 15";<br>} else if (num < 5) {<br>&nbsp;&nbsp;return "Smaller than 5";<br>} else {<br>&nbsp;&nbsp;return "Between 5 and 15";<br>}</blockquote>
+
+```js
+if (num > 15) {
+  return "Bigger than 15";
+} else if (num < 5) {
+  return "Smaller than 5";
+} else {
+  return "Between 5 and 15";
+}
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/introducing-else-statements.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/introducing-else-statements.english.md
@@ -8,7 +8,15 @@ videoUrl: 'https://scrimba.com/c/cek4Efq'
 ## Description
 <section id='description'>
 When a condition for an <code>if</code> statement is true, the block of code following it is executed. What about when that condition is false?  Normally nothing would happen. With an <code>else</code> statement, an alternate block of code can be executed.
-<blockquote>if (num > 10) {<br>&nbsp;&nbsp;return "Bigger than 10";<br>} else {<br>&nbsp;&nbsp;return "10 or Less";<br>}</blockquote>
+
+```js
+if (num > 10) {
+  return "Bigger than 10";
+} else {
+  return "10 or Less";
+}
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/iterate-odd-numbers-with-a-for-loop.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/iterate-odd-numbers-with-a-for-loop.english.md
@@ -9,7 +9,14 @@ videoUrl: 'https://scrimba.com/c/cm8n7T9'
 <section id='description'>
 For loops don't have to iterate one at a time. By changing our <code>final-expression</code>, we can count by even numbers.
 We'll start at <code>i = 0</code> and loop while <code>i &#60; 10</code>. We'll increment <code>i</code> by 2 each loop with <code>i += 2</code>.
-<blockquote>var ourArray = [];<br>for (var i = 0; i &#60; 10; i += 2) {<br>&nbsp;&nbsp;ourArray.push(i);<br>}</blockquote>
+
+```js
+var ourArray = [];
+for (var i = 0; i < 10; i += 2) {
+  ourArray.push(i);
+}
+```
+
 <code>ourArray</code> will now contain <code>[0,2,4,6,8]</code>.
 Let's change our <code>initialization</code> so we can count by odd numbers.
 </section>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/iterate-through-an-array-with-a-for-loop.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/iterate-through-an-array-with-a-for-loop.english.md
@@ -8,7 +8,14 @@ videoUrl: 'https://scrimba.com/c/caeR3HB'
 ## Description
 <section id='description'>
 A common task in JavaScript is to iterate through the contents of an array. One way to do that is with a <code>for</code> loop. This code will output each element of the array <code>arr</code> to the console:
-<blockquote>var arr = [10,9,8,7,6];<br>for (var i = 0; i < arr.length; i++) {<br>&nbsp;&nbsp; console.log(arr[i]);<br>}</blockquote>
+
+```js
+var arr = [10,9,8,7,6];
+for (var i = 0; i < arr.length; i++) {
+   console.log(arr[i]);
+}
+```
+
 Remember that Arrays have zero-based numbering, which means the last index of the array is length - 1. Our <dfn>condition</dfn> for this loop is <code>i < arr.length</code>, which stops when <code>i</code> is at length - 1.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/iterate-with-javascript-do...while-loops.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/iterate-with-javascript-do...while-loops.english.md
@@ -8,13 +8,40 @@ videoUrl: 'https://scrimba.com/c/cDqWGcp'
 ## Description
 <section id='description'>
 The next type of loop you will learn is called a <code>do...while</code> loop.  It is called a <code>do...while</code> loop because it will first <code>do</code> one pass of the code inside the loop no matter what, and then continue to run the loop <code>while</code> the specified condition evaluates to <code>true</code>.
-<blockquote>var ourArray = [];<br>var i = 0;<br>do {<br>&nbsp;&nbsp;ourArray.push(i);<br>&nbsp;&nbsp;i++;<br>} while (i < 5);</blockquote>
+
+```js
+var ourArray = [];
+var i = 0;
+do {
+  ourArray.push(i);
+  i++;
+} while (i < 5);
+```
+
 The example above behaves similar to other types of loops, and the resulting array will look like <code>[0, 1, 2, 3, 4]</code>. However, what makes the <code>do...while</code> different from other loops is how it behaves when the condition fails on the first check. Let's see this in action:
 Here is a regular <code>while</code> loop that will run the code in the loop as long as <code>i < 5</code>:
-<blockquote>var ourArray = []; <br>var i = 5;<br>while (i < 5) {<br>&nbsp;&nbsp;ourArray.push(i);<br>&nbsp;&nbsp;i++;<br>}</blockquote>
+
+```js
+var ourArray = []; 
+var i = 5;
+while (i < 5) {
+  ourArray.push(i);
+  i++;
+}
+```
+
 In this example, we initialize the value of <code>myArray</code> to an empty array and the value of <code>i</code> to 5. When we execute the <code>while</code> loop, the condition evaluates to <code>false</code> because <code>i</code> is not less than 5, so we do not execute the code inside the loop. The result is that <code>ourArray</code> will end up with no values added to it, and it will still look like <code>[]</code> when all of the code in the example above has completed running.
 Now, take a look at a <code>do...while</code> loop:
-<blockquote>var ourArray = []; <br>var i = 5;<br>do {<br>&nbsp;&nbsp;ourArray.push(i);<br>&nbsp;&nbsp;i++;<br>} while (i < 5);</blockquote>
+
+```js
+var ourArray = []; 
+var i = 5;
+do {
+  ourArray.push(i);
+  i++;
+} while (i < 5);
+```
+
 In this case, we initialize the value of <code>i</code> to 5, just like we did with the <code>while</code> loop. When we get to the next line, there is no condition to evaluate, so we go to the code inside the curly braces and execute it.  We will add a single element to the array and then increment <code>i</code> before we get to the condition check. When we finally evaluate the condition <code>i < 5</code> on the last line, we see that <code>i</code> is now 6, which fails the conditional check, so we exit the loop and are done. At the end of the above example, the value of <code>ourArray</code> is <code>[5]</code>.
 Essentially, a <code>do...while</code> loop ensures that the code inside the loop will run at least once.
 Let's try getting a <code>do...while</code> loop to work by pushing values to an array.

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/iterate-with-javascript-for-loops.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/iterate-with-javascript-for-loops.english.md
@@ -15,7 +15,14 @@ The <code>initialization</code> statement is executed one time only before the l
 The <code>condition</code> statement is evaluated at the beginning of every loop iteration and will continue as long as it evaluates to <code>true</code>. When <code>condition</code> is <code>false</code> at the start of the iteration, the loop will stop executing. This means if <code>condition</code> starts as <code>false</code>, your loop will never execute.
 The <code>final-expression</code> is executed at the end of each loop iteration, prior to the next <code>condition</code> check and is usually used to increment or decrement your loop counter.
 In the following example we initialize with <code>i = 0</code> and iterate while our condition <code>i &#60; 5</code> is true. We'll increment <code>i</code> by <code>1</code> in each loop iteration with <code>i++</code> as our <code>final-expression</code>.
-<blockquote>var ourArray = [];<br>for (var i = 0; i &#60; 5; i++) {<br>&nbsp;&nbsp;ourArray.push(i);<br>}</blockquote>
+
+```js
+var ourArray = [];
+for (var i = 0; i < 5; i++) {
+  ourArray.push(i);
+}
+```
+
 <code>ourArray</code> will now contain <code>[0,1,2,3,4]</code>.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/iterate-with-javascript-while-loops.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/iterate-with-javascript-while-loops.english.md
@@ -9,7 +9,16 @@ videoUrl: 'https://scrimba.com/c/c8QbnCM'
 <section id='description'>
 You can run the same code multiple times by using a loop.
 The first type of loop we will learn is called a <code>while</code> loop because it runs "while" a specified condition is true and stops once that condition is no longer true.
-<blockquote>var ourArray = [];<br>var i = 0;<br>while(i &#60; 5) {<br>&nbsp;&nbsp;ourArray.push(i);<br>&nbsp;&nbsp;i++;<br>}</blockquote>
+
+```js
+var ourArray = [];
+var i = 0;
+while(i < 5) {
+  ourArray.push(i);
+  i++;
+}
+```
+
 Let's try getting a while loop to work by pushing values to an array.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/local-scope-and-functions.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/local-scope-and-functions.english.md
@@ -9,7 +9,16 @@ videoUrl: 'https://scrimba.com/c/cd62NhM'
 <section id='description'>
 Variables which are declared within a function, as well as the function parameters have <dfn>local</dfn> scope. That means, they are only visible within that function.
 Here is a function <code>myTest</code> with a local variable called <code>loc</code>.
-<blockquote>function myTest() {<br>&nbsp;&nbsp;var loc = "foo";<br>&nbsp;&nbsp;console.log(loc);<br>}<br>myTest(); // logs "foo"<br>console.log(loc); // loc is not defined</blockquote>
+
+```js
+function myTest() {
+  var loc = "foo";
+  console.log(loc);
+}
+myTest(); // logs "foo"
+console.log(loc); // loc is not defined
+```
+
 <code>loc</code> is not defined outside of the function.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/logical-order-in-if-else-statements.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/logical-order-in-if-else-statements.english.md
@@ -11,11 +11,40 @@ Order is important in <code>if</code>, <code>else if</code> statements.
 The function is executed from top to bottom so you will want to be careful of what statement comes first.
 Take these two functions as an example.
 Here's the first:
-<blockquote>function foo(x) {<br>&nbsp;&nbsp;if (x < 1) {<br>&nbsp;&nbsp;&nbsp;&nbsp;return "Less than one";<br>&nbsp;&nbsp;} else if (x < 2) {<br>&nbsp;&nbsp;&nbsp;&nbsp;return "Less than two";<br>&nbsp;&nbsp;} else {<br>&nbsp;&nbsp;&nbsp;&nbsp;return "Greater than or equal to two";<br>&nbsp;&nbsp;}<br>}</blockquote>
+
+```js
+function foo(x) {
+  if (x < 1) {
+    return "Less than one";
+  } else if (x < 2) {
+    return "Less than two";
+  } else {
+    return "Greater than or equal to two";
+  }
+}
+```
+
 And the second just switches the order of the statements:
-<blockquote>function bar(x) {<br>&nbsp;&nbsp;if (x < 2) {<br>&nbsp;&nbsp;&nbsp;&nbsp;return "Less than two";<br>&nbsp;&nbsp;} else if (x < 1) {<br>&nbsp;&nbsp;&nbsp;&nbsp;return "Less than one";<br>&nbsp;&nbsp;} else {<br>&nbsp;&nbsp;&nbsp;&nbsp;return "Greater than or equal to two";<br>&nbsp;&nbsp;}<br>}</blockquote>
+
+```js
+function bar(x) {
+  if (x < 2) {
+    return "Less than two";
+  } else if (x < 1) {
+    return "Less than one";
+  } else {
+    return "Greater than or equal to two";
+  }
+}
+```
+
 While these two functions look nearly identical if we pass a number to both we get different outputs.
-<blockquote>foo(0) // "Less than one"<br>bar(0) // "Less than two"</blockquote>
+
+```js
+foo(0) // "Less than one"
+bar(0) // "Less than two"
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/manipulate-arrays-with-pop.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/manipulate-arrays-with-pop.english.md
@@ -10,7 +10,14 @@ videoUrl: 'https://scrimba.com/c/cRbVZAB'
 Another way to change the data in an array is with the <code>.pop()</code> function.
 <code>.pop()</code> is used to "pop" a value off of the end of an array. We can store this "popped off" value by assigning it to a variable. In other words, <code>.pop()</code> removes the last element from an array and returns that element.
 Any type of entry can be "popped" off of an array - numbers, strings, even nested arrays.
-<blockquote><code>var threeArr = [1, 4, 6];<br> var oneDown = threeArr.pop();<br> console.log(oneDown); // Returns 6<br> console.log(threeArr); // Returns [1, 4]</code></blockquote>
+
+```js
+var threeArr = [1, 4, 6];
+var oneDown = threeArr.pop();
+console.log(oneDown); // Returns 6
+console.log(threeArr); // Returns [1, 4]
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/manipulate-arrays-with-push.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/manipulate-arrays-with-push.english.md
@@ -9,7 +9,13 @@ videoUrl: 'https://scrimba.com/c/cnqmVtJ'
 <section id='description'>
 An easy way to append data to the end of an array is via the <code>push()</code> function.
 <code>.push()</code> takes one or more <dfn>parameters</dfn> and "pushes" them onto the end of the array.
-<blockquote>var arr = [1,2,3];<br>arr.push(4);<br>// arr is now [1,2,3,4]</blockquote>
+
+```js
+var arr = [1,2,3];
+arr.push(4);
+// arr is now [1,2,3,4]
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/manipulating-complex-objects.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/manipulating-complex-objects.english.md
@@ -30,7 +30,7 @@ This is an array which contains one object inside. The object has various pieces
 Objects hold data in a property, which has a key-value format. In the example above, <code>"artist": "Daft Punk"</code> is a property that has a key of <code>"artist"</code> and a value of <code>"Daft Punk"</code>.
 <a href='http://www.json.org/' target=_blank>JavaScript Object Notation</a> or <code>JSON</code> is a related data interchange format used to store data.
 
-```js
+```json
 {
   "artist": "Daft Punk",
   "title": "Homework",

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/manipulating-complex-objects.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/manipulating-complex-objects.english.md
@@ -9,11 +9,41 @@ videoUrl: 'https://scrimba.com/c/c9yNMfR'
 <section id='description'>
 Sometimes you may want to store data in a flexible <dfn>Data Structure</dfn>. A JavaScript object is one way to handle flexible data. They allow for arbitrary combinations of <dfn>strings</dfn>, <dfn>numbers</dfn>, <dfn>booleans</dfn>, <dfn>arrays</dfn>, <dfn>functions</dfn>, and <dfn>objects</dfn>.
 Here's an example of a complex data structure:
-<blockquote>var ourMusic = [<br>&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;"artist": "Daft Punk",<br>&nbsp;&nbsp;&nbsp;&nbsp;"title": "Homework",<br>&nbsp;&nbsp;&nbsp;&nbsp;"release_year": 1997,<br>&nbsp;&nbsp;&nbsp;&nbsp;"formats": [ <br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"CD", <br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"Cassette", <br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"LP"<br>&nbsp;&nbsp;&nbsp;&nbsp;],<br>&nbsp;&nbsp;&nbsp;&nbsp;"gold": true<br>&nbsp;&nbsp;}<br>];</blockquote>
+
+```js
+var ourMusic = [
+  {
+    "artist": "Daft Punk",
+    "title": "Homework",
+    "release_year": 1997,
+    "formats": [ 
+      "CD", 
+      "Cassette", 
+      "LP"
+    ],
+    "gold": true
+  }
+];
+```
+
 This is an array which contains one object inside. The object has various pieces of <dfn>metadata</dfn> about an album. It also has a nested <code>"formats"</code> array. If you want to add more album records, you can do this by adding records to the top level array.
 Objects hold data in a property, which has a key-value format. In the example above, <code>"artist": "Daft Punk"</code> is a property that has a key of <code>"artist"</code> and a value of <code>"Daft Punk"</code>.
 <a href='http://www.json.org/' target=_blank>JavaScript Object Notation</a> or <code>JSON</code> is a related data interchange format used to store data.
-<blockquote>{<br>&nbsp;&nbsp;"artist": "Daft Punk",<br>&nbsp;&nbsp;"title": "Homework",<br>&nbsp;&nbsp;"release_year": 1997,<br>&nbsp;&nbsp;"formats": [ <br>&nbsp;&nbsp;&nbsp;&nbsp;"CD",<br>&nbsp;&nbsp;&nbsp;&nbsp;"Cassette",<br>&nbsp;&nbsp;&nbsp;&nbsp;"LP"<br>&nbsp;&nbsp;],<br>&nbsp;&nbsp;"gold": true<br>}</blockquote>
+
+```js
+{
+  "artist": "Daft Punk",
+  "title": "Homework",
+  "release_year": 1997,
+  "formats": [ 
+    "CD",
+    "Cassette",
+    "LP"
+  ],
+  "gold": true
+}
+```
+
 <strong>Note</strong><br>You will need to place a comma after every object in the array, unless it is the last object in the array.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/modify-array-data-with-indexes.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/modify-array-data-with-indexes.english.md
@@ -9,7 +9,12 @@ videoUrl: 'https://scrimba.com/c/czQM4A8'
 <section id='description'>
 Unlike strings, the entries of arrays are <dfn>mutable</dfn> and can be changed freely.
 <strong>Example</strong>
-<blockquote>var ourArray = [50,40,30];<br>ourArray[0] = 15; // equals [15,40,30]</blockquote>
+
+```js
+var ourArray = [50,40,30];
+ourArray[0] = 15; // equals [15,40,30]
+```
+
 <strong>Note</strong><br>There shouldn't be any spaces between the array name and the square brackets, like <code>array [0]</code>. Although JavaScript is able to process this correctly, this may confuse other programmers reading your code.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/multiple-identical-options-in-switch-statements.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/multiple-identical-options-in-switch-statements.english.md
@@ -8,7 +8,19 @@ videoUrl: 'https://scrimba.com/c/cdBKWCV'
 ## Description
 <section id='description'>
 If the <code>break</code> statement is omitted from a <code>switch</code> statement's <code>case</code>, the following <code>case</code> statement(s) are executed until a <code>break</code> is encountered. If you have multiple inputs with the same output, you can represent them in a <code>switch</code> statement like this:
-<blockquote>switch(val) {<br>&nbsp;&nbsp;case 1:<br>&nbsp;&nbsp;case 2:<br>&nbsp;&nbsp;case 3:<br>&nbsp;&nbsp;&nbsp;&nbsp;result = "1, 2, or 3";<br>&nbsp;&nbsp;&nbsp;&nbsp;break;<br>&nbsp;&nbsp;case 4:<br>&nbsp;&nbsp;&nbsp;&nbsp;result = "4 alone";<br>}</blockquote>
+
+```js
+switch(val) {
+  case 1:
+  case 2:
+  case 3:
+    result = "1, 2, or 3";
+    break;
+  case 4:
+    result = "4 alone";
+}
+```
+
 Cases for 1, 2, and 3 will all produce the same result.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/multiply-two-numbers-with-javascript.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/multiply-two-numbers-with-javascript.english.md
@@ -11,7 +11,11 @@ We can also multiply one number by another.
 JavaScript uses the <code>*</code> symbol for multiplication of two numbers.
 
 <strong>Example</strong>
-<blockquote>myVar = 13 * 13; // assigned 169</blockquote>
+
+```js
+myVar = 13 * 13; // assigned 169
+```
+
 
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/nesting-for-loops.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/nesting-for-loops.english.md
@@ -8,7 +8,18 @@ videoUrl: 'https://scrimba.com/c/cRn6GHM'
 ## Description
 <section id='description'>
 If you have a multi-dimensional array, you can use the same logic as the prior waypoint to loop through both the array and any sub-arrays. Here is an example:
-<blockquote>var arr = [<br>&nbsp;&nbsp;[1,2], [3,4], [5,6]<br>];<br>for (var i=0; i &lt; arr.length; i++) {<br>&nbsp;&nbsp;for (var j=0; j &lt; arr[i].length; j++) {<br>&nbsp;&nbsp;&nbsp;&nbsp;console.log(arr[i][j]);<br>&nbsp;&nbsp;}<br>}</blockquote>
+
+```js
+var arr = [
+  [1,2], [3,4], [5,6]
+];
+for (var i=0; i < arr.length; i++) {
+  for (var j=0; j < arr[i].length; j++) {
+    console.log(arr[i][j]);
+  }
+}
+```
+
 This outputs each sub-element in <code>arr</code> one at a time. Note that for the inner loop, we are checking the <code>.length</code> of <code>arr[i]</code>, since <code>arr[i]</code> is itself an array.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/passing-values-to-functions-with-arguments.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/passing-values-to-functions-with-arguments.english.md
@@ -9,7 +9,13 @@ videoUrl: 'https://scrimba.com/c/cy8rahW'
 <section id='description'>
 <dfn>Parameters</dfn> are variables that act as placeholders for the values that are to be input to a function when it is called. When a function is defined, it is typically defined along with one or more parameters. The actual values that are input (or <dfn>"passed"</dfn>) into a function when it is called are known as <dfn>arguments</dfn>.
 Here is a function with two parameters, <code>param1</code> and <code>param2</code>:
-<blockquote>function testFun(param1, param2) {<br>&nbsp;&nbsp;console.log(param1, param2);<br>}</blockquote>
+
+```js
+function testFun(param1, param2) {
+  console.log(param1, param2);
+}
+```
+
 Then we can call <code>testFun</code>:
 <code>testFun("Hello", "World");</code>
 We have passed two arguments, <code>"Hello"</code> and <code>"World"</code>. Inside the function, <code>param1</code> will equal "Hello" and <code>param2</code> will equal "World". Note that you could call <code>testFun</code> again with different arguments and the parameters would take on the value of the new arguments.

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/practice-comparing-different-values.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/practice-comparing-different-values.english.md
@@ -10,9 +10,19 @@ videoUrl: 'https://scrimba.com/c/cm8PqCa'
 In the last two challenges, we learned about the equality operator (<code>==</code>) and the strict equality operator (<code>===</code>). Let's do a quick review and practice using these operators some more.
 If the values being compared are not of the same type, the equality operator will perform a type conversion, and then evaluate the values. However, the strict equality operator will compare both the data type and value as-is, without converting one type to the other.
 <strong>Examples</strong>
-<blockquote>3 == '3'  // returns true because JavaScript performs type conversion from string to number<br>3 === '3' // returns false because the types are different and type conversion is not performed</blockquote>
+
+```js
+3 == '3'  // returns true because JavaScript performs type conversion from string to number
+3 === '3' // returns false because the types are different and type conversion is not performed
+```
+
 <strong>Note</strong><br>In JavaScript, you can determine the type of a variable or a value with the <code>typeof</code> operator, as follows:
-<blockquote>typeof 3   // returns 'number'<br>typeof '3' // returns 'string'</blockquote>
+
+```js
+typeof 3   // returns 'number'
+typeof '3' // returns 'string'
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/quoting-strings-with-single-quotes.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/quoting-strings-with-single-quotes.english.md
@@ -8,11 +8,25 @@ videoUrl: 'https://scrimba.com/c/cbQmnhM'
 ## Description
 <section id='description'>
 <dfn>String</dfn> values in JavaScript may be written with single or double quotes, as long as you start and end with the same type of quote. Unlike some other programming languages, single and double quotes work the same in JavaScript.
-<blockquote>doubleQuoteStr = "This is a string"; <br/>singleQuoteStr = 'This is also a string';</blockquote>
+
+```js
+doubleQuoteStr = "This is a string"; 
+singleQuoteStr = 'This is also a string';
+```
+
 The reason why you might want to use one type of quote over the other is if you want to use both in a string. This might happen if you want to save a conversation in a string and have the conversation in quotes. Another use for it would be saving an <code>&#60;a&#62;</code> tag with various attributes in quotes, all within a string.
-<blockquote>conversation = 'Finn exclaims to Jake, "Algebraic!"';</blockquote>
+
+```js
+conversation = 'Finn exclaims to Jake, "Algebraic!"';
+```
+
 However, this becomes a problem if you need to use the outermost quotes within it. Remember, a string has the same kind of quote at the beginning and end. But if you have that same quote somewhere in the middle, the string will stop early and throw an error.
-<blockquote>goodStr = 'Jake asks Finn, "Hey, let\'s go on an adventure?"'; <br/>badStr = 'Finn responds, "Let's go!"'; // Throws an error</blockquote>
+
+```js
+goodStr = 'Jake asks Finn, "Hey, let\'s go on an adventure?"'; 
+badStr = 'Finn responds, "Let's go!"'; // Throws an error
+```
+
 In the <dfn>goodStr</dfn> above, you can use both quotes safely by using the backslash <code>\</code> as an escape character.
 <strong>Note</strong><br/>The backslash <code>\</code> should not be confused with the forward slash <code>/</code>. They do not do the same thing.
 </section>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/replacing-if-else-chains-with-switch.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/replacing-if-else-chains-with-switch.english.md
@@ -8,9 +8,32 @@ videoUrl: 'https://scrimba.com/c/c3JE8fy'
 ## Description
 <section id='description'>
 If you have many options to choose from, a <code>switch</code> statement can be easier to write than many chained <code>if</code>/<code>else if</code> statements. The following:
-<blockquote>if (val === 1) {<br>&nbsp;&nbsp;answer = "a";<br>} else if (val === 2) {<br>&nbsp;&nbsp;answer = "b";<br>} else {<br>&nbsp;&nbsp;answer = "c";<br>}</blockquote>
+
+```js
+if (val === 1) {
+  answer = "a";
+} else if (val === 2) {
+  answer = "b";
+} else {
+  answer = "c";
+}
+```
+
 can be replaced with:
-<blockquote>switch(val) {<br>&nbsp;&nbsp;case 1:<br>&nbsp;&nbsp;&nbsp;&nbsp;answer = "a";<br>&nbsp;&nbsp;&nbsp;&nbsp;break;<br>&nbsp;&nbsp;case 2:<br>&nbsp;&nbsp;&nbsp;&nbsp;answer = "b";<br>&nbsp;&nbsp;&nbsp;&nbsp;break;<br>&nbsp;&nbsp;default:<br>&nbsp;&nbsp;&nbsp;&nbsp;answer = "c";<br>}</blockquote>
+
+```js
+switch(val) {
+  case 1:
+    answer = "a";
+    break;
+  case 2:
+    answer = "b";
+    break;
+  default:
+    answer = "c";
+}
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/return-a-value-from-a-function-with-return.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/return-a-value-from-a-function-with-return.english.md
@@ -9,7 +9,14 @@ videoUrl: 'https://scrimba.com/c/cy87wue'
 <section id='description'>
 We can pass values into a function with <dfn>arguments</dfn>. You can use a <code>return</code> statement to send a value back out of a function.
 <strong>Example</strong>
-<blockquote>function plusThree(num) {<br>&nbsp;&nbsp;return num + 3;<br>}<br>var answer = plusThree(5); // 8</blockquote>
+
+```js
+function plusThree(num) {
+  return num + 3;
+}
+var answer = plusThree(5); // 8
+```
+
 <code>plusThree</code> takes an <dfn>argument</dfn> for <code>num</code> and returns a value equal to <code>num + 3</code>.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/return-early-pattern-for-functions.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/return-early-pattern-for-functions.english.md
@@ -9,7 +9,16 @@ videoUrl: 'https://scrimba.com/c/cQe39Sq'
 <section id='description'>
 When a <code>return</code> statement is reached, the execution of the current function stops and control returns to the calling location.
 <strong>Example</strong>
-<blockquote>function myFun() {<br>&nbsp;&nbsp;console.log("Hello");<br>&nbsp;&nbsp;return "World";<br>&nbsp;&nbsp;console.log("byebye")<br>}<br>myFun();</blockquote>
+
+```js
+function myFun() {
+  console.log("Hello");
+  return "World";
+  console.log("byebye")
+}
+myFun();
+```
+
 The above outputs "Hello" to the console, returns "World", but <code>"byebye"</code> is never output, because the function exits at the <code>return</code> statement.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/returning-boolean-values-from-functions.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/returning-boolean-values-from-functions.english.md
@@ -9,9 +9,25 @@ videoUrl: 'https://scrimba.com/c/cp62qAQ'
 <section id='description'>
 You may recall from <a href="learn/javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-equality-operator" target="_blank">Comparison with the Equality Operator</a> that all comparison operators return a boolean <code>true</code> or <code>false</code> value.
 Sometimes people use an if/else statement to do a comparison, like this:
-<blockquote>function isEqual(a,b) {<br>&nbsp;&nbsp;if (a === b) {<br>&nbsp;&nbsp;&nbsp;&nbsp;return true;<br>&nbsp;&nbsp;} else {<br>&nbsp;&nbsp;&nbsp;&nbsp;return false;<br>&nbsp;&nbsp;}<br>}</blockquote>
+
+```js
+function isEqual(a,b) {
+  if (a === b) {
+    return true;
+  } else {
+    return false;
+  }
+}
+```
+
 But there's a better way to do this. Since <code>===</code> returns <code>true</code> or <code>false</code>, we can return the result of the comparison:
-<blockquote>function isEqual(a,b) {<br>&nbsp;&nbsp;return a === b;<br>}</blockquote>
+
+```js
+function isEqual(a,b) {
+  return a === b;
+}
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/selecting-from-many-options-with-switch-statements.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/selecting-from-many-options-with-switch-statements.english.md
@@ -9,7 +9,22 @@ videoUrl: 'https://scrimba.com/c/c4mv4fm'
 <section id='description'>
 If you have many options to choose from, use a <code>switch</code> statement. A <code>switch</code> statement tests a value and can have many <code>case</code> statements which define various possible values. Statements are executed from the first matched <code>case</code> value until a <code>break</code> is encountered.
 Here is a <dfn>pseudocode</dfn> example:
-<blockquote>switch(num) {<br>&nbsp;&nbsp;case value1:<br>&nbsp;&nbsp;&nbsp;&nbsp;statement1;<br>&nbsp;&nbsp;&nbsp;&nbsp;break;<br>&nbsp;&nbsp;case value2:<br>&nbsp;&nbsp;&nbsp;&nbsp;statement2;<br>&nbsp;&nbsp;&nbsp;&nbsp;break;<br>...<br>&nbsp;&nbsp;case valueN:<br>&nbsp;&nbsp;&nbsp;&nbsp;statementN;<br>&nbsp;&nbsp;&nbsp;&nbsp;break;<br>}</blockquote>
+
+```js
+switch(num) {
+  case value1:
+    statement1;
+    break;
+  case value2:
+    statement2;
+    break;
+...
+  case valueN:
+    statementN;
+    break;
+}
+```
+
 <code>case</code> values are tested with strict equality (<code>===</code>). The <code>break</code> tells JavaScript to stop executing statements. If the <code>break</code> is omitted, the next statement will be executed.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/storing-values-with-the-assignment-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/storing-values-with-the-assignment-operator.english.md
@@ -11,7 +11,12 @@ In JavaScript, you can store a value in a variable with the <dfn>assignment</dfn
 <code>myVariable = 5;</code>
 This assigns the <code>Number</code> value <code>5</code> to <code>myVariable</code>.
 Assignment always goes from right to left. Everything to the right of the <code>=</code> operator is resolved before the value is assigned to the variable to the left of the operator.
-<blockquote>myVar = 5;<br>myNum = myVar;</blockquote>
+
+```js
+myVar = 5;
+myNum = myVar;
+```
+
 This assigns <code>5</code> to <code>myVar</code> and then resolves <code>myVar</code> to <code>5</code>  again and assigns it to <code>myNum</code>.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/subtract-one-number-from-another-with-javascript.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/subtract-one-number-from-another-with-javascript.english.md
@@ -11,7 +11,11 @@ We can also subtract one number from another.
 JavaScript uses the <code>-</code> symbol for subtraction.
 
 <strong>Example</strong>
-<blockquote>myVar = 12 - 6; // assigned 6</blockquote>
+
+```js
+myVar = 12 - 6; // assigned 6
+```
+
 
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/testing-objects-for-properties.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/testing-objects-for-properties.english.md
@@ -9,7 +9,16 @@ videoUrl: 'https://scrimba.com/c/cm8Q7Ua'
 <section id='description'>
 Sometimes it is useful to check if the property of a given object exists or not. We can use the <code>.hasOwnProperty(propname)</code> method of objects to determine if that object has the given property name. <code>.hasOwnProperty()</code> returns <code>true</code> or <code>false</code> if the property is found or not.
 <strong>Example</strong>
-<blockquote>var myObj = {<br>&nbsp;&nbsp;top: "hat",<br>&nbsp;&nbsp;bottom: "pants"<br>};<br>myObj.hasOwnProperty("top");    // true<br>myObj.hasOwnProperty("middle"); // false</blockquote>
+
+```js
+var myObj = {
+  top: "hat",
+  bottom: "pants"
+};
+myObj.hasOwnProperty("top");    // true
+myObj.hasOwnProperty("middle"); // false
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/understand-string-immutability.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/understand-string-immutability.english.md
@@ -9,9 +9,19 @@ videoUrl: 'https://scrimba.com/c/cWPVaUR'
 <section id='description'>
 In JavaScript, <code>String</code> values are <dfn>immutable</dfn>, which means that they cannot be altered once created.
 For example, the following code:
-<blockquote>var myStr = "Bob";<br>myStr[0] = "J";</blockquote>
+
+```js
+var myStr = "Bob";
+myStr[0] = "J";
+```
+
 cannot change the value of <code>myStr</code> to "Job", because the contents of <code>myStr</code> cannot be altered. Note that this does <em>not</em> mean that <code>myStr</code> cannot be changed, just that the individual characters of a <dfn>string literal</dfn> cannot be changed. The only way to change <code>myStr</code> would be to assign it with a new string, like this:
-<blockquote>var myStr = "Bob";<br>myStr = "Job";</blockquote>
+
+```js
+var myStr = "Bob";
+myStr = "Job";
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/understanding-case-sensitivity-in-variables.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/understanding-case-sensitivity-in-variables.english.md
@@ -12,7 +12,13 @@ In JavaScript all variables and function names are case sensitive. This means th
 <h4>Best Practice</h4>
 Write variable names in JavaScript in <dfn>camelCase</dfn>. In <dfn>camelCase</dfn>, multi-word variable names have the first word in lowercase and the first letter of each subsequent word is capitalized.
 <strong>Examples:</strong>
-<blockquote>var someVariable;<br>var anotherVariableName;<br>var thisVariableNameIsSoLong;</blockquote>
+
+```js
+var someVariable;
+var anotherVariableName;
+var thisVariableNameIsSoLong;
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/understanding-undefined-value-returned-from-a-function.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/understanding-undefined-value-returned-from-a-function.english.md
@@ -9,7 +9,15 @@ videoUrl: 'https://scrimba.com/c/ce2p7cL'
 <section id='description'>
 A function can include the <code>return</code> statement but it does not have to. In the case that the function doesn't have a <code>return</code> statement, when you call it, the function processes the inner code but the returned value is <code>undefined</code>.
 <strong>Example</strong>
-<blockquote>var sum = 0;<br>function addSum(num) {<br>&nbsp;&nbsp;sum = sum + num;<br>}<br>var returnedValue = addSum(3); // sum will be modified but returned value is undefined</blockquote>
+
+```js
+var sum = 0;
+function addSum(num) {
+  sum = sum + num;
+}
+var returnedValue = addSum(3); // sum will be modified but returned value is undefined
+```
+
 <code>addSum</code> is a function without a <code>return</code> statement. The function will change the global <code>sum</code> variable but the returned value of the function is <code>undefined</code>.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/updating-object-properties.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/updating-object-properties.english.md
@@ -9,7 +9,16 @@ videoUrl: 'https://scrimba.com/c/c9yEJT4'
 <section id='description'>
 After you've created a JavaScript object, you can update its properties at any time just like you would update any other variable. You can use either dot or bracket notation to update.
 For example, let's look at <code>ourDog</code>:
-<blockquote>var ourDog = {<br>&nbsp;&nbsp;"name": "Camper",<br>&nbsp;&nbsp;"legs": 4,<br>&nbsp;&nbsp;"tails": 1,<br>&nbsp;&nbsp;"friends": ["everything!"]<br>};</blockquote>
+
+```js
+var ourDog = {
+  "name": "Camper",
+  "legs": 4,
+  "tails": 1,
+  "friends": ["everything!"]
+};
+```
+
 Since he's a particularly happy dog, let's change his name to "Happy Camper". Here's how we update his object's name property:
 <code>ourDog.name = "Happy Camper";</code> or
 <code>ourDog["name"] = "Happy Camper";</code>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/use-conditional-logic-with-if-statements.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/use-conditional-logic-with-if-statements.english.md
@@ -10,13 +10,7 @@ videoUrl: 'https://scrimba.com/c/cy87mf3'
 <code>If</code> statements are used to make decisions in code. The keyword <code>if</code> tells JavaScript to execute the code in the curly braces under certain conditions, defined in the parentheses. These conditions are known as <code>Boolean</code> conditions and they may only be <code>true</code> or <code>false</code>.
 When the condition evaluates to <code>true</code>, the program executes the statement inside the curly braces. When the Boolean condition evaluates to <code>false</code>, the statement inside the curly braces will not execute.
 <strong>Pseudocode</strong>
-
-```js
-if (<i>condition is true</i>) {
-  <i>statement is executed</i>
-}
-```
-
+<blockquote>if (<i>condition is true</i>) {<br>&nbsp;&nbsp;<i>statement is executed</i><br>}</blockquote>
 <strong>Example</strong>
 
 ```js

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/use-conditional-logic-with-if-statements.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/use-conditional-logic-with-if-statements.english.md
@@ -10,9 +10,26 @@ videoUrl: 'https://scrimba.com/c/cy87mf3'
 <code>If</code> statements are used to make decisions in code. The keyword <code>if</code> tells JavaScript to execute the code in the curly braces under certain conditions, defined in the parentheses. These conditions are known as <code>Boolean</code> conditions and they may only be <code>true</code> or <code>false</code>.
 When the condition evaluates to <code>true</code>, the program executes the statement inside the curly braces. When the Boolean condition evaluates to <code>false</code>, the statement inside the curly braces will not execute.
 <strong>Pseudocode</strong>
-<blockquote>if (<i>condition is true</i>) {<br>&nbsp;&nbsp;<i>statement is executed</i><br>}</blockquote>
+
+```js
+if (<i>condition is true</i>) {
+  <i>statement is executed</i>
+}
+```
+
 <strong>Example</strong>
-<blockquote>function test (myCondition) {<br>&nbsp;&nbsp;if (myCondition) {<br>&nbsp;&nbsp;&nbsp;&nbsp; return "It was true";<br>&nbsp;&nbsp;}<br>&nbsp;&nbsp;return "It was false";<br>}<br>test(true);  // returns "It was true"<br>test(false); // returns "It was false"</blockquote>
+
+```js
+function test (myCondition) {
+  if (myCondition) {
+     return "It was true";
+  }
+  return "It was false";
+}
+test(true);  // returns "It was true"
+test(false); // returns "It was false"
+```
+
 When <code>test</code> is called with a value of <code>true</code>, the <code>if</code> statement evaluates <code>myCondition</code> to see if it is <code>true</code> or not. Since it is <code>true</code>, the function returns <code>"It was true"</code>. When we call <code>test</code> with a value of <code>false</code>, <code>myCondition</code> is <em>not</em> <code>true</code> and the statement in the curly braces is not executed and the function returns <code>"It was false"</code>.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/use-multiple-conditional-ternary-operators.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/use-multiple-conditional-ternary-operators.english.md
@@ -9,9 +9,29 @@ videoUrl: 'https://scrimba.com/c/cyWJBT4'
 <section id='description'>
 In the previous challenge, you used a single <code>conditional operator</code>. You can also chain them together to check for multiple conditions.
 The following function uses if, else if, and else statements to check multiple conditions:
-<blockquote>function findGreaterOrEqual(a, b) {<br>&nbsp;&nbsp;if (a === b) {<br>&nbsp;&nbsp;&nbsp;&nbsp;return "a and b are equal";<br>&nbsp;&nbsp;}<br>&nbsp;&nbsp;else if (a > b) {<br>&nbsp;&nbsp;&nbsp;&nbsp;return "a is greater";<br>&nbsp;&nbsp;}<br>&nbsp;&nbsp;else {<br>&nbsp;&nbsp;&nbsp;&nbsp;return "b is greater";<br>&nbsp;&nbsp;}<br>}</blockquote>
+
+```js
+function findGreaterOrEqual(a, b) {
+  if (a === b) {
+    return "a and b are equal";
+  }
+  else if (a > b) {
+    return "a is greater";
+  }
+  else {
+    return "b is greater";
+  }
+}
+```
+
 The above function can be re-written using multiple <code>conditional operators</code>:
-<blockquote>function findGreaterOrEqual(a, b) {<br>&nbsp;&nbsp;return (a === b) ? "a and b are equal" : (a > b) ? "a is greater" : "b is greater";<br>}</blockquote>
+
+```js
+function findGreaterOrEqual(a, b) {
+  return (a === b) ? "a and b are equal" : (a > b) ? "a is greater" : "b is greater";
+}
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/use-the-conditional-ternary-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/use-the-conditional-ternary-operator.english.md
@@ -11,9 +11,26 @@ The <dfn>conditional operator</dfn>, also called the <dfn>ternary operator</dfn>
 The syntax is:
 <code>condition ? statement-if-true : statement-if-false;</code>
 The following function uses an if-else statement to check a condition:
-<blockquote>function findGreater(a, b) {<br>&nbsp;&nbsp;if(a > b) {<br>&nbsp;&nbsp;&nbsp;&nbsp;return "a is greater";<br>&nbsp;&nbsp;}<br>&nbsp;&nbsp;else {<br>&nbsp;&nbsp;&nbsp;&nbsp;return "b is greater";<br>&nbsp;&nbsp;}<br>}</blockquote>
+
+```js
+function findGreater(a, b) {
+  if(a > b) {
+    return "a is greater";
+  }
+  else {
+    return "b is greater";
+  }
+}
+```
+
 This can be re-written using the <code>conditional operator</code>:
-<blockquote>function findGreater(a, b) {<br>&nbsp;&nbsp;return a > b ? "a is greater" : "b is greater";<br>}</blockquote>
+
+```js
+function findGreater(a, b) {
+  return a > b ? "a is greater" : "b is greater";
+}
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/using-objects-for-lookups.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/using-objects-for-lookups.english.md
@@ -9,7 +9,25 @@ videoUrl: 'https://scrimba.com/c/cdBk8sM'
 <section id='description'>
 Objects can be thought of as a key/value storage, like a dictionary. If you have tabular data, you can use an object to "lookup" values rather than a <code>switch</code> statement or an <code>if/else</code> chain. This is most useful when you know that your input data is limited to a certain range.
 Here is an example of a simple reverse alphabet lookup:
-<blockquote>var alpha = {<br>&nbsp;&nbsp;1:"Z",<br>&nbsp;&nbsp;2:"Y",<br>&nbsp;&nbsp;3:"X",<br>&nbsp;&nbsp;4:"W",<br>&nbsp;&nbsp;...<br>&nbsp;&nbsp;24:"C",<br>&nbsp;&nbsp;25:"B",<br>&nbsp;&nbsp;26:"A"<br>};<br>alpha[2]; // "Y"<br>alpha[24]; // "C"<br><br>var value = 2;<br>alpha[value]; // "Y"</blockquote>
+
+```js
+var alpha = {
+  1:"Z",
+  2:"Y",
+  3:"X",
+  4:"W",
+  ...
+  24:"C",
+  25:"B",
+  26:"A"
+};
+alpha[2]; // "Y"
+alpha[24]; // "C"
+
+var value = 2;
+alpha[value]; // "Y"
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/word-blanks.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/word-blanks.english.md
@@ -10,7 +10,11 @@ videoUrl: 'https://scrimba.com/c/cP3vVsm'
 We will now use our knowledge of strings to build a "<a href='https://en.wikipedia.org/wiki/Mad_Libs' target='_blank'>Mad Libs</a>" style word game we're calling "Word Blanks". You will create an (optionally humorous) "Fill in the Blanks" style sentence.
 In a "Mad Libs" game, you are provided sentences with some missing words, like nouns, verbs, adjectives and adverbs. You then fill in the missing pieces with words of your choice in a way that the completed sentence makes sense.
 Consider this sentence - "It was really <strong>____</strong>, and we <strong>____</strong> ourselves <strong>____</strong>". This sentence has three missing pieces- an adjective, a verb and an adverb, and we can add words of our choice to complete it. We can then assign the completed sentence to a variable as follows:
-<blockquote>var sentence = "It was really " + "hot" + ", and we " + "laughed" + " ourselves " + "silly" + ".";</blockquote>
+
+```js
+var sentence = "It was really " + "hot" + ", and we " + "laughed" + " ourselves " + "silly" + ".";
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/write-reusable-javascript-with-functions.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/write-reusable-javascript-with-functions.english.md
@@ -9,7 +9,13 @@ videoUrl: 'https://scrimba.com/c/cL6dqfy'
 <section id='description'>
 In JavaScript, we can divide up our code into reusable parts called <dfn>functions</dfn>.
 Here's an example of a function:
-<blockquote>function functionName() {<br>&nbsp;&nbsp;console.log("Hello World");<br>}</blockquote>
+
+```js
+function functionName() {
+  console.log("Hello World");
+}
+```
+
 You can call or <dfn>invoke</dfn> this function by using its name followed by parentheses, like this:
 <code>functionName();</code>
 Each time the function is called it will print out the message <code>"Hello World"</code> on the dev console. All of the code between the curly braces will be executed every time the function is called.

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/debugging/catch-missing-open-and-closing-parenthesis-after-a-function-call.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/debugging/catch-missing-open-and-closing-parenthesis-after-a-function-call.english.md
@@ -8,7 +8,15 @@ challengeType: 1
 <section id='description'>
 When a function or method doesn't take any arguments, you may forget to include the (empty) opening and closing parentheses when calling it. Often times the result of a function call is saved in a variable for other use in your code. This error can be detected by logging variable values (or their types) to the console and seeing that one is set to a function reference, instead of the expected value the function returns.
 The variables in the following example are different:
-<blockquote>function myFunction() {<br>&nbsp;&nbsp;return "You rock!";<br>}<br>let varOne = myFunction; // set to equal a function<br>let varTwo = myFunction(); // set to equal the string "You rock!"</blockquote>
+
+```js
+function myFunction() {
+  return "You rock!";
+}
+let varOne = myFunction; // set to equal a function
+let varTwo = myFunction(); // set to equal the string "You rock!"
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/debugging/catch-mixed-usage-of-single-and-double-quotes.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/debugging/catch-mixed-usage-of-single-and-double-quotes.english.md
@@ -9,9 +9,22 @@ challengeType: 1
 JavaScript allows the use of both single (<code>'</code>) and double (<code>"</code>) quotes to declare a string. Deciding which one to use generally comes down to personal preference, with some exceptions.
 Having two choices is great when a string has contractions or another piece of text that's in quotes. Just be careful that you don't close the string too early, which causes a syntax error.
 Here are some examples of mixing quotes:
-<blockquote>// These are correct:<br>const grouchoContraction = "I've had a perfectly wonderful evening, but this wasn't it.";<br>const quoteInString = "Groucho Marx once said 'Quote me as saying I was mis-quoted.'";<br>// This is incorrect:<br>const uhOhGroucho = 'I've had a perfectly wonderful evening, but this wasn't it.';</blockquote>
+
+```js
+// These are correct:
+const grouchoContraction = "I've had a perfectly wonderful evening, but this wasn't it.";
+const quoteInString = "Groucho Marx once said 'Quote me as saying I was mis-quoted.'";
+// This is incorrect:
+const uhOhGroucho = 'I've had a perfectly wonderful evening, but this wasn't it.';
+```
+
 Of course, it is okay to use only one style of quotes. You can escape the quotes inside the string by using the backslash (\) escape character:
-<blockquote>// Correct use of same quotes:<br>const allSameQuotes = 'I\'ve had a perfectly wonderful evening, but this wasn\'t it.';</blockquote>
+
+```js
+// Correct use of same quotes:
+const allSameQuotes = 'I\'ve had a perfectly wonderful evening, but this wasn\'t it.';
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/debugging/catch-off-by-one-errors-when-using-indexing.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/debugging/catch-off-by-one-errors-when-using-indexing.english.md
@@ -8,7 +8,24 @@ challengeType: 1
 <section id='description'>
 <code>Off by one errors</code> (sometimes called OBOE) crop up when you're trying to target a specific index of a string or array (to slice or access a segment), or when looping over the indices of them. JavaScript indexing starts at zero, not one, which means the last index is always one less than the length of the item. If you try to access an index equal to the length, the program may throw an "index out of range" reference error or print <code>undefined</code>.
 When you use string or array methods that take index ranges as arguments, it helps to read the documentation and understand if they are inclusive (the item at the given index is part of what's returned) or not. Here are some examples of off by one errors:
-<blockquote>let alphabet = "abcdefghijklmnopqrstuvwxyz";<br>let len = alphabet.length;<br>for (let i = 0; i <= len; i++) {<br>&nbsp;&nbsp;// loops one too many times at the end<br>&nbsp;&nbsp;console.log(alphabet[i]);<br>}<br>for (let j = 1; j < len; j++) {<br>&nbsp;&nbsp;// loops one too few times and misses the first character at index 0<br>&nbsp;&nbsp;console.log(alphabet[j]);<br>}<br>for (let k = 0; k < len; k++) {<br>&nbsp;&nbsp;// Goldilocks approves - this is just right<br>&nbsp;&nbsp;console.log(alphabet[k]);<br>}</blockquote>
+
+```js
+let alphabet = "abcdefghijklmnopqrstuvwxyz";
+let len = alphabet.length;
+for (let i = 0; i <= len; i++) {
+  // loops one too many times at the end
+  console.log(alphabet[i]);
+}
+for (let j = 1; j < len; j++) {
+  // loops one too few times and misses the first character at index 0
+  console.log(alphabet[j]);
+}
+for (let k = 0; k < len; k++) {
+  // Goldilocks approves - this is just right
+  console.log(alphabet[k]);
+}
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/debugging/catch-use-of-assignment-operator-instead-of-equality-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/debugging/catch-use-of-assignment-operator-instead-of-equality-operator.english.md
@@ -10,7 +10,17 @@ Branching programs, i.e. ones that do different things if certain conditions are
 This logic is spoken (in English, at least) as "if x equals y, then ..." which can literally translate into code using the <code>=</code>, or assignment operator. This leads to unexpected control flow in your program.
 As covered in previous challenges, the assignment operator (<code>=</code>) in JavaScript assigns a value to a variable name. And the <code>==</code> and <code>===</code> operators check for equality (the triple <code>===</code> tests for strict equality, meaning both value and type are the same).
 The code below assigns <code>x</code> to be 2, which evaluates as <code>true</code>. Almost every value on its own in JavaScript evaluates to <code>true</code>, except what are known as the "falsy" values: <code>false</code>, <code>0</code>, <code>""</code> (an empty string), <code>NaN</code>, <code>undefined</code>, and <code>null</code>.
-<blockquote>let x = 1;<br>let y = 2;<br>if (x = y) {<br>&nbsp;&nbsp;// this code block will run for any value of y (unless y were originally set as a falsy)<br>} else {<br>&nbsp;&nbsp;// this code block is what should run (but won't) in this example<br>}</blockquote>
+
+```js
+let x = 1;
+let y = 2;
+if (x = y) {
+  // this code block will run for any value of y (unless y were originally set as a falsy)
+} else {
+  // this code block is what should run (but won't) in this example
+}
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/debugging/prevent-infinite-loops-with-a-valid-terminal-condition.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/debugging/prevent-infinite-loops-with-a-valid-terminal-condition.english.md
@@ -8,7 +8,15 @@ challengeType: 1
 <section id='description'>
 The final topic is the dreaded infinite loop. Loops are great tools when you need your program to run a code block a certain number of times or until a condition is met, but they need a terminal condition that ends the looping. Infinite loops are likely to freeze or crash the browser, and cause general program execution mayhem, which no one wants.
 There was an example of an infinite loop in the introduction to this section - it had no terminal condition to break out of the <code>while</code> loop inside <code>loopy()</code>. Do NOT call this function!
-<blockquote>function loopy() {<br>&nbsp;&nbsp;while(true) {<br>&nbsp;&nbsp;&nbsp;&nbsp;console.log("Hello, world!");<br>&nbsp;&nbsp;}<br>}</blockquote>
+
+```js
+function loopy() {
+  while(true) {
+    console.log("Hello, world!");
+  }
+}
+```
+
 It's the programmer's job to ensure that the terminal condition, which tells the program when to break out of the loop code, is eventually reached. One error is incrementing or decrementing a counter variable in the wrong direction from the terminal condition. Another one is accidentally resetting a counter or index variable within the loop code, instead of incrementing or decrementing it.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/debugging/use-typeof-to-check-the-type-of-a-variable.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/debugging/use-typeof-to-check-the-type-of-a-variable.english.md
@@ -8,7 +8,14 @@ challengeType: 1
 <section id='description'>
 You can use <code>typeof</code> to check the data structure, or type, of a variable. This is useful in debugging when working with multiple data types. If you think you're adding two numbers, but one is actually a string, the results can be unexpected. Type errors can lurk in calculations or function calls. Be careful especially when you're accessing and working with external data in the form of a JavaScript Object Notation (JSON) object.
 Here are some examples using <code>typeof</code>:
-<blockquote>console.log(typeof ""); // outputs "string"<br>console.log(typeof 0); // outputs "number"<br>console.log(typeof []); // outputs "object"<br>console.log(typeof {}); // outputs "object"</blockquote>
+
+```js
+console.log(typeof ""); // outputs "string"
+console.log(typeof 0); // outputs "number"
+console.log(typeof []); // outputs "object"
+console.log(typeof {}); // outputs "object"
+```
+
 JavaScript recognizes six primitive (immutable) data types: <code>Boolean</code>, <code>Null</code>, <code>Undefined</code>, <code>Number</code>, <code>String</code>, and <code>Symbol</code> (new with ES6) and one type for mutable items: <code>Object</code>. Note that in JavaScript, arrays are technically a type of object.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/compare-scopes-of-the-var-and-let-keywords.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/compare-scopes-of-the-var-and-let-keywords.english.md
@@ -9,13 +9,65 @@ challengeType: 1
 When you declare a variable with the <code>var</code> keyword, it is declared globally, or locally if declared inside a function.
 The <code>let</code> keyword behaves similarly, but with some extra features. When you declare a variable with the <code>let</code> keyword inside a block, statement, or expression, its scope is limited to that block, statement, or expression.
 For example:
-<blockquote>var numArray = [];<br>for (var i = 0; i < 3; i++) {<br>&nbsp;&nbsp;numArray.push(i);<br>}<br>console.log(numArray);<br>// returns [0, 1, 2]<br>console.log(i);<br>// returns 3</blockquote>
+
+```js
+var numArray = [];
+for (var i = 0; i < 3; i++) {
+  numArray.push(i);
+}
+console.log(numArray);
+// returns [0, 1, 2]
+console.log(i);
+// returns 3
+```
+
 With the <code>var</code> keyword, <code>i</code> is declared globally. So when <code>i++</code> is executed, it updates the global variable. This code is similar to the following:
-<blockquote>var numArray = [];<br>var i;<br>for (i = 0; i < 3; i++) {<br>&nbsp;&nbsp;numArray.push(i);<br>}<br>console.log(numArray);<br>// returns [0, 1, 2]<br>console.log(i);<br>// returns 3</blockquote>
+
+```js
+var numArray = [];
+var i;
+for (i = 0; i < 3; i++) {
+  numArray.push(i);
+}
+console.log(numArray);
+// returns [0, 1, 2]
+console.log(i);
+// returns 3
+```
+
 This behavior will cause problems if you were to create a function and store it for later use inside a for loop that uses the <code>i</code> variable. This is because the stored function will always refer to the value of the updated global <code>i</code> variable.
-<blockquote>var printNumTwo;<br>for (var i = 0; i < 3; i++) {<br>&nbsp;&nbsp;if (i === 2) {<br>&nbsp;&nbsp;&nbsp;&nbsp;printNumTwo = function() {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return i;<br>&nbsp;&nbsp;&nbsp;&nbsp;};<br>&nbsp;&nbsp;}<br>}<br>console.log(printNumTwo());<br>// returns 3</blockquote>
+
+```js
+var printNumTwo;
+for (var i = 0; i < 3; i++) {
+  if (i === 2) {
+    printNumTwo = function() {
+      return i;
+    };
+  }
+}
+console.log(printNumTwo());
+// returns 3
+```
+
 As you can see, <code>printNumTwo()</code> prints 3 and not 2. This is because the value assigned to <code>i</code> was updated and the <code>printNumTwo()</code> returns the global <code>i</code> and not the value <code>i</code> had when the function was created in the for loop. The <code>let</code> keyword does not follow this behavior:
-<blockquote>'use strict';<br>let printNumTwo;<br>for (let i = 0; i < 3; i++) {<br>&nbsp;&nbsp;if (i === 2) {<br>&nbsp;&nbsp;&nbsp;&nbsp;printNumTwo = function() {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return i;<br>&nbsp;&nbsp;&nbsp;&nbsp;};<br>&nbsp;&nbsp;}<br>}<br>console.log(printNumTwo());<br>// returns 2<br>console.log(i);<br>// returns "i is not defined"</blockquote>
+
+```js
+'use strict';
+let printNumTwo;
+for (let i = 0; i < 3; i++) {
+  if (i === 2) {
+    printNumTwo = function() {
+      return i;
+    };
+  }
+}
+console.log(printNumTwo());
+// returns 2
+console.log(i);
+// returns "i is not defined"
+```
+
 <code>i</code> is not defined because it was not declared in the global scope. It is only declared within the for loop statement. <code>printNumTwo()</code> returned the correct value because three different <code>i</code> variables with unique values (0, 1, and 2) were created by the <code>let</code> keyword within the loop statement.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/create-an-export-fallback-with-export-default.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/create-an-export-fallback-with-export-default.english.md
@@ -9,7 +9,13 @@ challengeType: 1
 In the <code>export</code> lesson, you learned about the syntax referred to as a <dfn>named export</dfn>. This allowed you to make multiple functions and variables available for use in other files.
 There is another <code>export</code> syntax you need to know, known as <dfn>export default</dfn>. Usually you will use this syntax if only one value is being exported from a file. It is also used to create a fallback value for a file or module.
 Here is a quick example of <code>export default</code>:
-<blockquote>export default function add(x,y) {<br>&nbsp;&nbsp;return x + y;<br>}</blockquote>
+
+```js
+export default function add(x,y) {
+  return x + y;
+}
+```
+
 Note: Since <code>export default</code> is used to declare a fallback value for a module or file, you can only have one value be a default export in each module or file. Additionally, you cannot use <code>export default</code> with <code>var</code>, <code>let</code>, or <code>const</code>
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/create-strings-using-template-literals.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/create-strings-using-template-literals.english.md
@@ -9,7 +9,23 @@ challengeType: 1
 A new feature of ES6 is the <dfn>template literal</dfn>. This is a special type of string that makes creating complex strings easier.
 Template literals allow you to create multi-line strings and to use string interpolation features to create strings.
 Consider the code below:
-<blockquote>const person = {<br>&nbsp;&nbsp;name: "Zodiac Hasbro",<br>&nbsp;&nbsp;age: 56<br>};<br><br>// Template literal with multi-line and string interpolation<br>const greeting = `Hello, my name is ${person.name}!<br>I am ${person.age} years old.`;<br><br>console.log(greeting); // prints<br>// Hello, my name is Zodiac Hasbro!<br>// I am 56 years old.<br></blockquote>
+
+```js
+const person = {
+  name: "Zodiac Hasbro",
+  age: 56
+};
+
+// Template literal with multi-line and string interpolation
+const greeting = `Hello, my name is ${person.name}!
+I am ${person.age} years old.`;
+
+console.log(greeting); // prints
+// Hello, my name is Zodiac Hasbro!
+// I am 56 years old.
+
+```
+
 A lot of things happened there.
 Firstly, the example uses backticks (<code>`</code>), not quotes (<code>'</code> or <code>"</code>), to wrap the string.
 Secondly, notice that the string is multi-line, both in the code and the output. This saves inserting <code>\n</code> within strings.

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/declare-a-read-only-variable-with-the-const-keyword.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/declare-a-read-only-variable-with-the-const-keyword.english.md
@@ -8,7 +8,13 @@ challengeType: 1
 <section id='description'>
 The keyword <code>let</code> is not the only new way to declare variables. In ES6, you can also declare variables using the <code>const</code> keyword.
 <code>const</code> has all the awesome features that <code>let</code> has, with the added bonus that variables declared using <code>const</code> are read-only. They are a constant value, which means that once a variable is assigned with <code>const</code>, it cannot be reassigned.
-<blockquote>"use strict";<br>const FAV_PET = "Cats";<br>FAV_PET = "Dogs"; // returns error</blockquote>
+
+```js
+"use strict";
+const FAV_PET = "Cats";
+FAV_PET = "Dogs"; // returns error
+```
+
 As you can see, trying to reassign a variable declared with <code>const</code> will throw an error. You should always name variables you don't want to reassign using the <code>const</code> keyword. This helps when you accidentally attempt to reassign a variable that is meant to stay constant. A common practice when naming constants is to use all uppercase letters, with words separated by an underscore.
   
   <strong>Note:</strong> It is common for developers to use uppercase variable identifiers for immutable values and lowercase or camelCase for mutable values (objects and arrays). In a later challenge you will see an example of a lowercase variable identifier being used for an array.

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/explore-differences-between-the-var-and-let-keywords.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/explore-differences-between-the-var-and-let-keywords.english.md
@@ -7,17 +7,34 @@ challengeType: 1
 ## Description
 <section id='description'>
 One of the biggest problems with declaring variables with the <code>var</code> keyword is that you can overwrite variable declarations without an error.
-<blockquote>var camper = 'James';<br>var camper = 'David';<br>console.log(camper);<br>// logs 'David'</blockquote>
+
+```js
+var camper = 'James';
+var camper = 'David';
+console.log(camper);
+// logs 'David'
+```
+
 As you can see in the code above, the <code>camper</code> variable is originally declared as <code>James</code> and then overridden to be <code>David</code>.
 In a small application, you might not run into this type of problem, but when your code becomes larger, you might accidentally overwrite a variable that you did not intend to overwrite.
 Because this behavior does not throw an error, searching and fixing bugs becomes more difficult.<br>
 A new keyword called <code>let</code> was introduced in ES6 to solve this potential issue with the <code>var</code> keyword.
 If you were to replace <code>var</code> with <code>let</code> in the variable declarations of the code above, the result would be an error.
-<blockquote>let camper = 'James';<br>let camper = 'David'; // throws an error</blockquote>
+
+```js
+let camper = 'James';
+let camper = 'David'; // throws an error
+```
+
 This error can be seen in the console of your browser.
 So unlike <code>var</code>, when using <code>let</code>, a variable with the same name can only be declared once.
 Note the <code>"use strict"</code>. This enables Strict Mode, which catches common coding mistakes and "unsafe" actions. For instance:
-<blockquote>"use strict";<br>x = 3.14; // throws an error because x is not declared</blockquote>
+
+```js
+"use strict";
+x = 3.14; // throws an error because x is not declared
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/import-a-default-export.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/import-a-default-export.english.md
@@ -8,7 +8,12 @@ challengeType: 1
 <section id='description'>
 In the last challenge, you learned about <code>export default</code> and its uses. It is important to note that, to import a default export, you need to use a different <code>import</code> syntax.
 In the following example, we have a function, <code>add</code>, that is the default export of a file, <code>"math_functions"</code>. Here is how to import it:
-<blockquote>import add from "math_functions";<br>add(5,4); // Will return 9</blockquote>
+
+```js
+import add from "math_functions";
+add(5,4); // Will return 9
+```
+
 The syntax differs in one key place - the imported value, <code>add</code>, is not surrounded by curly braces, <code>{}</code>. Unlike exported values, the primary method of importing a default export is to simply write the value's name after <code>import</code>.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/mutate-an-array-declared-with-const.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/mutate-an-array-declared-with-const.english.md
@@ -9,7 +9,15 @@ challengeType: 1
 The <code>const</code> declaration has many use cases in modern JavaScript.
 Some developers prefer to assign all their variables using <code>const</code> by default, unless they know they will need to reassign the value. Only in that case, they use <code>let</code>.
 However, it is important to understand that objects (including arrays and functions) assigned to a variable using <code>const</code> are still mutable. Using the <code>const</code> declaration only prevents reassignment of the variable identifier.
-<blockquote>"use strict";<br>const s = [5, 6, 7];<br>s = [1, 2, 3]; // throws error, trying to assign a const<br>s[2] = 45; // works just as it would with an array declared with var or let<br>console.log(s); // returns [5, 6, 45]</blockquote>
+
+```js
+"use strict";
+const s = [5, 6, 7];
+s = [1, 2, 3]; // throws error, trying to assign a const
+s[2] = 45; // works just as it would with an array declared with var or let
+console.log(s); // returns [5, 6, 45]
+```
+
 As you can see, you can mutate the object <code>[5, 6, 7]</code> itself and the variable <code>s</code> will still point to the altered array <code>[5, 6, 45]</code>. Like all arrays, the array elements in <code>s</code> are mutable, but because <code>const</code> was used, you cannot use the variable identifier <code>s</code> to point to a different array using the assignment operator.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/prevent-object-mutation.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/prevent-object-mutation.english.md
@@ -8,7 +8,19 @@ challengeType: 1
 <section id='description'>
 As seen in the previous challenge, <code>const</code> declaration alone doesn't really protect your data from mutation. To ensure your data doesn't change, JavaScript provides a function <code>Object.freeze</code> to prevent data mutation.
 Once the object is frozen, you can no longer add, update, or delete properties from it. Any attempt at changing the object will be rejected without an error.
-<blockquote>let obj = {<br>&nbsp;&nbsp;name:"FreeCodeCamp",<br>&nbsp;&nbsp;review:"Awesome"<br>};<br>Object.freeze(obj);<br>obj.review = "bad"; // will be ignored. Mutation not allowed<br>obj.newProp = "Test"; // will be ignored. Mutation not allowed<br>console.log(obj); <br>// { name: "FreeCodeCamp", review:"Awesome"}</blockquote>
+
+```js
+let obj = {
+  name:"FreeCodeCamp",
+  review:"Awesome"
+};
+Object.freeze(obj);
+obj.review = "bad"; // will be ignored. Mutation not allowed
+obj.newProp = "Test"; // will be ignored. Mutation not allowed
+console.log(obj); 
+// { name: "FreeCodeCamp", review:"Awesome"}
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/set-default-parameters-for-your-functions.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/set-default-parameters-for-your-functions.english.md
@@ -8,7 +8,15 @@ challengeType: 1
 <section id='description'>
 In order to help us create more flexible functions, ES6 introduces <dfn>default parameters</dfn> for functions.
 Check out this code:
-<blockquote>function greeting(name = "Anonymous") {<br>&nbsp;&nbsp;return "Hello " + name;<br>}<br>console.log(greeting("John")); // Hello John<br>console.log(greeting()); // Hello Anonymous</blockquote>
+
+```js
+function greeting(name = "Anonymous") {
+  return "Hello " + name;
+}
+console.log(greeting("John")); // Hello John
+console.log(greeting()); // Hello Anonymous
+```
+
 The default parameter kicks in when the argument is not specified (it is undefined). As you can see in the example above, the parameter <code>name</code> will receive its default value <code>"Anonymous"</code> when you do not provide a value for the parameter. You can add default values for as many parameters as you want.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/understand-the-differences-between-import-and-require.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/understand-the-differences-between-import-and-require.english.md
@@ -9,9 +9,18 @@ challengeType: 1
 In the past, the function <code>require()</code> would be used to import the functions and code in external files and modules. While handy, this presents a problem: some files and modules are rather large, and you may only need certain code from those external resources.
 ES6 gives us a very handy tool known as <dfn>import</dfn>. With it, we can choose which parts of a module or file to load into a given file, saving time and memory.
 Consider the following example. Imagine that <code>math_array_functions</code> has about 20 functions, but I only need one, <code>countItems</code>, in my current file. The old <code>require()</code> approach would force me to bring in all 20 functions. With this new <code>import</code> syntax, I can bring in just the desired function, like so:
-<blockquote>import { countItems } from "math_array_functions"</blockquote>
+
+```js
+import { countItems } from "math_array_functions"
+```
+
 A description of the above code:
-<blockquote>import { function } from "file_path_goes_here"<br>// We can also import variables the same way!</blockquote>
+
+```js
+import { function } from "file_path_goes_here"
+// We can also import variables the same way!
+```
+
 There are a few ways to write an <code>import</code> statement, but the above is a very common use-case.
 <strong>Note</strong><br>The whitespace surrounding the function inside the curly braces is a best practice - it makes it easier to read the <code>import</code> statement.
 <strong>Note</strong><br>The lessons in this section handle non-browser features. <code>import</code>, and the statements we introduce in the rest of these lessons, won't work on a browser directly. However, we can use various tools to create code out of this to make it work in browser.

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use--to-import-everything-from-a-file.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use--to-import-everything-from-a-file.english.md
@@ -8,9 +8,20 @@ challengeType: 1
 <section id='description'>
 Suppose you have a file and you wish to import all of its contents into the current file. This can be done with the <code>import * as</code> syntax.
 Here's an example where the contents of a file named <code>"math_functions"</code> are imported into a file in the same directory:
-<blockquote>import * as myMathModule from "math_functions";<br>myMathModule.add(2,3);<br>myMathModule.subtract(5,3);</blockquote>
+
+```js
+import * as myMathModule from "math_functions";
+myMathModule.add(2,3);
+myMathModule.subtract(5,3);
+```
+
 And breaking down that code:
-<blockquote>import * as object_with_name_of_your_choice from "file_path_goes_here"<br>object_with_name_of_your_choice.imported_function</blockquote>
+
+```js
+import * as object_with_name_of_your_choice from "file_path_goes_here"
+object_with_name_of_your_choice.imported_function
+```
+
 You may use any name following the <code>import * as </code>portion of the statement. In order to utilize this method, it requires an object that receives the imported values (i.e., you must provide a name). From here, you will use the dot notation to call your imported values.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-arrow-functions-to-write-concise-anonymous-functions.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-arrow-functions-to-write-concise-anonymous-functions.english.md
@@ -8,11 +8,29 @@ challengeType: 1
 <section id='description'>
 In JavaScript, we often don't need to name our functions, especially when passing a function as an argument to another function. Instead, we create inline functions. We don't need to name these functions because we do not reuse them anywhere else.
 To achieve this, we often use the following syntax:
-<blockquote>const myFunc = function() {<br>&nbsp;&nbsp;const myVar = "value";<br>&nbsp;&nbsp;return myVar;<br>}</blockquote>
+
+```js
+const myFunc = function() {
+  const myVar = "value";
+  return myVar;
+}
+```
+
 ES6 provides us with the syntactic sugar to not have to write anonymous functions this way. Instead, you can use <strong>arrow function syntax</strong>:
-<blockquote>const myFunc = () => {<br>&nbsp;&nbsp;const myVar = "value";<br>&nbsp;&nbsp;return myVar;<br>}</blockquote>
+
+```js
+const myFunc = () => {
+  const myVar = "value";
+  return myVar;
+}
+```
+
 When there is no function body, and only a return value, arrow function syntax allows you to omit the keyword <code>return</code> as well as the brackets surrounding the code. This helps simplify smaller functions into one-line statements:
-<blockquote>const myFunc = () => "value"</blockquote>
+
+```js
+const myFunc = () => "value"
+```
+
 This code will still return <code>value</code> by default.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-class-syntax-to-define-a-constructor-function.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-class-syntax-to-define-a-constructor-function.english.md
@@ -9,9 +9,25 @@ challengeType: 1
 ES6 provides a new syntax to help create objects, using the keyword <dfn>class</dfn>.
 This is to be noted, that the <code>class</code> syntax is just a syntax, and not a full-fledged class based implementation of object oriented paradigm, unlike in languages like Java, or Python, or Ruby etc.
 In ES5, we usually define a constructor function, and use the <code>new</code> keyword to instantiate an object.
-<blockquote>var SpaceShuttle = function(targetPlanet){<br>&nbsp;&nbsp;this.targetPlanet = targetPlanet;<br>}<br>var zeus = new SpaceShuttle('Jupiter');</blockquote>
+
+```js
+var SpaceShuttle = function(targetPlanet){
+  this.targetPlanet = targetPlanet;
+}
+var zeus = new SpaceShuttle('Jupiter');
+```
+
 The class syntax simply replaces the constructor function creation:
-<blockquote>class SpaceShuttle {<br>&nbsp;&nbsp;constructor(targetPlanet) {<br>&nbsp;&nbsp;&nbsp;&nbsp;this.targetPlanet = targetPlanet;<br>&nbsp;&nbsp;}<br>}<br>const zeus = new SpaceShuttle('Jupiter');</blockquote>
+
+```js
+class SpaceShuttle {
+  constructor(targetPlanet) {
+    this.targetPlanet = targetPlanet;
+  }
+}
+const zeus = new SpaceShuttle('Jupiter');
+```
+
 Notice that the <code>class</code> keyword declares a new function, and a constructor was added, which would be invoked when <code>new</code> is called - to create a new object.<br>
 <strong>Notes:</strong><br><ul>
 <li> UpperCamelCase should be used by convention for ES6 class names, as in <code>SpaceShuttle</code> used above.</li>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-assign-variables-from-arrays.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-assign-variables-from-arrays.english.md
@@ -9,10 +9,20 @@ challengeType: 1
 ES6 makes destructuring arrays as easy as destructuring objects.
 One key difference between the spread operator and array destructuring is that the spread operator unpacks all contents of an array into a comma-separated list. Consequently, you cannot pick or choose which elements you want to assign to variables.
 Destructuring an array lets us do exactly that:
-<blockquote>const [a, b] = [1, 2, 3, 4, 5, 6];<br>console.log(a, b); // 1, 2</blockquote>
+
+```js
+const [a, b] = [1, 2, 3, 4, 5, 6];
+console.log(a, b); // 1, 2
+```
+
 The variable <code>a</code> is assigned the first value of the array, and <code>b</code> is assigned the second value of the array.
 We can also access the value at any index in an array with destructuring by using commas to reach the desired index:
-<blockquote>const [a, b,,, c] = [1, 2, 3, 4, 5, 6];<br>console.log(a, b, c); // 1, 2, 5 </blockquote>
+
+```js
+const [a, b,,, c] = [1, 2, 3, 4, 5, 6];
+console.log(a, b, c); // 1, 2, 5
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-assign-variables-from-nested-objects.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-assign-variables-from-nested-objects.english.md
@@ -8,7 +8,16 @@ challengeType: 1
 <section id='description'>
 We can similarly destructure <em>nested</em> objects into variables.
 Consider the following code:
-<blockquote>const a = {<br>&nbsp;&nbsp;start: { x: 5, y: 6 },<br>&nbsp;&nbsp;end: { x: 6, y: -9 }<br>};<br>const { start: { x: startX, y: startY }} = a;<br>console.log(startX, startY); // 5, 6</blockquote>
+
+```js
+const a = {
+  start: { x: 5, y: 6 },
+  end: { x: 6, y: -9 }
+};
+const { start: { x: startX, y: startY }} = a;
+console.log(startX, startY); // 5, 6
+```
+
 In the example above, the variable <code>startX</code> is assigned the value of <code>a.start.x</code>.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-assign-variables-from-objects.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-assign-variables-from-objects.english.md
@@ -9,11 +9,26 @@ challengeType: 1
 We saw earlier how spread operator can effectively spread, or unpack, the contents of the array.
 We can do something similar with objects as well. <dfn>Destructuring assignment</dfn> is special syntax for neatly assigning values taken directly from an object to variables.
 Consider the following ES5 code:
-<blockquote>var voxel = { x: 3.6, y: 7.4, z: 6.54 };<br>var x = voxel.x; // x = 3.6<br>var y = voxel.y; // y = 7.4<br>var z = voxel.z; // z = 6.54</blockquote>
+
+```js
+var voxel = { x: 3.6, y: 7.4, z: 6.54 };
+var x = voxel.x; // x = 3.6
+var y = voxel.y; // y = 7.4
+var z = voxel.z; // z = 6.54
+```
+
 Here's the same assignment statement with ES6 destructuring syntax:
-<blockquote>const { x, y, z } = voxel; // x = 3.6, y = 7.4, z = 6.54</blockquote>
+
+```js
+const { x, y, z } = voxel; // x = 3.6, y = 7.4, z = 6.54
+```
+
 If instead you want to store the values of <code>voxel.x</code> into <code>a</code>, <code>voxel.y</code> into <code>b</code>, and <code>voxel.z</code> into <code>c</code>, you have that freedom as well.
-<blockquote>const { x: a, y: b, z: c } = voxel; // a = 3.6, b = 7.4, c = 6.54</blockquote>
+
+```js
+const { x: a, y: b, z: c } = voxel; // a = 3.6, b = 7.4, c = 6.54
+```
+
 You may read it as "get the field <code>x</code> and copy the value into <code>a</code>," and so on.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-pass-an-object-as-a-functions-parameters.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-pass-an-object-as-a-functions-parameters.english.md
@@ -8,9 +8,22 @@ challengeType: 1
 <section id='description'>
 In some cases, you can destructure the object in a function argument itself.
 Consider the code below:
-<blockquote>const profileUpdate = (profileData) => {<br>&nbsp;&nbsp;const { name, age, nationality, location } = profileData;<br>&nbsp;&nbsp;// do something with these variables<br>}</blockquote>
+
+```js
+const profileUpdate = (profileData) => {
+  const { name, age, nationality, location } = profileData;
+  // do something with these variables
+}
+```
+
 This effectively destructures the object sent into the function. This can also be done in-place:
-<blockquote>const profileUpdate = ({ name, age, nationality, location }) => {<br>&nbsp;&nbsp;/* do something with these fields */<br>}</blockquote>
+
+```js
+const profileUpdate = ({ name, age, nationality, location }) => {
+  /* do something with these fields */
+}
+```
+
 This removes some extra lines and makes our code look neat.
 This has the added benefit of not having to manipulate an entire object in a function; only the fields that are needed are copied inside the function.
 </section>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-with-the-rest-parameter-to-reassign-array-elements.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-with-the-rest-parameter-to-reassign-array-elements.english.md
@@ -8,7 +8,13 @@ challengeType: 1
 <section id='description'>
 In some situations involving array destructuring, we might want to collect the rest of the elements into a separate array.
 The result is similar to <code>Array.prototype.slice()</code>, as shown below:
-<blockquote>const [a, b, ...arr] = [1, 2, 3, 4, 5, 7];<br>console.log(a, b); // 1, 2<br>console.log(arr); // [3, 4, 5, 7]</blockquote>
+
+```js
+const [a, b, ...arr] = [1, 2, 3, 4, 5, 7];
+console.log(a, b); // 1, 2
+console.log(arr); // [3, 4, 5, 7]
+```
+
 Variables <code>a</code> and <code>b</code> take the first and second values from the array. After that, because of rest parameter's presence, <code>arr</code> gets rest of the values in the form of an array.
 The rest element only works correctly as the last variable in the list. As in, you cannot use the rest parameter to catch a subarray that leaves out last element of the original array.
 </section>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-export-to-reuse-a-code-block.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-export-to-reuse-a-code-block.english.md
@@ -8,9 +8,25 @@ challengeType: 1
 <section id='description'>
 In the previous challenge, you learned about <code>import</code> and how it can be leveraged to import small amounts of code from large files. In order for this to work, though, we must utilize one of the statements that goes with <code>import</code>, known as <dfn>export</dfn>. When we want some code - a function, or a variable - to be usable in another file, we must export it in order to import it into another file. Like <code>import</code>, <code>export</code> is a non-browser feature.
 The following is what we refer to as a <dfn>named export</dfn>. With this, we can import any code we export into another file with the <code>import</code> syntax you learned in the last lesson. Here's an example:
-<blockquote>const capitalizeString = (string) => {<br>&nbsp;&nbsp;return string.charAt(0).toUpperCase() + string.slice(1);<br>}<br>export { capitalizeString } // How to export functions.<br>export const foo = "bar"; // How to export variables.</blockquote>
+
+```js
+const capitalizeString = (string) => {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}
+export { capitalizeString } // How to export functions.
+export const foo = "bar"; // How to export variables.
+```
+
 Alternatively, if you would like to compact all your <code>export</code> statements into one line, you can take this approach:
-<blockquote>const capitalizeString = (string) => {<br>&nbsp;&nbsp;return string.charAt(0).toUpperCase() + string.slice(1);<br>}<br>const foo = "bar";<br>export { capitalizeString, foo }</blockquote>
+
+```js
+const capitalizeString = (string) => {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}
+const foo = "bar";
+export { capitalizeString, foo }
+```
+
 Either approach is perfectly acceptable.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-getters-and-setters-to-control-access-to-an-object.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-getters-and-setters-to-control-access-to-an-object.english.md
@@ -10,7 +10,27 @@ You can obtain values from an object, and set a value of a property within an ob
 These are classically called <dfn>getters</dfn> and <dfn>setters</dfn>.
 Getter functions are meant to simply return (get) the value of an object's private variable to the user without the user directly accessing the private variable.
 Setter functions are meant to modify (set) the value of an object's private variable based on the value passed into the setter function. This change could involve calculations, or even overwriting the previous value completely.<br><br>
-<blockquote>class Book {<br>&nbsp;&nbsp;constructor(author) {<br>&nbsp;&nbsp;&nbsp;&nbsp;this._author = author;<br>&nbsp;&nbsp;}<br>&nbsp;&nbsp;// getter<br>&nbsp;&nbsp;get writer() {<br>&nbsp;&nbsp;&nbsp;&nbsp;return this._author;<br>&nbsp;&nbsp;}<br>&nbsp;&nbsp;// setter<br>&nbsp;&nbsp;set writer(updatedAuthor) {<br>&nbsp;&nbsp;&nbsp;&nbsp;this._author = updatedAuthor;<br>&nbsp;&nbsp;}<br>}<br>const lol = new Book('anonymous');<br>console.log(lol.writer);&nbsp;&nbsp;// anonymous<br>lol.writer = 'wut';<br>console.log(lol.writer);&nbsp;&nbsp;// wut</blockquote>
+
+```js
+class Book {
+  constructor(author) {
+    this._author = author;
+  }
+  // getter
+  get writer() {
+    return this._author;
+  }
+  // setter
+  set writer(updatedAuthor) {
+    this._author = updatedAuthor;
+  }
+}
+const lol = new Book('anonymous');
+console.log(lol.writer);  // anonymous
+lol.writer = 'wut';
+console.log(lol.writer);  // wut
+```
+
 Notice the syntax we are using to invoke the getter and setter - as if they are not even functions.
 Getters and setters are important, because they hide internal implementation details.
 <strong>Note:</strong> It is a convention to precede the name of a private variable with an underscore (<code>_</code>). The practice itself does not make a variable private.

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-the-rest-parameter-with-function-parameters.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-the-rest-parameter-with-function-parameters.english.md
@@ -8,8 +8,21 @@ challengeType: 1
 <section id='description'>
 In order to help us create more flexible functions, ES6 introduces the <dfn>rest parameter</dfn> for function parameters. With the rest parameter, you can create functions that take a variable number of arguments. These arguments are stored in an array that can be accessed later from inside the function.
 Check out this code:
+<<<<<<< HEAD:curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-the-rest-parameter-with-function-parameters.english.md
 <blockquote>function howMany(...args) {<br>&nbsp;&nbsp;return "You have passed " + args.length + " arguments.";<br>}<br>console.log(howMany(0, 1, 2)); // You have passed 3 arguments<br>console.log(howMany("string", null, [1, 2, 3], { })); // You have passed 4 arguments.</blockquote>
 The rest parameter eliminates the need to check the <code>args</code> array and allows us to apply <code>map()</code>, <code>filter()</code> and <code>reduce()</code> on the parameters array.
+=======
+
+```js
+function howMany(...args) {
+  return "You have passed " + args.length + " arguments.";
+}
+console.log(howMany(0, 1, 2)); // You have passed 3 arguments.
+console.log(howMany("string", null, [1, 2, 3], { })); // You have passed 4 arguments.
+```
+
+The rest operator eliminates the need to check the <code>args</code> array and allows us to apply <code>map()</code>, <code>filter()</code> and <code>reduce()</code> on the parameters array.
+>>>>>>> fix: convert js algorithms and data structures:curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-the-rest-operator-with-function-parameters.english.md
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-the-rest-parameter-with-function-parameters.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-the-rest-parameter-with-function-parameters.english.md
@@ -8,10 +8,6 @@ challengeType: 1
 <section id='description'>
 In order to help us create more flexible functions, ES6 introduces the <dfn>rest parameter</dfn> for function parameters. With the rest parameter, you can create functions that take a variable number of arguments. These arguments are stored in an array that can be accessed later from inside the function.
 Check out this code:
-<<<<<<< HEAD:curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-the-rest-parameter-with-function-parameters.english.md
-<blockquote>function howMany(...args) {<br>&nbsp;&nbsp;return "You have passed " + args.length + " arguments.";<br>}<br>console.log(howMany(0, 1, 2)); // You have passed 3 arguments<br>console.log(howMany("string", null, [1, 2, 3], { })); // You have passed 4 arguments.</blockquote>
-The rest parameter eliminates the need to check the <code>args</code> array and allows us to apply <code>map()</code>, <code>filter()</code> and <code>reduce()</code> on the parameters array.
-=======
 
 ```js
 function howMany(...args) {
@@ -21,8 +17,7 @@ console.log(howMany(0, 1, 2)); // You have passed 3 arguments.
 console.log(howMany("string", null, [1, 2, 3], { })); // You have passed 4 arguments.
 ```
 
-The rest operator eliminates the need to check the <code>args</code> array and allows us to apply <code>map()</code>, <code>filter()</code> and <code>reduce()</code> on the parameters array.
->>>>>>> fix: convert js algorithms and data structures:curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-the-rest-operator-with-function-parameters.english.md
+The rest parameter eliminates the need to check the <code>args</code> array and allows us to apply <code>map()</code>, <code>filter()</code> and <code>reduce()</code> on the parameters array.
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-the-spread-operator-to-evaluate-arrays-in-place.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-the-spread-operator-to-evaluate-arrays-in-place.english.md
@@ -8,13 +8,27 @@ challengeType: 1
 <section id='description'>
 ES6 introduces the <dfn>spread operator</dfn>, which allows us to expand arrays and other expressions in places where multiple parameters or elements are expected.
 The ES5 code below uses <code>apply()</code> to compute the maximum value in an array:
-<blockquote>var arr = [6, 89, 3, 45];<br>var maximus = Math.max.apply(null, arr); // returns 89</blockquote>
+
+```js
+var arr = [6, 89, 3, 45];
+var maximus = Math.max.apply(null, arr); // returns 89
+```
+
 We had to use <code>Math.max.apply(null, arr)</code> because <code>Math.max(arr)</code> returns <code>NaN</code>. <code>Math.max()</code> expects comma-separated arguments, but not an array.
 The spread operator makes this syntax much better to read and maintain.
-<blockquote>const arr = [6, 89, 3, 45];<br>const maximus = Math.max(...arr); // returns 89</blockquote>
+
+```js
+const arr = [6, 89, 3, 45];
+const maximus = Math.max(...arr); // returns 89
+```
+
 <code>...arr</code> returns an unpacked array. In other words, it <em>spreads</em> the array.
 However, the spread operator only works in-place, like in an argument to a function or in an array literal. The following code will not work:
-<blockquote>const spreaded = ...arr; // will throw a syntax error</blockquote>
+
+```js
+const spreaded = ...arr; // will throw a syntax error
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/write-arrow-functions-with-parameters.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/write-arrow-functions-with-parameters.english.md
@@ -7,11 +7,26 @@ challengeType: 1
 ## Description
 <section id='description'>
 Just like a regular function, you can pass arguments into an arrow function.
-<blockquote>// doubles input value and returns it<br>const doubler = (item) => item * 2;</blockquote>
+
+```js
+// doubles input value and returns it
+const doubler = (item) => item * 2;
+```
+
 If an arrow function has a single argument, the parentheses enclosing the argument may be omitted.
-<blockquote>// the same function, without the argument parentheses<br>const doubler = item => item * 2;</blockquote>
+
+```js
+// the same function, without the argument parentheses
+const doubler = item => item * 2;
+```
+
 It is possible to pass more than one argument into an arrow function.
-<blockquote>// multiplies the first input value by the second and returns it<br>const multiplier = (item, multi) => item * multi;</blockquote>
+
+```js
+// multiplies the first input value by the second and returns it
+const multiplier = (item, multi) => item * multi;
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/write-concise-declarative-functions-with-es6.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/write-concise-declarative-functions-with-es6.english.md
@@ -7,9 +7,27 @@ challengeType: 1
 ## Description
 <section id='description'>
 When defining functions within objects in ES5, we have to use the keyword <code>function</code> as follows:
-<blockquote>const person = {<br>&nbsp;&nbsp;name: "Taylor",<br>&nbsp;&nbsp;sayHello: function() {<br>&nbsp;&nbsp;&nbsp;&nbsp;return `Hello! My name is ${this.name}.`;<br>&nbsp;&nbsp;}<br>};</blockquote>
+
+```js
+const person = {
+  name: "Taylor",
+  sayHello: function() {
+    return `Hello! My name is ${this.name}.`;
+  }
+};
+```
+
 With ES6, You can remove the <code>function</code> keyword and colon altogether when defining functions in objects. Here's an example of this syntax:
-<blockquote>const person = {<br>&nbsp;&nbsp;name: "Taylor",<br>&nbsp;&nbsp;sayHello() {<br>&nbsp;&nbsp;&nbsp;&nbsp;return `Hello! My name is ${this.name}.`;<br>&nbsp;&nbsp;}<br>};</blockquote>
+
+```js
+const person = {
+  name: "Taylor",
+  sayHello() {
+    return `Hello! My name is ${this.name}.`;
+  }
+};
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/write-concise-object-literal-declarations-using-simple-fields.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/write-concise-object-literal-declarations-using-simple-fields.english.md
@@ -8,11 +8,22 @@ challengeType: 1
 <section id='description'>
 ES6 adds some nice support for easily defining object literals.
 Consider the following code:
-<blockquote>const getMousePosition = (x, y) => ({<br>&nbsp;&nbsp;x: x,<br>&nbsp;&nbsp;y: y<br>});</blockquote>
+
+```js
+const getMousePosition = (x, y) => ({
+  x: x,
+  y: y
+});
+```
+
 <code>getMousePosition</code> is a simple function that returns an object containing two fields.
 ES6 provides the syntactic sugar to eliminate the redundancy of having to write <code>x: x</code>. You can simply write <code>x</code> once, and it will be converted to<code>x: x</code> (or something equivalent) under the hood.
 Here is the same function from above rewritten to use this new syntax:
-<blockquote>const getMousePosition = (x, y) => ({ x, y });</blockquote>
+
+```js
+const getMousePosition = (x, y) => ({ x, y });
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/add-elements-to-the-end-of-an-array-using-concat-instead-of-push.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/add-elements-to-the-end-of-an-array-using-concat-instead-of-push.english.md
@@ -8,7 +8,14 @@ challengeType: 1
 <section id='description'>
 Functional programming is all about creating and using non-mutating functions.
 The last challenge introduced the <code>concat</code> method as a way to combine arrays into a new one without mutating the original arrays. Compare <code>concat</code> to the <code>push</code> method. <code>Push</code> adds an item to the end of the same array it is called on, which mutates that array. Here's an example:
-<blockquote>var arr = [1, 2, 3];<br>arr.push([4, 5, 6]);<br>// arr is changed to [1, 2, 3, [4, 5, 6]]<br>// Not the functional programming way</blockquote>
+
+```js
+var arr = [1, 2, 3];
+arr.push([4, 5, 6]);
+// arr is changed to [1, 2, 3, [4, 5, 6]]
+// Not the functional programming way
+```
+
 <code>Concat</code> offers a way to add new items to the end of an array without any mutating side effects.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/combine-an-array-into-a-string-using-the-join-method.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/combine-an-array-into-a-string-using-the-join-method.english.md
@@ -8,7 +8,13 @@ challengeType: 1
 <section id='description'>
 The <code>join</code> method is used to join the elements of an array together to create a string. It takes an argument for the delimiter that is used to separate the array elements in the string.
 Here's an example:
-<blockquote>var arr = ["Hello", "World"];<br>var str = arr.join(" ");<br>// Sets str to "Hello World"</blockquote>
+
+```js
+var arr = ["Hello", "World"];
+var str = arr.join(" ");
+// Sets str to "Hello World"
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/combine-two-arrays-using-the-concat-method.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/combine-two-arrays-using-the-concat-method.english.md
@@ -7,7 +7,12 @@ challengeType: 1
 ## Description
 <section id='description'>
 <code>Concatenation</code> means to join items end to end. JavaScript offers the <code>concat</code> method for both strings and arrays that work in the same way. For arrays, the method is called on one, then another array is provided as the argument to <code>concat</code>, which is added to the end of the first array. It returns a new array and does not mutate either of the original arrays. Here's an example:
-<blockquote>[1, 2, 3].concat([4, 5, 6]);<br>// Returns a new array [1, 2, 3, 4, 5, 6]</blockquote>
+
+```js
+[1, 2, 3].concat([4, 5, 6]);
+// Returns a new array [1, 2, 3, 4, 5, 6]
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/introduction-to-currying-and-partial-application.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/introduction-to-currying-and-partial-application.english.md
@@ -9,16 +9,45 @@ challengeType: 1
 The <code>arity</code> of a function is the number of arguments it requires. <code>Currying</code> a function means to convert a function of N <code>arity</code> into N functions of <code>arity</code> 1.
 In other words, it restructures a function so it takes one argument, then returns another function that takes the next argument, and so on.
 Here's an example:
-<blockquote>//Un-curried function<br>function unCurried(x, y) {<br>&nbsp;&nbsp;return x + y;<br>}<br><br>//Curried function<br>function curried(x) {<br>&nbsp;&nbsp;return function(y) {<br>&nbsp;&nbsp;&nbsp;&nbsp;return x + y;<br>&nbsp;&nbsp;}<br>}
-<br>//Alternative using ES6
-<br>const curried = x => y => x + y
-<br>
-<br>curried(1)(2) // Returns 3</blockquote>
+
+```js
+//Un-curried function
+function unCurried(x, y) {
+  return x + y;
+}
+
+//Curried function
+function curried(x) {
+  return function(y) {
+    return x + y;
+  }
+}
+//Alternative using ES6
+const curried = x => y => x + y
+
+curried(1)(2) // Returns 3
+```
+
 This is useful in your program if you can't supply all the arguments to a function at one time. You can save each function call into a variable, which will hold the returned function reference that takes the next argument when it's available. Here's an example using the <code>curried</code> function in the example above:
-<blockquote>// Call a curried function in parts:<br>var funcForY = curried(1);<br>console.log(funcForY(2)); // Prints 3</blockquote>
+
+```js
+// Call a curried function in parts:
+var funcForY = curried(1);
+console.log(funcForY(2)); // Prints 3
+```
+
 Similarly, <code>partial application</code> can be described as applying a few arguments to a function at a time and returning another function that is applied to more arguments.
 Here's an example:
-<blockquote>//Impartial function<br>function impartial(x, y, z) {<br>&nbsp;&nbsp;return x + y + z;<br>}<br>var partialFn = impartial.bind(this, 1, 2);<br>partialFn(10); // Returns 13</blockquote>
+
+```js
+//Impartial function
+function impartial(x, y, z) {
+  return x + y + z;
+}
+var partialFn = impartial.bind(this, 1, 2);
+partialFn(10); // Returns 13
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/remove-elements-from-an-array-using-slice-instead-of-splice.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/remove-elements-from-an-array-using-slice-instead-of-splice.english.md
@@ -7,7 +7,13 @@ challengeType: 1
 ## Description
 <section id='description'>
 A common pattern while working with arrays is when you want to remove items and keep the rest of the array. JavaScript offers the <code>splice</code> method for this, which takes arguments for the index of where to start removing items, then the number of items to remove. If the second argument is not provided, the default is to remove items through the end. However, the <code>splice</code> method mutates the original array it is called on. Here's an example:
-<blockquote>var cities = ["Chicago", "Delhi", "Islamabad", "London", "Berlin"];<br>cities.splice(3, 1); // Returns "London" and deletes it from the cities array<br>// cities is now ["Chicago", "Delhi", "Islamabad", "Berlin"]</blockquote>
+
+```js
+var cities = ["Chicago", "Delhi", "Islamabad", "London", "Berlin"];
+cities.splice(3, 1); // Returns "London" and deletes it from the cities array
+// cities is now ["Chicago", "Delhi", "Islamabad", "Berlin"]
+```
+
 As we saw in the last challenge, the <code>slice</code> method does not mutate the original array, but returns a new one which can be saved into a variable. Recall that the <code>slice</code> method takes two arguments for the indices to begin and end the slice (the end is non-inclusive), and returns those items in a new array. Using the <code>slice</code> method instead of <code>splice</code> helps to avoid any array-mutating side effects.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/return-part-of-an-array-using-the-slice-method.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/return-part-of-an-array-using-the-slice-method.english.md
@@ -8,7 +8,13 @@ challengeType: 1
 <section id='description'>
 The <code>slice</code> method returns a copy of certain elements of an array. It can take two arguments, the first gives the index of where to begin the slice, the second is the index for where to end the slice (and it's non-inclusive). If the arguments are not provided, the default is to start at the beginning of the array through the end, which is an easy way to make a copy of the entire array. The <code>slice</code> method does not mutate the original array, but returns a new one.
 Here's an example:
-<blockquote>var arr = ["Cat", "Dog", "Tiger", "Zebra"];<br>var newArray = arr.slice(1, 3);<br>// Sets newArray to ["Dog", "Tiger"]</blockquote>
+
+```js
+var arr = ["Cat", "Dog", "Tiger", "Zebra"];
+var newArray = arr.slice(1, 3);
+// Sets newArray to ["Dog", "Tiger"]
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/sort-an-array-alphabetically-using-the-sort-method.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/sort-an-array-alphabetically-using-the-sort-method.english.md
@@ -8,7 +8,25 @@ challengeType: 1
 <section id='description'>
 The <code>sort</code> method sorts the elements of an array according to the callback function.
 For example:
-<blockquote>function ascendingOrder(arr) {<br>&nbsp;&nbsp;return arr.sort(function(a, b) {<br>&nbsp;&nbsp;&nbsp;&nbsp;return a - b;<br>&nbsp;&nbsp;});<br>}<br>ascendingOrder([1, 5, 2, 3, 4]);<br>// Returns [1, 2, 3, 4, 5]<br><br>function reverseAlpha(arr) {<br>&nbsp;&nbsp;return arr.sort(function(a, b) {<br>&nbsp;&nbsp;&nbsp;&nbsp;return a === b ? 0 : a < b ? 1 : -1;<br>&nbsp;&nbsp;});<br>}<br>reverseAlpha(['l', 'h', 'z', 'b', 's']);<br>// Returns ['z', 's', 'l', 'h', 'b']</blockquote>
+
+```js
+function ascendingOrder(arr) {
+  return arr.sort(function(a, b) {
+    return a - b;
+  });
+}
+ascendingOrder([1, 5, 2, 3, 4]);
+// Returns [1, 2, 3, 4, 5]
+
+function reverseAlpha(arr) {
+  return arr.sort(function(a, b) {
+    return a === b ? 0 : a < b ? 1 : -1;
+  });
+}
+reverseAlpha(['l', 'h', 'z', 'b', 's']);
+// Returns ['z', 's', 'l', 'h', 'b']
+```
+
 JavaScript's default sorting method is by string Unicode point value, which may return unexpected results. Therefore, it is encouraged to provide a callback function to specify how to sort the array items. When such a callback function, normally called <code>compareFunction</code>, is supplied, the array elements are sorted according to the return value of the <code>compareFunction</code>:
 If <code>compareFunction(a,b)</code> returns a value less than 0 for two elements <code>a</code> and <code>b</code>, then <code>a</code> will come before <code>b</code>.
 If <code>compareFunction(a,b)</code> returns a value greater than 0 for two elements <code>a</code> and <code>b</code>, then <code>b</code> will come before <code>a</code>.

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/split-a-string-into-an-array-using-the-split-method.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/split-a-string-into-an-array-using-the-split-method.english.md
@@ -8,7 +8,17 @@ challengeType: 1
 <section id='description'>
 The <code>split</code> method splits a string into an array of strings. It takes an argument for the delimiter, which can be a character to use to break up the string or a regular expression. For example, if the delimiter is a space, you get an array of words, and if the delimiter is an empty string, you get an array of each character in the string.
 Here are two examples that split one string by spaces, then another by digits using a regular expression:
-<blockquote>var str = "Hello World";<br>var bySpace = str.split(" ");<br>// Sets bySpace to ["Hello", "World"]<br><br>var otherString = "How9are7you2today";<br>var byDigits = otherString.split(/\d/);<br>// Sets byDigits to ["How", "are", "you", "today"]</blockquote>
+
+```js
+var str = "Hello World";
+var bySpace = str.split(" ");
+// Sets bySpace to ["Hello", "World"]
+
+var otherString = "How9are7you2today";
+var byDigits = otherString.split(/\d/);
+// Sets byDigits to ["How", "are", "you", "today"]
+```
+
 Since strings are immutable, the <code>split</code> method makes it easier to work with them.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/use-the-every-method-to-check-that-every-element-in-an-array-meets-a-criteria.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/use-the-every-method-to-check-that-every-element-in-an-array-meets-a-criteria.english.md
@@ -8,7 +8,15 @@ challengeType: 1
 <section id='description'>
 The <code>every</code> method works with arrays to check if <em>every</em> element passes a particular test. It returns a Boolean value - <code>true</code> if all values meet the criteria, <code>false</code> if not.
 For example, the following code would check if every element in the <code>numbers</code> array is less than 10:
-<blockquote>var numbers = [1, 5, 8, 0, 10, 11];<br>numbers.every(function(currentValue) {<br>&nbsp;&nbsp;return currentValue < 10;<br>});<br>// Returns false</blockquote>
+
+```js
+var numbers = [1, 5, 8, 0, 10, 11];
+numbers.every(function(currentValue) {
+  return currentValue < 10;
+});
+// Returns false
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/use-the-some-method-to-check-that-any-elements-in-an-array-meet-a-criteria.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/use-the-some-method-to-check-that-any-elements-in-an-array-meet-a-criteria.english.md
@@ -8,7 +8,15 @@ challengeType: 1
 <section id='description'>
 The <code>some</code> method works with arrays to check if <em>any</em> element passes a particular test. It returns a Boolean value - <code>true</code> if any of the values meet the criteria, <code>false</code> if not.
 For example, the following code would check if any element in the <code>numbers</code> array is less than 10:
-<blockquote>var numbers = [10, 50, 8, 220, 110, 11];<br>numbers.some(function(currentValue) {<br>&nbsp;&nbsp;return currentValue < 10;<br>});<br>// Returns true</blockquote>
+
+```js
+var numbers = [10, 50, 8, 220, 110, 11];
+numbers.some(function(currentValue) {
+  return currentValue < 10;
+});
+// Returns true
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/make-a-person.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/make-a-person.english.md
@@ -7,12 +7,16 @@ challengeType: 5
 ## Description
 <section id='description'>
 Fill in the object constructor with the following methods below:
-<blockquote>getFirstName()
+
+```js
+getFirstName()
 getLastName()
 getFullName()
 setFirstName(first)
 setLastName(last)
-setFullName(firstAndLast)</blockquote>
+setFullName(firstAndLast)
+```
+
 Run the tests to see the expected output for each method.
 The methods that take an argument must accept only one argument and it has to be a string.
 These methods must be the only available means of interacting with the object.

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/javascript-algorithms-and-data-structures-projects/telephone-number-validator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/javascript-algorithms-and-data-structures-projects/telephone-number-validator.english.md
@@ -9,7 +9,16 @@ isRequired: true
 <section id='description'>
 Return <code>true</code> if the passed string looks like a valid US phone number.
 The user may fill out the form field any way they choose as long as it has the format of a valid US number. The following are examples of valid formats for US numbers (refer to the tests below for other variants):
-<blockquote>555-555-5555<br>(555)555-5555<br>(555) 555-5555<br>555 555 5555<br>5555555555<br>1 555 555 5555</blockquote>
+
+```js
+555-555-5555
+(555)555-5555
+(555) 555-5555
+555 555 5555
+5555555555
+1 555 555 5555
+```
+
 For this challenge you will be presented with a string such as <code>800-692-7753</code> or <code>8oo-six427676;laskdjf</code>. Your job is to validate or reject the US phone number based on any combination of the formats provided above. The area code is required. If the country code is provided, you must confirm that the country code is <code>1</code>. Return <code>true</code> if the string is a valid US phone number; otherwise return <code>false</code>.
 Remember to use <a href='http://forum.freecodecamp.org/t/how-to-get-help-when-you-are-stuck/19514' target='_blank'>Read-Search-Ask</a> if you get stuck. Try to pair program. Write your own code.
 </section>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/javascript-algorithms-and-data-structures-projects/telephone-number-validator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/javascript-algorithms-and-data-structures-projects/telephone-number-validator.english.md
@@ -9,16 +9,7 @@ isRequired: true
 <section id='description'>
 Return <code>true</code> if the passed string looks like a valid US phone number.
 The user may fill out the form field any way they choose as long as it has the format of a valid US number. The following are examples of valid formats for US numbers (refer to the tests below for other variants):
-
-```js
-555-555-5555
-(555)555-5555
-(555) 555-5555
-555 555 5555
-5555555555
-1 555 555 5555
-```
-
+<blockquote>555-555-5555<br>(555)555-5555<br>(555) 555-5555<br>555 555 5555<br>5555555555<br>1 555 555 5555</blockquote>
 For this challenge you will be presented with a string such as <code>800-692-7753</code> or <code>8oo-six427676;laskdjf</code>. Your job is to validate or reject the US phone number based on any combination of the formats provided above. The area code is required. If the country code is provided, you must confirm that the country code is <code>1</code>. Return <code>true</code> if the string is a valid US phone number; otherwise return <code>false</code>.
 Remember to use <a href='http://forum.freecodecamp.org/t/how-to-get-help-when-you-are-stuck/19514' target='_blank'>Read-Search-Ask</a> if you get stuck. Try to pair program. Write your own code.
 </section>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/add-methods-after-inheritance.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/add-methods-after-inheritance.english.md
@@ -8,11 +8,33 @@ challengeType: 1
 <section id='description'>
 A constructor function that inherits its <code>prototype</code> object from a <code>supertype</code> constructor function can still have its own methods in addition to inherited methods.
 For example, <code>Bird</code> is a constructor that inherits its <code>prototype</code> from <code>Animal</code>:
-<blockquote>function Animal() { }<br>Animal.prototype.eat = function() {<br>&nbsp;&nbsp;console.log("nom nom nom");<br>};<br>function Bird() { }<br>Bird.prototype = Object.create(Animal.prototype);<br>Bird.prototype.constructor = Bird;</blockquote>
+
+```js
+function Animal() { }
+Animal.prototype.eat = function() {
+  console.log("nom nom nom");
+};
+function Bird() { }
+Bird.prototype = Object.create(Animal.prototype);
+Bird.prototype.constructor = Bird;
+```
+
 In addition to what is inherited from <code>Animal</code>, you want to add behavior that is unique to <code>Bird</code> objects. Here, <code>Bird</code> will get a <code>fly()</code> function. Functions are added to <code>Bird's</code> <code>prototype</code> the same way as any constructor function:
-<blockquote>Bird.prototype.fly = function() {<br>&nbsp;&nbsp;console.log("I'm flying!");<br>};</blockquote>
+
+```js
+Bird.prototype.fly = function() {
+  console.log("I'm flying!");
+};
+```
+
 Now instances of <code>Bird</code> will have both <code>eat()</code> and <code>fly()</code> methods:
-<blockquote>let duck = new Bird();<br>duck.eat(); // prints "nom nom nom"<br>duck.fly(); // prints "I'm flying!"</blockquote>
+
+```js
+let duck = new Bird();
+duck.eat(); // prints "nom nom nom"
+duck.fly(); // prints "I'm flying!"
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/change-the-prototype-to-a-new-object.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/change-the-prototype-to-a-new-object.english.md
@@ -7,11 +7,37 @@ challengeType: 1
 ## Description
 <section id='description'>
 Up until now you have been adding properties to the <code>prototype</code> individually:
-<blockquote>Bird.prototype.numLegs = 2;</blockquote>
+
+```js
+Bird.prototype.numLegs = 2;
+```
+
 This becomes tedious after more than a few properties.
-<blockquote>Bird.prototype.eat = function() {<br>&nbsp;&nbsp;console.log("nom nom nom");<br>}<br><br>Bird.prototype.describe = function() {<br>&nbsp;&nbsp;console.log("My name is " + this.name);<br>}</blockquote>
+
+```js
+Bird.prototype.eat = function() {
+  console.log("nom nom nom");
+}
+
+Bird.prototype.describe = function() {
+  console.log("My name is " + this.name);
+}
+```
+
 A more efficient way is to set the <code>prototype</code> to a new object that already contains the properties. This way, the properties are added all at once:
-<blockquote>Bird.prototype = {<br>&nbsp;&nbsp;numLegs: 2, <br>&nbsp;&nbsp;eat: function() {<br>&nbsp;&nbsp;&nbsp;&nbsp;console.log("nom nom nom");<br>&nbsp;&nbsp;},<br>&nbsp;&nbsp;describe: function() {<br>&nbsp;&nbsp;&nbsp;&nbsp;console.log("My name is " + this.name);<br>&nbsp;&nbsp;}<br>};</blockquote>
+
+```js
+Bird.prototype = {
+  numLegs: 2, 
+  eat: function() {
+    console.log("nom nom nom");
+  },
+  describe: function() {
+    console.log("My name is " + this.name);
+  }
+};
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/create-a-basic-javascript-object.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/create-a-basic-javascript-object.english.md
@@ -10,7 +10,14 @@ Think about things people see everyday, like cars, shops, and birds. These are a
 What are some qualities of these <code>objects</code>? A car has wheels. Shops sell items. Birds have wings.
 These qualities, or <code>properties</code>, define what makes up an <code>object</code>. Note that similar <code>objects</code> share the same <code>properties</code>, but may have different values for those <code>properties</code>. For example, all cars have wheels, but not all cars have the same number of wheels.
 <code>Objects</code> in JavaScript are used to model real-world objects, giving them <code>properties</code> and behavior just like their real-world counterparts. Here's an example using these concepts to create a <code>duck</code> <code>object</code>:
-<blockquote>let duck = {<br>&nbsp;&nbsp;name: "Aflac",<br>&nbsp;&nbsp;numLegs: 2<br>};</blockquote>
+
+```js
+let duck = {
+  name: "Aflac",
+  numLegs: 2
+};
+```
+
 This <code>duck</code> <code>object</code> has two property/value pairs: a <code>name</code> of "Aflac" and a <code>numLegs</code> of 2.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/create-a-method-on-an-object.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/create-a-method-on-an-object.english.md
@@ -8,7 +8,17 @@ challengeType: 1
 <section id='description'>
 <code>Objects</code> can have a special type of <code>property</code>, called a <code>method</code>.
 <code>Methods</code> are <code>properties</code> that are functions. This adds different behavior to an <code>object</code>. Here is the <code>duck</code> example with a method:
-<blockquote>let duck = {<br>&nbsp;&nbsp;name: "Aflac",<br>&nbsp;&nbsp;numLegs: 2,<br>&nbsp;&nbsp;sayName: function() {return "The name of this duck is " + duck.name + ".";}<br>};<br>duck.sayName();<br>// Returns "The name of this duck is Aflac."</blockquote>
+
+```js
+let duck = {
+  name: "Aflac",
+  numLegs: 2,
+  sayName: function() {return "The name of this duck is " + duck.name + ".";}
+};
+duck.sayName();
+// Returns "The name of this duck is Aflac."
+```
+
 The example adds the <code>sayName</code> <code>method</code>, which is a function that returns a sentence giving the name of the <code>duck</code>.
 Notice that the <code>method</code> accessed the <code>name</code> property in the return statement using <code>duck.name</code>. The next challenge will cover another way to do this.
 </section>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/define-a-constructor-function.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/define-a-constructor-function.english.md
@@ -8,7 +8,15 @@ challengeType: 1
 <section id='description'>
 <code>Constructors</code> are functions that create new objects. They define properties and behaviors that will belong to the new object. Think of them as a blueprint for the creation of new objects.
 Here is an example of a <code>constructor</code>:
-<blockquote>function Bird() {<br>&nbsp;&nbsp;this.name = "Albert";<br>&nbsp;&nbsp;this.color = "blue";<br>&nbsp;&nbsp;this.numLegs = 2;<br>}</blockquote>
+
+```js
+function Bird() {
+  this.name = "Albert";
+  this.color = "blue";
+  this.numLegs = 2;
+}
+```
+
 This <code>constructor</code> defines a <code>Bird</code> object with properties <code>name</code>, <code>color</code>, and <code>numLegs</code> set to Albert, blue, and 2, respectively.
 <code>Constructors</code> follow a few conventions:
 <ul><li><code>Constructors</code> are defined with a capitalized name to distinguish them from other functions that are not <code>constructors</code>.</li><li><code>Constructors</code> use the keyword <code>this</code> to set properties of the object they will create. Inside the <code>constructor</code>, <code>this</code> refers to the new object it will create.</li><li><code>Constructors</code> define properties and behaviors instead of returning a value as other functions might.</li></ul>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/extend-constructors-to-receive-arguments.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/extend-constructors-to-receive-arguments.english.md
@@ -7,15 +7,35 @@ challengeType: 1
 ## Description
 <section id='description'>
 The <code>Bird</code> and <code>Dog</code> constructors from last challenge worked well. However, notice that all <code>Birds</code> that are created with the <code>Bird</code> constructor are automatically named Albert, are blue in color, and have two legs. What if you want birds with different values for name and color? It's possible to change the properties of each bird manually but that would be a lot of work:
-<blockquote>let swan = new Bird();<br>swan.name = "Carlos";<br>swan.color = "white";</blockquote>
+
+```js
+let swan = new Bird();
+swan.name = "Carlos";
+swan.color = "white";
+```
+
 Suppose you were writing a program to keep track of hundreds or even thousands of different birds in an aviary. It would take a lot of time to create all the birds, then change the properties to different values for every one.
 To more easily create different <code>Bird</code> objects, you can design your Bird constructor to accept parameters:
-<blockquote>function Bird(name, color) {<br>&nbsp;&nbsp;this.name = name;<br>&nbsp;&nbsp;this.color = color;<br>&nbsp;&nbsp;this.numLegs = 2;<br>}</blockquote>
+
+```js
+function Bird(name, color) {
+  this.name = name;
+  this.color = color;
+  this.numLegs = 2;
+}
+```
+
 Then pass in the values as arguments to define each unique bird into the <code>Bird</code> constructor:
 <code>let cardinal = new Bird("Bruce", "red");</code>
 This gives a new instance of <code>Bird</code> with name and color properties set to Bruce and red, respectively. The <code>numLegs</code> property is still set to 2.
 The <code>cardinal</code> has these properties:
-<blockquote>cardinal.name // => Bruce<br>cardinal.color // => red<br>cardinal.numLegs // => 2</blockquote>
+
+```js
+cardinal.name // => Bruce
+cardinal.color // => red
+cardinal.numLegs // => 2
+```
+
 The constructor is more flexible. It's now possible to define the properties for each <code>Bird</code> at the time it is created, which is one way that JavaScript constructors are so useful. They group objects together based on shared characteristics and behavior and define a blueprint that automates their creation.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/inherit-behaviors-from-a-supertype.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/inherit-behaviors-from-a-supertype.english.md
@@ -7,15 +7,35 @@ challengeType: 1
 ## Description
 <section id='description'>
 In the previous challenge, you created a <code>supertype</code> called <code>Animal</code> that defined behaviors shared by all animals:
-<blockquote>function Animal() { }<br>Animal.prototype.eat = function() {<br>&nbsp;&nbsp;console.log("nom nom nom");<br>};</blockquote>
+
+```js
+function Animal() { }
+Animal.prototype.eat = function() {
+  console.log("nom nom nom");
+};
+```
+
 This and the next challenge will cover how to reuse <code>Animal's</code> methods inside <code>Bird</code> and <code>Dog</code> without defining them again. It uses a technique called <code>inheritance</code>.
 This challenge covers the first step: make an instance of the <code>supertype</code> (or parent).
 You already know one way to create an instance of <code>Animal</code> using the <code>new</code> operator:
-<blockquote>let animal = new Animal();</blockquote>
+
+```js
+let animal = new Animal();
+```
+
 There are some disadvantages when using this syntax for <code>inheritance</code>, which are too complex for the scope of this challenge. Instead, here's an alternative approach without those disadvantages:
-<blockquote>let animal = Object.create(Animal.prototype);</blockquote>
+
+```js
+let animal = Object.create(Animal.prototype);
+```
+
 <code>Object.create(obj)</code> creates a new object, and sets <code>obj</code> as the new object's <code>prototype</code>. Recall that the <code>prototype</code> is like the "recipe" for creating an object. By setting the <code>prototype</code> of <code>animal</code> to be <code>Animal's</code> <code>prototype</code>, you are effectively giving the <code>animal</code> instance the same "recipe" as any other instance of <code>Animal</code>.
-<blockquote>animal.eat(); // prints "nom nom nom"<br>animal instanceof Animal; // => true</blockquote>
+
+```js
+animal.eat(); // prints "nom nom nom"
+animal instanceof Animal; // => true
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/iterate-over-all-properties.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/iterate-over-all-properties.english.md
@@ -7,9 +7,35 @@ challengeType: 1
 ## Description
 <section id='description'>
 You have now seen two kinds of properties: <code>own</code> properties and <code>prototype</code> properties. <code>Own</code> properties are defined directly on the object instance itself. And <code>prototype</code> properties are defined on the <code>prototype</code>.
-<blockquote>function Bird(name) {<br>&nbsp;&nbsp;this.name = name;  //own property<br>}<br><br>Bird.prototype.numLegs = 2; // prototype property<br><br>let duck = new Bird("Donald");</blockquote>
+
+```js
+function Bird(name) {
+  this.name = name;  //own property
+}
+
+Bird.prototype.numLegs = 2; // prototype property
+
+let duck = new Bird("Donald");
+```
+
 Here is how you add <code>duck</code>'s <code>own</code> properties to the array <code>ownProps</code> and <code>prototype</code> properties to the array <code>prototypeProps</code>:
-<blockquote>let ownProps = [];<br>let prototypeProps = [];<br><br>for (let property in duck) {<br>&nbsp;&nbsp;if(duck.hasOwnProperty(property)) {<br>&nbsp;&nbsp;&nbsp;&nbsp;ownProps.push(property);<br>&nbsp;&nbsp;} else {<br>&nbsp;&nbsp;&nbsp;&nbsp;prototypeProps.push(property);<br>&nbsp;&nbsp;}<br>}<br><br>console.log(ownProps); // prints ["name"]<br>console.log(prototypeProps); // prints ["numLegs"]</blockquote>
+
+```js
+let ownProps = [];
+let prototypeProps = [];
+
+for (let property in duck) {
+  if(duck.hasOwnProperty(property)) {
+    ownProps.push(property);
+  } else {
+    prototypeProps.push(property);
+  }
+}
+
+console.log(ownProps); // prints ["name"]
+console.log(prototypeProps); // prints ["numLegs"]
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/make-code-more-reusable-with-the-this-keyword.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/make-code-more-reusable-with-the-this-keyword.english.md
@@ -10,7 +10,15 @@ The last challenge introduced a <code>method</code> to the <code>duck</code> obj
 <code>sayName: function() {return "The name of this duck is " + duck.name + ".";}</code>
 While this is a valid way to access the object's property, there is a pitfall here. If the variable name changes, any code referencing the original name would need to be updated as well. In a short object definition, it isn't a problem, but if an object has many references to its properties there is a greater chance for error.
 A way to avoid these issues is with the <code>this</code> keyword:
-<blockquote>let duck = {<br>&nbsp;&nbsp;name: "Aflac",<br>&nbsp;&nbsp;numLegs: 2,<br>&nbsp;&nbsp;sayName: function() {return "The name of this duck is " + this.name + ".";}<br>};</blockquote>
+
+```js
+let duck = {
+  name: "Aflac",
+  numLegs: 2,
+  sayName: function() {return "The name of this duck is " + this.name + ".";}
+};
+```
+
 <code>this</code> is a deep topic, and the above example is only one way to use it. In the current context, <code>this</code> refers to the object that the method is associated with: <code>duck</code>.
 If the object's name is changed to <code>mallard</code>, it is not necessary to find all the references to <code>duck</code> in the code. It makes the code reusable and easier to read.
 </section>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/override-inherited-methods.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/override-inherited-methods.english.md
@@ -7,12 +7,36 @@ challengeType: 1
 ## Description
 <section id='description'>
 In previous lessons, you learned that an object can inherit its behavior (methods) from another object by cloning its <code>prototype</code> object:
-<blockquote>ChildObject.prototype = Object.create(ParentObject.prototype);</blockquote>
+
+```js
+ChildObject.prototype = Object.create(ParentObject.prototype);
+```
+
 Then the <code>ChildObject</code> received its own methods by chaining them onto its <code>prototype</code>:
-<blockquote>ChildObject.prototype.methodName = function() {...};</blockquote>
+
+```js
+ChildObject.prototype.methodName = function() {...};
+```
+
 It's possible to override an inherited method. It's done the same way - by adding a method to <code>ChildObject.prototype</code> using the same method name as the one to override.
 Here's an example of <code>Bird</code> overriding the <code>eat()</code> method inherited from <code>Animal</code>:
-<blockquote>function Animal() { }<br>Animal.prototype.eat = function() {<br>&nbsp;&nbsp;return "nom nom nom";<br>};<br>function Bird() { }<br><br>// Inherit all methods from Animal<br>Bird.prototype = Object.create(Animal.prototype);<br><br>// Bird.eat() overrides Animal.eat()<br>Bird.prototype.eat = function() {<br>&nbsp;&nbsp;return "peck peck peck";<br>};</blockquote>
+
+```js
+function Animal() { }
+Animal.prototype.eat = function() {
+  return "nom nom nom";
+};
+function Bird() { }
+
+// Inherit all methods from Animal
+Bird.prototype = Object.create(Animal.prototype);
+
+// Bird.eat() overrides Animal.eat()
+Bird.prototype.eat = function() {
+  return "peck peck peck";
+};
+```
+
 If you have an instance <code>let duck = new Bird();</code> and you call <code>duck.eat()</code>, this is how JavaScript looks for the method on <code>duck’s</code> <code>prototype</code> chain:
 1. duck => Is eat() defined here? No.
 2. Bird => Is eat() defined here? => Yes. Execute it and stop searching.

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/remember-to-set-the-constructor-property-when-changing-the-prototype.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/remember-to-set-the-constructor-property-when-changing-the-prototype.english.md
@@ -7,7 +7,13 @@ challengeType: 1
 ## Description
 <section id='description'>
 There is one crucial side effect of manually setting the prototype to a new object. It erases the <code>constructor</code> property! This property can be used to check which constructor function created the instance, but since the property has been overwritten, it now gives false results:
-<blockquote>duck.constructor === Bird; // false -- Oops <br>duck.constructor === Object; // true, all objects inherit from Object.prototype <br>duck instanceof Bird; // true, still works</blockquote>
+
+```js
+duck.constructor === Bird; // false -- Oops
+duck.constructor === Object; // true, all objects inherit from Object.prototype
+duck instanceof Bird; // true, still works
+```
+
 To fix this, whenever a prototype is manually set to a new object, remember to define the <code>constructor</code> property:
 
 ```js

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/remember-to-set-the-constructor-property-when-changing-the-prototype.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/remember-to-set-the-constructor-property-when-changing-the-prototype.english.md
@@ -7,13 +7,7 @@ challengeType: 1
 ## Description
 <section id='description'>
 There is one crucial side effect of manually setting the prototype to a new object. It erases the <code>constructor</code> property! This property can be used to check which constructor function created the instance, but since the property has been overwritten, it now gives false results:
-
-```js
-duck.constructor === Bird; // false -- Oops 
- duck.constructor === Object; // true, all objects inherit from Object.prototype 
- duck instanceof Bird; // true, still works
-```
-
+<blockquote>duck.constructor === Bird; // false -- Oops <br>duck.constructor === Object; // true, all objects inherit from Object.prototype <br>duck instanceof Bird; // true, still works</blockquote>
 To fix this, whenever a prototype is manually set to a new object, remember to define the <code>constructor</code> property:
 
 ```js

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/remember-to-set-the-constructor-property-when-changing-the-prototype.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/remember-to-set-the-constructor-property-when-changing-the-prototype.english.md
@@ -7,9 +7,28 @@ challengeType: 1
 ## Description
 <section id='description'>
 There is one crucial side effect of manually setting the prototype to a new object. It erases the <code>constructor</code> property! This property can be used to check which constructor function created the instance, but since the property has been overwritten, it now gives false results:
-<blockquote>duck.constructor === Bird; // false -- Oops <br> duck.constructor === Object; // true, all objects inherit from Object.prototype <br> duck instanceof Bird; // true, still works</blockquote>
+
+```js
+duck.constructor === Bird; // false -- Oops 
+ duck.constructor === Object; // true, all objects inherit from Object.prototype 
+ duck instanceof Bird; // true, still works
+```
+
 To fix this, whenever a prototype is manually set to a new object, remember to define the <code>constructor</code> property:
-<blockquote>Bird.prototype = {<br>&nbsp;&nbsp;constructor: Bird, // define the constructor property<br>&nbsp;&nbsp;numLegs: 2,<br>&nbsp;&nbsp;eat: function() {<br>&nbsp;&nbsp;&nbsp;&nbsp;console.log("nom nom nom");<br>&nbsp;&nbsp;},<br>&nbsp;&nbsp;describe: function() {<br>&nbsp;&nbsp;&nbsp;&nbsp;console.log("My name is " + this.name); <br>&nbsp;&nbsp;}<br>};</blockquote>
+
+```js
+Bird.prototype = {
+  constructor: Bird, // define the constructor property
+  numLegs: 2,
+  eat: function() {
+    console.log("nom nom nom");
+  },
+  describe: function() {
+    console.log("My name is " + this.name); 
+  }
+};
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/reset-an-inherited-constructor-property.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/reset-an-inherited-constructor-property.english.md
@@ -8,9 +8,21 @@ challengeType: 1
 <section id='description'>
 When an object inherits its <code>prototype</code> from another object, it also inherits the <code>supertype</code>'s constructor property.
 Here's an example:
-<blockquote>function Bird() { }<br>Bird.prototype = Object.create(Animal.prototype);<br>let duck = new Bird();<br>duck.constructor // function Animal(){...}</blockquote>
+
+```js
+function Bird() { }
+Bird.prototype = Object.create(Animal.prototype);
+let duck = new Bird();
+duck.constructor // function Animal(){...}
+```
+
 But <code>duck</code> and all instances of <code>Bird</code> should show that they were constructed by <code>Bird</code> and not <code>Animal</code>. To do so, you can manually set <code>Bird's</code> constructor property to the <code>Bird</code> object:
-<blockquote>Bird.prototype.constructor = Bird;<br>duck.constructor // function Bird(){...}</blockquote>
+
+```js
+Bird.prototype.constructor = Bird;
+duck.constructor // function Bird(){...}
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/set-the-childs-prototype-to-an-instance-of-the-parent.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/set-the-childs-prototype-to-an-instance-of-the-parent.english.md
@@ -8,9 +8,18 @@ challengeType: 1
 <section id='description'>
 In the previous challenge you saw the first step for inheriting behavior from the <code>supertype</code> (or parent) <code>Animal</code>: making a new instance of <code>Animal</code>.
 This challenge covers the next step: set the <code>prototype</code> of the <code>subtype</code> (or child)&mdash;in this case, <code>Bird</code>&mdash;to be an instance of <code>Animal</code>.
-<blockquote>Bird.prototype = Object.create(Animal.prototype);</blockquote>
+
+```js
+Bird.prototype = Object.create(Animal.prototype);
+```
+
 Remember that the <code>prototype</code> is like the "recipe" for creating an object. In a way, the recipe for <code>Bird</code> now includes all the key "ingredients" from <code>Animal</code>.
-<blockquote>let duck = new Bird("Donald");<br>duck.eat(); // prints "nom nom nom"</blockquote>
+
+```js
+let duck = new Bird("Donald");
+duck.eat(); // prints "nom nom nom"
+```
+
 <code>duck</code> inherits all of <code>Animal</code>'s properties, including the <code>eat</code> method.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/understand-own-properties.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/understand-own-properties.english.md
@@ -7,11 +7,33 @@ challengeType: 1
 ## Description
 <section id='description'>
 In the following example, the <code>Bird</code> constructor defines two properties: <code>name</code> and <code>numLegs</code>:
-<blockquote>function Bird(name) {<br>&nbsp;&nbsp;this.name  = name;<br>&nbsp;&nbsp;this.numLegs = 2;<br>}<br><br>let duck = new Bird("Donald");<br>let canary = new Bird("Tweety");</blockquote>
+
+```js
+function Bird(name) {
+  this.name  = name;
+  this.numLegs = 2;
+}
+
+let duck = new Bird("Donald");
+let canary = new Bird("Tweety");
+```
+
 <code>name</code> and <code>numLegs</code> are called <code>own</code> properties, because they are defined directly on the instance object. That means that <code>duck</code> and <code>canary</code> each has its own separate copy of these properties.
 In fact every instance of <code>Bird</code> will have its own copy of these properties.
 The following code adds all of the <code>own</code> properties of <code>duck</code> to the array <code>ownProps</code>:
-<blockquote>let ownProps = [];<br><br>for (let property in duck) {<br>&nbsp;&nbsp;if(duck.hasOwnProperty(property)) {<br>&nbsp;&nbsp;&nbsp;&nbsp;ownProps.push(property);<br>&nbsp;&nbsp;}<br>}<br><br>console.log(ownProps); // prints [ "name", "numLegs" ]</blockquote>
+
+```js
+let ownProps = [];
+
+for (let property in duck) {
+  if(duck.hasOwnProperty(property)) {
+    ownProps.push(property);
+  }
+}
+
+console.log(ownProps); // prints [ "name", "numLegs" ]
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/understand-the-constructor-property.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/understand-the-constructor-property.english.md
@@ -7,10 +7,28 @@ challengeType: 1
 ## Description
 <section id='description'>
 There is a special <code>constructor</code> property located on the object instances <code>duck</code> and <code>beagle</code> that were created in the previous challenges:
-<blockquote>let duck = new Bird();<br>let beagle = new Dog();<br><br>console.log(duck.constructor === Bird);  //prints true<br>console.log(beagle.constructor === Dog);  //prints true</blockquote>
+
+```js
+let duck = new Bird();
+let beagle = new Dog();
+
+console.log(duck.constructor === Bird);  //prints true
+console.log(beagle.constructor === Dog);  //prints true
+```
+
 Note that the <code>constructor</code> property is a reference to the constructor function that created the instance.
 The advantage of the <code>constructor</code> property is that it's possible to check for this property to find out what kind of object it is. Here's an example of how this could be used:
-<blockquote>function joinBirdFraternity(candidate) {<br>&nbsp;&nbsp;if (candidate.constructor === Bird) {<br>&nbsp;&nbsp;&nbsp;&nbsp;return true;<br>&nbsp;&nbsp;} else {<br>&nbsp;&nbsp;&nbsp;&nbsp;return false;<br>&nbsp;&nbsp;}<br>}</blockquote>
+
+```js
+function joinBirdFraternity(candidate) {
+  if (candidate.constructor === Bird) {
+    return true;
+  } else {
+    return false;
+  }
+}
+```
+
 <strong>Note</strong><br>Since the <code>constructor</code> property can be overwritten (which will be covered in the next two challenges) it’s generally better to use the <code>instanceof</code> method to check the type of an object.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/understand-the-immediately-invoked-function-expression-iife.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/understand-the-immediately-invoked-function-expression-iife.english.md
@@ -7,7 +7,14 @@ challengeType: 1
 ## Description
 <section id='description'>
 A common pattern in JavaScript is to execute a function as soon as it is declared:
-<blockquote>(function () {<br>&nbsp;&nbsp;console.log("Chirp, chirp!");<br>})(); // this is an anonymous function expression that executes right away<br>// Outputs "Chirp, chirp!" immediately</blockquote>
+
+```js
+(function () {
+  console.log("Chirp, chirp!");
+})(); // this is an anonymous function expression that executes right away
+// Outputs "Chirp, chirp!" immediately
+```
+
 Note that the function has no name and is not stored in a variable. The two parentheses () at the end of the function expression cause it to be immediately executed or invoked. This pattern is known as an <code>immediately invoked function expression</code> or <code>IIFE</code>.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/understand-the-prototype-chain.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/understand-the-prototype-chain.english.md
@@ -7,11 +7,29 @@ challengeType: 1
 ## Description
 <section id='description'>
 All objects in JavaScript (with a few exceptions) have a <code>prototype</code>. Also, an object’s <code>prototype</code> itself is an object.
-<blockquote>function Bird(name) {<br>&nbsp;&nbsp;this.name = name;<br>}<br><br>typeof Bird.prototype; // => object</blockquote>
+
+```js
+function Bird(name) {
+  this.name = name;
+}
+
+typeof Bird.prototype; // => object
+```
+
 Because a <code>prototype</code> is an object, a <code>prototype</code> can have its own <code>prototype</code>! In this case, the <code>prototype</code> of <code>Bird.prototype</code> is <code>Object.prototype</code>:
-<blockquote>Object.prototype.isPrototypeOf(Bird.prototype);<br>// returns true</blockquote>
+
+```js
+Object.prototype.isPrototypeOf(Bird.prototype);
+// returns true
+```
+
 How is this useful? You may recall the <code>hasOwnProperty</code> method from a previous challenge:
-<blockquote>let duck = new Bird("Donald");<br>duck.hasOwnProperty("name"); // => true</blockquote>
+
+```js
+let duck = new Bird("Donald");
+duck.hasOwnProperty("name"); // => true
+```
+
 The <code>hasOwnProperty</code> method is defined in <code>Object.prototype</code>, which can be accessed by <code>Bird.prototype</code>, which can then be accessed by <code>duck</code>. This is an example of the <code>prototype</code> chain.
 In this <code>prototype</code> chain, <code>Bird</code> is the <code>supertype</code> for <code>duck</code>, while <code>duck</code> is the <code>subtype</code>. <code>Object</code> is a <code>supertype</code> for both <code>Bird</code> and <code>duck</code>.
 <code>Object</code> is a <code>supertype</code> for all objects in JavaScript. Therefore, any object can use the <code>hasOwnProperty</code> method.

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/understand-where-an-objects-prototype-comes-from.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/understand-where-an-objects-prototype-comes-from.english.md
@@ -7,9 +7,22 @@ challengeType: 1
 ## Description
 <section id='description'>
 Just like people inherit genes from their parents, an object inherits its <code>prototype</code> directly from the constructor function that created it. For example, here the <code>Bird</code> constructor creates the <code>duck</code> object:
-<blockquote>function Bird(name) {<br>&nbsp;&nbsp;this.name = name;<br>}<br><br>let duck = new Bird("Donald");</blockquote>
+
+```js
+function Bird(name) {
+  this.name = name;
+}
+
+let duck = new Bird("Donald");
+```
+
 <code>duck</code> inherits its <code>prototype</code> from the <code>Bird</code> constructor function. You can show this relationship with the <code>isPrototypeOf</code> method:
-<blockquote>Bird.prototype.isPrototypeOf(duck);<br>// returns true</blockquote>
+
+```js
+Bird.prototype.isPrototypeOf(duck);
+// returns true
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/use-a-constructor-to-create-objects.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/use-a-constructor-to-create-objects.english.md
@@ -7,12 +7,34 @@ challengeType: 1
 ## Description
 <section id='description'>
 Here's the <code>Bird</code> constructor from the previous challenge:
-<blockquote>function Bird() {<br>&nbsp;&nbsp;this.name = "Albert";<br>&nbsp;&nbsp;this.color  = "blue";<br>&nbsp;&nbsp;this.numLegs = 2;<br>&nbsp;&nbsp;// "this" inside the constructor always refers to the object being created<br>}<br><br>let blueBird = new Bird();</blockquote>
+
+```js
+function Bird() {
+  this.name = "Albert";
+  this.color  = "blue";
+  this.numLegs = 2;
+  // "this" inside the constructor always refers to the object being created
+}
+
+let blueBird = new Bird();
+```
+
 Notice that the <code>new</code> operator is used when calling a constructor. This tells JavaScript to create a new <code>instance</code> of <code>Bird</code> called <code>blueBird</code>. Without the <code>new</code> operator, <code>this</code> inside the constructor would not point to the newly created object, giving unexpected results.
 Now <code>blueBird</code> has all the properties defined inside the <code>Bird</code> constructor:
-<blockquote>blueBird.name; // => Albert<br>blueBird.color; // => blue<br>blueBird.numLegs; // => 2</blockquote>
+
+```js
+blueBird.name; // => Albert
+blueBird.color; // => blue
+blueBird.numLegs; // => 2
+```
+
 Just like any other object, its properties can be accessed and modified:
-<blockquote>blueBird.name = 'Elvira';<br>blueBird.name; // => Elvira</blockquote>
+
+```js
+blueBird.name = 'Elvira';
+blueBird.name; // => Elvira
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/use-a-mixin-to-add-common-behavior-between-unrelated-objects.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/use-a-mixin-to-add-common-behavior-between-unrelated-objects.english.md
@@ -8,11 +8,39 @@ challengeType: 1
 <section id='description'>
 As you have seen, behavior is shared through inheritance. However, there are cases when inheritance is not the best solution. Inheritance does not work well for unrelated objects like <code>Bird</code> and <code>Airplane</code>. They can both fly, but a <code>Bird</code> is not a type of <code>Airplane</code> and vice versa.
 For unrelated objects, it's better to use <code>mixins</code>. A <code>mixin</code> allows other objects to use a collection of functions.
-<blockquote>let flyMixin = function(obj) {<br>&nbsp;&nbsp;obj.fly = function() {<br>&nbsp;&nbsp;&nbsp;&nbsp;console.log("Flying, wooosh!");<br>&nbsp;&nbsp;}<br>};</blockquote>
+
+```js
+let flyMixin = function(obj) {
+  obj.fly = function() {
+    console.log("Flying, wooosh!");
+  }
+};
+```
+
 The <code>flyMixin</code> takes any object and gives it the <code>fly</code> method.
-<blockquote>let bird = {<br>&nbsp;&nbsp;name: "Donald",<br>&nbsp;&nbsp;numLegs: 2<br>};<br><br>let plane = {<br>&nbsp;&nbsp;model: "777",<br>&nbsp;&nbsp;numPassengers: 524<br>};<br><br>flyMixin(bird);<br>flyMixin(plane);</blockquote>
+
+```js
+let bird = {
+  name: "Donald",
+  numLegs: 2
+};
+
+let plane = {
+  model: "777",
+  numPassengers: 524
+};
+
+flyMixin(bird);
+flyMixin(plane);
+```
+
 Here <code>bird</code> and <code>plane</code> are passed into <code>flyMixin</code>, which then assigns the <code>fly</code> function to each object. Now <code>bird</code> and <code>plane</code> can both fly:
-<blockquote>bird.fly(); // prints "Flying, wooosh!"<br>plane.fly(); // prints "Flying, wooosh!"</blockquote>
+
+```js
+bird.fly(); // prints "Flying, wooosh!"
+plane.fly(); // prints "Flying, wooosh!"
+```
+
 Note how the <code>mixin</code> allows for the same <code>fly</code> method to be reused by unrelated objects <code>bird</code> and <code>plane</code>.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/use-an-iife-to-create-a-module.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/use-an-iife-to-create-a-module.english.md
@@ -7,12 +7,47 @@ challengeType: 1
 ## Description
 <section id='description'>
 An <code>immediately invoked function expression</code> (<code>IIFE</code>) is often used to group related functionality into a single object or <code>module</code>. For example, an earlier challenge defined two mixins:
-<blockquote>function glideMixin(obj) {<br>&nbsp;&nbsp;obj.glide = function() {<br>&nbsp;&nbsp;&nbsp;&nbsp;console.log("Gliding on the water");<br>&nbsp;&nbsp;};<br>}<br>function flyMixin(obj) {<br>&nbsp;&nbsp;obj.fly = function() {<br>&nbsp;&nbsp;&nbsp;&nbsp;console.log("Flying, wooosh!");<br>&nbsp;&nbsp;};<br>}</blockquote>
+
+```js
+function glideMixin(obj) {
+  obj.glide = function() {
+    console.log("Gliding on the water");
+  };
+}
+function flyMixin(obj) {
+  obj.fly = function() {
+    console.log("Flying, wooosh!");
+  };
+}
+```
+
 We can group these <code>mixins</code> into a module as follows:
-<blockquote>let motionModule = (function () {<br>&nbsp;&nbsp;return {<br>&nbsp;&nbsp;&nbsp;&nbsp;glideMixin: function(obj) {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;obj.glide = function() {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;console.log("Gliding on the water");<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;};<br>&nbsp;&nbsp;&nbsp;&nbsp;},<br>&nbsp;&nbsp;&nbsp;&nbsp;flyMixin: function(obj) {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;obj.fly = function() {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;console.log("Flying, wooosh!");<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;};<br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>&nbsp;&nbsp;}<br>})(); // The two parentheses cause the function to be immediately invoked</blockquote>
+
+```js
+let motionModule = (function () {
+  return {
+    glideMixin: function(obj) {
+      obj.glide = function() {
+        console.log("Gliding on the water");
+      };
+    },
+    flyMixin: function(obj) {
+      obj.fly = function() {
+        console.log("Flying, wooosh!");
+      };
+    }
+  }
+})(); // The two parentheses cause the function to be immediately invoked
+```
+
 Note that you have an <code>immediately invoked function expression</code> (<code>IIFE</code>) that returns an object <code>motionModule</code>. This returned object contains all of the <code>mixin</code> behaviors as properties of the object.
 The advantage of the <code>module</code> pattern is that all of the motion behaviors can be packaged into a single object that can then be used by other parts of your code. Here is an example using it:
-<blockquote>motionModule.glideMixin(duck);<br>duck.glide();</blockquote>
+
+```js
+motionModule.glideMixin(duck);
+duck.glide();
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/use-closure-to-protect-properties-within-an-object-from-being-modified-externally.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/use-closure-to-protect-properties-within-an-object-from-being-modified-externally.english.md
@@ -9,12 +9,29 @@ challengeType: 1
 
 In the previous challenge, <code>bird</code> had a public property <code>name</code>. It is considered public because it can be accessed and changed outside of <code>bird</code>'s definition.
 
-<blockquote>bird.name = "Duffy";</blockquote>
+
+```js
+bird.name = "Duffy";
+```
+
 
 Therefore, any part of your code can easily change the name of <code>bird</code> to any value. Think about things like passwords and bank accounts being easily changeable by any part of your codebase. That could cause a lot of issues.
 
 The simplest way to make this public property private is by creating a variable within the constructor function. This changes the scope of that variable to be within the constructor function versus available globally. This way, the variable can only be accessed and changed by methods also within the constructor function.
-<blockquote>function Bird() {<br>&nbsp;&nbsp;let hatchedEgg = 10; // private variable<br><br>&nbsp;&nbsp;/* publicly available method that a bird object can use */<br>&nbsp;&nbsp;this.getHatchedEggCount = function() { <br>&nbsp;&nbsp;&nbsp;&nbsp;return hatchedEgg;<br>&nbsp;&nbsp;};<br>}<br>let ducky = new Bird();<br>ducky.getHatchedEggCount(); // returns 10</blockquote>
+
+```js
+function Bird() {
+  let hatchedEgg = 10; // private variable
+
+  /* publicly available method that a bird object can use */
+  this.getHatchedEggCount = function() { 
+    return hatchedEgg;
+  };
+}
+let ducky = new Bird();
+ducky.getHatchedEggCount(); // returns 10
+```
+
 Here <code>getHachedEggCount</code> is a privileged method, because it has access to the private variable <code>hatchedEgg</code>. This is possible because <code>hatchedEgg</code> is declared in the same context as <code>getHachedEggCount</code>. In JavaScript, a function always has access to the context in which it was created. This is called <code>closure</code>.
 
 </section>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/use-dot-notation-to-access-the-properties-of-an-object.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/use-dot-notation-to-access-the-properties-of-an-object.english.md
@@ -7,7 +7,16 @@ challengeType: 1
 ## Description
 <section id='description'>
 The last challenge created an <code>object</code> with various <code>properties</code>, now you'll see how to access the values of those <code>properties</code>. Here's an example:
-<blockquote>let duck = {<br>&nbsp;&nbsp;name: "Aflac",<br>&nbsp;&nbsp;numLegs: 2<br>};<br>console.log(duck.name);<br>// This prints "Aflac" to the console</blockquote>
+
+```js
+let duck = {
+  name: "Aflac",
+  numLegs: 2
+};
+console.log(duck.name);
+// This prints "Aflac" to the console
+```
+
 Dot notation is used on the <code>object</code> name, <code>duck</code>, followed by the name of the <code>property</code>, <code>name</code>, to access the value of "Aflac".
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/use-inheritance-so-you-dont-repeat-yourself.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/use-inheritance-so-you-dont-repeat-yourself.english.md
@@ -8,11 +8,48 @@ challengeType: 1
 <section id='description'>
 There's a principle in programming called <code>Don't Repeat Yourself (DRY)</code>. The reason repeated code is a problem is because any change requires fixing code in multiple places. This usually means more work for programmers and more room for errors.
 Notice in the example below that the <code>describe</code> method is shared by <code>Bird</code> and <code>Dog</code>:
-<blockquote>Bird.prototype = {<br>&nbsp;&nbsp;constructor: Bird,<br>&nbsp;&nbsp;describe: function() {<br>&nbsp;&nbsp;&nbsp;&nbsp;console.log("My name is " + this.name);<br>&nbsp;&nbsp;}<br>};<br><br>Dog.prototype = {<br>&nbsp;&nbsp;constructor: Dog,<br>&nbsp;&nbsp;describe: function() {<br>&nbsp;&nbsp;&nbsp;&nbsp;console.log("My name is " + this.name);<br>&nbsp;&nbsp;}<br>};</blockquote>
+
+```js
+Bird.prototype = {
+  constructor: Bird,
+  describe: function() {
+    console.log("My name is " + this.name);
+  }
+};
+
+Dog.prototype = {
+  constructor: Dog,
+  describe: function() {
+    console.log("My name is " + this.name);
+  }
+};
+```
+
 The <code>describe</code> method is repeated in two places. The code can be edited to follow the <code>DRY</code> principle by creating a <code>supertype</code> (or parent) called <code>Animal</code>:
-<blockquote>function Animal() { };<br><br>Animal.prototype = {<br>&nbsp;&nbsp;constructor: Animal, <br>&nbsp;&nbsp;describe: function() {<br>&nbsp;&nbsp;&nbsp;&nbsp;console.log("My name is " + this.name);<br>&nbsp;&nbsp;}<br>};</blockquote>
+
+```js
+function Animal() { };
+
+Animal.prototype = {
+  constructor: Animal, 
+  describe: function() {
+    console.log("My name is " + this.name);
+  }
+};
+```
+
 Since <code>Animal</code> includes the <code>describe</code> method, you can remove it from <code>Bird</code> and <code>Dog</code>:
-<blockquote>Bird.prototype = {<br>&nbsp;&nbsp;constructor: Bird<br>};<br><br>Dog.prototype = {<br>&nbsp;&nbsp;constructor: Dog<br>};</blockquote>
+
+```js
+Bird.prototype = {
+  constructor: Bird
+};
+
+Dog.prototype = {
+  constructor: Dog
+};
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/use-prototype-properties-to-reduce-duplicate-code.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/use-prototype-properties-to-reduce-duplicate-code.english.md
@@ -9,9 +9,18 @@ challengeType: 1
 Since <code>numLegs</code> will probably have the same value for all instances of <code>Bird</code>, you essentially have a duplicated variable <code>numLegs</code> inside each <code>Bird</code> instance.
 This may not be an issue when there are only two instances, but imagine if there are millions of instances. That would be a lot of duplicated variables.
 A better way is to use <code>Bird’s</code> <code>prototype</code>. The <code>prototype</code> is an object that is shared among ALL instances of <code>Bird</code>. Here's how to add <code>numLegs</code> to the <code>Bird prototype</code>:
-<blockquote>Bird.prototype.numLegs = 2;</blockquote>
+
+```js
+Bird.prototype.numLegs = 2;
+```
+
 Now all instances of <code>Bird</code> have the <code>numLegs</code> property.
-<blockquote>console.log(duck.numLegs);  // prints 2<br>console.log(canary.numLegs);  // prints 2</blockquote>
+
+```js
+console.log(duck.numLegs);  // prints 2
+console.log(canary.numLegs);  // prints 2
+```
+
 Since all instances automatically have the properties on the <code>prototype</code>, think of a <code>prototype</code> as a "recipe" for creating objects.
 Note that the <code>prototype</code> for <code>duck</code> and <code>canary</code> is part of the <code>Bird</code> constructor as <code>Bird.prototype</code>. Nearly every object in JavaScript has a <code>prototype</code> property which is part of the constructor function that created it.
 </section>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/verify-an-objects-constructor-with-instanceof.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/verify-an-objects-constructor-with-instanceof.english.md
@@ -7,9 +7,31 @@ challengeType: 1
 ## Description
 <section id='description'>
 Anytime a constructor function creates a new object, that object is said to be an <code>instance</code> of its constructor. JavaScript gives a convenient way to verify this with the <code>instanceof</code> operator. <code>instanceof</code> allows you to compare an object to a constructor, returning <code>true</code> or <code>false</code> based on whether or not that object was created with the constructor. Here's an example:
-<blockquote>let Bird = function(name, color) {<br>&nbsp;&nbsp;this.name = name;<br>&nbsp;&nbsp;this.color = color;<br>&nbsp;&nbsp;this.numLegs = 2;<br>}<br><br>let crow = new Bird("Alexis", "black");<br><br>crow instanceof Bird; // => true</blockquote>
+
+```js
+let Bird = function(name, color) {
+  this.name = name;
+  this.color = color;
+  this.numLegs = 2;
+}
+
+let crow = new Bird("Alexis", "black");
+
+crow instanceof Bird; // => true
+```
+
 If an object is created without using a constructor, <code>instanceof</code> will verify that it is not an instance of that constructor:
-<blockquote>let canary = {<br>&nbsp;&nbsp;name: "Mildred",<br>&nbsp;&nbsp;color: "Yellow",<br>&nbsp;&nbsp;numLegs: 2<br>};<br><br>canary instanceof Bird; // => false</blockquote>
+
+```js
+let canary = {
+  name: "Mildred",
+  color: "Yellow",
+  numLegs: 2
+};
+
+canary instanceof Bird; // => false
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/check-for-all-or-none.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/check-for-all-or-none.english.md
@@ -9,7 +9,15 @@ challengeType: 1
 Sometimes the patterns you want to search for may have parts of it that may or may not exist. However, it may be important to check for them nonetheless.
 You can specify the possible existence of an element with a question mark, <code>?</code>. This checks for zero or one of the preceding element. You can think of this symbol as saying the previous element is optional.
 For example, there are slight differences in American and British English and you can use the question mark to match both spellings.
-<blockquote>let american = "color";<br>let british = "colour";<br>let rainbowRegex= /colou?r/;<br>rainbowRegex.test(american); // Returns true<br>rainbowRegex.test(british); // Returns true</blockquote>
+
+```js
+let american = "color";
+let british = "colour";
+let rainbowRegex= /colou?r/;
+rainbowRegex.test(american); // Returns true
+rainbowRegex.test(british); // Returns true
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/check-for-mixed-grouping-of-characters.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/check-for-mixed-grouping-of-characters.english.md
@@ -9,7 +9,14 @@ challengeType: 1
 Sometimes we want to check for groups of characters using a Regular Expression and to achieve that we use parentheses <code>()</code>.
 If you want to find either <code>Penguin</code> or <code>Pumpkin</code> in a string, you can use the following Regular Expression: <code>/P(engu|umpk)in/g</code>
 Then check whether the desired string groups are in the test string by using the <code>test()</code> method.
-<blockquote>let testStr = "Pumpkin";<br>let testRegex = /P(engu|umpk)in/g;<br>testRegex.test(testStr);<br>// Returns true</blockquote>
+
+```js
+let testStr = "Pumpkin";
+let testRegex = /P(engu|umpk)in/g;
+testRegex.test(testStr);
+// Returns true
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/extract-matches.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/extract-matches.english.md
@@ -8,7 +8,16 @@ challengeType: 1
 <section id='description'>
 So far, you have only been checking if a pattern exists or not within a string. You can also extract the actual matches you found with the <code>.match()</code> method.
 To use the <code>.match()</code> method, apply the method on a string and pass in the regex inside the parentheses. Here's an example:
-<blockquote>"Hello, World!".match(/Hello/);<br>// Returns ["Hello"]<br>let ourStr = "Regular expressions";<br>let ourRegex = /expressions/;<br>ourStr.match(ourRegex);<br>// Returns ["expressions"]</blockquote>
+
+```js
+"Hello, World!".match(/Hello/);
+// Returns ["Hello"]
+let ourStr = "Regular expressions";
+let ourRegex = /expressions/;
+ourStr.match(ourRegex);
+// Returns ["expressions"]
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/find-more-than-the-first-match.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/find-more-than-the-first-match.english.md
@@ -7,9 +7,22 @@ challengeType: 1
 ## Description
 <section id='description'>
 So far, you have only been able to extract or search a pattern once.
-<blockquote>let testStr = "Repeat, Repeat, Repeat";<br>let ourRegex = /Repeat/;<br>testStr.match(ourRegex);<br>// Returns ["Repeat"]</blockquote>
+
+```js
+let testStr = "Repeat, Repeat, Repeat";
+let ourRegex = /Repeat/;
+testStr.match(ourRegex);
+// Returns ["Repeat"]
+```
+
 To search or extract a pattern more than once, you can use the <code>g</code> flag.
-<blockquote>let repeatRegex = /Repeat/g;<br>testStr.match(repeatRegex);<br>// Returns ["Repeat", "Repeat", "Repeat"]</blockquote>
+
+```js
+let repeatRegex = /Repeat/g;
+testStr.match(repeatRegex);
+// Returns ["Repeat", "Repeat", "Repeat"]
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/find-one-or-more-criminals-in-a-hunt.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/find-one-or-more-criminals-in-a-hunt.english.md
@@ -9,9 +9,23 @@ challengeType: 1
 Time to pause and test your new regex writing skills. A group of criminals escaped from jail and ran away, but you don't know how many. However, you do know that they stay close together when they are around other people. You are responsible for finding all of the criminals at once.
 Here's an example to review how to do this:
 The regex <code>/z+/</code> matches the letter <code>z</code> when it appears one or more times in a row. It would find matches in all of the following strings:
-<blockquote>"z"<br>"zzzzzz"<br>"ABCzzzz"<br>"zzzzABC"<br>"abczzzzzzzzzzzzzzzzzzzzzabc"</blockquote>
+
+```js
+"z"
+"zzzzzz"
+"ABCzzzz"
+"zzzzABC"
+"abczzzzzzzzzzzzzzzzzzzzzabc"
+```
+
 But it does not find matches in the following strings since there are no letter <code>z</code> characters:
-<blockquote>""<br>"ABC"<br>"abcabc"</blockquote>
+
+```js
+""
+"ABC"
+"abcabc"
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-all-letters-and-numbers.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-all-letters-and-numbers.english.md
@@ -8,7 +8,18 @@ challengeType: 1
 <section id='description'>
 Using character classes, you were able to search for all letters of the alphabet with <code>[a-z]</code>. This kind of character class is common enough that there is a shortcut for it, although it includes a few extra characters as well.
 The closest character class in JavaScript to match the alphabet is <code>\w</code>. This shortcut is equal to <code>[A-Za-z0-9_]</code>. This character class matches upper and lowercase letters plus numbers. Note, this character class also includes the underscore character (<code>_</code>).
-<blockquote>let longHand = /[A-Za-z0-9_]+/;<br>let shortHand = /\w+/;<br>let numbers = "42";<br>let varNames = "important_var";<br>longHand.test(numbers); // Returns true<br>shortHand.test(numbers); // Returns true<br>longHand.test(varNames); // Returns true<br>shortHand.test(varNames); // Returns true</blockquote>
+
+```js
+let longHand = /[A-Za-z0-9_]+/;
+let shortHand = /\w+/;
+let numbers = "42";
+let varNames = "important_var";
+longHand.test(numbers); // Returns true
+shortHand.test(numbers); // Returns true
+longHand.test(varNames); // Returns true
+shortHand.test(varNames); // Returns true
+```
+
 These shortcut character classes are also known as <code>shorthand character classes</code>.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-anything-with-wildcard-period.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-anything-with-wildcard-period.english.md
@@ -8,7 +8,15 @@ challengeType: 1
 <section id='description'>
 Sometimes you won't (or don't need to) know the exact characters in your patterns. Thinking of all words that match, say, a misspelling would take a long time. Luckily, you can save time using the wildcard character: <code>.</code>
 The wildcard character <code>.</code> will match any one character. The wildcard is also called <code>dot</code> and <code>period</code>. You can use the wildcard character just like any other character in the regex. For example, if you wanted to match <code>"hug"</code>, <code>"huh"</code>, <code>"hut"</code>, and <code>"hum"</code>, you can use the regex <code>/hu./</code> to match all four words.
-<blockquote>let humStr = "I'll hum a song";<br>let hugStr = "Bear hug";<br>let huRegex = /hu./;<br>humStr.test(huRegex); // Returns true<br>hugStr.test(huRegex); // Returns true</blockquote>
+
+```js
+let humStr = "I'll hum a song";
+let hugStr = "Bear hug";
+let huRegex = /hu./;
+humStr.test(huRegex); // Returns true
+hugStr.test(huRegex); // Returns true
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-beginning-string-patterns.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-beginning-string-patterns.english.md
@@ -8,7 +8,17 @@ challengeType: 1
 <section id='description'>
 Prior challenges showed that regular expressions can be used to look for a number of matches. They are also used to search for patterns in specific positions in strings.
 In an earlier challenge, you used the <code>caret</code> character (<code>^</code>) inside a <code>character set</code> to create a <code>negated character set</code> in the form <code>[^thingsThatWillNotBeMatched]</code>. Outside of a <code>character set</code>, the <code>caret</code> is used to search for patterns at the beginning of strings.
-<blockquote>let firstString = "Ricky is first and can be found.";<br>let firstRegex = /^Ricky/;<br>firstRegex.test(firstString);<br>// Returns true<br>let notFirst = "You can't find Ricky now.";<br>firstRegex.test(notFirst);<br>// Returns false</blockquote>
+
+```js
+let firstString = "Ricky is first and can be found.";
+let firstRegex = /^Ricky/;
+firstRegex.test(firstString);
+// Returns true
+let notFirst = "You can't find Ricky now.";
+firstRegex.test(notFirst);
+// Returns false
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-characters-that-occur-zero-or-more-times.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-characters-that-occur-zero-or-more-times.english.md
@@ -8,7 +8,17 @@ challengeType: 1
 <section id='description'>
 The last challenge used the plus <code>+</code> sign to look for characters that occur one or more times. There's also an option that matches characters that occur zero or more times.
 The character to do this is the <code>asterisk</code> or <code>star</code>: <code>*</code>.
-<blockquote>let soccerWord = "gooooooooal!";<br>let gPhrase = "gut feeling";<br>let oPhrase = "over the moon";<br>let goRegex = /go*/;<br>soccerWord.match(goRegex); // Returns ["goooooooo"]<br>gPhrase.match(goRegex); // Returns ["g"]<br>oPhrase.match(goRegex); // Returns null</blockquote>
+
+```js
+let soccerWord = "gooooooooal!";
+let gPhrase = "gut feeling";
+let oPhrase = "over the moon";
+let goRegex = /go*/;
+soccerWord.match(goRegex); // Returns ["goooooooo"]
+gPhrase.match(goRegex); // Returns ["g"]
+oPhrase.match(goRegex); // Returns null
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-ending-string-patterns.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-ending-string-patterns.english.md
@@ -8,7 +8,18 @@ challengeType: 1
 <section id='description'>
 In the last challenge, you learned to use the <code>caret</code> character to search for patterns at the beginning of strings. There is also a way to search for patterns at the end of strings.
 You can search the end of strings using the <code>dollar sign</code> character <code>$</code> at the end of the regex.
-<blockquote>let theEnding = "This is a never ending story";<br>let storyRegex = /story$/;<br>storyRegex.test(theEnding);<br>// Returns true<br>let noEnding = "Sometimes a story will have to end";<br>storyRegex.test(noEnding);<br>// Returns false<br></blockquote>
+
+```js
+let theEnding = "This is a never ending story";
+let storyRegex = /story$/;
+storyRegex.test(theEnding);
+// Returns true
+let noEnding = "Sometimes a story will have to end";
+storyRegex.test(noEnding);
+// Returns false
+
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-everything-but-letters-and-numbers.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-everything-but-letters-and-numbers.english.md
@@ -8,7 +8,16 @@ challengeType: 1
 <section id='description'>
 You've learned that you can use a shortcut to match alphanumerics <code>[A-Za-z0-9_]</code> using <code>\w</code>. A natural pattern you might want to search for is the opposite of alphanumerics.
 You can search for the opposite of the <code>\w</code> with <code>\W</code>. Note, the opposite pattern uses a capital letter. This shortcut is the same as <code>[^A-Za-z0-9_]</code>.
-<blockquote>let shortHand = /\W/;<br>let numbers = "42%";<br>let sentence = "Coding!";<br>numbers.match(shortHand); // Returns ["%"]<br>sentence.match(shortHand); // Returns ["!"]<br></blockquote>
+
+```js
+let shortHand = /\W/;
+let numbers = "42%";
+let sentence = "Coding!";
+numbers.match(shortHand); // Returns ["%"]
+sentence.match(shortHand); // Returns ["!"]
+
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-everything-but-letters-and-numbers.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-everything-but-letters-and-numbers.english.md
@@ -15,7 +15,6 @@ let numbers = "42%";
 let sentence = "Coding!";
 numbers.match(shortHand); // Returns ["%"]
 sentence.match(shortHand); // Returns ["!"]
-
 ```
 
 </section>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-letters-of-the-alphabet.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-letters-of-the-alphabet.english.md
@@ -9,7 +9,17 @@ challengeType: 1
 You saw how you can use <code>character sets</code> to specify a group of characters to match, but that's a lot of typing when you need to match a large range of characters (for example, every letter in the alphabet). Fortunately, there is a built-in feature that makes this short and simple.
 Inside a <code>character set</code>, you can define a range of characters to match using a <code>hyphen</code> character: <code>-</code>.
 For example, to match lowercase letters <code>a</code> through <code>e</code> you would use <code>[a-e]</code>.
-<blockquote>let catStr = "cat";<br>let batStr = "bat";<br>let matStr = "mat";<br>let bgRegex = /[a-e]at/;<br>catStr.match(bgRegex); // Returns ["cat"]<br>batStr.match(bgRegex); // Returns ["bat"]<br>matStr.match(bgRegex); // Returns null</blockquote>
+
+```js
+let catStr = "cat";
+let batStr = "bat";
+let matStr = "mat";
+let bgRegex = /[a-e]at/;
+catStr.match(bgRegex); // Returns ["cat"]
+batStr.match(bgRegex); // Returns ["bat"]
+matStr.match(bgRegex); // Returns null
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-literal-strings.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-literal-strings.english.md
@@ -7,9 +7,22 @@ challengeType: 1
 ## Description
 <section id='description'>
 In the last challenge, you searched for the word <code>"Hello"</code> using the regular expression <code>/Hello/</code>. That regex searched for a literal match of the string <code>"Hello"</code>. Here's another example searching for a literal match of the string <code>"Kevin"</code>:
-<blockquote>let testStr = "Hello, my name is Kevin.";<br>let testRegex = /Kevin/;<br>testRegex.test(testStr);<br>// Returns true</blockquote>
+
+```js
+let testStr = "Hello, my name is Kevin.";
+let testRegex = /Kevin/;
+testRegex.test(testStr);
+// Returns true
+```
+
 Any other forms of <code>"Kevin"</code> will not match. For example, the regex <code>/Kevin/</code> will not match <code>"kevin"</code> or <code>"KEVIN"</code>.
-<blockquote>let wrongRegex = /kevin/;<br>wrongRegex.test(testStr);<br>// Returns false</blockquote>
+
+```js
+let wrongRegex = /kevin/;
+wrongRegex.test(testStr);
+// Returns false
+```
+
 A future challenge will show how to match those other forms as well.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-non-whitespace-characters.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-non-whitespace-characters.english.md
@@ -8,7 +8,13 @@ challengeType: 1
 <section id='description'>
 You learned about searching for whitespace using <code>\s</code>, with a lowercase <code>s</code>. You can also search for everything except whitespace.
 Search for non-whitespace using <code>\S</code>, which is an uppercase <code>s</code>. This pattern will not match whitespace, carriage return, tab, form feed, and new line characters. You can think of it being similar to the character class <code>[^ \r\t\f\n\v]</code>.
-<blockquote>let whiteSpace = "Whitespace. Whitespace everywhere!"<br>let nonSpaceRegex = /\S/g;<br>whiteSpace.match(nonSpaceRegex).length; // Returns 32</blockquote>
+
+```js
+let whiteSpace = "Whitespace. Whitespace everywhere!"
+let nonSpaceRegex = /\S/g;
+whiteSpace.match(nonSpaceRegex).length; // Returns 32
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-numbers-and-letters-of-the-alphabet.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-numbers-and-letters-of-the-alphabet.english.md
@@ -9,7 +9,14 @@ challengeType: 1
 Using the hyphen (<code>-</code>) to match a range of characters is not limited to letters. It also works to match a range of numbers.
 For example, <code>/[0-5]/</code> matches any number between <code>0</code> and <code>5</code>, including the <code>0</code> and <code>5</code>.
 Also, it is possible to combine a range of letters and numbers in a single character set.
-<blockquote>let jennyStr = "Jenny8675309";<br>let myRegex = /[a-z0-9]/ig;<br>// matches all letters and numbers in jennyStr<br>jennyStr.match(myRegex);</blockquote>
+
+```js
+let jennyStr = "Jenny8675309";
+let myRegex = /[a-z0-9]/ig;
+// matches all letters and numbers in jennyStr
+jennyStr.match(myRegex);
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-single-character-with-multiple-possibilities.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-single-character-with-multiple-possibilities.english.md
@@ -9,7 +9,19 @@ challengeType: 1
 You learned how to match literal patterns (<code>/literal/</code>) and wildcard character (<code>/./</code>). Those are the extremes of regular expressions, where one finds exact matches and the other matches everything. There are options that are a balance between the two extremes.
 You can search for a literal pattern with some flexibility with <code>character classes</code>. Character classes allow you to define a group of characters you wish to match by placing them inside square (<code>[</code> and <code>]</code>) brackets.
 For example, you want to match <code>"bag"</code>, <code>"big"</code>, and <code>"bug"</code> but not <code>"bog"</code>. You can create the regex <code>/b[aiu]g/</code> to do this. The <code>[aiu]</code> is the character class that will only match the characters <code>"a"</code>, <code>"i"</code>, or <code>"u"</code>.
-<blockquote>let bigStr = "big";<br>let bagStr = "bag";<br>let bugStr = "bug";<br>let bogStr = "bog";<br>let bgRegex = /b[aiu]g/;<br>bigStr.match(bgRegex); // Returns ["big"]<br>bagStr.match(bgRegex); // Returns ["bag"]<br>bugStr.match(bgRegex); // Returns ["bug"]<br>bogStr.match(bgRegex); // Returns null</blockquote>
+
+```js
+let bigStr = "big";
+let bagStr = "bag";
+let bugStr = "bug";
+let bogStr = "bog";
+let bgRegex = /b[aiu]g/;
+bigStr.match(bgRegex); // Returns ["big"]
+bagStr.match(bgRegex); // Returns ["bag"]
+bugStr.match(bgRegex); // Returns ["bug"]
+bogStr.match(bgRegex); // Returns null
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-whitespace.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-whitespace.english.md
@@ -14,7 +14,6 @@ let whiteSpace = "Whitespace. Whitespace everywhere!"
 let spaceRegex = /\s/g;
 whiteSpace.match(spaceRegex);
 // Returns [" ", " "]
-
 ```
 
 </section>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-whitespace.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-whitespace.english.md
@@ -8,7 +8,15 @@ challengeType: 1
 <section id='description'>
 The challenges so far have covered matching letters of the alphabet and numbers. You can also match the whitespace or spaces between letters.
 You can search for whitespace using <code>\s</code>, which is a lowercase <code>s</code>. This pattern not only matches whitespace, but also carriage return, tab, form feed, and new line characters. You can think of it as similar to the character class <code>[ \r\t\f\n\v]</code>.
-<blockquote>let whiteSpace = "Whitespace. Whitespace everywhere!"<br>let spaceRegex = /\s/g;<br>whiteSpace.match(spaceRegex);<br>// Returns [" ", " "]<br></blockquote>
+
+```js
+let whiteSpace = "Whitespace. Whitespace everywhere!"
+let spaceRegex = /\s/g;
+whiteSpace.match(spaceRegex);
+// Returns [" ", " "]
+
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/positive-and-negative-lookahead.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/positive-and-negative-lookahead.english.md
@@ -11,9 +11,24 @@ There are two kinds of <code>lookaheads</code>: <code>positive lookahead</code> 
 A <code>positive lookahead</code> will look to make sure the element in the search pattern is there, but won't actually match it. A positive lookahead is used as <code>(?=...)</code> where the <code>...</code> is the required part that is not matched.
 On the other hand, a <code>negative lookahead</code> will look to make sure the element in the search pattern is not there. A negative lookahead is used as <code>(?!...)</code> where the <code>...</code> is the pattern that you do not want to be there. The rest of the pattern is returned if the negative lookahead part is not present.
 Lookaheads are a bit confusing but some examples will help.
-<blockquote>let quit = "qu";<br>let noquit = "qt";<br>let quRegex= /q(?=u)/;<br>let qRegex = /q(?!u)/;<br>quit.match(quRegex); // Returns ["q"]<br>noquit.match(qRegex); // Returns ["q"]</blockquote>
+
+```js
+let quit = "qu";
+let noquit = "qt";
+let quRegex= /q(?=u)/;
+let qRegex = /q(?!u)/;
+quit.match(quRegex); // Returns ["q"]
+noquit.match(qRegex); // Returns ["q"]
+```
+
 A more practical use of <code>lookaheads</code> is to check two or more patterns in one string. Here is a (naively) simple password checker that looks for between 3 and 6 characters and at least one number:
-<blockquote>let password = "abc123";<br>let checkPass = /(?=\w{3,6})(?=\D*\d)/;<br>checkPass.test(password); // Returns true</blockquote>
+
+```js
+let password = "abc123";
+let checkPass = /(?=\w{3,6})(?=\D*\d)/;
+checkPass.test(password); // Returns true
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/reuse-patterns-using-capture-groups.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/reuse-patterns-using-capture-groups.english.md
@@ -10,7 +10,14 @@ Some patterns you search for will occur multiple times in a string. It is wastef
 You can search for repeat substrings using <code>capture groups</code>. Parentheses, <code>(</code> and <code>)</code>, are used to find repeat substrings. You put the regex of the pattern that will repeat in between the parentheses.
 To specify where that repeat string will appear, you use a backslash (<code>\</code>) and then a number. This number starts at 1 and increases with each additional capture group you use. An example would be <code>\1</code> to match the first group.
 The example below matches any word that occurs twice separated by a space:
-<blockquote>let repeatStr = "regex regex";<br>let repeatRegex = /(\w+)\s\1/;<br>repeatRegex.test(repeatStr); // Returns true<br>repeatStr.match(repeatRegex); // Returns ["regex regex", "regex"]</blockquote>
+
+```js
+let repeatStr = "regex regex";
+let repeatRegex = /(\w+)\s\1/;
+repeatRegex.test(repeatStr); // Returns true
+repeatStr.match(repeatRegex); // Returns ["regex regex", "regex"]
+```
+
 Using the <code>.match()</code> method on a string will return an array with the string it matches, along with its capture group.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/specify-exact-number-of-matches.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/specify-exact-number-of-matches.english.md
@@ -9,7 +9,17 @@ challengeType: 1
 You can specify the lower and upper number of patterns with <code>quantity specifiers</code> using curly brackets. Sometimes you only want a specific number of matches.
 To specify a certain number of patterns, just have that one number between the curly brackets.
 For example, to match only the word <code>"hah"</code> with the letter <code>a</code> <code>3</code> times, your regex would be <code>/ha{3}h/</code>.
-<blockquote>let A4 = "haaaah";<br>let A3 = "haaah";<br>let A100 = "h" + "a".repeat(100) + "h";<br>let multipleHA = /ha{3}h/;<br>multipleHA.test(A4); // Returns false<br>multipleHA.test(A3); // Returns true<br>multipleHA.test(A100); // Returns false</blockquote>
+
+```js
+let A4 = "haaaah";
+let A3 = "haaah";
+let A100 = "h" + "a".repeat(100) + "h";
+let multipleHA = /ha{3}h/;
+multipleHA.test(A4); // Returns false
+multipleHA.test(A3); // Returns true
+multipleHA.test(A100); // Returns false
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/specify-only-the-lower-number-of-matches.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/specify-only-the-lower-number-of-matches.english.md
@@ -9,7 +9,17 @@ challengeType: 1
 You can specify the lower and upper number of patterns with <code>quantity specifiers</code> using curly brackets. Sometimes you only want to specify the lower number of patterns with no upper limit.
 To only specify the lower number of patterns, keep the first number followed by a comma.
 For example, to match only the string <code>"hah"</code> with the letter <code>a</code> appearing at least <code>3</code> times, your regex would be <code>/ha{3,}h/</code>.
-<blockquote>let A4 = "haaaah";<br>let A2 = "haah";<br>let A100 = "h" + "a".repeat(100) + "h";<br>let multipleA = /ha{3,}h/;<br>multipleA.test(A4); // Returns true<br>multipleA.test(A2); // Returns false<br>multipleA.test(A100); // Returns true</blockquote>
+
+```js
+let A4 = "haaaah";
+let A2 = "haah";
+let A100 = "h" + "a".repeat(100) + "h";
+let multipleA = /ha{3,}h/;
+multipleA.test(A4); // Returns true
+multipleA.test(A2); // Returns false
+multipleA.test(A100); // Returns true
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/specify-upper-and-lower-number-of-matches.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/specify-upper-and-lower-number-of-matches.english.md
@@ -9,7 +9,15 @@ challengeType: 1
 Recall that you use the plus sign <code>+</code> to look for one or more characters and the asterisk <code>*</code> to look for zero or more characters. These are convenient but sometimes you want to match a certain range of patterns.
 You can specify the lower and upper number of patterns with <code>quantity specifiers</code>. Quantity specifiers are used with curly brackets (<code>{</code> and <code>}</code>). You put two numbers between the curly brackets - for the lower and upper number of patterns.
 For example, to match only the letter <code>a</code> appearing between <code>3</code> and <code>5</code> times in the string <code>"ah"</code>, your regex would be <code>/a{3,5}h/</code>.
-<blockquote>let A4 = "aaaah";<br>let A2 = "aah";<br>let multipleA = /a{3,5}h/;<br>multipleA.test(A4); // Returns true<br>multipleA.test(A2); // Returns false</blockquote>
+
+```js
+let A4 = "aaaah";
+let A2 = "aah";
+let multipleA = /a{3,5}h/;
+multipleA.test(A4); // Returns true
+multipleA.test(A2); // Returns false
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/use-capture-groups-to-search-and-replace.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/use-capture-groups-to-search-and-replace.english.md
@@ -8,9 +8,21 @@ challengeType: 1
 <section id='description'>
 Searching is useful. However, you can make searching even more powerful when it also changes (or replaces) the text you match.
 You can search and replace text in a string using <code>.replace()</code> on a string. The inputs for <code>.replace()</code> is first the regex pattern you want to search for. The second parameter is the string to replace the match or a function to do something.
-<blockquote>let wrongText = "The sky is silver.";<br>let silverRegex = /silver/;<br>wrongText.replace(silverRegex, "blue");<br>// Returns "The sky is blue."</blockquote>
+
+```js
+let wrongText = "The sky is silver.";
+let silverRegex = /silver/;
+wrongText.replace(silverRegex, "blue");
+// Returns "The sky is blue."
+```
+
 You can also access capture groups in the replacement string with dollar signs (<code>$</code>).
-<blockquote>"Code Camp".replace(/(\w+)\s(\w+)/, '$2 $1');<br>// Returns "Camp Code"</blockquote>
+
+```js
+"Code Camp".replace(/(\w+)\s(\w+)/, '$2 $1');
+// Returns "Camp Code"
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/using-the-test-method.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/using-the-test-method.english.md
@@ -9,7 +9,14 @@ challengeType: 1
 Regular expressions are used in programming languages to match parts of strings. You create patterns to help you do that matching.
 If you want to find the word <code>"the"</code> in the string <code>"The dog chased the cat"</code>, you could use the following regular expression: <code>/the/</code>. Notice that quote marks are not required within the regular expression.
 JavaScript has multiple ways to use regexes. One way to test a regex is using the <code>.test()</code> method. The <code>.test()</code> method takes the regex, applies it to a string (which is placed inside the parentheses), and returns <code>true</code> or <code>false</code> if your pattern finds something or not.
-<blockquote>let testStr = "freeCodeCamp";<br>let testRegex = /Code/;<br>testRegex.test(testStr);<br>// Returns true</blockquote>
+
+```js
+let testStr = "freeCodeCamp";
+let testRegex = /Code/;
+testRegex.test(testStr);
+// Returns true
+```
+
 </section>
 
 ## Instructions


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

**PR Purpose:** Converts `blockquote` elements to triple backtick syntax in the `Description` and `Instructions` sections of the `JavaScript Algorithms and Data Structures` challenges.

Related to issue #35991