### PR TITLE
docs: update link text to reflect article title

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Our community also has:
 
 ### Found a bug?
 
-If you think you've found a bug, first read the [Help I've Found a Bug](https://www.freecodecamp.org/forum/t/how-to-report-a-bug/19543) article and follow its instructions. If you're confident it's a new bug, and have confirmed that someone else is facing the same issue, go ahead and create a new GitHub issue. Be sure to include as much information as possible so we can reproduce the bug.
+If you think you've found a bug, first read the [How to Report a Bug](https://www.freecodecamp.org/forum/t/how-to-report-a-bug/19543) article and follow its instructions. If you're confident it's a new bug, and have confirmed that someone else is facing the same issue, go ahead and create a new GitHub issue. Be sure to include as much information as possible so we can reproduce the bug.
 
 ### Found a security issue?
 


### PR DESCRIPTION
Changed hyperlink text to correctly reflect article title

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `master` branch of freeCodeCamp.
- [X] None of my changes are plagiarized from another source without proper attribution.
- [X] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [X] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX
