### PR TITLE
Update footer and about page: replace link to Medium with link to News

### DIFF
--- a/client/src/components/Footer/index.js
+++ b/client/src/components/Footer/index.js
@@ -80,7 +80,7 @@ function Footer() {
             <Link to='https://www.youtube.com/freecodecamp'>Youtube</Link>
             <Link to='https://podcast.freecodecamp.org'>Podcast</Link>
             <Link to='https://twitter.com/freecodecamp'>Twitter</Link>
-            <Link to='https://medium.freecodecamp.org'>Medium</Link>
+            <Link to='https://www.freecodecamp.org/news'>News</Link>
             <Link to='https://instagram.com/freecodecamp'>Instagram</Link>
           </Col>
         </Row>

--- a/client/src/components/Footer/index.js
+++ b/client/src/components/Footer/index.js
@@ -80,7 +80,6 @@ function Footer() {
             <Link to='https://www.youtube.com/freecodecamp'>Youtube</Link>
             <Link to='https://podcast.freecodecamp.org'>Podcast</Link>
             <Link to='https://twitter.com/freecodecamp'>Twitter</Link>
-            <Link to='https://www.freecodecamp.org/news'>News</Link>
             <Link to='https://instagram.com/freecodecamp'>Instagram</Link>
           </Col>
         </Row>

--- a/client/src/pages/about.js
+++ b/client/src/pages/about.js
@@ -53,8 +53,8 @@ const AboutPage = () => {
             <p>
               If you add up all the people who use our learning platform, read
               our{' '}
-              <Link to='https://medium.freecodecamp.org'>
-                Medium publication
+              <Link to='https://www.freecodecamp.org/news'>
+                news
               </Link>
               , watch our{' '}
               <Link to='https://youtube.com/freecodecamp'>YouTube channel</Link>

--- a/client/src/pages/about.js
+++ b/client/src/pages/about.js
@@ -53,8 +53,8 @@ const AboutPage = () => {
             <p>
               If you add up all the people who use our learning platform, read
               our{' '}
-              <Link to='https://medium.freecodecamp.org'>
-                Medium publication
+              <Link to='https://www.freecodecamp.org/news'>
+                News
               </Link>
               , watch our{' '}
               <Link to='https://youtube.com/freecodecamp'>YouTube channel</Link>


### PR DESCRIPTION
This minor change updates the link to Medium (https://medium.freecodecamp.org) with the link to News (https://www.freecodecamp.org/news).

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to #35397 