### PR TITLE
fix : add URL to a missing link

### DIFF
--- a/guide/english/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/boo-who/index.md
+++ b/guide/english/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/boo-who/index.md
@@ -53,7 +53,6 @@ Uses the operator `typeof` to check if the variable is a boolean. If it is, it w
 
 #### Relevant Links
 
-*   <a href ='https://learn.freecodecamp.org/javascript-algorithms-and-data-structures/debugging/use-typeof-to-check-the-type-of-a-variable' target='_blank' rel='nofollow'>Using typeof</a>
 *   <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof' target='_blank' rel='nofollow'>typeof</a>
 
 ## ![:clipboard:](https://forum.freecodecamp.com/images/emoji/emoji_one/clipboard.png?v=3 ":clipboard:") NOTES FOR CONTRIBUTIONS:

--- a/guide/english/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/boo-who/index.md
+++ b/guide/english/certifications/javascript-algorithms-and-data-structures/basic-algorithm-scripting/boo-who/index.md
@@ -53,7 +53,7 @@ Uses the operator `typeof` to check if the variable is a boolean. If it is, it w
 
 #### Relevant Links
 
-*   <a>Using typeof</a>
+*   <a href ='https://learn.freecodecamp.org/javascript-algorithms-and-data-structures/debugging/use-typeof-to-check-the-type-of-a-variable' target='_blank' rel='nofollow'>Using typeof</a>
 *   <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof' target='_blank' rel='nofollow'>typeof</a>
 
 ## ![:clipboard:](https://forum.freecodecamp.com/images/emoji/emoji_one/clipboard.png?v=3 ":clipboard:") NOTES FOR CONTRIBUTIONS:


### PR DESCRIPTION
In Relevant Links (line 54), the first URL text 'Using typeof' was missing a href value. I fixed it by adding the link to a FreeCodeCamp's Javascript Debugging curriculum that introduces typeof method. (
Debugging: Use typeof to Check the Type of a Variable : https://learn.freecodecamp.org/javascript-algorithms-and-data-structures/debugging/use-typeof-to-check-the-type-of-a-variable)

* I'm a first-time open source contributor. If you have any feedback about my pull request, feel free to share it with me.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX
