### PR TITLE
feat(client): Add support question covering browser extensions

### DIFF
--- a/client/src/pages/support.js
+++ b/client/src/pages/support.js
@@ -93,6 +93,14 @@ const SupportPage = () => {
               </Link>
               .
             </p>
+            <h4>I cannot pass a challenge, but I think my code is correct</h4>
+            <p>
+              Some browser extensions can interfere with challenge tests. If you
+              are using any, try disabling them and running the tests again. If
+              the problem remains, click the challenge's 'Ask for Help' button
+              to post on the forum. You will need to create a forum account if
+              you don't already have one.
+            </p>
             <h4>I have a support question that isn't answered here.</h4>
             <p>
               You can ask for help on our forum, and the freeCodeCamp volunteer


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

In #35959 @moT01 and I discussed how best to warn that browser extensions can cause tests to fail.  In the end we decided that the support page was a pretty safe place to put a warning.  We didn't want to encourage people to give up early, but if they're looking on the support page, that's probably as a last resort.

Closes #35959
