### PR TITLE
fix(forum): workaround fix for URI length error - help button

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,6 @@
   "extends": ["@freecodecamp/eslint-config", "prettier", "prettier/react"],
   "plugins": ["prettier"],
   "rules": {
-    "import/no-unresolved": "off",
     "max-len": [
       "error",
       { "code": 80, "ignoreUrls": true, "ignoreTemplateLiterals": true }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,6 +3,7 @@
   "extends": ["@freecodecamp/eslint-config", "prettier", "prettier/react"],
   "plugins": ["prettier"],
   "rules": {
+    "import/no-unresolved": "off",
     "max-len": [
       "error",
       { "code": 80, "ignoreUrls": true, "ignoreTemplateLiterals": true }

--- a/client/src/templates/Challenges/redux/create-question-epic.js
+++ b/client/src/templates/Challenges/redux/create-question-epic.js
@@ -44,28 +44,63 @@ function createQuestionEpic(action$, state$, { window }) {
         navigator: { userAgent },
         location: { href }
       } = window;
+
       const textMessage = [
         "**Tell us what's happening:**\n\n\n\n",
         '**Your code so far**\n',
         filesToMarkdown(files),
         '**Your browser information:**\n\n',
-        'User Agent is: `',
+        'User Agent is: <code>',
         userAgent,
-        '`.\n\n',
+        '</code>.\n\n',
         '**Challenge:**\n',
         challengeTitle,
         '\n**Link to the challenge:**\n',
         href
       ].join('');
-      window.open(
-        'https://forum.freecodecamp.org/new-topic' +
-          '?category=' +
-          window.encodeURIComponent(helpCategory[challengeType] || 'Help') +
-          '&title=' +
-          '&body=' +
-          window.encodeURIComponent(textMessage),
-        '_blank'
+
+      const altTextMessage = [
+        "**Tell us what's happening:**\n\n\n\n",
+        '**Your code so far**\n\n',
+        'WARNING\n\n',
+        'The challenge seed code and/or your solution exceeded the maximum',
+        ' length we can port over from the challenge.\n\n',
+        'You will need to take an additional step here so the code you wrote',
+        'presents in an easy to read format.\n\n',
+        'Please copy/paste all the editor code showing in the challenge ',
+        'from where you just linked.\n\n',
+        '```js\n\n',
+        'Replace these two sentences with your copied code. \n',
+        'Please leave the ```js line above and the ``` line below, ',
+        'because they allow your code to properly format in the post.\n\n',
+        '```\n\n',
+        '**Your browser information:**\n\n',
+        'User Agent is: <code>',
+        userAgent,
+        '</code>.\n\n',
+        '**Challenge:**\n',
+        challengeTitle,
+        '\n\n**Link to the challenge:**\n',
+        href
+      ].join('');
+
+      const category = window.encodeURIComponent(
+        helpCategory[challengeType] || 'Help'
       );
+
+      const studentCode = window.encodeURIComponent(textMessage);
+      const altStudentCode = window.encodeURIComponent(altTextMessage);
+
+      const defaultURI = `https://forum.freecodecamp.org/new-topic?category=${category}
+                          &title=&body=${studentCode}`;
+      const altURI = `https://forum.freecodecamp.org/new-topic?category=${category}
+      &title=&body=${altStudentCode}`;
+
+      if (defaultURI.length < 8000) {
+        window.open(defaultURI, '_blank');
+      } else {
+        window.open(altURI, '_blank');
+      }
     }),
     mapTo(closeModal('help'))
   );


### PR DESCRIPTION
The error is occurring because the user's current code is being sent as an encoded query parameter in a get request to the forum.  The standard default character limit for URI's in most browsers is 2083...I tested it out with a test URI and discovered that the limit set by the forum's backend is currently 8,138....so it looks like this has been an ongoing problem, and the character limit has been raised before as a hacky workaround, but this info should be sent via post request.  I fixed this issue by constructing a default URI and an alternative URI with the alternate data suggested by @RandellDawson in the following thread. 

If the default URI has a length of over 8,000 characters, the alternative URI is used to get to the forum.

I also added a line to eslintrc.json to allow commiting with 'unable to resolve path to module' linter warning...I was unable to commit because the linter couldn't resolve the import statement on line 1 (which is obviously needed).

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #18005 
