### PR TITLE
fix(guide): replace url with empty array in the Guide solutions for No Repeats Please challenge

### DIFF
--- a/guide/english/certifications/coding-interview-prep/algorithms/no-repeats-please/index.md
+++ b/guide/english/certifications/coding-interview-prep/algorithms/no-repeats-please/index.md
@@ -97,11 +97,11 @@ A way to visualize this is by considering a tree that starts with the first char
     function permAlone(str) {
 
       // Create a regex to match repeated consecutive characters.
-      var regex = /(.)\1+/g;
+      var regex = /(.)\1+/;
 
       // Split the string into an array of characters.
       var arr = str.split('');
-      var permutations = <a href='https://forum.freecodecamp.com/images/emoji/emoji_one/rocket.png?v=3 ":rocket:"' target='_blank' rel='nofollow'>];
+      var permutations = [];
       var tmp;
 
       // Return 0 if str contains same character.


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Closes #36377

* Replaced the url with an array
* Removed the unnecessary `g` flag in regex
