### PR TITLE
fix(curriculum): Remove unnecessary assert message argument from English Coding Interview Prep challenges - Project Euler - 05

### DIFF
--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-371-licence-plates.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-371-licence-plates.english.md
@@ -32,7 +32,7 @@ Note: We assume that each licence plate seen is equally likely to have any three
 ```yml
 tests:
   - text: <code>euler371()</code> should return 40.66368097.
-    testString: assert.strictEqual(euler371(), 40.66368097, '<code>euler371()</code> should return 40.66368097.');
+    testString: assert.strictEqual(euler371(), 40.66368097);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-372-pencils-of-rays.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-372-pencils-of-rays.english.md
@@ -26,7 +26,7 @@ Note:  represents the floor function.
 ```yml
 tests:
   - text: <code>euler372()</code> should return 301450082318807040.
-    testString: assert.strictEqual(euler372(), 301450082318807040, '<code>euler372()</code> should return 301450082318807040.');
+    testString: assert.strictEqual(euler372(), 301450082318807040);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-373-circumscribed-circles.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-373-circumscribed-circles.english.md
@@ -29,7 +29,7 @@ Find S(107).
 ```yml
 tests:
   - text: <code>euler373()</code> should return 727227472448913.
-    testString: assert.strictEqual(euler373(), 727227472448913, '<code>euler373()</code> should return 727227472448913.');
+    testString: assert.strictEqual(euler373(), 727227472448913);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-374-maximum-integer-partition-product.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-374-maximum-integer-partition-product.english.md
@@ -39,7 +39,7 @@ Give your answer modulo 982451653, the 50 millionth prime.
 ```yml
 tests:
   - text: <code>euler374()</code> should return 334420941.
-    testString: assert.strictEqual(euler374(), 334420941, '<code>euler374()</code> should return 334420941.');
+    testString: assert.strictEqual(euler374(), 334420941);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-375-minimum-of-subsequences.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-375-minimum-of-subsequences.english.md
@@ -35,7 +35,7 @@ Find M(2 000 000 000).
 ```yml
 tests:
   - text: <code>euler375()</code> should return 7435327983715286000.
-    testString: assert.strictEqual(euler375(), 7435327983715286000, '<code>euler375()</code> should return 7435327983715286000.');
+    testString: assert.strictEqual(euler375(), 7435327983715286000);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-376-nontransitive-sets-of-dice.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-376-nontransitive-sets-of-dice.english.md
@@ -56,7 +56,7 @@ How many are there for N = 30 ?
 ```yml
 tests:
   - text: <code>euler376()</code> should return 973059630185670.
-    testString: assert.strictEqual(euler376(), 973059630185670, '<code>euler376()</code> should return 973059630185670.');
+    testString: assert.strictEqual(euler376(), 973059630185670);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-377-sum-of-digits-experience-13.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-377-sum-of-digits-experience-13.english.md
@@ -29,7 +29,7 @@ Give the last 9 digits as your answer.
 ```yml
 tests:
   - text: <code>euler377()</code> should return 732385277.
-    testString: assert.strictEqual(euler377(), 732385277, '<code>euler377()</code> should return 732385277.');
+    testString: assert.strictEqual(euler377(), 732385277);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-378-triangle-triples.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-378-triangle-triples.english.md
@@ -38,7 +38,7 @@ Give the last 18 digits of your answer.
 ```yml
 tests:
   - text: <code>euler378()</code> should return 147534623725724700.
-    testString: assert.strictEqual(euler378(), 147534623725724700, '<code>euler378()</code> should return 147534623725724700.');
+    testString: assert.strictEqual(euler378(), 147534623725724700);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-379-least-common-multiple-count.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-379-least-common-multiple-count.english.md
@@ -30,7 +30,7 @@ Find g(1012).
 ```yml
 tests:
   - text: <code>euler379()</code> should return 132314136838185.
-    testString: assert.strictEqual(euler379(), 132314136838185, '<code>euler379()</code> should return 132314136838185.');
+    testString: assert.strictEqual(euler379(), 132314136838185);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-38-pandigital-multiples.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-38-pandigital-multiples.english.md
@@ -26,7 +26,7 @@ What is the largest 1 to 9 pandigital 9-digit number that can be formed as the c
 ```yml
 tests:
   - text: <code>pandigitalMultiples()</code> should return 932718654.
-    testString: assert.strictEqual(pandigitalMultiples(), 932718654, '<code>pandigitalMultiples()</code> should return 932718654.');
+    testString: assert.strictEqual(pandigitalMultiples(), 932718654);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-380-amazing-mazes.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-380-amazing-mazes.english.md
@@ -33,7 +33,7 @@ E.g. if the answer is 1234567891011 then the answer format would be 1.2346e12.
 ```yml
 tests:
   - text: <code>euler380()</code> should return Infinity.
-    testString: assert.strictEqual(euler380(), Infinity, '<code>euler380()</code> should return Infinity.');
+    testString: assert.strictEqual(euler380(), Infinity);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-381-prime-k-factorial.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-381-prime-k-factorial.english.md
@@ -31,7 +31,7 @@ Find ∑S(p) for 5 ≤ p < 108.
 ```yml
 tests:
   - text: <code>euler381()</code> should return 139602943319822.
-    testString: assert.strictEqual(euler381(), 139602943319822, '<code>euler381()</code> should return 139602943319822.');
+    testString: assert.strictEqual(euler381(), 139602943319822);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-382-generating-polygons.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-382-generating-polygons.english.md
@@ -43,7 +43,7 @@ Find the last 9 digits of f(1018).
 ```yml
 tests:
   - text: <code>euler382()</code> should return 697003956.
-    testString: assert.strictEqual(euler382(), 697003956, '<code>euler382()</code> should return 697003956.');
+    testString: assert.strictEqual(euler382(), 697003956);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-383-divisibility-comparison-between-factorials.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-383-divisibility-comparison-between-factorials.english.md
@@ -30,7 +30,7 @@ Find T5(1018).
 ```yml
 tests:
   - text: <code>euler383()</code> should return 22173624649806.
-    testString: assert.strictEqual(euler383(), 22173624649806, '<code>euler383()</code> should return 22173624649806.');
+    testString: assert.strictEqual(euler383(), 22173624649806);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-384-rudin-shapiro-sequence.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-384-rudin-shapiro-sequence.english.md
@@ -44,7 +44,7 @@ Find ΣGF(t) for 2≤t≤45.
 ```yml
 tests:
   - text: <code>euler384()</code> should return 3354706415856333000.
-    testString: assert.strictEqual(euler384(), 3354706415856333000, '<code>euler384()</code> should return 3354706415856333000.');
+    testString: assert.strictEqual(euler384(), 3354706415856333000);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-385-ellipses-inside-triangles.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-385-ellipses-inside-triangles.english.md
@@ -40,7 +40,7 @@ Find A(1 000 000 000).
 ```yml
 tests:
   - text: <code>euler385()</code> should return 3776957309612154000.
-    testString: assert.strictEqual(euler385(), 3776957309612154000, '<code>euler385()</code> should return 3776957309612154000.');
+    testString: assert.strictEqual(euler385(), 3776957309612154000);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-386-maximum-length-of-an-antichain.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-386-maximum-length-of-an-antichain.english.md
@@ -30,7 +30,7 @@ Find ΣN(n) for 1 ≤ n ≤ 108
 ```yml
 tests:
   - text: <code>euler386()</code> should return 528755790.
-    testString: assert.strictEqual(euler386(), 528755790, '<code>euler386()</code> should return 528755790.');
+    testString: assert.strictEqual(euler386(), 528755790);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-387-harshad-numbers.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-387-harshad-numbers.english.md
@@ -36,7 +36,7 @@ Find the sum of the strong, right truncatable Harshad primes less than 1014.
 ```yml
 tests:
   - text: <code>euler387()</code> should return 696067597313468.
-    testString: assert.strictEqual(euler387(), 696067597313468, '<code>euler387()</code> should return 696067597313468.');
+    testString: assert.strictEqual(euler387(), 696067597313468);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-388-distinct-lines.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-388-distinct-lines.english.md
@@ -29,7 +29,7 @@ Find D(1010). Give as your answer the first nine digits followed by the last nin
 ```yml
 tests:
   - text: <code>euler388()</code> should return 831907372805130000.
-    testString: assert.strictEqual(euler388(), 831907372805130000, '<code>euler388()</code> should return 831907372805130000.');
+    testString: assert.strictEqual(euler388(), 831907372805130000);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-389-platonic-dice.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-389-platonic-dice.english.md
@@ -21,7 +21,7 @@ Find the variance of I, and give your answer rounded to 4 decimal places.
 ```yml
 tests:
   - text: <code>euler389()</code> should return 2406376.3623.
-    testString: assert.strictEqual(euler389(), 2406376.3623, '<code>euler389()</code> should return 2406376.3623.');
+    testString: assert.strictEqual(euler389(), 2406376.3623);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-39-integer-right-triangles.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-39-integer-right-triangles.english.md
@@ -22,13 +22,13 @@ For which value of p ≤ n, is the number of solutions maximised?
 ```yml
 tests:
   - text: <code>intRightTriangles(500)</code> should return 420.
-    testString: assert(intRightTriangles(500) == 420, '<code>intRightTriangles(500)</code> should return 420.');
+    testString: assert(intRightTriangles(500) == 420);
   - text: <code>intRightTriangles(800)</code> should return 420.
-    testString: assert(intRightTriangles(800) == 420, '<code>intRightTriangles(800)</code> should return 420.');
+    testString: assert(intRightTriangles(800) == 420);
   - text: <code>intRightTriangles(900)</code> should return 840.
-    testString: assert(intRightTriangles(900) == 840, '<code>intRightTriangles(900)</code> should return 840.');
+    testString: assert(intRightTriangles(900) == 840);
   - text: <code>intRightTriangles(1000)</code> should return 840.
-    testString: assert(intRightTriangles(1000) == 840, '<code>intRightTriangles(1000)</code> should return 840.');
+    testString: assert(intRightTriangles(1000) == 840);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-390-triangles-with-non-rational-sides-and-integral-area.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-390-triangles-with-non-rational-sides-and-integral-area.english.md
@@ -29,7 +29,7 @@ Find S(1010).
 ```yml
 tests:
   - text: <code>euler390()</code> should return 2919133642971.
-    testString: assert.strictEqual(euler390(), 2919133642971, '<code>euler390()</code> should return 2919133642971.');
+    testString: assert.strictEqual(euler390(), 2919133642971);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-391-hopping-game.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-391-hopping-game.english.md
@@ -47,7 +47,7 @@ Find Σ(M(n))3 for 1 ≤ n ≤ 1000.
 ```yml
 tests:
   - text: <code>euler391()</code> should return 61029882288.
-    testString: assert.strictEqual(euler391(), 61029882288, '<code>euler391()</code> should return 61029882288.');
+    testString: assert.strictEqual(euler391(), 61029882288);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-392-enmeshed-unit-circle.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-392-enmeshed-unit-circle.english.md
@@ -36,7 +36,7 @@ Give as your answer the area occupied by the red cells rounded to 10 digits behi
 ```yml
 tests:
   - text: <code>euler392()</code> should return 3.1486734435.
-    testString: assert.strictEqual(euler392(), 3.1486734435, '<code>euler392()</code> should return 3.1486734435.');
+    testString: assert.strictEqual(euler392(), 3.1486734435);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-393-migrating-ants.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-393-migrating-ants.english.md
@@ -26,7 +26,7 @@ Find  f(10).
 ```yml
 tests:
   - text: <code>euler393()</code> should return 112398351350823100.
-    testString: assert.strictEqual(euler393(), 112398351350823100, '<code>euler393()</code> should return 112398351350823100.');
+    testString: assert.strictEqual(euler393(), 112398351350823100);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-394-eating-pie.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-394-eating-pie.english.md
@@ -36,7 +36,7 @@ Find E(40) rounded to 10 decimal places behind the decimal point.
 ```yml
 tests:
   - text: <code>euler394()</code> should return 3.2370342194.
-    testString: assert.strictEqual(euler394(), 3.2370342194, '<code>euler394()</code> should return 3.2370342194.');
+    testString: assert.strictEqual(euler394(), 3.2370342194);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-395-pythagorean-tree.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-395-pythagorean-tree.english.md
@@ -38,7 +38,7 @@ Find the smallest area possible for such a bounding rectangle, and give your ans
 ```yml
 tests:
   - text: <code>euler395()</code> should return 28.2453753155.
-    testString: assert.strictEqual(euler395(), 28.2453753155, '<code>euler395()</code> should return 28.2453753155.');
+    testString: assert.strictEqual(euler395(), 28.2453753155);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-396-weak-goodstein-sequence.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-396-weak-goodstein-sequence.english.md
@@ -44,7 +44,7 @@ Find the last 9 digits of ΣG(n) for 1 ≤ n < 16.
 ```yml
 tests:
   - text: <code>euler396()</code> should return 173214653.
-    testString: assert.strictEqual(euler396(), 173214653, '<code>euler396()</code> should return 173214653.');
+    testString: assert.strictEqual(euler396(), 173214653);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-397-triangle-on-parabola.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-397-triangle-on-parabola.english.md
@@ -27,7 +27,7 @@ Find F(106, 109).
 ```yml
 tests:
   - text: <code>euler397()</code> should return 141630459461893730.
-    testString: assert.strictEqual(euler397(), 141630459461893730, '<code>euler397()</code> should return 141630459461893730.');
+    testString: assert.strictEqual(euler397(), 141630459461893730);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-398-cutting-rope.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-398-cutting-rope.english.md
@@ -29,7 +29,7 @@ Give your answer rounded to 5 decimal places behind the decimal point.
 ```yml
 tests:
   - text: <code>euler398()</code> should return 2010.59096.
-    testString: assert.strictEqual(euler398(), 2010.59096, '<code>euler398()</code> should return 2010.59096.');
+    testString: assert.strictEqual(euler398(), 2010.59096);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-399-squarefree-fibonacci-numbers.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-399-squarefree-fibonacci-numbers.english.md
@@ -41,7 +41,7 @@ If it happens that the conjecture is false, then the accepted answer to this pro
 ```yml
 tests:
   - text: <code>euler399()</code> should return 1508395636674243, 6.5e27330467.
-    testString: assert.strictEqual(euler399(), 1508395636674243, 6.5e27330467, '<code>euler399()</code> should return 1508395636674243, 6.5e27330467.');
+    testString: assert.strictEqual(euler399(), 1508395636674243, 6.5e27330467);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-4-largest-palindrome-product.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-4-largest-palindrome-product.english.md
@@ -21,9 +21,9 @@ Find the largest palindrome made from the product of two <code>n</code>-digit nu
 ```yml
 tests:
   - text: <code>largestPalindromeProduct(2)</code> should return 9009.
-    testString: assert.strictEqual(largestPalindromeProduct(2), 9009, '<code>largestPalindromeProduct(2)</code> should return 9009.');
+    testString: assert.strictEqual(largestPalindromeProduct(2), 9009);
   - text: <code>largestPalindromeProduct(3)</code> should return 906609.
-    testString: assert.strictEqual(largestPalindromeProduct(3), 906609, '<code>largestPalindromeProduct(3)</code> should return 906609.');
+    testString: assert.strictEqual(largestPalindromeProduct(3), 906609);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-40-champernownes-constant.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-40-champernownes-constant.english.md
@@ -24,11 +24,11 @@ If <i>d<sub>n</sub></i> represents the <i>n</i><sup>th</sup> digit of the fracti
 ```yml
 tests:
   - text: <code>champernownesConstant(100)</code> should return 5.
-    testString: assert.strictEqual(champernownesConstant(100), 5, '<code>champernownesConstant(100)</code> should return 5.');
+    testString: assert.strictEqual(champernownesConstant(100), 5);
   - text: <code>champernownesConstant(1000)</code> should return 15.
-    testString: assert.strictEqual(champernownesConstant(1000), 15, '<code>champernownesConstant(1000)</code> should return 15.');
+    testString: assert.strictEqual(champernownesConstant(1000), 15);
   - text: <code>champernownesConstant(1000000)</code> should return 210.
-    testString: assert.strictEqual(champernownesConstant(1000000), 210, '<code>champernownesConstant(1000000)</code> should return 210.');
+    testString: assert.strictEqual(champernownesConstant(1000000), 210);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-400-fibonacci-tree-game.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-400-fibonacci-tree-game.english.md
@@ -41,7 +41,7 @@ Find f(10000). Give the last 18 digits of your answer.
 ```yml
 tests:
   - text: <code>euler400()</code> should return 438505383468410600.
-    testString: assert.strictEqual(euler400(), 438505383468410600, '<code>euler400()</code> should return 438505383468410600.');
+    testString: assert.strictEqual(euler400(), 438505383468410600);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-401-sum-of-squares-of-divisors.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-401-sum-of-squares-of-divisors.english.md
@@ -31,7 +31,7 @@ Find SIGMA2(1015) modulo 109.
 ```yml
 tests:
   - text: <code>euler401()</code> should return 281632621.
-    testString: assert.strictEqual(euler401(), 281632621, '<code>euler401()</code> should return 281632621.');
+    testString: assert.strictEqual(euler401(), 281632621);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-402-integer-valued-polynomials.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-402-integer-valued-polynomials.english.md
@@ -37,7 +37,7 @@ Find the last 9 digits of Σ S(Fk) for 2 ≤ k ≤ 1234567890123.
 ```yml
 tests:
   - text: <code>euler402()</code> should return 356019862.
-    testString: assert.strictEqual(euler402(), 356019862, '<code>euler402()</code> should return 356019862.');
+    testString: assert.strictEqual(euler402(), 356019862);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-403-lattice-points-enclosed-by-parabola-and-line.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-403-lattice-points-enclosed-by-parabola-and-line.english.md
@@ -31,7 +31,7 @@ Find S(1012). Give your answer mod 108.
 ```yml
 tests:
   - text: <code>euler403()</code> should return 18224771.
-    testString: assert.strictEqual(euler403(), 18224771, '<code>euler403()</code> should return 18224771.');
+    testString: assert.strictEqual(euler403(), 18224771);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-404-crisscross-ellipses.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-404-crisscross-ellipses.english.md
@@ -39,7 +39,7 @@ Find C(1017).
 ```yml
 tests:
   - text: <code>euler404()</code> should return 1199215615081353.
-    testString: assert.strictEqual(euler404(), 1199215615081353, '<code>euler404()</code> should return 1199215615081353.');
+    testString: assert.strictEqual(euler404(), 1199215615081353);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-405-a-rectangular-tiling.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-405-a-rectangular-tiling.english.md
@@ -41,7 +41,7 @@ Find f(10k) for k = 1018, give your answer modulo 177.
 ```yml
 tests:
   - text: <code>euler405()</code> should return 237696125.
-    testString: assert.strictEqual(euler405(), 237696125, '<code>euler405()</code> should return 237696125.');
+    testString: assert.strictEqual(euler405(), 237696125);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-406-guessing-game.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-406-guessing-game.english.md
@@ -43,7 +43,7 @@ Let Fk be the Fibonacci numbers: Fk = Fk-1 + Fk-2 with base cases F1 = F2 = 1.Fi
 ```yml
 tests:
   - text: <code>euler406()</code> should return 36813.12757207.
-    testString: assert.strictEqual(euler406(), 36813.12757207, '<code>euler406()</code> should return 36813.12757207.');
+    testString: assert.strictEqual(euler406(), 36813.12757207);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-407-idempotents.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-407-idempotents.english.md
@@ -28,7 +28,7 @@ Find ∑M(n) for 1 ≤ n ≤ 107.
 ```yml
 tests:
   - text: <code>euler407()</code> should return 39782849136421.
-    testString: assert.strictEqual(euler407(), 39782849136421, '<code>euler407()</code> should return 39782849136421.');
+    testString: assert.strictEqual(euler407(), 39782849136421);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-408-admissible-paths-through-a-grid.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-408-admissible-paths-through-a-grid.english.md
@@ -29,7 +29,7 @@ Find P(10 000 000) mod 1 000 000 007.
 ```yml
 tests:
   - text: <code>euler408()</code> should return 299742733.
-    testString: assert.strictEqual(euler408(), 299742733, '<code>euler408()</code> should return 299742733.');
+    testString: assert.strictEqual(euler408(), 299742733);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-409-nim-extreme.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-409-nim-extreme.english.md
@@ -26,7 +26,7 @@ Find W(10 000 000) mod 1 000 000 007.
 ```yml
 tests:
   - text: <code>euler409()</code> should return 253223948.
-    testString: assert.strictEqual(euler409(), 253223948, '<code>euler409()</code> should return 253223948.');
+    testString: assert.strictEqual(euler409(), 253223948);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-41-pandigital-prime.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-41-pandigital-prime.english.md
@@ -21,9 +21,9 @@ What is the largest <i>n</i>-length digit pandigital prime that exists?
 ```yml
 tests:
   - text: <code>pandigitalPrime(4)</code> should return 4231.
-    testString: assert(pandigitalPrime(4) == 4231, '<code>pandigitalPrime(4)</code> should return 4231.');
+    testString: assert(pandigitalPrime(4) == 4231);
   - text: <code>pandigitalPrime(7)</code> should return 7652413.
-    testString: assert(pandigitalPrime(7) == 7652413, '<code>pandigitalPrime(7)</code> should return 7652413.');
+    testString: assert(pandigitalPrime(7) == 7652413);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-410-circle-and-tangent-line.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-410-circle-and-tangent-line.english.md
@@ -27,7 +27,7 @@ Find F(108, 109) + F(109, 108).
 ```yml
 tests:
   - text: <code>euler410()</code> should return 799999783589946600.
-    testString: assert.strictEqual(euler410(), 799999783589946600, '<code>euler410()</code> should return 799999783589946600.');
+    testString: assert.strictEqual(euler410(), 799999783589946600);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-411-uphill-paths.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-411-uphill-paths.english.md
@@ -32,7 +32,7 @@ Find ∑ S(k5) for 1 ≤ k ≤ 30.
 ```yml
 tests:
   - text: <code>euler411()</code> should return 9936352.
-    testString: assert.strictEqual(euler411(), 9936352, '<code>euler411()</code> should return 9936352.');
+    testString: assert.strictEqual(euler411(), 9936352);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-412-gnomon-numbering.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-412-gnomon-numbering.english.md
@@ -34,7 +34,7 @@ Find LC(10000, 5000) mod 76543217.
 ```yml
 tests:
   - text: <code>euler412()</code> should return 38788800.
-    testString: assert.strictEqual(euler412(), 38788800, '<code>euler412()</code> should return 38788800.');
+    testString: assert.strictEqual(euler412(), 38788800);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-413-one-child-numbers.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-413-one-child-numbers.english.md
@@ -29,7 +29,7 @@ Find F(1019).
 ```yml
 tests:
   - text: <code>euler413()</code> should return 3079418648040719.
-    testString: assert.strictEqual(euler413(), 3079418648040719, '<code>euler413()</code> should return 3079418648040719.');
+    testString: assert.strictEqual(euler413(), 3079418648040719);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-414-kaprekar-constant.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-414-kaprekar-constant.english.md
@@ -51,7 +51,7 @@ Give the last 18 digits as your answer.
 ```yml
 tests:
   - text: <code>euler414()</code> should return 552506775824935500.
-    testString: assert.strictEqual(euler414(), 552506775824935500, '<code>euler414()</code> should return 552506775824935500.');
+    testString: assert.strictEqual(euler414(), 552506775824935500);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-415-titanic-sets.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-415-titanic-sets.english.md
@@ -29,7 +29,7 @@ Find T(1011) mod 108.
 ```yml
 tests:
   - text: <code>euler415()</code> should return 55859742.
-    testString: assert.strictEqual(euler415(), 55859742, '<code>euler415()</code> should return 55859742.');
+    testString: assert.strictEqual(euler415(), 55859742);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-416-a-frogs-trip.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-416-a-frogs-trip.english.md
@@ -25,7 +25,7 @@ Find the last 9 digits of F(10, 1012).
 ```yml
 tests:
   - text: <code>euler416()</code> should return 898082747.
-    testString: assert.strictEqual(euler416(), 898082747, '<code>euler416()</code> should return 898082747.');
+    testString: assert.strictEqual(euler416(), 898082747);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-417-reciprocal-cycles-ii.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-417-reciprocal-cycles-ii.english.md
@@ -42,7 +42,7 @@ Find ∑L(n) for 3 ≤ n ≤ 100 000 000
 ```yml
 tests:
   - text: <code>euler417()</code> should return 446572970925740.
-    testString: assert.strictEqual(euler417(), 446572970925740, '<code>euler417()</code> should return 446572970925740.');
+    testString: assert.strictEqual(euler417(), 446572970925740);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-418-factorisation-triples.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-418-factorisation-triples.english.md
@@ -29,7 +29,7 @@ Find f(43!).
 ```yml
 tests:
   - text: <code>euler418()</code> should return 1177163565297340400.
-    testString: assert.strictEqual(euler418(), 1177163565297340400, '<code>euler418()</code> should return 1177163565297340400.');
+    testString: assert.strictEqual(euler418(), 1177163565297340400);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-419-look-and-say-sequence.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-419-look-and-say-sequence.english.md
@@ -37,7 +37,7 @@ E.g. for n = 40 the answer would be 31254,20259,11625
 ```yml
 tests:
   - text: <code>euler419()</code> should return 998567458, 1046245404, 43363922.
-    testString: assert.strictEqual(euler419(), 998567458, 1046245404, 43363922, '<code>euler419()</code> should return 998567458, 1046245404, 43363922.');
+    testString: assert.strictEqual(euler419(), 998567458, 1046245404, 43363922);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-42-coded-triangle-numbers.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-42-coded-triangle-numbers.english.md
@@ -23,13 +23,13 @@ Using words array of n-length, how many are triangle words?
 ```yml
 tests:
   - text: <code>codedTriangleNumbers(1400)</code> should return 129.
-    testString: assert(codedTriangleNumbers(1400) == 129, '<code>codedTriangleNumbers(1400)</code> should return 129.');
+    testString: assert(codedTriangleNumbers(1400) == 129);
   - text: <code>codedTriangleNumbers(1500)</code> should return 137.
-    testString: assert(codedTriangleNumbers(1500) == 137, '<code>codedTriangleNumbers(1500)</code> should return 137.');
+    testString: assert(codedTriangleNumbers(1500) == 137);
   - text: <code>codedTriangleNumbers(1600)</code> should return 141.
-    testString: assert(codedTriangleNumbers(1600) == 141, '<code>codedTriangleNumbers(1600)</code> should return 141.');
+    testString: assert(codedTriangleNumbers(1600) == 141);
   - text: <code>codedTriangleNumbers(1786)</code> should return 162.
-    testString: assert(codedTriangleNumbers(1786) == 162, '<code>codedTriangleNumbers(1786)</code> should return 162.');
+    testString: assert(codedTriangleNumbers(1786) == 162);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-420-2x2-positive-integer-matrix.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-420-2x2-positive-integer-matrix.english.md
@@ -32,7 +32,7 @@ Find F(107).
 ```yml
 tests:
   - text: <code>euler420()</code> should return 145159332.
-    testString: assert.strictEqual(euler420(), 145159332, '<code>euler420()</code> should return 145159332.');
+    testString: assert.strictEqual(euler420(), 145159332);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-421-prime-factors-of-n151.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-421-prime-factors-of-n151.english.md
@@ -28,7 +28,7 @@ Find ∑ s(n,108) for 1 ≤ n ≤ 1011.
 ```yml
 tests:
   - text: <code>euler421()</code> should return 2304215802083466200.
-    testString: assert.strictEqual(euler421(), 2304215802083466200, '<code>euler421()</code> should return 2304215802083466200.');
+    testString: assert.strictEqual(euler421(), 2304215802083466200);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-422-sequence-of-points-on-a-hyperbola.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-422-sequence-of-points-on-a-hyperbola.english.md
@@ -32,7 +32,7 @@ For n = 7, the answer would have been: 806236837.
 ```yml
 tests:
   - text: <code>euler422()</code> should return 92060460.
-    testString: assert.strictEqual(euler422(), 92060460, '<code>euler422()</code> should return 92060460.');
+    testString: assert.strictEqual(euler422(), 92060460);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-423-consecutive-die-throws.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-423-consecutive-die-throws.english.md
@@ -37,7 +37,7 @@ Find S(50 000 000) mod 1 000 000 007.
 ```yml
 tests:
   - text: <code>euler423()</code> should return 653972374.
-    testString: assert.strictEqual(euler423(), 653972374, '<code>euler423()</code> should return 653972374.');
+    testString: assert.strictEqual(euler423(), 653972374);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-424-kakuro.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-424-kakuro.english.md
@@ -40,7 +40,7 @@ Find the sum of the answers for the 200 puzzles.
 ```yml
 tests:
   - text: <code>euler424()</code> should return 1059760019628.
-    testString: assert.strictEqual(euler424(), 1059760019628, '<code>euler424()</code> should return 1059760019628.');
+    testString: assert.strictEqual(euler424(), 1059760019628);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-425-prime-connection.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-425-prime-connection.english.md
@@ -37,7 +37,7 @@ Find F(107).
 ```yml
 tests:
   - text: <code>euler425()</code> should return 46479497324.
-    testString: assert.strictEqual(euler425(), 46479497324, '<code>euler425()</code> should return 46479497324.');
+    testString: assert.strictEqual(euler425(), 46479497324);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-426-box-ball-system.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-426-box-ball-system.english.md
@@ -49,7 +49,7 @@ Give as your answer the sum of the squares of the elements of the final state. F
 ```yml
 tests:
   - text: <code>euler426()</code> should return 31591886008.
-    testString: assert.strictEqual(euler426(), 31591886008, '<code>euler426()</code> should return 31591886008.');
+    testString: assert.strictEqual(euler426(), 31591886008);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-427-n-sequences.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-427-n-sequences.english.md
@@ -30,7 +30,7 @@ Find f(7 500 000) mod 1 000 000 009.
 ```yml
 tests:
   - text: <code>euler427()</code> should return 97138867.
-    testString: assert.strictEqual(euler427(), 97138867, '<code>euler427()</code> should return 97138867.');
+    testString: assert.strictEqual(euler427(), 97138867);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-428-necklace-of-circles.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-428-necklace-of-circles.english.md
@@ -33,7 +33,7 @@ Find T(1&nbsp;000&nbsp;000&nbsp;000).
 ```yml
 tests:
   - text: <code>necklace(1000000000)</code> should return 747215561862.
-    testString: assert.strictEqual(necklace(1000000000), 747215561862, '<code>necklace(1000000000)</code> should return 747215561862.');
+    testString: assert.strictEqual(necklace(1000000000), 747215561862);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-429-sum-of-squares-of-unitary-divisors.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-429-sum-of-squares-of-unitary-divisors.english.md
@@ -28,7 +28,7 @@ Find S(100 000 000!) modulo 1 000 000 009.
 ```yml
 tests:
   - text: <code>euler429()</code> should return 98792821.
-    testString: assert.strictEqual(euler429(), 98792821, '<code>euler429()</code> should return 98792821.');
+    testString: assert.strictEqual(euler429(), 98792821);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-43-sub-string-divisibility.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-43-sub-string-divisibility.english.md
@@ -29,7 +29,7 @@ Find the numbers of all 0 to 9 pandigital numbers with this property.
 ```yml
 tests:
   - text: <code>substringDivisibility()</code> should return [ 1430952867, 1460357289, 1406357289, 4130952867, 4160357289, 4106357289 ].
-    testString: assert.deepEqual(substringDivisibility(), [ 1430952867, 1460357289, 1406357289, 4130952867, 4160357289, 4106357289 ], '<code>substringDivisibility()</code> should return [ 1430952867, 1460357289, 1406357289, 4130952867, 4160357289, 4106357289 ].');
+    testString: assert.deepEqual(substringDivisibility(), [ 1430952867, 1460357289, 1406357289, 4130952867, 4160357289, 4106357289 ]);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-430-range-flips.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-430-range-flips.english.md
@@ -34,7 +34,7 @@ Give your answer rounded to 2 decimal places behind the decimal point.
 ```yml
 tests:
   - text: <code>euler430()</code> should return 5000624921.38.
-    testString: assert.strictEqual(euler430(), 5000624921.38, '<code>euler430()</code> should return 5000624921.38.');
+    testString: assert.strictEqual(euler430(), 5000624921.38);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-431-square-space-silo.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-431-square-space-silo.english.md
@@ -31,7 +31,7 @@ If Quick thinking Quentin is to satisfy frustratingly fussy Fred the farmer's ap
 ```yml
 tests:
   - text: <code>euler431()</code> should return 23.386029052.
-    testString: assert.strictEqual(euler431(), 23.386029052, '<code>euler431()</code> should return 23.386029052.');
+    testString: assert.strictEqual(euler431(), 23.386029052);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-432-totient-sum.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-432-totient-sum.english.md
@@ -25,7 +25,7 @@ Give the last 9 digits of your answer.
 ```yml
 tests:
   - text: <code>euler432()</code> should return 754862080.
-    testString: assert.strictEqual(euler432(), 754862080, '<code>euler432()</code> should return 754862080.');
+    testString: assert.strictEqual(euler432(), 754862080);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-433-steps-in-euclids-algorithm.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-433-steps-in-euclids-algorithm.english.md
@@ -31,7 +31,7 @@ Find S(5·106).
 ```yml
 tests:
   - text: <code>euler433()</code> should return 326624372659664.
-    testString: assert.strictEqual(euler433(), 326624372659664, '<code>euler433()</code> should return 326624372659664.');
+    testString: assert.strictEqual(euler433(), 326624372659664);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-434-rigid-graphs.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-434-rigid-graphs.english.md
@@ -35,7 +35,7 @@ Find S(100), give your answer modulo 1000000033
 ```yml
 tests:
   - text: <code>euler434()</code> should return 863253606.
-    testString: assert.strictEqual(euler434(), 863253606, '<code>euler434()</code> should return 863253606.');
+    testString: assert.strictEqual(euler434(), 863253606);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-435-polynomials-of-fibonacci-numbers.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-435-polynomials-of-fibonacci-numbers.english.md
@@ -23,7 +23,7 @@ Let n = 1015. Find the sum [∑0≤x≤100 Fn(x)] mod 1307674368000 (= 15!).
 ```yml
 tests:
   - text: <code>euler435()</code> should return 252541322550.
-    testString: assert.strictEqual(euler435(), 252541322550, '<code>euler435()</code> should return 252541322550.');
+    testString: assert.strictEqual(euler435(), 252541322550);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-436-unfair-wager.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-436-unfair-wager.english.md
@@ -34,7 +34,7 @@ Give your answer rounded to 10 places behind the decimal point in the form 0.abc
 ```yml
 tests:
   - text: <code>euler436()</code> should return 0.5276662759.
-    testString: assert.strictEqual(euler436(), 0.5276662759, '<code>euler436()</code> should return 0.5276662759.');
+    testString: assert.strictEqual(euler436(), 0.5276662759);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-437-fibonacci-primitive-roots.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-437-fibonacci-primitive-roots.english.md
@@ -38,7 +38,7 @@ Find the sum of the primes less than 100,000,000 with at least one Fibonacci pri
 ```yml
 tests:
   - text: <code>euler437()</code> should return 74204709657207.
-    testString: assert.strictEqual(euler437(), 74204709657207, '<code>euler437()</code> should return 74204709657207.');
+    testString: assert.strictEqual(euler437(), 74204709657207);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-438-integer-part-of-polynomial-equations-solutions.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-438-integer-part-of-polynomial-equations-solutions.english.md
@@ -32,7 +32,7 @@ Find ∑S(t) for n = 7.
 ```yml
 tests:
   - text: <code>euler438()</code> should return 2046409616809.
-    testString: assert.strictEqual(euler438(), 2046409616809, '<code>euler438()</code> should return 2046409616809.');
+    testString: assert.strictEqual(euler438(), 2046409616809);
 
 ```
 


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Related to issue #36400

This PR removes assert message arguments from `testString` for another 75 `Project Euler` challenges in the `Coding Interview Prep` curriculum section.