### PR TITLE
fix(curriculum): changed to h4 > s in selector for 2nd test of the Use the s Tag to Strikethrough Text challenge

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/use-the-s-tag-to-strikethrough-text.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/use-the-s-tag-to-strikethrough-text.english.md
@@ -21,11 +21,11 @@ Wrap the <code>s</code> tag around "Google" inside the <code>h4</code> tag and t
 ```yml
 tests:
   - text: Your code should add one <code>s</code> tag to the markup.
-    testString: assert($('s').length == 1, 'Your code should add one <code>s</code> tag to the markup.');
+    testString: assert($('s').length == 1);
   - text: A <code>s</code> tag should wrap around the Google text in the <code>h4</code> tag. It should not contain the word Alphabet.
-    testString: assert($('s').text().match(/Google/gi) && !$('s').text().match(/Alphabet/gi), 'A <code>s</code> tag should wrap around the Google text in the <code>h4</code> tag. It should not contain the word Alphabet.');
+    testString: assert($('h4 > s').text().match(/Google/gi) && !$('h4 > s').text().match(/Alphabet/gi));
   - text: Include the word Alphabet in the <code>h4</code> tag, without strikethrough formatting.
-    testString: assert($('h4').html().match(/Alphabet/gi), 'Include the word Alphabet in the <code>h4</code> tag, without strikethrough formatting.');
+    testString: assert($('h4').html().match(/Alphabet/gi));
 
 ```
 


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Closes #36022

Fixed a bug where the user could wrap the `Google` text nested in the `p` element instead of the `h4` element.  Also, removed unnecessary assert message arguments.
