### PR TITLE
Href in documentation quick reference

### DIFF
--- a/README.spanish.md
+++ b/README.spanish.md
@@ -1,0 +1,149 @@
+![freeCodeCamp.org Social Banner](https://s3.amazonaws.com/freecodecamp/wide-social-banner.png)
+[![Build Status](https://travis-ci.org/freeCodeCamp/freeCodeCamp.svg?branch=staging)](https://travis-ci.org/freeCodeCamp/freeCodeCamp)
+[![Pull Requests Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat)](http://makeapullrequest.com)
+[![first-timers-only Friendly](https://img.shields.io/badge/first--timers--only-friendly-blue.svg)](http://www.firsttimersonly.com/)
+[![Open Source Helpers](https://www.codetriage.com/freecodecamp/freecodecamp/badges/users.svg)](https://www.codetriage.com/freecodecamp/freecodecamp)
+
+## ¡Bienvenido al plan de estudios y repositorio público de freeCodeCamp.org!
+
+[freeCodeCamp.org](https://www.freecodecamp.org) es una comunidad amigable donde puedes aprender a programar gratis. Es administrado por una organización sin fines de lucro respaldada por donantes ([donor-supported 501(c)(3) nonprofit](https://donate.freecodecamp.org)) y cuyo objetivo es ayudar a millones de adultos en la transición laboral a campos vinculados con la tecnología. Nuestra comunidad ya ha ayudado a más de 10,000 de personas a obtener su primer trabajo como desarrolladores.
+
+Nuestro plan de estudios de desarrollo web full-stack es completamente gratuito y cada uno puede hacerlo a su propio ritmo. Tenemos miles de desafíos inteactivos de programación para ayudarte a expandir tus habilidades.
+
+## Índice
+
+- [Certificaciones](#certificaciones)
+- [La plataforma de aprendizaje](#la-plataforma-de-aprendizaje)
+- [Encontraste un bug](#encontraste-un-bug)
+- [Encontraste un problema de seguridad](#encontraste-un-problema-de-seguridad)
+- [Contribuciones](#contribuciones)
+- [Licencia](#licencia)
+
+### Certificaciones
+
+freeCodeCamp.org ofrece varias certificaciones de desarrollador web gratuitas. Cada una implica desarrollar 5 proyectos de aplicaciones web, junto con cientos de desafíos de programación optativos que ayudan a prepararte para dichos proyectos. Estimamos que a un programador principiante, cada certificación le llevará alrededor de 300 horas.
+
+Cada uno de estos 30 proyectos del plan de estudios de freeCodeCamp.org tiene sus propias historias de usuario ágiles y tests automatizados. Éstos te ayudan a construir tu proyecto de forma incremental y garantizan que hayas cumplido con todas las historias de usuario antes de enviarlo.
+
+Puedes hacer un pull de estos test desde [freeCodeCamp's CDN](https://cdn.freecodecamp.org/testable-projects-fcc/v1/bundle.js). Esto significa que puedes construir dichos proyectos en sitios web como CodePen y Glitch - o incluso localmente en tu computadora.
+
+Una vez que hayas conseguido una certificación, siempre la tendrás. Siempre tendrás permitido agregar el link a ella desde tu LinkedIn o tu CV. Y cuando tus futuros empleadores o clientes hagan click en ese link, verán tu certificación verificada.
+
+La única excepción a esto es en caso en que descubramos una violación a nuestras [Políticas de Honestidad Académica](https://www.freecodecamp.org/academic-honesty). Cuando atrapamos a las personas sin ambigüedad plagiando (presentando el código o los proyectos de otras personas como si fueran suyos sin citación), hacemos lo que deben hacer todas las instituciones de aprendizaje rigurosas: revocamos sus certificaciones y prohibimos a esas personas.
+
+Éstas son nuestras seis principales certificaciones:
+
+#### 1. Certificación de Diseño Web Responsive
+
+- [Basic HTML and HTML5](https://learn.freecodecamp.org/responsive-web-design/basic-html-and-html5)
+- [Basic CSS](https://learn.freecodecamp.org/responsive-web-design/basic-css)
+- [Applied Visual Design](https://learn.freecodecamp.org/responsive-web-design/applied-visual-design)
+- [Applied Accessibility](https://learn.freecodecamp.org/responsive-web-design/applied-accessibility)
+- [Responsive Web Design Principles](https://learn.freecodecamp.org/responsive-web-design/responsive-web-design-principles)
+- [CSS Flexbox](https://learn.freecodecamp.org/responsive-web-design/css-flexbox)
+- [CSS Grid](https://learn.freecodecamp.org/responsive-web-design/css-grid)
+  <br />
+  <br />
+  **Proyectos**: Tribute Page, Survey Form, Product Landing Page, Technical Documentation Page, Personal Portfolio Webpage
+
+#### 2. Certificación de Algoritmos en JavaScript y Estructura de Datos
+
+- [Basic JavaScript](https://learn.freecodecamp.org/javascript-algorithms-and-data-structures/basic-javascript)
+- [ES6](https://learn.freecodecamp.org/javascript-algorithms-and-data-structures/es6)
+- [Regular Expressions](https://learn.freecodecamp.org/javascript-algorithms-and-data-structures/regular-expressions)
+- [Debugging](https://learn.freecodecamp.org/javascript-algorithms-and-data-structures/debugging)
+- [Basic Data Structures](https://learn.freecodecamp.org/javascript-algorithms-and-data-structures/basic-data-structures)
+- [Algorithm Scripting](https://learn.freecodecamp.org/javascript-algorithms-and-data-structures/basic-algorithm-scripting)
+- [Object Oriented Programming](https://learn.freecodecamp.org/javascript-algorithms-and-data-structures/object-oriented-programming)
+- [Functional Programming](https://learn.freecodecamp.org/javascript-algorithms-and-data-structures/functional-programming)
+- [Intermediate Algorithm Scripting](https://learn.freecodecamp.org/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting)
+  <br />
+  <br />
+  **Proyectos**: Palindrome Checker, Roman Numeral Converter, Caesar's Cipher, Telephone Number Validator, Cash Register
+
+#### 3. Certificación de Librerías de Front End
+
+- [Bootstrap](https://learn.freecodecamp.org/front-end-libraries/bootstrap)
+- [jQuery](https://learn.freecodecamp.org/front-end-libraries/jquery)
+- [Sass](https://learn.freecodecamp.org/front-end-libraries/sass)
+- [React](https://learn.freecodecamp.org/front-end-libraries/react)
+- [Redux](https://learn.freecodecamp.org/front-end-libraries/redux)
+- [React and Redux](https://learn.freecodecamp.org/front-end-libraries/react-and-redux)
+  <br />
+  <br />
+  **Proyectos**: Random Quote Machine, Markdown Previewer, Drum Machine, JavaScript Calculator, Pomodoro Clock
+
+#### 4. Certificación de Visualización de Datos
+
+- [Data Visualization with D3](https://learn.freecodecamp.org/data-visualization/data-visualization-with-d3)
+- [JSON APIs and Ajax](https://learn.freecodecamp.org/data-visualization/json-apis-and-ajax)
+  <br />
+  <br />
+  **Proyectos**: Bar Chart, Scatterplot Graph, Heat Map, Choropleth Map, Treemap Diagram
+
+#### 5. Certificación de APIs y Microservicios
+
+- [Managing Packages with Npm](https://learn.freecodecamp.org/apis-and-microservices/managing-packages-with-npm)
+- [Basic Node and Express](https://learn.freecodecamp.org/apis-and-microservices/basic-node-and-express)
+- [MongoDB and Mongoose](https://learn.freecodecamp.org/apis-and-microservices/mongodb-and-mongoose)
+  <br />
+  <br />
+  **Proyectos**: Timestamp Microservice, Request Header Parser, URL Shortener, Exercise Tracker, File Metadata Microservice
+
+#### 6. Certificación de Seguridad Informática y Control de Calidad
+
+- [Information Security with HelmetJS](https://learn.freecodecamp.org/information-security-and-quality-assurance/information-security-with-helmetjs)
+- [Quality Assurance and Testing with Chai](https://learn.freecodecamp.org/information-security-and-quality-assurance/quality-assurance-and-testing-with-chai)
+- [Advanced Node and Express](https://learn.freecodecamp.org/information-security-and-quality-assurance/advanced-node-and-express)
+  <br />
+  <br />
+  **Proyectos**: Metric-Imperial Converter, Issue Tracker, Personal Library, Stock Price Checker, Anonymous Message Board
+
+#### Certificación de Desarrollo Full Stack
+
+Una vez que hayas obtenido las 6 de estas certificaciones,podrás reclamar tu certificación de Desarrollo Full Stack de freeCodeCamp.org. Esta última distinción significa que has completado aproximadamente 1,800 horas de programación con una amplia gama de herramientas de desarrollo web.
+
+#### Legacy Certifications
+
+Además contamos con 3 certificaciones legacy de nuestro plan de estudios del 2015, las cuales todavía se encuentran vigentes. Todos los proyectos requeridos para dichas certificaciones legacy permanecerán disponibles en freeCodeCamp.org.
+
+- Certificación Legacy de Desarrollo Front End
+- Certificación Legacy de Visualización de Datos
+- Certificación Legacy de Desarrollo Back End
+
+### La plataforma de aprendizaje
+
+Este código impacta en [freeCodeCamp.org](https://www.freecodecamp.org).
+
+Nuestra comunidad además cuenta con:
+
+- Un [foro](https://www.freecodecamp.org/forum) donde a menudo puedes obtener ayuda en temas de programación o feedback sobre tus proyectos en cuestión de horas.
+- Un [canal de YouTube](https://youtube.com/freecodecamp) con cursos gratuitos sobre Python, SQL, Android, y una gran variedad de otras tecnologías.
+- Un [podcast](https://podcast.freecodecamp.org/) con noticias sobre tecnología e inspiradoras historias sobre programadores.
+- [Grupos de estudio locales](https://study-group-directory.freecodecamp.org/) alrededor del mundo, para que puedas reunirte y programar junto con otras personas.
+- Una completa [guía de miles de temas de programación](https://guide.freecodecamp.org/)
+- La [publicación técnica más extensa](https://medium.freecodecamp.org) de Medium.
+- Un [grupo de Facebook](https://www.facebook.com/groups/freeCodeCampEarth/permalink/428140994253892/) con más de 100,000 miembros alrededor del mundo.
+
+### [Unite a nuestra comunidad aquí](https://www.freecodecamp.org/signin).
+
+### Encontraste un bug?
+
+Si piensas que encontraste un bug, primero lee [How to Report a Bug](https://www.freecodecamp.org/forum/t/how-to-report-a-bug/19543) y sigue las instrucciones. Si estás seguro de que es un bug nuevo y has confirmado que afecta a otras personas, continúa y crea un ticket en GitHub. Asegúrate de incluir tanta información como sea posible para poder reproducir el bug..
+
+### Encontraste un problema de seguridad?
+
+Por favor, no crees un ticket en GitHub sobre problemas de seguridad. En cambio, envía un correo electrónico a `security @ freecodecamp.org` y lo veremos de inmediato.
+
+### Contribuciones
+
+#### [Por favor seguir los siguientes pasos para contribuir.](CONTRIBUTING.md)
+
+### Licencia
+
+Copyright © 2019 freeCodeCamp.org
+
+El contenido de este repositorio está sujeto a las siguientes licencias:
+
+- Los recursos de software se encuentran registrados bajo la licencia [BSD-3-Clause](LICENSE.md).
+- Los recursos de aprendizaje en las carpetas [`/curriculum`](/curriculum) y [`/guide`](/guide) incluyendo sus subcarpetas se encuentran registrados bajo la licencia [CC-BY-SA-4.0](/curriculum/LICENSE.md).


### PR DESCRIPTION
In the header of the Documentation Quick Reference, the href of the English version pointed to the CONTRIBUTING.md. The correct path is /docs/README.md


<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x ] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [ x ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ x ] My pull request targets the `master` branch of freeCodeCamp.
- [ x ] None of my changes are plagiarized from another source without proper attribution.
- [ x ] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [ x ] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX
