### PR TITLE
fix(challenge): rename challenge, change fields to properties, fix test

### DIFF
--- a/curriculum/challenges/_meta/es6/meta.json
+++ b/curriculum/challenges/_meta/es6/meta.json
@@ -78,7 +78,7 @@
     ],
     [
       "587d7b8a367417b2b2512b4f",
-      "Write Concise Object Literal Declarations Using Simple Fields"
+      "Write Concise Object Literal Declarations Using Object Property Shorthand"
     ],
     [
       "587d7b8b367417b2b2512b50",

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/write-concise-object-literal-declarations-using-object-property-shorthand.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/write-concise-object-literal-declarations-using-object-property-shorthand.md
@@ -1,6 +1,6 @@
 ---
 id: 587d7b8a367417b2b2512b4f
-title: Write Concise Object Literal Declarations Using Simple Fields
+title: Write Concise Object Literal Declarations Using Object Property Shorthand
 challengeType: 1
 ---
 
@@ -16,7 +16,7 @@ const getMousePosition = (x, y) => ({
 });
 ```
 
-<code>getMousePosition</code> is a simple function that returns an object containing two fields.
+<code>getMousePosition</code> is a simple function that returns an object containing two properties.
 ES6 provides the syntactic sugar to eliminate the redundancy of having to write <code>x: x</code>. You can simply write <code>x</code> once, and it will be converted to<code>x: x</code> (or something equivalent) under the hood.
 Here is the same function from above rewritten to use this new syntax:
 
@@ -28,7 +28,7 @@ const getMousePosition = (x, y) => ({ x, y });
 
 ## Instructions
 <section id='instructions'>
-Use simple fields with object literals to create and return a <code>Person</code> object with <code>name</code>, <code>age</code> and <code>gender</code> properties.
+Use object property shorthand with object literals to create and return a <code>Person</code> object with <code>name</code>, <code>age</code> and <code>gender</code> properties.
 </section>
 
 ## Tests
@@ -37,9 +37,9 @@ Use simple fields with object literals to create and return a <code>Person</code
 ```yml
 tests:
   - text: 'The output is <code>{name: "Zodiac Hasbro", age: 56, gender: "male"}</code>.'
-    testString: 'assert((() => {const res={name:"Zodiac Hasbro",age:56,gender:"male"}; const person=createPerson("Zodiac Hasbro", 56, "male"); return Object.keys(person).every(k => person[k] === res[k]);})(), ''The output is <code>{name: "Zodiac Hasbro", age: 56, gender: "male"}</code>.'');'
+    testString: assert((() => {const res={name:"Zodiac Hasbro",age:56,gender:"male"}; const person=createPerson("Zodiac Hasbro", 56, "male"); return Boolean(person) && JSON.stringify(res) === JSON.stringify(person);})());
   - text: No <code>key:value</code> were used.
-    testString: getUserInput => assert(!getUserInput('index').match(/:/g), 'No <code>key:value</code> were used.');
+    testString: getUserInput => assert(!getUserInput('index').match(/:/g));
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/write-concise-object-literal-declarations-using-object-property-shorthand.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/write-concise-object-literal-declarations-using-object-property-shorthand.md
@@ -36,8 +36,8 @@ Use object property shorthand with object literals to create and return a <code>
 
 ```yml
 tests:
-  - text: 'The output is <code>{name: "Zodiac Hasbro", age: 56, gender: "male"}</code>.'
-    testString: assert((() => {const res={name:"Zodiac Hasbro",age:56,gender:"male"}; const person=createPerson("Zodiac Hasbro", 56, "male"); return Boolean(person) && JSON.stringify(res) === JSON.stringify(person);})());
+  - text: '<code>createPerson("Zodiac Hasbro", 56, "male")</code> should return <code>{name: "Zodiac Hasbro", age: 56, gender: "male"}</code>.'
+    testString: assert.deepEqual({name:"Zodiac Hasbro",age:56,gender:"male"}, createPerson("Zodiac Hasbro", 56, "male"));
   - text: No <code>key:value</code> were used.
     testString: getUserInput => assert(!getUserInput('index').match(/:/g));
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/write-concise-object-literal-declarations-using-object-property-shorthand.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/write-concise-object-literal-declarations-using-object-property-shorthand.md
@@ -38,7 +38,7 @@ Use object property shorthand with object literals to create and return a <code>
 tests:
   - text: '<code>createPerson("Zodiac Hasbro", 56, "male")</code> should return <code>{name: "Zodiac Hasbro", age: 56, gender: "male"}</code>.'
     testString: assert.deepEqual({name:"Zodiac Hasbro",age:56,gender:"male"}, createPerson("Zodiac Hasbro", 56, "male"));
-  - text: No <code>key:value</code> were used.
+  - text: Your code should not use <code>key:value</code>.
     testString: getUserInput => assert(!getUserInput('index').match(/:/g));
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/write-concise-object-literal-declarations-using-object-property-shorthand.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/write-concise-object-literal-declarations-using-object-property-shorthand.md
@@ -28,7 +28,7 @@ const getMousePosition = (x, y) => ({ x, y });
 
 ## Instructions
 <section id='instructions'>
-Use object property shorthand with object literals to create and return a <code>Person</code> object with <code>name</code>, <code>age</code> and <code>gender</code> properties.
+Use object property shorthand with object literals to create and return an object with <code>name</code>, <code>age</code> and <code>gender</code> properties.
 </section>
 
 ## Tests


### PR DESCRIPTION
1. The current challenge (on master) lets you pass using an empty object.

2. Rename the challenge to:

> Write Concise Object Literal Declarations Using Object Property Shorthand

3. Switch out the term fields for properties.

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/36325
