### PR TITLE
PT-BR: Fixing wrongly used words at PHP While guide

### DIFF
--- a/guide/portuguese/php/while/index.md
+++ b/guide/portuguese/php/while/index.md
@@ -4,7 +4,7 @@ localeTitle: While Loop
 ---
 ## While Loops
 
-Um `while` ciclo executa instruções dentro do ciclo enquanto que a condição for satisfeita laçadas.
+A função `while` executa instruções dentro do ciclo enquanto sua condição for satisfeita.
 
 ### Sintaxe:
 
@@ -16,7 +16,7 @@ $x = 0;
  } 
 ```
 
-**Nota:** O código do bloco deve ter uma declaração que altere ou aumente a condição. Caso contrário, um loop infinito poderia resultar.
+**Nota:** O código do bloco deve ter uma declaração que altere ou aumente a condição. Caso contrário, um loop infinito poderia ocorrer.
 
 ### Mais Informações:
 


### PR DESCRIPTION
* Changing the use of wrongly translated words to the correct words

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.