### PR TITLE
feat(client): Add syntax highlighting to challenge instructions

### DIFF
--- a/client/src/components/layouts/Learn.js
+++ b/client/src/components/layouts/Learn.js
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import DonateModal from '../Donation';
 
 import 'prismjs/themes/prism.css';
+import './prism.css';
+import './prism-night.css';
 import 'react-reflex/styles.css';
 import './learn.css';
 

--- a/client/src/components/layouts/prism-night.css
+++ b/client/src/components/layouts/prism-night.css
@@ -25,7 +25,7 @@
 	-moz-hyphens: none;
 	-ms-hyphens: none;
 	hyphens: none;
-
+  text-shadow: none;
 }
 
 .night pre[class*="language-"] code[class*="language-"] {

--- a/client/src/components/layouts/prism-night.css
+++ b/client/src/components/layouts/prism-night.css
@@ -1,0 +1,127 @@
+/**
+ * Adapted from:
+ * prism.js tomorrow night eighties for JavaScript, CoffeeScript, CSS and HTML
+ * Based on https://github.com/chriskempson/tomorrow-theme
+ * @author Rose Pritchard
+ */
+
+.night code[class*="language-"],
+.night pre[class*="language-"] {
+	color: #ccc;
+	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+	font-size: 1em;
+	text-align: left;
+	white-space: pre;
+	word-spacing: normal;
+	word-break: normal;
+	word-wrap: normal;
+	line-height: 1.5;
+
+	-moz-tab-size: 4;
+	-o-tab-size: 4;
+	tab-size: 4;
+
+	-webkit-hyphens: none;
+	-moz-hyphens: none;
+	-ms-hyphens: none;
+	hyphens: none;
+
+}
+
+.night pre[class*="language-"] code[class*="language-"] {
+  color: #d4d4d4;
+}
+
+/* Code blocks */
+.night pre[class*="language-"] {
+	padding: 1em;
+	margin: .5em 0;
+	overflow: auto;
+}
+
+.night :not(pre) > code[class*="language-"],
+.night pre[class*="language-"] {
+  background: #242424;
+}
+
+/* Inline code */
+.night :not(pre) > code[class*="language-"] {
+	padding: .1em;
+	border-radius: .3em;
+	white-space: normal;
+}
+
+.night .token.comment,
+.night .token.block-comment,
+.night .token.prolog,
+.night .token.doctype,
+.night .token.cdata {
+  color: #608b4e;
+}
+
+.night .token.punctuation {
+  color: #ffff00;
+}
+
+.night .token.tag,
+.night .token.attr-name,
+.night .token.namespace,
+.night .token.deleted {
+	color: #e2777a;
+}
+
+.night .token.function-name {
+  color: #d4d4d4;
+}
+
+.night .token.boolean,
+.night .token.number,
+.night .token.function {
+  color: #569cd6;
+}
+
+.night .token.property,
+.night .token.class-name,
+.night .token.constant,
+.night .token.symbol {
+	color: #f8c555;
+}
+
+.night .token.selector,
+.night .token.important,
+.night .token.atrule,
+.night .token.keyword,
+.night .token.builtin {
+  color: #569cd6;
+}
+
+.night .token.string,
+.night .token.char,
+.night .token.attr-value,
+.night .token.regex,
+.night .token.variable {
+	color: #7ec699;
+}
+
+.night .token.operator,
+.night .token.entity,
+.night .token.url {
+	color: #67cdcc;
+  background: none;
+}
+
+.night .token.important,
+.night .token.bold {
+	font-weight: bold;
+}
+.night .token.italic {
+	font-style: italic;
+}
+
+.night .token.entity {
+	cursor: help;
+}
+
+.night .token.inserted {
+	color: green;
+}

--- a/client/src/components/layouts/prism-night.css
+++ b/client/src/components/layouts/prism-night.css
@@ -5,50 +5,50 @@
  * @author Rose Pritchard
  */
 
-.night code[class*="language-"],
-.night pre[class*="language-"] {
-	color: #ccc;
-	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
-	font-size: 1em;
-	text-align: left;
-	white-space: pre;
-	word-spacing: normal;
-	word-break: normal;
-	word-wrap: normal;
-	line-height: 1.5;
+.night code[class*='language-'],
+.night pre[class*='language-'] {
+  color: #ccc;
+  font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+  font-size: 1em;
+  text-align: left;
+  white-space: pre;
+  word-spacing: normal;
+  word-break: normal;
+  word-wrap: normal;
+  line-height: 1.5;
 
-	-moz-tab-size: 4;
-	-o-tab-size: 4;
-	tab-size: 4;
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
+  tab-size: 4;
 
-	-webkit-hyphens: none;
-	-moz-hyphens: none;
-	-ms-hyphens: none;
-	hyphens: none;
+  -webkit-hyphens: none;
+  -moz-hyphens: none;
+  -ms-hyphens: none;
+  hyphens: none;
   text-shadow: none;
 }
 
-.night pre[class*="language-"] code[class*="language-"] {
+.night pre[class*='language-'] code[class*='language-'] {
   color: #d4d4d4;
 }
 
 /* Code blocks */
-.night pre[class*="language-"] {
-	padding: 1em;
-	margin: .5em 0;
-	overflow: auto;
+.night pre[class*='language-'] {
+  padding: 1em;
+  margin: 0.5em 0;
+  overflow: auto;
 }
 
-.night :not(pre) > code[class*="language-"],
-.night pre[class*="language-"] {
+.night :not(pre) > code[class*='language-'],
+.night pre[class*='language-'] {
   background: #242424;
 }
 
 /* Inline code */
-.night :not(pre) > code[class*="language-"] {
-	padding: .1em;
-	border-radius: .3em;
-	white-space: normal;
+.night :not(pre) > code[class*='language-'] {
+  padding: 0.1em;
+  border-radius: 0.3em;
+  white-space: normal;
 }
 
 .night .token.comment,
@@ -67,7 +67,7 @@
 .night .token.attr-name,
 .night .token.namespace,
 .night .token.deleted {
-	color: #e2777a;
+  color: #e2777a;
 }
 
 .night .token.function-name {
@@ -84,7 +84,7 @@
 .night .token.class-name,
 .night .token.constant,
 .night .token.symbol {
-	color: #f8c555;
+  color: #f8c555;
 }
 
 .night .token.selector,
@@ -100,28 +100,28 @@
 .night .token.attr-value,
 .night .token.regex,
 .night .token.variable {
-	color: #7ec699;
+  color: #7ec699;
 }
 
 .night .token.operator,
 .night .token.entity,
 .night .token.url {
-	color: #67cdcc;
+  color: #67cdcc;
   background: none;
 }
 
 .night .token.important,
 .night .token.bold {
-	font-weight: bold;
+  font-weight: bold;
 }
 .night .token.italic {
-	font-style: italic;
+  font-style: italic;
 }
 
 .night .token.entity {
-	cursor: help;
+  cursor: help;
 }
 
 .night .token.inserted {
-	color: green;
+  color: green;
 }

--- a/client/src/components/layouts/prism.css
+++ b/client/src/components/layouts/prism.css
@@ -1,0 +1,3 @@
+code .token.operator {
+  background: none;
+}

--- a/client/src/templates/Challenges/components/Challenge-Description.js
+++ b/client/src/templates/Challenges/components/Challenge-Description.js
@@ -1,4 +1,5 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, Component } from 'react';
+import Prism from 'prismjs';
 import PropTypes from 'prop-types';
 
 import './challenge-description.css';
@@ -9,19 +10,37 @@ const propTypes = {
   section: PropTypes.string
 };
 
-function ChallengeDescription({ description, instructions, section }) {
-  return (
-    <div className={`challenge-instructions ${section}`}>
-      <div dangerouslySetInnerHTML={{ __html: description }} />
-      {instructions && (
-        <Fragment>
-          <hr />
-          <div dangerouslySetInnerHTML={{ __html: instructions }} />
-        </Fragment>
-      )}
-      <hr />
-    </div>
-  );
+class ChallengeDescription extends Component {
+  componentDidMount() {
+    // Just in case 'current' has not been created, though it should have been.
+    if (this.instructionsRef.current) {
+      Prism.highlightAllUnder(this.instructionsRef.current);
+    }
+  }
+
+  constructor(props) {
+    super(props);
+    this.instructionsRef = React.createRef();
+  }
+
+  render() {
+    const { description, instructions, section } = this.props;
+    return (
+      <div
+        className={`challenge-instructions ${section}`}
+        ref={this.instructionsRef}
+      >
+        <div dangerouslySetInnerHTML={{ __html: description }} />
+        {instructions && (
+          <Fragment>
+            <hr />
+            <div dangerouslySetInnerHTML={{ __html: instructions }} />
+          </Fragment>
+        )}
+        <hr />
+      </div>
+    );
+  }
 }
 
 ChallengeDescription.displayName = 'ChallengeDescription';


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This is my first stab at syntax highlighting; mostly a proof of concept.  Currently default mode looks pretty good, but the css for night mode will need some work.

Closes #35999