### PR TITLE
fixed grammar: removed middlewares

### DIFF
--- a/curriculum/challenges/english/05-apis-and-microservices/basic-node-and-express/serve-static-assets.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/basic-node-and-express/serve-static-assets.english.md
@@ -6,7 +6,7 @@ challengeType: 2
 
 ## Description
 <section id='description'>
-An HTML server usually has one or more directories that are accessible by the user. You can place there the static assets needed by your application (stylesheets, scripts, images). In Express, you can put in place this functionality using the middleware <code>express.static(path)</code>, where the `<code>path</code> parameter is the absolute path of the folder containing the assets. If you don’t know what middleware is... don’t worry, we will discuss in detail later. Basically, middleware functions are functions that intercept route handlers, adding some kind of information. A middleware needs to be mounted using the method <code>app.use(path, middlewareFunction)</code>. The first <code>path</code> argument is optional. If you don’t pass it, the middleware will be executed for all requests.
+An HTML server usually has one or more directories that are accessible by the user. You can place there the static assets needed by your application (stylesheets, scripts, images). In Express, you can put in place this functionality using the middleware <code>express.static(path)</code>, where the <code>path</code> parameter is the absolute path of the folder containing the assets. If you don’t know what middleware is... don’t worry, we will discuss in detail later. Basically, middleware are functions that intercept route handlers, adding some kind of information. A middleware needs to be mounted using the method <code>app.use(path, middlewareFunction)</code>. The first <code>path</code> argument is optional. If you don’t pass it, the middleware will be executed for all requests.
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/05-apis-and-microservices/basic-node-and-express/serve-static-assets.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/basic-node-and-express/serve-static-assets.english.md
@@ -6,7 +6,7 @@ challengeType: 2
 
 ## Description
 <section id='description'>
-An HTML server usually has one or more directories that are accessible by the user. You can place there the static assets needed by your application (stylesheets, scripts, images). In Express, you can put in place this functionality using the middleware <code>express.static(path)</code>, where the `<code>path</code> parameter is the absolute path of the folder containing the assets. If you don’t know what middleware is... don’t worry, we will discuss in detail later. Basically, middlewares are functions that intercept route handlers, adding some kind of information. A middleware needs to be mounted using the method <code>app.use(path, middlewareFunction)</code>. The first <code>path</code> argument is optional. If you don’t pass it, the middleware will be executed for all requests.
+An HTML server usually has one or more directories that are accessible by the user. You can place there the static assets needed by your application (stylesheets, scripts, images). In Express, you can put in place this functionality using the middleware <code>express.static(path)</code>, where the `<code>path</code> parameter is the absolute path of the folder containing the assets. If you don’t know what middleware is... don’t worry, we will discuss in detail later. Basically, middleware functions are functions that intercept route handlers, adding some kind of information. A middleware needs to be mounted using the method <code>app.use(path, middlewareFunction)</code>. The first <code>path</code> argument is optional. If you don’t pass it, the middleware will be executed for all requests.
 </section>
 
 ## Instructions


### PR DESCRIPTION
Replaced **middlewares** to **middleware functions**.  Middleware is an uncountable noun, just like *software*.  No such word as *softwares*

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x ] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.


