### PR TITLE
fix(client): Use current challenge-md-parser

### DIFF
--- a/curriculum/package.json
+++ b/curriculum/package.json
@@ -30,7 +30,7 @@
     "@commitlint/cli": "^7.0.0",
     "@commitlint/config-conventional": "^7.0.1",
     "@commitlint/travis-cli": "^7.0.0",
-    "@freecodecamp/challenge-md-parser": "^1.0.0",
+    "@freecodecamp/challenge-md-parser": "^0.0.1",
     "@semantic-release/changelog": "^2.0.2",
     "@semantic-release/git": "^5.0.0",
     "babel-cli": "^6.3.17",


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

"@freecodecamp/challenge-md-parser": "^1.0.0", was fetching the published version, which is 9 months old, so this gets the local version instead.

Alternatively, we could update the parser to "1.0.1" - that might be better, but it was recently downgraded, so I wasn't sure!

Closes #36324
