### PR TITLE
fix(curriculum): Remove unnecessary assert message argument from English Coding Interview Prep challenges - Project Euler - 01

### DIFF
--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-1-multiples-of-3-and-5.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-1-multiples-of-3-and-5.english.md
@@ -21,13 +21,13 @@ Find the sum of all the multiples of 3 or 5 below the provided parameter value <
 ```yml
 tests:
   - text: <code>multiplesOf3and5(1000)</code> should return 233168.
-    testString: assert.strictEqual(multiplesOf3and5(1000), 233168, '<code>multiplesOf3and5(1000)</code> should return 233168.');
+    testString: assert.strictEqual(multiplesOf3and5(1000), 233168);
   - text: <code>multiplesOf3and5(49)</code> should return 543.
-    testString: assert.strictEqual(multiplesOf3and5(49), 543, '<code>multiplesOf3and5(49)</code> should return 543.');
+    testString: assert.strictEqual(multiplesOf3and5(49), 543);
   - text: <code>multiplesOf3and5(19564)</code> should return 89301183.
-    testString: assert.strictEqual(multiplesOf3and5(19564), 89301183, '<code>multiplesOf3and5(19564)</code> should return 89301183.');
+    testString: assert.strictEqual(multiplesOf3and5(19564), 89301183);
   - text: Your function is not returning the correct result using our tests values.
-    testString: assert.strictEqual(multiplesOf3and5(8456), 16687353, 'Your function is not returning the correct result using our tests values.');
+    testString: assert.strictEqual(multiplesOf3and5(8456), 16687353);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-10-summation-of-primes.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-10-summation-of-primes.english.md
@@ -21,13 +21,13 @@ Find the sum of all the primes below n.
 ```yml
 tests:
   - text: <code>primeSummation(17)</code> should return 41.
-    testString: assert.strictEqual(primeSummation(17), 41, '<code>primeSummation(17)</code> should return 41.');
+    testString: assert.strictEqual(primeSummation(17), 41);
   - text: <code>primeSummation(2001)</code> should return 277050.
-    testString: assert.strictEqual(primeSummation(2001), 277050, '<code>primeSummation(2001)</code> should return 277050.');
+    testString: assert.strictEqual(primeSummation(2001), 277050);
   - text: <code>primeSummation(140759)</code> should return 873608362.
-    testString: assert.strictEqual(primeSummation(140759), 873608362, '<code>primeSummation(140759)</code> should return 873608362.');
+    testString: assert.strictEqual(primeSummation(140759), 873608362);
   - text: <code>primeSummation(2000000)</code> should return 142913828922.
-    testString: assert.strictEqual(primeSummation(2000000), 142913828922, '<code>primeSummation(2000000)</code> should return 142913828922.');
+    testString: assert.strictEqual(primeSummation(2000000), 142913828922);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-100-arranged-probability.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-100-arranged-probability.english.md
@@ -22,7 +22,7 @@ By finding the first arrangement to contain over 1012 = 1,000,000,000,000 discs 
 ```yml
 tests:
   - text: <code>euler100()</code> should return 756872327473.
-    testString: assert.strictEqual(euler100(), 756872327473, '<code>euler100()</code> should return 756872327473.');
+    testString: assert.strictEqual(euler100(), 756872327473);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-101-optimum-polynomial.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-101-optimum-polynomial.english.md
@@ -40,7 +40,7 @@ Find the sum of FITs for the BOPs.
 ```yml
 tests:
   - text: <code>euler101()</code> should return 37076114526.
-    testString: assert.strictEqual(euler101(), 37076114526, '<code>euler101()</code> should return 37076114526.');
+    testString: assert.strictEqual(euler101(), 37076114526);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-102-triangle-containment.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-102-triangle-containment.english.md
@@ -26,7 +26,7 @@ NOTE: The first two examples in the file represent the triangles in the example 
 ```yml
 tests:
   - text: <code>euler102()</code> should return 228.
-    testString: assert.strictEqual(euler102(), 228, '<code>euler102()</code> should return 228.');
+    testString: assert.strictEqual(euler102(), 228);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-103-special-subset-sums-optimum.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-103-special-subset-sums-optimum.english.md
@@ -28,7 +28,7 @@ NOTE: This problem is related to Problem 105 and Problem 106.
 ```yml
 tests:
   - text: <code>euler103()</code> should return 20313839404245.
-    testString: assert.strictEqual(euler103(), 20313839404245, '<code>euler103()</code> should return 20313839404245.');
+    testString: assert.strictEqual(euler103(), 20313839404245);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-104-pandigital-fibonacci-ends.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-104-pandigital-fibonacci-ends.english.md
@@ -23,7 +23,7 @@ Given that Fk is the first Fibonacci number for which the first nine digits AND 
 ```yml
 tests:
   - text: <code>euler104()</code> should return 329468.
-    testString: assert.strictEqual(euler104(), 329468, '<code>euler104()</code> should return 329468.');
+    testString: assert.strictEqual(euler104(), 329468);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-105-special-subset-sums-testing.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-105-special-subset-sums-testing.english.md
@@ -25,7 +25,7 @@ NOTE: This problem is related to Problem 103 and Problem 106.
 ```yml
 tests:
   - text: <code>euler105()</code> should return 73702.
-    testString: assert.strictEqual(euler105(), 73702, '<code>euler105()</code> should return 73702.');
+    testString: assert.strictEqual(euler105(), 73702);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-106-special-subset-sums-meta-testing.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-106-special-subset-sums-meta-testing.english.md
@@ -26,7 +26,7 @@ NOTE: This problem is related to Problem 103 and Problem 105.
 ```yml
 tests:
   - text: <code>euler106()</code> should return 21384.
-    testString: assert.strictEqual(euler106(), 21384, '<code>euler106()</code> should return 21384.');
+    testString: assert.strictEqual(euler106(), 21384);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-107-minimal-network.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-107-minimal-network.english.md
@@ -35,7 +35,7 @@ Using network.txt (right click and 'Save Link/Target As...'), a 6K text file con
 ```yml
 tests:
   - text: <code>euler107()</code> should return 259679.
-    testString: assert.strictEqual(euler107(), 259679, '<code>euler107()</code> should return 259679.');
+    testString: assert.strictEqual(euler107(), 259679);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-108-diophantine-reciprocals-i.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-108-diophantine-reciprocals-i.english.md
@@ -24,7 +24,7 @@ What is the least value of <var>n</var> for which the number of distinct solutio
 ```yml
 tests:
   - text: <code>diophantineOne()</code> should return 180180.
-    testString: assert.strictEqual(diophantineOne(), 180180, '<code>diophantineOne()</code> should return 180180.');
+    testString: assert.strictEqual(diophantineOne(), 180180);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-109-darts.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-109-darts.english.md
@@ -66,7 +66,7 @@ How many distinct ways can a player checkout with a score less than 100?
 ```yml
 tests:
   - text: <code>euler109()</code> should return 38182.
-    testString: assert.strictEqual(euler109(), 38182, '<code>euler109()</code> should return 38182.');
+    testString: assert.strictEqual(euler109(), 38182);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-11-largest-product-in-a-grid.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-11-largest-product-in-a-grid.english.md
@@ -44,9 +44,9 @@ What is the greatest product of four adjacent numbers in the same direction (up,
 ```yml
 tests:
   - text: <code>largestGridProduct(grid)</code> should return 70600674.
-    testString: assert.strictEqual(largestGridProduct(grid), 70600674, '<code>largestGridProduct(grid)</code> should return 70600674.');
+    testString: assert.strictEqual(largestGridProduct(grid), 70600674);
   - text: <code>largestGridProduct(testGrid)</code> should return 14169081.
-    testString: assert.strictEqual(largestGridProduct(testGrid), 14169081, '<code>largestGridProduct(testGrid)</code> should return 14169081.');
+    testString: assert.strictEqual(largestGridProduct(testGrid), 14169081);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-110-diophantine-reciprocals-ii.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-110-diophantine-reciprocals-ii.english.md
@@ -22,8 +22,8 @@ What is the least value of <var>n</var> for which the number of distinct solutio
 
 ```yml
 tests:
-  - text: <code>diophantineTwo</code> should return 9350130049860600.
-    testString: assert.strictEqual(diophantineTwo(), 9350130049860600, '<code>diophantineTwo()</code> should return 9350130049860600.');
+  - text: <code>diophantineTwo()</code> should return 9350130049860600.
+    testString: assert.strictEqual(diophantineTwo(), 9350130049860600);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-111-primes-with-runs.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-111-primes-with-runs.english.md
@@ -72,7 +72,7 @@ Find the sum of all S(10, d).
 ```yml
 tests:
   - text: <code>euler111()</code> should return 612407567715.
-    testString: assert.strictEqual(euler111(), 612407567715, '<code>euler111()</code> should return 612407567715.');
+    testString: assert.strictEqual(euler111(), 612407567715);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-112-bouncy-numbers.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-112-bouncy-numbers.english.md
@@ -25,7 +25,7 @@ Find the least number for which the proportion of bouncy numbers is exactly 99%.
 ```yml
 tests:
   - text: <code>euler112()</code> should return 1587000.
-    testString: assert.strictEqual(euler112(), 1587000, '<code>euler112()</code> should return 1587000.');
+    testString: assert.strictEqual(euler112(), 1587000);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-113-non-bouncy-numbers.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-113-non-bouncy-numbers.english.md
@@ -24,7 +24,7 @@ How many numbers below a googol (10100) are not bouncy?
 ```yml
 tests:
   - text: <code>euler113()</code> should return 51161058134250.
-    testString: assert.strictEqual(euler113(), 51161058134250, '<code>euler113()</code> should return 51161058134250.');
+    testString: assert.strictEqual(euler113(), 51161058134250);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-114-counting-block-combinations-i.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-114-counting-block-combinations-i.english.md
@@ -123,7 +123,7 @@ NOTE: Although the example above does not lend itself to the possibility, in gen
 ```yml
 tests:
   - text: <code>euler114()</code> should return 16475640049.
-    testString: assert.strictEqual(euler114(), 16475640049, '<code>euler114()</code> should return 16475640049.');
+    testString: assert.strictEqual(euler114(), 16475640049);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-115-counting-block-combinations-ii.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-115-counting-block-combinations-ii.english.md
@@ -26,7 +26,7 @@ For m = 50, find the least value of n for which the fill-count function first ex
 ```yml
 tests:
   - text: <code>euler115()</code> should return 168.
-    testString: assert.strictEqual(euler115(), 168, '<code>euler115()</code> should return 168.');
+    testString: assert.strictEqual(euler115(), 168);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-116-red-green-or-blue-tiles.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-116-red-green-or-blue-tiles.english.md
@@ -93,7 +93,7 @@ NOTE: This is related to Problem 117.
 ```yml
 tests:
   - text: <code>euler116()</code> should return 20492570929.
-    testString: assert.strictEqual(euler116(), 20492570929, '<code>euler116()</code> should return 20492570929.');
+    testString: assert.strictEqual(euler116(), 20492570929);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-117-red-green-and-blue-tiles.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-117-red-green-and-blue-tiles.english.md
@@ -101,7 +101,7 @@ NOTE: This is related to Problem 116.
 ```yml
 tests:
   - text: <code>euler117()</code> should return 100808458960497.
-    testString: assert.strictEqual(euler117(), 100808458960497, '<code>euler117()</code> should return 100808458960497.');
+    testString: assert.strictEqual(euler117(), 100808458960497);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-118-pandigital-prime-sets.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-118-pandigital-prime-sets.english.md
@@ -21,7 +21,7 @@ How many distinct sets containing each of the digits one through nine exactly on
 ```yml
 tests:
   - text: <code>euler118()</code> should return 44680.
-    testString: assert.strictEqual(euler118(), 44680, '<code>euler118()</code> should return 44680.');
+    testString: assert.strictEqual(euler118(), 44680);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-119-digit-power-sum.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-119-digit-power-sum.english.md
@@ -23,7 +23,7 @@ Find a30.
 ```yml
 tests:
   - text: <code>euler119()</code> should return 248155780267521.
-    testString: assert.strictEqual(euler119(), 248155780267521, '<code>euler119()</code> should return 248155780267521.');
+    testString: assert.strictEqual(euler119(), 248155780267521);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-12-highly-divisible-triangular-number.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-12-highly-divisible-triangular-number.english.md
@@ -31,15 +31,15 @@ What is the value of the first triangle number to have over <code>n</code> divis
 ```yml
 tests:
   - text: <code>divisibleTriangleNumber(5)</code> should return 28.
-    testString: assert.strictEqual(divisibleTriangleNumber(5), 28, '<code>divisibleTriangleNumber(5)</code> should return 28.');
+    testString: assert.strictEqual(divisibleTriangleNumber(5), 28);
   - text: <code>divisibleTriangleNumber(23)</code> should return 630.
-    testString: assert.strictEqual(divisibleTriangleNumber(23), 630, '<code>divisibleTriangleNumber(23)</code> should return 630.');
+    testString: assert.strictEqual(divisibleTriangleNumber(23), 630);
   - text: <code>divisibleTriangleNumber(167)</code> should return 1385280.
-    testString: assert.strictEqual(divisibleTriangleNumber(167), 1385280, '<code>divisibleTriangleNumber(167)</code> should return 1385280.');
+    testString: assert.strictEqual(divisibleTriangleNumber(167), 1385280);
   - text: <code>divisibleTriangleNumber(374)</code> should return 17907120.
-    testString: assert.strictEqual(divisibleTriangleNumber(374), 17907120, '<code>divisibleTriangleNumber(374)</code> should return 17907120.');
+    testString: assert.strictEqual(divisibleTriangleNumber(374), 17907120);
   - text: <code>divisibleTriangleNumber(500)</code> should return 76576500.
-    testString: assert.strictEqual(divisibleTriangleNumber(500), 76576500, '<code>divisibleTriangleNumber(500)</code> should return 76576500.');
+    testString: assert.strictEqual(divisibleTriangleNumber(500), 76576500);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-120-square-remainders.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-120-square-remainders.english.md
@@ -22,7 +22,7 @@ For 3 ≤ a ≤ 1000, find ∑ rmax.
 ```yml
 tests:
   - text: <code>euler120()</code> should return 333082500.
-    testString: assert.strictEqual(euler120(), 333082500, '<code>euler120()</code> should return 333082500.');
+    testString: assert.strictEqual(euler120(), 333082500);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-121-disc-game-prize-fund.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-121-disc-game-prize-fund.english.md
@@ -23,7 +23,7 @@ Find the maximum prize fund that should be allocated to a single game in which f
 ```yml
 tests:
   - text: <code>euler121()</code> should return 2269.
-    testString: assert.strictEqual(euler121(), 2269, '<code>euler121()</code> should return 2269.');
+    testString: assert.strictEqual(euler121(), 2269);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-122-efficient-exponentiation.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-122-efficient-exponentiation.english.md
@@ -27,7 +27,7 @@ For 1 ≤ k ≤ 200, find ∑ m(k).
 ```yml
 tests:
   - text: <code>euler122()</code> should return 1582.
-    testString: assert.strictEqual(euler122(), 1582, '<code>euler122()</code> should return 1582.');
+    testString: assert.strictEqual(euler122(), 1582);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-123-prime-square-remainders.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-123-prime-square-remainders.english.md
@@ -23,7 +23,7 @@ Find the least value of n for which the remainder first exceeds 1010.
 ```yml
 tests:
   - text: <code>euler123()</code> should return 21035.
-    testString: assert.strictEqual(euler123(), 21035, '<code>euler123()</code> should return 21035.');
+    testString: assert.strictEqual(euler123(), 21035);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-124-ordered-radicals.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-124-ordered-radicals.english.md
@@ -62,7 +62,7 @@ If rad(n) is sorted for 1 ≤ n ≤ 100000, find E(10000).
 ```yml
 tests:
   - text: <code>euler124()</code> should return 21417.
-    testString: assert.strictEqual(euler124(), 21417, '<code>euler124()</code> should return 21417.');
+    testString: assert.strictEqual(euler124(), 21417);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-125-palindromic-sums.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-125-palindromic-sums.english.md
@@ -22,7 +22,7 @@ Find the sum of all the numbers less than 108 that are both palindromic and can 
 ```yml
 tests:
   - text: <code>euler125()</code> should return 2906969179.
-    testString: assert.strictEqual(euler125(), 2906969179, '<code>euler125()</code> should return 2906969179.');
+    testString: assert.strictEqual(euler125(), 2906969179);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-126-cuboid-layers.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-126-cuboid-layers.english.md
@@ -27,7 +27,7 @@ Find the least value of n for which C(n) = 1000.
 ```yml
 tests:
   - text: <code>euler126()</code> should return 18522.
-    testString: assert.strictEqual(euler126(), 18522, '<code>euler126()</code> should return 18522.');
+    testString: assert.strictEqual(euler126(), 18522);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-127-abc-hits.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-127-abc-hits.english.md
@@ -32,7 +32,7 @@ Find ∑c for c < 120000.
 ```yml
 tests:
   - text: <code>euler127()</code> should return 18407904.
-    testString: assert.strictEqual(euler127(), 18407904, '<code>euler127()</code> should return 18407904.');
+    testString: assert.strictEqual(euler127(), 18407904);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-128-hexagonal-tile-differences.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-128-hexagonal-tile-differences.english.md
@@ -29,7 +29,7 @@ Find the 2000th tile in this sequence.
 ```yml
 tests:
   - text: <code>euler128()</code> should return 14516824220.
-    testString: assert.strictEqual(euler128(), 14516824220, '<code>euler128()</code> should return 14516824220.');
+    testString: assert.strictEqual(euler128(), 14516824220);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-129-repunit-divisibility.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-129-repunit-divisibility.english.md
@@ -23,7 +23,7 @@ Find the least value of n for which A(n) first exceeds one-million.
 ```yml
 tests:
   - text: <code>euler129()</code> should return 1000023.
-    testString: assert.strictEqual(euler129(), 1000023, '<code>euler129()</code> should return 1000023.');
+    testString: assert.strictEqual(euler129(), 1000023);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-13-large-sum.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-13-large-sum.english.md
@@ -121,9 +121,9 @@ Work out the first ten digits of the sum of the following one-hundred 50-digit n
 ```yml
 tests:
   - text: <code>largeSum(testNums)</code> should return 8348422521.
-    testString: assert.strictEqual(largeSum(testNums), 8348422521, '<code>largeSum(testNums)</code> should return 8348422521.');
+    testString: assert.strictEqual(largeSum(testNums), 8348422521);
   - text: <code>largeSum(fiftyDigitNums)</code> should return 5537376230.
-    testString: assert.strictEqual(largeSum(fiftyDigitNums), 5537376230, '<code>largeSum(fiftyDigitNums)</code> should return 5537376230.');
+    testString: assert.strictEqual(largeSum(fiftyDigitNums), 5537376230);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-130-composites-with-prime-repunit-property.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-130-composites-with-prime-repunit-property.english.md
@@ -24,7 +24,7 @@ Find the sum of the first twenty-five composite values of n for whichGCD(n, 10) 
 ```yml
 tests:
   - text: <code>euler130()</code> should return 149253.
-    testString: assert.strictEqual(euler130(), 149253, '<code>euler130()</code> should return 149253.');
+    testString: assert.strictEqual(euler130(), 149253);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-131-prime-cube-partnership.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-131-prime-cube-partnership.english.md
@@ -23,7 +23,7 @@ How many primes below one million have this remarkable property?
 ```yml
 tests:
   - text: <code>euler131()</code> should return 173.
-    testString: assert.strictEqual(euler131(), 173, '<code>euler131()</code> should return 173.');
+    testString: assert.strictEqual(euler131(), 173);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-132-large-repunit-factors.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-132-large-repunit-factors.english.md
@@ -22,7 +22,7 @@ Find the sum of the first forty prime factors of R(109).
 ```yml
 tests:
   - text: <code>euler132()</code> should return 843296.
-    testString: assert.strictEqual(euler132(), 843296, '<code>euler132()</code> should return 843296.');
+    testString: assert.strictEqual(euler132(), 843296);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-133-repunit-nonfactors.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-133-repunit-nonfactors.english.md
@@ -23,7 +23,7 @@ Find the sum of all the primes below one-hundred thousand that will never be a f
 ```yml
 tests:
   - text: <code>euler133()</code> should return 453647705.
-    testString: assert.strictEqual(euler133(), 453647705, '<code>euler133()</code> should return 453647705.');
+    testString: assert.strictEqual(euler133(), 453647705);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-134-prime-pair-connection.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-134-prime-pair-connection.english.md
@@ -22,7 +22,7 @@ Find ∑ S for every pair of consecutive primes with 5 ≤ p1 ≤ 1000000.
 ```yml
 tests:
   - text: <code>euler134()</code> should return 18613426663617120.
-    testString: assert.strictEqual(euler134(), 18613426663617120, '<code>euler134()</code> should return 18613426663617120.');
+    testString: assert.strictEqual(euler134(), 18613426663617120);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-135-same-differences.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-135-same-differences.english.md
@@ -23,7 +23,7 @@ How many values of n less than one million have exactly ten distinct solutions?
 ```yml
 tests:
   - text: <code>euler135()</code> should return 4989.
-    testString: assert.strictEqual(euler135(), 4989, '<code>euler135()</code> should return 4989.');
+    testString: assert.strictEqual(euler135(), 4989);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-136-singleton-difference.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-136-singleton-difference.english.md
@@ -23,7 +23,7 @@ How many values of n less than fifty million have exactly one solution?
 ```yml
 tests:
   - text: <code>euler136()</code> should return 2544559.
-    testString: assert.strictEqual(euler136(), 2544559, '<code>euler136()</code> should return 2544559.');
+    testString: assert.strictEqual(euler136(), 2544559);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-137-fibonacci-golden-nuggets.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-137-fibonacci-golden-nuggets.english.md
@@ -41,7 +41,7 @@ Find the 15th golden nugget.
 ```yml
 tests:
   - text: <code>euler137()</code> should return 1120149658760.
-    testString: assert.strictEqual(euler137(), 1120149658760, '<code>euler137()</code> should return 1120149658760.');
+    testString: assert.strictEqual(euler137(), 1120149658760);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-138-special-isosceles-triangles.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-138-special-isosceles-triangles.english.md
@@ -25,7 +25,7 @@ Find ∑ L for the twelve smallest isosceles triangles for which h = b ± 1 and 
 ```yml
 tests:
   - text: <code>euler138()</code> should return 1118049290473932.
-    testString: assert.strictEqual(euler138(), 1118049290473932, '<code>euler138()</code> should return 1118049290473932.');
+    testString: assert.strictEqual(euler138(), 1118049290473932);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-139-pythagorean-tiles.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-139-pythagorean-tiles.english.md
@@ -25,7 +25,7 @@ Given that the perimeter of the right triangle is less than one-hundred million,
 ```yml
 tests:
   - text: <code>euler139()</code> should return 10057761.
-    testString: assert.strictEqual(euler139(), 10057761, '<code>euler139()</code> should return 10057761.');
+    testString: assert.strictEqual(euler139(), 10057761);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-14-longest-collatz-sequence.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-14-longest-collatz-sequence.english.md
@@ -27,15 +27,15 @@ NOTE: Once the chain starts the terms are allowed to go above one million.
 ```yml
 tests:
   - text: <code>longestCollatzSequence(14)</code> should return 9.
-    testString: assert.strictEqual(longestCollatzSequence(14), 9, '<code>longestCollatzSequence(14)</code> should return 9.');
+    testString: assert.strictEqual(longestCollatzSequence(14), 9);
   - text: <code>longestCollatzSequence(5847)</code> should return 3711.
-    testString: assert.strictEqual(longestCollatzSequence(5847), 3711, '<code>longestCollatzSequence(5847)</code> should return 3711.');
+    testString: assert.strictEqual(longestCollatzSequence(5847), 3711);
   - text: <code>longestCollatzSequence(46500)</code> should return 35655.
-    testString: assert.strictEqual(longestCollatzSequence(46500), 35655, '<code>longestCollatzSequence(46500)</code> should return 35655.');
+    testString: assert.strictEqual(longestCollatzSequence(46500), 35655);
   - text: <code>longestCollatzSequence(54512)</code> should return 52527.
-    testString: assert.strictEqual(longestCollatzSequence(54512), 52527, '<code>longestCollatzSequence(54512)</code> should return 52527.');
+    testString: assert.strictEqual(longestCollatzSequence(54512), 52527);
   - text: <code>longestCollatzSequence(1000000)</code> should return 837799.
-    testString: assert.strictEqual(longestCollatzSequence(1000000), 837799, '<code>longestCollatzSequence(1000000)</code> should return 837799.');
+    testString: assert.strictEqual(longestCollatzSequence(1000000), 837799);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-140-modified-fibonacci-golden-nuggets.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-140-modified-fibonacci-golden-nuggets.english.md
@@ -32,7 +32,7 @@ Find the sum of the first thirty golden nuggets.
 ```yml
 tests:
   - text: <code>euler140()</code> should return 5673835352990.
-    testString: assert.strictEqual(euler140(), 5673835352990, '<code>euler140()</code> should return 5673835352990.');
+    testString: assert.strictEqual(euler140(), 5673835352990);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-141-investigating-progressive-numbers-n-which-are-also-square.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-141-investigating-progressive-numbers-n-which-are-also-square.english.md
@@ -24,7 +24,7 @@ Find the sum of all progressive perfect squares below one trillion (1012).
 ```yml
 tests:
   - text: <code>euler141()</code> should return 878454337159.
-    testString: assert.strictEqual(euler141(), 878454337159, '<code>euler141()</code> should return 878454337159.');
+    testString: assert.strictEqual(euler141(), 878454337159);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-142-perfect-square-collection.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-142-perfect-square-collection.english.md
@@ -20,7 +20,7 @@ Find the smallest x + y + z with integers x > y > z > 0 such that x + y, x − y
 ```yml
 tests:
   - text: <code>euler142()</code> should return 1006193.
-    testString: assert.strictEqual(euler142(), 1006193, '<code>euler142()</code> should return 1006193.');
+    testString: assert.strictEqual(euler142(), 1006193);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-143-investigating-the-torricelli-point-of-a-triangle.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-143-investigating-the-torricelli-point-of-a-triangle.english.md
@@ -25,7 +25,7 @@ Find the sum of all distinct values of p + q + r ≤ 120000 for Torricelli trian
 ```yml
 tests:
   - text: <code>euler143()</code> should return 30758397.
-    testString: assert.strictEqual(euler143(), 30758397, '<code>euler143()</code> should return 30758397.');
+    testString: assert.strictEqual(euler143(), 30758397);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-144-investigating-multiple-reflections-of-a-laser-beam.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-144-investigating-multiple-reflections-of-a-laser-beam.english.md
@@ -29,7 +29,7 @@ How many times does the beam hit the internal surface of the white cell before e
 ```yml
 tests:
   - text: <code>euler144()</code> should return 354.
-    testString: assert.strictEqual(euler144(), 354, '<code>euler144()</code> should return 354.');
+    testString: assert.strictEqual(euler144(), 354);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-145-how-many-reversible-numbers-are-there-below-one-billion.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-145-how-many-reversible-numbers-are-there-below-one-billion.english.md
@@ -24,7 +24,7 @@ How many reversible numbers are there below one-billion (109)?
 ```yml
 tests:
   - text: <code>euler145()</code> should return 608720.
-    testString: assert.strictEqual(euler145(), 608720, '<code>euler145()</code> should return 608720.');
+    testString: assert.strictEqual(euler145(), 608720);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-146-investigating-a-prime-pattern.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-146-investigating-a-prime-pattern.english.md
@@ -22,7 +22,7 @@ What is the sum of all such integers n below 150 million?
 ```yml
 tests:
   - text: <code>euler146()</code> should return 676333270.
-    testString: assert.strictEqual(euler146(), 676333270, '<code>euler146()</code> should return 676333270.');
+    testString: assert.strictEqual(euler146(), 676333270);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-147-rectangles-in-cross-hatched-grids.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-147-rectangles-in-cross-hatched-grids.english.md
@@ -31,7 +31,7 @@ How many different rectangles could be situated within 47x43 and smaller grids?
 ```yml
 tests:
   - text: <code>euler147()</code> should return 846910284.
-    testString: assert.strictEqual(euler147(), 846910284, '<code>euler147()</code> should return 846910284.');
+    testString: assert.strictEqual(euler147(), 846910284);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-148-exploring-pascals-triangle.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-148-exploring-pascals-triangle.english.md
@@ -31,7 +31,7 @@ Find the number of entries which are not divisible by 7 in the first one billion
 ```yml
 tests:
   - text: <code>euler148()</code> should return 2129970655314432.
-    testString: assert.strictEqual(euler148(), 2129970655314432, '<code>euler148()</code> should return 2129970655314432.');
+    testString: assert.strictEqual(euler148(), 2129970655314432);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-149-searching-for-a-maximum-sum-subsequence.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-149-searching-for-a-maximum-sum-subsequence.english.md
@@ -36,7 +36,7 @@ Finally, find the greatest sum of (any number of) adjacent entries in any direct
 ```yml
 tests:
   - text: <code>euler149()</code> should return 52852124.
-    testString: assert.strictEqual(euler149(), 52852124, '<code>euler149()</code> should return 52852124.');
+    testString: assert.strictEqual(euler149(), 52852124);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-15-lattice-paths.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-15-lattice-paths.english.md
@@ -24,11 +24,11 @@ How many such routes are there through a given <code>gridSize</code>?
 ```yml
 tests:
   - text: <code>latticePaths(4)</code> should return 70.
-    testString: assert.strictEqual(latticePaths(4), 70, '<code>latticePaths(4)</code> should return 70.');
+    testString: assert.strictEqual(latticePaths(4), 70);
   - text: <code>latticePaths(9)</code> should return 48620.
-    testString: assert.strictEqual(latticePaths(9), 48620, '<code>latticePaths(9)</code> should return 48620.');
+    testString: assert.strictEqual(latticePaths(9), 48620);
   - text: <code>latticePaths(20)</code> should return 137846528820.
-    testString: assert.strictEqual(latticePaths(20), 137846528820, '<code>latticePaths(20)</code> should return 137846528820.');
+    testString: assert.strictEqual(latticePaths(20), 137846528820);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-150-searching-a-triangular-array-for-a-sub-triangle-having-minimum-sum.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-150-searching-a-triangular-array-for-a-sub-triangle-having-minimum-sum.english.md
@@ -45,7 +45,7 @@ Find the smallest possible sub-triangle sum.
 ```yml
 tests:
   - text: <code>euler150()</code> should return -271248680.
-    testString: assert.strictEqual(euler150(), -271248680, '<code>euler150()</code> should return -271248680.');
+    testString: assert.strictEqual(euler150(), -271248680);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-151-paper-sheets-of-standard-sizes-an-expected-value-problem.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-151-paper-sheets-of-standard-sizes-an-expected-value-problem.english.md
@@ -27,7 +27,7 @@ Give your answer rounded to six decimal places using the format x.xxxxxx .
 ```yml
 tests:
   - text: <code>euler151()</code> should return 0.464399.
-    testString: assert.strictEqual(euler151(), 0.464399, '<code>euler151()</code> should return 0.464399.');
+    testString: assert.strictEqual(euler151(), 0.464399);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-152-writing-one-half-as-a-sum-of-inverse-squares.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-152-writing-one-half-as-a-sum-of-inverse-squares.english.md
@@ -24,7 +24,7 @@ How many ways are there to write the number 1/2 as a sum of inverse squares usin
 ```yml
 tests:
   - text: <code>euler152()</code> should return 301.
-    testString: assert.strictEqual(euler152(), 301, '<code>euler152()</code> should return 301.');
+    testString: assert.strictEqual(euler152(), 301);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-153-investigating-gaussian-integers.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-153-investigating-gaussian-integers.english.md
@@ -64,7 +64,7 @@ What is ∑ s(n) for 1 ≤ n ≤ 108?
 ```yml
 tests:
   - text: <code>euler153()</code> should return 17971254122360636.
-    testString: assert.strictEqual(euler153(), 17971254122360636, '<code>euler153()</code> should return 17971254122360636.');
+    testString: assert.strictEqual(euler153(), 17971254122360636);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-154-exploring-pascals-pyramid.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-154-exploring-pascals-pyramid.english.md
@@ -27,7 +27,7 @@ How many coefficients in the expansion of (x + y + z)200000 are multiples of 101
 ```yml
 tests:
   - text: <code>euler154()</code> should return 479742450.
-    testString: assert.strictEqual(euler154(), 479742450, '<code>euler154()</code> should return 479742450.');
+    testString: assert.strictEqual(euler154(), 479742450);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-155-counting-capacitor-circuits.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-155-counting-capacitor-circuits.english.md
@@ -29,7 +29,7 @@ whereas when connecting them in series, the overall capacitance is given by:
 ```yml
 tests:
   - text: <code>euler155()</code> should return 3857447.
-    testString: assert.strictEqual(euler155(), 3857447, '<code>euler155()</code> should return 3857447.');
+    testString: assert.strictEqual(euler155(), 3857447);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-156-counting-digits.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-156-counting-digits.english.md
@@ -52,7 +52,7 @@ Note: if, for some n, f(n,d)=n
 ```yml
 tests:
   - text: <code>euler156()</code> should return 21295121502550.
-    testString: assert.strictEqual(euler156(), 21295121502550, '<code>euler156()</code> should return 21295121502550.');
+    testString: assert.strictEqual(euler156(), 21295121502550);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-157-solving-the-diophantine-equation.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-157-solving-the-diophantine-equation.english.md
@@ -42,7 +42,7 @@ How many solutions has this equation for 1 ≤ n ≤ 9?
 ```yml
 tests:
   - text: <code>euler157()</code> should return 53490.
-    testString: assert.strictEqual(euler157(), 53490, '<code>euler157()</code> should return 53490.');
+    testString: assert.strictEqual(euler157(), 53490);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-158-exploring-strings-for-which-only-one-character-comes-lexicographically-after-its-neighbour-to-the-left.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-158-exploring-strings-for-which-only-one-character-comes-lexicographically-after-its-neighbour-to-the-left.english.md
@@ -27,7 +27,7 @@ What is the maximum value of p(n)?
 ```yml
 tests:
   - text: <code>euler158()</code> should return 409511334375.
-    testString: assert.strictEqual(euler158(), 409511334375, '<code>euler158()</code> should return 409511334375.');
+    testString: assert.strictEqual(euler158(), 409511334375);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-159-digital-root-sums-of-factorisations.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-159-digital-root-sums-of-factorisations.english.md
@@ -45,7 +45,7 @@ Find ∑mdrs(n) for 1 < n < 1,000,000.
 ```yml
 tests:
   - text: <code>euler159()</code> should return 14489159.
-    testString: assert.strictEqual(euler159(), 14489159, '<code>euler159()</code> should return 14489159.');
+    testString: assert.strictEqual(euler159(), 14489159);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-16-power-digit-sum.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-16-power-digit-sum.english.md
@@ -21,11 +21,11 @@ What is the sum of the digits of the number 2<sup><code>exponent</code></sup>?
 ```yml
 tests:
   - text: <code>powerDigitSum(15)</code> should return 26.
-    testString: assert.strictEqual(powerDigitSum(15), 26, '<code>powerDigitSum(15)</code> should return 26.');
+    testString: assert.strictEqual(powerDigitSum(15), 26);
   - text: <code>powerDigitSum(128)</code> should return 166.
-    testString: assert.strictEqual(powerDigitSum(128), 166, '<code>powerDigitSum(128)</code> should return 166.');
+    testString: assert.strictEqual(powerDigitSum(128), 166);
   - text: <code>powerDigitSum(1000)</code> should return 1366.
-    testString: assert.strictEqual(powerDigitSum(1000), 1366, '<code>powerDigitSum(1000)</code> should return 1366.');
+    testString: assert.strictEqual(powerDigitSum(1000), 1366);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-160-factorial-trailing-digits.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-160-factorial-trailing-digits.english.md
@@ -25,7 +25,7 @@ Find f(1,000,000,000,000)
 ```yml
 tests:
   - text: <code>euler160()</code> should return 16576.
-    testString: assert.strictEqual(euler160(), 16576, '<code>euler160()</code> should return 16576.');
+    testString: assert.strictEqual(euler160(), 16576);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-161-triominoes.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-161-triominoes.english.md
@@ -34,7 +34,7 @@ In how many ways can a 9 by 12 grid be tiled in this way by triominoes?
 ```yml
 tests:
   - text: <code>euler161()</code> should return 20574308184277972.
-    testString: assert.strictEqual(euler161(), 20574308184277972, '<code>euler161()</code> should return 20574308184277972.');
+    testString: assert.strictEqual(euler161(), 20574308184277972);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-163-cross-hatched-triangles.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-163-cross-hatched-triangles.english.md
@@ -27,7 +27,7 @@ Find T(36).
 ```yml
 tests:
   - text: <code>euler163()</code> should return 343047.
-    testString: assert.strictEqual(euler163(), 343047, '<code>euler163()</code> should return 343047.');
+    testString: assert.strictEqual(euler163(), 343047);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-164-numbers-for-which-no-three-consecutive-digits-have-a-sum-greater-than-a-given-value.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-164-numbers-for-which-no-three-consecutive-digits-have-a-sum-greater-than-a-given-value.english.md
@@ -20,7 +20,7 @@ How many 20 digit numbers n (without any leading zero) exist such that no three 
 ```yml
 tests:
   - text: <code>euler164()</code> should return 378158756814587.
-    testString: assert.strictEqual(euler164(), 378158756814587, '<code>euler164()</code> should return 378158756814587.');
+    testString: assert.strictEqual(euler164(), 378158756814587);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-165-intersections.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-165-intersections.english.md
@@ -37,7 +37,7 @@ How many distinct true intersection points are found among the 5000 line segment
 ```yml
 tests:
   - text: <code>euler165()</code> should return 2868868.
-    testString: assert.strictEqual(euler165(), 2868868, '<code>euler165()</code> should return 2868868.');
+    testString: assert.strictEqual(euler165(), 2868868);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-166-criss-cross.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-166-criss-cross.english.md
@@ -32,7 +32,7 @@ In how many ways can you fill a 4x4 grid with the digits d, 0 ≤ d ≤ 9 so tha
 ```yml
 tests:
   - text: <code>euler166()</code> should return 7130034.
-    testString: assert.strictEqual(euler166(), 7130034, '<code>euler166()</code> should return 7130034.');
+    testString: assert.strictEqual(euler166(), 7130034);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-167-investigating-ulam-sequences.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-167-investigating-ulam-sequences.english.md
@@ -25,7 +25,7 @@ Find ∑U(2,2n+1)k for 2 ≤ n ≤10, where k = 1011.
 ```yml
 tests:
   - text: <code>euler167()</code> should return 3916160068885.
-    testString: assert.strictEqual(euler167(), 3916160068885, '<code>euler167()</code> should return 3916160068885.');
+    testString: assert.strictEqual(euler167(), 3916160068885);
 
 ```
 


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Related to issue #36400

This PR removes assert message arguments from `testString` for the first 75 `Project Euler` challenges in the `Coding Interview Prep` curriculum section.