### PR TITLE
fix/es6-destructuring-reword+new-lesson

### DIFF
--- a/curriculum/challenges/_meta/es6/meta.json
+++ b/curriculum/challenges/_meta/es6/meta.json
@@ -49,6 +49,10 @@
       "Use the Spread Operator to Evaluate Arrays In-Place"
     ],
     [
+      "5cfa550e84205a357704ccb6",
+      "Use Destructuring Assignment to Extract Values from Objects"
+    ],
+    [
       "587d7b89367417b2b2512b49",
       "Use Destructuring Assignment to Assign Variables from Objects"
     ],

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-assign-variables-from-nested-objects.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-assign-variables-from-nested-objects.english.md
@@ -25,7 +25,7 @@ Here's how to extract the values into variables with the same name as they have 
 const { johnDoe: { age, email }} = user;
 ```
 
-And here's how you can assign new variable names when destructuring a nested object like this:
+And here's how you can assign new variable names when destructuring a nested object:
 
 ```js
 const { johnDoe: { age: userAge, email: userEmail }} = user;

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-assign-variables-from-nested-objects.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-assign-variables-from-nested-objects.english.md
@@ -90,7 +90,7 @@ const LOCAL_FORECAST = {
 
 // change code below this line
   
-const { today { low: lowToday, high: highToday }} = LOCAL_FORECAST;
+const { today: { low: lowToday, high: highToday }} = LOCAL_FORECAST;
 
 // change code above this line
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-assign-variables-from-nested-objects.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-assign-variables-from-nested-objects.english.md
@@ -46,9 +46,9 @@ tests:
   - text: You should remove the ES5 assignment syntax.
     testString: assert(!code.match(/lowToday = LOCAL_FORECAST\.today\.low/g) && !code.match(/highToday = LOCAL_FORECAST\.today.high/g))
   - text: You should use destructuring to create the <code>lowToday</code> variable.
-    testString: assert(code.match(/(var|const|let)\s*{\s*today\s*:\s*{\s*(low\s*:\s*lowToday[^}]*|[^,]*,\s*low\s*:\s*lowToday\s*)}\s*}\s*=\s*LOCAL_FORECAST/g));
+    testString: assert(code.match(/(var|const|let)\s*{\s*today\s*:\s*{\s*(low\s*:\s*lowToday[^}]*|[^,]*,\s*low\s*:\s*lowToday\s*)}\s*}\s*=\s*LOCAL_FORECAST(;|\s+|\/\/)/g));
   - text: You should use destructuring to create the <code>highToday</code> variable.
-    testString: assert(code.match(/(var|const|let)\s*{\s*today\s*:\s*{\s*(high\s*:\s*highToday[^}]*|[^,]*,\s*high\s*:\s*highToday\s*)}\s*}\s*=\s*LOCAL_FORECAST/g));
+    testString: assert(code.match(/(var|const|let)\s*{\s*today\s*:\s*{\s*(high\s*:\s*highToday[^}]*|[^,]*,\s*high\s*:\s*highToday\s*)}\s*}\s*=\s*LOCAL_FORECAST(;|\s+|\/\/)/g));
 ```
 
 </section>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-assign-variables-from-nested-objects.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-assign-variables-from-nested-objects.english.md
@@ -19,13 +19,13 @@ const user = {
 };
 ```
 
-Here's how to extract the values into variables with the same name as they have in the object:
+Here's how to extract the values of object properties and assign them to variables with the same name:
 
 ```js
 const { johnDoe: { age, email }} = user;
 ```
 
-And here's how you can assign new variable names when destructuring a nested object:
+And here's how you can assign an object properties' values to variables with different names:
 
 ```js
 const { johnDoe: { age: userAge, email: userEmail }} = user;

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-assign-variables-from-nested-objects.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-assign-variables-from-nested-objects.english.md
@@ -8,7 +8,7 @@ challengeType: 1
 <section id='description'>
 You can use the same principles from the previous two lessons to destructure values from nested objects.
 
-Using a similar object from previous examples:
+Using an object similar to previous examples:
 
 ```js
 const user = {

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-assign-variables-from-nested-objects.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-assign-variables-from-nested-objects.english.md
@@ -6,24 +6,36 @@ challengeType: 1
 
 ## Description
 <section id='description'>
-We can similarly destructure <em>nested</em> objects into variables.
-Consider the following code:
+You can use the same principles from the previous two lessons to destructure values from nested objects.
+
+Using a similar object from previous examples:
 
 ```js
-const a = {
-  start: { x: 5, y: 6 },
-  end: { x: 6, y: -9 }
+const user = {
+  johnDoe: { 
+    age: 34,
+    email: 'johnDoe@freeCodeCamp.com'
+  }
 };
-const { start: { x: startX, y: startY }} = a;
-console.log(startX, startY); // 5, 6
 ```
 
-In the example above, the variable <code>startX</code> is assigned the value of <code>a.start.x</code>.
+Here's how to extract the values into variables with the same name as they have in the object:
+
+```js
+const { johnDoe: { age, email }} = user;
+```
+
+And here's how you can assign new variable names when destructuring a nested object like this:
+
+```js
+const { johnDoe: { age: userAge, email: userEmail }} = user;
+```
+
 </section>
 
 ## Instructions
 <section id='instructions'>
-Use destructuring assignment to obtain <code>max</code> of <code>forecast.tomorrow</code> and assign it to <code>maxOfTomorrow</code>.
+Replace the two assignments with an equivalent destructuring assignment. It should still assign the variables <code>lowToday</code> and <code>highToday</code> the values of <code>today.low</code> and <code>tomorrow.high</code> from the <code>LOCAL_FORECAST</code> object.
 </section>
 
 ## Tests
@@ -31,41 +43,39 @@ Use destructuring assignment to obtain <code>max</code> of <code>forecast.tomorr
 
 ```yml
 tests:
-  - text: <code>maxOfTomorrow</code> equals <code>84.6</code>
-    testString: assert(getMaxOfTmrw(LOCAL_FORECAST) === 84.6, '<code>maxOfTomorrow</code> equals <code>84.6</code>');
-  - text: nested destructuring was used
-    testString: getUserInput => assert(getUserInput('index').match(/\{\s*tomorrow\s*:\s*\{\s*max\s*:\s*maxOfTomorrow\s*\}\s*\}\s*=\s*forecast/g),'nested destructuring was used');
-
+  - text: You should remove the ES5 assignment syntax.
+    testString: assert(!code.match(/lowToday = LOCAL_FORECAST\.today\.low/g) && !code.match(/highToday = LOCAL_FORECAST\.today.high/g))
+  - text: You should use destructuring to create the <code>lowToday</code> variable.
+    testString: assert(code.match(/(var|const|let)\s*{\s*today\s*:\s*{\s*(low\s*:\s*lowToday[^}]*|[^,]*,\s*low\s*:\s*lowToday\s*)}\s*}\s*=\s*LOCAL_FORECAST/g));
+  - text: You should use destructuring to create the <code>highToday</code> variable.
+    testString: assert(code.match(/(var|const|let)\s*{\s*today\s*:\s*{\s*(high\s*:\s*highToday[^}]*|[^,]*,\s*high\s*:\s*highToday\s*)}\s*}\s*=\s*LOCAL_FORECAST/g));
 ```
 
 </section>
 
 ## Challenge Seed
 <section id='challengeSeed'>
-
 <div id='js-seed'>
 
 ```js
 const LOCAL_FORECAST = {
-  today: { min: 72, max: 83 },
-  tomorrow: { min: 73.3, max: 84.6 }
+  yesterday: { low: 61, high: 75 },
+  today: { low: 64, high: 77 },
+  tomorrow: { low: 68, high: 80 }
 };
 
-function getMaxOfTmrw(forecast) {
-  "use strict";
-  // change code below this line
-  const maxOfTomorrow = undefined; // change this line
-  // change code above this line
-  return maxOfTomorrow;
-}
+// change code below this line
+  
+const lowToday = LOCAL_FORECAST.today.low;
+const highToday = LOCAL_FORECAST.today.high;
 
-console.log(getMaxOfTmrw(LOCAL_FORECAST)); // should be 84.6
+// change code above this line
+
+console.log(lowToday); // should be 64
+console.log(highToday); // should be 77
 ```
 
 </div>
-
-
-
 </section>
 
 ## Solution
@@ -73,18 +83,18 @@ console.log(getMaxOfTmrw(LOCAL_FORECAST)); // should be 84.6
 
 ```js
 const LOCAL_FORECAST = {
-  today: { min: 72, max: 83 },
-  tomorrow: { min: 73.3, max: 84.6 }
+  yesterday: { low: 61, high: 75 },
+  today: { low: 64, high: 77 },
+  tomorrow: { low: 68, high: 80 }
 };
 
-function getMaxOfTmrw(forecast) {
-  "use strict";
-  // change code below this line
-   const {tomorrow : {max : maxOfTomorrow}} = forecast; // change this line
-  // change code above this line
-  return maxOfTomorrow;
-}
+// change code below this line
+  
+const { today { low: lowToday, high: highToday }} = LOCAL_FORECAST;
 
-console.log(getMaxOfTmrw(LOCAL_FORECAST)); // should be 84.6
+// change code above this line
+
+console.log(highToday); // should be 77
+console.log(highTomorrow); // should be 80
 ```
 </section>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-assign-variables-from-nested-objects.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-assign-variables-from-nested-objects.english.md
@@ -35,7 +35,7 @@ const { johnDoe: { age: userAge, email: userEmail }} = user;
 
 ## Instructions
 <section id='instructions'>
-Replace the two assignments with an equivalent destructuring assignment. It should still assign the variables <code>lowToday</code> and <code>highToday</code> the values of <code>today.low</code> and <code>tomorrow.high</code> from the <code>LOCAL_FORECAST</code> object.
+Replace the two assignments with an equivalent destructuring assignment. It should still assign the variables <code>lowToday</code> and <code>highToday</code> the values of <code>today.low</code> and <code>today.high</code> from the <code>LOCAL_FORECAST</code> object.
 </section>
 
 ## Tests

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-assign-variables-from-objects.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-assign-variables-from-objects.english.md
@@ -21,7 +21,7 @@ const { name: userName, age: userAge } = user;
 // userName = 'John Doe', userAge = 34
 ```
 
-You may read it as "get the value of <code>user.name</code> and copy it into <code>userName</code>" and so on.
+You may read it as "get the value of <code>user.name</code> and assign it to a new variable named <code>userName</code>" and so on.
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-assign-variables-from-objects.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-assign-variables-from-objects.english.md
@@ -37,9 +37,9 @@ tests:
   - text: You should remove the ES5 assignment syntax.
     testString: assert(!code.match(/highToday = HIGH_TEMPERATURES\.today/g) && !code.match(/highTomorrow = HIGH_TEMPERATURES\.tomorrow/g))
   - text: You should use destructuring to create the <code>highToday</code> variable.
-    testString: assert(code.match(/(var|const|let)\s*{\s*(today:\s*highToday[^}]*|[^,]*,\s*today\s*:\s*highToday\s*)}\s*=\s*HIGH_TEMPERATURES/g));
+    testString: assert(code.match(/(var|const|let)\s*{\s*(today:\s*highToday[^}]*|[^,]*,\s*today\s*:\s*highToday\s*)}\s*=\s*HIGH_TEMPERATURES(;|\s+|\/\/)/g));
   - text: You should use destructuring to create the <code>highTomorrow</code> variable.
-    testString: assert(code.match(/(var|const|let)\s*{\s*(tomorrow:\s*highTomorrow[^}]*|[^,]*,\s*tomorrow\s*:\s*highTomorrow\s*)}\s*=\s*HIGH_TEMPERATURES/g));
+    testString: assert(code.match(/(var|const|let)\s*{\s*(tomorrow:\s*highTomorrow[^}]*|[^,]*,\s*tomorrow\s*:\s*highTomorrow\s*)}\s*=\s*HIGH_TEMPERATURES(;|\s+|\/\/)/g));
 ```
 
 </section>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-assign-variables-from-objects.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-assign-variables-from-objects.english.md
@@ -6,7 +6,7 @@ challengeType: 1
 
 ## Description
 <section id='description'>
-Destructuring allows you to assign a new variable name when extracting values by putting the new name after a colon when assigning the value.
+Destructuring allows you to assign a new variable name when extracting values. You can do this by putting the new name after a colon when assigning the value.
 
 Using the same object from the last example:
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-assign-variables-from-objects.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-assign-variables-from-objects.english.md
@@ -21,7 +21,7 @@ const { name: userName, age: userAge } = user;
 // userName = 'John Doe', userAge = 34
 ```
 
-You may read it as "get the field <code>name</code> and copy the value into <code>userName</code>" and so on.
+You may read it as "get the value of <code>user.name</code> and copy it into <code>userName</code>" and so on.
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-assign-variables-from-objects.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-assign-variables-from-objects.english.md
@@ -6,35 +6,27 @@ challengeType: 1
 
 ## Description
 <section id='description'>
-We saw earlier how spread operator can effectively spread, or unpack, the contents of the array.
-We can do something similar with objects as well. <dfn>Destructuring assignment</dfn> is special syntax for neatly assigning values taken directly from an object to variables.
-Consider the following ES5 code:
+Destructuring allows you to assign a new variable name when extracting values by putting the new name after a colon when assigning the value.
+
+Using the same object from the last example:
 
 ```js
-var voxel = { x: 3.6, y: 7.4, z: 6.54 };
-var x = voxel.x; // x = 3.6
-var y = voxel.y; // y = 7.4
-var z = voxel.z; // z = 6.54
+const user = { name: 'John Doe', age: 34 };
 ```
 
-Here's the same assignment statement with ES6 destructuring syntax:
+Here's how you can give new variable names in the assignment:
 
 ```js
-const { x, y, z } = voxel; // x = 3.6, y = 7.4, z = 6.54
+const { name: userName, age: userAge } = user;
+// userName = 'John Doe', userAge = 34
 ```
 
-If instead you want to store the values of <code>voxel.x</code> into <code>a</code>, <code>voxel.y</code> into <code>b</code>, and <code>voxel.z</code> into <code>c</code>, you have that freedom as well.
-
-```js
-const { x: a, y: b, z: c } = voxel; // a = 3.6, b = 7.4, c = 6.54
-```
-
-You may read it as "get the field <code>x</code> and copy the value into <code>a</code>," and so on.
+You may read it as "get the field <code>name</code> and copy the value into <code>userName</code>" and so on.
 </section>
 
 ## Instructions
 <section id='instructions'>
-Use destructuring to obtain the average temperature for tomorrow from the input object <code>AVG_TEMPERATURES</code>, and assign value with key <code>tomorrow</code> to <code>tempOfTomorrow</code> in line.
+Replace the two assignments with an equivalent destructuring assignment. It should still assign the variables <code>highToday</code> and <code>highTomorrow</code> the values of <code>today</code> and <code>tomorrow</code> from the <code>HIGH_TEMPERATURES</code> object.
 </section>
 
 ## Tests
@@ -42,62 +34,59 @@ Use destructuring to obtain the average temperature for tomorrow from the input 
 
 ```yml
 tests:
-  - text: <code>getTempOfTmrw(AVG_TEMPERATURES)</code> should be <code>79</code>
-    testString: assert(getTempOfTmrw(AVG_TEMPERATURES) === 79);
-  - text: destructuring with reassignment was used
-    testString: getUserInput => assert(code.match(/{[\S\s]*\w+\s*:[\S\s]*\w+\s*}\s*=\s*(avgTemperatures|AVG_TEMPERATURES)/));
-  - text: The key <code>tomorrow</code> was destructured from <code>AVG_TEMPERATURES</code>
-    testString: getUserInput => assert(code.match(/{[\S\s]*tomorrow\s*:\s*tempOfTomorrow[\S\s]*}\s*=\s*(avgTemperatures|AVG_TEMPERATURES)/)); 
-
+  - text: You should remove the ES5 assignment syntax.
+    testString: assert(!code.match(/highToday = HIGH_TEMPERATURES\.today/g) && !code.match(/highTomorrow = HIGH_TEMPERATURES\.tomorrow/g))
+  - text: You should use destructuring to create the <code>highToday</code> variable.
+    testString: assert(code.match(/(var|const|let)\s*{\s*(today:\s*highToday[^}]*|[^,]*,\s*today\s*:\s*highToday\s*)}\s*=\s*HIGH_TEMPERATURES/g));
+  - text: You should use destructuring to create the <code>highTomorrow</code> variable.
+    testString: assert(code.match(/(var|const|let)\s*{\s*(tomorrow:\s*highTomorrow[^}]*|[^,]*,\s*tomorrow\s*:\s*highTomorrow\s*)}\s*=\s*HIGH_TEMPERATURES/g));
 ```
 
 </section>
 
 ## Challenge Seed
 <section id='challengeSeed'>
-
 <div id='js-seed'>
 
 ```js
-const AVG_TEMPERATURES = {
-  today: 77.5,
-  tomorrow: 79
+const HIGH_TEMPERATURES = {
+  yesterday: 75,
+  today: 77,
+  tomorrow: 80
 };
 
-function getTempOfTmrw(avgTemperatures) {
-  "use strict";
-  // change code below this line
-  const tempOfTomorrow = undefined; // change this line
-  // change code above this line
-  return tempOfTomorrow;
-}
+// change code below this line
+  
+const highToday = HIGH_TEMPERATURES.today;
+const highTomorrow = HIGH_TEMPERATURES.tomorrow; 
 
-console.log(getTempOfTmrw(AVG_TEMPERATURES)); // should be 79
+// change code above this line
+
+console.log(yesterday) // should be not defined
+console.log(highToday); // should be 77
+console.log(highTomorrow); // should be 80
 ```
 
 </div>
-
-
-
 </section>
 
 ## Solution
 <section id='solution'>
 
 ```js
-const AVG_TEMPERATURES = {
-  today: 77.5,
-  tomorrow: 79
+const HIGH_TEMPERATURES = {
+  yesterday: 75,
+  today: 77,
+  tomorrow: 80
 };
 
-function getTempOfTmrw(avgTemperatures) {
-  "use strict";
-  // change code below this line
-  const {tomorrow:tempOfTomorrow} = avgTemperatures; // change this line
-  // change code above this line
-  return tempOfTomorrow;
-}
+// change code below this line
+  
+const { today: highToday, tomorrow: highTomorrow } = HIGH_TEMPERATURES;
 
-console.log(getTempOfTmrw(AVG_TEMPERATURES)); // should be 79
+// change code above this line
+
+console.log(highToday); // should be 77
+console.log(highTomorrow); // should be 80
 ```
 </section>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-extract-values-from-objects.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-extract-values-from-objects.english.md
@@ -1,0 +1,98 @@
+---
+id: 5cfa550e84205a357704ccb6
+title: Use Destructuring Assignment to Extract Values from Objects
+challengeType: 1
+---
+
+## Description
+<section id='description'>
+<dfn>Destructuring assignment</dfn> is special syntax introduced in ES6, for neatly assigning values taken directly from an object.
+
+Consider the following ES5 code:
+
+```js
+const user = { name: 'John Doe', age: 34 };
+
+const name = user.name; // name = 'John Doe'
+const age = user.age; // age = 34
+```
+
+Here's an equivalent assignment statement using the ES6 destructuring syntax:
+
+```js
+const { name, age } = user;
+// name = 'John Doe', age = 34
+```
+
+Here, the <code>name</code> and <code>age</code> variables will be created and assigned the values of their respective values from the <code>user</code> object. You can see how much cleaner this is.
+
+You can extract as many or few values from the object as you want.
+</section>
+
+## Instructions
+<section id='instructions'>
+Replace the two assignments with an equivalent destructuring assignment. It should still assign the variables <code>today</code> and <code>tomorrow</code> the values of <code>today</code> and <code>tomorrow</code> from the <code>HIGH_TEMPERATURES</code> object.
+</section>
+
+## Tests
+<section id='tests'>
+
+```yml
+tests:
+  - text: You should remove the ES5 assignment syntax.
+    testString: assert(!code.match(/today = HIGH_TEMPERATURES\.today/g) && !code.match(/tomorrow = HIGH_TEMPERATURES\.tomorrow/g))
+  - text: You should use destructuring to create the <code>today</code> variable.
+    testString: assert(code.match(/(var|let|const)\s*{\s*(today[^}]*|[^,]*,\s*today)\s*}\s*=\s*HIGH_TEMPERATURES/g));
+  - text: You should use destructuring to create the <code>tomorrow</code> variable.
+    testString: assert(code.match(/(var|let|const)\s*{\s*(tomorrow[^}]*|[^,]*,\s*tomorrow)\s*}\s*=\s*HIGH_TEMPERATURES/g));
+```
+
+</section>
+
+## Challenge Seed
+<section id='challengeSeed'>
+<div id='js-seed'>
+
+```js
+const HIGH_TEMPERATURES = {
+  yesterday: 75,
+  today: 77,
+  tomorrow: 80
+};
+
+// change code below this line
+
+const today = HIGH_TEMPERATURES.today;
+const tomorrow = HIGH_TEMPERATURES.tomorrow; 
+
+// change code above this line
+
+console.log(yesterday) // should be not defined
+console.log(today); // should be 77
+console.log(tomorrow); // should be 80
+```
+
+</div>
+</section>
+
+## Solution
+<section id='solution'>
+
+```js
+const HIGH_TEMPERATURES = {
+  yesterday: 75,
+  today: 77,
+  tomorrow: 80
+};
+
+// change code below this line
+
+const { today, tomorrow } = HIGH_TEMPERATURES;
+
+// change code above this line
+
+console.log(yesterday) // should be not defined
+console.log(today); // should be 77
+console.log(tomorrow); // should be 80
+```
+</section>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-extract-values-from-objects.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-extract-values-from-objects.english.md
@@ -42,9 +42,9 @@ tests:
   - text: You should remove the ES5 assignment syntax.
     testString: assert(!code.match(/today = HIGH_TEMPERATURES\.today/g) && !code.match(/tomorrow = HIGH_TEMPERATURES\.tomorrow/g))
   - text: You should use destructuring to create the <code>today</code> variable.
-    testString: assert(code.match(/(var|let|const)\s*{\s*(today[^}]*|[^,]*,\s*today)\s*}\s*=\s*HIGH_TEMPERATURES/g));
+    testString: assert(code.match(/(var|let|const)\s*{\s*(today[^}]*|[^,]*,\s*today)\s*}\s*=\s*HIGH_TEMPERATURES(;|\s+|\/\/)/g));
   - text: You should use destructuring to create the <code>tomorrow</code> variable.
-    testString: assert(code.match(/(var|let|const)\s*{\s*(tomorrow[^}]*|[^,]*,\s*tomorrow)\s*}\s*=\s*HIGH_TEMPERATURES/g));
+    testString: assert(code.match(/(var|let|const)\s*{\s*(tomorrow[^}]*|[^,]*,\s*tomorrow)\s*}\s*=\s*HIGH_TEMPERATURES(;|\s+|\/\/)/g));
 ```
 
 </section>


### PR DESCRIPTION
- Added new lesson "Use Destructuring Assignment to Extract Values from Objects" to teach destructure without renaming variables.
- Rewrote "Use Destructuring Assignment to Assign Variables from Objects" to focus on destructure+renaming
- Rewrote "Use Destructuring Assignment to Assign Variables from Nested Objects" to align with the other lessons - and since the example there was abstract, I thought it could use it.
<!-- -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #35574
