### PR TITLE
fix/regex-upper-and-lower-bounds-tests

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/specify-upper-and-lower-number-of-matches.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/specify-upper-and-lower-number-of-matches.english.md
@@ -22,7 +22,7 @@ multipleA.test(A2); // Returns false
 
 ## Instructions
 <section id='instructions'>
-Change the regex <code>ohRegex</code> to match the phrase <code>"Oh no"</code> only when it has <code>3</code> to <code>6</code> letter <code>h</code>'s.
+Change the regex <code>ohRegex</code> to match the entire phrase <code>"Oh no"</code> only when it has <code>3</code> to <code>6</code> letter <code>h</code>'s.
 </section>
 
 ## Tests

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/specify-upper-and-lower-number-of-matches.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/specify-upper-and-lower-number-of-matches.english.md
@@ -9,12 +9,20 @@ challengeType: 1
 Recall that you use the plus sign <code>+</code> to look for one or more characters and the asterisk <code>*</code> to look for zero or more characters. These are convenient but sometimes you want to match a certain range of patterns.
 You can specify the lower and upper number of patterns with <code>quantity specifiers</code>. Quantity specifiers are used with curly brackets (<code>{</code> and <code>}</code>). You put two numbers between the curly brackets - for the lower and upper number of patterns.
 For example, to match only the letter <code>a</code> appearing between <code>3</code> and <code>5</code> times in the string <code>"ah"</code>, your regex would be <code>/a{3,5}h/</code>.
-<blockquote>let A4 = "aaaah";<br>let A2 = "aah";<br>let multipleA = /a{3,5}h/;<br>multipleA.test(A4); // Returns true<br>multipleA.test(A2); // Returns false</blockquote>
+
+```js
+let A4 = "aaaah";
+let A2 = "aah";
+let multipleA = /a{3,5}h/;
+multipleA.test(A4); // Returns true
+multipleA.test(A2); // Returns false
+```
+
 </section>
 
 ## Instructions
 <section id='instructions'>
-Change the regex <code>ohRegex</code> to match only <code>3</code> to <code>6</code> letter <code>h</code>'s in the word <code>"Oh no"</code>.
+Change the regex <code>ohRegex</code> to match the phrase <code>"Oh no"</code> only when it has <code>3</code> to <code>6</code> letter <code>h</code>'s.
 </section>
 
 ## Tests
@@ -23,19 +31,19 @@ Change the regex <code>ohRegex</code> to match only <code>3</code> to <code>6</c
 ```yml
 tests:
   - text: Your regex should use curly brackets.
-    testString: assert(ohRegex.source.match(/{.*?}/).length > 0, 'Your regex should use curly brackets.');
+    testString: assert(ohRegex.source.match(/{.*?}/).length > 0);
   - text: Your regex should not match <code>"Ohh no"</code>
-    testString: assert(!ohRegex.test("Ohh no"), 'Your regex should not match <code>"Ohh no"</code>');
+    testString: assert(!ohRegex.test("Ohh no"));
   - text: Your regex should match <code>"Ohhh no"</code>
-    testString: assert(ohRegex.test("Ohhh no"), 'Your regex should match <code>"Ohhh no"</code>');
+    testString: assert("Ohhh no".match(ohRegex)[0].length === 7);
   - text: Your regex should match <code>"Ohhhh no"</code>
-    testString: assert(ohRegex.test("Ohhhh no"), 'Your regex should match <code>"Ohhhh no"</code>');
+    testString: assert("Ohhhh no".match(ohRegex)[0].length === 8);
   - text: Your regex should match <code>"Ohhhhh no"</code>
-    testString: assert(ohRegex.test("Ohhhhh no"), 'Your regex should match <code>"Ohhhhh no"</code>');
+    testString: assert("Ohhhhh no".match(ohRegex)[0].length === 9);
   - text: Your regex should match <code>"Ohhhhhh no"</code>
-    testString: assert(ohRegex.test("Ohhhhhh no"), 'Your regex should match <code>"Ohhhhhh no"</code>');
+    testString: assert("Ohhhhhh no".match(ohRegex)[0].length === 10);
   - text: Your regex should not match <code>"Ohhhhhhh no"</code>
-    testString: assert(!ohRegex.test("Ohhhhhhh no"), 'Your regex should not match <code>"Ohhhhhhh no"</code>');
+    testString: assert(!ohRegex.test("Ohhhhhhh no"));
 
 ```
 
@@ -62,8 +70,6 @@ let result = ohRegex.test(ohStr);
 <section id='solution'>
 
 ```js
-let ohStr = "Ohhh no";
-let ohRegex = /Oh{3,6} no/; // Change this line
-let result = ohRegex.test(ohStr);
+// solution required
 ```
 </section>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/specify-upper-and-lower-number-of-matches.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/specify-upper-and-lower-number-of-matches.english.md
@@ -51,7 +51,6 @@ tests:
 
 ## Challenge Seed
 <section id='challengeSeed'>
-
 <div id='js-seed'>
 
 ```js
@@ -61,15 +60,15 @@ let result = ohRegex.test(ohStr);
 ```
 
 </div>
-
-
-
 </section>
 
 ## Solution
 <section id='solution'>
 
 ```js
-// solution required
+let ohStr = "Ohhh no";
+let ohRegex = /Oh{3,6} no/; // Change this line
+let result = ohRegex.test(ohStr);
 ```
+
 </section>


### PR DESCRIPTION
- I fixed the tests to check that it matches the whole word and not just part of it.
- I changed the blockquote to backticks so it doesn't create conflicts later from @RandellDawson's backtick conversion PR
- I reworded the instructions to be slightly more clear
- I removed the old assert text that is no longer used

<!-- -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/36058
