### PR TITLE
Add link to boilerplate Glitch file

### DIFF
--- a/curriculum/challenges/english/05-apis-and-microservices/basic-node-and-express/meet-the-node-console.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/basic-node-and-express/meet-the-node-console.english.md
@@ -14,7 +14,7 @@ We recommend to keep the log panel open while working at these challenges. By re
 ## Instructions
 <section id='instructions'>
   
-  * Start a new project on Glitch using [this link](https://glitch.com/#!/import/github/freeCodeCamp/boilerplate-express/)  
+* If you have not already done so, please read the instructions in [the introduction](/learn/apis-and-microservices/basic-node-and-express/) and start a new project on Glitch using [this link](https://glitch.com/#!/import/github/freeCodeCamp/boilerplate-express/).
   
   * Modify the <code>myApp.js</code> file to log "Hello World" to the console. 
   

--- a/curriculum/challenges/english/05-apis-and-microservices/basic-node-and-express/meet-the-node-console.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/basic-node-and-express/meet-the-node-console.english.md
@@ -14,9 +14,9 @@ We recommend to keep the log panel open while working at these challenges. By re
 ## Instructions
 <section id='instructions'>
 
-* If you have not already done so, please read the instructions in [the introduction](/learn/apis-and-microservices/basic-node-and-express/) and start a new project on Glitch using [this link](https://glitch.com/#!/import/github/freeCodeCamp/boilerplate-express/).
+If you have not already done so, please read the instructions in [the introduction](/learn/apis-and-microservices/basic-node-and-express/) and start a new project on Glitch using [this link](https://glitch.com/#!/import/github/freeCodeCamp/boilerplate-express/).
   
-* Modify the <code>myApp.js</code> file to log "Hello World" to the console. 
+Modify the <code>myApp.js</code> file to log "Hello World" to the console. 
 
 </section>
 

--- a/curriculum/challenges/english/05-apis-and-microservices/basic-node-and-express/meet-the-node-console.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/basic-node-and-express/meet-the-node-console.english.md
@@ -16,7 +16,7 @@ We recommend to keep the log panel open while working at these challenges. By re
   
 * If you have not already done so, please read the instructions in [the introduction](/learn/apis-and-microservices/basic-node-and-express/) and start a new project on Glitch using [this link](https://glitch.com/#!/import/github/freeCodeCamp/boilerplate-express/).
   
-  * Modify the <code>myApp.js</code> file to log "Hello World" to the console. 
+* Modify the <code>myApp.js</code> file to log "Hello World" to the console. 
   
 </section>
 

--- a/curriculum/challenges/english/05-apis-and-microservices/basic-node-and-express/meet-the-node-console.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/basic-node-and-express/meet-the-node-console.english.md
@@ -16,7 +16,6 @@ We recommend to keep the log panel open while working at these challenges. By re
 * If you have not already done so, please read the instructions in [the introduction](/learn/apis-and-microservices/basic-node-and-express/) and start a new project on Glitch using [this link](https://glitch.com/#!/import/github/freeCodeCamp/boilerplate-express/).
   
 * Modify the <code>myApp.js</code> file to log "Hello World" to the console. 
-  
 </section>
 
 ## Tests

--- a/curriculum/challenges/english/05-apis-and-microservices/basic-node-and-express/meet-the-node-console.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/basic-node-and-express/meet-the-node-console.english.md
@@ -17,6 +17,7 @@ We recommend to keep the log panel open while working at these challenges. By re
 * If you have not already done so, please read the instructions in [the introduction](/learn/apis-and-microservices/basic-node-and-express/) and start a new project on Glitch using [this link](https://glitch.com/#!/import/github/freeCodeCamp/boilerplate-express/).
   
 * Modify the <code>myApp.js</code> file to log "Hello World" to the console. 
+
 </section>
 
 ## Tests

--- a/curriculum/challenges/english/05-apis-and-microservices/basic-node-and-express/meet-the-node-console.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/basic-node-and-express/meet-the-node-console.english.md
@@ -13,7 +13,11 @@ We recommend to keep the log panel open while working at these challenges. By re
 
 ## Instructions
 <section id='instructions'>
-Modify the <code>myApp.js</code> file to log "Hello World" to the console. 
+  
+  * Start a new project on Glitch using [this link](https://glitch.com/#!/import/github/freeCodeCamp/boilerplate-express/)  
+  
+  * Modify the <code>myApp.js</code> file to log "Hello World" to the console. 
+  
 </section>
 
 ## Tests

--- a/curriculum/challenges/english/05-apis-and-microservices/basic-node-and-express/meet-the-node-console.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/basic-node-and-express/meet-the-node-console.english.md
@@ -13,6 +13,7 @@ We recommend to keep the log panel open while working at these challenges. By re
 
 ## Instructions
 <section id='instructions'>
+
 * If you have not already done so, please read the instructions in [the introduction](/learn/apis-and-microservices/basic-node-and-express/) and start a new project on Glitch using [this link](https://glitch.com/#!/import/github/freeCodeCamp/boilerplate-express/).
   
 * Modify the <code>myApp.js</code> file to log "Hello World" to the console. 

--- a/curriculum/challenges/english/05-apis-and-microservices/basic-node-and-express/meet-the-node-console.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/basic-node-and-express/meet-the-node-console.english.md
@@ -13,7 +13,6 @@ We recommend to keep the log panel open while working at these challenges. By re
 
 ## Instructions
 <section id='instructions'>
-  
 * If you have not already done so, please read the instructions in [the introduction](/learn/apis-and-microservices/basic-node-and-express/) and start a new project on Glitch using [this link](https://glitch.com/#!/import/github/freeCodeCamp/boilerplate-express/).
   
 * Modify the <code>myApp.js</code> file to log "Hello World" to the console. 


### PR DESCRIPTION
The boilerplate link is hard to see in the previous "introduction" page. I was using the old Glitch project link, and was confused.

When I googled for a solution, it was clear others were also confused. I believe this additional instruction will help many people.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x ] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [ x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ x] My pull request targets the `master` branch of freeCodeCamp.
- [x ] None of my changes are plagiarized from another source without proper attribution.
- [x ] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [ x] My changes do not use shortened URLs or affiliate links.