### PR TITLE
fix(curriculum): Remove unnecessary assert message argument from English Coding Interview Prep challenges - Project Euler - 02

### DIFF
--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-168-number-rotations.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-168-number-rotations.english.md
@@ -23,7 +23,7 @@ Find the last 5 digits of the sum of all integers n, 10 < n < 10100, that have t
 ```yml
 tests:
   - text: <code>euler168()</code> should return 59206.
-    testString: assert.strictEqual(euler168(), 59206, '<code>euler168()</code> should return 59206.');
+    testString: assert.strictEqual(euler168(), 59206);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-169-exploring-the-number-of-different-ways-a-number-can-be-expressed-as-a-sum-of-powers-of-2.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-169-exploring-the-number-of-different-ways-a-number-can-be-expressed-as-a-sum-of-powers-of-2.english.md
@@ -26,7 +26,7 @@ What is f(1025)?
 ```yml
 tests:
   - text: <code>euler169()</code> should return 178653872807.
-    testString: assert.strictEqual(euler169(), 178653872807, '<code>euler169()</code> should return 178653872807.');
+    testString: assert.strictEqual(euler169(), 178653872807);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-17-number-letter-counts.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-17-number-letter-counts.english.md
@@ -22,11 +22,11 @@ If all the numbers from 1 to given <code>limit</code> inclusive were written out
 ```yml
 tests:
   - text: <code>numberLetterCounts(5)</code> should return 19.
-    testString: assert.strictEqual(numberLetterCounts(5), 19, '<code>numberLetterCounts(5)</code> should return 19.');
+    testString: assert.strictEqual(numberLetterCounts(5), 19);
   - text: <code>numberLetterCounts(150)</code> should return 1903.
-    testString: assert.strictEqual(numberLetterCounts(150), 1903, '<code>numberLetterCounts(150)</code> should return 1903.');
+    testString: assert.strictEqual(numberLetterCounts(150), 1903);
   - text: <code>numberLetterCounts(1000)</code> should return 21124.
-    testString: assert.strictEqual(numberLetterCounts(1000), 21124, '<code>numberLetterCounts(1000)</code> should return 21124.');
+    testString: assert.strictEqual(numberLetterCounts(1000), 21124);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-170-find-the-largest-0-to-9-pandigital-that-can-be-formed-by-concatenating-products.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-170-find-the-largest-0-to-9-pandigital-that-can-be-formed-by-concatenating-products.english.md
@@ -29,7 +29,7 @@ What is the largest 0 to 9 pandigital 10-digit concatenated product of an intege
 ```yml
 tests:
   - text: <code>euler170()</code> should return 9857164023.
-    testString: assert.strictEqual(euler170(), 9857164023, '<code>euler170()</code> should return 9857164023.');
+    testString: assert.strictEqual(euler170(), 9857164023);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-171-finding-numbers-for-which-the-sum-of-the-squares-of-the-digits-is-a-square.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-171-finding-numbers-for-which-the-sum-of-the-squares-of-the-digits-is-a-square.english.md
@@ -24,7 +24,7 @@ Find the last nine digits of the sum of all n, 0 < n < 1020, such that f(n) is a
 ```yml
 tests:
   - text: <code>euler171()</code> should return 142989277.
-    testString: assert.strictEqual(euler171(), 142989277, '<code>euler171()</code> should return 142989277.');
+    testString: assert.strictEqual(euler171(), 142989277);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-172-investigating-numbers-with-few-repeated-digits.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-172-investigating-numbers-with-few-repeated-digits.english.md
@@ -20,7 +20,7 @@ How many 18-digit numbers n (without leading zeros) are there such that no digit
 ```yml
 tests:
   - text: <code>euler172()</code> should return 227485267000992000.
-    testString: assert.strictEqual(euler172(), 227485267000992000, '<code>euler172()</code> should return 227485267000992000.');
+    testString: assert.strictEqual(euler172(), 227485267000992000);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-173-using-up-to-one-million-tiles-how-many-different-hollow-square-laminae-can-be-formed.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-173-using-up-to-one-million-tiles-how-many-different-hollow-square-laminae-can-be-formed.english.md
@@ -24,7 +24,7 @@ Using up to one million tiles how many different square laminae can be formed?
 ```yml
 tests:
   - text: <code>euler173()</code> should return 1572729.
-    testString: assert.strictEqual(euler173(), 1572729, '<code>euler173()</code> should return 1572729.');
+    testString: assert.strictEqual(euler173(), 1572729);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-174-counting-the-number-of-hollow-square-laminae-that-can-form-one-two-three-...-distinct-arrangements.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-174-counting-the-number-of-hollow-square-laminae-that-can-form-one-two-three-...-distinct-arrangements.english.md
@@ -26,7 +26,7 @@ What is ∑ N(n) for 1 ≤ n ≤ 10?
 ```yml
 tests:
   - text: <code>euler174()</code> should return 209566.
-    testString: assert.strictEqual(euler174(), 209566, '<code>euler174()</code> should return 209566.');
+    testString: assert.strictEqual(euler174(), 209566);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-175-fractions-involving-the-number-of-different-ways-a-number-can-be-expressed-as-a-sum-of-powers-of-2.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-175-fractions-involving-the-number-of-different-ways-a-number-can-be-expressed-as-a-sum-of-powers-of-2.english.md
@@ -29,7 +29,7 @@ Give your answer as comma separated integers, without any whitespaces.
 ```yml
 tests:
   - text: <code>euler175()</code> should return 1, 13717420, 8.
-    testString: assert.strictEqual(euler175(), 1, 13717420, 8, '<code>euler175()</code> should return 1, 13717420, 8.');
+    testString: assert.strictEqual(euler175(), 1, 13717420, 8);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-176-right-angled-triangles-that-share-a-cathetus.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-176-right-angled-triangles-that-share-a-cathetus.english.md
@@ -21,7 +21,7 @@ Find the smallest integer that can be the length of a cathetus of exactly 47547 
 ```yml
 tests:
   - text: <code>euler176()</code> should return 96818198400000.
-    testString: assert.strictEqual(euler176(), 96818198400000, '<code>euler176()</code> should return 96818198400000.');
+    testString: assert.strictEqual(euler176(), 96818198400000);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-177-integer-angled-quadrilaterals.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-177-integer-angled-quadrilaterals.english.md
@@ -25,7 +25,7 @@ Note: In your calculations you may assume that a calculated angle is integral if
 ```yml
 tests:
   - text: <code>euler177()</code> should return 129325.
-    testString: assert.strictEqual(euler177(), 129325, '<code>euler177()</code> should return 129325.');
+    testString: assert.strictEqual(euler177(), 129325);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-178-step-numbers.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-178-step-numbers.english.md
@@ -25,7 +25,7 @@ How many pandigital step numbers less than 1040 are there?
 ```yml
 tests:
   - text: <code>euler178()</code> should return 126461847755.
-    testString: assert.strictEqual(euler178(), 126461847755, '<code>euler178()</code> should return 126461847755.');
+    testString: assert.strictEqual(euler178(), 126461847755);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-179-consecutive-positive-divisors.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-179-consecutive-positive-divisors.english.md
@@ -20,7 +20,7 @@ Find the number of integers 1 < n < 107, for which n and n + 1 have the same num
 ```yml
 tests:
   - text: <code>euler179()</code> should return 986262.
-    testString: assert.strictEqual(euler179(), 986262, '<code>euler179()</code> should return 986262.');
+    testString: assert.strictEqual(euler179(), 986262);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-18-maximum-path-sum-i.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-18-maximum-path-sum-i.english.md
@@ -25,9 +25,9 @@ Find the maximum total from top to bottom of the triangle below:
 ```yml
 tests:
   - text: <code>maximumPathSumI(testTriangle)</code> should return 23.
-    testString: assert.strictEqual(maximumPathSumI(testTriangle), 23, '<code>maximumPathSumI(testTriangle)</code> should return 23.');
+    testString: assert.strictEqual(maximumPathSumI(testTriangle), 23);
   - text: <code>maximumPathSumI(numTriangle)</code> should return 1074.
-    testString: assert.strictEqual(maximumPathSumI(numTriangle), 1074, '<code>maximumPathSumI(numTriangle)</code> should return 1074.');
+    testString: assert.strictEqual(maximumPathSumI(numTriangle), 1074);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-180-rational-zeros-of-a-function-of-three-variables.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-180-rational-zeros-of-a-function-of-three-variables.english.md
@@ -28,7 +28,7 @@ Find u + v.
 ```yml
 tests:
   - text: <code>euler180()</code> should return 285196020571078980.
-    testString: assert.strictEqual(euler180(), 285196020571078980, '<code>euler180()</code> should return 285196020571078980.');
+    testString: assert.strictEqual(euler180(), 285196020571078980);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-181-investigating-in-how-many-ways-objects-of-two-different-colours-can-be-grouped.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-181-investigating-in-how-many-ways-objects-of-two-different-colours-can-be-grouped.english.md
@@ -23,7 +23,7 @@ In how many ways can sixty black objects B and forty white objects W be  thus gr
 ```yml
 tests:
   - text: <code>euler181()</code> should return 83735848679360670.
-    testString: assert.strictEqual(euler181(), 83735848679360670, '<code>euler181()</code> should return 83735848679360670.');
+    testString: assert.strictEqual(euler181(), 83735848679360670);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-182-rsa-encryption.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-182-rsa-encryption.english.md
@@ -34,7 +34,7 @@ Find the sum of all values of e, 1<e<φ(1009,3643) and gcd(e,φ)=1, so that the 
 ```yml
 tests:
   - text: <code>euler182()</code> should return 399788195976.
-    testString: assert.strictEqual(euler182(), 399788195976, '<code>euler182()</code> should return 399788195976.');
+    testString: assert.strictEqual(euler182(), 399788195976);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-183-maximum-product-of-parts.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-183-maximum-product-of-parts.english.md
@@ -35,7 +35,7 @@ Find ΣD(N) for 5 ≤ N ≤ 10000.
 ```yml
 tests:
   - text: <code>euler183()</code> should return 48861552.
-    testString: assert.strictEqual(euler183(), 48861552, '<code>euler183()</code> should return 48861552.');
+    testString: assert.strictEqual(euler183(), 48861552);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-184-triangles-containing-the-origin.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-184-triangles-containing-the-origin.english.md
@@ -26,7 +26,7 @@ How many triangles are there containing the origin in the interior and having al
 ```yml
 tests:
   - text: <code>euler184()</code> should return 1725323624056.
-    testString: assert.strictEqual(euler184(), 1725323624056, '<code>euler184()</code> should return 1725323624056.');
+    testString: assert.strictEqual(euler184(), 1725323624056);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-185-number-mind.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-185-number-mind.english.md
@@ -57,7 +57,7 @@ Find the unique 16-digit secret sequence.
 ```yml
 tests:
   - text: <code>euler185()</code> should return 4640261571849533.
-    testString: assert.strictEqual(euler185(), 4640261571849533, '<code>euler185()</code> should return 4640261571849533.');
+    testString: assert.strictEqual(euler185(), 4640261571849533);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-186-connectedness-of-a-network.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-186-connectedness-of-a-network.english.md
@@ -32,7 +32,7 @@ The Prime Minister's phone number is 524287. After how many successful calls, no
 ```yml
 tests:
   - text: <code>euler186()</code> should return 2325629.
-    testString: assert.strictEqual(euler186(), 2325629, '<code>euler186()</code> should return 2325629.');
+    testString: assert.strictEqual(euler186(), 2325629);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-187-semiprimes.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-187-semiprimes.english.md
@@ -25,7 +25,7 @@ How many composite integers, n < 108, have precisely two, not necessarily distin
 ```yml
 tests:
   - text: <code>euler187()</code> should return 17427258.
-    testString: assert.strictEqual(euler187(), 17427258, '<code>euler187()</code> should return 17427258.');
+    testString: assert.strictEqual(euler187(), 17427258);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-188-the-hyperexponentiation-of-a-number.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-188-the-hyperexponentiation-of-a-number.english.md
@@ -25,7 +25,7 @@ Find the last 8 digits of 1777↑↑1855.
 ```yml
 tests:
   - text: <code>euler188()</code> should return 95962097.
-    testString: assert.strictEqual(euler188(), 95962097, '<code>euler188()</code> should return 95962097.');
+    testString: assert.strictEqual(euler188(), 95962097);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-189-tri-colouring-a-triangular-grid.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-189-tri-colouring-a-triangular-grid.english.md
@@ -32,7 +32,7 @@ How many distinct valid colourings are there for the above configuration?
 ```yml
 tests:
   - text: <code>euler189()</code> should return 10834893628237824.
-    testString: assert.strictEqual(euler189(), 10834893628237824, '<code>euler189()</code> should return 10834893628237824.');
+    testString: assert.strictEqual(euler189(), 10834893628237824);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-19-counting-sundays.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-19-counting-sundays.english.md
@@ -22,11 +22,11 @@ How many Sundays fell on the first of the month during the twentieth century (1 
 ```yml
 tests:
   - text: <code>countingSundays(1943, 1946)</code> should return 6.
-    testString: assert.strictEqual(countingSundays(1943, 1946), 6, '<code>countingSundays(1943, 1946)</code> should return 6.');
+    testString: assert.strictEqual(countingSundays(1943, 1946), 6);
   - text: <code>countingSundays(1995, 2000)</code> should return 10.
-    testString: assert.strictEqual(countingSundays(1995, 2000), 10, '<code>countingSundays(1995, 2000)</code> should return 10.');
+    testString: assert.strictEqual(countingSundays(1995, 2000), 10);
   - text: <code>countingSundays(1901, 2000)</code> should return 171.
-    testString: assert.strictEqual(countingSundays(1901, 2000), 171, '<code>countingSundays(1901, 2000)</code> should return 171.');
+    testString: assert.strictEqual(countingSundays(1901, 2000), 171);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-190-maximising-a-weighted-product.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-190-maximising-a-weighted-product.english.md
@@ -24,7 +24,7 @@ Find Σ[Pm] for 2 ≤ m ≤ 15.
 ```yml
 tests:
   - text: <code>euler190()</code> should return 371048281.
-    testString: assert.strictEqual(euler190(), 371048281, '<code>euler190()</code> should return 371048281.');
+    testString: assert.strictEqual(euler190(), 371048281);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-191-prize-strings.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-191-prize-strings.english.md
@@ -32,7 +32,7 @@ How many "prize" strings exist over a 30-day period?
 ```yml
 tests:
   - text: <code>euler191()</code> should return 1918080160.
-    testString: assert.strictEqual(euler191(), 1918080160, '<code>euler191()</code> should return 1918080160.');
+    testString: assert.strictEqual(euler191(), 1918080160);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-192-best-approximations.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-192-best-approximations.english.md
@@ -27,7 +27,7 @@ Find the sum of all denominators of the best approximations to √n for the deno
 ```yml
 tests:
   - text: <code>euler192()</code> should return 57060635927998344.
-    testString: assert.strictEqual(euler192(), 57060635927998344, '<code>euler192()</code> should return 57060635927998344.');
+    testString: assert.strictEqual(euler192(), 57060635927998344);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-193-squarefree-numbers.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-193-squarefree-numbers.english.md
@@ -22,7 +22,7 @@ How many squarefree numbers are there below 250?
 ```yml
 tests:
   - text: <code>euler193()</code> should return 684465067343069.
-    testString: assert.strictEqual(euler193(), 684465067343069, '<code>euler193()</code> should return 684465067343069.');
+    testString: assert.strictEqual(euler193(), 684465067343069);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-194-coloured-configurations.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-194-coloured-configurations.english.md
@@ -30,7 +30,7 @@ Find the last 8 digits of N(25,75,1984).
 ```yml
 tests:
   - text: <code>euler194()</code> should return 61190912.
-    testString: assert.strictEqual(euler194(), 61190912, '<code>euler194()</code> should return 61190912.');
+    testString: assert.strictEqual(euler194(), 61190912);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-195-inscribed-circles-of-triangles-with-one-angle-of-60-degrees.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-195-inscribed-circles-of-triangles-with-one-angle-of-60-degrees.english.md
@@ -26,7 +26,7 @@ Find T(1053779).
 ```yml
 tests:
   - text: <code>euler195()</code> should return 75085391.
-    testString: assert.strictEqual(euler195(), 75085391, '<code>euler195()</code> should return 75085391.');
+    testString: assert.strictEqual(euler195(), 75085391);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-196-prime-triplets.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-196-prime-triplets.english.md
@@ -46,7 +46,7 @@ Find  S(5678027) + S(7208785).
 ```yml
 tests:
   - text: <code>euler196()</code> should return 322303240771079940.
-    testString: assert.strictEqual(euler196(), 322303240771079940, '<code>euler196()</code> should return 322303240771079940.');
+    testString: assert.strictEqual(euler196(), 322303240771079940);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-197-investigating-the-behaviour-of-a-recursively-defined-sequence.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-197-investigating-the-behaviour-of-a-recursively-defined-sequence.english.md
@@ -24,7 +24,7 @@ Give your answer with 9 digits after the decimal point.
 ```yml
 tests:
   - text: <code>euler197()</code> should return 1.710637717.
-    testString: assert.strictEqual(euler197(), 1.710637717, '<code>euler197()</code> should return 1.710637717.');
+    testString: assert.strictEqual(euler197(), 1.710637717);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-198-ambiguous-numbers.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-198-ambiguous-numbers.english.md
@@ -26,7 +26,7 @@ How many ambiguous numbers x = p/q,
 ```yml
 tests:
   - text: <code>euler198()</code> should return 52374425.
-    testString: assert.strictEqual(euler198(), 52374425, '<code>euler198()</code> should return 52374425.');
+    testString: assert.strictEqual(euler198(), 52374425);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-199-iterative-circle-packing.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-199-iterative-circle-packing.english.md
@@ -28,7 +28,7 @@ Give your answer rounded to eight decimal places using the format x.xxxxxxxx .
 ```yml
 tests:
   - text: <code>euler199()</code> should return 0.00396087.
-    testString: assert.strictEqual(euler199(), 0.00396087, '<code>euler199()</code> should return 0.00396087.');
+    testString: assert.strictEqual(euler199(), 0.00396087);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-2-even-fibonacci-numbers.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-2-even-fibonacci-numbers.english.md
@@ -22,15 +22,15 @@ By considering the terms in the Fibonacci sequence that do not exceed the <code>
 ```yml
 tests:
   - text: <code>fiboEvenSum(10)</code> should return 44.
-    testString: assert.strictEqual(fiboEvenSum(10), 44, '<code>fiboEvenSum(10)</code> should return 44.');
+    testString: assert.strictEqual(fiboEvenSum(10), 44);
   - text: <code>fiboEvenSum(18)</code> should return 3382.
-    testString: assert.strictEqual(fiboEvenSum(18), 3382, '<code>fiboEvenSum(18)</code> should return 3382.');
+    testString: assert.strictEqual(fiboEvenSum(18), 3382);
   - text: <code>fiboEvenSum(23)</code> should return 60696.
-    testString: assert.strictEqual(fiboEvenSum(23), 60696, '<code>fiboEvenSum(23)</code> should return 60696.');
+    testString: assert.strictEqual(fiboEvenSum(23), 60696);
   - text: <code>fiboEvenSum(43)</code> should return 350704366.
-    testString: assert.strictEqual(fiboEvenSum(43), 350704366, '<code>fiboEvenSum(43)</code> should return 350704366.');
+    testString: assert.strictEqual(fiboEvenSum(43), 350704366);
   - text: Your function should return an <code>even</code> value.
-    testString: assert.equal(fiboEvenSum(10) % 2 === 0, true, 'Your function should return an <code>even</code> value.');
+    testString: assert.equal(fiboEvenSum(10) % 2 === 0, true);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-20-factorial-digit-sum.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-20-factorial-digit-sum.english.md
@@ -22,15 +22,15 @@ Find the sum of the digits <var>n</var>!
 ```yml
 tests:
   - text: <code>sumFactorialDigits(10)</code> should return 27.
-    testString: assert.strictEqual(sumFactorialDigits(10), 27, '<code>sumFactorialDigits(10)</code> should return 27.');
+    testString: assert.strictEqual(sumFactorialDigits(10), 27);
   - text: <code>sumFactorialDigits(25)</code> should return 72.
-    testString: assert.strictEqual(sumFactorialDigits(25), 72, '<code>sumFactorialDigits(25)</code> should return 72.');
+    testString: assert.strictEqual(sumFactorialDigits(25), 72);
   - text: <code>sumFactorialDigits(50)</code> should return 216.
-    testString: assert.strictEqual(sumFactorialDigits(50), 216, '<code>sumFactorialDigits(50)</code> should return 216.');
+    testString: assert.strictEqual(sumFactorialDigits(50), 216);
   - text: <code>sumFactorialDigits(75)</code> should return 432.
-    testString: assert.strictEqual(sumFactorialDigits(75), 432, '<code>sumFactorialDigits(75)</code> should return 432.');
+    testString: assert.strictEqual(sumFactorialDigits(75), 432);
   - text: <code>sumFactorialDigits(100)</code> should return 648.
-    testString: assert.strictEqual(sumFactorialDigits(100), 648, '<code>sumFactorialDigits(100)</code> should return 648.');
+    testString: assert.strictEqual(sumFactorialDigits(100), 648);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-200-find-the-200th-prime-proof-sqube-containing-the-contiguous-sub-string-200.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-200-find-the-200th-prime-proof-sqube-containing-the-contiguous-sub-string-200.english.md
@@ -27,7 +27,7 @@ Find the 200th prime-proof sqube containing the contiguous sub-string "200".
 ```yml
 tests:
   - text: <code>euler200()</code> should return 229161792008.
-    testString: assert.strictEqual(euler200(), 229161792008, '<code>euler200()</code> should return 229161792008.');
+    testString: assert.strictEqual(euler200(), 229161792008);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-201-subsets-with-a-unique-sum.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-201-subsets-with-a-unique-sum.english.md
@@ -51,7 +51,7 @@ Determine the sum of all integers which are the sum of exactly one of the 50-ele
 ```yml
 tests:
   - text: <code>euler201()</code> should return 115039000.
-    testString: assert.strictEqual(euler201(), 115039000, '<code>euler201()</code> should return 115039000.');
+    testString: assert.strictEqual(euler201(), 115039000);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-202-laserbeam.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-202-laserbeam.english.md
@@ -29,7 +29,7 @@ In how many ways can a laser beam enter at vertex C, bounce off 12017639147 surf
 ```yml
 tests:
   - text: <code>euler202()</code> should return 1209002624.
-    testString: assert.strictEqual(euler202(), 1209002624, '<code>euler202()</code> should return 1209002624.');
+    testString: assert.strictEqual(euler202(), 1209002624);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-203-squarefree-binomial-coefficients.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-203-squarefree-binomial-coefficients.english.md
@@ -33,7 +33,7 @@ Find the sum of the distinct squarefree numbers in the first 51 rows of Pascal's
 ```yml
 tests:
   - text: <code>euler203()</code> should return 34029210557338.
-    testString: assert.strictEqual(euler203(), 34029210557338, '<code>euler203()</code> should return 34029210557338.');
+    testString: assert.strictEqual(euler203(), 34029210557338);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-204-generalised-hamming-numbers.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-204-generalised-hamming-numbers.english.md
@@ -27,7 +27,7 @@ How many generalised Hamming numbers of type 100 are there which don't exceed 10
 ```yml
 tests:
   - text: <code>euler204()</code> should return 2944730.
-    testString: assert.strictEqual(euler204(), 2944730, '<code>euler204()</code> should return 2944730.');
+    testString: assert.strictEqual(euler204(), 2944730);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-205-dice-game.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-205-dice-game.english.md
@@ -25,7 +25,7 @@ What is the probability that Pyramidal Pete beats Cubic Colin? Give your answer 
 ```yml
 tests:
   - text: <code>euler205()</code> should return 0.5731441.
-    testString: assert.strictEqual(euler205(), 0.5731441, '<code>euler205()</code> should return 0.5731441.');
+    testString: assert.strictEqual(euler205(), 0.5731441);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-206-concealed-square.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-206-concealed-square.english.md
@@ -20,7 +20,7 @@ Find the unique positive integer whose square has the form 1_2_3_4_5_6_7_8_9_0, 
 ```yml
 tests:
   - text: <code>euler206()</code> should return 1389019170.
-    testString: assert.strictEqual(euler206(), 1389019170, '<code>euler206()</code> should return 1389019170.');
+    testString: assert.strictEqual(euler206(), 1389019170);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-207-integer-partition-equations.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-207-integer-partition-equations.english.md
@@ -41,7 +41,7 @@ Find the smallest m for which P(m) < 1/12345
 ```yml
 tests:
   - text: <code>euler207()</code> should return 44043947822.
-    testString: assert.strictEqual(euler207(), 44043947822, '<code>euler207()</code> should return 44043947822.');
+    testString: assert.strictEqual(euler207(), 44043947822);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-208-robot-walks.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-208-robot-walks.english.md
@@ -27,7 +27,7 @@ Given that the robot starts facing North, how many journeys of 70 arcs in length
 ```yml
 tests:
   - text: <code>euler208()</code> should return 331951449665644800.
-    testString: assert.strictEqual(euler208(), 331951449665644800, '<code>euler208()</code> should return 331951449665644800.');
+    testString: assert.strictEqual(euler208(), 331951449665644800);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-209-circular-logic.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-209-circular-logic.english.md
@@ -30,7 +30,7 @@ for all 6-bit inputs (a, b, c, d, e, f)?
 ```yml
 tests:
   - text: <code>euler209()</code> should return 15964587728784.
-    testString: assert.strictEqual(euler209(), 15964587728784, '<code>euler209()</code> should return 15964587728784.');
+    testString: assert.strictEqual(euler209(), 15964587728784);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-21-amicable-numbers.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-21-amicable-numbers.english.md
@@ -23,13 +23,13 @@ Evaluate the sum of all the amicable numbers under <var>n</var>.
 ```yml
 tests:
   - text: <code>sumAmicableNum(1000)</code> should return 504.
-    testString: assert.strictEqual(sumAmicableNum(1000), 504, '<code>sumAmicableNum(1000)</code> should return 504.');
+    testString: assert.strictEqual(sumAmicableNum(1000), 504);
   - text: <code>sumAmicableNum(2000)</code> should return 2898.
-    testString: assert.strictEqual(sumAmicableNum(2000), 2898, '<code>sumAmicableNum(2000)</code> should return 2898.');
+    testString: assert.strictEqual(sumAmicableNum(2000), 2898);
   - text: <code>sumAmicableNum(5000)</code> should return 8442.
-    testString: assert.strictEqual(sumAmicableNum(5000), 8442, '<code>sumAmicableNum(5000)</code> should return 8442.');
+    testString: assert.strictEqual(sumAmicableNum(5000), 8442);
   - text: <code>sumAmicableNum(10000)</code> should return 31626.
-    testString: assert.strictEqual(sumAmicableNum(10000), 31626, '<code>sumAmicableNum(10000)</code> should return 31626.');
+    testString: assert.strictEqual(sumAmicableNum(10000), 31626);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-210-obtuse-angled-triangles.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-210-obtuse-angled-triangles.english.md
@@ -25,7 +25,7 @@ What is N(1,000,000,000)?
 ```yml
 tests:
   - text: <code>euler210()</code> should return 1598174770174689500.
-    testString: assert.strictEqual(euler210(), 1598174770174689500, '<code>euler210()</code> should return 1598174770174689500.');
+    testString: assert.strictEqual(euler210(), 1598174770174689500);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-211-divisor-square-sum.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-211-divisor-square-sum.english.md
@@ -22,7 +22,7 @@ Find the sum of all n, 0 < n < 64,000,000 such that σ2(n) is a perfect square.
 ```yml
 tests:
   - text: <code>euler211()</code> should return 1922364685.
-    testString: assert.strictEqual(euler211(), 1922364685, '<code>euler211()</code> should return 1922364685.');
+    testString: assert.strictEqual(euler211(), 1922364685);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-212-combined-volume-of-cuboids.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-212-combined-volume-of-cuboids.english.md
@@ -34,7 +34,7 @@ What is the combined volume of all 50000 cuboids, C1,...,C50000 ?
 ```yml
 tests:
   - text: <code>euler212()</code> should return 328968937309.
-    testString: assert.strictEqual(euler212(), 328968937309, '<code>euler212()</code> should return 328968937309.');
+    testString: assert.strictEqual(euler212(), 328968937309);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-213-flea-circus.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-213-flea-circus.english.md
@@ -23,7 +23,7 @@ What is the expected number of unoccupied squares after 50 rings of the bell? Gi
 ```yml
 tests:
   - text: <code>euler213()</code> should return 330.721154.
-    testString: assert.strictEqual(euler213(), 330.721154, '<code>euler213()</code> should return 330.721154.');
+    testString: assert.strictEqual(euler213(), 330.721154);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-214-totient-chains.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-214-totient-chains.english.md
@@ -39,7 +39,7 @@ What is the sum of all primes less than 40000000 which generate a chain of lengt
 ```yml
 tests:
   - text: <code>euler214()</code> should return 1677366278943.
-    testString: assert.strictEqual(euler214(), 1677366278943, '<code>euler214()</code> should return 1677366278943.');
+    testString: assert.strictEqual(euler214(), 1677366278943);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-215-crack-free-walls.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-215-crack-free-walls.english.md
@@ -29,7 +29,7 @@ Calculate W(32,10).
 ```yml
 tests:
   - text: <code>euler215()</code> should return 806844323190414.
-    testString: assert.strictEqual(euler215(), 806844323190414, '<code>euler215()</code> should return 806844323190414.');
+    testString: assert.strictEqual(euler215(), 806844323190414);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-216-investigating-the-primality-of-numbers-of-the-form-2n2-1.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-216-investigating-the-primality-of-numbers-of-the-form-2n2-1.english.md
@@ -25,7 +25,7 @@ How many numbers t(n) are prime for n ≤ 50,000,000 ?
 ```yml
 tests:
   - text: <code>euler216()</code> should return 5437849.
-    testString: assert.strictEqual(euler216(), 5437849, '<code>euler216()</code> should return 5437849.');
+    testString: assert.strictEqual(euler216(), 5437849);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-217-balanced-numbers.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-217-balanced-numbers.english.md
@@ -24,7 +24,7 @@ Find T(47) mod 315
 ```yml
 tests:
   - text: <code>euler217()</code> should return 6273134.
-    testString: assert.strictEqual(euler217(), 6273134, '<code>euler217()</code> should return 6273134.');
+    testString: assert.strictEqual(euler217(), 6273134);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-218-perfect-right-angled-triangles.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-218-perfect-right-angled-triangles.english.md
@@ -34,7 +34,7 @@ How many perfect right-angled triangles with c≤1016 exist that are not super-p
 ```yml
 tests:
   - text: <code>euler218()</code> should return 0.
-    testString: assert.strictEqual(euler218(), 0, '<code>euler218()</code> should return 0.');
+    testString: assert.strictEqual(euler218(), 0);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-219-skew-cost-coding.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-219-skew-cost-coding.english.md
@@ -32,7 +32,7 @@ What is Cost(109) ?
 ```yml
 tests:
   - text: <code>euler219()</code> should return 64564225042.
-    testString: assert.strictEqual(euler219(), 64564225042, '<code>euler219()</code> should return 64564225042.');
+    testString: assert.strictEqual(euler219(), 64564225042);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-22-names-scores.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-22-names-scores.english.md
@@ -22,11 +22,11 @@ What is the total of all the name scores in the file?
 ```yml
 tests:
   - text: <code>namesScores(test1)</code> should return 791.
-    testString: assert.strictEqual(namesScores(test1), 791, '<code>namesScores(test1)</code> should return 791.');
+    testString: assert.strictEqual(namesScores(test1), 791);
   - text: <code>namesScores(test2)</code> should return 1468.
-    testString: assert.strictEqual(namesScores(test2), 1468, '<code>namesScores(test2)</code> should return 1468.');
+    testString: assert.strictEqual(namesScores(test2), 1468);
   - text: <code>namesScores(names)</code> should return 871198282.
-    testString: assert.strictEqual(namesScores(names), 871198282, '<code>namesScores(names)</code> should return 871198282.');
+    testString: assert.strictEqual(namesScores(names), 871198282);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-220-heighway-dragon.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-220-heighway-dragon.english.md
@@ -35,7 +35,7 @@ Give your answer in the form x,y with no spaces.
 ```yml
 tests:
   - text: <code>euler220()</code> should return 139776, 963904.
-    testString: assert.strictEqual(euler220(), 139776, 963904, '<code>euler220()</code> should return 139776, 963904.');
+    testString: assert.strictEqual(euler220(), 139776, 963904);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-221-alexandrian-integers.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-221-alexandrian-integers.english.md
@@ -39,7 +39,7 @@ Find the 150000th Alexandrian integer.
 ```yml
 tests:
   - text: <code>euler221()</code> should return 1884161251122450.
-    testString: assert.strictEqual(euler221(), 1884161251122450, '<code>euler221()</code> should return 1884161251122450.');
+    testString: assert.strictEqual(euler221(), 1884161251122450);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-222-sphere-packing.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-222-sphere-packing.english.md
@@ -22,7 +22,7 @@ Give your answer in micrometres (10-6 m) rounded to the nearest integer.
 ```yml
 tests:
   - text: <code>euler222()</code> should return 1590933.
-    testString: assert.strictEqual(euler222(), 1590933, '<code>euler222()</code> should return 1590933.');
+    testString: assert.strictEqual(euler222(), 1590933);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-223-almost-right-angled-triangles-i.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-223-almost-right-angled-triangles-i.english.md
@@ -22,7 +22,7 @@ How many barely acute triangles are there with perimeter ≤ 25,000,000?
 ```yml
 tests:
   - text: <code>euler223()</code> should return 61614848.
-    testString: assert.strictEqual(euler223(), 61614848, '<code>euler223()</code> should return 61614848.');
+    testString: assert.strictEqual(euler223(), 61614848);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-224-almost-right-angled-triangles-ii.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-224-almost-right-angled-triangles-ii.english.md
@@ -22,7 +22,7 @@ How many barely obtuse triangles are there with perimeter ≤ 75,000,000?
 ```yml
 tests:
   - text: <code>euler224()</code> should return 4137330.
-    testString: assert.strictEqual(euler224(), 4137330, '<code>euler224()</code> should return 4137330.');
+    testString: assert.strictEqual(euler224(), 4137330);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-225-tribonacci-non-divisors.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-225-tribonacci-non-divisors.english.md
@@ -26,7 +26,7 @@ Find the 124th odd number that does not divide any terms of the above sequence.
 ```yml
 tests:
   - text: <code>euler225()</code> should return 2009.
-    testString: assert.strictEqual(euler225(), 2009, '<code>euler225()</code> should return 2009.');
+    testString: assert.strictEqual(euler225(), 2009);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-226-a-scoop-of-blancmange.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-226-a-scoop-of-blancmange.english.md
@@ -29,7 +29,7 @@ What area under the blancmange curve is enclosed by C?Give your answer rounded t
 ```yml
 tests:
   - text: <code>euler226()</code> should return 0.11316017.
-    testString: assert.strictEqual(euler226(), 0.11316017, '<code>euler226()</code> should return 0.11316017.');
+    testString: assert.strictEqual(euler226(), 0.11316017);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-227-the-chase.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-227-the-chase.english.md
@@ -27,7 +27,7 @@ Give your answer rounded to ten significant digits.
 ```yml
 tests:
   - text: <code>euler227()</code> should return 3780.618622.
-    testString: assert.strictEqual(euler227(), 3780.618622, '<code>euler227()</code> should return 3780.618622.');
+    testString: assert.strictEqual(euler227(), 3780.618622);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-228-minkowski-sums.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-228-minkowski-sums.english.md
@@ -42,7 +42,7 @@ How many sides does S1864 + S1865 + … + S1909 have?
 ```yml
 tests:
   - text: <code>euler228()</code> should return 86226.
-    testString: assert.strictEqual(euler228(), 86226, '<code>euler228()</code> should return 86226.');
+    testString: assert.strictEqual(euler228(), 86226);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-229-four-representations-using-squares.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-229-four-representations-using-squares.english.md
@@ -38,7 +38,7 @@ How many such numbers are there that do not exceed 2×109?
 ```yml
 tests:
   - text: <code>euler229()</code> should return 11325263.
-    testString: assert.strictEqual(euler229(), 11325263, '<code>euler229()</code> should return 11325263.');
+    testString: assert.strictEqual(euler229(), 11325263);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-23-non-abundant-sums.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-23-non-abundant-sums.english.md
@@ -23,13 +23,13 @@ Find the sum of all positive integers <= <var>n</var> which cannot be written as
 ```yml
 tests:
   - text: <code>sumOfNonAbundantNumbers(10000)</code> should return 3731004.
-    testString: assert(sumOfNonAbundantNumbers(10000) === 3731004, '<code>sumOfNonAbundantNumbers(10000)</code> should return 3731004.');
+    testString: assert(sumOfNonAbundantNumbers(10000) === 3731004);
   - text: <code>sumOfNonAbundantNumbers(15000)</code> should return 4039939.
-    testString: assert(sumOfNonAbundantNumbers(15000) === 4039939, '<code>sumOfNonAbundantNumbers(15000)</code> should return 4039939.');
+    testString: assert(sumOfNonAbundantNumbers(15000) === 4039939);
   - text: <code>sumOfNonAbundantNumbers(20000)</code> should return 4159710.
-    testString: assert(sumOfNonAbundantNumbers(20000) === 4159710, '<code>sumOfNonAbundantNumbers(20000)</code> should return 4159710.');
+    testString: assert(sumOfNonAbundantNumbers(20000) === 4159710);
   - text: <code>sumOfNonAbundantNumbers(28123)</code> should return 4179871.
-    testString: assert(sumOfNonAbundantNumbers(28123) === 4179871, '<code>sumOfNonAbundantNumbers(28123)</code> should return 4179871.');
+    testString: assert(sumOfNonAbundantNumbers(28123) === 4179871);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-230-fibonacci-words.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-230-fibonacci-words.english.md
@@ -46,7 +46,7 @@ Find ∑n = 0,1,...,17   10n× DA,B((127+19n)×7n) .
 ```yml
 tests:
   - text: <code>euler230()</code> should return 850481152593119200.
-    testString: assert.strictEqual(euler230(), 850481152593119200, '<code>euler230()</code> should return 850481152593119200.');
+    testString: assert.strictEqual(euler230(), 850481152593119200);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-231-the-prime-factorisation-of-binomial-coefficients.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-231-the-prime-factorisation-of-binomial-coefficients.english.md
@@ -24,7 +24,7 @@ Find the sum of the terms in the prime factorisation of 20000000C15000000.
 ```yml
 tests:
   - text: <code>euler231()</code> should return 7526965179680.
-    testString: assert.strictEqual(euler231(), 7526965179680, '<code>euler231()</code> should return 7526965179680.');
+    testString: assert.strictEqual(euler231(), 7526965179680);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-232-the-race.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-232-the-race.english.md
@@ -26,7 +26,7 @@ Give your answer rounded to eight decimal places in the form 0.abcdefgh .
 ```yml
 tests:
   - text: <code>euler232()</code> should return 0.83648556.
-    testString: assert.strictEqual(euler232(), 0.83648556, '<code>euler232()</code> should return 0.83648556.');
+    testString: assert.strictEqual(euler232(), 0.83648556);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-233-lattice-points-on-a-circle.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-233-lattice-points-on-a-circle.english.md
@@ -23,7 +23,7 @@ What is the sum of all positive integers N ≤ 1011 such that f(N) = 420
 ```yml
 tests:
   - text: <code>euler233()</code> should return 271204031455541300.
-    testString: assert.strictEqual(euler233(), 271204031455541300, '<code>euler233()</code> should return 271204031455541300.');
+    testString: assert.strictEqual(euler233(), 271204031455541300);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-234-semidivisible-numbers.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-234-semidivisible-numbers.english.md
@@ -27,7 +27,7 @@ What is the sum of all semidivisible numbers not exceeding 999966663333 ?
 ```yml
 tests:
   - text: <code>euler234()</code> should return 1259187438574927000.
-    testString: assert.strictEqual(euler234(), 1259187438574927000, '<code>euler234()</code> should return 1259187438574927000.');
+    testString: assert.strictEqual(euler234(), 1259187438574927000);
 
 ```
 


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Related to issue #36400

This PR removes assert message arguments from `testString` for another 75 `Project Euler` challenges in the `Coding Interview Prep` curriculum section.