### PR TITLE
fix(client): Remove redundant prop and allow navigationMenu to be und…

### DIFF
--- a/client/gatsby-browser.js
+++ b/client/gatsby-browser.js
@@ -31,11 +31,7 @@ export const wrapPageElement = ({ element, props }) => {
     location: { pathname }
   } = props;
   if (pathname === '/') {
-    return (
-      <DefaultLayout disableSettings={true} landingPage={true}>
-        {element}
-      </DefaultLayout>
-    );
+    return <DefaultLayout landingPage={true}>{element}</DefaultLayout>;
   }
   if (/^\/certification(\/.*)*/.test(pathname)) {
     return <CertificationLayout>{element}</CertificationLayout>;

--- a/client/src/components/layouts/Default.js
+++ b/client/src/components/layouts/Default.js
@@ -68,7 +68,7 @@ const propTypes = {
   isOnline: PropTypes.bool.isRequired,
   isSignedIn: PropTypes.bool,
   landingPage: PropTypes.bool,
-  navigationMenu: PropTypes.element.isRequired,
+  navigationMenu: PropTypes.element,
   onlineStatusChange: PropTypes.func.isRequired,
   removeFlashMessage: PropTypes.func.isRequired,
   showFooter: PropTypes.bool


### PR DESCRIPTION
…efined

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The PR #35943 went through a lot of iterations and ended up not allowing `navigationMenu` to be undefined, which it is for everything except the guide, and still using `disableSettings`, which no longer does anything.  This is just a tiny cleanup.
