### PR TITLE
fix(Client): make footer stick to bottom of viewport.

### DIFF
--- a/client/src/components/Footer/footer.css
+++ b/client/src/components/Footer/footer.css
@@ -3,6 +3,7 @@
   font-size: 0.9em;
   width: 100%;
   padding-top: 40px;
+  margin-top: auto;
 }
 
 .footer .col-header {

--- a/client/src/components/layouts/Default.js
+++ b/client/src/components/layouts/Default.js
@@ -173,8 +173,8 @@ class DefaultLayout extends Component {
             <Flash messages={flashMessages} onClose={removeFlashMessage} />
           ) : null}
           {children}
+          {showFooter && <Footer />}
         </div>
-        {showFooter && <Footer />}
       </Fragment>
     );
   }

--- a/client/src/components/layouts/layout.css
+++ b/client/src/components/layouts/layout.css
@@ -594,5 +594,9 @@ pre code {
   }
 }
 .default-layout {
+  display: flex;
+  flex-direction: column;
   margin-top: var(--header-height);
+  margin-top: var(--header-height);
+  min-height: calc(100vh - var(--header-height));
 }


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #35950

__NOTE:__ _To make this fix, I followed the example set forth by @ValeraS in #35989 - Kudos to him for chiming in and pointing me in the right direction. Thanks, buddy!_

---

The fix for this issue was simple enough. 3 changes, 3 files:

1) Added an auto margin to the top of the footer @ footer.css; 
2) Moved the footer inside of div.default-layout @ Layout.js;
3) Used flexbox to make .default-layout class auto-fit Viewport (Viewport - HeaderHeight) regardless of content height - most importantly in cases where the content height is not enough to fill the viewport @ layout.css;

Thanks for the opportunity to help out, now that I have figured out my local version of the site, I will definitely be contributing more often moving forward. Let me know if I need to change anything.

_Charles M._