### PR TITLE
fix(client): Donate other displays correct submit button text

### DIFF
--- a/client/src/pages/donate-other.js
+++ b/client/src/pages/donate-other.js
@@ -67,17 +67,17 @@ class DonateOtherPage extends Component {
         }
         target='_blank'
       >
-        <input defaultValue='_s-xclick' name='cmd' type='hidden' />{' '}
+        <input name='cmd' type='hidden' value='_s-xclick' />{' '}
         <input
-          defaultValue={item.defaultValueHash}
           name='hosted_button_id'
           type='hidden'
+          value={item.defaultValueHash}
         />{' '}
         <input
           className='btn btn-cta signup-btn btn-block'
-          defaultValue={item.defaultValue}
           name='submit'
           type='submit'
+          value={item.defaultValue}
         />
       </form>
     );


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

If you're signed into rocks, the /donate-other page loads correctly, then changes so it looks like this:
![DonateOther](https://user-images.githubusercontent.com/15801806/57399649-fc821d80-71d1-11e9-9dee-cc28c03efd28.png)

For some reason, the `value` set by `defaultValue` isn't persisting, but setting it directly solves the problem.