### PR TITLE
fix: Remove non-functional css

### DIFF
--- a/client/src/pages/certification.css
+++ b/client/src/pages/certification.css
@@ -116,16 +116,6 @@
   background-color: #efefef;
 }
 
-/*adds vertical alignment when the height is bigger than required to display everything*/
-@media screen and (min-height: 700px) {
-  .certification-namespace body {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    height: 100vh;
-  }
-}
-
 /*mobile media queries*/
 @media screen and (max-width: 992px) {
   .certification-namespace header {


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to  https://github.com/freeCodeCamp/freeCodeCamp/issues/36382

This css was never used, since elements with `.certification-namespace`  are descendants of `body` not the other way around.  Also, if present, it creates the problems discussed in https://github.com/freeCodeCamp/freeCodeCamp/issues/36382