### PR TITLE
fix(client): Initialize test output in backend challenges

### DIFF
--- a/client/src/templates/Challenges/backend/Show.js
+++ b/client/src/templates/Challenges/backend/Show.js
@@ -10,6 +10,7 @@ import {
   challengeMounted,
   challengeTestsSelector,
   consoleOutputSelector,
+  initConsole,
   initTests,
   updateBackendFormValues,
   updateChallengeMeta,
@@ -44,6 +45,7 @@ const propTypes = {
   description: PropTypes.string,
   executeChallenge: PropTypes.func.isRequired,
   id: PropTypes.string,
+  initConsole: PropTypes.func.isRequired,
   initTests: PropTypes.func.isRequired,
   isSignedIn: PropTypes.bool,
   output: PropTypes.string,
@@ -71,6 +73,7 @@ const mapStateToProps = createSelector(
 const mapDispatchToActions = {
   challengeMounted,
   executeChallenge,
+  initConsole,
   initTests,
   updateBackendFormValues,
   updateChallengeMeta,
@@ -96,6 +99,7 @@ export class BackEnd extends Component {
   componentDidMount() {
     const {
       challengeMounted,
+      initConsole,
       initTests,
       updateChallengeMeta,
       data: {
@@ -106,6 +110,7 @@ export class BackEnd extends Component {
       },
       pageContext: { challengeMeta }
     } = this.props;
+    initConsole('');
     initTests(tests);
     updateChallengeMeta({ ...challengeMeta, challengeType });
     challengeMounted(challengeMeta.id);
@@ -128,6 +133,7 @@ export class BackEnd extends Component {
     } = prevProps;
     const {
       challengeMounted,
+      initConsole,
       initTests,
       updateChallengeMeta,
       data: {
@@ -140,6 +146,7 @@ export class BackEnd extends Component {
       pageContext: { challengeMeta }
     } = this.props;
     if (prevTitle !== currentTitle) {
+      initConsole('');
       initTests(tests);
       updateChallengeMeta({ ...challengeMeta, challengeType });
       challengeMounted(challengeMeta.id);

--- a/client/src/templates/Challenges/backend/Show.js
+++ b/client/src/templates/Challenges/backend/Show.js
@@ -97,23 +97,7 @@ export class BackEnd extends Component {
   }
 
   componentDidMount() {
-    const {
-      challengeMounted,
-      initConsole,
-      initTests,
-      updateChallengeMeta,
-      data: {
-        challengeNode: {
-          fields: { tests },
-          challengeType
-        }
-      },
-      pageContext: { challengeMeta }
-    } = this.props;
-    initConsole('');
-    initTests(tests);
-    updateChallengeMeta({ ...challengeMeta, challengeType });
-    challengeMounted(challengeMeta.id);
+    this.initializeComponent();
     window.addEventListener('resize', this.updateDimensions);
   }
 
@@ -132,25 +116,33 @@ export class BackEnd extends Component {
       }
     } = prevProps;
     const {
+      data: {
+        challengeNode: { title: currentTitle }
+      }
+    } = this.props;
+    if (prevTitle !== currentTitle) {
+      this.initializeComponent();
+    }
+  }
+
+  initializeComponent() {
+    const {
       challengeMounted,
       initConsole,
       initTests,
       updateChallengeMeta,
       data: {
         challengeNode: {
-          title: currentTitle,
           fields: { tests },
           challengeType
         }
       },
       pageContext: { challengeMeta }
     } = this.props;
-    if (prevTitle !== currentTitle) {
-      initConsole('');
-      initTests(tests);
-      updateChallengeMeta({ ...challengeMeta, challengeType });
-      challengeMounted(challengeMeta.id);
-    }
+    initConsole('');
+    initTests(tests);
+    updateChallengeMeta({ ...challengeMeta, challengeType });
+    challengeMounted(challengeMeta.id);
   }
 
   handleSubmit(values) {

--- a/client/src/templates/Challenges/classic/Show.js
+++ b/client/src/templates/Challenges/classic/Show.js
@@ -28,6 +28,7 @@ import {
   createFiles,
   challengeFilesSelector,
   challengeTestsSelector,
+  initConsole,
   initTests,
   updateChallengeMeta,
   challengeMounted,
@@ -47,6 +48,7 @@ const mapDispatchToProps = dispatch =>
   bindActionCreators(
     {
       createFiles,
+      initConsole,
       initTests,
       updateChallengeMeta,
       challengeMounted
@@ -63,6 +65,7 @@ const propTypes = {
   files: PropTypes.shape({
     key: PropTypes.string
   }),
+  initConsole: PropTypes.func.isRequired,
   initTests: PropTypes.func.isRequired,
   output: PropTypes.string,
   pageContext: PropTypes.shape({
@@ -106,6 +109,7 @@ class ShowClassic extends Component {
     const {
       challengeMounted,
       createFiles,
+      initConsole,
       initTests,
       updateChallengeMeta,
       data: {
@@ -118,6 +122,7 @@ class ShowClassic extends Component {
       },
       pageContext: { challengeMeta }
     } = this.props;
+    initConsole('');
     createFiles(files);
     initTests(tests);
     updateChallengeMeta({ ...challengeMeta, title, challengeType });
@@ -133,6 +138,7 @@ class ShowClassic extends Component {
     const {
       challengeMounted,
       createFiles,
+      initConsole,
       initTests,
       updateChallengeMeta,
       data: {
@@ -146,6 +152,7 @@ class ShowClassic extends Component {
       pageContext: { challengeMeta }
     } = this.props;
     if (prevTitle !== currentTitle) {
+      initConsole('');
       createFiles(files);
       initTests(tests);
       updateChallengeMeta({

--- a/client/src/templates/Challenges/classic/Show.js
+++ b/client/src/templates/Challenges/classic/Show.js
@@ -107,6 +107,31 @@ class ShowClassic extends Component {
 
   componentDidMount() {
     const {
+      data: {
+        challengeNode: { title }
+      }
+    } = this.props;
+    this.initializeComponent(title);
+  }
+
+  componentDidUpdate(prevProps) {
+    const {
+      data: {
+        challengeNode: { title: prevTitle }
+      }
+    } = prevProps;
+    const {
+      data: {
+        challengeNode: { title: currentTitle }
+      }
+    } = this.props;
+    if (prevTitle !== currentTitle) {
+      this.initializeComponent(currentTitle);
+    }
+  }
+
+  initializeComponent(title) {
+    const {
       challengeMounted,
       createFiles,
       initConsole,
@@ -115,7 +140,6 @@ class ShowClassic extends Component {
       data: {
         challengeNode: {
           files,
-          title,
           fields: { tests },
           challengeType
         }
@@ -127,41 +151,6 @@ class ShowClassic extends Component {
     initTests(tests);
     updateChallengeMeta({ ...challengeMeta, title, challengeType });
     challengeMounted(challengeMeta.id);
-  }
-
-  componentDidUpdate(prevProps) {
-    const {
-      data: {
-        challengeNode: { title: prevTitle }
-      }
-    } = prevProps;
-    const {
-      challengeMounted,
-      createFiles,
-      initConsole,
-      initTests,
-      updateChallengeMeta,
-      data: {
-        challengeNode: {
-          files,
-          title: currentTitle,
-          fields: { tests },
-          challengeType
-        }
-      },
-      pageContext: { challengeMeta }
-    } = this.props;
-    if (prevTitle !== currentTitle) {
-      initConsole('');
-      createFiles(files);
-      initTests(tests);
-      updateChallengeMeta({
-        ...challengeMeta,
-        title: currentTitle,
-        challengeType
-      });
-      challengeMounted(challengeMeta.id);
-    }
   }
 
   componentWillUnmount() {

--- a/client/src/templates/Challenges/components/Side-Panel.js
+++ b/client/src/templates/Challenges/components/Side-Panel.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 
 import ChallengeTitle from './Challenge-Title';
 import ChallengeDescription from './Challenge-Description';
@@ -9,7 +8,7 @@ import ToolPanel from './Tool-Panel';
 import TestSuite from './Test-Suite';
 import Spacer from '../../../components/helpers/Spacer';
 
-import { initConsole, challengeTestsSelector } from '../redux';
+import { challengeTestsSelector } from '../redux';
 import { createSelector } from 'reselect';
 import './side-panel.css';
 
@@ -20,20 +19,11 @@ const mapStateToProps = createSelector(
   })
 );
 
-const mapDispatchToProps = dispatch =>
-  bindActionCreators(
-    {
-      initConsole
-    },
-    dispatch
-  );
-
 const MathJax = global.MathJax;
 
 const propTypes = {
   description: PropTypes.string,
   guideUrl: PropTypes.string,
-  initConsole: PropTypes.func.isRequired,
   instructions: PropTypes.string,
   section: PropTypes.string,
   showToolPanel: PropTypes.bool,
@@ -56,7 +46,6 @@ export class SidePanel extends Component {
       MathJax.Hub,
       document.querySelector('.rosetta-code')
     ]);
-    this.props.initConsole('');
   }
 
   render() {
@@ -91,7 +80,4 @@ export class SidePanel extends Component {
 SidePanel.displayName = 'SidePanel';
 SidePanel.propTypes = propTypes;
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(SidePanel);
+export default connect(mapStateToProps)(SidePanel);


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The test output is not initialized for backend challenges as it happens in `SidePanel` which they don't use.  As a result, the last test output appears when you start a backend challenge:

![ConsoleInit](https://user-images.githubusercontent.com/15801806/59836896-a239b800-934c-11e9-83cf-e0c4b18aeb9b.gif)

The first commit fixes this, putting the initialization in the right places.  The second commit just cuts down on code duplication.  

One question I had was should `title` be passed to `updateChallengeMeta`?  Presumably, but I wasn't sure, so I left it alone for now.