### PR TITLE
fix(client): add tooltip for calendar-heatmap

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3379,8 +3379,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -3398,13 +3397,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -3417,18 +3414,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -3531,8 +3525,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -3542,7 +3535,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -3555,20 +3547,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3585,7 +3574,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -3658,8 +3646,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3669,7 +3656,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3745,8 +3731,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3776,7 +3761,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -3794,7 +3778,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3833,13 +3816,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -7002,8 +6983,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7024,14 +7004,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7046,20 +7024,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7176,8 +7151,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7189,7 +7163,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7204,7 +7177,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7212,14 +7184,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -7238,7 +7208,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7319,8 +7288,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7332,7 +7300,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7418,8 +7385,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7455,7 +7421,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7475,7 +7440,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7519,14 +7483,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -7723,8 +7685,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -7742,13 +7703,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -7761,18 +7720,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -7875,8 +7831,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -7886,7 +7841,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -7899,20 +7853,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -7929,7 +7880,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -8002,8 +7952,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -8013,7 +7962,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -8089,8 +8037,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -8120,7 +8067,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -8138,7 +8084,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -8177,13 +8122,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -8578,8 +8521,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -8597,13 +8539,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -8616,18 +8556,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -8730,8 +8667,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -8741,7 +8677,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -8754,20 +8689,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -8784,7 +8716,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -8857,8 +8788,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -8868,7 +8798,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -8944,8 +8873,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -8975,7 +8903,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -8993,7 +8920,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -9032,13 +8958,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -9152,8 +9076,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -9171,13 +9094,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -9190,18 +9111,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -9304,8 +9222,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -9315,7 +9232,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -9328,20 +9244,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -9358,7 +9271,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -9431,8 +9343,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -9442,7 +9353,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -9518,8 +9428,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -9549,7 +9458,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -9567,7 +9475,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -9606,13 +9513,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -16472,6 +16377,15 @@
           "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==",
           "dev": true
         }
+      }
+    },
+    "react-tooltip": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-3.10.0.tgz",
+      "integrity": "sha512-GGdxJvM1zSFztkTP7gCQbLTstWr1OOoMpJ5WZUGhimj0nhRY+MPz+92MpEnKmj0cftJ9Pd/M6FfSl0sfzmZWkg==",
+      "requires": {
+        "classnames": "^2.2.5",
+        "prop-types": "^15.6.0"
       }
     },
     "react-transition-group": {

--- a/client/package.json
+++ b/client/package.json
@@ -53,6 +53,7 @@
     "react-responsive": "^6.1.1",
     "react-spinkit": "^3.0.0",
     "react-stripe-elements": "^2.0.3",
+    "react-tooltip": "^3.10.0",
     "react-transition-group": "^4.1.0",
     "react-youtube": "^7.9.0",
     "redux": "^4.0.1",

--- a/client/src/components/profile/components/HeatMap.js
+++ b/client/src/components/profile/components/HeatMap.js
@@ -39,9 +39,11 @@ function HeatMap({ calendar, streak }) {
   for (let timestamp in calendar) {
     if (calendar.hasOwnProperty(timestamp)) {
       timestamp = Number(timestamp * 1000) || null;
-      const startOfTimestampDay = format(startOfDay(timestamp), 'YYYY-MM-DD');
-      calendarData[startOfTimestampDay] =
-        calendarData[startOfTimestampDay] + 1 || 1;
+      if (timestamp) {
+        const startOfTimestampDay = format(startOfDay(timestamp), 'YYYY-MM-DD');
+        calendarData[startOfTimestampDay] =
+          calendarData[startOfTimestampDay] + 1 || 1;
+      }
     }
   }
 

--- a/client/src/components/profile/components/HeatMap.js
+++ b/client/src/components/profile/components/HeatMap.js
@@ -69,7 +69,7 @@ function HeatMap({ calendar, streak }) {
           tooltipDataAttrs={value => {
             let valueCount;
             if (value && value.count === 1) {
-              valueCount = `${value.count} point`;
+              valueCount = '1 point';
             } else if (value && value.count > 1) {
               valueCount = `${value.count} points`;
             } else {
@@ -78,7 +78,7 @@ function HeatMap({ calendar, streak }) {
             return {
               'data-tip': `<strong>${valueCount}</strong> on ${new Date(
                 value.date
-              ).toLocaleDateString('default', {
+              ).toLocaleDateString('en-US', {
                 year: 'numeric',
                 month: 'short',
                 day: 'numeric'

--- a/client/src/components/profile/components/HeatMap.js
+++ b/client/src/components/profile/components/HeatMap.js
@@ -5,7 +5,6 @@ import CalendarHeatMap from 'react-calendar-heatmap';
 import ReactTooltip from 'react-tooltip';
 import addDays from 'date-fns/add_days';
 import addMonths from 'date-fns/add_months';
-import startOfMonth from 'date-fns/start_of_month';
 import startOfDay from 'date-fns/start_of_day';
 import format from 'date-fns/format';
 
@@ -24,18 +23,13 @@ const propTypes = {
 };
 
 function HeatMap({ calendar, streak }) {
-  const now = Date.now();
-  const startOfToday = startOfDay(now);
-  const startOfThisMonth = startOfMonth(startOfToday);
-  const startOfSixMonthsAgo = addMonths(startOfThisMonth, -6);
+  const startOfToday = startOfDay(Date.now());
+  const sixMonthsAgo = addMonths(startOfToday, -6);
+  const startOfCalendar = format(addDays(sixMonthsAgo, -1), 'YYYY-MM-DD');
   const endOfCalendar = format(startOfToday, 'YYYY-MM-DD');
-  const startOfCalendar = format(
-    addDays(startOfSixMonthsAgo, -1),
-    'YYYY-MM-DD'
-  );
 
   let calendarData = {};
-  let dayCounter = startOfSixMonthsAgo;
+  let dayCounter = sixMonthsAgo;
 
   while (dayCounter <= startOfToday) {
     calendarData[format(dayCounter, 'YYYY-MM-DD')] = 0;
@@ -68,7 +62,7 @@ function HeatMap({ calendar, streak }) {
       <FullWidthRow>
         <CalendarHeatMap
           classForValue={value => {
-            if (value.count < 1) {
+            if (!value || value.count < 1) {
               return 'colour-empty';
             }
             if (value.count > 4) {
@@ -80,9 +74,9 @@ function HeatMap({ calendar, streak }) {
           startDate={startOfCalendar}
           tooltipDataAttrs={value => {
             let valueCount = '';
-            if (value.count === 1) {
+            if (value && value.count === 1) {
               valueCount = `${value.count} item on `;
-            } else if (value.count > 1) {
+            } else if (value && value.count > 1) {
               valueCount = `${value.count} items on `;
             }
             return {

--- a/client/src/components/profile/components/HeatMap.js
+++ b/client/src/components/profile/components/HeatMap.js
@@ -68,8 +68,6 @@ function HeatMap({ calendar, streak }) {
       <FullWidthRow>
         <CalendarHeatMap
           classForValue={value => {
-            console.log('value');
-            console.log(value);
             if (value.count < 1) {
               return 'colour-empty';
             }

--- a/client/src/components/profile/components/HeatMap.js
+++ b/client/src/components/profile/components/HeatMap.js
@@ -80,11 +80,14 @@ function HeatMap({ calendar, streak }) {
           gutterSize={2}
           startDate={startOfCalendar}
           tooltipDataAttrs={value => {
+            let valueCount = '';
+            if (value.count === 1) {
+              valueCount = `${value.count} item on `;
+            } else if (value.count > 1) {
+              valueCount = `${value.count} items on `;
+            }
             return {
-              'data-tip': `${value.count} items on ${format(
-                value.date,
-                'MMMM Do, YYYY'
-              )}`
+              'data-tip': `${valueCount}${format(value.date, 'MMMM Do, YYYY')}`
             };
           }}
           values={calendarValues}

--- a/client/src/components/profile/components/HeatMap.js
+++ b/client/src/components/profile/components/HeatMap.js
@@ -77,7 +77,6 @@ function HeatMap({ calendar, streak }) {
             return `colour-scale-${value.count}`;
           }}
           endDate={endOfCalendar}
-          gutterSize={2}
           startDate={startOfCalendar}
           tooltipDataAttrs={value => {
             let valueCount = '';

--- a/client/src/components/profile/components/HeatMap.js
+++ b/client/src/components/profile/components/HeatMap.js
@@ -69,11 +69,11 @@ function HeatMap({ calendar, streak }) {
           tooltipDataAttrs={value => {
             let valueCount;
             if (value && value.count === 1) {
-              valueCount = `${value.count} item`;
+              valueCount = `${value.count} point`;
             } else if (value && value.count > 1) {
-              valueCount = `${value.count} items`;
+              valueCount = `${value.count} points`;
             } else {
-              valueCount = 'No items';
+              valueCount = 'No points';
             }
             return {
               'data-tip': `<strong>${valueCount}</strong> on ${new Date(
@@ -93,10 +93,10 @@ function HeatMap({ calendar, streak }) {
       <FullWidthRow>
         <div className='streak-container'>
           <span className='streak'>
-            <strong>Longest Streak:</strong> {streak.longest || 1}
+            <strong>Longest Streak:</strong> {streak.longest || 0}
           </span>
           <span className='streak'>
-            <strong>Current Streak:</strong> {streak.current || 1}
+            <strong>Current Streak:</strong> {streak.current || 0}
           </span>
         </div>
       </FullWidthRow>

--- a/client/src/components/profile/components/HeatMap.js
+++ b/client/src/components/profile/components/HeatMap.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Helmet } from 'react-helmet';
 import CalendarHeatMap from 'react-calendar-heatmap';
 import ReactTooltip from 'react-tooltip';
 import addDays from 'date-fns/add_days';
@@ -53,14 +52,7 @@ function HeatMap({ calendar, streak }) {
   }));
 
   return (
-    <FullWidthRow id='cal-heatmap-container'>
-      <Helmet>
-        <script
-          src='https://cdnjs.cloudflare.com/ajax/libs/d3/5.7.0/d3.min.js'
-          type='text/javascript'
-        />
-        <link href='/css/cal-heatmap.css' rel='stylesheet' />
-      </Helmet>
+    <FullWidthRow>
       <FullWidthRow>
         <CalendarHeatMap
           classForValue={value => {
@@ -75,19 +67,27 @@ function HeatMap({ calendar, streak }) {
           endDate={endOfCalendar}
           startDate={startOfCalendar}
           tooltipDataAttrs={value => {
-            let valueCount = '';
+            let valueCount;
             if (value && value.count === 1) {
-              valueCount = `${value.count} item on `;
+              valueCount = `${value.count} item`;
             } else if (value && value.count > 1) {
-              valueCount = `${value.count} items on `;
+              valueCount = `${value.count} items`;
+            } else {
+              valueCount = 'No items';
             }
             return {
-              'data-tip': `${valueCount}${format(value.date, 'MMMM Do, YYYY')}`
+              'data-tip': `<strong>${valueCount}</strong> on ${new Date(
+                value.date
+              ).toLocaleDateString('default', {
+                year: 'numeric',
+                month: 'short',
+                day: 'numeric'
+              })}`
             };
           }}
           values={calendarValues}
         />
-        <ReactTooltip className='react-tooltip' />
+        <ReactTooltip className='react-tooltip' effect='solid' html={true} />
       </FullWidthRow>
       <Spacer />
       <FullWidthRow>

--- a/client/src/components/profile/components/heatmap.css
+++ b/client/src/components/profile/components/heatmap.css
@@ -31,3 +31,8 @@
 .react-calendar-heatmap .colour-scale-a-lot {
   fill: #006400;
 }
+
+.react-tooltip {
+  background-color: #006400 !important;
+  border: 1px solid black !important;
+}


### PR DESCRIPTION
This fixes up the heatmap calendar a little.
- Add's the tooltip back
- added react-tooltip package for the tooltip
- rework the function to create the data for the map

<!-- -->
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

I'm hoping it can close these issues:
https://github.com/freeCodeCamp/freeCodeCamp/issues/35916
https://github.com/freeCodeCamp/freeCodeCamp/issues/17299
https://github.com/freeCodeCamp/freeCodeCamp/issues/17822
https://github.com/freeCodeCamp/freeCodeCamp/issues/22031
