### PR TITLE
fix(curriculum): Remove unnecessary assert message argument from English challenges JavaScript Algorithms and Data Structures - 04

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/add-methods-after-inheritance.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/add-methods-after-inheritance.english.md
@@ -48,15 +48,15 @@ Add all necessary code so the <code>Dog</code> object inherits from <code>Animal
 ```yml
 tests:
   - text: <code>Animal</code> should not respond to the <code>bark()</code> method.
-    testString: assert(typeof Animal.prototype.bark == "undefined", '<code>Animal</code> should not respond to the <code>bark()</code> method.');
+    testString: assert(typeof Animal.prototype.bark == "undefined");
   - text: <code>Dog</code> should inherit the <code>eat()</code> method from <code>Animal</code>.
-    testString: assert(typeof Dog.prototype.eat == "function", '<code>Dog</code> should inherit the <code>eat()</code> method from <code>Animal</code>.');
+    testString: assert(typeof Dog.prototype.eat == "function");
   - text: <code>Dog</code> should have the <code>bark()</code> method as an <code>own</code> property.
-    testString: assert(Dog.prototype.hasOwnProperty('bark'), '<code>Dog</code> should have the <code>bark()</code> method as an <code>own</code> property.');
+    testString: assert(Dog.prototype.hasOwnProperty('bark'));
   - text: <code>beagle</code> should be an <code>instanceof</code> <code>Animal</code>.
-    testString: assert(beagle instanceof Animal, '<code>beagle</code> should be an <code>instanceof</code> <code>Animal</code>.');
+    testString: assert(beagle instanceof Animal);
   - text: The constructor for <code>beagle</code> should be set to <code>Dog</code>.
-    testString: assert(beagle.constructor === Dog, 'The constructor for <code>beagle</code> should be set to <code>Dog</code>.');
+    testString: assert(beagle.constructor === Dog);
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/change-the-prototype-to-a-new-object.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/change-the-prototype-to-a-new-object.english.md
@@ -51,13 +51,13 @@ Add the property <code>numLegs</code> and the two methods <code>eat()</code> and
 ```yml
 tests:
   - text: <code>Dog.prototype</code> should be set to a new object.
-    testString: assert((/Dog\.prototype\s*?=\s*?{/).test(code), '<code>Dog.prototype</code> should be set to a new object.');
+    testString: assert((/Dog\.prototype\s*?=\s*?{/).test(code));
   - text: <code>Dog.prototype</code> should have the property <code>numLegs</code>.
-    testString: assert(Dog.prototype.numLegs !== undefined, '<code>Dog.prototype</code> should have the property <code>numLegs</code>.');
+    testString: assert(Dog.prototype.numLegs !== undefined);
   - text: <code>Dog.prototype</code> should have the method <code>eat()</code>.
-    testString: assert(typeof Dog.prototype.eat === 'function', '<code>Dog.prototype</code> should have the method <code>eat()</code>.');
+    testString: assert(typeof Dog.prototype.eat === 'function');
   - text: <code>Dog.prototype</code> should have the method <code>describe()</code>.
-    testString: assert(typeof Dog.prototype.describe === 'function', '<code>Dog.prototype</code> should have the method <code>describe()</code>.');
+    testString: assert(typeof Dog.prototype.describe === 'function');
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/create-a-basic-javascript-object.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/create-a-basic-javascript-object.english.md
@@ -32,11 +32,11 @@ Create a <code>dog</code> <code>object</code> with <code>name</code> and <code>n
 ```yml
 tests:
   - text: <code>dog</code> should be an <code>object</code>.
-    testString: assert(typeof(dog) === 'object', '<code>dog</code> should be an <code>object</code>.');
+    testString: assert(typeof(dog) === 'object');
   - text: <code>dog</code> should have a <code>name</code> property set to a <code>string</code>.
-    testString: assert(typeof(dog.name) === 'string', '<code>dog</code> should have a <code>name</code> property set to a <code>string</code>.');
+    testString: assert(typeof(dog.name) === 'string');
   - text: <code>dog</code> should have a <code>numLegs</code> property set to a <code>number</code>.
-    testString: assert(typeof(dog.numLegs) === 'number', '<code>dog</code> should have a <code>numLegs</code> property set to a <code>number</code>.');
+    testString: assert(typeof(dog.numLegs) === 'number');
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/create-a-method-on-an-object.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/create-a-method-on-an-object.english.md
@@ -34,9 +34,9 @@ Using the <code>dog</code> <code>object</code>, give it a method called <code>sa
 ```yml
 tests:
   - text: <code>dog.sayLegs()</code> should be a function.
-    testString: assert(typeof(dog.sayLegs) === 'function', '<code>dog.sayLegs()</code> should be a function.');
+    testString: assert(typeof(dog.sayLegs) === 'function');
   - text: <code>dog.sayLegs()</code> should return the given string - note that punctuation and spacing matter.
-    testString: assert(dog.sayLegs() === 'This dog has 4 legs.', '<code>dog.sayLegs()</code> should return the given string - note that punctuation and spacing matter.');
+    testString: assert(dog.sayLegs() === 'This dog has 4 legs.');
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/define-a-constructor-function.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/define-a-constructor-function.english.md
@@ -33,11 +33,11 @@ Create a <code>constructor</code>, <code>Dog</code>, with properties <code>name<
 ```yml
 tests:
   - text: <code>Dog</code> should have a <code>name</code> property set to a string.
-    testString: assert(typeof (new Dog()).name === 'string', '<code>Dog</code> should have a <code>name</code> property set to a string.');
+    testString: assert(typeof (new Dog()).name === 'string');
   - text: <code>Dog</code> should have a <code>color</code> property set to a string.
-    testString: assert(typeof (new Dog()).color === 'string', '<code>Dog</code> should have a <code>color</code> property set to a string.');
+    testString: assert(typeof (new Dog()).color === 'string');
   - text: <code>Dog</code> should have a <code>numLegs</code> property set to a number.
-    testString: assert(typeof (new Dog()).numLegs === 'number', '<code>Dog</code> should have a <code>numLegs</code> property set to a number.');
+    testString: assert(typeof (new Dog()).numLegs === 'number');
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/extend-constructors-to-receive-arguments.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/extend-constructors-to-receive-arguments.english.md
@@ -50,13 +50,13 @@ Create another <code>Dog</code> constructor. This time, set it up to take the pa
 ```yml
 tests:
   - text: <code>Dog</code> should receive an argument for <code>name</code>.
-    testString: assert((new Dog('Clifford')).name === 'Clifford', '<code>Dog</code> should receive an argument for <code>name</code>.');
+    testString: assert((new Dog('Clifford')).name === 'Clifford');
   - text: <code>Dog</code> should receive an argument for <code>color</code>.
     testString: assert((new Dog('Clifford', 'yellow')).color === 'yellow', '<code>Dog</code> should receive an argument for <code>color</code>.');
   - text: <code>Dog</code> should have property <code>numLegs</code> set to 4.
-    testString: assert((new Dog('Clifford')).numLegs === 4, '<code>Dog</code> should have property <code>numLegs</code> set to 4.');
+    testString: assert((new Dog('Clifford')).numLegs === 4);
   - text: <code>terrier</code> should be created using the <code>Dog</code> constructor.
-    testString: assert(terrier instanceof Dog, '<code>terrier</code> should be created using the <code>Dog</code> constructor.');
+    testString: assert(terrier instanceof Dog);
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/inherit-behaviors-from-a-supertype.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/inherit-behaviors-from-a-supertype.english.md
@@ -49,17 +49,17 @@ Use <code>Object.create</code> to make two instances of <code>Animal</code> name
 ```yml
 tests:
   - text: The <code>duck</code> variable should be defined.
-    testString: assert(typeof duck !== "undefined", 'The <code>duck</code> variable should be defined.');
+    testString: assert(typeof duck !== "undefined");
   - text: The <code>beagle</code> variable should be defined.
-    testString: assert(typeof beagle !== "undefined", 'The <code>beagle</code> variable should be defined.');
+    testString: assert(typeof beagle !== "undefined");
   - text: The <code>duck</code> variable should be initialised with <code>Object.create</code>.
-    testString: assert(/(let|const|var)\s{1,}duck\s*=\s*Object\.create\s*\(\s*Animal\.prototype\s*\)\s*/.test(code), 'The <code>duck</code> variable should be initialised with <code>Object.create</code>.');
+    testString: assert(/(let|const|var)\s{1,}duck\s*=\s*Object\.create\s*\(\s*Animal\.prototype\s*\)\s*/.test(code));
   - text: The <code>beagle</code> variable should be initialised with <code>Object.create</code>.
-    testString: assert(/(let|const|var)\s{1,}beagle\s*=\s*Object\.create\s*\(\s*Animal\.prototype\s*\)\s*/.test(code), 'The <code>beagle</code> variable should be initialised with <code>Object.create</code>.');
+    testString: assert(/(let|const|var)\s{1,}beagle\s*=\s*Object\.create\s*\(\s*Animal\.prototype\s*\)\s*/.test(code));
   - text: <code>duck</code> should have a <code>prototype</code> of <code>Animal</code>.
-    testString: assert(duck instanceof Animal, '<code>duck</code> should have a <code>prototype</code> of <code>Animal</code>.');
+    testString: assert(duck instanceof Animal);
   - text: <code>beagle</code> should have a <code>prototype</code> of <code>Animal</code>.
-    testString: assert(beagle instanceof Animal, '<code>beagle</code> should have a <code>prototype</code> of <code>Animal</code>.');
+    testString: assert(beagle instanceof Animal);
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/iterate-over-all-properties.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/iterate-over-all-properties.english.md
@@ -49,11 +49,11 @@ Add all of the <code>own</code> properties of <code>beagle</code> to the array <
 ```yml
 tests:
   - text: The <code>ownProps</code> array should include <code>"name"</code>.
-    testString: assert(ownProps.indexOf('name') !== -1, 'The <code>ownProps</code> array should include <code>"name"</code>.');
+    testString: assert(ownProps.indexOf('name') !== -1);
   - text: The <code>prototypeProps</code> array should include <code>"numLegs"</code>.
-    testString: assert(prototypeProps.indexOf('numLegs') !== -1, 'The <code>prototypeProps</code> array should include <code>"numLegs"</code>.');
+    testString: assert(prototypeProps.indexOf('numLegs') !== -1);
   - text: Solve this challenge without using the built in method <code>Object.keys()</code>.
-    testString: assert(!/\Object.keys/.test(code), 'Solve this challenge without using the built in method <code>Object.keys()</code>.');
+    testString: assert(!/\Object.keys/.test(code));
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/make-code-more-reusable-with-the-this-keyword.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/make-code-more-reusable-with-the-this-keyword.english.md
@@ -34,9 +34,9 @@ Modify the <code>dog.sayLegs</code> method to remove any references to <code>dog
 ```yml
 tests:
   - text: <code>dog.sayLegs()</code> should return the given string.
-    testString: assert(dog.sayLegs() === 'This dog has 4 legs.', '<code>dog.sayLegs()</code> should return the given string.');
+    testString: assert(dog.sayLegs() === 'This dog has 4 legs.');
   - text: Your code should use the <code>this</code> keyword to access the <code>numLegs</code> property of <code>dog</code>.
-    testString: assert(code.match(/this\.numLegs/g), 'Your code should use the <code>this</code> keyword to access the <code>numLegs</code> property of <code>dog</code>.');
+    testString: assert(code.match(/this\.numLegs/g));
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/override-inherited-methods.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/override-inherited-methods.english.md
@@ -55,9 +55,9 @@ Override the <code>fly()</code> method for <code>Penguin</code> so that it retur
 ```yml
 tests:
   - text: <code>penguin.fly()</code> should return the string "Alas, this is a flightless bird."
-    testString: assert(penguin.fly() === "Alas, this is a flightless bird.", '<code>penguin.fly()</code> should return the string "Alas, this is a flightless bird."');
+    testString: assert(penguin.fly() === "Alas, this is a flightless bird.");
   - text: The <code>bird.fly()</code> method should return "I am flying!"
-    testString: assert((new Bird()).fly() === "I am flying!", 'The <code>bird.fly()</code> method should return "I am flying!"');
+    testString: assert((new Bird()).fly() === "I am flying!");
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/remember-to-set-the-constructor-property-when-changing-the-prototype.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/remember-to-set-the-constructor-property-when-changing-the-prototype.english.md
@@ -42,7 +42,7 @@ Define the <code>constructor</code> property on the <code>Dog</code> <code>proto
 ```yml
 tests:
   - text: <code>Dog.prototype</code> should set the <code>constructor</code> property.
-    testString: assert(Dog.prototype.constructor === Dog, '<code>Dog.prototype</code> should set the <code>constructor</code> property.');
+    testString: assert(Dog.prototype.constructor === Dog);
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/reset-an-inherited-constructor-property.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/reset-an-inherited-constructor-property.english.md
@@ -36,13 +36,13 @@ Fix the code so <code>duck.constructor</code> and <code>beagle.constructor</code
 ```yml
 tests:
   - text: <code>Bird.prototype</code> should be an instance of <code>Animal</code>.
-    testString: assert(Animal.prototype.isPrototypeOf(Bird.prototype), '<code>Bird.prototype</code> should be an instance of <code>Animal</code>.');
+    testString: assert(Animal.prototype.isPrototypeOf(Bird.prototype));
   - text: <code>duck.constructor</code> should return <code>Bird</code>.
-    testString: assert(duck.constructor === Bird, '<code>duck.constructor</code> should return <code>Bird</code>.');
+    testString: assert(duck.constructor === Bird);
   - text: <code>Dog.prototype</code> should be an instance of <code>Animal</code>.
-    testString: assert(Animal.prototype.isPrototypeOf(Dog.prototype), '<code>Dog.prototype</code> should be an instance of <code>Animal</code>.');
+    testString: assert(Animal.prototype.isPrototypeOf(Dog.prototype));
   - text: <code>beagle.constructor</code> should return <code>Dog</code>.
-    testString: assert(beagle.constructor === Dog, '<code>beagle.constructor</code> should return <code>Dog</code>.');
+    testString: assert(beagle.constructor === Dog);
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/set-the-childs-prototype-to-an-instance-of-the-parent.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/set-the-childs-prototype-to-an-instance-of-the-parent.english.md
@@ -34,7 +34,7 @@ Modify the code so that instances of <code>Dog</code> inherit from <code>Animal<
 ```yml
 tests:
   - text: <code>Dog.prototype</code> should be an instance of <code>Animal</code>.
-    testString: assert(Animal.prototype.isPrototypeOf(Dog.prototype), '<code>Dog.prototype</code> should be an instance of <code>Animal</code>.');
+    testString: assert(Animal.prototype.isPrototypeOf(Dog.prototype));
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/understand-the-constructor-property.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/understand-the-constructor-property.english.md
@@ -43,11 +43,11 @@ Write a <code>joinDogFraternity</code> function that takes a <code>candidate</co
 ```yml
 tests:
   - text: <code>joinDogFraternity</code> should be defined as a function.
-    testString: assert(typeof(joinDogFraternity) === 'function', '<code>joinDogFraternity</code> should be defined as a function.');
+    testString: assert(typeof(joinDogFraternity) === 'function');
   - text: <code>joinDogFraternity</code> should return true if<code>candidate</code> is an instance of <code>Dog</code>.
-    testString: assert(joinDogFraternity(new Dog("")) === true, '<code>joinDogFraternity</code> should return true if<code>candidate</code> is an instance of <code>Dog</code>.');
+    testString: assert(joinDogFraternity(new Dog("")) === true);
   - text: <code>joinDogFraternity</code> should use the <code>constructor</code> property.
-    testString: assert(/\.constructor/.test(code) && !/instanceof/.test(code), '<code>joinDogFraternity</code> should use the <code>constructor</code> property.');
+    testString: assert(/\.constructor/.test(code) && !/instanceof/.test(code));
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/understand-where-an-objects-prototype-comes-from.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/understand-where-an-objects-prototype-comes-from.english.md
@@ -36,7 +36,7 @@ Use <code>isPrototypeOf</code> to check the <code>prototype</code> of <code>beag
 ```yml
 tests:
   - text: Show that <code>Dog.prototype</code> is the <code>prototype</code> of <code>beagle</code>
-    testString: assert(/Dog\.prototype\.isPrototypeOf\(beagle\)/.test(code), 'Show that <code>Dog.prototype</code> is the <code>prototype</code> of <code>beagle</code>');
+    testString: assert(/Dog\.prototype\.isPrototypeOf\(beagle\)/.test(code));
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/use-a-constructor-to-create-objects.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/use-a-constructor-to-create-objects.english.md
@@ -48,9 +48,9 @@ Use the <code>Dog</code> constructor from the last lesson to create a new instan
 ```yml
 tests:
   - text: <code>hound</code> should be created using the <code>Dog</code> constructor.
-    testString: assert(hound instanceof Dog, '<code>hound</code> should be created using the <code>Dog</code> constructor.');
+    testString: assert(hound instanceof Dog);
   - text: Your code should use the <code>new</code> operator to create an <code>instance</code> of <code>Dog</code>.
-    testString: assert(code.match(/new/g), 'Your code should use the <code>new</code> operator to create an <code>instance</code> of <code>Dog</code>.');
+    testString: assert(code.match(/new/g));
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/use-a-mixin-to-add-common-behavior-between-unrelated-objects.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/use-a-mixin-to-add-common-behavior-between-unrelated-objects.english.md
@@ -55,11 +55,11 @@ Create a <code>mixin</code> named <code>glideMixin</code> that defines a method 
 ```yml
 tests:
   - text: Your code should declare a <code>glideMixin</code> variable that is a function.
-    testString: assert(typeof glideMixin === "function", 'Your code should declare a <code>glideMixin</code> variable that is a function.');
+    testString: assert(typeof glideMixin === "function");
   - text: Your code should use the <code>glideMixin</code> on the <code>bird</code> object to give it the <code>glide</code> method.
-    testString: assert(typeof bird.glide === "function", 'Your code should use the <code>glideMixin</code> on the <code>bird</code> object to give it the <code>glide</code> method.');
+    testString: assert(typeof bird.glide === "function");
   - text: Your code should use the <code>glideMixin</code> on the <code>boat</code> object to give it the <code>glide</code> method.
-    testString: assert(typeof boat.glide === "function", 'Your code should use the <code>glideMixin</code> on the <code>boat</code> object to give it the <code>glide</code> method.');
+    testString: assert(typeof boat.glide === "function");
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/use-an-iife-to-create-a-module.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/use-an-iife-to-create-a-module.english.md
@@ -61,11 +61,11 @@ Create a <code>module</code> named <code>funModule</code> to wrap the two <code>
 ```yml
 tests:
   - text: <code>funModule</code> should be defined and return an object.
-    testString: assert(typeof funModule === "object", '<code>funModule</code> should be defined and return an object.');
+    testString: assert(typeof funModule === "object");
   - text: <code>funModule.isCuteMixin</code> should access a function.
-    testString: assert(typeof funModule.isCuteMixin === "function", '<code>funModule.isCuteMixin</code> should access a function.');
+    testString: assert(typeof funModule.isCuteMixin === "function");
   - text: <code>funModule.singMixin</code> should access a function.
-    testString: assert(typeof funModule.singMixin === "function", '<code>funModule.singMixin</code> should access a function.');
+    testString: assert(typeof funModule.singMixin === "function");
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/use-closure-to-protect-properties-within-an-object-from-being-modified-externally.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/use-closure-to-protect-properties-within-an-object-from-being-modified-externally.english.md
@@ -47,11 +47,11 @@ Change how <code>weight</code> is declared in the <code>Bird</code> function so 
 ```yml
 tests:
   - text: The <code>weight</code> property should be a private variable and should be assigned the value of <code>15</code>.
-    testString: assert(code.match(/(var|let|const)\s+weight\s*\=\s*15\;?/g), 'The <code>weight</code> property should be a private variable and should be assigned the value of <code>15</code>.');
+    testString: assert(code.match(/(var|let|const)\s+weight\s*\=\s*15\;?/g));
   - text: Your code should create a method in <code>Bird</code> called <code>getWeight</code> that returns the value of the private variable <code>weight</code>.
-    testString: assert((new Bird()).getWeight() === 15, 'Your code should create a method in <code>Bird</code> called <code>getWeight</code> that returns the value of the private variable <code>weight</code>.');
+    testString: assert((new Bird()).getWeight() === 15);
   - text: Your <code>getWeight</code> function should return the private variable <code>weight</code>.
-    testString: assert(code.match(/((return\s+)|(\(\s*\)\s*\=\>\s*))weight\;?/g), 'Your <code>getWeight</code> function should return the private variable <code>weight</code>.');
+    testString: assert(code.match(/((return\s+)|(\(\s*\)\s*\=\>\s*))weight\;?/g));
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/use-inheritance-so-you-dont-repeat-yourself.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/use-inheritance-so-you-dont-repeat-yourself.english.md
@@ -63,11 +63,11 @@ The <code>eat</code> method is repeated in both <code>Cat</code> and <code>Bear<
 ```yml
 tests:
   - text: <code>Animal.prototype</code> should have the <code>eat</code> property.
-    testString: assert(Animal.prototype.hasOwnProperty('eat'), '<code>Animal.prototype</code> should have the <code>eat</code> property.');
+    testString: assert(Animal.prototype.hasOwnProperty('eat'));
   - text: <code>Bear.prototype</code> should not have the <code>eat</code> property.
-    testString: assert(!(Bear.prototype.hasOwnProperty('eat')), '<code>Bear.prototype</code> should not have the <code>eat</code> property.');
+    testString: assert(!(Bear.prototype.hasOwnProperty('eat')));
   - text: <code>Cat.prototype</code> should not have the <code>eat</code> property.
-    testString: assert(!(Cat.prototype.hasOwnProperty('eat')), '<code>Cat.prototype</code> should not have the <code>eat</code> property.');
+    testString: assert(!(Cat.prototype.hasOwnProperty('eat')));
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/use-prototype-properties-to-reduce-duplicate-code.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/use-prototype-properties-to-reduce-duplicate-code.english.md
@@ -36,11 +36,11 @@ Add a <code>numLegs</code> property to the <code>prototype</code> of <code>Dog</
 ```yml
 tests:
   - text: <code>beagle</code> should have a <code>numLegs</code> property.
-    testString: assert(beagle.numLegs !== undefined, '<code>beagle</code> should have a <code>numLegs</code> property.');
+    testString: assert(beagle.numLegs !== undefined);
   - text: <code>beagle.numLegs</code> should be a number.
-    testString: assert(typeof(beagle.numLegs) === 'number' , '<code>beagle.numLegs</code> should be a number.');
+    testString: assert(typeof(beagle.numLegs) === 'number' );
   - text: <code>numLegs</code> should be a <code>prototype</code> property not an <code>own</code> property.
-    testString: assert(beagle.hasOwnProperty('numLegs') === false, '<code>numLegs</code> should be a <code>prototype</code> property not an <code>own</code> property.');
+    testString: assert(beagle.hasOwnProperty('numLegs') === false);
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/verify-an-objects-constructor-with-instanceof.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/verify-an-objects-constructor-with-instanceof.english.md
@@ -45,9 +45,9 @@ Create a new instance of the <code>House</code> constructor, calling it <code>my
 ```yml
 tests:
   - text: <code>myHouse</code> should have a <code>numBedrooms</code> attribute set to a number.
-    testString: assert(typeof myHouse.numBedrooms === 'number', '<code>myHouse</code> should have a <code>numBedrooms</code> attribute set to a number.');
+    testString: assert(typeof myHouse.numBedrooms === 'number');
   - text: Be sure to verify that <code>myHouse</code> is an instance of <code>House</code> using the <code>instanceof</code> operator.
-    testString: assert(/myHouse\s*instanceof\s*House/.test(code), 'Be sure to verify that <code>myHouse</code> is an instance of <code>House</code> using the <code>instanceof</code> operator.');
+    testString: assert(/myHouse\s*instanceof\s*House/.test(code));
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/check-for-all-or-none.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/check-for-all-or-none.english.md
@@ -31,13 +31,13 @@ Change the regex <code>favRegex</code> to match both the American English (favor
 ```yml
 tests:
   - text: Your regex should use the optional symbol, <code>?</code>.
-    testString: assert(favRegex.source.match(/\?/).length > 0, 'Your regex should use the optional symbol, <code>?</code>.');
+    testString: assert(favRegex.source.match(/\?/).length > 0);
   - text: Your regex should match <code>"favorite"</code>
-    testString: assert(favRegex.test("favorite"), 'Your regex should match <code>"favorite"</code>');
+    testString: assert(favRegex.test("favorite"));
   - text: Your regex should match <code>"favourite"</code>
-    testString: assert(favRegex.test("favourite"), 'Your regex should match <code>"favourite"</code>');
+    testString: assert(favRegex.test("favourite"));
   - text: Your regex should not match <code>"fav"</code>
-    testString: assert(!favRegex.test("fav"), 'Your regex should not match <code>"fav"</code>');
+    testString: assert(!favRegex.test("fav"));
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/check-for-mixed-grouping-of-characters.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/check-for-mixed-grouping-of-characters.english.md
@@ -31,15 +31,15 @@ Then fix the code so that the regex that you have created is checked against <co
 ```yml
 tests:
   - text: Your regex <code>myRegex</code> should return <code>true</code> for the string <code>Franklin D. Roosevelt</code>
-    testString: assert(myRegex.test('Franklin D. Roosevelt'), 'Your regex <code>myRegex</code> should return <code>true</code> for the string <code>Franklin D. Roosevelt</code>');
+    testString: assert(myRegex.test('Franklin D. Roosevelt'));
   - text: Your regex <code>myRegex</code> should return <code>true</code> for the string <code>Eleanor Roosevelt</code>
-    testString: assert(myRegex.test('Eleanor Roosevelt'), 'Your regex <code>myRegex</code> should return <code>true</code> for the string <code>Eleanor Roosevelt</code>');
+    testString: assert(myRegex.test('Eleanor Roosevelt'));
   - text: Your regex <code>myRegex</code> should return <code>false</code> for the string <code>Franklin Rosevelt</code>
-    testString: assert(!myRegex.test('Franklin Rosevelt'), 'Your regex <code>myRegex</code> should return <code>false</code> for the string <code>Franklin Rosevelt</code>');
+    testString: assert(!myRegex.test('Franklin Rosevelt'));
   - text: You should use <code>.test()</code> to test the regex.
-    testString: assert(code.match(/myRegex.test\(\s*myString\s*\)/), 'You should use <code>.test()</code> to test the regex.');
+    testString: assert(code.match(/myRegex.test\(\s*myString\s*\)/));
   - text: Your result should return <code>true</code>.
-    testString: assert(result === true, 'Your result should return <code>true</code>.');
+    testString: assert(result === true);
 ```
 
 </section>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/extract-matches.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/extract-matches.english.md
@@ -31,11 +31,11 @@ Apply the <code>.match()</code> method to extract the word <code>coding</code>.
 ```yml
 tests:
   - text: The <code>result</code> should have the word <code>coding</code>
-    testString: assert(result.join() === "coding", 'The <code>result</code> should have the word <code>coding</code>');
+    testString: assert(result.join() === "coding");
   - text: Your regex <code>codingRegex</code> should search for <code>coding</code>
-    testString: assert(codingRegex.source === "coding", 'Your regex <code>codingRegex</code> should search for <code>coding</code>');
+    testString: assert(codingRegex.source === "coding");
   - text: You should use the <code>.match()</code> method.
-    testString: assert(code.match(/\.match\(.*\)/), 'You should use the <code>.match()</code> method.');
+    testString: assert(code.match(/\.match\(.*\)/));
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/find-characters-with-lazy-matching.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/find-characters-with-lazy-matching.english.md
@@ -24,7 +24,7 @@ Fix the regex <code>/&lt;.*&gt;/</code> to return the HTML tag <code>&lt;h1&gt;<
 ```yml
 tests:
   - text: The <code>result</code> variable should be an array with <code>&lt;h1&gt;</code> in it
-    testString: assert(result[0] == '<h1>', 'The <code>result</code> variable should be an array with <code>&lt;h1&gt;</code> in it');
+    testString: assert(result[0] == '<h1>');
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/find-more-than-the-first-match.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/find-more-than-the-first-match.english.md
@@ -37,13 +37,13 @@ Using the regex <code>starRegex</code>, find and extract both <code>"Twinkle"</c
 ```yml
 tests:
   - text: Your regex <code>starRegex</code> should use the global flag <code>g</code>
-    testString: assert(starRegex.flags.match(/g/).length == 1, 'Your regex <code>starRegex</code> should use the global flag <code>g</code>');
+    testString: assert(starRegex.flags.match(/g/).length == 1);
   - text: Your regex <code>starRegex</code> should use the case insensitive flag <code>i</code>
-    testString: assert(starRegex.flags.match(/i/).length == 1, 'Your regex <code>starRegex</code> should use the case insensitive flag <code>i</code>');
+    testString: assert(starRegex.flags.match(/i/).length == 1);
   - text: Your match should match both occurrences of the word <code>"Twinkle"</code>
-    testString: assert(result.sort().join() == twinkleStar.match(/twinkle/gi).sort().join(), 'Your match should match both occurrences of the word <code>"Twinkle"</code>');
+    testString: assert(result.sort().join() == twinkleStar.match(/twinkle/gi).sort().join());
   - text: Your match <code>result</code> should have two elements in it.
-    testString: assert(result.length == 2, 'Your match <code>result</code> should have two elements in it.');
+    testString: assert(result.length == 2);
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/find-one-or-more-criminals-in-a-hunt.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/find-one-or-more-criminals-in-a-hunt.english.md
@@ -39,19 +39,19 @@ Write a <code>greedy</code> regex that finds one or more criminals within a grou
 ```yml
 tests:
   - text: Your regex should match <code>one</code> criminal (<code>C</code>) in <code>"C"</code>
-    testString: assert('C'.match(reCriminals) && 'C'.match(reCriminals)[0] == 'C', 'Your regex should match <code>one</code> criminal (<code>C</code>) in <code>"C"</code>');
+    testString: assert('C'.match(reCriminals) && 'C'.match(reCriminals)[0] == 'C');
   - text: Your regex should match <code>two</code> criminals (<code>CC</code>) in <code>"CC"</code>
-    testString: assert('CC'.match(reCriminals) && 'CC'.match(reCriminals)[0] == 'CC', 'Your regex should match <code>two</code> criminals (<code>CC</code>) in <code>"CC"</code>');
+    testString: assert('CC'.match(reCriminals) && 'CC'.match(reCriminals)[0] == 'CC');
   - text: Your regex should match <code>three</code> criminals (<code>CCC</code>) in <code>"P1P5P4CCCP2P6P3"</code>
-    testString: assert('P1P5P4CCCP2P6P3'.match(reCriminals) && 'P1P5P4CCCP2P6P3'.match(reCriminals)[0] == 'CCC', 'Your regex should match <code>three</code> criminals (<code>CCC</code>) in <code>"P1P5P4CCCP2P6P3"</code>');
+    testString: assert('P1P5P4CCCP2P6P3'.match(reCriminals) && 'P1P5P4CCCP2P6P3'.match(reCriminals)[0] == 'CCC');
   - text: Your regex should match <code>five</code> criminals (<code>CCCCC</code>) in <code>"P6P2P7P4P5CCCCCP3P1"</code>
-    testString: assert('P6P2P7P4P5CCCCCP3P1'.match(reCriminals) && 'P6P2P7P4P5CCCCCP3P1'.match(reCriminals)[0] == 'CCCCC', 'Your regex should match <code>five</code> criminals (<code>CCCCC</code>) in <code>"P6P2P7P4P5CCCCCP3P1"</code>');
+    testString: assert('P6P2P7P4P5CCCCCP3P1'.match(reCriminals) && 'P6P2P7P4P5CCCCCP3P1'.match(reCriminals)[0] == 'CCCCC');
   - text: Your regex should not match any criminals in <code>""</code>
-    testString: assert(!reCriminals.test(''), 'Your regex should not match any criminals in <code>""</code>');
+    testString: assert(!reCriminals.test(''));
   - text: Your regex should not match any criminals in <code>"P1P2P3"</code>
-    testString: assert(!reCriminals.test('P1P2P3'), 'Your regex should not match any criminals in <code>"P1P2P3"</code>');
+    testString: assert(!reCriminals.test('P1P2P3'));
   - text: Your regex should match <code>fifty</code> criminals (<code>CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC</code>) in <code>"P2P1P5P4CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCP3"</code>.
-    testString: assert('P2P1P5P4CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCP3'.match(reCriminals) && 'P2P1P5P4CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCP3'.match(reCriminals)[0] == "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC", 'Your regex should match <code>fifty</code> criminals (<code>CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC</code>) in <code>"P2P1P5P4CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCP3"</code>.');
+    testString: assert('P2P1P5P4CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCP3'.match(reCriminals) && 'P2P1P5P4CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCP3'.match(reCriminals)[0] == "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC");
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/ignore-case-while-matching.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/ignore-case-while-matching.english.md
@@ -22,25 +22,25 @@ Write a regex <code>fccRegex</code> to match <code>"freeCodeCamp"</code>, no mat
 ```yml
 tests:
   - text: Your regex should match <code>freeCodeCamp</code>
-    testString: assert(fccRegex.test('freeCodeCamp'), 'Your regex should match <code>freeCodeCamp</code>');
+    testString: assert(fccRegex.test('freeCodeCamp'));
   - text: Your regex should match <code>FreeCodeCamp</code>
-    testString: assert(fccRegex.test('FreeCodeCamp'), 'Your regex should match <code>FreeCodeCamp</code>');
+    testString: assert(fccRegex.test('FreeCodeCamp'));
   - text: Your regex should match <code>FreecodeCamp</code>
-    testString: assert(fccRegex.test('FreecodeCamp'), 'Your regex should match <code>FreecodeCamp</code>');
+    testString: assert(fccRegex.test('FreecodeCamp'));
   - text: Your regex should match <code>FreeCodecamp</code>
-    testString: assert(fccRegex.test('FreeCodecamp'), 'Your regex should match <code>FreeCodecamp</code>');
+    testString: assert(fccRegex.test('FreeCodecamp'));
   - text: Your regex should not match <code>Free Code Camp</code>
-    testString: assert(!fccRegex.test('Free Code Camp'), 'Your regex should not match <code>Free Code Camp</code>');
+    testString: assert(!fccRegex.test('Free Code Camp'));
   - text: Your regex should match <code>FreeCOdeCamp</code>
-    testString: assert(fccRegex.test('FreeCOdeCamp'), 'Your regex should match <code>FreeCOdeCamp</code>');
+    testString: assert(fccRegex.test('FreeCOdeCamp'));
   - text: Your regex should not match <code>FCC</code>
-    testString: assert(!fccRegex.test('FCC'), 'Your regex should not match <code>FCC</code>');
+    testString: assert(!fccRegex.test('FCC'));
   - text: Your regex should match <code>FrEeCoDeCamp</code>
-    testString: assert(fccRegex.test('FrEeCoDeCamp'), 'Your regex should match <code>FrEeCoDeCamp</code>');
+    testString: assert(fccRegex.test('FrEeCoDeCamp'));
   - text: Your regex should match <code>FrEeCodECamp</code>
-    testString: assert(fccRegex.test('FrEeCodECamp'), 'Your regex should match <code>FrEeCodECamp</code>');
+    testString: assert(fccRegex.test('FrEeCodECamp'));
   - text: Your regex should match <code>FReeCodeCAmp</code>
-    testString: assert(fccRegex.test('FReeCodeCAmp'), 'Your regex should match <code>FReeCodeCAmp</code>');
+    testString: assert(fccRegex.test('FReeCodeCAmp'));
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-a-literal-string-with-different-possibilities.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-a-literal-string-with-different-possibilities.english.md
@@ -23,19 +23,19 @@ Complete the regex <code>petRegex</code> to match the pets <code>"dog"</code>, <
 ```yml
 tests:
   - text: Your regex <code>petRegex</code> should return <code>true</code> for the string <code>"John has a pet dog."</code>
-    testString: assert(petRegex.test('John has a pet dog.'), 'Your regex <code>petRegex</code> should return <code>true</code> for the string <code>"John has a pet dog."</code>');
+    testString: assert(petRegex.test('John has a pet dog.'));
   - text: Your regex <code>petRegex</code> should return <code>false</code> for the string <code>"Emma has a pet rock."</code>
-    testString: assert(!petRegex.test('Emma has a pet rock.'), 'Your regex <code>petRegex</code> should return <code>false</code> for the string <code>"Emma has a pet rock."</code>');
+    testString: assert(!petRegex.test('Emma has a pet rock.'));
   - text: Your regex <code>petRegex</code> should return <code>true</code> for the string <code>"Emma has a pet bird."</code>
-    testString: assert(petRegex.test('Emma has a pet bird.'), 'Your regex <code>petRegex</code> should return <code>true</code> for the string <code>"Emma has a pet bird."</code>');
+    testString: assert(petRegex.test('Emma has a pet bird.'));
   - text: Your regex <code>petRegex</code> should return <code>true</code> for the string <code>"Liz has a pet cat."</code>
-    testString: assert(petRegex.test('Liz has a pet cat.'), 'Your regex <code>petRegex</code> should return <code>true</code> for the string <code>"Liz has a pet cat."</code>');
+    testString: assert(petRegex.test('Liz has a pet cat.'));
   - text: Your regex <code>petRegex</code> should return <code>false</code> for the string <code>"Kara has a pet dolphin."</code>
-    testString: assert(!petRegex.test('Kara has a pet dolphin.'), 'Your regex <code>petRegex</code> should return <code>false</code> for the string <code>"Kara has a pet dolphin."</code>');
+    testString: assert(!petRegex.test('Kara has a pet dolphin.'));
   - text: Your regex <code>petRegex</code> should return <code>true</code> for the string <code>"Alice has a pet fish."</code>
-    testString: assert(petRegex.test('Alice has a pet fish.'), 'Your regex <code>petRegex</code> should return <code>true</code> for the string <code>"Alice has a pet fish."</code>');
+    testString: assert(petRegex.test('Alice has a pet fish.'));
   - text: Your regex <code>petRegex</code> should return <code>false</code> for the string <code>"Jimmy has a pet computer."</code>
-    testString: assert(!petRegex.test('Jimmy has a pet computer.'), 'Your regex <code>petRegex</code> should return <code>false</code> for the string <code>"Jimmy has a pet computer."</code>');
+    testString: assert(!petRegex.test('Jimmy has a pet computer.'));
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-all-letters-and-numbers.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-all-letters-and-numbers.english.md
@@ -34,17 +34,17 @@ Use the shorthand character class <code>\w</code> to count the number of alphanu
 ```yml
 tests:
   - text: Your regex should use the global flag.
-    testString: assert(alphabetRegexV2.global, 'Your regex should use the global flag.');
-  - text: Your regex should use the shorthand character
-    testString: assert(/\\w/.test(alphabetRegexV2.source), 'Your regex should use the shorthand character <code>\w</code> to match all characters which are alphanumeric.');
+    testString: assert(alphabetRegexV2.global);
+  - text: Your regex should use the shorthand character <code>\w</code> to match all characters which are alphanumeric.
+    testString: assert(/\\w/.test(alphabetRegexV2.source));
   - text: Your regex should find 31 alphanumeric characters in <code>"The five boxing wizards jump quickly."</code>
-    testString: assert("The five boxing wizards jump quickly.".match(alphabetRegexV2).length === 31, 'Your regex should find 31 alphanumeric characters in <code>"The five boxing wizards jump quickly."</code>');
+    testString: assert("The five boxing wizards jump quickly.".match(alphabetRegexV2).length === 31);
   - text: Your regex should find 32 alphanumeric characters in <code>"Pack my box with five dozen liquor jugs."</code>
-    testString: assert("Pack my box with five dozen liquor jugs.".match(alphabetRegexV2).length === 32, 'Your regex should find 32 alphanumeric characters in <code>"Pack my box with five dozen liquor jugs."</code>');
+    testString: assert("Pack my box with five dozen liquor jugs.".match(alphabetRegexV2).length === 32);
   - text: Your regex should find 30 alphanumeric characters in <code>"How vexingly quick daft zebras jump!"</code>
-    testString: assert("How vexingly quick daft zebras jump!".match(alphabetRegexV2).length === 30, 'Your regex should find 30 alphanumeric characters in <code>"How vexingly quick daft zebras jump!"</code>');
+    testString: assert("How vexingly quick daft zebras jump!".match(alphabetRegexV2).length === 30);
   - text: Your regex should find 36 alphanumeric characters in <code>"123 456 7890 ABC def GHI jkl MNO pqr STU vwx YZ."</code>
-    testString: assert("123 456 7890 ABC def GHI jkl MNO pqr STU vwx YZ.".match(alphabetRegexV2).length === 36, 'Your regex should find 36 alphanumeric characters in <code>"123 456 7890 ABC def GHI jkl MNO pqr STU vwx YZ."</code>');
+    testString: assert("123 456 7890 ABC def GHI jkl MNO pqr STU vwx YZ.".match(alphabetRegexV2).length === 36);
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-all-non-numbers.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-all-non-numbers.english.md
@@ -21,19 +21,19 @@ Use the shorthand character class for non-digits <code>\D</code> to count how ma
 ```yml
 tests:
   - text: Your regex should use the shortcut character to match non-digit characters
-    testString: assert(/\\D/.test(noNumRegex.source), 'Your regex should use the shortcut character to match non-digit characters');
+    testString: assert(/\\D/.test(noNumRegex.source));
   - text: Your regex should use the global flag.
-    testString: assert(noNumRegex.global, 'Your regex should use the global flag.');
+    testString: assert(noNumRegex.global);
   - text: Your regex should find no non-digits in <code>"9"</code>.
-    testString: assert("9".match(noNumRegex) == null, 'Your regex should find no non-digits in <code>"9"</code>.');
+    testString: assert("9".match(noNumRegex) == null);
   - text: Your regex should find 6 non-digits in <code>"Catch 22"</code>.
-    testString: assert("Catch 22".match(noNumRegex).length == 6, 'Your regex should find 6 non-digits in <code>"Catch 22"</code>.');
+    testString: assert("Catch 22".match(noNumRegex).length == 6);
   - text: Your regex should find 11 non-digits in <code>"101 Dalmatians"</code>.
-    testString: assert("101 Dalmatians".match(noNumRegex).length == 11, 'Your regex should find 11 non-digits in <code>"101 Dalmatians"</code>.');
+    testString: assert("101 Dalmatians".match(noNumRegex).length == 11);
   - text: Your regex should find 15 non-digits in <code>"One, Two, Three"</code>.
-    testString: assert("One, Two, Three".match(noNumRegex).length == 15, 'Your regex should find 15 non-digits in <code>"One, Two, Three"</code>.');
+    testString: assert("One, Two, Three".match(noNumRegex).length == 15);
   - text: Your regex should find 12 non-digits in <code>"21 Jump Street"</code>.
-    testString: assert("21 Jump Street".match(noNumRegex).length == 12, 'Your regex should find 12 non-digits in <code>"21 Jump Street"</code>.');
+    testString: assert("21 Jump Street".match(noNumRegex).length == 12);
   - text: 'Your regex should find 17 non-digits in <code>"2001: A Space Odyssey"</code>.'
     testString: 'assert("2001: A Space Odyssey".match(noNumRegex).length == 17, ''Your regex should find 17 non-digits in <code>"2001: A Space Odyssey"</code>.'');'
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-all-numbers.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-all-numbers.english.md
@@ -21,19 +21,19 @@ Use the shorthand character class <code>\d</code> to count how many digits are i
 ```yml
 tests:
   - text: Your regex should use the shortcut character to match digit characters
-    testString: assert(/\\d/.test(numRegex.source), 'Your regex should use the shortcut character to match digit characters');
+    testString: assert(/\\d/.test(numRegex.source));
   - text: Your regex should use the global flag.
-    testString: assert(numRegex.global, 'Your regex should use the global flag.');
+    testString: assert(numRegex.global);
   - text: Your regex should find 1 digit in <code>"9"</code>.
-    testString: assert("9".match(numRegex).length == 1, 'Your regex should find 1 digit in <code>"9"</code>.');
+    testString: assert("9".match(numRegex).length == 1);
   - text: Your regex should find 2 digits in <code>"Catch 22"</code>.
-    testString: assert("Catch 22".match(numRegex).length == 2, 'Your regex should find 2 digits in <code>"Catch 22"</code>.');
+    testString: assert("Catch 22".match(numRegex).length == 2);
   - text: Your regex should find 3 digits in <code>"101 Dalmatians"</code>.
-    testString: assert("101 Dalmatians".match(numRegex).length == 3, 'Your regex should find 3 digits in <code>"101 Dalmatians"</code>.');
+    testString: assert("101 Dalmatians".match(numRegex).length == 3);
   - text: Your regex should find no digits in <code>"One, Two, Three"</code>.
-    testString: assert("One, Two, Three".match(numRegex) == null, 'Your regex should find no digits in <code>"One, Two, Three"</code>.');
+    testString: assert("One, Two, Three".match(numRegex) == null);
   - text: Your regex should find 2 digits in <code>"21 Jump Street"</code>.
-    testString: assert("21 Jump Street".match(numRegex).length == 2, 'Your regex should find 2 digits in <code>"21 Jump Street"</code>.');
+    testString: assert("21 Jump Street".match(numRegex).length == 2);
   - text: 'Your regex should find 4 digits in <code>"2001: A Space Odyssey"</code>.'
     testString: 'assert("2001: A Space Odyssey".match(numRegex).length == 4, ''Your regex should find 4 digits in <code>"2001: A Space Odyssey"</code>.'');'
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-anything-with-wildcard-period.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-anything-with-wildcard-period.english.md
@@ -30,25 +30,25 @@ Complete the regex <code>unRegex</code> so that it matches the strings <code>"ru
 ```yml
 tests:
   - text: You should use the <code>.test()</code> method.
-    testString: assert(code.match(/\.test\(.*\)/), 'You should use the <code>.test()</code> method.');
+    testString: assert(code.match(/\.test\(.*\)/));
   - text: You should use the wildcard character in your regex <code>unRegex</code>
-    testString: assert(/\./.test(unRegex.source), 'You should use the wildcard character in your regex <code>unRegex</code>');
+    testString: assert(/\./.test(unRegex.source));
   - text: Your regex <code>unRegex</code> should match <code>"run"</code> in <code>"Let us go on a run."</code>
-    testString: assert(unRegex.test("Let us go on a run."), 'Your regex <code>unRegex</code> should match <code>"run"</code> in <code>"Let us go on a run."</code>');
+    testString: assert(unRegex.test("Let us go on a run."));
   - text: Your regex <code>unRegex</code> should match <code>"sun"</code> in <code>"The sun is out today."</code>
-    testString: assert(unRegex.test("The sun is out today."), 'Your regex <code>unRegex</code> should match <code>"sun"</code> in <code>"The sun is out today."</code>');
+    testString: assert(unRegex.test("The sun is out today."));
   - text: Your regex <code>unRegex</code> should match <code>"fun"</code> in <code>"Coding is a lot of fun."</code>
-    testString: assert(unRegex.test("Coding is a lot of fun."), 'Your regex <code>unRegex</code> should match <code>"fun"</code> in <code>"Coding is a lot of fun."</code>');
+    testString: assert(unRegex.test("Coding is a lot of fun."));
   - text: Your regex <code>unRegex</code> should match <code>"pun"</code> in <code>"Seven days without a pun makes one weak."</code>
-    testString: assert(unRegex.test("Seven days without a pun makes one weak."), 'Your regex <code>unRegex</code> should match <code>"pun"</code> in <code>"Seven days without a pun makes one weak."</code>');
+    testString: assert(unRegex.test("Seven days without a pun makes one weak."));
   - text: Your regex <code>unRegex</code> should match <code>"nun"</code> in <code>"One takes a vow to be a nun."</code>
-    testString: assert(unRegex.test("One takes a vow to be a nun."), 'Your regex <code>unRegex</code> should match <code>"nun"</code> in <code>"One takes a vow to be a nun."</code>');
+    testString: assert(unRegex.test("One takes a vow to be a nun."));
   - text: Your regex <code>unRegex</code> should match <code>"bun"</code> in <code>"She got fired from the hot dog stand for putting her hair in a bun."</code>
-    testString: assert(unRegex.test("She got fired from the hot dog stand for putting her hair in a bun."), 'Your regex <code>unRegex</code> should match <code>"bun"</code> in <code>"She got fired from the hot dog stand for putting her hair in a bun."</code>');
+    testString: assert(unRegex.test("She got fired from the hot dog stand for putting her hair in a bun."));
   - text: Your regex <code>unRegex</code> should not match <code>"There is a bug in my code."</code>
-    testString: assert(!unRegex.test("There is a bug in my code."), 'Your regex <code>unRegex</code> should not match <code>"There is a bug in my code."</code>');
+    testString: assert(!unRegex.test("There is a bug in my code."));
   - text: Your regex <code>unRegex</code> should not match <code>"Catch me if you can."</code>
-    testString: assert(!unRegex.test("Can me if you can."), 'Your regex <code>unRegex</code> should not match <code>"Catch me if you can."</code>');
+    testString: assert(!unRegex.test("Can me if you can."));
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-beginning-string-patterns.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-beginning-string-patterns.english.md
@@ -32,13 +32,13 @@ Use the <code>caret</code> character in a regex to find <code>"Cal"</code> only 
 ```yml
 tests:
   - text: Your regex should search for <code>"Cal"</code> with a capital letter.
-    testString: assert(calRegex.source == "^Cal", 'Your regex should search for <code>"Cal"</code> with a capital letter.');
+    testString: assert(calRegex.source == "^Cal");
   - text: Your regex should not use any flags.
-    testString: assert(calRegex.flags == "", 'Your regex should not use any flags.');
+    testString: assert(calRegex.flags == "");
   - text: Your regex should match <code>"Cal"</code> at the beginning of the string.
-    testString: assert(calRegex.test("Cal and Ricky both like racing."), 'Your regex should match <code>"Cal"</code> at the beginning of the string.');
+    testString: assert(calRegex.test("Cal and Ricky both like racing."));
   - text: Your regex should not match <code>"Cal"</code> in the middle of a string.
-    testString: assert(!calRegex.test("Ricky and Cal both like racing."), 'Your regex should not match <code>"Cal"</code> in the middle of a string.');
+    testString: assert(!calRegex.test("Ricky and Cal both like racing."));
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-characters-that-occur-one-or-more-times.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-characters-that-occur-one-or-more-times.english.md
@@ -23,11 +23,11 @@ You want to find matches when the letter <code>s</code> occurs one or more times
 ```yml
 tests:
   - text: Your regex <code>myRegex</code> should use the <code>+</code> sign to match one or more <code>s</code> characters.
-    testString: assert(/\+/.test(myRegex.source), 'Your regex <code>myRegex</code> should use the <code>+</code> sign to match one or more <code>s</code> characters.');
+    testString: assert(/\+/.test(myRegex.source));
   - text: Your regex <code>myRegex</code> should match 2 items.
-    testString: assert(result.length == 2, 'Your regex <code>myRegex</code> should match 2 items.');
+    testString: assert(result.length == 2);
   - text: The <code>result</code> variable should be an array with two matches of <code>"ss"</code>
-    testString: assert(result[0] == 'ss' && result[1] == 'ss', 'The <code>result</code> variable should be an array with two matches of <code>"ss"</code>');
+    testString: assert(result[0] == 'ss' && result[1] == 'ss');
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-ending-string-patterns.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-ending-string-patterns.english.md
@@ -33,11 +33,11 @@ Use the anchor character (<code>$</code>) to match the string <code>"caboose"</c
 ```yml
 tests:
   - text: You should search for <code>"caboose"</code> with the dollar sign <code>$</code> anchor in your regex.
-    testString: assert(lastRegex.source == "caboose$", 'You should search for <code>"caboose"</code> with the dollar sign <code>$</code> anchor in your regex.');
+    testString: assert(lastRegex.source == "caboose$");
   - text: Your regex should not use any flags.
-    testString: assert(lastRegex.flags == "", 'Your regex should not use any flags.');
+    testString: assert(lastRegex.flags == "");
   - text: You should match <code>"caboose"</code> at the end of the string <code>"The last car on a train is the caboose"</code>
-    testString: assert(lastRegex.test("The last car on a train is the caboose"), 'You should match <code>"caboose"</code> at the end of the string <code>"The last car on a train is the caboose"</code>');
+    testString: assert(lastRegex.test("The last car on a train is the caboose"));
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-everything-but-letters-and-numbers.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-everything-but-letters-and-numbers.english.md
@@ -30,17 +30,17 @@ Use the shorthand character class <code>\W</code> to count the number of non-alp
 ```yml
 tests:
   - text: Your regex should use the global flag.
-    testString: assert(nonAlphabetRegex.global, 'Your regex should use the global flag.');
+    testString: assert(nonAlphabetRegex.global);
   - text: Your regex should find 6 non-alphanumeric characters in <code>"The five boxing wizards jump quickly."</code>.
-    testString: assert("The five boxing wizards jump quickly.".match(nonAlphabetRegex).length == 6, 'Your regex should find 6 non-alphanumeric characters in <code>"The five boxing wizards jump quickly."</code>.');
-  - text: Your regex should use the shorthand character.
-    testString: assert(/\\W/.test(nonAlphabetRegex.source), 'Your regex should use the shorthand character to match characters which are non-alphanumeric.');
+    testString: assert("The five boxing wizards jump quickly.".match(nonAlphabetRegex).length == 6);
+  - text: Your regex should use the shorthand character to match characters which are non-alphanumeric.
+    testString: assert(/\\W/.test(nonAlphabetRegex.source));
   - text: Your regex should find 8 non-alphanumeric characters in <code>"Pack my box with five dozen liquor jugs."</code>
-    testString: assert("Pack my box with five dozen liquor jugs.".match(nonAlphabetRegex).length == 8, 'Your regex should find 8 non-alphanumeric characters in <code>"Pack my box with five dozen liquor jugs."</code>');
+    testString: assert("Pack my box with five dozen liquor jugs.".match(nonAlphabetRegex).length == 8);
   - text: Your regex should find 6 non-alphanumeric characters in <code>"How vexingly quick daft zebras jump!"</code>
-    testString: assert("How vexingly quick daft zebras jump!".match(nonAlphabetRegex).length == 6, 'Your regex should find 6 non-alphanumeric characters in <code>"How vexingly quick daft zebras jump!"</code>');
+    testString: assert("How vexingly quick daft zebras jump!".match(nonAlphabetRegex).length == 6);
   - text: Your regex should find 12 non-alphanumeric characters in <code>"123 456 7890 ABC def GHI jkl MNO pqr STU vwx YZ."</code>
-    testString: assert("123 456 7890 ABC def GHI jkl MNO pqr STU vwx YZ.".match(nonAlphabetRegex).length == 12, 'Your regex should find 12 non-alphanumeric characters in <code>"123 456 7890 ABC def GHI jkl MNO pqr STU vwx YZ."</code>');
+    testString: assert("123 456 7890 ABC def GHI jkl MNO pqr STU vwx YZ.".match(nonAlphabetRegex).length == 12);
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-letters-of-the-alphabet.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-letters-of-the-alphabet.english.md
@@ -34,11 +34,11 @@ Match all the letters in the string <code>quoteSample</code>.
 ```yml
 tests:
   - text: Your regex <code>alphabetRegex</code> should match 35 items.
-    testString: assert(result.length == 35, 'Your regex <code>alphabetRegex</code> should match 35 items.');
+    testString: assert(result.length == 35);
   - text: Your regex <code>alphabetRegex</code> should use the global flag.
-    testString: assert(alphabetRegex.flags.match(/g/).length == 1, 'Your regex <code>alphabetRegex</code> should use the global flag.');
+    testString: assert(alphabetRegex.flags.match(/g/).length == 1);
   - text: Your regex <code>alphabetRegex</code> should use the case insensitive flag.
-    testString: assert(alphabetRegex.flags.match(/i/).length == 1, 'Your regex <code>alphabetRegex</code> should use the case insensitive flag.');
+    testString: assert(alphabetRegex.flags.match(/i/).length == 1);
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-literal-strings.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-literal-strings.english.md
@@ -37,11 +37,11 @@ Complete the regex <code>waldoRegex</code> to find <code>"Waldo"</code> in the s
 ```yml
 tests:
   - text: Your regex <code>waldoRegex</code> should find <code>"Waldo"</code>
-    testString: assert(waldoRegex.test(waldoIsHiding), 'Your regex <code>waldoRegex</code> should find <code>"Waldo"</code>');
+    testString: assert(waldoRegex.test(waldoIsHiding));
   - text: Your regex <code>waldoRegex</code> should not search for anything else.
-    testString: assert(!waldoRegex.test('Somewhere is hiding in this text.'), 'Your regex <code>waldoRegex</code> should not search for anything else.');
+    testString: assert(!waldoRegex.test('Somewhere is hiding in this text.'));
   - text: You should perform a literal string match with your regex.
-    testString: assert(!/\/.*\/i/.test(code), 'You should perform a literal string match with your regex.');
+    testString: assert(!/\/.*\/i/.test(code));
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-non-whitespace-characters.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-non-whitespace-characters.english.md
@@ -28,15 +28,15 @@ Change the regex <code>countNonWhiteSpace</code> to look for multiple non-whites
 ```yml
 tests:
   - text: Your regex should use the global flag.
-    testString: assert(countNonWhiteSpace.global, 'Your regex should use the global flag.');
-  - text: Your regex should use the shorthand character
-    testString: assert(/\\S/.test(countNonWhiteSpace.source), 'Your regex should use the shorthand character <code>\S/code> to match all non-whitespace characters.');
+    testString: assert(countNonWhiteSpace.global);
+  - text: Your regex should use the shorthand character <code>\S/code> to match all non-whitespace characters.
+    testString: assert(/\\S/.test(countNonWhiteSpace.source));
   - text: Your regex should find 35 non-spaces in <code>"Men are from Mars and women are from Venus."</code>
-    testString: assert("Men are from Mars and women are from Venus.".match(countNonWhiteSpace).length == 35, 'Your regex should find 35 non-spaces in <code>"Men are from Mars and women are from Venus."</code>');
+    testString: assert("Men are from Mars and women are from Venus.".match(countNonWhiteSpace).length == 35);
   - text: 'Your regex should find 23 non-spaces in <code>"Space: the final frontier."</code>'
     testString: 'assert("Space: the final frontier.".match(countNonWhiteSpace).length == 23, ''Your regex should find 23 non-spaces in <code>"Space: the final frontier."</code>'');'
   - text: Your regex should find 21 non-spaces in <code>"MindYourPersonalSpace"</code>
-    testString: assert("MindYourPersonalSpace".match(countNonWhiteSpace).length == 21, 'Your regex should find 21 non-spaces in <code>"MindYourPersonalSpace"</code>');
+    testString: assert("MindYourPersonalSpace".match(countNonWhiteSpace).length == 21);
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-numbers-and-letters-of-the-alphabet.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-numbers-and-letters-of-the-alphabet.english.md
@@ -30,11 +30,11 @@ Create a single regex that matches a range of letters between <code>h</code> and
 ```yml
 tests:
   - text: Your regex <code>myRegex</code> should match 17 items.
-    testString: assert(result.length == 17, 'Your regex <code>myRegex</code> should match 17 items.');
+    testString: assert(result.length == 17);
   - text: Your regex <code>myRegex</code> should use the global flag.
-    testString: assert(myRegex.flags.match(/g/).length == 1, 'Your regex <code>myRegex</code> should use the global flag.');
+    testString: assert(myRegex.flags.match(/g/).length == 1);
   - text: Your regex <code>myRegex</code> should use the case insensitive flag.
-    testString: assert(myRegex.flags.match(/i/).length == 1, 'Your regex <code>myRegex</code> should use the case insensitive flag.');
+    testString: assert(myRegex.flags.match(/i/).length == 1);
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-single-character-with-multiple-possibilities.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-single-character-with-multiple-possibilities.english.md
@@ -36,15 +36,15 @@ Use a character class with vowels (<code>a</code>, <code>e</code>, <code>i</code
 ```yml
 tests:
   - text: You should find all 25 vowels.
-    testString: assert(result.length == 25, 'You should find all 25 vowels.');
+    testString: assert(result.length == 25);
   - text: Your regex <code>vowelRegex</code> should use a character class.
-    testString: assert(/\[.*\]/.test(vowelRegex.source), 'Your regex <code>vowelRegex</code> should use a character class.');
+    testString: assert(/\[.*\]/.test(vowelRegex.source));
   - text: Your regex <code>vowelRegex</code> should use the global flag.
-    testString: assert(vowelRegex.flags.match(/g/).length == 1, 'Your regex <code>vowelRegex</code> should use the global flag.');
+    testString: assert(vowelRegex.flags.match(/g/).length == 1);
   - text: Your regex <code>vowelRegex</code> should use the case insensitive flag.
-    testString: assert(vowelRegex.flags.match(/i/).length == 1, 'Your regex <code>vowelRegex</code> should use the case insensitive flag.');
+    testString: assert(vowelRegex.flags.match(/i/).length == 1);
   - text: Your regex should not match any consonants.
-    testString: assert(!/[b-df-hj-np-tv-z]/gi.test(result.join()), 'Your regex should not match any consonants.');
+    testString: assert(!/[b-df-hj-np-tv-z]/gi.test(result.join()));
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-single-characters-not-specified.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-single-characters-not-specified.english.md
@@ -22,11 +22,11 @@ Create a single regex that matches all characters that are not a number or a vow
 ```yml
 tests:
   - text: Your regex <code>myRegex</code> should match 9 items.
-    testString: assert(result.length == 9, 'Your regex <code>myRegex</code> should match 9 items.');
+    testString: assert(result.length == 9);
   - text: Your regex <code>myRegex</code> should use the global flag.
-    testString: assert(myRegex.flags.match(/g/).length == 1, 'Your regex <code>myRegex</code> should use the global flag.');
+    testString: assert(myRegex.flags.match(/g/).length == 1);
   - text: Your regex <code>myRegex</code> should use the case insensitive flag.
-    testString: assert(myRegex.flags.match(/i/).length == 1, 'Your regex <code>myRegex</code> should use the case insensitive flag.');
+    testString: assert(myRegex.flags.match(/i/).length == 1);
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-whitespace.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-whitespace.english.md
@@ -29,15 +29,15 @@ Change the regex <code>countWhiteSpace</code> to look for multiple whitespace ch
 ```yml
 tests:
   - text: Your regex should use the global flag.
-    testString: assert(countWhiteSpace.global, 'Your regex should use the global flag.');
-  - text: Your regex should use the shorthand character
-    testString: assert(/\\s/.test(countWhiteSpace.source), 'Your regex should use the shorthand character <code>\s</code> to match all whitespace characters.');
+    testString: assert(countWhiteSpace.global);
+  - text: Your regex should use the shorthand character <code>\s</code> to match all whitespace characters.
+    testString: assert(/\\s/.test(countWhiteSpace.source));
   - text: Your regex should find eight spaces in <code>"Men are from Mars and women are from Venus."</code>
-    testString: assert("Men are from Mars and women are from Venus.".match(countWhiteSpace).length == 8, 'Your regex should find eight spaces in <code>"Men are from Mars and women are from Venus."</code>');
+    testString: assert("Men are from Mars and women are from Venus.".match(countWhiteSpace).length == 8);
   - text: 'Your regex should find three spaces in <code>"Space: the final frontier."</code>'
     testString: 'assert("Space: the final frontier.".match(countWhiteSpace).length == 3, ''Your regex should find three spaces in <code>"Space: the final frontier."</code>'');'
   - text: Your regex should find no spaces in <code>"MindYourPersonalSpace"</code>
-    testString: assert("MindYourPersonalSpace".match(countWhiteSpace) == null, 'Your regex should find no spaces in <code>"MindYourPersonalSpace"</code>');
+    testString: assert("MindYourPersonalSpace".match(countWhiteSpace) == null);
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/positive-and-negative-lookahead.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/positive-and-negative-lookahead.english.md
@@ -42,21 +42,21 @@ Use <code>lookaheads</code> in the <code>pwRegex</code> to match passwords that 
 ```yml
 tests:
   - text: Your regex should use two positive <code>lookaheads</code>.
-    testString: assert(pwRegex.source.match(/\(\?=.*?\)\(\?=.*?\)/) !== null, 'Your regex should use two positive <code>lookaheads</code>.');
+    testString: assert(pwRegex.source.match(/\(\?=.*?\)\(\?=.*?\)/) !== null);
   - text: Your regex should not match <code>"astronaut"</code>
-    testString: assert(!pwRegex.test("astronaut"), 'Your regex should not match <code>"astronaut"</code>');
+    testString: assert(!pwRegex.test("astronaut"));
   - text: Your regex should not match <code>"airplanes"</code>
-    testString: assert(!pwRegex.test("airplanes"), 'Your regex should not match <code>"airplanes"</code>');
+    testString: assert(!pwRegex.test("airplanes"));
   - text: Your regex should not match <code>"banan1"</code>
-    testString: assert(!pwRegex.test("banan1"), 'Your regex should not match <code>"banan1"</code>');
+    testString: assert(!pwRegex.test("banan1"));
   - text: Your regex should match <code>"bana12"</code>
-    testString: assert(pwRegex.test("bana12"), 'Your regex should match <code>"bana12"</code>');
+    testString: assert(pwRegex.test("bana12"));
   - text: Your regex should match <code>"abc123"</code>
-    testString: assert(pwRegex.test("abc123"), 'Your regex should match <code>"abc123"</code>');
+    testString: assert(pwRegex.test("abc123"));
   - text: Your regex should not match <code>"123"</code>
-    testString: assert(!pwRegex.test("123"), 'Your regex should not match <code>"123"</code>');
+    testString: assert(!pwRegex.test("123"));
   - text: Your regex should not match <code>"1234"</code>
-    testString: assert(!pwRegex.test("1234"), 'Your regex should not match <code>"1234"</code>');
+    testString: assert(!pwRegex.test("1234"));
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/remove-whitespace-from-start-and-end.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/remove-whitespace-from-start-and-end.english.md
@@ -21,11 +21,11 @@ Write a regex and use the appropriate string methods to remove whitespace at the
 ```yml
 tests:
   - text: <code>result</code> should equal to <code>"Hello, World!"</code>
-    testString: assert(result == "Hello, World!", '<code>result</code> should equal to <code>"Hello, World!"</code>');
+    testString: assert(result == "Hello, World!");
   - text: You should not use the <code>.trim()</code> method.
-    testString: assert(!code.match(/\.trim\(.*?\)/), 'You should not use the <code>.trim()</code> method.');
+    testString: assert(!code.match(/\.trim\(.*?\)/));
   - text: The <code>result</code> variable should not be set equal to a string.
-    testString: assert(!code.match(/result\s*=\s*".*?"/), 'The <code>result</code> variable should not be set equal to a string.');
+    testString: assert(!code.match(/result\s*=\s*".*?"/));
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/specify-exact-number-of-matches.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/specify-exact-number-of-matches.english.md
@@ -33,17 +33,17 @@ Change the regex <code>timRegex</code> to match the word <code>"Timber"</code> o
 ```yml
 tests:
   - text: Your regex should use curly brackets.
-    testString: assert(timRegex.source.match(/{.*?}/).length > 0, 'Your regex should use curly brackets.');
+    testString: assert(timRegex.source.match(/{.*?}/).length > 0);
   - text: Your regex should not match <code>"Timber"</code>
-    testString: assert(!timRegex.test("Timber"), 'Your regex should not match <code>"Timber"</code>');
+    testString: assert(!timRegex.test("Timber"));
   - text: Your regex should not match <code>"Timmber"</code>
-    testString: assert(!timRegex.test("Timmber"), 'Your regex should not match <code>"Timmber"</code>');
+    testString: assert(!timRegex.test("Timmber"));
   - text: Your regex should not match <code>"Timmmber"</code>
-    testString: assert(!timRegex.test("Timmmber"), 'Your regex should not match <code>"Timmmber"</code>');
+    testString: assert(!timRegex.test("Timmmber"));
   - text: Your regex should match <code>"Timmmmber"</code>
-    testString: assert(timRegex.test("Timmmmber"), 'Your regex should match <code>"Timmmmber"</code>');
+    testString: assert(timRegex.test("Timmmmber"));
   - text: Your regex should not match <code>"Timber"</code> with 30 <code>m</code>'s in it.
-    testString: assert(!timRegex.test("Ti" + "m".repeat(30) + "ber"), 'Your regex should not match <code>"Timber"</code> with 30 <code>m</code>\'s in it.');
+    testString: assert(!timRegex.test("Ti" + "m".repeat(30) + "ber"));
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/use-capture-groups-to-search-and-replace.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/use-capture-groups-to-search-and-replace.english.md
@@ -36,11 +36,11 @@ Write a regex so that it will search for the string <code>"good"</code>. Then up
 ```yml
 tests:
   - text: You should use <code>.replace()</code> to search and replace.
-    testString: assert(code.match(/\.replace\(.*\)/), 'You should use <code>.replace()</code> to search and replace.');
+    testString: assert(code.match(/\.replace\(.*\)/));
   - text: Your regex should change <code>"This sandwich is good."</code> to <code>"This sandwich is okey-dokey."</code>
-    testString: assert(result == "This sandwich is okey-dokey." && replaceText === "okey-dokey", 'Your regex should change <code>"This sandwich is good."</code> to <code>"This sandwich is okey-dokey."</code>');
+    testString: assert(result == "This sandwich is okey-dokey." && replaceText === "okey-dokey");
   - text: You should not change the last line.
-    testString: assert(code.match(/result\s*=\s*huhText\.replace\(.*?\)/), 'You should not change the last line.');
+    testString: assert(code.match(/result\s*=\s*huhText\.replace\(.*?\)/));
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/using-the-test-method.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/using-the-test-method.english.md
@@ -30,9 +30,9 @@ Apply the regex <code>myRegex</code> on the string <code>myString</code> using t
 ```yml
 tests:
   - text: You should use <code>.test()</code> to test the regex.
-    testString: assert(code.match(/myRegex.test\(\s*myString\s*\)/), 'You should use <code>.test()</code> to test the regex.');
+    testString: assert(code.match(/myRegex.test\(\s*myString\s*\)/));
   - text: Your result should return <code>true</code>.
-    testString: assert(result === true, 'Your result should return <code>true</code>.');
+    testString: assert(result === true);
 
 ```
 


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Related to issue #36400

This PR removes assert message arguments from `testString` for the following sub sections of the `JavaScript Algorithms and Data Structures` curriculum section:
* Object Oriented Programming
* Regular Expressions