### PR TITLE
fix(docs): Added format rule regarding multiple notes for challenge files

### DIFF
--- a/docs/style-guide-for-curriculum-challenges.md
+++ b/docs/style-guide-for-curriculum-challenges.md
@@ -127,6 +127,7 @@ Here are specific formatting guidelines for challenge text and examples:
 - Multi-line code examples go in `<blockquote>` tags, and use the `<br>` tag to separate lines. For HTML examples, remember to use escape characters to represent the angle brackets
 - A single horizontal rules (`<hr>` tag) should separate the text discussing the challenge concept and the challenge instructions
 - Additional information in the form of a note should be formatted `<strong>Note:</strong> Rest of note text...`
+- If multiple notes are needed, then list all of the notes in separate sentences using the format `<strong>Notes:</strong> First note text.  Second note text.`. 
 - Use double quotes where applicable
 
 ## Formatting seed code


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

This PR attempts to close out the following issue with respect to how to format challenges with multiple notes.

Closes #35464
