### PR TITLE
fix: regex to match require statement without .js extension

### DIFF
--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/clean-up-your-project-with-modules.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/clean-up-your-project-with-modules.english.md
@@ -36,7 +36,7 @@ Congratulations- you're at the end of this section of Advanced Node and Express 
 ```yml
 tests:
   - text: Modules present
-    testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /require.*("|').\/routes.js("|')/gi, 'You should have required your new files'); assert.match(data, /mongo.connect[^]*routes/gi, 'Your new modules should be called after your connection to the database'); }, xhr => { throw new Error(xhr.statusText); })
+    testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /require\s*\(('|")\.\/routes(\.js)?\1\)/gi, 'You should have required your new files'); assert.match(data, /mongo.connect[^]*routes/gi, 'Your new modules should be called after your connection to the database'); }, xhr => { throw new Error(xhr.statusText); })
 
 ```
 


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #36283

I fixed regexp to match files without `.js` extension.

Also, previous regexp matched strings like `require("./routes.js')` (with mixed quotation marks) or even stuff like `requirefoo"./routes.js'`

Now it should work properly