### PR TITLE
fix(curriculum): Convert blockquote elements to triple backtick syntax for Coding Interview Prep

### DIFF
--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/adjacency-list.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/adjacency-list.english.md
@@ -8,13 +8,7 @@ challengeType: 1
 <section id='description'>
 Graphs can be represented in different ways. Here we describe one way, which is called an <dfn>adjacency list</dfn>.
 An adjacency list is essentially a bulleted list where the left side is the node and the right side lists all the other nodes it's connected to. Below is a representation of an adjacency list.
-
-```js
-Node1: Node2, Node3
-Node2: Node1
-Node3: Node1
-```
-
+<blockquote>Node1: Node2, Node3<br>Node2: Node1<br>Node3: Node1</blockquote>
 Above is an undirected graph because <code>Node1</code> is connected to <code>Node2</code> and <code>Node3</code>, and that information is consistent with the connections <code>Node2</code> and <code>Node3</code> show. An adjacency list for a directed graph would mean each row of the list shows direction. If the above was directed, then <code>Node2: Node1</code> would mean there the directed edge is pointing from <code>Node2</code> towards <code>Node1</code>.
 We can represent the undirected graph above as an adjacency list by putting it within a JavaScript object.
 
@@ -30,9 +24,9 @@ This can also be more simply represented as an array where the nodes just have n
 
 ```js
 var undirectedGArr = [
-  [1, 2], # Node1
-  [0],    # Node2
-  [0]     # Node3
+  [1, 2], // Node1
+  [0],    // Node2
+  [0]     // Node3
 ];
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/adjacency-list.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/adjacency-list.english.md
@@ -8,12 +8,34 @@ challengeType: 1
 <section id='description'>
 Graphs can be represented in different ways. Here we describe one way, which is called an <dfn>adjacency list</dfn>.
 An adjacency list is essentially a bulleted list where the left side is the node and the right side lists all the other nodes it's connected to. Below is a representation of an adjacency list.
-<blockquote>Node1: Node2, Node3<br>Node2: Node1<br>Node3: Node1</blockquote>
+
+```js
+Node1: Node2, Node3
+Node2: Node1
+Node3: Node1
+```
+
 Above is an undirected graph because <code>Node1</code> is connected to <code>Node2</code> and <code>Node3</code>, and that information is consistent with the connections <code>Node2</code> and <code>Node3</code> show. An adjacency list for a directed graph would mean each row of the list shows direction. If the above was directed, then <code>Node2: Node1</code> would mean there the directed edge is pointing from <code>Node2</code> towards <code>Node1</code>.
 We can represent the undirected graph above as an adjacency list by putting it within a JavaScript object.
-<blockquote>var undirectedG = {<br>  Node1: ["Node2", "Node3"],<br>  Node2: ["Node1"],<br>  Node3: ["Node1"]<br>};</blockquote>
+
+```js
+var undirectedG = {
+  Node1: ["Node2", "Node3"],
+  Node2: ["Node1"],
+  Node3: ["Node1"]
+};
+```
+
 This can also be more simply represented as an array where the nodes just have numbers rather than string labels.
-<blockquote>var undirectedGArr = [<br>  [1, 2], # Node1<br>  [0],    # Node2<br>  [0]     # Node3<br>];</blockquote>
+
+```js
+var undirectedGArr = [
+  [1, 2], # Node1
+  [0],    # Node2
+  [0]     # Node3
+];
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/adjacency-matrix.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/adjacency-matrix.english.md
@@ -8,15 +8,7 @@ challengeType: 1
 <section id='description'>
 Another way to represent a graph is to put it in an <dfn>adjacency matrix</dfn>.
 An <dfn>adjacency matrix</dfn> is a two-dimensional (2D) array where each nested array has the same number of elements as the outer array. In other words, it is a matrix or grid of numbers, where the numbers represent the edges. Zeros mean there is no edge or relationship.
-
-```js
-    1 2 3
-    -----
-1 | 0 1 1
-2 | 1 0 0
-3 | 1 0 0
-```
-
+<blockquote>    1 2 3<br>   ------<br>1 | 0 1 1<br>2 | 1 0 0<br>3 | 1 0 0</blockquote>
 Above is a very simple, undirected graph where you have three nodes, where the first node is connected to the second and third node. <strong>Note</strong>: The numbers to the top and left of the matrix are just labels for the nodes.
 Below is a JavaScript implementation of the same thing.
 

--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/adjacency-matrix.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/adjacency-matrix.english.md
@@ -8,13 +8,37 @@ challengeType: 1
 <section id='description'>
 Another way to represent a graph is to put it in an <dfn>adjacency matrix</dfn>.
 An <dfn>adjacency matrix</dfn> is a two-dimensional (2D) array where each nested array has the same number of elements as the outer array. In other words, it is a matrix or grid of numbers, where the numbers represent the edges. Zeros mean there is no edge or relationship.
-<blockquote>    1 2 3<br>   ------<br>1 | 0 1 1<br>2 | 1 0 0<br>3 | 1 0 0</blockquote>
+
+```js
+    1 2 3
+    -----
+1 | 0 1 1
+2 | 1 0 0
+3 | 1 0 0
+```
+
 Above is a very simple, undirected graph where you have three nodes, where the first node is connected to the second and third node. <strong>Note</strong>: The numbers to the top and left of the matrix are just labels for the nodes.
 Below is a JavaScript implementation of the same thing.
-<blockquote>var adjMat = [<br>  [0, 1, 1],<br>  [1, 0, 0],<br>  [1, 0, 0]<br>];</blockquote>
+
+```js
+var adjMat = [
+  [0, 1, 1],
+  [1, 0, 0],
+  [1, 0, 0]
+];
+```
+
 Unlike an adjacency list, each "row" of the matrix has to have the same number of elements as nodes in the graph. Here we have a three by three matrix, which means we have three nodes in our graph.
 A directed graph would look similar. Below is a graph where the first node has an edge pointing toward the second node, and then the second node has an edge pointing to the third node.
-<blockquote>var adjMatDirected = [<br>  [0, 1, 0],<br>  [0, 0, 1],<br>  [0, 0, 0]<br>];</blockquote>
+
+```js
+var adjMatDirected = [
+  [0, 1, 0],
+  [0, 0, 1],
+  [0, 0, 0]
+];
+```
+
 Graphs can also have <dfn>weights</dfn> on their edges. So far, we have <dfn>unweighted</dfn> edges where just the presence and lack of edge is binary (<code>0</code> or <code>1</code>). You can have different weights depending on your application.
 </section>
 

--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/create-a-set-class.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/create-a-set-class.english.md
@@ -8,7 +8,17 @@ challengeType: 1
 <section id='description'>
 In this exercise we are going to create a class named <code>Set</code> to emulate an abstract data structure called "set". A set is like an array, but it cannot contain duplicate values. The typical use for a set is to simply check for the presence of an item. 
 We can see how ES6 set object works in the example below-
-<blockquote>const set1 = new Set([1, 2, 3, 5, 5, 2, 0]);<br>console.log(set1);<br>// output: {1, 2, 3, 5, 0}<br>console.log(set1.has(1));<br>// output: true<br>console.log(set1.has(6));<br>// output: false</blockquote>
+
+```js
+const set1 = new Set([1, 2, 3, 5, 5, 2, 0]);
+console.log(set1);
+// output: {1, 2, 3, 5, 0}
+console.log(set1.has(1));
+// output: true
+console.log(set1.has(6));
+// output: false
+```
+
 First, we will create an add method that adds a value to our set collection as long as the value does not already exist in the set.
 Then we will create a remove method that removes a value from the set collection if it already exists.
 And finally, we will create a size method that returns the number of elements inside the set collection.

--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/create-and-add-to-sets-in-es6.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/create-and-add-to-sets-in-es6.english.md
@@ -14,9 +14,19 @@ You can create a set with a value:
 You can create a set with an array:
 <code>var set = new Set([1, 2, 3]);</code>
 Once you have created a set, you can add the values you wish using the <code>add</code> method:
-<blockquote>var set = new Set([1, 2, 3]);<br>set.add([4, 5, 6]);</blockquote>
+
+```js
+var set = new Set([1, 2, 3]);
+set.add([4, 5, 6]);
+```
+
 As a reminder, a set is a data structure that cannot contain duplicate values:
-<blockquote>var set = new Set([1, 2, 3, 1, 2, 3]);<br>// set contains [1, 2, 3] only</blockquote>
+
+```js
+var set = new Set([1, 2, 3, 1, 2, 3]);
+// set contains [1, 2, 3] only
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/incidence-matrix.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/incidence-matrix.english.md
@@ -10,26 +10,9 @@ Yet another way to represent a graph is to put it in an <dfn>incidence matrix.</
 An <dfn>incidence matrix</dfn> is a two-dimensional (2D) array. Generally speaking, an incidence matrix relates two different classes of objects between its two dimensions. This kind of matrix is similar to an adjacency matrix. However, the rows and columns mean something else here.
 In graphs, we have edges and nodes. These will be our "two different classes of objects". This matrix will have the rows be the nodes and columns be the edges. This means that we can have an uneven number of rows and columns.
 Each column will represent a unique edge. Also, each edge connects two nodes. To show that there is an edge between two nodes, you will put a 1 in the two rows of a particular column. Below is a 3 node graph with one edge between node 1 and node 3.
-
-```js
-    1
-   ---
-1 | 1
-2 | 0
-3 | 1
-```
-
+<blockquote>    1<br>   ---<br>1 | 1<br>2 | 0<br>3 | 1</blockquote>
 Here is an example of an <code>incidence matrix</code> with 4 edges and 4 nodes. Remember, the columns are the edges and rows are the nodes themselves.
-
-```js
-    1 2 3 4
-    -------
-1 | 0 1 1 1
-2 | 1 1 0 0
-3 | 1 0 0 1
-4 | 0 0 1 0
-```
-
+<blockquote>    1 2 3 4<br>   --------<br>1 | 0 1 1 1<br>2 | 1 1 0 0<br>3 | 1 0 0 1<br>4 | 0 0 1 0</blockquote>
 Below is a JavaScript implementation of the same thing.
 
 ```js

--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/incidence-matrix.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/incidence-matrix.english.md
@@ -10,13 +10,48 @@ Yet another way to represent a graph is to put it in an <dfn>incidence matrix.</
 An <dfn>incidence matrix</dfn> is a two-dimensional (2D) array. Generally speaking, an incidence matrix relates two different classes of objects between its two dimensions. This kind of matrix is similar to an adjacency matrix. However, the rows and columns mean something else here.
 In graphs, we have edges and nodes. These will be our "two different classes of objects". This matrix will have the rows be the nodes and columns be the edges. This means that we can have an uneven number of rows and columns.
 Each column will represent a unique edge. Also, each edge connects two nodes. To show that there is an edge between two nodes, you will put a 1 in the two rows of a particular column. Below is a 3 node graph with one edge between node 1 and node 3.
-<blockquote>    1<br>   ---<br>1 | 1<br>2 | 0<br>3 | 1</blockquote>
+
+```js
+    1
+   ---
+1 | 1
+2 | 0
+3 | 1
+```
+
 Here is an example of an <code>incidence matrix</code> with 4 edges and 4 nodes. Remember, the columns are the edges and rows are the nodes themselves.
-<blockquote>    1 2 3 4<br>   --------<br>1 | 0 1 1 1<br>2 | 1 1 0 0<br>3 | 1 0 0 1<br>4 | 0 0 1 0</blockquote>
+
+```js
+    1 2 3 4
+    -------
+1 | 0 1 1 1
+2 | 1 1 0 0
+3 | 1 0 0 1
+4 | 0 0 1 0
+```
+
 Below is a JavaScript implementation of the same thing.
-<blockquote>var incMat = [<br>  [0, 1, 1, 1],<br>  [1, 1, 0, 0],<br>  [1, 0, 0, 1],<br>  [0, 0, 1, 0]<br>];</blockquote>
+
+```js
+var incMat = [
+  [0, 1, 1, 1],
+  [1, 1, 0, 0],
+  [1, 0, 0, 1],
+  [0, 0, 1, 0]
+];
+```
+
 To make a directed graph, use <code>-1</code> for an edge leaving a particular node and <code>1</code> for an edge entering a node.
-<blockquote>var incMatDirected = [<br>  [ 0, -1,  1, -1],<br>  [-1,  1,  0,  0],<br>  [ 1,  0,  0,  1],<br>  [ 0,  0, -1,  0]<br>];</blockquote>
+
+```js
+var incMatDirected = [
+  [ 0, -1,  1, -1],
+  [-1,  1,  0,  0],
+  [ 1,  0,  0,  1],
+  [ 0,  0, -1,  0]
+];
+```
+
 Graphs can also have <dfn>weights</dfn> on their edges. So far, we have <dfn>unweighted</dfn> edges where just the presence and lack of edge is binary (<code>0</code> or <code>1</code>). You can have different weights depending on your application. A different weight is represented as numbers greater than 1.
 </section>
 

--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/remove-items-from-a-set-in-es6.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/remove-items-from-a-set-in-es6.english.md
@@ -10,7 +10,12 @@ Let's practice removimg items from an ES6 Set using the <code>delete</code> meth
 First, create an ES6 Set
 <code>var set = new Set([1,2,3]);</code>
 Now remove an item from your Set with the <code>delete</code> method.
-<blockquote>set.delete(1);<br>console.log([...set]) // should return [ 2, 3 ]<blockquote>
+
+```js
+set.delete(1);
+console.log([...set]) // should return [ 2, 3 ]
+```
+
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/typed-arrays.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/typed-arrays.english.md
@@ -13,12 +13,33 @@ However, in the world of high performance and different element types, sometimes
 <dfn>Typed arrays</dfn> are the answer to this problem. You are now able to say how much memory you want to give an array. Below is a basic overview of the different types of arrays available and the size in bytes for each element in that array.
 <table class='table table-striped'><tr><th>Type</th><th>Each element size in bytes</th></tr><tr><td><code>Int8Array</code></td><td>1</td></tr><tr><td><code>Uint8Array</code></td><td>1</td></tr><tr><td><code>Uint8ClampedArray</code></td><td>1</td></tr><tr><td><code>Int16Array</code></td><td>2</td></tr><tr><td><code>Uint16Array</code></td><td>2</td></tr><tr><td><code>Int32Array</code></td><td>4</td></tr><tr><td><code>Uint32Array</code></td><td>4</td></tr><tr><td><code>Float32Array</code></td><td>4</td></tr><tr><td><code>Float64Array</code></td><td>8</td></tr></table>
 There are two ways in creating these kind of arrays. One way is to create it directly. Below is how to create a 3 length <code>Int16Array</code>.
-<blockquote>var i8 = new Int16Array(3);<br>console.log(i8);<br>// Returns [0, 0, 0]</blockquote>
+
+```js
+var i8 = new Int16Array(3);
+console.log(i8);
+// Returns [0, 0, 0]
+```
+
 You can also create a <dfn>buffer</dfn> to assign how much data (in bytes) you want the array to take up.
 <strong>Note</strong><br>To create typed arrays using buffers, you need to assign the number of bytes to be a multiple of the bytes listed above.
-<blockquote>// Create same Int16Array array differently<br>var byteSize = 6; // Needs to be multiple of 2<br>var buffer = new ArrayBuffer(byteSize);<br>var i8View = new Int16Array(buffer);<br>buffer.byteLength; // Returns 6<br>i8View.byteLength; // Returns 6<br>console.log(i8View); // Returns [0, 0, 0]</blockquote>
+
+```js
+// Create same Int16Array array differently
+var byteSize = 6; // Needs to be multiple of 2
+var buffer = new ArrayBuffer(byteSize);
+var i8View = new Int16Array(buffer);
+buffer.byteLength; // Returns 6
+i8View.byteLength; // Returns 6
+console.log(i8View); // Returns [0, 0, 0]
+```
+
 <dfn>Buffers</dfn> are general purpose objects that just carry data. You cannot access them normally. To access them, you need to first create a <dfn>view</dfn>.
-<blockquote>i8View[0] = 42;<br>console.log(i8View); // Returns [42, 0, 0]</blockquote>
+
+```js
+i8View[0] = 42;
+console.log(i8View); // Returns [42, 0, 0]
+```
+
 <strong>Note</strong><br>Typed arrays do not have some of the methods traditional arrays have such as <code>.pop()</code> or <code>.push()</code>. Typed arrays also fail <code>Array.isArray()</code> that checks if something is an array. Although simpler, this can be an advantage for less-sophisticated JavaScript engines to implement them.
 </section>
 

--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/use-spread-and-notes-for-es5-set-integration.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/use-spread-and-notes-for-es5-set-integration.english.md
@@ -9,7 +9,13 @@ challengeType: 1
 Do you remember the ES6 spread operator <code>...</code>?
 <code>...</code> can take iterable objects in ES6 and turn them into arrays.
 Let's create a Set, and check out the spread function.
-<blockquote>var set = new Set([1,2,3]);<br>var setToArr = [...set]<br>console.log(setToArr) // returns [ 1, 2, 3 ]</blockquote>
+
+```js
+var set = new Set([1,2,3]);
+var setToArr = [...set]
+console.log(setToArr) // returns [ 1, 2, 3 ]
+```
+
 </section>
 
 ## Instructions


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

**PR Purpose:** Converts `blockquote` elements to triple backtick syntax in the `Description` and `Instructions` sections of the `Coding Interview Prep` challenges.

Related to issue #35991