### PR TITLE
fix(curriculum): Remove unnecessary assert message argument from English Responsive Web Design challenges - 02

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/add-a-negative-margin-to-an-element.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/add-a-negative-margin-to-an-element.english.md
@@ -23,7 +23,7 @@ Change the <code>margin</code> of the blue box to <code>-15px</code>, so it fill
 ```yml
 tests:
   - text: Your <code>blue-box</code> class should give elements <code>-15px</code> of <code>margin</code>.
-    testString: assert($(".blue-box").css("margin-top") === "-15px", 'Your <code>blue-box</code> class should give elements <code>-15px</code> of <code>margin</code>.');
+    testString: assert($(".blue-box").css("margin-top") === "-15px");
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/add-borders-around-your-elements.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/add-borders-around-your-elements.english.md
@@ -35,15 +35,15 @@ Remember that you can apply multiple classes to an element using its <code>class
 ```yml
 tests:
   - text: Your <code>img</code> element should have the class <code>smaller-image</code>.
-    testString: assert($("img").hasClass("smaller-image"), 'Your <code>img</code> element should have the class <code>smaller-image</code>.');
+    testString: assert($("img").hasClass("smaller-image"));
   - text: Your <code>img</code> element should have the class <code>thick-green-border</code>.
-    testString: assert($("img").hasClass("thick-green-border"), 'Your <code>img</code> element should have the class <code>thick-green-border</code>.');
+    testString: assert($("img").hasClass("thick-green-border"));
   - text: Give your image a border width of <code>10px</code>.
-    testString: assert($("img").hasClass("thick-green-border") && parseInt($("img").css("border-top-width"), 10) >= 8 && parseInt($("img").css("border-top-width"), 10) <= 12, 'Give your image a border width of <code>10px</code>.');
+    testString: assert($("img").hasClass("thick-green-border") && parseInt($("img").css("border-top-width"), 10) >= 8 && parseInt($("img").css("border-top-width"), 10) <= 12);
   - text: Give your image a border style of <code>solid</code>.
-    testString: assert($("img").css("border-right-style") === "solid", 'Give your image a border style of <code>solid</code>.');
+    testString: assert($("img").css("border-right-style") === "solid");
   - text: The border around your <code>img</code> element should be green.
-    testString: assert($("img").css("border-left-color") === "rgb(0, 128, 0)", 'The border around your <code>img</code> element should be green.');
+    testString: assert($("img").css("border-left-color") === "rgb(0, 128, 0)");
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/add-different-margins-to-each-side-of-an-element.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/add-different-margins-to-each-side-of-an-element.english.md
@@ -22,13 +22,13 @@ Give the blue box a <code>margin</code> of <code>40px</code> on its top and left
 ```yml
 tests:
   - text: Your <code>blue-box</code> class should give the top of elements <code>40px</code> of <code>margin</code>.
-    testString: assert($(".blue-box").css("margin-top") === "40px", 'Your <code>blue-box</code> class should give the top of elements <code>40px</code> of <code>margin</code>.');
+    testString: assert($(".blue-box").css("margin-top") === "40px");
   - text: Your <code>blue-box</code> class should give the right of elements <code>20px</code> of <code>margin</code>.
-    testString: assert($(".blue-box").css("margin-right") === "20px", 'Your <code>blue-box</code> class should give the right of elements <code>20px</code> of <code>margin</code>.');
+    testString: assert($(".blue-box").css("margin-right") === "20px");
   - text: Your <code>blue-box</code> class should give the bottom of elements <code>20px</code> of <code>margin</code>.
-    testString: assert($(".blue-box").css("margin-bottom") === "20px", 'Your <code>blue-box</code> class should give the bottom of elements <code>20px</code> of <code>margin</code>.');
+    testString: assert($(".blue-box").css("margin-bottom") === "20px");
   - text: Your <code>blue-box</code> class should give the left of elements <code>40px</code> of <code>margin</code>.
-    testString: assert($(".blue-box").css("margin-left") === "40px", 'Your <code>blue-box</code> class should give the left of elements <code>40px</code> of <code>margin</code>.');
+    testString: assert($(".blue-box").css("margin-left") === "40px");
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/add-different-padding-to-each-side-of-an-element.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/add-different-padding-to-each-side-of-an-element.english.md
@@ -22,13 +22,13 @@ Give the blue box a <code>padding</code> of <code>40px</code> on its top and lef
 ```yml
 tests:
   - text: Your <code>blue-box</code> class should give the top of the elements <code>40px</code> of <code>padding</code>.
-    testString: assert($(".blue-box").css("padding-top") === "40px", 'Your <code>blue-box</code> class should give the top of the elements <code>40px</code> of <code>padding</code>.');
+    testString: assert($(".blue-box").css("padding-top") === "40px");
   - text: Your <code>blue-box</code> class should give the right of the elements <code>20px</code> of <code>padding</code>.
-    testString: assert($(".blue-box").css("padding-right") === "20px", 'Your <code>blue-box</code> class should give the right of the elements <code>20px</code> of <code>padding</code>.');
+    testString: assert($(".blue-box").css("padding-right") === "20px");
   - text: Your <code>blue-box</code> class should give the bottom of the elements <code>20px</code> of <code>padding</code>.
-    testString: assert($(".blue-box").css("padding-bottom") === "20px", 'Your <code>blue-box</code> class should give the bottom of the elements <code>20px</code> of <code>padding</code>.');
+    testString: assert($(".blue-box").css("padding-bottom") === "20px");
   - text: Your <code>blue-box</code> class should give the left of the elements <code>40px</code> of <code>padding</code>.
-    testString: assert($(".blue-box").css("padding-left") === "40px", 'Your <code>blue-box</code> class should give the left of the elements <code>40px</code> of <code>padding</code>.');
+    testString: assert($(".blue-box").css("padding-left") === "40px");
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/add-rounded-corners-with-border-radius.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/add-rounded-corners-with-border-radius.english.md
@@ -22,9 +22,9 @@ You can specify a <code>border-radius</code> with pixels. Give your cat photo a 
 ```yml
 tests:
   - text: Your image element should have the class "thick-green-border".
-    testString: assert($("img").hasClass("thick-green-border"), 'Your image element should have the class "thick-green-border".');
+    testString: assert($("img").hasClass("thick-green-border"));
   - text: Your image should have a border radius of <code>10px</code>
-    testString: assert($("img").css("border-top-left-radius") === '10px' && $("img").css("border-top-right-radius") === '10px' && $("img").css("border-bottom-left-radius") === '10px' && $("img").css("border-bottom-right-radius") === '10px', 'Your image should have a border radius of <code>10px</code>');
+    testString: assert($("img").css("border-top-left-radius") === '10px' && $("img").css("border-top-right-radius") === '10px' && $("img").css("border-bottom-left-radius") === '10px' && $("img").css("border-bottom-right-radius") === '10px');
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/adjust-the-margin-of-an-element.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/adjust-the-margin-of-an-element.english.md
@@ -23,7 +23,7 @@ Change the <code>margin</code> of the blue box to match that of the red box.
 ```yml
 tests:
   - text: Your <code>blue-box</code> class should give elements <code>20px</code> of <code>margin</code>.
-    testString: assert($(".blue-box").css("margin-top") === "20px", 'Your <code>blue-box</code> class should give elements <code>20px</code> of <code>margin</code>.');
+    testString: assert($(".blue-box").css("margin-top") === "20px");
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/adjust-the-padding-of-an-element.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/adjust-the-padding-of-an-element.english.md
@@ -26,7 +26,7 @@ Change the <code>padding</code> of your blue box to match that of your red box.
 ```yml
 tests:
   - text: Your <code>blue-box</code> class should give elements <code>20px</code> of <code>padding</code>.
-    testString: assert($(".blue-box").css("padding-top") === "20px", 'Your <code>blue-box</code> class should give elements <code>20px</code> of <code>padding</code>.');
+    testString: assert($(".blue-box").css("padding-top") === "20px");
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/attach-a-fallback-value-to-a-css-variable.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/attach-a-fallback-value-to-a-css-variable.english.md
@@ -30,9 +30,9 @@ It looks like there is a problem with the variables supplied to the <code>.pengu
 ```yml
 tests:
   - text: Apply the fallback value of <code>black</code> to the <code>background</code> property of the <code>penguin-top</code> class.
-    testString: assert(code.match(/.penguin-top\s*?{[\s\S]*background\s*?:\s*?var\(\s*?--pengiun-skin\s*?,\s*?black\s*?\)\s*?;[\s\S]*}[\s\S]*.penguin-bottom\s{/gi), 'Apply the fallback value of <code>black</code> to the <code>background</code> property of the <code>penguin-top</code> class.');
+    testString: assert(code.match(/.penguin-top\s*?{[\s\S]*background\s*?:\s*?var\(\s*?--pengiun-skin\s*?,\s*?black\s*?\)\s*?;[\s\S]*}[\s\S]*.penguin-bottom\s{/gi));
   - text: Apply the fallback value of <code>black</code> to the <code>background</code> property of the <code>penguin-bottom</code> class.
-    testString: assert(code.match(/.penguin-bottom\s*?{[\s\S]*background\s*?:\s*?var\(\s*?--pengiun-skin\s*?,\s*?black\s*?\)\s*?;[\s\S]*}/gi), 'Apply the fallback value of <code>black</code> to the <code>background</code> property of the <code>penguin-bottom</code> class.');
+    testString: assert(code.match(/.penguin-bottom\s*?{[\s\S]*background\s*?:\s*?var\(\s*?--pengiun-skin\s*?,\s*?black\s*?\)\s*?;[\s\S]*}/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/change-a-variable-for-a-specific-area.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/change-a-variable-for-a-specific-area.english.md
@@ -22,7 +22,7 @@ Change the value of <code>--penguin-belly</code> to <code>white</code> in the <c
 ```yml
 tests:
   - text: The <code>penguin</code> class should reassign the <code>--penguin-belly</code> variable to <code>white</code>.
-    testString: assert(code.match(/.penguin\s*?{[\s\S]*--penguin-belly\s*?:\s*?white\s*?;[\s\S]*}/gi), 'The <code>penguin</code> class should reassign the <code>--penguin-belly</code> variable to <code>white</code>.');
+    testString: assert(code.match(/.penguin\s*?{[\s\S]*--penguin-belly\s*?:\s*?white\s*?;[\s\S]*}/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/change-the-font-size-of-an-element.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/change-the-font-size-of-an-element.english.md
@@ -28,7 +28,7 @@ Inside the same <code>&#60;style&#62;</code> tag that contains your <code>red-te
 ```yml
 tests:
   - text: Between the <code>style</code> tags, give the <code>p</code> elements <code>font-size</code> of <code>16px</code>. Browser and Text zoom should be at 100%.
-    testString: assert(code.match(/p\s*{\s*font-size\s*:\s*16\s*px\s*;\s*}/i), 'Between the <code>style</code> tags, give the <code>p</code> elements <code>font-size</code> of <code>16px</code>. Browser and Text zoom should be at 100%.');
+    testString: assert(code.match(/p\s*{\s*font-size\s*:\s*16\s*px\s*;\s*}/i));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/create-a-custom-css-variable.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/create-a-custom-css-variable.english.md
@@ -28,7 +28,7 @@ In the <code>penguin</code> class, create a variable name <code>--penguin-skin</
 ```yml
 tests:
   - text: <code>penguin</code> class should declare the <code>--penguin-skin</code> variable and assign it to <code>gray</code>.
-    testString: assert(code.match(/.penguin\s*?{[\s\S]*--penguin-skin\s*?:\s*?gray\s*?;[\s\S]*}/gi), '<code>penguin</code> class should declare the <code>--penguin-skin</code> variable and assign it to <code>gray</code>.');
+    testString: assert(code.match(/.penguin\s*?{[\s\S]*--penguin-skin\s*?:\s*?gray\s*?;[\s\S]*}/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/give-a-background-color-to-a-div-element.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/give-a-background-color-to-a-div-element.english.md
@@ -29,9 +29,9 @@ Create a class called <code>silver-background</code> with the <code>background-c
 ```yml
 tests:
   - text: Give your <code>div</code> element the class <code>silver-background</code>.
-    testString: assert($("div").hasClass("silver-background"), 'Give your <code>div</code> element the class <code>silver-background</code>.');
+    testString: assert($("div").hasClass("silver-background"));
   - text: Your <code>div</code> element should have a silver background.
-    testString: assert($("div").css("background-color") === "rgb(192, 192, 192)", 'Your <code>div</code> element should have a silver background.');
+    testString: assert($("div").css("background-color") === "rgb(192, 192, 192)");
   - text: Define a class named <code>silver-background</code> within the <code>style</code> element and assign the value of <code>silver</code> to the <code>background-color</code> property.
     testString: assert(code.match(/\.silver-background\s*{\s*background-color:\s*silver;\s*}/), "Define a class named <code>silver-background</code> within the <code>style</code> element and assign the value of <code>silver</code> to the <code>background-color</code> property.");
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/import-a-google-font.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/import-a-google-font.english.md
@@ -28,13 +28,13 @@ Create a <code>font-family</code> CSS rule that uses the <code>Lobster</code> fo
 ```yml
 tests:
   - text: Import the <code>Lobster</code> font.
-    testString: assert(new RegExp("googleapis", "gi").test(code), 'Import the <code>Lobster</code> font.');
+    testString: assert(new RegExp("googleapis", "gi").test(code));
   - text: Your <code>h2</code> element should use the font <code>Lobster</code>.
-    testString: assert($("h2").css("font-family").match(/lobster/i), 'Your <code>h2</code> element should use the font <code>Lobster</code>.');
+    testString: assert($("h2").css("font-family").match(/lobster/i));
   - text: Use an <code>h2</code> CSS selector to change the font.
     testString: 'assert(/\s*h2\s*\{\s*font-family\:\s*(\"|")?Lobster(\"|")?(.{0,})\s*;\s*\}/gi.test(code), "Use an <code>h2</code> CSS selector to change the font.");'
   - text: Your <code>p</code> element should still use the font <code>monospace</code>.
-    testString: assert($("p").css("font-family").match(/monospace/i), 'Your <code>p</code> element should still use the font <code>monospace</code>.');
+    testString: assert($("p").css("font-family").match(/monospace/i));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/inherit-css-variables.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/inherit-css-variables.english.md
@@ -23,7 +23,7 @@ Define a variable named <code>--penguin-belly</code> in the <code>:root</code> s
 ```yml
 tests:
   - text: Declare the <code>--penguin-belly</code> variable in the <code>:root</code> and assign it to <code>pink</code>.
-    testString: assert(code.match(/:root\s*?{[\s\S]*--penguin-belly\s*?:\s*?pink\s*?;[\s\S]*}/gi), 'Declare the <code>--penguin-belly</code> variable in the <code>:root</code> and assign it to <code>pink</code>.');
+    testString: assert(code.match(/:root\s*?{[\s\S]*--penguin-belly\s*?:\s*?pink\s*?;[\s\S]*}/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/inherit-styles-from-the-body-element.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/inherit-styles-from-the-body-element.english.md
@@ -24,19 +24,19 @@ Finally, give your <code>body</code> element the font-family of <code>monospace<
 ```yml
 tests:
   - text: Create an <code>h1</code> element.
-    testString: assert(($("h1").length > 0), 'Create an <code>h1</code> element.');
+    testString: assert(($("h1").length > 0));
   - text: Your <code>h1</code> element should have the text <code>Hello World</code>.
-    testString: assert(($("h1").length > 0 && $("h1").text().match(/hello world/i)), 'Your <code>h1</code> element should have the text <code>Hello World</code>.');
+    testString: assert(($("h1").length > 0 && $("h1").text().match(/hello world/i)));
   - text: Make sure your <code>h1</code> element has a closing tag.
-    testString: assert(code.match(/<\/h1>/g) && code.match(/<h1/g) && code.match(/<\/h1>/g).length === code.match(/<h1/g).length, 'Make sure your <code>h1</code> element has a closing tag.');
+    testString: assert(code.match(/<\/h1>/g) && code.match(/<h1/g) && code.match(/<\/h1>/g).length === code.match(/<h1/g).length);
   - text: Give your <code>body</code> element the <code>color</code> property of <code>green</code>.
-    testString: assert(($("body").css("color") === "rgb(0, 128, 0)"), 'Give your <code>body</code> element the <code>color</code> property of <code>green</code>.');
+    testString: assert(($("body").css("color") === "rgb(0, 128, 0)"));
   - text: Give your <code>body</code> element the <code>font-family</code> property of <code>monospace</code>.
-    testString: assert(($("body").css("font-family").match(/monospace/i)), 'Give your <code>body</code> element the <code>font-family</code> property of <code>monospace</code>.');
+    testString: assert(($("body").css("font-family").match(/monospace/i)));
   - text: Your <code>h1</code> element should inherit the font <code>monospace</code> from your <code>body</code> element.
-    testString: assert(($("h1").length > 0 && $("h1").css("font-family").match(/monospace/i)), 'Your <code>h1</code> element should inherit the font <code>monospace</code> from your <code>body</code> element.');
+    testString: assert(($("h1").length > 0 && $("h1").css("font-family").match(/monospace/i)));
   - text: Your <code>h1</code> element should inherit the color green from your <code>body</code> element.
-    testString: assert(($("h1").length > 0 && $("h1").css("color") === "rgb(0, 128, 0)"), 'Your <code>h1</code> element should inherit the color green from your <code>body</code> element.');
+    testString: assert(($("h1").length > 0 && $("h1").css("color") === "rgb(0, 128, 0)"));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/make-circular-images-with-a-border-radius.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/make-circular-images-with-a-border-radius.english.md
@@ -21,9 +21,9 @@ Give your cat photo a <code>border-radius</code> of <code>50%</code>.
 ```yml
 tests:
   - text: Your image should have a border radius of <code>50%</code>, making it perfectly circular.
-    testString: assert(parseInt($("img").css("border-top-left-radius")) > 48, 'Your image should have a border radius of <code>50%</code>, making it perfectly circular.');
+    testString: assert(parseInt($("img").css("border-top-left-radius")) > 48);
   - text: Be sure to use a percentage value of <code>50%</code>.
-    testString: assert(code.match(/50%/g), 'Be sure to use a percentage value of <code>50%</code>.');
+    testString: assert(code.match(/50%/g));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/override-all-other-styles-by-using-important.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/override-all-other-styles-by-using-important.english.md
@@ -26,17 +26,17 @@ An example of how to do this is:
 ```yml
 tests:
   - text: Your <code>h1</code> element should have the class <code>pink-text</code>.
-    testString: assert($("h1").hasClass("pink-text"), 'Your <code>h1</code> element should have the class <code>pink-text</code>.');
+    testString: assert($("h1").hasClass("pink-text"));
   - text: Your <code>h1</code> element should have the class <code>blue-text</code>.
-    testString: assert($("h1").hasClass("blue-text"), 'Your <code>h1</code> element should have the class <code>blue-text</code>.');
+    testString: assert($("h1").hasClass("blue-text"));
   - text: Your <code>h1</code> element should have the id of <code>orange-text</code>.
-    testString: assert($("h1").attr("id") === "orange-text", 'Your <code>h1</code> element should have the id of <code>orange-text</code>.');
+    testString: assert($("h1").attr("id") === "orange-text");
   - text: Your <code>h1</code> element should have the inline style of <code>color&#58; white</code>.
-    testString: assert(code.match(/<h1.*style/gi) && code.match(/<h1.*style.*color\s*?:/gi), 'Your <code>h1</code> element should have the inline style of <code>color&#58; white</code>.');
+    testString: assert(code.match(/<h1.*style/gi) && code.match(/<h1.*style.*color\s*?:/gi));
   - text: Your <code>pink-text</code> class declaration should have the <code>!important</code> keyword to override all other declarations.
-    testString: assert(code.match(/\.pink-text\s*?\{[\s\S]*?color:.*pink.*!important\s*;?[^\.]*\}/g), 'Your <code>pink-text</code> class declaration should have the <code>!important</code> keyword to override all other declarations.');
+    testString: assert(code.match(/\.pink-text\s*?\{[\s\S]*?color:.*pink.*!important\s*;?[^\.]*\}/g));
   - text: Your <code>h1</code> element should be pink.
-    testString: assert($("h1").css("color") === "rgb(255, 192, 203)", 'Your <code>h1</code> element should be pink.');
+    testString: assert($("h1").css("color") === "rgb(255, 192, 203)");
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/override-class-declarations-by-styling-id-attributes.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/override-class-declarations-by-styling-id-attributes.english.md
@@ -34,19 +34,19 @@ Create a CSS declaration for your <code>orange-text</code> id in your <code>styl
 ```yml
 tests:
   - text: Your <code>h1</code> element should have the class <code>pink-text</code>.
-    testString: assert($("h1").hasClass("pink-text"), 'Your <code>h1</code> element should have the class <code>pink-text</code>.');
+    testString: assert($("h1").hasClass("pink-text"));
   - text: Your <code>h1</code> element should have the class <code>blue-text</code>.
-    testString: assert($("h1").hasClass("blue-text"), 'Your <code>h1</code> element should have the class <code>blue-text</code>.');
+    testString: assert($("h1").hasClass("blue-text"));
   - text: Give your <code>h1</code> element the id of <code>orange-text</code>.
-    testString: assert($("h1").attr("id") === "orange-text", 'Give your <code>h1</code> element the id of <code>orange-text</code>.');
+    testString: assert($("h1").attr("id") === "orange-text");
   - text: There should be only one <code>h1</code> element.
-    testString: assert(($("h1").length === 1), 'There should be only one <code>h1</code> element.');
+    testString: assert(($("h1").length === 1));
   - text: Create a CSS declaration for your <code>orange-text</code> id
-    testString: assert(code.match(/#orange-text\s*{/gi), 'Create a CSS declaration for your <code>orange-text</code> id');
+    testString: assert(code.match(/#orange-text\s*{/gi));
   - text: Do not give your <code>h1</code> any <code>style</code> attributes.
-    testString: assert(!code.match(/<h1.*style.*>/gi), 'Do not give your <code>h1</code> any <code>style</code> attributes.');
+    testString: assert(!code.match(/<h1.*style.*>/gi));
   - text: Your <code>h1</code> element should be orange.
-    testString: assert($("h1").css("color") === "rgb(255, 165, 0)", 'Your <code>h1</code> element should be orange.');
+    testString: assert($("h1").css("color") === "rgb(255, 165, 0)");
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/override-class-declarations-with-inline-styles.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/override-class-declarations-with-inline-styles.english.md
@@ -24,15 +24,15 @@ Leave the <code>blue-text</code> and <code>pink-text</code> classes on your <cod
 ```yml
 tests:
   - text: Your <code>h1</code> element should have the class <code>pink-text</code>.
-    testString: assert($("h1").hasClass("pink-text"), 'Your <code>h1</code> element should have the class <code>pink-text</code>.');
+    testString: assert($("h1").hasClass("pink-text"));
   - text: Your <code>h1</code> element should have the class <code>blue-text</code>.
-    testString: assert($("h1").hasClass("blue-text"), 'Your <code>h1</code> element should have the class <code>blue-text</code>.');
+    testString: assert($("h1").hasClass("blue-text"));
   - text: Your <code>h1</code> element should have the id of <code>orange-text</code>.
-    testString: assert($("h1").attr("id") === "orange-text", 'Your <code>h1</code> element should have the id of <code>orange-text</code>.');
+    testString: assert($("h1").attr("id") === "orange-text");
   - text: Give your <code>h1</code> element an inline style.
-    testString: assert(document.querySelector('h1[style]'), 'Give your <code>h1</code> element an inline style.');
+    testString: assert(document.querySelector('h1[style]'));
   - text: Your <code>h1</code> element should be white.
-    testString: assert($("h1").css("color") === "rgb(255, 255, 255)", 'Your <code>h1</code> element should be white.');
+    testString: assert($("h1").css("color") === "rgb(255, 255, 255)");
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/override-styles-in-subsequent-css.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/override-styles-in-subsequent-css.english.md
@@ -27,13 +27,13 @@ However, the order of the <code>class</code> declarations in the <code>&#60;styl
 ```yml
 tests:
   - text: Your <code>h1</code> element should have the class <code>pink-text</code>.
-    testString: assert($("h1").hasClass("pink-text"), 'Your <code>h1</code> element should have the class <code>pink-text</code>.');
+    testString: assert($("h1").hasClass("pink-text"));
   - text: Your <code>h1</code> element should have the class <code>blue-text</code>.
-    testString: assert($("h1").hasClass("blue-text"), 'Your <code>h1</code> element should have the class <code>blue-text</code>.');
+    testString: assert($("h1").hasClass("blue-text"));
   - text: Both <code>blue-text</code> and <code>pink-text</code> should belong to the same <code>h1</code> element.
-    testString: assert($(".pink-text").hasClass("blue-text"), 'Both <code>blue-text</code> and <code>pink-text</code> should belong to the same <code>h1</code> element.');
+    testString: assert($(".pink-text").hasClass("blue-text"));
   - text: Your <code>h1</code> element should be blue.
-    testString: assert($("h1").css("color") === "rgb(0, 0, 255)", 'Your <code>h1</code> element should be blue.');
+    testString: assert($("h1").css("color") === "rgb(0, 0, 255)");
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/prioritize-one-style-over-another.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/prioritize-one-style-over-another.english.md
@@ -24,11 +24,11 @@ Give your <code>h1</code> element the class of <code>pink-text</code>.
 ```yml
 tests:
   - text: Your <code>h1</code> element should have the class <code>pink-text</code>.
-    testString: assert($("h1").hasClass("pink-text"), 'Your <code>h1</code> element should have the class <code>pink-text</code>.');
+    testString: assert($("h1").hasClass("pink-text"));
   - text: Your <code>&#60;style&#62;</code> should have a <code>pink-text</code> CSS class that changes the <code>color</code>.
-    testString: assert(code.match(/\.pink-text\s*\{\s*color\s*:\s*.+\s*;\s*\}/g), 'Your <code>&#60;style&#62;</code> should have a <code>pink-text</code> CSS class that changes the <code>color</code>.');
+    testString: assert(code.match(/\.pink-text\s*\{\s*color\s*:\s*.+\s*;\s*\}/g));
   - text: Your <code>h1</code> element should be pink.
-    testString: assert($("h1").css("color") === "rgb(255, 192, 203)", 'Your <code>h1</code> element should be pink.');
+    testString: assert($("h1").css("color") === "rgb(255, 192, 203)");
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/set-the-font-family-of-an-element.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/set-the-font-family-of-an-element.english.md
@@ -29,7 +29,7 @@ Make all of your <code>p</code> elements use the <code>monospace</code> font.
 ```yml
 tests:
   - text: Your <code>p</code> elements should use the font <code>monospace</code>.
-    testString: assert($("p").not(".red-text").css("font-family").match(/monospace/i), 'Your <code>p</code> elements should use the font <code>monospace</code>.');
+    testString: assert($("p").not(".red-text").css("font-family").match(/monospace/i));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/set-the-id-of-an-element.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/set-the-id-of-an-element.english.md
@@ -25,7 +25,7 @@ Give your <code>form</code> element the id <code>cat-photo-form</code>.
 ```yml
 tests:
   - text: Give your <code>form</code> element the id of <code>cat-photo-form</code>.
-    testString: assert($("form").attr("id") === "cat-photo-form", 'Give your <code>form</code> element the id of <code>cat-photo-form</code>.');
+    testString: assert($("form").attr("id") === "cat-photo-form");
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/size-your-images.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/size-your-images.english.md
@@ -32,9 +32,9 @@ Create a class called <code>smaller-image</code> and use it to resize the image 
 ```yml
 tests:
   - text: Your <code>img</code> element should have the class <code>smaller-image</code>.
-    testString: assert($("img[src='https://bit.ly/fcc-relaxing-cat']").attr('class') === "smaller-image", 'Your <code>img</code> element should have the class <code>smaller-image</code>.');
+    testString: assert($("img[src='https://bit.ly/fcc-relaxing-cat']").attr('class') === "smaller-image");
   - text: Your image should be 100 pixels wide. Browser zoom should be at 100%.
-    testString: assert($("img").width() === 100, 'Your image should be 100 pixels wide. Browser zoom should be at 100%.');
+    testString: assert($("img").width() === 100);
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/specify-how-fonts-should-degrade.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/specify-how-fonts-should-degrade.english.md
@@ -33,13 +33,13 @@ In the last challenge, you imported the <code>Lobster</code> font using the <cod
 ```yml
 tests:
   - text: Your h2 element should use the font <code>Lobster</code>.
-    testString: assert($("h2").css("font-family").match(/^"?lobster/i), 'Your h2 element should use the font <code>Lobster</code>.');
+    testString: assert($("h2").css("font-family").match(/^"?lobster/i));
   - text: Your h2 element should degrade to the font <code>monospace</code> when <code>Lobster</code> is not available.
-    testString: assert(/\s*h2\s*\{\s*font-family\:\s*(\'|")?Lobster(\'|")?,\s*monospace\s*;\s*\}/gi.test(code), 'Your h2 element should degrade to the font <code>monospace</code> when <code>Lobster</code> is not available.');
-  - text: Comment out your call to Google for the <code>Lobster</code> font by putting <code>&#60!--</code> in front of it.
-    testString: assert(new RegExp("<!--[^fc]", "gi").test(code), 'Comment out your call to Google for the <code>Lobster</code> font by putting <code>&#60;!--</code> in front of it.');
+    testString: assert(/\s*h2\s*\{\s*font-family\:\s*(\'|")?Lobster(\'|")?,\s*monospace\s*;\s*\}/gi.test(code));
+  - text: Comment out your call to Google for the <code>Lobster</code> font by putting <code>&#60;!--</code> in front of it.
+    testString: assert(new RegExp("<!--[^fc]", "gi").test(code));
   - text: Be sure to close your comment by adding <code>--&#62;!</code>.
-    testString: assert(new RegExp("[^fc]-->", "gi").test(code), 'Be sure to close your comment by adding <code>--&#62;!</code>.');
+    testString: assert(new RegExp("[^fc]-->", "gi").test(code));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/style-multiple-elements-with-a-css-class.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/style-multiple-elements-with-a-css-class.english.md
@@ -21,15 +21,15 @@ Classes allow you to use the same CSS styles on multiple HTML elements. You can 
 ```yml
 tests:
   - text: Your <code>h2</code> element should be red.
-    testString: assert($("h2").css("color") === "rgb(255, 0, 0)", 'Your <code>h2</code> element should be red.');
+    testString: assert($("h2").css("color") === "rgb(255, 0, 0)");
   - text: Your <code>h2</code> element should have the class <code>red-text</code>.
-    testString: assert($("h2").hasClass("red-text"), 'Your <code>h2</code> element should have the class <code>red-text</code>.');
+    testString: assert($("h2").hasClass("red-text"));
   - text: Your first <code>p</code> element should be red.
-    testString: assert($("p:eq(0)").css("color") === "rgb(255, 0, 0)", 'Your first <code>p</code> element should be red.');
+    testString: assert($("p:eq(0)").css("color") === "rgb(255, 0, 0)");
   - text: Your second and third <code>p</code> elements should not be red.
-    testString: assert(!($("p:eq(1)").css("color") === "rgb(255, 0, 0)") && !($("p:eq(2)").css("color") === "rgb(255, 0, 0)"), 'Your second and third <code>p</code> elements should not be red.');
+    testString: assert(!($("p:eq(1)").css("color") === "rgb(255, 0, 0)") && !($("p:eq(2)").css("color") === "rgb(255, 0, 0)"));
   - text: Your first <code>p</code> element should have the class <code>red-text</code>.
-    testString: assert($("p:eq(0)").hasClass("red-text"), 'Your first <code>p</code> element should have the class <code>red-text</code>.');
+    testString: assert($("p:eq(0)").hasClass("red-text"));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/style-the-html-body-element.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/style-the-html-body-element.english.md
@@ -30,11 +30,11 @@ body {
 ```yml
 tests:
   - text: Give your <code>body</code> element the <code>background-color</code> of black.
-    testString: assert($("body").css("background-color") === "rgb(0, 0, 0)", 'Give your <code>body</code> element the <code>background-color</code> of black.');
+    testString: assert($("body").css("background-color") === "rgb(0, 0, 0)");
   - text: Make sure your CSS rule is properly formatted with both opening and closing curly brackets.
-    testString: assert(code.match(/<style>\s*body\s*\{\s*background.*\s*:\s*.*;\s*\}\s*<\/style>/i), 'Make sure your CSS rule is properly formatted with both opening and closing curly brackets.');
+    testString: assert(code.match(/<style>\s*body\s*\{\s*background.*\s*:\s*.*;\s*\}\s*<\/style>/i));
   - text: Make sure your CSS rule ends with a semi-colon.
-    testString: assert(code.match(/<style>\s*body\s*\{\s*background.*\s*:\s*.*;\s*\}\s*<\/style>/i), 'Make sure your CSS rule ends with a semi-colon.');
+    testString: assert(code.match(/<style>\s*body\s*\{\s*background.*\s*:\s*.*;\s*\}\s*<\/style>/i));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/understand-absolute-versus-relative-units.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/understand-absolute-versus-relative-units.english.md
@@ -24,9 +24,9 @@ Add a <code>padding</code> property to the element with class <code>red-box</cod
 ```yml
 tests:
   - text: Your <code>red-box</code> class should have a <code>padding</code> property.
-    testString: assert($('.red-box').css('padding-top') != '0px' && $('.red-box').css('padding-right') != '0px' && $('.red-box').css('padding-bottom') != '0px' && $('.red-box').css('padding-left') != '0px', 'Your <code>red-box</code> class should have a <code>padding</code> property.');
+    testString: assert($('.red-box').css('padding-top') != '0px' && $('.red-box').css('padding-right') != '0px' && $('.red-box').css('padding-bottom') != '0px' && $('.red-box').css('padding-left') != '0px');
   - text: Your <code>red-box</code> class should give elements 1.5em of <code>padding</code>.
-    testString: assert(code.match(/\.red-box\s*?{(\s|.)*?padding:\s*?1\.5em/gi), 'Your <code>red-box</code> class should give elements 1.5em of <code>padding</code>.');
+    testString: assert(code.match(/\.red-box\s*?{(\s|.)*?padding:\s*?1\.5em/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-a-css-class-to-style-an-element.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-a-css-class-to-style-an-element.english.md
@@ -36,13 +36,13 @@ Give your <code>h2</code> element the <code>class</code> attribute with a value 
 ```yml
 tests:
   - text: Your <code>h2</code> element should be red.
-    testString: assert($("h2").css("color") === "rgb(255, 0, 0)", 'Your <code>h2</code> element should be red.');
+    testString: assert($("h2").css("color") === "rgb(255, 0, 0)");
   - text: Your <code>h2</code> element should have the class <code>red-text</code>.
-    testString: assert($("h2").hasClass("red-text"), 'Your <code>h2</code> element should have the class <code>red-text</code>.');
+    testString: assert($("h2").hasClass("red-text"));
   - text: Your stylesheet should declare a <code>red-text</code> class and have its color set to red.
-    testString: assert(code.match(/\.red-text\s*\{\s*color\s*:\s*red;\s*\}/g), 'Your stylesheet should declare a <code>red-text</code> class and have its color set to red.');
+    testString: assert(code.match(/\.red-text\s*\{\s*color\s*:\s*red;\s*\}/g));
   - text: Do not use inline style declarations like <code>style="color&#58; red"</code> in your <code>h2</code> element.
-    testString: assert($("h2").attr("style") === undefined, 'Do not use inline style declarations like <code>style="color&#58; red"</code> in your <code>h2</code> element.');
+    testString: assert($("h2").attr("style") === undefined);
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-a-custom-css-variable.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-a-custom-css-variable.english.md
@@ -28,13 +28,13 @@ Apply the <code>--penguin-skin</code> variable to the <code>background</code> pr
 ```yml
 tests:
   - text: Apply the <code>--penguin-skin</code> variable to the <code>background</code> property of the <code>penguin-top</code> class.
-    testString: assert(code.match(/.penguin-top\s*?{[\s\S]*background\s*?:\s*?var\s*?\(\s*?--penguin-skin\s*?\)\s*?;[\s\S]*}[\s\S]*.penguin-bottom\s{/gi), 'Apply the <code>--penguin-skin</code> variable to the <code>background</code> property of the <code>penguin-top</code> class.');
+    testString: assert(code.match(/.penguin-top\s*?{[\s\S]*background\s*?:\s*?var\s*?\(\s*?--penguin-skin\s*?\)\s*?;[\s\S]*}[\s\S]*.penguin-bottom\s{/gi));
   - text: Apply the <code>--penguin-skin</code> variable to the <code>background</code> property of the <code>penguin-bottom</code> class.
-    testString: assert(code.match(/.penguin-bottom\s*?{[\s\S]*background\s*?:\s*?var\s*?\(\s*?--penguin-skin\s*?\)\s*?;[\s\S]*}[\s\S]*.right-hand\s{/gi), 'Apply the <code>--penguin-skin</code> variable to the <code>background</code> property of the <code>penguin-bottom</code> class.');
+    testString: assert(code.match(/.penguin-bottom\s*?{[\s\S]*background\s*?:\s*?var\s*?\(\s*?--penguin-skin\s*?\)\s*?;[\s\S]*}[\s\S]*.right-hand\s{/gi));
   - text: Apply the <code>--penguin-skin</code> variable to the <code>background</code> property of the <code>right-hand</code> class.
-    testString: assert(code.match(/.right-hand\s*?{[\s\S]*background\s*?:\s*?var\s*?\(\s*?--penguin-skin\s*?\)\s*?;[\s\S]*}[\s\S]*.left-hand\s{/gi), 'Apply the <code>--penguin-skin</code> variable to the <code>background</code> property of the <code>right-hand</code> class.');
+    testString: assert(code.match(/.right-hand\s*?{[\s\S]*background\s*?:\s*?var\s*?\(\s*?--penguin-skin\s*?\)\s*?;[\s\S]*}[\s\S]*.left-hand\s{/gi));
   - text: Apply the <code>--penguin-skin</code> variable to the <code>background</code> property of the <code>left-hand</code> class.
-    testString: assert(code.match(/.left-hand\s*?{[\s\S]*background\s*?:\s*?var\s*?\(\s*?--penguin-skin\s*?\)\s*?;[\s\S]*}/gi), 'Apply the <code>--penguin-skin</code> variable to the <code>background</code> property of the <code>left-hand</code> class.');
+    testString: assert(code.match(/.left-hand\s*?{[\s\S]*background\s*?:\s*?var\s*?\(\s*?--penguin-skin\s*?\)\s*?;[\s\S]*}/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-a-media-query-to-change-a-variable.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-a-media-query-to-change-a-variable.english.md
@@ -22,9 +22,9 @@ In the <code>:root</code> selector of the <code>media query</code>, change it so
 ```yml
 tests:
   - text: <code>:root</code> should reassign the <code>--penguin-size</code> variable to <code>200px</code>.
-    testString: assert(code.match(/media\s*?\(\s*?max-width\s*?:\s*?350px\s*?\)\s*?{[\s\S]*:root\s*?{[\s\S]*--penguin-size\s*?:\s*?200px\s*?;[\s\S]*}[\s\S]*}/gi), '<code>:root</code> should reassign the <code>--penguin-size</code> variable to <code>200px</code>.');
+    testString: assert(code.match(/media\s*?\(\s*?max-width\s*?:\s*?350px\s*?\)\s*?{[\s\S]*:root\s*?{[\s\S]*--penguin-size\s*?:\s*?200px\s*?;[\s\S]*}[\s\S]*}/gi));
   - text: <code>:root</code> should reassign the <code>--penguin-skin</code> variable to <code>black</code>.
-    testString: assert(code.match(/media\s*?\(\s*?max-width\s*?:\s*?350px\s*?\)\s*?{[\s\S]*:root\s*?{[\s\S]*--penguin-skin\s*?:\s*?black\s*?;[\s\S]*}[\s\S]*}/gi), '<code>:root</code> should reassign the <code>--penguin-skin</code> variable to <code>black</code>.');
+    testString: assert(code.match(/media\s*?\(\s*?max-width\s*?:\s*?350px\s*?\)\s*?{[\s\S]*:root\s*?{[\s\S]*--penguin-skin\s*?:\s*?black\s*?;[\s\S]*}[\s\S]*}/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-abbreviated-hex-code.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-abbreviated-hex-code.english.md
@@ -24,21 +24,21 @@ Go ahead, try using the abbreviated hex codes to color the correct elements.
 ```yml
 tests:
   - text: Give your <code>h1</code> element with the text <code>I am red!</code> the <code>color</code> red.
-    testString: assert($('.red-text').css('color') === 'rgb(255, 0, 0)', 'Give your <code>h1</code> element with the text <code>I am red!</code> the <code>color</code> red.');
+    testString: assert($('.red-text').css('color') === 'rgb(255, 0, 0)');
   - text: Use the abbreviate <code>hex code</code> for the color red instead of the hex code <code>#FF0000</code>.
-    testString: assert(code.match(/\.red-text\s*?{\s*?color:\s*?#F00\s*?;\s*?}/gi), 'Use the abbreviate <code>hex code</code> for the color red instead of the hex code <code>#FF0000</code>.');
+    testString: assert(code.match(/\.red-text\s*?{\s*?color:\s*?#F00\s*?;\s*?}/gi));
   - text: Give your <code>h1</code> element with the text <code>I am green!</code> the <code>color</code> green.
-    testString: assert($('.green-text').css('color') === 'rgb(0, 255, 0)', 'Give your <code>h1</code> element with the text <code>I am green!</code> the <code>color</code> green.');
+    testString: assert($('.green-text').css('color') === 'rgb(0, 255, 0)');
   - text: Use the abbreviated <code>hex code</code> for the color green instead of the hex code <code>#00FF00</code>.
-    testString: assert(code.match(/\.green-text\s*?{\s*?color:\s*?#0F0\s*?;\s*?}/gi), 'Use the abbreviated <code>hex code</code> for the color green instead of the hex code <code>#00FF00</code>.');
+    testString: assert(code.match(/\.green-text\s*?{\s*?color:\s*?#0F0\s*?;\s*?}/gi));
   - text: Give your <code>h1</code> element with the text <code>I am cyan!</code> the <code>color</code> cyan.
-    testString: assert($('.cyan-text').css('color') === 'rgb(0, 255, 255)', 'Give your <code>h1</code> element with the text <code>I am cyan!</code> the <code>color</code> cyan.');
+    testString: assert($('.cyan-text').css('color') === 'rgb(0, 255, 255)');
   - text: Use the abbreviated <code>hex code</code> for the color cyan instead of the hex code <code>#00FFFF</code>.
-    testString: assert(code.match(/\.cyan-text\s*?{\s*?color:\s*?#0FF\s*?;\s*?}/gi), 'Use the abbreviated <code>hex code</code> for the color cyan instead of the hex code <code>#00FFFF</code>.');
+    testString: assert(code.match(/\.cyan-text\s*?{\s*?color:\s*?#0FF\s*?;\s*?}/gi));
   - text: Give your <code>h1</code> element with the text <code>I am fuchsia!</code> the <code>color</code> fuchsia.
-    testString: assert($('.fuchsia-text').css('color') === 'rgb(255, 0, 255)', 'Give your <code>h1</code> element with the text <code>I am fuchsia!</code> the <code>color</code> fuchsia.');
+    testString: assert($('.fuchsia-text').css('color') === 'rgb(255, 0, 255)');
   - text: Use the abbreviated <code>hex code</code> for the color fuchsia instead of the hex code <code>#FF00FF</code>.
-    testString: assert(code.match(/\.fuchsia-text\s*?{\s*?color:\s*?#F0F\s*?;\s*?}/gi), 'Use the abbreviated <code>hex code</code> for the color fuchsia instead of the hex code <code>#FF00FF</code>.');
+    testString: assert(code.match(/\.fuchsia-text\s*?{\s*?color:\s*?#F0F\s*?;\s*?}/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-an-id-attribute-to-style-an-element.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-an-id-attribute-to-style-an-element.english.md
@@ -31,13 +31,13 @@ Try giving your form, which now has the <code>id</code> attribute of <code>cat-p
 ```yml
 tests:
   - text: Give your <code>form</code> element the id of <code>cat-photo-form</code>.
-    testString: assert($("form").attr("id") === "cat-photo-form", 'Give your <code>form</code> element the id of <code>cat-photo-form</code>.');
+    testString: assert($("form").attr("id") === "cat-photo-form");
   - text: Your <code>form</code> element should have the <code>background-color</code> of green.
-    testString: assert($("#cat-photo-form").css("background-color") === "rgb(0, 128, 0)", 'Your <code>form</code> element should have the <code>background-color</code> of green.');
+    testString: assert($("#cat-photo-form").css("background-color") === "rgb(0, 128, 0)");
   - text: Make sure your <code>form</code> element has an <code>id</code> attribute.
-    testString: assert(code.match(/<form.*cat-photo-form.*>/gi) && code.match(/<form.*cat-photo-form.*>/gi).length > 0, 'Make sure your <code>form</code> element has an <code>id</code> attribute.');
+    testString: assert(code.match(/<form.*cat-photo-form.*>/gi) && code.match(/<form.*cat-photo-form.*>/gi).length > 0);
   - text: Do not give your <code>form</code> any <code>class</code> or <code>style</code> attributes.
-    testString: assert(!code.match(/<form.*style.*>/gi) && !code.match(/<form.*class.*>/gi), 'Do not give your <code>form</code> any <code>class</code> or <code>style</code> attributes.');
+    testString: assert(!code.match(/<form.*style.*>/gi) && !code.match(/<form.*class.*>/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-attribute-selectors-to-style-elements.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-attribute-selectors-to-style-elements.english.md
@@ -30,11 +30,11 @@ Using the <code>type</code> attribute selector, try to give the checkboxes in Ca
 ```yml
 tests:
   - text: The <code>type</code> attribute selector should be used to select the checkboxes.
-    testString: assert(code.match(/<style>[\s\S]*?\[type=("|')checkbox\1\]\s*?{[\s\S]*?}[\s\S]*?<\/style>/gi),'The <code>type</code> attribute selector should be used to select the checkboxes.');
+    testString: assert(code.match(/<style>[\s\S]*?\[type=("|')checkbox\1\]\s*?{[\s\S]*?}[\s\S]*?<\/style>/gi));
   - text: The top margins of the checkboxes should be 10px.
-    testString: assert((function() {var count=0; $("[type='checkbox']").each(function() { if($(this).css('marginTop') === '10px') {count++;}});return (count===3)}()),'The top margins of the checkboxes should be 10px.');
+    testString: assert((function() {var count=0; $("[type='checkbox']").each(function() { if($(this).css('marginTop') === '10px') {count++;}});return (count===3)}()));
   - text: The bottom margins of the checkboxes should be 15px.
-    testString: assert((function() {var count=0; $("[type='checkbox']").each(function() { if($(this).css('marginBottom') === '15px') {count++;}});return (count===3)}()),'The bottom margins of the checkboxes should be 15px.');
+    testString: assert((function() {var count=0; $("[type='checkbox']").each(function() { if($(this).css('marginBottom') === '15px') {count++;}});return (count===3)}()));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-clockwise-notation-to-specify-the-padding-of-an-element.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-clockwise-notation-to-specify-the-padding-of-an-element.english.md
@@ -23,13 +23,13 @@ Use Clockwise Notation to give the ".blue-box" class a <code>padding</code> of <
 ```yml
 tests:
   - text: Your <code>blue-box</code> class should give the top of elements <code>40px</code> of <code>padding</code>.
-    testString: assert($(".blue-box").css("padding-top") === "40px", 'Your <code>blue-box</code> class should give the top of elements <code>40px</code> of <code>padding</code>.');
+    testString: assert($(".blue-box").css("padding-top") === "40px");
   - text: Your <code>blue-box</code> class should give the right of elements <code>20px</code> of <code>padding</code>.
-    testString: assert($(".blue-box").css("padding-right") === "20px", 'Your <code>blue-box</code> class should give the right of elements <code>20px</code> of <code>padding</code>.');
+    testString: assert($(".blue-box").css("padding-right") === "20px");
   - text: Your <code>blue-box</code> class should give the bottom of elements <code>20px</code> of <code>padding</code>.
-    testString: assert($(".blue-box").css("padding-bottom") === "20px", 'Your <code>blue-box</code> class should give the bottom of elements <code>20px</code> of <code>padding</code>.');
+    testString: assert($(".blue-box").css("padding-bottom") === "20px");
   - text: Your <code>blue-box</code> class should give the left of elements <code>40px</code> of <code>padding</code>.
-    testString: assert($(".blue-box").css("padding-left") === "40px", 'Your <code>blue-box</code> class should give the left of elements <code>40px</code> of <code>padding</code>.');
+    testString: assert($(".blue-box").css("padding-left") === "40px");
   - text: You should use the clockwise notation to set the padding of <code>blue-box</code> class.
     testString: const removeCssComments = str => str.replace(/\/\*[\s\S]+?\*\//g, '');assert(/\.blue-box\s*{[\s\S]*padding[\s]*:\s*\d+px\s+\d+px\s+\d+px\s+\d+px(;\s*[^}]+\s*}|;?\s*})/.test(removeCssComments($('style').text())));
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-css-selectors-to-style-elements.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-css-selectors-to-style-elements.english.md
@@ -41,15 +41,15 @@ Delete your <code>h2</code> element's style attribute, and instead create a CSS 
 ```yml
 tests:
   - text: Remove the style attribute from your <code>h2</code> element.
-    testString: assert(!$("h2").attr("style"), 'Remove the style attribute from your <code>h2</code> element.');
+    testString: assert(!$("h2").attr("style"));
   - text: Create a <code>style</code> element.
-    testString: assert($("style") && $("style").length >= 1, 'Create a <code>style</code> element.');
+    testString: assert($("style") && $("style").length >= 1);
   - text: Your <code>h2</code> element should be blue.
-    testString: assert($("h2").css("color") === "rgb(0, 0, 255)", 'Your <code>h2</code> element should be blue.');
+    testString: assert($("h2").css("color") === "rgb(0, 0, 255)");
   - text: Ensure that your stylesheet <code>h2</code> declaration is valid with a semicolon and closing brace.
-    testString: assert(code.match(/h2\s*\{\s*color\s*:.*;\s*\}/g), 'Ensure that your stylesheet <code>h2</code> declaration is valid with a semicolon and closing brace.');
+    testString: assert(code.match(/h2\s*\{\s*color\s*:.*;\s*\}/g));
   - text: Make sure all your <code>style</code> elements are valid and have a closing tag.
-    testString: assert(code.match(/<\/style>/g) && code.match(/<\/style>/g).length === (code.match(/<style((\s)*((type|media|scoped|title|disabled)="[^"]*")?(\s)*)*>/g) || []).length, 'Make sure all your <code>style</code> elements are valid and have a closing tag.');
+    testString: assert(code.match(/<\/style>/g) && code.match(/<\/style>/g).length === (code.match(/<style((\s)*((type|media|scoped|title|disabled)="[^"]*")?(\s)*)*>/g) || []).length);
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-css-variables-to-change-several-elements-at-once.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-css-variables-to-change-several-elements-at-once.english.md
@@ -22,11 +22,11 @@ In the <code>penguin</code> class, change the <code>black</code> value to <code>
 ```yml
 tests:
   - text: <code>penguin</code> class should declare the <code>--penguin-skin</code> variable and assign it to <code>gray</code>.
-    testString: assert(code.match(/.penguin\s*?{[\s\S]*--penguin-skin\s*?:\s*?gray\s*?;[\s\S]*}/gi), '<code>penguin</code> class should declare the <code>--penguin-skin</code> variable and assign it to <code>gray</code>.');
+    testString: assert(code.match(/.penguin\s*?{[\s\S]*--penguin-skin\s*?:\s*?gray\s*?;[\s\S]*}/gi));
   - text: <code>penguin</code> class should declare the <code>--penguin-belly</code> variable and assign it to <code>white</code>.
-    testString: assert(code.match(/.penguin\s*?{[\s\S]*--penguin-belly\s*?:\s*?white\s*?;[\s\S]*}/gi), '<code>penguin</code> class should declare the <code>--penguin-belly</code> variable and assign it to <code>white</code>.');
+    testString: assert(code.match(/.penguin\s*?{[\s\S]*--penguin-belly\s*?:\s*?white\s*?;[\s\S]*}/gi));
   - text: <code>penguin</code> class should declare the <code>--penguin-beak</code> variable and assign it to <code>orange</code>.
-    testString: assert(code.match(/.penguin\s*?{[\s\S]*--penguin-beak\s*?:\s*?orange\s*?;[\s\S]*}/gi), '<code>penguin</code> class should declare the <code>--penguin-beak</code> variable and assign it to <code>orange</code>.');
+    testString: assert(code.match(/.penguin\s*?{[\s\S]*--penguin-beak\s*?:\s*?orange\s*?;[\s\S]*}/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-hex-code-for-specific-colors.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-hex-code-for-specific-colors.english.md
@@ -30,9 +30,9 @@ Replace the word <code>black</code> in our <code>body</code> element's backgroun
 ```yml
 tests:
   - text: Give your <code>body</code> element the background-color of black.
-    testString: assert($("body").css("background-color") === "rgb(0, 0, 0)", 'Give your <code>body</code> element the background-color of black.');
+    testString: assert($("body").css("background-color") === "rgb(0, 0, 0)");
   - text: Use the <code>hex code</code> for the color black instead of the word <code>black</code>.
-    testString: assert(code.match(/body\s*{(([\s\S]*;\s*?)|\s*?)background.*\s*:\s*?#000(000)?((\s*})|(;[\s\S]*?}))/gi), 'Use the <code>hex code</code> for the color black instead of the word <code>black</code>.');
+    testString: assert(code.match(/body\s*{(([\s\S]*;\s*?)|\s*?)background.*\s*:\s*?#000(000)?((\s*})|(;[\s\S]*?}))/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-hex-code-to-mix-colors.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-hex-code-to-mix-colors.english.md
@@ -26,21 +26,21 @@ Replace the color words in our <code>style</code> element with their correct hex
 ```yml
 tests:
   - text: Give your <code>h1</code> element with the text <code>I am red!</code> the <code>color</code> red.
-    testString: assert($('.red-text').css('color') === 'rgb(255, 0, 0)', 'Give your <code>h1</code> element with the text <code>I am red!</code> the <code>color</code> red.');
+    testString: assert($('.red-text').css('color') === 'rgb(255, 0, 0)');
   - text: Use the <code>hex code</code> for the color red instead of the word <code>red</code>.
-    testString: assert(code.match(/\.red-text\s*?{\s*?color:\s*?#FF0000\s*?;\s*?}/gi), 'Use the <code>hex code</code> for the color red instead of the word <code>red</code>.');
+    testString: assert(code.match(/\.red-text\s*?{\s*?color:\s*?#FF0000\s*?;\s*?}/gi));
   - text: Give your <code>h1</code> element with the text <code>I am green!</code> the <code>color</code> green.
-    testString: assert($('.green-text').css('color') === 'rgb(0, 255, 0)', 'Give your <code>h1</code> element with the text <code>I am green!</code> the <code>color</code> green.');
+    testString: assert($('.green-text').css('color') === 'rgb(0, 255, 0)');
   - text: Use the <code>hex code</code> for the color green instead of the word <code>green</code>.
-    testString: assert(code.match(/\.green-text\s*?{\s*?color:\s*?#00FF00\s*?;\s*?}/gi), 'Use the <code>hex code</code> for the color green instead of the word <code>green</code>.');
+    testString: assert(code.match(/\.green-text\s*?{\s*?color:\s*?#00FF00\s*?;\s*?}/gi));
   - text: Give your <code>h1</code> element with the text <code>I am dodger blue!</code> the <code>color</code> dodger blue.
-    testString: assert($('.dodger-blue-text').css('color') === 'rgb(30, 144, 255)', 'Give your <code>h1</code> element with the text <code>I am dodger blue!</code> the <code>color</code> dodger blue.');
+    testString: assert($('.dodger-blue-text').css('color') === 'rgb(30, 144, 255)');
   - text: Use the <code>hex code</code> for the color dodger blue instead of the word <code>dodgerblue</code>.
-    testString: assert(code.match(/\.dodger-blue-text\s*?{\s*?color:\s*?#1E90FF\s*?;\s*?}/gi), 'Use the <code>hex code</code> for the color dodger blue instead of the word <code>dodgerblue</code>.');
+    testString: assert(code.match(/\.dodger-blue-text\s*?{\s*?color:\s*?#1E90FF\s*?;\s*?}/gi));
   - text: Give your <code>h1</code> element with the text <code>I am orange!</code> the <code>color</code> orange.
-    testString: assert($('.orange-text').css('color') === 'rgb(255, 165, 0)', 'Give your <code>h1</code> element with the text <code>I am orange!</code> the <code>color</code> orange.');
+    testString: assert($('.orange-text').css('color') === 'rgb(255, 165, 0)');
   - text: Use the <code>hex code</code> for the color orange instead of the word <code>orange</code>.
-    testString: assert(code.match(/\.orange-text\s*?{\s*?color:\s*?#FFA500\s*?;\s*?}/gi), 'Use the <code>hex code</code> for the color orange instead of the word <code>orange</code>.');
+    testString: assert(code.match(/\.orange-text\s*?{\s*?color:\s*?#FFA500\s*?;\s*?}/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-rgb-to-mix-colors.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-rgb-to-mix-colors.english.md
@@ -22,21 +22,21 @@ Replace the hex codes in our <code>style</code> element with their correct RGB v
 ```yml
 tests:
   - text: Give your <code>h1</code> element with the text <code>I am red!</code> the <code>color</code> red.
-    testString: assert($('.red-text').css('color') === 'rgb(255, 0, 0)', 'Give your <code>h1</code> element with the text <code>I am red!</code> the <code>color</code> red.');
+    testString: assert($('.red-text').css('color') === 'rgb(255, 0, 0)');
   - text: Use <code>rgb</code> for the color red.
-    testString: assert(code.match(/\.red-text\s*?{\s*?color:\s*?rgb\(\s*?255\s*?,\s*?0\s*?,\s*?0\s*?\)\s*?;\s*?}/gi), 'Use <code>rgb</code> for the color red.');
+    testString: assert(code.match(/\.red-text\s*?{\s*?color:\s*?rgb\(\s*?255\s*?,\s*?0\s*?,\s*?0\s*?\)\s*?;\s*?}/gi));
   - text: Give your <code>h1</code> element with the text <code>I am orchid!</code> the <code>color</code> orchid.
-    testString: assert($('.orchid-text').css('color') === 'rgb(218, 112, 214)', 'Give your <code>h1</code> element with the text <code>I am orchid!</code> the <code>color</code> orchid.');
+    testString: assert($('.orchid-text').css('color') === 'rgb(218, 112, 214)');
   - text: Use <code>rgb</code> for the color orchid.
-    testString: assert(code.match(/\.orchid-text\s*?{\s*?color:\s*?rgb\(\s*?218\s*?,\s*?112\s*?,\s*?214\s*?\)\s*?;\s*?}/gi), 'Use <code>rgb</code> for the color orchid.');
+    testString: assert(code.match(/\.orchid-text\s*?{\s*?color:\s*?rgb\(\s*?218\s*?,\s*?112\s*?,\s*?214\s*?\)\s*?;\s*?}/gi));
   - text: Give your <code>h1</code> element with the text <code>I am blue!</code> the <code>color</code> blue.
-    testString: assert($('.blue-text').css('color') === 'rgb(0, 0, 255)', 'Give your <code>h1</code> element with the text <code>I am blue!</code> the <code>color</code> blue.');
+    testString: assert($('.blue-text').css('color') === 'rgb(0, 0, 255)');
   - text: Use <code>rgb</code> for the color blue.
-    testString: assert(code.match(/\.blue-text\s*?{\s*?color:\s*?rgb\(\s*?0\s*?,\s*?0\s*?,\s*?255\s*?\)\s*?;\s*?}/gi), 'Use <code>rgb</code> for the color blue.');
+    testString: assert(code.match(/\.blue-text\s*?{\s*?color:\s*?rgb\(\s*?0\s*?,\s*?0\s*?,\s*?255\s*?\)\s*?;\s*?}/gi));
   - text: Give your <code>h1</code> element with the text <code>I am sienna!</code> the <code>color</code> sienna.
-    testString: assert($('.sienna-text').css('color') === 'rgb(160, 82, 45)', 'Give your <code>h1</code> element with the text <code>I am sienna!</code> the <code>color</code> sienna.');
+    testString: assert($('.sienna-text').css('color') === 'rgb(160, 82, 45)');
   - text: Use <code>rgb</code> for the color sienna.
-    testString: assert(code.match(/\.sienna-text\s*?{\s*?color:\s*?rgb\(\s*?160\s*?,\s*?82\s*?,\s*?45\s*?\)\s*?;\s*?}/gi), 'Use <code>rgb</code> for the color sienna.');
+    testString: assert(code.match(/\.sienna-text\s*?{\s*?color:\s*?rgb\(\s*?160\s*?,\s*?82\s*?,\s*?45\s*?\)\s*?;\s*?}/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-rgb-values-to-color-elements.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-rgb-values-to-color-elements.english.md
@@ -35,9 +35,9 @@ Let's replace the hex code in our <code>body</code> element's background color w
 ```yml
 tests:
   - text: Your <code>body</code> element should have a black background.
-    testString: assert($("body").css("background-color") === "rgb(0, 0, 0)", 'Your <code>body</code> element should have a black background.');
+    testString: assert($("body").css("background-color") === "rgb(0, 0, 0)");
   - text: Use <code>rgb</code> to give your <code>body</code> element a color of black.
-    testString: assert(code.match(/rgb\s*\(\s*0\s*,\s*0\s*,\s*0\s*\)/ig), 'Use <code>rgb</code> to give your <code>body</code> element a color of black.');
+    testString: assert(code.match(/rgb\s*\(\s*0\s*,\s*0\s*,\s*0\s*\)/ig));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/add-a-submit-button-to-a-form.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/add-a-submit-button-to-a-form.english.md
@@ -23,13 +23,13 @@ Add a button as the last element of your <code>form</code> element with a type o
 ```yml
 tests:
   - text: Your form should have a button inside it.
-    testString: assert($("form").children("button").length > 0, 'Your form should have a button inside it.');
+    testString: assert($("form").children("button").length > 0);
   - text: Your submit button should have the attribute <code>type</code> set to <code>submit</code>.
-    testString: assert($("button").attr("type") === "submit", 'Your submit button should have the attribute <code>type</code> set to <code>submit</code>.');
+    testString: assert($("button").attr("type") === "submit");
   - text: Your submit button should only have the text "Submit".
-    testString: assert($("button").text().match(/^\s*submit\s*$/gi), 'Your submit button should only have the text "Submit".');
+    testString: assert($("button").text().match(/^\s*submit\s*$/gi));
   - text: Make sure your <code>button</code> element has a closing tag.
-    testString: assert(code.match(/<\/button>/g) && code.match(/<button/g) && code.match(/<\/button>/g).length === code.match(/<button/g).length, 'Make sure your <code>button</code> element has a closing tag.');
+    testString: assert(code.match(/<\/button>/g) && code.match(/<button/g) && code.match(/<\/button>/g).length === code.match(/<button/g).length);
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/check-radio-buttons-and-checkboxes-by-default.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/check-radio-buttons-and-checkboxes-by-default.english.md
@@ -23,9 +23,9 @@ Set the first of your <code>radio button</code>s and the first of your <code>che
 ```yml
 tests:
   - text: Your first radio button on your form should be checked by default.
-    testString: assert($('input[type="radio"]').prop("checked"), 'Your first radio button on your form should be checked by default.');
+    testString: assert($('input[type="radio"]').prop("checked"));
   - text: Your first checkbox on your form should be checked by default.
-    testString: assert($('input[type="checkbox"]').prop("checked"), 'Your first checkbox on your form should be checked by default.');
+    testString: assert($('input[type="checkbox"]').prop("checked"));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/comment-out-html.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/comment-out-html.english.md
@@ -22,15 +22,15 @@ Comment out your <code>h1</code> element and your <code>p</code> element, but no
 ```yml
 tests:
   - text: Comment out your <code>h1</code> element so that it is not visible on your page.
-    testString: assert(($("h1").length === 0), 'Comment out your <code>h1</code> element so that it is not visible on your page.');
+    testString: assert(($("h1").length === 0));
   - text: Leave your <code>h2</code> element uncommented so that it is visible on your page.
-    testString: assert(($("h2").length > 0), 'Leave your <code>h2</code> element uncommented so that it is visible on your page.');
+    testString: assert(($("h2").length > 0));
   - text: Comment out your <code>p</code> element so that it is not visible on your page.
-    testString: assert(($("p").length === 0), 'Comment out your <code>p</code> element so that it is not visible on your page.');
+    testString: assert(($("p").length === 0));
   - text: Be sure to close each of your comments with <code>--&#62;</code>.
-    testString: assert(code.match(/[^fc]-->/g).length > 1, 'Be sure to close each of your comments with <code>--&#62;</code>.');
+    testString: assert(code.match(/[^fc]-->/g).length > 1);
   - text: Do not change the order of the <code>h1</code> <code>h2</code> or <code>p</code> in the code.
-    testString: assert((code.match(/<([a-z0-9]){1,2}>/g)[0]==="<h1>" && code.match(/<([a-z0-9]){1,2}>/g)[1]==="<h2>" && code.match(/<([a-z0-9]){1,2}>/g)[2]==="<p>") , 'Do not change the order of the <code>h1</code> <code>h2</code> or <code>p</code> in the code.');
+    testString: assert((code.match(/<([a-z0-9]){1,2}>/g)[0]==="<h1>" && code.match(/<([a-z0-9]){1,2}>/g)[1]==="<h2>" && code.match(/<([a-z0-9]){1,2}>/g)[2]==="<p>") );
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/create-a-bulleted-unordered-list.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/create-a-bulleted-unordered-list.english.md
@@ -32,15 +32,15 @@ Remove the last two <code>p</code> elements and create an unordered list of thre
 ```yml
 tests:
   - text: Create a <code>ul</code> element.
-    testString: assert($("ul").length > 0, 'Create a <code>ul</code> element.');
+    testString: assert($("ul").length > 0);
   - text: You should have three <code>li</code> elements within your <code>ul</code> element.
-    testString: assert($("ul li").length > 2, 'You should have three <code>li</code> elements within your <code>ul</code> element.');
+    testString: assert($("ul li").length > 2);
   - text: Make sure your <code>ul</code> element has a closing tag.
-    testString: assert(code.match(/<\/ul>/gi) && code.match(/<ul/gi) && code.match(/<\/ul>/gi).length === code.match(/<ul/gi).length, 'Make sure your <code>ul</code> element has a closing tag.');
+    testString: assert(code.match(/<\/ul>/gi) && code.match(/<ul/gi) && code.match(/<\/ul>/gi).length === code.match(/<ul/gi).length);
   - text: Make sure your <code>li</code> elements have closing tags.
-    testString: assert(code.match(/<\/li>/gi) && code.match(/<li[\s>]/gi) && code.match(/<\/li>/gi).length === code.match(/<li[\s>]/gi).length, 'Make sure your <code>li</code> elements have closing tags.');
+    testString: assert(code.match(/<\/li>/gi) && code.match(/<li[\s>]/gi) && code.match(/<\/li>/gi).length === code.match(/<li[\s>]/gi).length);
   - text: Make sure your <code>li</code> elements don’t contain an empty string or only white-space.
-    testString: assert($("ul li").filter((_, item) => !$(item).text().trim()).length === 0, 'Make sure your <code>li</code> elements don\’t contain an empty string or only white-space.');
+    testString: assert($("ul li").filter((_, item) => !$(item).text().trim()).length === 0);
 ```
 
 </section>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/create-a-form-element.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/create-a-form-element.english.md
@@ -23,11 +23,11 @@ Nest your text field inside a <code>form</code> element, and add the <code>actio
 ```yml
 tests:
   - text: Nest your text input element within a <code>form</code> element.
-    testString: assert($("form") && $("form").children("input") && $("form").children("input").length > 0, 'Nest your text input element within a <code>form</code> element.');
+    testString: assert($("form") && $("form").children("input") && $("form").children("input").length > 0);
   - text: Make sure your <code>form</code> has an <code>action</code> attribute which is set to <code>/submit-cat-photo</code>
-    testString: assert($("form").attr("action") === "/submit-cat-photo", 'Make sure your <code>form</code> has an <code>action</code> attribute which is set to <code>/submit-cat-photo</code>');
+    testString: assert($("form").attr("action") === "/submit-cat-photo");
   - text: Make sure your <code>form</code> element has well-formed open and close tags.
-    testString: assert(code.match(/<\/form>/g) && code.match(/<form [^<]*>/g) && code.match(/<\/form>/g).length === code.match(/<form [^<]*>/g).length, 'Make sure your <code>form</code> element has well-formed open and close tags.');
+    testString: assert(code.match(/<\/form>/g) && code.match(/<form [^<]*>/g) && code.match(/<\/form>/g).length === code.match(/<form [^<]*>/g).length);
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/create-a-set-of-checkboxes.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/create-a-set-of-checkboxes.english.md
@@ -27,15 +27,15 @@ Add to your form a set of three checkboxes. Each checkbox should be nested withi
 ```yml
 tests:
   - text: Your page should have three checkbox elements.
-    testString: assert($('input[type="checkbox"]').length > 2, 'Your page should have three checkbox elements.');
+    testString: assert($('input[type="checkbox"]').length > 2);
   - text: Each of your three checkbox elements should be nested in its own <code>label</code> element.
-    testString: assert($('label > input[type="checkbox"]:only-child').length > 2, 'Each of your three checkbox elements should be nested in its own <code>label</code> element.');
+    testString: assert($('label > input[type="checkbox"]:only-child').length > 2);
   - text: Make sure each of your <code>label</code> elements has a closing tag.
-    testString: assert(code.match(/<\/label>/g) && code.match(/<label/g) && code.match(/<\/label>/g).length === code.match(/<label/g).length, 'Make sure each of your <code>label</code> elements has a closing tag.');
+    testString: assert(code.match(/<\/label>/g) && code.match(/<label/g) && code.match(/<\/label>/g).length === code.match(/<label/g).length);
   - text: Give your checkboxes the <code>name</code> attribute of <code>personality</code>.
-    testString: assert($('label > input[type="checkbox"]').filter('[name="personality"]').length > 2, 'Give your checkboxes the <code>name</code> attribute of <code>personality</code>.');
+    testString: assert($('label > input[type="checkbox"]').filter('[name="personality"]').length > 2);
   - text: Each of your checkboxes should be added within the <code>form</code> tag.
-    testString: assert($('label').parent().get(0).tagName.match('FORM'), 'Each of your checkboxes should be added within the <code>form</code> tag.');
+    testString: assert($('label').parent().get(0).tagName.match('FORM'));
     
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/create-a-set-of-radio-buttons.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/create-a-set-of-radio-buttons.english.md
@@ -40,19 +40,19 @@ Add a pair of radio buttons to your form, each nested in its own <code>label</co
 ```yml
 tests:
   - text: Your page should have two radio button elements.
-    testString: assert($('input[type="radio"]').length > 1, 'Your page should have two radio button elements.');
+    testString: assert($('input[type="radio"]').length > 1);
   - text: Give your radio buttons the <code>name</code> attribute of <code>indoor-outdoor</code>.
-    testString: assert($('input[type="radio"]').filter("[name='indoor-outdoor']").length > 1, 'Give your radio buttons the <code>name</code> attribute of <code>indoor-outdoor</code>.');
+    testString: assert($('input[type="radio"]').filter("[name='indoor-outdoor']").length > 1);
   - text: Each of your two radio button elements should be nested in its own <code>label</code> element.
-    testString: assert($('label > input[type="radio"]:only-child').length > 1, 'Each of your two radio button elements should be nested in its own <code>label</code> element.');
+    testString: assert($('label > input[type="radio"]:only-child').length > 1);
   - text: Make sure each of your <code>label</code> elements has a closing tag.
-    testString: assert((code.match(/<\/label>/g) && code.match(/<label/g) && code.match(/<\/label>/g).length === code.match(/<label/g).length), 'Make sure each of your <code>label</code> elements has a closing tag.');
+    testString: assert((code.match(/<\/label>/g) && code.match(/<label/g) && code.match(/<\/label>/g).length === code.match(/<label/g).length));
   - text: One of your radio buttons should have the label <code>indoor</code>.
-    testString: assert($("label").text().match(/indoor/gi), 'One of your radio buttons should have the label <code>indoor</code>.');
+    testString: assert($("label").text().match(/indoor/gi));
   - text: One of your radio buttons should have the label <code>outdoor</code>.
-    testString: assert($("label").text().match(/outdoor/gi), 'One of your radio buttons should have the label <code>outdoor</code>.');
+    testString: assert($("label").text().match(/outdoor/gi));
   - text: Each of your radio button elements should be added within the <code>form</code> tag.
-    testString: assert($("label").parent().get(0).tagName.match('FORM'), 'Each of your radio button elements should be added within the <code>form</code> tag.');
+    testString: assert($("label").parent().get(0).tagName.match('FORM'));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/create-a-text-field.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/create-a-text-field.english.md
@@ -25,7 +25,7 @@ Create an <code>input</code> element of type <code>text</code> below your lists.
 ```yml
 tests:
   - text: Your app should have an <code>input</code> element of type <code>text</code>.
-    testString: assert($("input[type=text]").length > 0, 'Your app should have an <code>input</code> element of type <code>text</code>.');
+    testString: assert($("input[type=text]").length > 0);
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/create-an-ordered-list.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/create-an-ordered-list.english.md
@@ -33,23 +33,23 @@ Create an ordered list of the top 3 things cats hate the most.
 ```yml
 tests:
   - text: You should have an ordered list for "Top 3 things cats hate:"
-    testString: assert((/Top 3 things cats hate:/i).test($("ol").prev().text()), 'You should have an ordered list for "Top 3 things cats hate:"');
+    testString: assert((/Top 3 things cats hate:/i).test($("ol").prev().text()));
   - text: You should have an unordered list for "Things cats love:"
-    testString: assert((/Things cats love:/i).test($("ul").prev().text()), 'You should have an unordered list for "Things cats love:"');
+    testString: assert((/Things cats love:/i).test($("ul").prev().text()));
   - text: You should have only one <code>ul</code> element.
-    testString: assert.equal($("ul").length, 1, 'You should have only one <code>ul</code> element.');
+    testString: assert.equal($("ul").length, 1);
   - text: You should have only one <code>ol</code> element.
-    testString: assert.equal($("ol").length, 1, 'You should have only one <code>ol</code> element.');
+    testString: assert.equal($("ol").length, 1);
   - text: You should have three <code>li</code> elements within your <code>ul</code> element.
-    testString: assert.equal($("ul li").length, 3, 'You should have three <code>li</code> elements within your <code>ul</code> element.');
+    testString: assert.equal($("ul li").length, 3);
   - text: You should have three <code>li</code> elements within your <code>ol</code> element.
-    testString: assert.equal($("ol li").length, 3, 'You should have three <code>li</code> elements within your <code>ol</code> element.');
+    testString: assert.equal($("ol li").length, 3);
   - text: Make sure your <code>ul</code> element has a closing tag.
-    testString: assert(code.match(/<\/ul>/g) && code.match(/<\/ul>/g).length === code.match(/<ul>/g).length, 'Make sure your <code>ul</code> element has a closing tag.');
+    testString: assert(code.match(/<\/ul>/g) && code.match(/<\/ul>/g).length === code.match(/<ul>/g).length);
   - text: Make sure your <code>ol</code> element has a closing tag.
-    testString: assert(code.match(/<\/ol>/g) && code.match(/<\/ol>/g).length === code.match(/<ol>/g).length, 'Make sure your <code>ol</code> element has a closing tag.');
+    testString: assert(code.match(/<\/ol>/g) && code.match(/<\/ol>/g).length === code.match(/<ol>/g).length);
   - text: Make sure your <code>li</code> element has a closing tag.
-    testString: assert(code.match(/<\/li>/g) && code.match(/<li>/g) && code.match(/<\/li>/g).length === code.match(/<li>/g).length, 'Make sure your <code>li</code> element has a closing tag.');
+    testString: assert(code.match(/<\/li>/g) && code.match(/<li>/g) && code.match(/<\/li>/g).length === code.match(/<li>/g).length);
   - text: The <code>li</code> elements in your unordered list should not be empty.
     testString: $('ul li').each((i, val) => assert(val.textContent.replace(/\s/g, ''), 'Your <code>li</code> elements in your unordered list should not be empty.'));
   - text: The <code>li</code> elements in your ordered list should not be empty.

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/declare-the-doctype-of-an-html-document.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/declare-the-doctype-of-an-html-document.english.md
@@ -34,11 +34,11 @@ Add a <code>DOCTYPE</code> tag for HTML5 to the top of the blank HTML document i
 ```yml
 tests:
   - text: Your code should include a <code>&lt;!DOCTYPE html&gt;</code> tag.
-    testString: assert(code.match(/<!DOCTYPE\s+?html\s*?>/gi), 'Your code should include a <code>&lt;!DOCTYPE html&gt;</code> tag.');
+    testString: assert(code.match(/<!DOCTYPE\s+?html\s*?>/gi));
   - text: There should be one <code>html</code> element.
-    testString: assert($('html').length == 1, 'There should be one <code>html</code> element.');
+    testString: assert($('html').length == 1);
   - text: The <code>html</code> tags should wrap around one <code>h1</code> element.
-    testString: assert(code.match(/<html>\s*?<h1>\s*?.*?\s*?<\/h1>\s*?<\/html>/gi), 'The <code>html</code> tags should wrap around one <code>h1</code> element.');
+    testString: assert(code.match(/<html>\s*?<h1>\s*?.*?\s*?<\/h1>\s*?<\/html>/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/define-the-head-and-body-of-an-html-document.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/define-the-head-and-body-of-an-html-document.english.md
@@ -36,17 +36,17 @@ Edit the markup so there's a <code>head</code> and a <code>body</code>. The <cod
 ```yml
 tests:
   - text: There should be only one <code>head</code> element on the page.
-    testString: assert($('head').length == 1, 'There should be only one <code>head</code> element on the page.');
+    testString: assert($('head').length == 1);
   - text: There should be only one <code>body</code> element on the page.
-    testString: assert($('body').length == 1, 'There should be only one <code>body</code> element on the page.');
+    testString: assert($('body').length == 1);
   - text: The <code>head</code> element should be a child of the <code>html</code> element.
-    testString: assert($('html').children('head').length == 1, 'The <code>head</code> element should be a child of the <code>html</code> element.');
+    testString: assert($('html').children('head').length == 1);
   - text: The <code>body</code> element should be a child of the <code>html</code> element.
-    testString: assert($('html').children('body').length == 1, 'The <code>body</code> element should be a child of the <code>html</code> element.');
+    testString: assert($('html').children('body').length == 1);
   - text: The <code>head</code> element should wrap around the <code>title</code> element.
-    testString: assert(code.match(/<head>\s*?<title>\s*?.*?\s*?<\/title>\s*?<\/head>/gi), 'The <code>head</code> element should wrap around the <code>title</code> element.');
-  - text: The <code>body</code> element should wrap around both the <code>h1</code> and <code>p</code> .
-    testString: assert(code.match(/<body>\s*?(((<h1>\s*?.*?\s*?<\/h1>\s*?)(<p>(.*\s*)*?<\/p>\s*?))|((<p>\s*?.*?\s*?<\/p>\s*?)(<h1>(.*\s*)*?<\/h1>\s*?)))<\/body>/gi), 'The <code>body</code> element should wrap around both the <code>h1</code>and <code>p</code> elements');		
+    testString: assert(code.match(/<head>\s*?<title>\s*?.*?\s*?<\/title>\s*?<\/head>/gi));
+  - text: The <code>body</code> element should wrap around both the <code>h1</code> and <code>p</code> elements.
+    testString: assert(code.match(/<body>\s*?(((<h1>\s*?.*?\s*?<\/h1>\s*?)(<p>(.*\s*)*?<\/p>\s*?))|((<p>\s*?.*?\s*?<\/p>\s*?)(<h1>(.*\s*)*?<\/h1>\s*?)))<\/body>/gi));		
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/delete-html-elements.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/delete-html-elements.english.md
@@ -22,11 +22,11 @@ Delete your <code>h1</code> element so we can simplify our view.
 ```yml
 tests:
   - text: Delete your <code>h1</code> element.
-    testString: assert(!code.match(/<h1>/gi) && !code.match(/<\/h1>/gi), 'Delete your <code>h1</code> element.');
+    testString: assert(!code.match(/<h1>/gi) && !code.match(/<\/h1>/gi));
   - text: Leave your <code>h2</code> element on the page.
-    testString: assert(code.match(/<h2>[\w\W]*<\/h2>/gi), 'Leave your <code>h2</code> element on the page.');
+    testString: assert(code.match(/<h2>[\w\W]*<\/h2>/gi));
   - text: Leave your <code>p</code> element on the page.
-    testString: assert(code.match(/<p>[\w\W]*<\/p>/gi), 'Leave your <code>p</code> element on the page.');
+    testString: assert(code.match(/<p>[\w\W]*<\/p>/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/fill-in-the-blank-with-placeholder-text.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/fill-in-the-blank-with-placeholder-text.english.md
@@ -23,7 +23,7 @@ Replace the text inside your <code>p</code> element with the first few words of 
 ```yml
 tests:
   - text: Your <code>p</code> element should contain the first few words of the provided <code>kitty ipsum text</code>.
-    testString: assert.isTrue((/Kitty(\s)+ipsum/gi).test($("p").text()), 'Your <code>p</code> element should contain the first few words of the provided <code>kitty ipsum text</code>.');
+    testString: assert.isTrue((/Kitty(\s)+ipsum/gi).test($("p").text()));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/headline-with-the-h2-element.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/headline-with-the-h2-element.english.md
@@ -23,13 +23,13 @@ Add an <code>h2</code> tag that says "CatPhotoApp" to create a second HTML <code
 ```yml
 tests:
   - text: Create an <code>h2</code> element.
-    testString: assert(($("h2").length > 0), 'Create an <code>h2</code> element.');
+    testString: assert(($("h2").length > 0));
   - text: Make sure your <code>h2</code> element has a closing tag.
-    testString: assert(code.match(/<\/h2>/g) && code.match(/<\/h2>/g).length === code.match(/<h2>/g).length, 'Make sure your <code>h2</code> element has a closing tag.');
+    testString: assert(code.match(/<\/h2>/g) && code.match(/<\/h2>/g).length === code.match(/<h2>/g).length);
   - text: Your <code>h2</code> element should have the text "CatPhotoApp".
-    testString: assert.isTrue((/cat(\s)?photo(\s)?app/gi).test($("h2").text()), 'Your <code>h2</code> element should have the text "CatPhotoApp".');
+    testString: assert.isTrue((/cat(\s)?photo(\s)?app/gi).test($("h2").text()));
   - text: Your <code>h1</code> element should have the text "Hello World".
-    testString: assert.isTrue((/hello(\s)+world/gi).test($("h1").text()), 'Your <code>h1</code> element should have the text "Hello World".');
+    testString: assert.isTrue((/hello(\s)+world/gi).test($("h1").text()));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/inform-with-the-paragraph-element.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/inform-with-the-paragraph-element.english.md
@@ -23,12 +23,12 @@ Create a <code>p</code> element below your <code>h2</code> element, and give it 
 
 ```yml
 tests:
-  - text: Create a <code>p</code> element.
-    testString: assert(($("p").length > 0), 'Create a valid <code>p</code> element.');
+  - text: Your code should have a valid <code>p</code> element.
+    testString: assert(($("p").length > 0));
   - text: Your <code>p</code> element should have the text "Hello Paragraph".
-    testString: assert.isTrue((/hello(\s)+paragraph/gi).test($("p").text()), 'Your <code>p</code> element should have the text "Hello Paragraph".');
+    testString: assert.isTrue((/hello(\s)+paragraph/gi).test($("p").text()));
   - text: Make sure your <code>p</code> element has a closing tag.
-    testString: assert(code.match(/<\/p>/g) && code.match(/<\/p>/g).length === code.match(/<p/g).length, 'Make sure your <code>p</code> element has a closing tag.');
+    testString: assert(code.match(/<\/p>/g) && code.match(/<\/p>/g).length === code.match(/<p/g).length);
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/introduction-to-html5-elements.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/introduction-to-html5-elements.english.md
@@ -33,19 +33,19 @@ Then, create a <code>main</code> element and nest the two <code>p</code> element
 ```yml
 tests:
   - text: You need 2 <code>p</code> elements with Kitty Ipsum text.
-    testString: assert($("p").length > 1, 'You need 2 <code>p</code> elements with Kitty Ipsum text.');
+    testString: assert($("p").length > 1);
   - text: Make sure each of your <code>p</code> elements has a closing tag.
-    testString: assert(code.match(/<\/p>/g) && code.match(/<\/p>/g).length === code.match(/<p/g).length, 'Make sure each of your <code>p</code> elements has a closing tag.');
+    testString: assert(code.match(/<\/p>/g) && code.match(/<\/p>/g).length === code.match(/<p/g).length);
   - text: Your <code>p</code> element should contain the first few words of the provided additional <code>kitty ipsum text</code>.
-    testString: assert.isTrue((/Purr\s+jump\s+eat/gi).test($("p").text()), 'Your <code>p</code> element should contain the first few words of the provided additional <code>kitty ipsum text</code>.');
+    testString: assert.isTrue((/Purr\s+jump\s+eat/gi).test($("p").text()));
   - text: Your code should have one <code>main</code> element.
-    testString: assert($('main').length === 1, 'Your code should have one <code>main</code> element.');
+    testString: assert($('main').length === 1);
   - text: The <code>main</code> element should have two paragraph elements as children.
-    testString: assert($("main").children("p").length === 2, 'The <code>main</code> element should have two paragraph elements as children.');
+    testString: assert($("main").children("p").length === 2);
   - text: The opening <code>main</code> tag should come before the first paragraph tag.
-    testString: assert(code.match(/<main>\s*?<p>/g), 'The opening <code>main</code> tag should come before the first paragraph tag.');
+    testString: assert(code.match(/<main>\s*?<p>/g));
   - text: The closing <code>main</code> tag should come after the second closing paragraph tag.
-    testString: assert(code.match(/<\/p>\s*?<\/main>/g), 'The closing <code>main</code> tag should come after the second closing paragraph tag.');
+    testString: assert(code.match(/<\/p>\s*?<\/main>/g));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/link-to-external-pages-with-anchor-elements.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/link-to-external-pages-with-anchor-elements.english.md
@@ -24,11 +24,11 @@ Create an <code>a</code> element that links to <code>http://freecatphotoapp.com<
 ```yml
 tests:
   - text: Your <code>a</code> element should have the <code>anchor text</code> of "cat photos".
-    testString: assert((/cat photos/gi).test($("a").text()), 'Your <code>a</code> element should have the <code>anchor text</code> of "cat photos".');
+    testString: assert((/cat photos/gi).test($("a").text()));
   - text: You need an <code>a</code> element that links to <code>http&#58;//freecatphotoapp<wbr>.com</code>
-    testString: assert(/http:\/\/(www\.)?freecatphotoapp\.com/gi.test($("a").attr("href")), 'You need an <code>a</code> element that links to <code>http&#58;//freecatphotoapp<wbr>.com</code>');
+    testString: assert(/http:\/\/(www\.)?freecatphotoapp\.com/gi.test($("a").attr("href")));
   - text: Make sure your <code>a</code> element has a closing tag.
-    testString: assert(code.match(/<\/a>/g) && code.match(/<\/a>/g).length === code.match(/<a/g).length, 'Make sure your <code>a</code> element has a closing tag.');
+    testString: assert(code.match(/<\/a>/g) && code.match(/<\/a>/g).length === code.match(/<a/g).length);
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/link-to-internal-sections-of-a-page-with-anchor-elements.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/link-to-internal-sections-of-a-page-with-anchor-elements.english.md
@@ -33,17 +33,17 @@ Then add an <code>id</code> attribute with a value of "footer" to the <code>&lt;
 ```yml
 tests:
   - text: There should be only one anchor tag on your page.
-    testString: assert($('a').length == 1, 'There should be only one anchor tag on your page.');
+    testString: assert($('a').length == 1);
   - text: There should be only one <code>footer</code> tag on your page.
-    testString: assert($('footer').length == 1, 'There should be only one <code>footer</code> tag on your page.');
+    testString: assert($('footer').length == 1);
   - text: The <code>a</code> tag should have an <code>href</code> attribute set to "#footer".
-    testString: assert($('a').eq(0).attr('href') == "#footer", 'The <code>a</code> tag should have an <code>href</code> attribute set to "#footer".');
+    testString: assert($('a').eq(0).attr('href') == "#footer");
   - text: The <code>a</code> tag should not have a <code>target</code> attribute
-    testString: assert(typeof $('a').eq(0).attr('target') == typeof undefined || $('a').eq(0).attr('target') == true, 'The <code>a</code> tag should not have a <code>target</code> attribute');
+    testString: assert(typeof $('a').eq(0).attr('target') == typeof undefined || $('a').eq(0).attr('target') == true);
   - text: The <code>a</code> text should be "Jump to Bottom".
-    testString: assert($('a').eq(0).text().match(/Jump to Bottom/gi), 'The <code>a</code> text should be "Jump to Bottom".');
+    testString: assert($('a').eq(0).text().match(/Jump to Bottom/gi));
   - text: The <code>footer</code> tag should have an <code>id</code> attribute set to "footer".
-    testString: assert($('footer').eq(0).attr('id') == "footer", 'The <code>footer</code> tag should have an <code>id</code> attribute set to "footer".');
+    testString: assert($('footer').eq(0).attr('id') == "footer");
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/make-dead-links-using-the-hash-symbol.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/make-dead-links-using-the-hash-symbol.english.md
@@ -23,7 +23,7 @@ For example: <code>href="#"</code>
 ```yml
 tests:
   - text: Your <code>a</code> element should be a dead link with the value of the <code>href</code> attribute set to "#".
-    testString: assert($("a").attr("href") === "#", 'Your <code>a</code> element should be a dead link with the value of the <code>href</code> attribute set to "#".');
+    testString: assert($("a").attr("href") === "#");
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/nest-an-anchor-element-within-a-paragraph.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/nest-an-anchor-element-within-a-paragraph.english.md
@@ -35,21 +35,21 @@ Now nest the existing <code>a</code> element within a new <code>p</code> element
 ```yml
 tests:
   - text: You need an <code>a</code> element that links to "http://freecatphotoapp.com".
-    testString: assert(($("a[href=\"http://freecatphotoapp.com\"]").length > 0 || $("a[href=\"http://www.freecatphotoapp.com\"]").length > 0), 'You need an <code>a</code> element that links to "http://freecatphotoapp.com".');
+    testString: assert(($("a[href=\"http://freecatphotoapp.com\"]").length > 0 || $("a[href=\"http://www.freecatphotoapp.com\"]").length > 0));
   - text: Your <code>a</code> element should have the anchor text of "cat photos"
-    testString: assert($("a").text().match(/cat\sphotos/gi), 'Your <code>a</code> element should have the anchor text of "cat photos"');
+    testString: assert($("a").text().match(/cat\sphotos/gi));
   - text: Create a new <code>p</code> element around your <code>a</code> element. There should be at least 3 total <code>p</code> tags in your HTML code.
-    testString: assert($("p") && $("p").length > 2, 'Create a new <code>p</code> element around your <code>a</code> element. There should be at least 3 total <code>p</code> tags in your HTML code.');
+    testString: assert($("p") && $("p").length > 2);
   - text: Your <code>a</code> element should be nested within your new <code>p</code> element.
-    testString: assert(($("a[href=\"http://freecatphotoapp.com\"]").parent().is("p") || $("a[href=\"http://www.freecatphotoapp.com\"]").parent().is("p")), 'Your <code>a</code> element should be nested within your new <code>p</code> element.');
+    testString: assert(($("a[href=\"http://freecatphotoapp.com\"]").parent().is("p") || $("a[href=\"http://www.freecatphotoapp.com\"]").parent().is("p")));
   - text: Your <code>p</code> element should have the text "View more " (with a space after it).
-    testString: assert(($("a[href=\"http://freecatphotoapp.com\"]").parent().text().match(/View\smore\s/gi) || $("a[href=\"http://www.freecatphotoapp.com\"]").parent().text().match(/View\smore\s/gi)), 'Your <code>p</code> element should have the text "View more " (with a space after it).');
+    testString: assert(($("a[href=\"http://freecatphotoapp.com\"]").parent().text().match(/View\smore\s/gi) || $("a[href=\"http://www.freecatphotoapp.com\"]").parent().text().match(/View\smore\s/gi)));
   - text: Your <code>a</code> element should <em>not</em> have the text "View more".
-    testString: assert(!$("a").text().match(/View\smore/gi), 'Your <code>a</code> element should <em>not</em> have the text "View more".');
+    testString: assert(!$("a").text().match(/View\smore/gi));
   - text: Make sure each of your <code>p</code> elements has a closing tag.
-    testString: assert(code.match(/<\/p>/g) && code.match(/<p/g) && code.match(/<\/p>/g).length === code.match(/<p/g).length, 'Make sure each of your <code>p</code> elements has a closing tag.');
+    testString: assert(code.match(/<\/p>/g) && code.match(/<p/g) && code.match(/<\/p>/g).length === code.match(/<p/g).length);
   - text: Make sure each of your <code>a</code> elements has a closing tag.
-    testString: assert(code.match(/<\/a>/g) && code.match(/<a/g) && code.match(/<\/a>/g).length === code.match(/<a/g).length, 'Make sure each of your <code>a</code> elements has a closing tag.');
+    testString: assert(code.match(/<\/a>/g) && code.match(/<a/g) && code.match(/<\/a>/g).length === code.match(/<a/g).length);
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/nest-many-elements-within-a-single-div-element.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/nest-many-elements-within-a-single-div-element.english.md
@@ -24,13 +24,13 @@ Hint: Try putting your opening <code>div</code> tag above your "Things cats love
 ```yml
 tests:
   - text: Nest your <code>p</code> elements inside your <code>div</code> element.
-    testString: assert($("div").children("p").length > 1, 'Nest your <code>p</code> elements inside your <code>div</code> element.');
+    testString: assert($("div").children("p").length > 1);
   - text: Nest your <code>ul</code> element inside your <code>div</code> element.
-    testString: assert($("div").children("ul").length > 0, 'Nest your <code>ul</code> element inside your <code>div</code> element.');
+    testString: assert($("div").children("ul").length > 0);
   - text: Nest your <code>ol</code> element inside your <code>div</code> element.
-    testString: assert($("div").children("ol").length > 0, 'Nest your <code>ol</code> element inside your <code>div</code> element.');
+    testString: assert($("div").children("ol").length > 0);
   - text: Make sure your <code>div</code> element has a closing tag.
-    testString: assert(code.match(/<\/div>/g) && code.match(/<\/div>/g).length === code.match(/<div>/g).length, 'Make sure your <code>div</code> element has a closing tag.');
+    testString: assert(code.match(/<\/div>/g) && code.match(/<\/div>/g).length === code.match(/<div>/g).length);
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/say-hello-to-html-elements.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/say-hello-to-html-elements.english.md
@@ -30,7 +30,7 @@ To pass the test on this challenge, change your <code>h1</code> element's text t
 ```yml
 tests:
   - text: Your <code>h1</code> element should have the text "Hello World".
-    testString: assert.isTrue((/hello(\s)+world/gi).test($('h1').text()), 'Your <code>h1</code> element should have the text "Hello World".');
+    testString: assert.isTrue((/hello(\s)+world/gi).test($('h1').text()));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/turn-an-image-into-a-link.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/turn-an-image-into-a-link.english.md
@@ -25,11 +25,11 @@ Once you've done this, hover over your image with your cursor. Your cursor's nor
 ```yml
 tests:
   - text: Nest the existing <code>img</code> element within an <code>a</code> element.
-    testString: assert($("a").children("img").length > 0, 'Nest the existing <code>img</code> element within an <code>a</code> element.');
+    testString: assert($("a").children("img").length > 0);
   - text: Your <code>a</code> element should be a dead link with a <code>href</code> attribute set to <code>#</code>.
-    testString: assert(new RegExp("#").test($("a").children("img").parent().attr("href")), 'Your <code>a</code> element should be a dead link with a <code>href</code> attribute set to <code>#</code>.');
+    testString: assert(new RegExp("#").test($("a").children("img").parent().attr("href")));
   - text: Make sure each of your <code>a</code> elements has a closing tag.
-    testString: assert(code.match(/<\/a>/g) && code.match(/<a/g) && code.match(/<\/a>/g).length === code.match(/<a/g).length, 'Make sure each of your <code>a</code> elements has a closing tag.');
+    testString: assert(code.match(/<\/a>/g) && code.match(/<a/g) && code.match(/<\/a>/g).length === code.match(/<a/g).length);
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/uncomment-html.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/uncomment-html.english.md
@@ -23,11 +23,11 @@ Uncomment your <code>h1</code>, <code>h2</code> and <code>p</code> elements.
 ```yml
 tests:
   - text: Make your <code>h1</code> element visible on your page by uncommenting it.
-    testString: assert($("h1").length > 0, 'Make your <code>h1</code> element visible on your page by uncommenting it.');
+    testString: assert($("h1").length > 0);
   - text: Make your <code>h2</code> element visible on your page by uncommenting it.
-    testString: assert($("h2").length > 0, 'Make your <code>h2</code> element visible on your page by uncommenting it.');
+    testString: assert($("h2").length > 0);
   - text: Make your <code>p</code> element visible on your page by uncommenting it.
-    testString: assert($("p").length > 0, 'Make your <code>p</code> element visible on your page by uncommenting it.');
+    testString: assert($("p").length > 0);
   - text: Be sure to delete all trailing comment tags&#44; i.e. <code>--&#62;</code>.
     testString: assert(!/[^fc]-->/gi.test(code.replace(/ *<!--[^fc]*\n/g,'')), 'Be sure to delete all trailing comment tags&#44; i.e. <code>--&#62;</code>.');
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/use-html5-to-require-a-field.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/use-html5-to-require-a-field.english.md
@@ -23,7 +23,7 @@ Then try to submit the form without inputting any text. See how your HTML5 form 
 ```yml
 tests:
   - text: Your text <code>input</code> element should have the <code>required</code> attribute.
-    testString: assert($("input").prop("required"), 'Your text <code>input</code> element should have the <code>required</code> attribute.');
+    testString: assert($("input").prop("required"));
 
 ```
 


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Related to issue #36400

This PR removes assert message arguments from `testString` for the following sub sections of the `Responsive Web Design` curriculum section:
* Basic CSS
* Basic HTML and HTML5