### PR TITLE
fix(client): Remove all trailing slashes from user submitted urls

### DIFF
--- a/client/src/components/formHelpers/Form.js
+++ b/client/src/components/formHelpers/Form.js
@@ -2,7 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm } from 'redux-form';
 
-import { FormFields, BlockSaveButton, BlockSaveWrapper } from './';
+import {
+  FormFields,
+  BlockSaveButton,
+  BlockSaveWrapper,
+  formatUrlValues
+} from './';
 
 const propTypes = {
   buttonText: PropTypes.string,
@@ -48,7 +53,9 @@ export function DynamicForm({
   return (
     <form
       id={`dynamic-${id}`}
-      onSubmit={handleSubmit(submit)}
+      onSubmit={handleSubmit((values, ...args) =>
+        submit(formatUrlValues(values, options), ...args)
+      )}
       style={{ width: '100%' }}
     >
       <FormFields

--- a/client/src/components/formHelpers/index.js
+++ b/client/src/components/formHelpers/index.js
@@ -15,6 +15,16 @@ export function callIfDefined(fn) {
   return value => (value ? fn(value) : value);
 }
 
+export function formatUrlValues(values, options) {
+  return Object.keys(values).reduce((result, key) => {
+    let value = values[key];
+    if (options.types[key] === 'url') {
+      value = normalizeUrl(value, normalizeOptions);
+    }
+    return { ...result, [key]: value };
+  }, {});
+}
+
 // formatUrl(url: String) => String
 export function formatUrl(url) {
   if (typeof url === 'string' && url.length > 4 && url.indexOf('.') !== -1) {

--- a/client/src/templates/Challenges/backend/Show.js
+++ b/client/src/templates/Challenges/backend/Show.js
@@ -4,6 +4,7 @@ import { Grid, Col, Row } from '@freecodecamp/react-bootstrap';
 import { createSelector } from 'reselect';
 import { reduxForm } from 'redux-form';
 import { graphql } from 'gatsby';
+import normalizeUrl from 'normalize-url';
 
 import {
   executeChallenge,
@@ -11,6 +12,7 @@ import {
   challengeTestsSelector,
   consoleOutputSelector,
   initTests,
+  updateBackendFormValues,
   updateChallengeMeta,
   updateProjectFormValues,
   backendNS
@@ -55,6 +57,7 @@ const propTypes = {
   output: PropTypes.string,
   tests: PropTypes.array,
   title: PropTypes.string,
+  updateBackendFormValues: PropTypes.func.isRequired,
   updateChallengeMeta: PropTypes.func.isRequired,
   updateProjectFormValues: PropTypes.func.isRequired,
   ...reduxFormPropTypes
@@ -79,6 +82,7 @@ const mapDispatchToActions = {
   challengeMounted,
   executeChallenge,
   initTests,
+  updateBackendFormValues,
   updateChallengeMeta,
   updateProjectFormValues
 };
@@ -96,6 +100,7 @@ export class BackEnd extends Component {
     super(props);
     this.state = {};
     this.updateDimensions = this.updateDimensions.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
   }
 
   componentDidMount() {
@@ -151,6 +156,13 @@ export class BackEnd extends Component {
     }
   }
 
+  handleSubmit(values) {
+    const { updateBackendFormValues, executeChallenge } = this.props;
+    values.solution = normalizeUrl(values.solution);
+    updateBackendFormValues(values);
+    executeChallenge();
+  }
+
   render() {
     const {
       data: {
@@ -174,6 +186,7 @@ export class BackEnd extends Component {
       ? 'Submit and go to my next challenge'
       : "I've completed this challenge";
     const blockNameTitle = `${blockName} - ${title}`;
+
     return (
       <LearnLayout>
         <Grid>
@@ -191,7 +204,7 @@ export class BackEnd extends Component {
                   formFields={formFields}
                   id={backendNS}
                   options={options}
-                  submit={executeChallenge}
+                  submit={this.handleSubmit}
                 />
               ) : (
                 <ProjectForm

--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -49,6 +49,7 @@ export const types = createTypes(
     'initTests',
     'initConsole',
     'initLogs',
+    'updateBackendFormValues',
     'updateConsole',
     'updateChallengeMeta',
     'updateFile',
@@ -125,6 +126,9 @@ export const updateTests = createAction(types.updateTests);
 
 export const initConsole = createAction(types.initConsole);
 export const initLogs = createAction(types.initLogs);
+export const updateBackendFormValues = createAction(
+  types.updateBackendFormValues
+);
 export const updateChallengeMeta = createAction(types.updateChallengeMeta);
 export const updateFile = createAction(types.updateFile);
 export const updateConsole = createAction(types.updateConsole);
@@ -171,7 +175,8 @@ export const isResetModalOpenSelector = state => state[ns].modal.reset;
 export const isBuildEnabledSelector = state => state[ns].isBuildEnabled;
 export const successMessageSelector = state => state[ns].successMessage;
 
-export const backendFormValuesSelector = state => state.form[backendNS] || {};
+export const backendFormValuesSelector = state =>
+  state[ns].backendFormValues || {};
 export const projectFormValuesSelector = state =>
   state[ns].projectFormValues || {};
 
@@ -187,7 +192,7 @@ export const challengeDataSelector = state => {
       files: challengeFilesSelector(state)
     };
   } else if (challengeType === challengeTypes.backend) {
-    const { solution: { value: url } = {} } = backendFormValuesSelector(state);
+    const { solution: url = {} } = backendFormValuesSelector(state);
     challengeData = {
       ...challengeData,
       url
@@ -305,6 +310,10 @@ export const reducer = handleActions(
         testString
       })),
       consoleOut: ''
+    }),
+    [types.updateBackendFormValues]: (state, { payload }) => ({
+      ...state,
+      backendFormValues: payload
     }),
     [types.updateProjectFormValues]: (state, { payload }) => ({
       ...state,


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

As discussed in #36067 valid solutions can be rejected because they have a trailing slash.  Almost all challenge tests that get user submitted URLs append `/some/path` to them. If the user's server doesn't know how to deal with URLs like `http://example.com//some/path` they will fail.  This just strips any trailing slashes to avoid this.

Closes #36067
