### PR TITLE
fix(tools): Use polling to reliably watch challenges

### DIFF
--- a/client/plugins/fcc-source-challenges/gatsby-node.js
+++ b/client/plugins/fcc-source-challenges/gatsby-node.js
@@ -28,7 +28,8 @@ exports.sourceNodes = function sourceChallengesSourceNodes(
   const { createNode } = actions;
   const watcher = chokidar.watch(curriculumPath, {
     ignored: /(^|[\/\\])\../,
-    persistent: true
+    persistent: true,
+    usePolling: true
   });
 
   watcher.on('ready', sourceAndCreateNodes).on('change', filePath =>


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Without using polling I found that changes to challenge markdown were not always triggering Gatsby's hot-reload, but turning it on seems to fix that.
