### PR TITLE
fix: renamed folder without starting dash for Iterate Through the Keys of an Object with a for...in Statement challenge

### DIFF
--- a/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-data-structures/iterate-through-the-keys-of-an-object-with-a-for...in-statement.arabic.md
+++ b/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-data-structures/iterate-through-the-keys-of-an-object-with-a-for...in-statement.arabic.md
@@ -1,6 +1,6 @@
 ---
 id: 587d7b7d367417b2b2512b1d
-title: ' Iterate Through the Keys of an Object with a for...in Statement'
+title: 'Iterate Through the Keys of an Object with a for...in Statement'
 challengeType: 1
 videoUrl: ''
 localeTitle: يتكرر عبر مفاتيح كائن مع لـ ... في بيان

--- a/curriculum/challenges/chinese/02-javascript-algorithms-and-data-structures/basic-data-structures/iterate-through-the-keys-of-an-object-with-a-for...in-statement.chinese.md
+++ b/curriculum/challenges/chinese/02-javascript-algorithms-and-data-structures/basic-data-structures/iterate-through-the-keys-of-an-object-with-a-for...in-statement.chinese.md
@@ -1,6 +1,6 @@
 ---
 id: 587d7b7d367417b2b2512b1d
-title: ' Iterate Through the Keys of an Object with a for...in Statement'
+title: 'Iterate Through the Keys of an Object with a for...in Statement'
 challengeType: 1
 videoUrl: ''
 localeTitle: 使用for ... in Statement中的对象键迭代

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/iterate-through-the-keys-of-an-object-with-a-for...in-statement.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/iterate-through-the-keys-of-an-object-with-a-for...in-statement.english.md
@@ -1,6 +1,6 @@
 ---
 id: 587d7b7d367417b2b2512b1d
-title: ' Iterate Through the Keys of an Object with a for...in Statement'
+title: 'Iterate Through the Keys of an Object with a for...in Statement'
 challengeType: 1
 ---
 

--- a/curriculum/challenges/portuguese/02-javascript-algorithms-and-data-structures/basic-data-structures/iterate-through-the-keys-of-an-object-with-a-for...in-statement.portuguese.md
+++ b/curriculum/challenges/portuguese/02-javascript-algorithms-and-data-structures/basic-data-structures/iterate-through-the-keys-of-an-object-with-a-for...in-statement.portuguese.md
@@ -1,6 +1,6 @@
 ---
 id: 587d7b7d367417b2b2512b1d
-title: ' Iterate Through the Keys of an Object with a for...in Statement'
+title: 'Iterate Through the Keys of an Object with a for...in Statement'
 challengeType: 1
 videoUrl: ''
 localeTitle: Iterar através das chaves de um objeto com um para ... em declaração

--- a/curriculum/challenges/russian/02-javascript-algorithms-and-data-structures/basic-data-structures/iterate-through-the-keys-of-an-object-with-a-for...in-statement.russian.md
+++ b/curriculum/challenges/russian/02-javascript-algorithms-and-data-structures/basic-data-structures/iterate-through-the-keys-of-an-object-with-a-for...in-statement.russian.md
@@ -1,6 +1,6 @@
 ---
 id: 587d7b7d367417b2b2512b1d
-title: ' Iterate Through the Keys of an Object with a for...in Statement'
+title: 'Iterate Through the Keys of an Object with a for...in Statement'
 challengeType: 1
 videoUrl: ''
 localeTitle: Итерация через ключи объекта с помощью for for ... in Statement

--- a/curriculum/challenges/spanish/02-javascript-algorithms-and-data-structures/basic-data-structures/iterate-through-the-keys-of-an-object-with-a-for...in-statement.spanish.md
+++ b/curriculum/challenges/spanish/02-javascript-algorithms-and-data-structures/basic-data-structures/iterate-through-the-keys-of-an-object-with-a-for...in-statement.spanish.md
@@ -1,6 +1,6 @@
 ---
 id: 587d7b7d367417b2b2512b1d
-title: ' Iterate Through the Keys of an Object with a for...in Statement'
+title: 'Iterate Through the Keys of an Object with a for...in Statement'
 challengeType: 1
 videoUrl: ''
 localeTitle: Iterar a través de las claves de un objeto con for ... in

--- a/guide/arabic/certifications/javascript-algorithms-and-data-structures/basic-data-structures/iterate-through-the-keys-of-an-object-with-a-for...in-statement/index.md
+++ b/guide/arabic/certifications/javascript-algorithms-and-data-structures/basic-data-structures/iterate-through-the-keys-of-an-object-with-a-for...in-statement/index.md
@@ -1,5 +1,5 @@
 ---
-title:  Iterate Through the Keys of an Object with a for...in Statement
+title: Iterate Through the Keys of an Object with a for...in Statement
 localeTitle:  يتكرر عبر مفاتيح كائن مع لـ ... في بيان
 ---
 ## يتكرر عبر مفاتيح كائن مع لـ ... في بيان

--- a/guide/chinese/certifications/javascript-algorithms-and-data-structures/basic-data-structures/iterate-through-the-keys-of-an-object-with-a-for...in-statement/index.md
+++ b/guide/chinese/certifications/javascript-algorithms-and-data-structures/basic-data-structures/iterate-through-the-keys-of-an-object-with-a-for...in-statement/index.md
@@ -1,16 +1,16 @@
 ---
-title:  Iterate Through the Keys of an Object with a for...in Statement
-localeTitle:  Iterar através das chaves de um objeto com um para ... em declaração
+title: Iterate Through the Keys of an Object with a for...in Statement
+localeTitle:  使用for ... in Statement中的对象键迭代
 ---
-## Iterar através das chaves de um objeto com um para ... em declaração
+## 使用for ... in Statement中的对象键迭代
 
-Método:
+方法：
 
-*   Nota: `dot-notation` causará erros neste desafio.
-*   `[square-bracket]` notação `[square-bracket]` deve ser usada para chamar um nome de propriedade variável.
-*   O código a seguir não funcionará.
+*   注意： `dot-notation`会导致此挑战出错。
+*   必须使用`[square-bracket]`表示法来调用变量属性名称。
+*   以下代码无效。
 
-### Exemplo 1:
+### 例1：
 
 ```javascript
 for (let user in obj) {
@@ -20,9 +20,9 @@ for (let user in obj) {
 }
 ```
 
-*   O exemplo 2 demonstra como usar a notação `[square-bracket]` o código será executado.
+*   示例2演示了如何使用`[square-bracket]`表示法执行代码。
 
-### Exemplo 2:
+### 例2：
 
 ```javascript
 for (let user in obj) {
@@ -32,7 +32,7 @@ for (let user in obj) {
 }
 ```
 
-### Solução:
+### 解：
 
 ```javascript
 let users = { 

--- a/guide/english/certifications/javascript-algorithms-and-data-structures/basic-data-structures/iterate-through-the-keys-of-an-object-with-a-for...in-statement/index.md
+++ b/guide/english/certifications/javascript-algorithms-and-data-structures/basic-data-structures/iterate-through-the-keys-of-an-object-with-a-for...in-statement/index.md
@@ -1,5 +1,5 @@
 ---
-title:  Iterate Through the Keys of an Object with a for...in Statement
+title: Iterate Through the Keys of an Object with a for...in Statement
 ---
 ##  Iterate Through the Keys of an Object with a for...in Statement
 

--- a/guide/portuguese/certifications/javascript-algorithms-and-data-structures/basic-data-structures/iterate-through-the-keys-of-an-object-with-a-for...in-statement/index.md
+++ b/guide/portuguese/certifications/javascript-algorithms-and-data-structures/basic-data-structures/iterate-through-the-keys-of-an-object-with-a-for...in-statement/index.md
@@ -1,16 +1,16 @@
 ---
-title:  Iterate Through the Keys of an Object with a for...in Statement
-localeTitle:  使用for ... in Statement中的对象键迭代
+title: Iterate Through the Keys of an Object with a for...in Statement
+localeTitle:  Iterar através das chaves de um objeto com um para ... em declaração
 ---
-## 使用for ... in Statement中的对象键迭代
+## Iterar através das chaves de um objeto com um para ... em declaração
 
-方法：
+Método:
 
-*   注意： `dot-notation`会导致此挑战出错。
-*   必须使用`[square-bracket]`表示法来调用变量属性名称。
-*   以下代码无效。
+*   Nota: `dot-notation` causará erros neste desafio.
+*   `[square-bracket]` notação `[square-bracket]` deve ser usada para chamar um nome de propriedade variável.
+*   O código a seguir não funcionará.
 
-### 例1：
+### Exemplo 1:
 
 ```javascript
 for (let user in obj) {
@@ -20,9 +20,9 @@ for (let user in obj) {
 }
 ```
 
-*   示例2演示了如何使用`[square-bracket]`表示法执行代码。
+*   O exemplo 2 demonstra como usar a notação `[square-bracket]` o código será executado.
 
-### 例2：
+### Exemplo 2:
 
 ```javascript
 for (let user in obj) {
@@ -32,7 +32,7 @@ for (let user in obj) {
 }
 ```
 
-### 解：
+### Solução:
 
 ```javascript
 let users = { 

--- a/guide/russian/certifications/javascript-algorithms-and-data-structures/basic-data-structures/iterate-through-the-keys-of-an-object-with-a-for...in-statement/index.md
+++ b/guide/russian/certifications/javascript-algorithms-and-data-structures/basic-data-structures/iterate-through-the-keys-of-an-object-with-a-for...in-statement/index.md
@@ -1,5 +1,5 @@
 ---
-title:  Iterate Through the Keys of an Object with a for...in Statement
+title: Iterate Through the Keys of an Object with a for...in Statement
 localeTitle:  Итерация через ключи объекта с помощью for for ... in Statement
 ---
 ## Итерация через ключи объекта с помощью for for ... in Statement

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-data-structures/iterate-through-the-keys-of-an-object-with-a-for...in-statement/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-data-structures/iterate-through-the-keys-of-an-object-with-a-for...in-statement/index.md
@@ -1,5 +1,5 @@
 ---
-title:  Iterate Through the Keys of an Object with a for...in Statement
+title: Iterate Through the Keys of an Object with a for...in Statement
 localeTitle:  Iterar a través de las claves de un objeto con una for ... in Statement
 ---
 ## Iterar a través de las claves de un objeto con una for ... in Statement


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [ ] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

This is change may be considered unnecessary, but it has always bothered me that the name of the folder started with a dash `-`.  This PR removes the dash from the start of the folder name for the curriculum and corresponding guide folders across all languages (just for completeness).  I also had to remove a space in the title of each file because I discovered that space must have been why the original dash was placed in front (to get it to work).

**Attention Mods:** Before running `npm run develop` locally, you will need to run `npm run seed` so the dashed version is no longer present in the database.