### PR TITLE
fix(guide): Update Challenges Style Guide to recommend triple backticks instead of blockquote

### DIFF
--- a/docs/style-guide-for-curriculum-challenges.md
+++ b/docs/style-guide-for-curriculum-challenges.md
@@ -123,8 +123,23 @@ Here are specific formatting guidelines for challenge text and examples:
 
 - Language keywords go in `<code>` tags. For example, HTML tag names or CSS property names
 - The first instance of a keyword when it's being defined, or general keywords (i.e. "object" or "immutable") go in `<dfn>` tags
-- Single line code examples go in `<code>` tags
-- Multi-line code examples go in `<blockquote>` tags, and use the `<br>` tag to separate lines. For HTML examples, remember to use escape characters to represent the angle brackets
+- References to code parts (i.e. function, method or variable names) should be wrapped in `<code>` tags. See example below:
+
+````
+Use <code>parseInt</code> to convert the variable <code>realNumber</code> into an integer.
+````
+- Multi-line code blocks **must be preceded by an empty line**.  The next line must start with three backticks followed immediately by one of the [supported languages](https://prismjs.com/#supported-languages).  To complete the code block, you must start a newline only has three backticks.
+**Note:** If you are going to use an example code in YAML, use `yaml` instead of `yml`.
+See example below:
+````
+The following is an example of code:
+
+```{language}
+
+[YOUR CODE HERE]
+
+```
+````
 - A single horizontal rules (`<hr>` tag) should separate the text discussing the challenge concept and the challenge instructions
 - Additional information in the form of a note should be formatted `<strong>Note:</strong> Rest of note text...`
 - Use double quotes where applicable

--- a/docs/style-guide-for-curriculum-challenges.md
+++ b/docs/style-guide-for-curriculum-challenges.md
@@ -140,7 +140,6 @@ The following is an example of code:
 
 ```
 ````
-- A single horizontal rules (`<hr>` tag) should separate the text discussing the challenge concept and the challenge instructions
 - Additional information in the form of a note should be formatted `<strong>Note:</strong> Rest of note text...`
 - Use double quotes where applicable
 

--- a/docs/style-guide-for-curriculum-challenges.md
+++ b/docs/style-guide-for-curriculum-challenges.md
@@ -128,8 +128,8 @@ Here are specific formatting guidelines for challenge text and examples:
 ````
 Use <code>parseInt</code> to convert the variable <code>realNumber</code> into an integer.
 ````
-- Multi-line code blocks **must be preceded by an empty line**.  The next line must start with three backticks followed immediately by one of the [supported languages](https://prismjs.com/#supported-languages).  To complete the code block, you must start a newline only has three backticks.
-**Note:** If you are going to use an example code in YAML, use `yaml` instead of `yml`.
+- Multi-line code blocks **must be preceded by an empty line**.  The next line must start with three backticks followed immediately by one of the [supported languages](https://prismjs.com/#supported-languages).  To complete the code block, you must start a newline which only has three backticks and **another empty line**.
+**Note:** If you are going to use an example code in YAML, use `yaml` instead of `yml` for the language to the right of the backticks.
 See example below:
 ````
 The following is an example of code:
@@ -139,6 +139,7 @@ The following is an example of code:
 [YOUR CODE HERE]
 
 ```
+
 ````
 - Additional information in the form of a note should be formatted `<strong>Note:</strong> Rest of note text...`
 - Use double quotes where applicable


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Now, we can use triple backticks instead of `blockquote` elements. And this PR updates the Style Guide for Curriculum Challenges to recommend the use of the triple backticks when inserting a multi-line code in a challenge. 

Closes #35921