### PR TITLE
fix(guide): Remove repl.it links from challenge related guide articles (Spanish)

### DIFF
--- a/guide/spanish/certifications/coding-interview-prep/algorithms/find-the-symmetric-difference/index.md
+++ b/guide/spanish/certifications/coding-interview-prep/algorithms/find-the-symmetric-difference/index.md
@@ -86,7 +86,6 @@ A = {1, 2, 3}
 
 ```](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce) 
 
- [![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:")](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce) [Ejecutar código](https://repl.it/C4II/0)
 
 ### Explicación del código:
 
@@ -141,7 +140,6 @@ A = {1, 2, 3}
     sym([1, 2, 3], [5, 2, 1, 4]); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLoc/0)
 
 ### Explicación del código:
 
@@ -176,7 +174,6 @@ A = {1, 2, 3}
     sym([1, 2, 3], [5, 2, 1, 4]); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/@ashenm/Symmetric-Difference)
 
 ### Explicación del código:
 

--- a/guide/spanish/certifications/coding-interview-prep/algorithms/implement-bubble-sort/index.md
+++ b/guide/spanish/certifications/coding-interview-prep/algorithms/implement-bubble-sort/index.md
@@ -38,7 +38,6 @@ function swap(a, b, arr){
 
 `js function bubbleSort(array) { for (let i = 0; i < array.length; i++){ for (let j = 0; j < array.length-1-i; j++){ if (array[j] > array[j+1]) [array[j], array[j+1]] = [array[j+1], array[j]]; // Using ES6 array destructuring to swap } } return array; }`
 
-*   [Ejecutar código](https://repl.it/@ezioda004/Bubble-Sort)
     
     ### Referencias:
     

--- a/guide/spanish/certifications/coding-interview-prep/algorithms/implement-insertion-sort/index.md
+++ b/guide/spanish/certifications/coding-interview-prep/algorithms/implement-insertion-sort/index.md
@@ -32,7 +32,6 @@ function insertionSort(array) {
  } 
 ```
 
-*   [Ejecutar código](https://repl.it/@ezioda004/Insertion-Sort)
 
 ### Referencias:
 

--- a/guide/spanish/certifications/coding-interview-prep/algorithms/implement-merge-sort/index.md
+++ b/guide/spanish/certifications/coding-interview-prep/algorithms/implement-merge-sort/index.md
@@ -48,7 +48,6 @@ localeTitle: Implementar Merge Sort
  } 
 ```
 
-*   [Ejecutar código](https://repl.it/@ezioda004/Merge-Sort)
 
 ### Referencias:
 

--- a/guide/spanish/certifications/coding-interview-prep/algorithms/implement-quick-sort/index.md
+++ b/guide/spanish/certifications/coding-interview-prep/algorithms/implement-quick-sort/index.md
@@ -48,7 +48,6 @@ localeTitle: Implementar ordenación rápida
  } 
 ```
 
-*   [Ejecutar código](https://repl.it/@ezioda004/Quick-Sort)
 
 ### Referencia:
 

--- a/guide/spanish/certifications/coding-interview-prep/algorithms/inventory-update/index.md
+++ b/guide/spanish/certifications/coding-interview-prep/algorithms/inventory-update/index.md
@@ -106,7 +106,6 @@ Devuelve el inventario completado en orden alfabético.
     updateInventory(curInv, newInv); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLok/0)
 
 ### Explicación del código:
 
@@ -192,7 +191,6 @@ Devuelve el inventario completado en orden alfabético.
     updateInventory(curInv, newInv); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLol/0)
 
 ### Explicación del código:
 
@@ -268,7 +266,6 @@ Devuelve el inventario completado en orden alfabético.
     updateInventory(curInv, newInv); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/MQvv/latest)
 
 ### Explicación del código:
 

--- a/guide/spanish/certifications/coding-interview-prep/algorithms/no-repeats-please/index.md
+++ b/guide/spanish/certifications/coding-interview-prep/algorithms/no-repeats-please/index.md
@@ -145,7 +145,6 @@ function permAlone(str) {
  permAlone('aab'); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLop/0)
 
 ### Explicación del código:
 

--- a/guide/spanish/certifications/coding-interview-prep/project-euler/problem-1-multiples-of-3-and-5/index.md
+++ b/guide/spanish/certifications/coding-interview-prep/project-euler/problem-1-multiples-of-3-and-5/index.md
@@ -24,7 +24,6 @@ function multiplesOf3and5(number) {
  } 
 ```
 
-*   [Ejecutar código](https://repl.it/@ezioda004/Project-Euler-Problem-1-Multiples-of-3-and-5)
 
 ### Referencia:
 

--- a/guide/spanish/certifications/coding-interview-prep/project-euler/problem-2-even-fibonacci-numbers/index.md
+++ b/guide/spanish/certifications/coding-interview-prep/project-euler/problem-2-even-fibonacci-numbers/index.md
@@ -56,7 +56,6 @@ function fiboEvenSum(n) {
  } 
 ```
 
-*   [Ejecutar código](https://repl.it/@ezioda004/Project-Euler-Problem-2-Even-Fibonacci-Numbers)
 
 ### Referencias:
 

--- a/guide/spanish/certifications/coding-interview-prep/project-euler/problem-3-largest-prime-factor/index.md
+++ b/guide/spanish/certifications/coding-interview-prep/project-euler/problem-3-largest-prime-factor/index.md
@@ -26,7 +26,6 @@ function largestPrimeFactor(number) {
  } 
 ```
 
-*   [Ejecutar código](https://repl.it/@ezioda004/Problem-3-Largest-prime-factor)
 
 ### Recursos:
 

--- a/guide/spanish/certifications/coding-interview-prep/project-euler/problem-4-largest-palindrome-product/index.md
+++ b/guide/spanish/certifications/coding-interview-prep/project-euler/problem-4-largest-palindrome-product/index.md
@@ -50,7 +50,6 @@ function largestPalindromeProduct(n) {
  } 
 ```
 
-*   [Ejecutar código](https://repl.it/@ezioda004/Problem-4-Largest-palindrome-product)
 
 ### Referencias:
 

--- a/guide/spanish/certifications/coding-interview-prep/project-euler/problem-5-smallest-multiple/index.md
+++ b/guide/spanish/certifications/coding-interview-prep/project-euler/problem-5-smallest-multiple/index.md
@@ -37,7 +37,6 @@ localeTitle: Múltiplo más pequeño
  } 
 ```
 
-*   [Ejecutar código](https://repl.it/@ezioda004/Problem-5-Smallest-multiple)
 
 ### Referencias:
 

--- a/guide/spanish/certifications/coding-interview-prep/project-euler/problem-6-sum-square-difference/index.md
+++ b/guide/spanish/certifications/coding-interview-prep/project-euler/problem-6-sum-square-difference/index.md
@@ -29,7 +29,6 @@ function sumSquareDifference(n) {
  } 
 ```
 
-*   [Ejecutar código](https://repl.it/@ezioda004/Problem-6-Sum-square-difference)
 
 ### Referencias:
 

--- a/guide/spanish/certifications/coding-interview-prep/project-euler/problem-7-10001st-prime/index.md
+++ b/guide/spanish/certifications/coding-interview-prep/project-euler/problem-7-10001st-prime/index.md
@@ -49,7 +49,6 @@ function nthPrime(n) {
  } 
 ```
 
-\- [Ejecutar código](https://repl.it/@ezioda004/Project-Euler-Problem-7-10001st-prime)
 
 ### Referencias:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/boo-who/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/boo-who/index.md
@@ -49,7 +49,6 @@ Este programa es muy simple, el truco es entender qué es un primitivo booleano.
     booWho(null); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLnK/0)
 
 # Explicación del código:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/chunky-monkey/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/chunky-monkey/index.md
@@ -72,7 +72,6 @@ Finalmente, necesitamos un método para hacer la división real y podemos usar `
     } 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLjU/24)
 
 ### Explicación del código:
 
@@ -101,7 +100,6 @@ Finalmente, necesitamos un método para hacer la división real y podemos usar `
     } 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/Cj9x/3)
 
 ### Explicación del código:
 
@@ -134,7 +132,6 @@ Finalmente, necesitamos un método para hacer la división real y podemos usar `
     chunkArrayInGroups(["a", "b", "c", "d"], 2); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLjU/26)
 
 ### Explicación del código:
 
@@ -169,7 +166,6 @@ Finalmente, necesitamos un método para hacer la división real y podemos usar `
     } 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLjU/579)
 
 ### Explicación del código:
 
@@ -198,7 +194,6 @@ Finalmente, necesitamos un método para hacer la división real y podemos usar `
     } 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLjU/579)
 
 ### Explicación del código:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/confirm-the-ending/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/confirm-the-ending/index.md
@@ -19,7 +19,6 @@ function confirmEnding(str, target) {
  confirmEnding("He has to give me a new name", "name"); 
 ```
 
-#### 🚀 [Ejecutar Código](https://repl.it/repls/SardonicRoundAfkgaming)
 
 # Explicación del código:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/factorialize-a-number/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/factorialize-a-number/index.md
@@ -93,7 +93,6 @@ function factorialize(num) {
  factorialize(5); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLjU/1)
 
 ## Explicación del código:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/falsy-bouncer/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/falsy-bouncer/index.md
@@ -45,7 +45,6 @@ function bouncer(arr) {
  } 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLjU/32)
 
 ### Explicación del código:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/find-the-longest-word-in-a-string/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/find-the-longest-word-in-a-string/index.md
@@ -52,7 +52,6 @@ function findLongestWordLength(str) {
  } 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLjU/5)
 
 ### Explicación del código:
 
@@ -76,7 +75,6 @@ function findLongestWordLength(s) {
  } 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLjU/6)
 
 ### Explicación del código:
 
@@ -122,7 +120,6 @@ function findLongestWordLength(str) {
  } 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLjU/7)
 
 ### Explicación del código:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/mutations/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/mutations/index.md
@@ -51,7 +51,6 @@ function mutation(arr) {
  } 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLjU/30)
 
 ### Explicación del código:
 
@@ -79,7 +78,6 @@ function mutation(arr) {
  } 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLjU/31)
 
 ### Explicación del código:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/repeat-a-string-repeat-a-string/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/repeat-a-string-repeat-a-string/index.md
@@ -50,7 +50,6 @@ function repeatStringNumTimes(str, num) {
  } 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLjU/19)
 
 ### Explicación del código:
 
@@ -76,7 +75,6 @@ function repeatStringNumTimes(str, num) {
  } 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLjU/21)
 
 ### Explicación del código:
 
@@ -98,7 +96,6 @@ function repeatStringNumTimes(str, num) {
  repeatStringNumTimes("abc", 3); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLjU/85)
 
 ### Explicación del código:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/return-largest-numbers-in-arrays/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/return-largest-numbers-in-arrays/index.md
@@ -53,7 +53,6 @@ function largestOfFour(arr) {
  } 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLjU/734)
 
 ### Explicación del código:
 
@@ -82,7 +81,6 @@ function largestOfFour(arr) {
  } 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLjU/733)
 
 ### Explicación del código:
 
@@ -106,7 +104,6 @@ function largestOfFour(arr) {
  } 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLjU/17)
 
 ### Explicación del código:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/reverse-a-string/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/reverse-a-string/index.md
@@ -45,7 +45,6 @@ function reverseString(str) {
  } 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLjU)
 
 ### Explicación del código:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/slice-and-splice/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/slice-and-splice/index.md
@@ -52,7 +52,6 @@ function frankenSplice(arr1, arr2, n) {
  } 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLjU)
 
 ### Explicación del código:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/title-case-a-sentence/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/title-case-a-sentence/index.md
@@ -58,7 +58,6 @@ String.prototype.replaceAt = function(index, character) {
  } 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLjU/8)
 
 ### Explicación del código:
 
@@ -86,7 +85,6 @@ function titleCase(str) {
  titleCase("I'm a little tea pot"); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLjU/9)
 
 ### Explicación del código:
 
@@ -103,7 +101,6 @@ function titleCase(str) {
  } 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLjU/14)
 
 ### Explicación del código:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/truncate-a-string/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/truncate-a-string/index.md
@@ -51,7 +51,6 @@ function truncateString(str, num) {
  } 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLjU/55)
 
 ### Explicación del código:
 
@@ -71,7 +70,6 @@ function truncateString(str, num) {
  } 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLjU/54)
 
 ### Explicación del código:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/where-do-i-belong/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/where-do-i-belong/index.md
@@ -52,7 +52,6 @@ function getIndexToIns(arr, num) {
  } 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLjU/36)
 
 ## Explicación del código:
 
@@ -77,7 +76,6 @@ function getIndexToIns(arr, num) {
  getIndexToIns([40, 60], 50); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLjU/2547)
 
 ## Explicación del código:
 
@@ -106,7 +104,6 @@ function getIndexToIns(arr, num) {
  getIndexToIns([40, 60], 50); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLjU/4135)
 
 ## Explicación del código:
 
@@ -125,7 +122,6 @@ function getIndexToIns(arr, num) {
  } 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/EB10/1)
 
 ## Explicación del código:
 
@@ -154,7 +150,6 @@ function getIndexToIns(arr, num) {
  getIndexToIns([40, 60], 500); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLjU/63)
 
 ## Explicación del código:
 
@@ -181,7 +176,6 @@ function getIndexToIns(arr, num) {
  getIndexToIns([1,3,4],2); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/IUJE/0)
 
 ## Explicación del código:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-javascript/chaining-if-else-statements/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-javascript/chaining-if-else-statements/index.md
@@ -52,7 +52,6 @@ function testSize(num) {
  } 
 ```
 
-· Ejecutar código en [repl.it](https://repl.it/@AdrianSkar/Basic-JS-Chaining-ifelse-statements)
 
 ### Explicación del código
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-equality-operator/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-equality-operator/index.md
@@ -31,7 +31,6 @@ function testEqual(val) {
  testEqual(10); 
 ```
 
-· [Ejecutar código en repl.it](https://repl.it/@AdrianSkar/Basic-JS-Equality-operator)
 
 ### Explicación del código
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-javascript/comparisons-with-the-logical-and-operator/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-javascript/comparisons-with-the-logical-and-operator/index.md
@@ -42,8 +42,6 @@ function testLogicalAnd(val) {
  testLogicalAnd(10); 
 ```
 
-· [Ejecutar código en repl.it](https://repl.it/@AdrianSkar/Basic-JS-Comparison-with-the-and-operator)
-
 ### Explicación del código
 
 La función primero evalúa `if` la condición `val <= 50` evalúa como `true` conversión de `val` en un número si es necesario, luego hace lo mismo con `val >=25` debido al operador lógico AND ( `&&` ); Si ambos devuelven verdadero, se ejecuta la instrucción de `return "Yes"` .

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-javascript/counting-cards/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-javascript/counting-cards/index.md
@@ -120,7 +120,6 @@ function cc(card) {
  } 
 ```
 
-· Ejecutar código en [repl.it.](https://repl.it/@AdrianSkar/Basic-JS-Counting-cards)
 
 ### Explicación del código
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-javascript/golf-code/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-javascript/golf-code/index.md
@@ -112,7 +112,6 @@ var names = ["Hole-in-one!", "Eagle", "Birdie", "Par", "Bogey", "Double Bogey", 
  golfScore(5, 4); 
 ```
 
-· Ejecutar en [repl.it](https://repl.it/@AdrianSkar/Basic-JS-Golf-code)
 
 \## explicación del código Como ya tenemos una matriz definida en los `names` las variables, podemos aprovecharla y utilizarla para nuestras declaraciones de devolución usando índices (por ejemplo: `names[0] is the first one` ). De esa manera, si alguna vez necesita cambiar un resultado específico, no tendría que buscarlo dentro de la función, estaría al principio, en su matriz.
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-javascript/introducing-else-if-statements/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-javascript/introducing-else-if-statements/index.md
@@ -56,7 +56,7 @@ function testElseIf(val) {
  testElseIf(7); 
 ```
 
-: cohete: [Ejecutar código](https://repl.it/@RyanPisuena/GoldenWorriedRuntime) ## explicación del código La estructura de un **flujo lógico else-if** es una declaración inicial `if` , una instrucción `if-else` y una instrucción `else` final.
+## explicación del código La estructura de un **flujo lógico else-if** es una declaración inicial `if` , una instrucción `if-else` y una instrucción `else` final.
 
 ### Recursos
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-javascript/introducing-else-statements/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-javascript/introducing-else-statements/index.md
@@ -47,7 +47,6 @@ function testElse(val) {
  testElse(4); 
 ```
 
-· [Ejecutar código en repl.it](https://repl.it/@AdrianSkar/Introducing-else-statements)
 
 ### Explicación del código
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-javascript/multiple-identical-options-in-switch-statements/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-javascript/multiple-identical-options-in-switch-statements/index.md
@@ -85,7 +85,6 @@ function sequentialSizes(val) {
  sequentialSizes(1); 
 ```
 
-· Ejecutar código en [repl.it.](https://repl.it/@AdrianSkar/Basic-JS-Multiple-opts-in-switch)
 
 ### Explicación del código
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-javascript/record-collection/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-javascript/record-collection/index.md
@@ -72,7 +72,6 @@ function updateRecords(id, prop, value) {
  } 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/C2AZ/0)
 
 ### Explicación del código:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-javascript/returning-boolean-values-from-functions/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-javascript/returning-boolean-values-from-functions/index.md
@@ -46,8 +46,6 @@ function isLess(a, b) {
  isLess(10, 15); 
 ```
 
-Ejecute el código en [repl.it.](https://repl.it/@AdrianSkar/Basic-Js-Returning-boolean-from-function)
-
 ### Recursos
 
 *   ["Operador menor o igual (<=)" - _MDN Referencia de Javascript_](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Less_than_or_equal_operator_(%3C))

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-javascript/selecting-from-many-options-with-switch-statements/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-javascript/selecting-from-many-options-with-switch-statements/index.md
@@ -116,7 +116,6 @@ function caseInSwitch(val) {
  caseInSwitch(1); 
 ```
 
-· Ejecutar código en [repl.it.](https://repl.it/@AdrianSkar/Basic-JS-Switch-statements)
 
 ### Explicación del código
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-javascript/using-objects-for-lookups/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/basic-javascript/using-objects-for-lookups/index.md
@@ -66,7 +66,6 @@ function phoneticLookup(val) {
 
 javascript resultado = búsqueda \[val\]; \`\` \`
 
-· Ejecutar código en [repl.it.](https://repl.it/@AdrianSkar/Using-objects-for-lookups)
 
 ### Recursos
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/es6/set-default-parameters-for-your-functions/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/es6/set-default-parameters-for-your-functions/index.md
@@ -52,7 +52,6 @@ const increment = (function() {
  console.log(increment(5)); // returns NaN 
 ```
 
-: cohete: [Ejecutar código](https://repl.it/@RyanPisuena/PleasingFumblingThings)
 
 ## Explicación del Código
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/arguments-optional/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/arguments-optional/index.md
@@ -95,7 +95,6 @@ En el caso de que solo se haya pasado un argumento, no se preocupe acerca de có
     addTogether(2,3); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLnz/0)
 
 ### Explicación del código:
 
@@ -154,7 +153,6 @@ En el caso de que solo se haya pasado un argumento, no se preocupe acerca de có
     addTogether(2,3); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLoA/0)
 
 ### Explicación del código:
 
@@ -189,7 +187,6 @@ En el caso de que solo se haya pasado un argumento, no se preocupe acerca de có
     addTogether(2,3); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLoB/0)
 
 ### Explicación del código:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/binary-agents/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/binary-agents/index.md
@@ -61,7 +61,6 @@ Asegúrate de que cada vez que transcodifiques un carácter de binario a decimal
     binaryAgent("01000001 01110010 01100101 01101110 00100111 01110100 00100000 01100010 01101111 01101110 01100110 01101001 01110010 01100101 01110011 00100000 01100110 01110101 01101110 00100001 00111111"); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLnm/0)
 
 # Explicación del código:
 
@@ -114,7 +113,6 @@ Asegúrate de que cada vez que transcodifiques un carácter de binario a decimal
     binaryAgent("01000001 01110010 01100101 01101110 00100111 01110100 00100000 01100010 01101111 01101110 01100110 01101001 01110010 01100101 01110011 00100000 01100110 01110101 01101110 00100001 00111111"); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLno/0)
 
 # Explicación del Código
 
@@ -141,7 +139,6 @@ Asegúrate de que cada vez que transcodifiques un carácter de binario a decimal
     binaryAgent("01000001 01110010 01100101 01101110 00100111 01110100 00100000 01100010 01101111 01101110 01100110 01101001 01110010 01100101 01110011 00100000 01100110 01110101 01101110 00100001 00111111"); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLnp/0)
 
 # Explicación del Código
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/convert-html-entities/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/convert-html-entities/index.md
@@ -82,7 +82,6 @@ Explica la solución aquí y agrega cualquier enlace relevante.
 *   [arr.join ()](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/join)
 *   [declaración de cambio](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Statements/switch)
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLnP/0)
 
 ## ![:sunflower:](https://forum.freecodecamp.com/images/emoji/emoji_one/sunflower.png?v=3 ":girasol:") Solución de código intermedio:
 ```
@@ -96,7 +95,6 @@ function convertHTML(str) {
  convertHTML("Dolce & Gabbana"); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLnQ/0)
 
 ### Explicación del código:
 
@@ -127,7 +125,6 @@ Explica la solución aquí y agrega cualquier enlace relevante.
     convertHTML("Dolce & Gabbana"); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLnR/0)
 
 ### Explicación del código:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/diff-two-arrays/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/diff-two-arrays/index.md
@@ -66,7 +66,6 @@ La mejor manera de realizar la función de devolución de llamada es verificar s
     diffArray([1, 2, 3, 5], [1, 2, 3, 4, 5]); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLme/0)
 
 ### Explicación del código:
 
@@ -90,7 +89,6 @@ Lee los comentarios en el código.
     diffArray([1, 2, 3, 5], [1, 2, 3, 4, 5]); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CNYb/0)
 
 ### Explicación del código:
 
@@ -115,7 +113,6 @@ function diffArray(arr1, arr2) {
  diffArray([1, 2, 3, 5], [1, 2, 3, 4, 5]); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CNYU/0)
 
 ### Explicación del código:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/dna-pairing/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/dna-pairing/index.md
@@ -85,7 +85,6 @@ Este problema no implica reorganizar la entrada en diferentes combinaciones o pe
     pairElement("GCG"); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLmz/0)
 
 ### Explicación del código:
 
@@ -118,7 +117,6 @@ Este problema no implica reorganizar la entrada en diferentes combinaciones o pe
   pairElement("GCG"); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/repls/ThoroughSphericalComputeranimation)
 
 ## Explicación del código:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/drop-it/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/drop-it/index.md
@@ -59,7 +59,6 @@ function dropElements(arr, func) {
  dropElements([1, 2, 3, 4], function(n) {return n >= 3;}) 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLna/0)
 
 ### Explicación del código:
 
@@ -82,7 +81,6 @@ function dropElements(arr, func) {
  dropElements([1, 2, 3, 4], function(n) {return n >= 3;}); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLnc/0)
 
 ### Explicación del código:
 
@@ -108,7 +106,6 @@ function dropElements(arr, func) {
  dropElements([1, 2, 3, 4], function(n) {return n >= 3;}); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLnf/0)
 
 ### Explicación del Código
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/everything-be-true/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/everything-be-true/index.md
@@ -61,7 +61,6 @@ function truthCheck(collection, pre) {
  truthCheck([{"user": "Tinky-Winky", "sex": "male"}, {"user": "Dipsy", "sex": "male"}, {"user": "Laa-Laa", "sex": "female"}, {"user": "Po", "sex": "female"}], "sex"); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLnw/0)
 
 ### Explicación del código:
 
@@ -88,7 +87,6 @@ function truthCheck(collection, pre) {
  truthCheck([{"user": "Tinky-Winky", "sex": "male"}, {"user": "Dipsy", "sex": "male"}, {"user": "Laa-Laa", "sex": "female"}, {"user": "Po", "sex": "female"}], "sex"); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLny/0)
 
 ### Explicación del código:
 
@@ -110,7 +108,6 @@ function truthCheck(collection, pre) {
  truthCheck([{"user": "Tinky-Winky", "sex": "male"}, {"user": "Dipsy", "sex": "male"}, {"user": "Laa-Laa", "sex": "female"}, {"user": "Po", "sex": "female"}], "sex"); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/E2u6/0)
 
 ### Explicación del código:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/make-a-person/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/make-a-person/index.md
@@ -90,7 +90,6 @@ var Person = function(firstAndLast) {
  bob.getFullName(); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLov/0)
 
 ### Explicación del código:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/map-the-debris/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/map-the-debris/index.md
@@ -70,7 +70,6 @@ function orbitalPeriod(arr) {
  orbitalPeriod([{name : "sputnik", avgAlt : 35873.5553}]); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLow/0)
 
 ### Explicación del código:
 
@@ -112,7 +111,6 @@ function orbitalPeriod(arr) {
  orbitalPeriod([{name : "sputnik", avgAlt : 35873.5553}]); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLoy/0)
 
 ### Explicación del código:
 
@@ -143,7 +141,6 @@ function orbitalPeriod(arr) {
  orbitalPeriod([{name : "sputnik", avgAlt : 35873.5553}]); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLoz/0)
 
 ### Explicación del código:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/missing-letters/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/missing-letters/index.md
@@ -61,7 +61,6 @@ function fearNotLetter(str) {
  fearNotLetter("abce"); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLnD/0)
 
 ### Explicación del código:
 
@@ -99,7 +98,6 @@ function fearNotLetter(str) {
  fearNotLetter("abce"); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLnE/0)
 
 ### Explicación del código:
 
@@ -148,7 +146,6 @@ function fearNotLetter(str) {
  fearNotLetter("abce"); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLnG/0)
 
 ### Explicación del código:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/pig-latin/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/pig-latin/index.md
@@ -68,7 +68,6 @@ function translatePigLatin(str) {
  translatePigLatin("consonant"); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLmt/0)
 
 ### Explicación del código:
 
@@ -102,7 +101,6 @@ function translatePigLatin(str) {
  translatePigLatin("consonant"); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLmw/0)
 
 ### Explicación del código:
 
@@ -148,7 +146,6 @@ function translatePigLatin(str) {
  translatePigLatin("consonant"); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLmv/0)
 
 ### Explicación del código:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/search-and-replace/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/search-and-replace/index.md
@@ -57,7 +57,6 @@ function myReplace(str, before, after) {
  myReplace("A quick brown fox jumped over the lazy dog", "jumped", "leaped"); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLmo/0)
 
 ### Explicación del código:
 
@@ -93,7 +92,6 @@ function myReplace(str, before, after) {
  myReplace("A quick brown fox jumped over the lazy dog", "jumped", "leaped"); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLmp/0)
 
 ### Explicación del código:
 
@@ -139,7 +137,6 @@ function myReplace(str, before, after) {
  myReplace("A quick brown fox jumped over the lazy dog", "jumped", "leaped"); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLmq/0)
 
 ### Explicación del código:
 
@@ -199,7 +196,6 @@ function myReplace(str, before, after) {
  } 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/@kr3at0/SearchAndReplace)
 
 ## ![:rotating_light:](https://forum.freecodecamp.com/images/emoji/emoji_one/rotating_light.png?v=3 ": rotando luz:") Solución alternativa de código avanzado 2:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/seek-and-destroy/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/seek-and-destroy/index.md
@@ -53,7 +53,6 @@ function destroyer(arr) {
  } 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLjU/95)
 
 ### Explicación del código:
 
@@ -85,7 +84,6 @@ function destroyer(arr) {
  } 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/Ck2m/0)
 
 ### Explicación del código:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/smallest-common-multiple/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/smallest-common-multiple/index.md
@@ -82,7 +82,6 @@ function smallestCommons(arr) {
  smallestCommons([1,5]); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLn2/0)
 
 ### Explicación del código:
 
@@ -139,7 +138,6 @@ function smallestCommons(arr) {
  smallestCommons([1,5]); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLn4/0)
 
 ### Explicación del código:
 
@@ -199,7 +197,6 @@ function smallestCommons(arr) {
  smallestCommons([1,5]); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/MR9P/latest)
 
 ### Explicación del código:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/sorted-union/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/sorted-union/index.md
@@ -65,7 +65,6 @@ function uniteUnique(arr1, arr2, arr3) {
  uniteUnique([1, 3, 2], [5, 2, 1, 4], [2, 1]); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLnM/0)
 
 ### Explicación del código:
 
@@ -122,7 +121,6 @@ function uniteUnique(arr1, arr2, arr3) {
  uniteUnique([1, 3, 2], [5, 2, 1, 4], [2, 1]); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLnO/0)
 
 ### Explicación del código:
 
@@ -155,7 +153,6 @@ function uniteUnique() {
  uniteUnique([1, 3, 2], [5, 2, 1, 4], [2, 1]); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLnN/0)
 
 ### Explicación del código:
 
@@ -185,7 +182,6 @@ function uniteUnique() {
  uniteUnique([1, 3, 2], [5, 2, 1, 4], [2, 1]); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CcWk/0)
 
 ### Explicación del código:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/spinal-tap-case/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/spinal-tap-case/index.md
@@ -56,7 +56,6 @@ function spinalCase(str) {
  spinalCase('This Is Spinal Tap'); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLnS/0)
 
 ### Explicación del código:
 
@@ -77,7 +76,6 @@ function spinalCase(str) {
  spinalCase('This Is Spinal Tap'); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLnT/0)
 
 ### Explicación del código:
 
@@ -99,7 +97,6 @@ function spinalCase(str) {
  } 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/EUZV)
 
 ### Explicación del código:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/steamroller/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/steamroller/index.md
@@ -62,7 +62,6 @@ function steamrollArray(arr) {
  steamrollArray([1, [2], [3, [[4]]]]); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLnh/0)
 
 ### Explicación del código:
 
@@ -87,7 +86,6 @@ function steamrollArray(arr) {
  flattenArray([1, [2], [3, [[4]]]]); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLni/0)
 
 ### Explicación del código:
 
@@ -121,7 +119,6 @@ function steamrollArray(arr) {
  } 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CpDy/4)
 
 ### Explicación del código:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/sum-all-numbers-in-a-range/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/sum-all-numbers-in-a-range/index.md
@@ -47,7 +47,6 @@ function sumAll(arr) {
  sumAll([1, 4]); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLm6/0)
 
 ### Explicación del código:
 
@@ -79,7 +78,6 @@ function sumAll(arr) {
  } 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLm7/0)
 
 ### Explicación del código:
 
@@ -109,7 +107,6 @@ function sumAll(arr) {
  sumAll([1, 4]); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLm8/0)
 
 ### Explicación del código:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/sum-all-odd-fibonacci-numbers/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/sum-all-odd-fibonacci-numbers/index.md
@@ -58,7 +58,6 @@ function sumFibs(num) {
  sumFibs(4); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLnV/0)
 
 ### Explicación del código:
 
@@ -100,7 +99,6 @@ function sumFibs(num) {
  sumFibs(4); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/repls/ImpassionedFineConnection)
 
 ### Explicación del código:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/sum-all-primes/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/sum-all-primes/index.md
@@ -73,7 +73,6 @@ function sumPrimes(num) {
  sumPrimes(10); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLnZ/0)
 
 ### Explicación del código:
 
@@ -122,7 +121,6 @@ function sumPrimes(num) {
  sumPrimes(10); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLn0/0)
 
 ### Explicación del código:
 
@@ -157,7 +155,6 @@ function sumPrimes(num) {
  sumPrimes(977); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/DoOo/3)
 
 ### Explicación del código:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/wherefore-art-thou/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/wherefore-art-thou/index.md
@@ -61,7 +61,6 @@ function whatIsInAName(collection, source) {
  whatIsInAName([{ first: "Romeo", last: "Montague" }, { first: "Mercutio", last: null }, { first: "Tybalt", last: "Capulet" }], { last: "Capulet" }); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLmh/0)
 
 ### Explicación del código:
 
@@ -95,7 +94,6 @@ function whatIsInAName(collection, source) {
  whatIsInAName([{ first: "Romeo", last: "Montague" }, { first: "Mercutio", last: null }, { first: "Tybalt", last: "Capulet" }], { last: "Capulet" }); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLmi/0)
 
 ### Explicación del código:
 
@@ -133,7 +131,6 @@ function whatIsInAName(collection, source) {
  whatIsInAName([{ first: "Romeo", last: "Montague" }, { first: "Mercutio", last: null }, { first: "Tybalt", last: "Capulet" }], { last: "Capulet" }); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLmj/0)
 
 ### Explicación del código:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/javascript-algorithms-and-data-structures-projects/caesars-cipher/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/javascript-algorithms-and-data-structures-projects/caesars-cipher/index.md
@@ -63,7 +63,6 @@ Deja cualquier cosa que no se interponga entre AZ como es.
     } 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLjU/38)
 
 ### Explicación del código:
 
@@ -152,7 +151,6 @@ ALPHA    KEY BASE             ROTATED    ROT13
 *   [Regex](https://forum.freecodecamp.com/t/regular-expressions-resources/15931)
 *   [Regex.test](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test)
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLjU/39)
 
 ## ![:rotating_light:](https://forum.freecodecamp.com/images/emoji/emoji_one/rotating_light.png?v=3 ": rotando luz:") Solución avanzada de código:
 ```

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/javascript-algorithms-and-data-structures-projects/cash-register/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/javascript-algorithms-and-data-structures-projects/cash-register/index.md
@@ -112,7 +112,6 @@ localeTitle: Caja registradora
  checkCashRegister(19.50, 20.00, [["PENNY", 1.01], ["NICKEL", 2.05], ["DIME", 3.10], ["QUARTER", 4.25], ["ONE", 90.00], ["FIVE", 55.00], ["TEN", 20.00], ["TWENTY", 60.00], ["ONE HUNDRED", 100.00]]); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/@scissorsneedfoo/cash-register-example)
 
 ### Explicación del código:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/javascript-algorithms-and-data-structures-projects/palindrome-checker/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/javascript-algorithms-and-data-structures-projects/palindrome-checker/index.md
@@ -52,7 +52,6 @@ Los métodos `Array.prototype.split` y `Array.prototype.join` pueden ser de util
     } 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLjU/2)
 
 ### Explicación del código:
 
@@ -85,7 +84,6 @@ Los métodos `Array.prototype.split` y `Array.prototype.join` pueden ser de util
     } 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLjU/3)
 
 ### Explicación del código:
 
@@ -134,7 +132,6 @@ Los métodos `Array.prototype.split` y `Array.prototype.join` pueden ser de util
     } 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLjU/4)
 
 ### Explicación del código:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/javascript-algorithms-and-data-structures-projects/roman-numeral-converter/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/javascript-algorithms-and-data-structures-projects/roman-numeral-converter/index.md
@@ -62,7 +62,6 @@ var convertToRoman = function(num) {
  convertToRoman(36); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLmf/0)
 
 ### Explicación del código:
 
@@ -128,7 +127,6 @@ function convertToRoman(num) {
  convertToRoman(97); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/C1YV)
 
 ### Explicación del código:
 
@@ -185,7 +183,6 @@ function convertToRoman(num) {
  convertToRoman(36); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/C1YV)
 
 ### Explicación del código:
 

--- a/guide/spanish/certifications/javascript-algorithms-and-data-structures/javascript-algorithms-and-data-structures-projects/telephone-number-validator/index.md
+++ b/guide/spanish/certifications/javascript-algorithms-and-data-structures/javascript-algorithms-and-data-structures-projects/telephone-number-validator/index.md
@@ -47,7 +47,6 @@ function telephoneCheck(str) {
  telephoneCheck("555-555-5555"); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLo9/0)
 
 ### Explicación del código:
 
@@ -75,7 +74,6 @@ function telephoneCheck(str) {
  telephoneCheck("555-555-5555"); 
 ```
 
-![:rocket:](https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":cohete:") [Ejecutar código](https://repl.it/CLoa/0)
 
 ### Explicación del código:
 


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Related to issue #35479

This PR removes all repl.it Run code links from the Spanish challenge related Guide articles.
