### PR TITLE
fix(curriculum): Remove unnecessary assert message argument from English Responsive Web Design challenges - 03

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/add-flex-superpowers-to-the-tweet-embed.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/add-flex-superpowers-to-the-tweet-embed.english.md
@@ -22,19 +22,19 @@ Add the CSS property <code>display: flex</code> to all of the following items - 
 ```yml
 tests:
   - text: Your <code>header</code> should have a <code>display</code> property set to flex.
-    testString: assert($('header').css('display') == 'flex', 'Your <code>header</code> should have a <code>display</code> property set to flex.');
+    testString: assert($('header').css('display') == 'flex');
   - text: Your <code>footer</code> should have a <code>display</code> property set to flex.
-    testString: assert($('footer').css('display') == 'flex', 'Your <code>footer</code> should have a <code>display</code> property set to flex.');
+    testString: assert($('footer').css('display') == 'flex');
   - text: Your <code>h3</code> should have a <code>display</code> property set to flex.
-    testString: assert($('h3').css('display') == 'flex', 'Your <code>h3</code> should have a <code>display</code> property set to flex.');
+    testString: assert($('h3').css('display') == 'flex');
   - text: Your <code>h4</code> should have a <code>display</code> property set to flex.
-    testString: assert($('h4').css('display') == 'flex', 'Your <code>h4</code> should have a <code>display</code> property set to flex.');
+    testString: assert($('h4').css('display') == 'flex');
   - text: Your <code>.profile-name</code> should have a <code>display</code> property set to flex.
-    testString: assert($('.profile-name').css('display') == 'flex', 'Your <code>.profile-name</code> should have a <code>display</code> property set to flex.');
+    testString: assert($('.profile-name').css('display') == 'flex');
   - text: Your <code>.follow-btn</code> should have a <code>display</code> property set to flex.
-    testString: assert($('.follow-btn').css('display') == 'flex', 'Your <code>.follow-btn</code> should have a <code>display</code> property set to flex.');
+    testString: assert($('.follow-btn').css('display') == 'flex');
   - text: Your <code>.stats</code> should have a <code>display</code> property set to flex.
-    testString: assert($('.stats').css('display') == 'flex', 'Your <code>.stats</code> should have a <code>display</code> property set to flex.');
+    testString: assert($('.stats').css('display') == 'flex');
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/align-elements-using-the-align-items-property.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/align-elements-using-the-align-items-property.english.md
@@ -26,7 +26,7 @@ An example helps show this property in action. Add the CSS property <code>align-
 ```yml
 tests:
   - text: The <code>#box-container</code> element should have an <code>align-items</code> property set to a value of center.
-    testString: assert($('#box-container').css('align-items') == 'center', 'The <code>#box-container</code> element should have an <code>align-items</code> property set to a value of center.');
+    testString: assert($('#box-container').css('align-items') == 'center');
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/align-elements-using-the-justify-content-property.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/align-elements-using-the-justify-content-property.english.md
@@ -27,7 +27,7 @@ An example helps show this property in action. Add the CSS property <code>justif
 ```yml
 tests:
   - text: The <code>#box-container</code> element should have a <code>justify-content</code> property set to a value of center.
-    testString: assert($('#box-container').css('justify-content') == 'center', 'The <code>#box-container</code> element should have a <code>justify-content</code> property set to a value of center.');
+    testString: assert($('#box-container').css('justify-content') == 'center');
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/apply-the-flex-direction-property-to-create-a-column-in-the-tweet-embed.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/apply-the-flex-direction-property-to-create-a-column-in-the-tweet-embed.english.md
@@ -21,7 +21,7 @@ Add the CSS property <code>flex-direction</code> to the header's <code>.profile-
 ```yml
 tests:
   - text: The <code>.profile-name</code> element should have a <code>flex-direction</code> property set to column.
-    testString: assert($('.profile-name').css('flex-direction') == 'column', 'The <code>.profile-name</code> element should have a <code>flex-direction</code> property set to column.');
+    testString: assert($('.profile-name').css('flex-direction') == 'column');
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/apply-the-flex-direction-property-to-create-rows-in-the-tweet-embed.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/apply-the-flex-direction-property-to-create-rows-in-the-tweet-embed.english.md
@@ -21,9 +21,9 @@ Add the CSS property <code>flex-direction</code> to both the <code>header</code>
 ```yml
 tests:
   - text: The <code>header</code> should have a <code>flex-direction</code> property set to row.
-    testString: assert(code.match(/header\s*?{[^}]*?flex-direction:\s*?row;/g), 'The <code>header</code> should have a <code>flex-direction</code> property set to row.');
+    testString: assert(code.match(/header\s*?{[^}]*?flex-direction:\s*?row;/g));
   - text: The <code>footer</code> should have a <code>flex-direction</code> property set to row.
-    testString: assert(code.match(/footer\s*?{[^}]*?flex-direction:\s*?row;/g), 'The <code>footer</code> should have a <code>flex-direction</code> property set to row.');
+    testString: assert(code.match(/footer\s*?{[^}]*?flex-direction:\s*?row;/g));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-display-flex-to-position-two-boxes.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-display-flex-to-position-two-boxes.english.md
@@ -22,7 +22,7 @@ Add the CSS property <code>display</code> to <code>#box-container</code> and set
 ```yml
 tests:
   - text: <code>#box-container</code> should have the <code>display</code> property set to a value of flex.
-    testString: assert($('#box-container').css('display') == 'flex', '<code>#box-container</code> should have the <code>display</code> property set to a value of flex.');
+    testString: assert($('#box-container').css('display') == 'flex');
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-align-items-property-in-the-tweet-embed.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-align-items-property-in-the-tweet-embed.english.md
@@ -21,7 +21,7 @@ Add the CSS property <code>align-items</code> to the header's <code>.follow-btn<
 ```yml
 tests:
   - text: The <code>.follow-btn</code> element should have the <code>align-items</code> property set to a value of center.
-    testString: assert($('.follow-btn').css('align-items') == 'center', 'The <code>.follow-btn</code> element should have the <code>align-items</code> property set to a value of center.');
+    testString: assert($('.follow-btn').css('align-items') == 'center');
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-align-self-property.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-align-self-property.english.md
@@ -22,9 +22,9 @@ Add the CSS property <code>align-self</code> to both <code>#box-1</code> and <co
 ```yml
 tests:
   - text: The <code>#box-1</code> element should have the <code>align-self</code> property set to a value of center.
-    testString: assert($('#box-1').css('align-self') == 'center', 'The <code>#box-1</code> element should have the <code>align-self</code> property set to a value of center.');
+    testString: assert($('#box-1').css('align-self') == 'center');
   - text: The <code>#box-2</code> element should have the <code>align-self</code> property set to a value of flex-end.
-    testString: assert($('#box-2').css('align-self') == 'flex-end', 'The <code>#box-2</code> element should have the <code>align-self</code> property set to a value of flex-end.');
+    testString: assert($('#box-2').css('align-self') == 'flex-end');
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-flex-basis-property-to-set-the-initial-size-of-an-item.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-flex-basis-property-to-set-the-initial-size-of-an-item.english.md
@@ -22,13 +22,13 @@ Set the initial size of the boxes using <code>flex-basis</code>. Add the CSS pro
 ```yml
 tests:
   - text: The <code>#box-1</code> element should have a <code>flex-basis</code> property.
-    testString: assert($('#box-1').css('flex-basis') != 'auto', 'The <code>#box-1</code> element should have a <code>flex-basis</code> property.');
+    testString: assert($('#box-1').css('flex-basis') != 'auto');
   - text: The <code>#box-1</code> element should have a <code>flex-basis</code> value of <code>10em</code>.
-    testString: assert(code.match(/#box-1\s*?{\s*?.*?\s*?.*?\s*?flex-basis:\s*?10em;/g), 'The <code>#box-1</code> element should have a <code>flex-basis</code> value of <code>10em</code>.');
+    testString: assert(code.match(/#box-1\s*?{\s*?.*?\s*?.*?\s*?flex-basis:\s*?10em;/g));
   - text: The <code>#box-2</code> element should have the <code>flex-basis</code> property.
-    testString: assert($('#box-2').css('flex-basis') != 'auto', 'The <code>#box-2</code> element should have the <code>flex-basis</code> property.');
+    testString: assert($('#box-2').css('flex-basis') != 'auto');
   - text: The <code>#box-2</code> element should have a <code>flex-basis</code> value of <code>20em</code>.
-    testString: assert(code.match(/#box-2\s*?{\s*?.*?\s*?.*?\s*?flex-basis:\s*?20em;/g), 'The <code>#box-2</code> element should have a <code>flex-basis</code> value of <code>20em</code>.');
+    testString: assert(code.match(/#box-2\s*?{\s*?.*?\s*?.*?\s*?flex-basis:\s*?20em;/g));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-flex-direction-property-to-make-a-column.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-flex-direction-property-to-make-a-column.english.md
@@ -21,7 +21,7 @@ Add the CSS property <code>flex-direction</code> to the <code>#box-container</co
 ```yml
 tests:
   - text: The <code>#box-container</code> element should have a <code>flex-direction</code> property set to column.
-    testString: assert($('#box-container').css('flex-direction') == 'column', 'The <code>#box-container</code> element should have a <code>flex-direction</code> property set to column.');
+    testString: assert($('#box-container').css('flex-direction') == 'column');
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-flex-direction-property-to-make-a-row.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-flex-direction-property-to-make-a-row.english.md
@@ -23,7 +23,7 @@ Add the CSS property <code>flex-direction</code> to the <code>#box-container</co
 ```yml
 tests:
   - text: The <code>#box-container</code> element should have a <code>flex-direction</code> property set to row-reverse.
-    testString: assert($('#box-container').css('flex-direction') == 'row-reverse', 'The <code>#box-container</code> element should have a <code>flex-direction</code> property set to row-reverse.');
+    testString: assert($('#box-container').css('flex-direction') == 'row-reverse');
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-flex-grow-property-to-expand-items.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-flex-grow-property-to-expand-items.english.md
@@ -22,9 +22,9 @@ Add the CSS property <code>flex-grow</code> to both <code>#box-1</code> and <cod
 ```yml
 tests:
   - text: The <code>#box-1</code> element should have the <code>flex-grow</code> property set to a value of 1.
-    testString: assert($('#box-1').css('flex-grow') == '1', 'The <code>#box-1</code> element should have the <code>flex-grow</code> property set to a value of 1.');
+    testString: assert($('#box-1').css('flex-grow') == '1');
   - text: The <code>#box-2</code> element should have the <code>flex-grow</code> property set to a value of 2.
-    testString: assert($('#box-2').css('flex-grow') == '2', 'The <code>#box-2</code> element should have the <code>flex-grow</code> property set to a value of 2.');
+    testString: assert($('#box-2').css('flex-grow') == '2');
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-flex-shorthand-property.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-flex-shorthand-property.english.md
@@ -24,11 +24,11 @@ These values will cause <code>#box-1</code> to grow to fill the extra space at t
 ```yml
 tests:
   - text: The <code>#box-1</code> element should have the <code>flex</code> property set to a value of 2 2 150px.
-    testString: assert($('#box-1').css('flex-grow') == '2' && $('#box-1').css('flex-shrink') == '2' && $('#box-1').css('flex-basis') == '150px', 'The <code>#box-1</code> element should have the <code>flex</code> property set to a value of 2 2 150px.');
+    testString: assert($('#box-1').css('flex-grow') == '2' && $('#box-1').css('flex-shrink') == '2' && $('#box-1').css('flex-basis') == '150px');
   - text: The <code>#box-2</code> element should have the <code>flex</code> property set to a value of 1 1 150px.
-    testString: assert($('#box-2').css('flex-grow') == '1' && $('#box-2').css('flex-shrink') == '1' && $('#box-2').css('flex-basis') == '150px', 'The <code>#box-2</code> element should have the <code>flex</code> property set to a value of 1 1 150px.');
+    testString: assert($('#box-2').css('flex-grow') == '1' && $('#box-2').css('flex-shrink') == '1' && $('#box-2').css('flex-basis') == '150px');
   - text: Your code should use the <code>flex</code> property for <code>#box-1</code> and <code>#box-2</code>.
-    testString: assert(code.match(/flex:\s*?\d\s+?\d\s+?150px;/g).length == 2, 'Your code should use the <code>flex</code> property for <code>#box-1</code> and <code>#box-2</code>.');
+    testString: assert(code.match(/flex:\s*?\d\s+?\d\s+?150px;/g).length == 2);
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-flex-shrink-property-to-shrink-items.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-flex-shrink-property-to-shrink-items.english.md
@@ -23,9 +23,9 @@ Add the CSS property <code>flex-shrink</code> to both <code>#box-1</code> and <c
 ```yml
 tests:
   - text: The <code>#box-1</code> element should have the <code>flex-shrink</code> property set to a value of 1.
-    testString: assert($('#box-1').css('flex-shrink') == '1', 'The <code>#box-1</code> element should have the <code>flex-shrink</code> property set to a value of 1.');
+    testString: assert($('#box-1').css('flex-shrink') == '1');
   - text: The <code>#box-2</code> element should have the <code>flex-shrink</code> property set to a value of 2.
-    testString: assert($('#box-2').css('flex-shrink') == '2', 'The <code>#box-2</code> element should have the <code>flex-shrink</code> property set to a value of 2.');
+    testString: assert($('#box-2').css('flex-shrink') == '2');
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-flex-wrap-property-to-wrap-a-row-or-column.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-flex-wrap-property-to-wrap-a-row-or-column.english.md
@@ -24,7 +24,7 @@ The current layout has too many boxes for one row. Add the CSS property <code>fl
 ```yml
 tests:
   - text: The <code>#box-container</code> element should have the <code>flex-wrap</code> property set to a value of wrap.
-    testString: assert($('#box-container').css('flex-wrap') == 'wrap', 'The <code>#box-container</code> element should have the <code>flex-wrap</code> property set to a value of wrap.');
+    testString: assert($('#box-container').css('flex-wrap') == 'wrap');
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-order-property-to-rearrange-items.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-order-property-to-rearrange-items.english.md
@@ -21,9 +21,9 @@ Add the CSS property <code>order</code> to both <code>#box-1</code> and <code>#b
 ```yml
 tests:
   - text: The <code>#box-1</code> element should have the <code>order</code> property set to a value of 2.
-    testString: assert($('#box-1').css('order') == '2', 'The <code>#box-1</code> element should have the <code>order</code> property set to a value of 2.');
+    testString: assert($('#box-1').css('order') == '2');
   - text: The <code>#box-2</code> element should have the <code>order</code> property set to a value of 1.
-    testString: assert($('#box-2').css('order') == '1', 'The <code>#box-2</code> element should have the <code>order</code> property set to a value of 1.');
+    testString: assert($('#box-2').css('order') == '1');
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-grid/add-columns-with-grid-template-columns.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-grid/add-columns-with-grid-template-columns.english.md
@@ -31,7 +31,7 @@ Give the grid container three columns that are each <code>100px</code> wide.
 ```yml
 tests:
   - text: <code>container</code> class should have a <code>grid-template-columns</code> property with three units of <code>100px</code>.
-    testString: assert(code.match(/.container\s*?{[\s\S]*grid-template-columns\s*?:\s*?100px\s*?100px\s*?100px\s*?;[\s\S]*}/gi), '<code>container</code> class should have a <code>grid-template-columns</code> property with three units of <code>100px</code>.');
+    testString: assert(code.match(/.container\s*?{[\s\S]*grid-template-columns\s*?:\s*?100px\s*?100px\s*?100px\s*?;[\s\S]*}/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-grid/add-gaps-faster-with-grid-gap.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-grid/add-gaps-faster-with-grid-gap.english.md
@@ -21,7 +21,7 @@ Use <code>grid-gap</code> to introduce a <code>10px</code> gap between the rows 
 ```yml
 tests:
   - text: <code>container</code> class should have a <code>grid-gap</code> property that introduces <code>10px</code> gap between the rows and <code>20px</code> gap between the columns.
-    testString: assert(code.match(/.container\s*?{[\s\S]*grid-gap\s*?:\s*?10px\s+?20px\s*?;[\s\S]*}/gi), '<code>container</code> class should have a <code>grid-gap</code> property that introduces <code>10px</code> gap between the rows and <code>20px</code> gap between the columns.');
+    testString: assert(code.match(/.container\s*?{[\s\S]*grid-gap\s*?:\s*?10px\s+?20px\s*?;[\s\S]*}/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-grid/add-rows-with-grid-template-rows.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-grid/add-rows-with-grid-template-rows.english.md
@@ -21,7 +21,7 @@ Add two rows to the grid that are <code>50px</code> tall each.
 ```yml
 tests:
   - text: <code>container</code> class should have a <code>grid-template-rows</code> property with two units of <code>50px</code>.
-    testString: assert(code.match(/.container\s*?{[\s\S]*grid-template-rows\s*?:\s*?50px\s*?50px\s*?;[\s\S]*}/gi), '<code>container</code> class should have a <code>grid-template-rows</code> property with two units of <code>50px</code>.');
+    testString: assert(code.match(/.container\s*?{[\s\S]*grid-template-rows\s*?:\s*?50px\s*?50px\s*?;[\s\S]*}/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-grid/align-all-items-horizontally-using-justify-items.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-grid/align-all-items-horizontally-using-justify-items.english.md
@@ -21,7 +21,7 @@ Use this property to center all our items horizontally.
 ```yml
 tests:
   - text: <code>container</code> class should have a <code>justify-items</code> property that has the value of <code>center</code>.
-    testString: assert(code.match(/.container\s*?{[\s\S]*justify-items\s*?:\s*?center\s*?;[\s\S]*}/gi), '<code>container</code> class should have a <code>justify-items</code> property that has the value of <code>center</code>.');
+    testString: assert(code.match(/.container\s*?{[\s\S]*justify-items\s*?:\s*?center\s*?;[\s\S]*}/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-grid/align-all-items-vertically-using-align-items.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-grid/align-all-items-vertically-using-align-items.english.md
@@ -21,7 +21,7 @@ Use it now to move all the items to the end of each cell.
 ```yml
 tests:
   - text: <code>container</code> class should have a <code>align-items</code> property that has the value of <code>end</code>.
-    testString: assert(code.match(/.container\s*?{[\s\S]*align-items\s*?:\s*?end\s*?;[\s\S]*}/gi), '<code>container</code> class should have a <code>align-items</code> property that has the value of <code>end</code>.');
+    testString: assert(code.match(/.container\s*?{[\s\S]*align-items\s*?:\s*?end\s*?;[\s\S]*}/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-grid/align-an-item-horizontally-using-justify-self.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-grid/align-an-item-horizontally-using-justify-self.english.md
@@ -24,7 +24,7 @@ Use the <code>justify-self</code> property to center the item with the class <co
 ```yml
 tests:
   - text: <code>item2</code> class should have a <code>justify-self</code> property that has the value of <code>center</code>.
-    testString: assert(code.match(/.item2\s*?{[\s\S]*justify-self\s*?:\s*?center\s*?;[\s\S]*}/gi), '<code>item2</code> class should have a <code>justify-self</code> property that has the value of <code>center</code>.');
+    testString: assert(code.match(/.item2\s*?{[\s\S]*justify-self\s*?:\s*?center\s*?;[\s\S]*}/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-grid/align-an-item-vertically-using-align-self.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-grid/align-an-item-vertically-using-align-self.english.md
@@ -21,7 +21,7 @@ Align the item with the class <code>item3</code> vertically at the <code>end</co
 ```yml
 tests:
   - text: <code>item3</code> class should have a <code>align-self</code> property that has the value of <code>end</code>.
-    testString: assert(code.match(/.item3\s*?{[\s\S]*align-self\s*?:\s*?end\s*?;[\s\S]*}/gi), '<code>item3</code> class should have a <code>align-self</code> property that has the value of <code>end</code>.');
+    testString: assert(code.match(/.item3\s*?{[\s\S]*align-self\s*?:\s*?end\s*?;[\s\S]*}/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-grid/create-a-column-gap-using-grid-column-gap.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-grid/create-a-column-gap-using-grid-column-gap.english.md
@@ -27,7 +27,7 @@ Give the columns in the grid a <code>20px</code> gap.
 ```yml
 tests:
   - text: <code>container</code> class should have a <code>grid-column-gap</code> property that has the value of <code>20px</code>.
-    testString: assert(code.match(/.container\s*?{[\s\S]*grid-column-gap\s*?:\s*?20px\s*?;[\s\S]*}/gi), '<code>container</code> class should have a <code>grid-column-gap</code> property that has the value of <code>20px</code>.');
+    testString: assert(code.match(/.container\s*?{[\s\S]*grid-column-gap\s*?:\s*?20px\s*?;[\s\S]*}/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-grid/create-a-row-gap-using-grid-row-gap.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-grid/create-a-row-gap-using-grid-row-gap.english.md
@@ -21,7 +21,7 @@ Create a gap for the rows that is <code>5px</code> tall.
 ```yml
 tests:
   - text: <code>container</code> class should have a <code>grid-row-gap</code> property that has the value of <code>5px</code>.
-    testString: assert(code.match(/.container\s*?{[\s\S]*grid-row-gap\s*?:\s*?5px\s*?;[\s\S]*}/gi), '<code>container</code> class should have a <code>grid-row-gap</code> property that has the value of <code>5px</code>.');
+    testString: assert(code.match(/.container\s*?{[\s\S]*grid-row-gap\s*?:\s*?5px\s*?;[\s\S]*}/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-grid/create-flexible-layouts-using-auto-fill.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-grid/create-flexible-layouts-using-auto-fill.english.md
@@ -28,7 +28,7 @@ In the first grid, use <code>auto-fill</code> with <code>repeat</code> to fill t
 ```yml
 tests:
   - text: <code>container</code> class should have a <code>grid-template-columns</code> property with <code>repeat</code> and <code>auto-fill</code> that will fill the grid with columns that have a minimum width of <code>60px</code> and maximum of <code>1fr</code>.
-    testString: assert(code.match(/.container\s*?{[\s\S]*grid-template-columns\s*?:\s*?repeat\s*?\(\s*?auto-fill\s*?,\s*?minmax\s*?\(\s*?60px\s*?,\s*?1fr\s*?\)\s*?\)\s*?;[\s\S]*}/gi), '<code>container</code> class should have a <code>grid-template-columns</code> property with <code>repeat</code> and <code>auto-fill</code> that will fill the grid with columns that have a minimum width of <code>60px</code> and maximum of <code>1fr</code>.');
+    testString: assert(code.match(/.container\s*?{[\s\S]*grid-template-columns\s*?:\s*?repeat\s*?\(\s*?auto-fill\s*?,\s*?minmax\s*?\(\s*?60px\s*?,\s*?1fr\s*?\)\s*?\)\s*?;[\s\S]*}/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-grid/create-flexible-layouts-using-auto-fit.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-grid/create-flexible-layouts-using-auto-fit.english.md
@@ -22,7 +22,7 @@ In the second grid, use <code>auto-fit</code> with <code>repeat</code> to fill t
 ```yml
 tests:
   - text: <code>container2</code> class should have a <code>grid-template-columns</code> property with <code>repeat</code> and <code>auto-fit</code> that will fill the grid with columns that have a minimum width of <code>60px</code> and maximum of <code>1fr</code>.
-    testString: assert(code.match(/.container\s*?{[\s\S]*grid-template-columns\s*?:\s*?repeat\s*?\(\s*?auto-fit\s*?,\s*?minmax\s*?\(\s*?60px\s*?,\s*?1fr\s*?\)\s*?\)\s*?;[\s\S]*}/gi), '<code>container2</code> class should have a <code>grid-template-columns</code> property with <code>repeat</code> and <code>auto-fit</code> that will fill the grid with columns that have a minimum width of <code>60px</code> and maximum of <code>1fr</code>.');
+    testString: assert(code.match(/.container\s*?{[\s\S]*grid-template-columns\s*?:\s*?repeat\s*?\(\s*?auto-fit\s*?,\s*?minmax\s*?\(\s*?60px\s*?,\s*?1fr\s*?\)\s*?\)\s*?;[\s\S]*}/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-grid/create-grids-within-grids.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-grid/create-grids-within-grids.english.md
@@ -22,9 +22,9 @@ Turn the element with the <code>item3</code> class into a grid with two columns 
 ```yml
 tests:
   - text: <code>item3</code> class should have a <code>grid-template-columns</code> property with <code>auto</code> and <code>1fr</code> as values.
-    testString: assert(code.match(/.item3\s*?{[\s\S]*grid-template-columns\s*?:\s*?auto\s*?1fr\s*?;[\s\S]*}/gi), '<code>item3</code> class should have a <code>grid-template-columns</code> property with <code>auto</code> and <code>1fr</code> as values.');
+    testString: assert(code.match(/.item3\s*?{[\s\S]*grid-template-columns\s*?:\s*?auto\s*?1fr\s*?;[\s\S]*}/gi));
   - text: <code>item3</code> class should have a <code>display</code> property with the value of <code>grid</code>.
-    testString: assert(code.match(/.item3\s*?{[\s\S]*display\s*?:\s*?grid\s*?;[\s\S]*}/gi), '<code>item3</code> class should have a <code>display</code> property with the value of <code>grid</code>.');
+    testString: assert(code.match(/.item3\s*?{[\s\S]*display\s*?:\s*?grid\s*?;[\s\S]*}/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-grid/create-your-first-css-grid.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-grid/create-your-first-css-grid.english.md
@@ -22,7 +22,7 @@ Change the display of the div with the <code>container</code> class to <code>gri
 ```yml
 tests:
   - text: <code>container</code> class should have a <code>display</code> property with a value of <code>grid</code>.
-    testString: assert(code.match(/.container\s*?{[\s\S]*display\s*?:\s*?grid\s*?;[\s\S]*}/gi), '<code>container</code> class should have a <code>display</code> property with a value of <code>grid</code>.');
+    testString: assert(code.match(/.container\s*?{[\s\S]*display\s*?:\s*?grid\s*?;[\s\S]*}/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-grid/divide-the-grid-into-an-area-template.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-grid/divide-the-grid-into-an-area-template.english.md
@@ -32,7 +32,7 @@ Place the area template so that the cell labeled <code>advert</code> becomes an 
 ```yml
 tests:
   - text: <code>container</code> class should have a <code>grid-template-areas</code> property similar to the preview but has <code>.</code> instead of the <code>advert</code> area.
-    testString: assert(code.match(/.container\s*?{[\s\S]*grid-template-areas\s*?:\s*?"\s*?header\s*?header\s*?header\s*?"\s*?"\s*?.\s*?content\s*?content\s*?"\s*?"\s*?footer\s*?footer\s*?footer\s*?"\s*?;[\s\S]*}/gi), '<code>container</code> class should have a <code>grid-template-areas</code> propertiy similar to the preview but has <code>.</code> instead of the <code>advert</code> area.');
+    testString: assert(code.match(/.container\s*?{[\s\S]*grid-template-areas\s*?:\s*?"\s*?header\s*?header\s*?header\s*?"\s*?"\s*?.\s*?content\s*?content\s*?"\s*?"\s*?footer\s*?footer\s*?footer\s*?"\s*?;[\s\S]*}/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-grid/limit-item-size-using-the-minmax-function.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-grid/limit-item-size-using-the-minmax-function.english.md
@@ -27,7 +27,7 @@ Using the <code>minmax</code> function, replace the <code>1fr</code> in the <cod
 ```yml
 tests:
   - text: <code>container</code> class should have a <code>grid-template-columns</code> property that is set to repeat 3 columns with the minimum width of <code>90px</code> and maximum width of <code>1fr</code>.
-    testString: assert(code.match(/.container\s*?{[\s\S]*grid-template-columns\s*?:\s*?repeat\s*?\(\s*?3\s*?,\s*?minmax\s*?\(\s*?90px\s*?,\s*?1fr\s*?\)\s*?\)\s*?;[\s\S]*}/gi), '<code>container</code> class should have a <code>grid-template-columns</code> property that is set to repeat 3 columns with the minimum width of <code>90px</code> and maximum width of <code>1fr</code>.');
+    testString: assert(code.match(/.container\s*?{[\s\S]*grid-template-columns\s*?:\s*?repeat\s*?\(\s*?3\s*?,\s*?minmax\s*?\(\s*?90px\s*?,\s*?1fr\s*?\)\s*?\)\s*?;[\s\S]*}/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-grid/place-items-in-grid-areas-using-the-grid-area-property.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-grid/place-items-in-grid-areas-using-the-grid-area-property.english.md
@@ -29,7 +29,7 @@ Place an element with the <code>item5</code> class in the <code>footer</code> ar
 ```yml
 tests:
   - text: <code>item5</code> class should have a <code>grid-area</code> property that has the value of <code>footer</code>.
-    testString: assert(code.match(/.item5\s*?{[\s\S]*grid-area\s*?:\s*?footer\s*?;[\s\S]*}/gi), '<code>item5</code> class should have a <code>grid-area</code> property that has the value of <code>footer</code>.');
+    testString: assert(code.match(/.item5\s*?{[\s\S]*grid-area\s*?:\s*?footer\s*?;[\s\S]*}/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-grid/reduce-repetition-using-the-repeat-function.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-grid/reduce-repetition-using-the-repeat-function.english.md
@@ -41,7 +41,7 @@ Use <code>repeat</code> to remove repetition from the <code>grid-template-column
 ```yml
 tests:
   - text: <code>container</code> class should have a <code>grid-template-columns</code> property that is set to repeat 3 columns with the width of <code>1fr</code>.
-    testString: assert(code.match(/.container\s*?{[\s\S]*grid-template-columns\s*?:\s*?repeat\s*?\(\s*?3\s*?,\s*?1fr\s*?\)\s*?;[\s\S]*}/gi), '<code>container</code> class should have a <code>grid-template-columns</code> property that is set to repeat 3 columns with the width of <code>1fr</code>.');
+    testString: assert(code.match(/.container\s*?{[\s\S]*grid-template-columns\s*?:\s*?repeat\s*?\(\s*?3\s*?,\s*?1fr\s*?\)\s*?;[\s\S]*}/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-grid/use-grid-area-without-creating-an-areas-template.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-grid/use-grid-area-without-creating-an-areas-template.english.md
@@ -33,7 +33,7 @@ Using the <code>grid-area</code> property, place the element with <code>item5</c
 ```yml
 tests:
   - text: <code>item5</code> class should have a <code>grid-area</code> property such that it is between the third and fourth horizontal lines and between the first and fourth vertical lines.
-    testString: assert(code.match(/.item5\s*?{[\s\S]*grid-area\s*?:\s*?3\s*?\/\s*?1\s*?\/\s*?4\s*?\/\s*?4\s*?;[\s\S]*}/gi), '<code>item5</code> class should have a <code>grid-area</code> property such that it is between the third and fourth horizontal lines and between the first and fourth vertical lines.');
+    testString: assert(code.match(/.item5\s*?{[\s\S]*grid-area\s*?:\s*?3\s*?\/\s*?1\s*?\/\s*?4\s*?\/\s*?4\s*?;[\s\S]*}/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-grid/use-grid-row-to-control-spacing.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-grid/use-grid-row-to-control-spacing.english.md
@@ -21,7 +21,7 @@ Make the element with the <code>item5</code> class consume the last two rows.
 ```yml
 tests:
   - text: <code>item5</code> class should have a <code>grid-row</code> property that has the value of <code>2 / 4</code>.
-    testString: assert(code.match(/.item5\s*?{[\s\S]*grid-row\s*?:\s*?2\s*?\/\s*?4\s*?;[\s\S]*}/gi), '<code>item5</code> class should have a <code>grid-row</code> property that has the value of <code>2 / 4</code>.');
+    testString: assert(code.match(/.item5\s*?{[\s\S]*grid-row\s*?:\s*?2\s*?\/\s*?4\s*?;[\s\S]*}/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-grid/use-media-queries-to-create-responsive-layouts.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-grid/use-media-queries-to-create-responsive-layouts.english.md
@@ -22,7 +22,7 @@ When the viewport width is <code>400px</code> or more, make the header area occu
 ```yml
 tests:
   - text: When the viewport is <code>400px</code> or more, <code>container</code> class should have a <code>grid-template-areas</code> property in which the header and footer areas occupy the top and bottom rows respectively and advert and content occupy the left and right columns of the middle row.
-    testString: assert(code.match(/@media\s*?\(\s*?min-width\s*?:\s*?400px\s*?\)[\s\S]*.container\s*?{[\s\S]*grid-template-areas\s*?:\s*?"\s*?header\s*?header\s*?"\s*?"\s*?advert\s*?content\s*?"\s*?"\s*?footer\s*?footer\s*?"\s*?;[\s\S]*}/gi), 'When the viewport is <code>400px</code> or more, <code>container</code> class should have a <code>grid-template-areas</code> property in which the header and footer areas occupy the top and bottom rows respectively and advert and content occupy the left and right columns of the middle row.');
+    testString: assert(code.match(/@media\s*?\(\s*?min-width\s*?:\s*?400px\s*?\)[\s\S]*.container\s*?{[\s\S]*grid-template-areas\s*?:\s*?"\s*?header\s*?header\s*?"\s*?"\s*?advert\s*?content\s*?"\s*?"\s*?footer\s*?footer\s*?"\s*?;[\s\S]*}/gi));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/responsive-web-design-principles/make-an-image-responsive.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/responsive-web-design-principles/make-an-image-responsive.english.md
@@ -33,11 +33,11 @@ Add style rules for the <code>img</code> tag to make it responsive to the size o
 ```yml
 tests:
   - text: Your <code>img</code> tag should have a <code>max-width</code> set to 100%.
-    testString: assert(code.match(/max-width:\s*?100%;/g), 'Your <code>img</code> tag should have a <code>max-width</code> set to 100%.');
+    testString: assert(code.match(/max-width:\s*?100%;/g));
   - text: Your <code>img</code> tag should have a <code>display</code> set to block.
-    testString: assert($('img').css('display') == 'block', 'Your <code>img</code> tag should have a <code>display</code> set to block.');
+    testString: assert($('img').css('display') == 'block');
   - text: Your <code>img</code> tag should have a <code>height</code> set to auto.
-    testString: assert(code.match(/height:\s*?auto;/g), 'Your <code>img</code> tag should have a <code>height</code> set to auto.');
+    testString: assert(code.match(/height:\s*?auto;/g));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/responsive-web-design-principles/make-typography-responsive.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/responsive-web-design-principles/make-typography-responsive.english.md
@@ -25,9 +25,9 @@ Set the <code>width</code> of the <code>h2</code> tag to 80% of the viewport's w
 ```yml
 tests:
   - text: Your <code>h2</code> tag should have a <code>width</code> of 80vw.
-    testString: assert(code.match(/h2\s*?{\s*?width:\s*?80vw;\s*?}/g), 'Your <code>h2</code> tag should have a <code>width</code> of 80vw.');
+    testString: assert(code.match(/h2\s*?{\s*?width:\s*?80vw;\s*?}/g));
   - text: Your <code>p</code> tag should have a <code>width</code> of 75vmin.
-    testString: assert(code.match(/p\s*?{\s*?width:\s*?75vmin;\s*?}/g), 'Your <code>p</code> tag should have a <code>width</code> of 75vmin.');
+    testString: assert(code.match(/p\s*?{\s*?width:\s*?75vmin;\s*?}/g));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/responsive-web-design-principles/use-a-retina-image-for-higher-resolution-displays.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/responsive-web-design-principles/use-a-retina-image-for-higher-resolution-displays.english.md
@@ -32,9 +32,9 @@ Set the <code>width</code> and <code>height</code> of the <code>img</code> tag t
 ```yml
 tests:
   - text: Your <code>img</code> tag should have a <code>width</code> of 100 pixels.
-    testString: assert($('img').css('width') == '100px', 'Your <code>img</code> tag should have a <code>width</code> of 100 pixels.');
+    testString: assert($('img').css('width') == '100px');
   - text: Your <code>img</code> tag should have a <code>height</code> of 100 pixels.
-    testString: assert($('img').css('height') == '100px', 'Your <code>img</code> tag should have a <code>height</code> of 100 pixels.');
+    testString: assert($('img').css('height') == '100px');
 
 ```
 


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Related to issue #36400

This PR removes assert message arguments from `testString` for the following sub sections of the `Responsive Web Design` curriculum section:
* CSS Flexbox
* CSS Grid
* Responsive Web Design Principles