### PR TITLE
feat(client): Highlight footer links on hover

### DIFF
--- a/client/src/components/Footer/footer.css
+++ b/client/src/components/Footer/footer.css
@@ -15,6 +15,10 @@
   display: block;
 }
 
+.footer a:hover {
+  background-color: #E0E0E0;
+}
+
 .night .footer {
   color: #606f7b;
   background: #222;
@@ -26,4 +30,5 @@
 
 .night .footer a:hover {
   color: #606f7b;
+  background-color: #2A2A2A;
 }

--- a/client/src/components/Footer/footer.css
+++ b/client/src/components/Footer/footer.css
@@ -8,15 +8,19 @@
 
 .footer .col-header {
   padding-bottom: 5px;
+  padding-left: 5px;
   font-weight: bold;
 }
 
 .footer a:not([class*='inline']) {
   display: block;
+  padding-left: 5px
 }
 
 .footer a:hover {
-  background-color: #E0E0E0;
+  outline-offset: 1px;
+  outline: 1px dashed #A0A0A0;
+  background-color: #ffbe41;
 }
 
 .night .footer {
@@ -30,5 +34,6 @@
 
 .night .footer a:hover {
   color: #606f7b;
-  background-color: #2A2A2A;
+  outline-offset: 1px;
+  outline: 1px dashed #A0A0A0;
 }

--- a/client/src/pages/index.css
+++ b/client/src/pages/index.css
@@ -10,6 +10,13 @@
 .night .landing-page #top-right-nav li > a, .night #top-right-nav li > span {
   color: #fff;
 }
+.night .landing-page a {
+  color: #006400;
+}
+.night .landing-page a:hover {
+  color: #001800;
+}
+
 /* End night mode override */
 
 .black-text {


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Slightly changes the background on hover to indicate that the whole area is a link, and not just the text.  Also fixes the donate link on the front page.  In night mode its text is white on a white background, but should look like this:
![DonateLink](https://user-images.githubusercontent.com/15801806/58815167-6225c600-8627-11e9-83dd-fae8bdaa65d0.png)


Closes #36126
