### PR TITLE
fix(curriculum): Remove unnecessary assert message argument from English Coding Interview Prep challenges - Project Euler - 06

### DIFF
--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-439-sum-of-sum-of-divisors.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-439-sum-of-sum-of-divisors.english.md
@@ -25,7 +25,7 @@ Find S(1011) mod 109.
 ```yml
 tests:
   - text: <code>euler439()</code> should return 968697378.
-    testString: assert.strictEqual(euler439(), 968697378, '<code>euler439()</code> should return 968697378.');
+    testString: assert.strictEqual(euler439(), 968697378);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-44-pentagon-numbers.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-44-pentagon-numbers.english.md
@@ -23,7 +23,7 @@ Find the pair of pentagonal numbers, P<sub>j</sub> and P<sub>k</sub>, for which 
 ```yml
 tests:
   - text: <code>pentagonNumbers()</code> should return 5482660.
-    testString: assert.strictEqual(pentagonNumbers(), 5482660, '<code>pentagonNumbers()</code> should return 5482660.');
+    testString: assert.strictEqual(pentagonNumbers(), 5482660);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-440-gcd-and-tiling.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-440-gcd-and-tiling.english.md
@@ -34,7 +34,7 @@ Find S(2000) mod 987 898 789.
 ```yml
 tests:
   - text: <code>euler440()</code> should return 970746056.
-    testString: assert.strictEqual(euler440(), 970746056, '<code>euler440()</code> should return 970746056.');
+    testString: assert.strictEqual(euler440(), 970746056);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-441-the-inverse-summation-of-coprime-couples.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-441-the-inverse-summation-of-coprime-couples.english.md
@@ -30,7 +30,7 @@ Find S(107). Give your answer rounded to four decimal places.
 ```yml
 tests:
   - text: <code>euler441()</code> should return 5000088.8395.
-    testString: assert.strictEqual(euler441(), 5000088.8395, '<code>euler441()</code> should return 5000088.8395.');
+    testString: assert.strictEqual(euler441(), 5000088.8395);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-442-eleven-free-integers.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-442-eleven-free-integers.english.md
@@ -26,7 +26,7 @@ Find E(1018).
 ```yml
 tests:
   - text: <code>euler442()</code> should return 1295552661530920200.
-    testString: assert.strictEqual(euler442(), 1295552661530920200, '<code>euler442()</code> should return 1295552661530920200.');
+    testString: assert.strictEqual(euler442(), 1295552661530920200);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-443-gcd-sequence.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-443-gcd-sequence.english.md
@@ -32,7 +32,7 @@ Find g(1015).
 ```yml
 tests:
   - text: <code>euler443()</code> should return 2744233049300770.
-    testString: assert.strictEqual(euler443(), 2744233049300770, '<code>euler443()</code> should return 2744233049300770.');
+    testString: assert.strictEqual(euler443(), 2744233049300770);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-444-the-roundtable-lottery.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-444-the-roundtable-lottery.english.md
@@ -36,7 +36,7 @@ Find S20(1014) and write the answer in scientific notation rounded to 10 signifi
 ```yml
 tests:
   - text: <code>euler444()</code> should return 1.200856722e+263.
-    testString: assert.strictEqual(euler444(), 1.200856722e+263, '<code>euler444()</code> should return 1.200856722e+263.');
+    testString: assert.strictEqual(euler444(), 1.200856722e+263);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-445-retractions-a.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-445-retractions-a.english.md
@@ -31,7 +31,7 @@ Give your answer modulo 1 000 000 007.
 ```yml
 tests:
   - text: <code>euler445()</code> should return 659104042.
-    testString: assert.strictEqual(euler445(), 659104042, '<code>euler445()</code> should return 659104042.');
+    testString: assert.strictEqual(euler445(), 659104042);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-446-retractions-b.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-446-retractions-b.english.md
@@ -29,7 +29,7 @@ Find F(107) (mod 1 000 000 007)
 ```yml
 tests:
   - text: <code>euler446()</code> should return 907803852.
-    testString: assert.strictEqual(euler446(), 907803852, '<code>euler446()</code> should return 907803852.');
+    testString: assert.strictEqual(euler446(), 907803852);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-447-retractions-c.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-447-retractions-c.english.md
@@ -30,7 +30,7 @@ Find F(1014) (mod 1 000 000 007).
 ```yml
 tests:
   - text: <code>euler447()</code> should return 530553372.
-    testString: assert.strictEqual(euler447(), 530553372, '<code>euler447()</code> should return 530553372.');
+    testString: assert.strictEqual(euler447(), 530553372);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-448-average-least-common-multiple.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-448-average-least-common-multiple.english.md
@@ -28,7 +28,7 @@ Find S(99999999019) mod 999999017.
 ```yml
 tests:
   - text: <code>euler448()</code> should return 106467648.
-    testString: assert.strictEqual(euler448(), 106467648, '<code>euler448()</code> should return 106467648.');
+    testString: assert.strictEqual(euler448(), 106467648);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-449-chocolate-covered-candy.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-449-chocolate-covered-candy.english.md
@@ -32,7 +32,7 @@ Find the amount of chocolate in mm3 required if a=3 mm and b=1 mm. Give your ans
 ```yml
 tests:
   - text: <code>euler449()</code> should return 103.37870096.
-    testString: assert.strictEqual(euler449(), 103.37870096, '<code>euler449()</code> should return 103.37870096.');
+    testString: assert.strictEqual(euler449(), 103.37870096);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-45-triangular-pentagonal-and-hexagonal.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-45-triangular-pentagonal-and-hexagonal.english.md
@@ -25,7 +25,7 @@ Find the next triangle number that is also pentagonal and hexagonal.
 ```yml
 tests:
   - text: <code>triPentaHexa(40756)</code> should return 1533776805.
-    testString: assert.strictEqual(triPentaHexa(40756), 1533776805, '<code>triPentaHexa(40756)</code> should return 1533776805.');
+    testString: assert.strictEqual(triPentaHexa(40756), 1533776805);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-450-hypocycloid-and-lattice-points.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-450-hypocycloid-and-lattice-points.english.md
@@ -48,7 +48,7 @@ Find T(106).
 ```yml
 tests:
   - text: <code>euler450()</code> should return 583333163984220900.
-    testString: assert.strictEqual(euler450(), 583333163984220900, '<code>euler450()</code> should return 583333163984220900.');
+    testString: assert.strictEqual(euler450(), 583333163984220900);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-451-modular-inverses.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-451-modular-inverses.english.md
@@ -35,7 +35,7 @@ Find ∑I(n) for 3≤n≤2·107
 ```yml
 tests:
   - text: <code>euler451()</code> should return 153651073760956.
-    testString: assert.strictEqual(euler451(), 153651073760956, '<code>euler451()</code> should return 153651073760956.');
+    testString: assert.strictEqual(euler451(), 153651073760956);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-452-long-products.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-452-long-products.english.md
@@ -23,7 +23,7 @@ Find F(109, 109) mod 1 234 567 891.
 ```yml
 tests:
   - text: <code>euler452()</code> should return 345558983.
-    testString: assert.strictEqual(euler452(), 345558983, '<code>euler452()</code> should return 345558983.');
+    testString: assert.strictEqual(euler452(), 345558983);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-453-lattice-quadrilaterals.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-453-lattice-quadrilaterals.english.md
@@ -28,7 +28,7 @@ Find Q(12345, 6789) mod 135707531.
 ```yml
 tests:
   - text: <code>euler453()</code> should return 104354107.
-    testString: assert.strictEqual(euler453(), 104354107, '<code>euler453()</code> should return 104354107.');
+    testString: assert.strictEqual(euler453(), 104354107);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-454-diophantine-reciprocals-iii.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-454-diophantine-reciprocals-iii.english.md
@@ -31,7 +31,7 @@ Find F(1012).
 ```yml
 tests:
   - text: <code>euler454()</code> should return 5435004633092.
-    testString: assert.strictEqual(euler454(), 5435004633092, '<code>euler454()</code> should return 5435004633092.');
+    testString: assert.strictEqual(euler454(), 5435004633092);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-455-powers-with-trailing-digits.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-455-powers-with-trailing-digits.english.md
@@ -28,7 +28,7 @@ Find Σf(n), 2 ≤ n ≤ 106.
 ```yml
 tests:
   - text: <code>euler455()</code> should return 450186511399999.
-    testString: assert.strictEqual(euler455(), 450186511399999, '<code>euler455()</code> should return 450186511399999.');
+    testString: assert.strictEqual(euler455(), 450186511399999);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-456-triangles-containing-the-origin-ii.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-456-triangles-containing-the-origin-ii.english.md
@@ -35,7 +35,7 @@ Find C(2 000 000).
 ```yml
 tests:
   - text: <code>euler456()</code> should return 333333208685971500.
-    testString: assert.strictEqual(euler456(), 333333208685971500, '<code>euler456()</code> should return 333333208685971500.');
+    testString: assert.strictEqual(euler456(), 333333208685971500);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-457-a-polynomial-modulo-the-square-of-a-prime.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-457-a-polynomial-modulo-the-square-of-a-prime.english.md
@@ -28,7 +28,7 @@ Find SR(107).
 ```yml
 tests:
   - text: <code>euler457()</code> should return 2647787126797397000.
-    testString: assert.strictEqual(euler457(), 2647787126797397000, '<code>euler457()</code> should return 2647787126797397000.');
+    testString: assert.strictEqual(euler457(), 2647787126797397000);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-458-permutations-of-project.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-458-permutations-of-project.english.md
@@ -26,7 +26,7 @@ Find T(1012). Give the last 9 digits of your answer.
 ```yml
 tests:
   - text: <code>euler458()</code> should return 423341841.
-    testString: assert.strictEqual(euler458(), 423341841, '<code>euler458()</code> should return 423341841.');
+    testString: assert.strictEqual(euler458(), 423341841);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-459-flipping-game.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-459-flipping-game.english.md
@@ -40,7 +40,7 @@ Find W(106).
 ```yml
 tests:
   - text: <code>euler459()</code> should return 3996390106631.
-    testString: assert.strictEqual(euler459(), 3996390106631, '<code>euler459()</code> should return 3996390106631.');
+    testString: assert.strictEqual(euler459(), 3996390106631);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-46-goldbachs-other-conjecture.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-46-goldbachs-other-conjecture.english.md
@@ -28,7 +28,7 @@ What is the smallest odd composite that cannot be written as the sum of a prime 
 ```yml
 tests:
   - text: <code>goldbachsOtherConjecture()</code> should return 5777.
-    testString: assert.strictEqual(goldbachsOtherConjecture(), 5777, '<code>goldbachsOtherConjecture()</code> should return 5777.');
+    testString: assert.strictEqual(goldbachsOtherConjecture(), 5777);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-460-an-ant-on-the-move.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-460-an-ant-on-the-move.english.md
@@ -40,7 +40,7 @@ Find F(10000). Give your answer rounded to nine decimal places.
 ```yml
 tests:
   - text: <code>euler460()</code> should return 18.420738199.
-    testString: assert.strictEqual(euler460(), 18.420738199, '<code>euler460()</code> should return 18.420738199.');
+    testString: assert.strictEqual(euler460(), 18.420738199);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-461-almost-pi.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-461-almost-pi.english.md
@@ -26,7 +26,7 @@ Find g(10000).
 ```yml
 tests:
   - text: <code>euler461()</code> should return 159820276.
-    testString: assert.strictEqual(euler461(), 159820276, '<code>euler461()</code> should return 159820276.');
+    testString: assert.strictEqual(euler461(), 159820276);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-462-permutation-of-3-smooth-numbers.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-462-permutation-of-3-smooth-numbers.english.md
@@ -34,7 +34,7 @@ When giving your answer, use a lowercase e to separate mantissa and exponent. E.
 ```yml
 tests:
   - text: <code>euler462()</code> should return Infinity.
-    testString: assert.strictEqual(euler462(), Infinity, '<code>euler462()</code> should return Infinity.');
+    testString: assert.strictEqual(euler462(), Infinity);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-463-a-weird-recurrence-relation.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-463-a-weird-recurrence-relation.english.md
@@ -29,7 +29,7 @@ Find $S(3^{37})$. Give the last 9 digits of your answer.
 ```yml
 tests:
   - text: <code>euler463()</code> should return 808981553.
-    testString: assert.strictEqual(euler463(), 808981553, '<code>euler463()</code> should return 808981553.');
+    testString: assert.strictEqual(euler463(), 808981553);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-464-mbius-function-and-intervals.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-464-mbius-function-and-intervals.english.md
@@ -39,7 +39,7 @@ Find C(20 000 000).
 ```yml
 tests:
   - text: <code>euler464()</code> should return 198775297232878.
-    testString: assert.strictEqual(euler464(), 198775297232878, '<code>euler464()</code> should return 198775297232878.');
+    testString: assert.strictEqual(euler464(), 198775297232878);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-465-polar-polygons.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-465-polar-polygons.english.md
@@ -36,7 +36,7 @@ Find P(713) mod 1 000 000 007.
 ```yml
 tests:
   - text: <code>euler465()</code> should return 585965659.
-    testString: assert.strictEqual(euler465(), 585965659, '<code>euler465()</code> should return 585965659.');
+    testString: assert.strictEqual(euler465(), 585965659);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-466-distinct-terms-in-a-multiplication-table.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-466-distinct-terms-in-a-multiplication-table.english.md
@@ -35,7 +35,7 @@ Find P(64,1016).
 ```yml
 tests:
   - text: <code>euler466()</code> should return 258381958195474750.
-    testString: assert.strictEqual(euler466(), 258381958195474750, '<code>euler466()</code> should return 258381958195474750.');
+    testString: assert.strictEqual(euler466(), 258381958195474750);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-467-superinteger.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-467-superinteger.english.md
@@ -38,7 +38,7 @@ Find f(10 000) mod 1 000 000 007.
 ```yml
 tests:
   - text: <code>euler467()</code> should return 775181359.
-    testString: assert.strictEqual(euler467(), 775181359, '<code>euler467()</code> should return 775181359.');
+    testString: assert.strictEqual(euler467(), 775181359);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-468-smooth-divisors-of-binomial-coefficients.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-468-smooth-divisors-of-binomial-coefficients.english.md
@@ -34,7 +34,7 @@ Find F(11 111 111) mod 1 000 000 993.
 ```yml
 tests:
   - text: <code>euler468()</code> should return 852950321.
-    testString: assert.strictEqual(euler468(), 852950321, '<code>euler468()</code> should return 852950321.');
+    testString: assert.strictEqual(euler468(), 852950321);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-469-empty-chairs.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-469-empty-chairs.english.md
@@ -30,7 +30,7 @@ Find E(1018). Give your answer rounded to fourteen decimal places in the form 0.
 ```yml
 tests:
   - text: <code>euler469()</code> should return 0.56766764161831.
-    testString: assert.strictEqual(euler469(), 0.56766764161831, '<code>euler469()</code> should return 0.56766764161831.');
+    testString: assert.strictEqual(euler469(), 0.56766764161831);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-47-distinct-primes-factors.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-47-distinct-primes-factors.english.md
@@ -27,11 +27,11 @@ Find the first four consecutive integers to have four distinct prime factors eac
 ```yml
 tests:
   - text: <code>distinctPrimeFactors(2, 2)</code> should return 14.
-    testString: assert.strictEqual(distinctPrimeFactors(2, 2), 14, '<code>distinctPrimeFactors(2, 2)</code> should return 14.');
+    testString: assert.strictEqual(distinctPrimeFactors(2, 2), 14);
   - text: <code>distinctPrimeFactors(3, 3)</code> should return 644.
-    testString: assert.strictEqual(distinctPrimeFactors(3, 3), 644, '<code>distinctPrimeFactors(3, 3)</code> should return 644.');
+    testString: assert.strictEqual(distinctPrimeFactors(3, 3), 644);
   - text: <code>distinctPrimeFactors(4, 4)</code> should return 134043.
-    testString: assert.strictEqual(distinctPrimeFactors(4, 4), 134043, '<code>distinctPrimeFactors(4, 4)</code> should return 134043.');
+    testString: assert.strictEqual(distinctPrimeFactors(4, 4), 134043);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-470-super-ramvok.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-470-super-ramvok.english.md
@@ -32,7 +32,7 @@ Calculate F(20), rounded to the nearest integer.
 ```yml
 tests:
   - text: <code>euler470()</code> should return 147668794.
-    testString: assert.strictEqual(euler470(), 147668794, '<code>euler470()</code> should return 147668794.');
+    testString: assert.strictEqual(euler470(), 147668794);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-471-triangle-inscribed-in-ellipse.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-471-triangle-inscribed-in-ellipse.english.md
@@ -29,7 +29,7 @@ For G(10) the answer would have been 2.059722222e1.
 ```yml
 tests:
   - text: <code>euler471()</code> should return 1.895093981e+31.
-    testString: assert.strictEqual(euler471(), 1.895093981e+31, '<code>euler471()</code> should return 1.895093981e+31.');
+    testString: assert.strictEqual(euler471(), 1.895093981e+31);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-472-comfortable-distance-ii.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-472-comfortable-distance-ii.english.md
@@ -37,7 +37,7 @@ Find ∑f(N) for 1 ≤ N ≤ 1012. Give the last 8 digits of your answer.
 ```yml
 tests:
   - text: <code>euler472()</code> should return 73811586.
-    testString: assert.strictEqual(euler472(), 73811586, '<code>euler472()</code> should return 73811586.');
+    testString: assert.strictEqual(euler472(), 73811586);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-473-phigital-number-base.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-473-phigital-number-base.english.md
@@ -37,7 +37,7 @@ Find the sum of the positive integers not exceeding $10^{10}$ whose phigital rep
 ```yml
 tests:
   - text: <code>euler473()</code> should return 35856681704365.
-    testString: assert.strictEqual(euler473(), 35856681704365, '<code>euler473()</code> should return 35856681704365.');
+    testString: assert.strictEqual(euler473(), 35856681704365);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-474-last-digits-of-divisors.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-474-last-digits-of-divisors.english.md
@@ -27,7 +27,7 @@ Find F(106!, 65432) modulo (1016 + 61).
 ```yml
 tests:
   - text: <code>euler474()</code> should return 9690646731515010.
-    testString: assert.strictEqual(euler474(), 9690646731515010, '<code>euler474()</code> should return 9690646731515010.');
+    testString: assert.strictEqual(euler474(), 9690646731515010);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-475-music-festival.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-475-music-festival.english.md
@@ -27,7 +27,7 @@ Find f(600) mod 1 000 000 007.
 ```yml
 tests:
   - text: <code>euler475()</code> should return 75780067.
-    testString: assert.strictEqual(euler475(), 75780067, '<code>euler475()</code> should return 75780067.');
+    testString: assert.strictEqual(euler475(), 75780067);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-476-circle-packing-ii.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-476-circle-packing-ii.english.md
@@ -23,7 +23,7 @@ Find S(1803) rounded to 5 decimal places behind the decimal point.
 ```yml
 tests:
   - text: <code>euler476()</code> should return 110242.87794.
-    testString: assert.strictEqual(euler476(), 110242.87794, '<code>euler476()</code> should return 110242.87794.');
+    testString: assert.strictEqual(euler476(), 110242.87794);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-477-number-sequence-game.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-477-number-sequence-game.english.md
@@ -34,7 +34,7 @@ Find F(108).
 ```yml
 tests:
   - text: <code>euler477()</code> should return 25044905874565164.
-    testString: assert.strictEqual(euler477(), 25044905874565164, '<code>euler477()</code> should return 25044905874565164.');
+    testString: assert.strictEqual(euler477(), 25044905874565164);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-478-mixtures.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-478-mixtures.english.md
@@ -40,7 +40,7 @@ Find E(10 000 000) mod 118.
 ```yml
 tests:
   - text: <code>euler478()</code> should return 59510340.
-    testString: assert.strictEqual(euler478(), 59510340, '<code>euler478()</code> should return 59510340.');
+    testString: assert.strictEqual(euler478(), 59510340);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-479-roots-on-the-rise.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-479-roots-on-the-rise.english.md
@@ -28,7 +28,7 @@ Find S(106) modulo 1 000 000 007.
 ```yml
 tests:
   - text: <code>euler479()</code> should return 191541795.
-    testString: assert.strictEqual(euler479(), 191541795, '<code>euler479()</code> should return 191541795.');
+    testString: assert.strictEqual(euler479(), 191541795);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-48-self-powers.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-48-self-powers.english.md
@@ -21,13 +21,13 @@ Find the last ten digits of the series, 1<sup>1</sup> + 2<sup>2</sup> + 3<sup>3<
 ```yml
 tests:
   - text: <code>selfPowers(10, 3)</code> should return 317.
-    testString: assert.strictEqual(selfPowers(10, 3), 317, '<code>selfPowers(10, 3)</code> should return 317.');
+    testString: assert.strictEqual(selfPowers(10, 3), 317);
   - text: <code>selfPowers(150, 6)</code> should return 29045.
-    testString: assert.strictEqual(selfPowers(150, 6), 29045, '<code>selfPowers(150, 6)</code> should return 29045.');
+    testString: assert.strictEqual(selfPowers(150, 6), 29045);
   - text: <code>selfPowers(673, 7)</code> should return 2473989.
-    testString: assert.strictEqual(selfPowers(673, 7), 2473989, '<code>selfPowers(673, 7)</code> should return 2473989.');
+    testString: assert.strictEqual(selfPowers(673, 7), 2473989);
   - text: <code>selfPowers(1000, 10)</code> should return 9110846700.
-    testString: assert.strictEqual(selfPowers(1000, 10), 9110846700, '<code>selfPowers(1000, 10)</code> should return 9110846700.');
+    testString: assert.strictEqual(selfPowers(1000, 10), 9110846700);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-480-the-last-question.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-480-the-last-question.english.md
@@ -58,7 +58,7 @@ Give your answer using lowercase characters (no punctuation or space).
 ```yml
 tests:
   - text: <code>euler480()</code> should return turnthestarson.
-    testString: assert.strictEqual(euler480(), turnthestarson, '<code>euler480()</code> should return turnthestarson.');
+    testString: assert.strictEqual(euler480(), turnthestarson);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-49-prime-permutations.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-49-prime-permutations.english.md
@@ -22,7 +22,7 @@ What 12-digit number do you form by concatenating the three terms in this sequen
 ```yml
 tests:
   - text: <code>primePermutations()</code> should return 296962999629.
-    testString: assert.strictEqual(primePermutations(), 296962999629, '<code>primePermutations()</code> should return 296962999629.');
+    testString: assert.strictEqual(primePermutations(), 296962999629);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-5-smallest-multiple.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-5-smallest-multiple.english.md
@@ -21,15 +21,15 @@ What is the smallest positive number that is evenly divisible by all of the numb
 ```yml
 tests:
   - text: <code>smallestMult(5)</code> should return 60.
-    testString: assert.strictEqual(smallestMult(5), 60, '<code>smallestMult(5)</code> should return 60.');
+    testString: assert.strictEqual(smallestMult(5), 60);
   - text: <code>smallestMult(7)</code> should return 420.
-    testString: assert.strictEqual(smallestMult(7), 420, '<code>smallestMult(7)</code> should return 420.');
+    testString: assert.strictEqual(smallestMult(7), 420);
   - text: <code>smallestMult(10)</code> should return 2520.
-    testString: assert.strictEqual(smallestMult(10), 2520, '<code>smallestMult(10)</code> should return 2520.');
+    testString: assert.strictEqual(smallestMult(10), 2520);
   - text: <code>smallestMult(13)</code> should return 360360.
-    testString: assert.strictEqual(smallestMult(13), 360360, '<code>smallestMult(13)</code> should return 360360.');
+    testString: assert.strictEqual(smallestMult(13), 360360);
   - text: <code>smallestMult(20)</code> should return 232792560.
-    testString: assert.strictEqual(smallestMult(20), 232792560, '<code>smallestMult(20)</code> should return 232792560.');
+    testString: assert.strictEqual(smallestMult(20), 232792560);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-50-consecutive-prime-sum.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-50-consecutive-prime-sum.english.md
@@ -24,9 +24,9 @@ Which prime, below one-million, can be written as the sum of the most consecutiv
 ```yml
 tests:
   - text: <code>consecutivePrimeSum(1000)</code> should return 953.
-    testString: assert.strictEqual(consecutivePrimeSum(1000), 953, '<code>consecutivePrimeSum(1000)</code> should return 953.');
+    testString: assert.strictEqual(consecutivePrimeSum(1000), 953);
   - text: <code>consecutivePrimeSum(1000000)</code> should return 997651.
-    testString: assert.strictEqual(consecutivePrimeSum(1000000), 997651, '<code>consecutivePrimeSum(1000000)</code> should return 997651.');
+    testString: assert.strictEqual(consecutivePrimeSum(1000000), 997651);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-51-prime-digit-replacements.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-51-prime-digit-replacements.english.md
@@ -22,7 +22,7 @@ Find the smallest prime which, by replacing part of the number (not necessarily 
 ```yml
 tests:
   - text: <code>euler51()</code> should return 121313.
-    testString: assert.strictEqual(euler51(), 121313, '<code>euler51()</code> should return 121313.');
+    testString: assert.strictEqual(euler51(), 121313);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-52-permuted-multiples.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-52-permuted-multiples.english.md
@@ -21,7 +21,7 @@ Find the smallest positive integer, x, such that 2x, 3x, 4x, 5x, and 6x, contain
 ```yml
 tests:
   - text: <code>permutedMultiples()</code> should return 142857.
-    testString: assert.strictEqual(permutedMultiples(), 142857, '<code>permutedMultiples()</code> should return 142857.');
+    testString: assert.strictEqual(permutedMultiples(), 142857);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-53-combinatoric-selections.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-53-combinatoric-selections.english.md
@@ -30,13 +30,13 @@ How many, not necessarily distinct, values of  nCr, for 1 ≤ n ≤ 100, are gr
 ```yml
 tests:
   - text: <code>combinatoricSelections(1000)</code> should return 4626.
-    testString: assert.strictEqual(combinatoricSelections(1000), 4626, '<code>combinatoricSelections(1000)</code> should return 4626.');
+    testString: assert.strictEqual(combinatoricSelections(1000), 4626);
   - text: <code>combinatoricSelections(10000)</code> should return 4431.
-    testString: assert.strictEqual(combinatoricSelections(10000), 4431, '<code>combinatoricSelections(10000)</code> should return 4431.');
+    testString: assert.strictEqual(combinatoricSelections(10000), 4431);
   - text: <code>combinatoricSelections(100000)</code> should return 4255.
-    testString: assert.strictEqual(combinatoricSelections(100000), 4255, '<code>combinatoricSelections(100000)</code> should return 4255.');
+    testString: assert.strictEqual(combinatoricSelections(100000), 4255);
   - text: <code>combinatoricSelections(1000000)</code> should return 4075.
-    testString: assert.strictEqual(combinatoricSelections(1000000), 4075, '<code>combinatoricSelections(1000000)</code> should return 4075.');
+    testString: assert.strictEqual(combinatoricSelections(1000000), 4075);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-54-poker-hands.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-54-poker-hands.english.md
@@ -43,7 +43,7 @@ How many hands does Player 1 win?
 ```yml
 tests:
   - text: <code>euler54()</code> should return 376.
-    testString: assert.strictEqual(euler54(), 376, '<code>euler54()</code> should return 376.');
+    testString: assert.strictEqual(euler54(), 376);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-55-lychrel-numbers.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-55-lychrel-numbers.english.md
@@ -29,15 +29,15 @@ NOTE: Wording was modified slightly on 24 April 2007 to emphasise the theoretica
 ```yml
 tests:
   - text: <code>countLychrelNumbers(1000)</code> should return 13.
-    testString: assert.strictEqual(countLychrelNumbers(1000), 13, '<code>countLychrelNumbers(1000)</code> should return 13.');
+    testString: assert.strictEqual(countLychrelNumbers(1000), 13);
   - text: <code>countLychrelNumbers(5000)</code> should return 76.
-    testString: assert.strictEqual(countLychrelNumbers(5000), 76, '<code>countLychrelNumbers(5000)</code> should return 76.');
+    testString: assert.strictEqual(countLychrelNumbers(5000), 76);
   - text: <code>countLychrelNumbers(10000)</code> should return 249.
-    testString: assert.strictEqual(countLychrelNumbers(10000), 249, '<code>countLychrelNumbers(10000)</code> should return 249.');
+    testString: assert.strictEqual(countLychrelNumbers(10000), 249);
   - text: Your function should count all Lychrel numbers.
-    testString: assert.strictEqual(countLychrelNumbers(3243), 39, 'Your function should count all Lychrel numbers.');
+    testString: assert.strictEqual(countLychrelNumbers(3243), 39);
   - text: Your function should pass all test cases.
-    testString: assert.strictEqual(countLychrelNumbers(7654), 140, 'Your function should pass all test cases.');
+    testString: assert.strictEqual(countLychrelNumbers(7654), 140);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-56-powerful-digit-sum.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-56-powerful-digit-sum.english.md
@@ -21,7 +21,7 @@ Considering natural numbers of the form, ab, where a, b < 100, what is the maxim
 ```yml
 tests:
   - text: <code>euler56()</code> should return 972.
-    testString: assert.strictEqual(euler56(), 972, '<code>euler56()</code> should return 972.');
+    testString: assert.strictEqual(euler56(), 972);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-57-square-root-convergents.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-57-square-root-convergents.english.md
@@ -28,7 +28,7 @@ In the first one-thousand expansions, how many fractions contain a numerator wit
 ```yml
 tests:
   - text: <code>euler57()</code> should return 153.
-    testString: assert.strictEqual(euler57(), 153, '<code>euler57()</code> should return 153.');
+    testString: assert.strictEqual(euler57(), 153);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-58-spiral-primes.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-58-spiral-primes.english.md
@@ -28,7 +28,7 @@ If one complete new layer is wrapped around the spiral above, a square spiral wi
 ```yml
 tests:
   - text: <code>euler58()</code> should return 26241.
-    testString: assert.strictEqual(euler58(), 26241, '<code>euler58()</code> should return 26241.');
+    testString: assert.strictEqual(euler58(), 26241);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-59-xor-decryption.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-59-xor-decryption.english.md
@@ -24,7 +24,7 @@ Your task has been made easy, as the encryption key consists of three lower case
 ```yml
 tests:
   - text: <code>euler59()</code> should return 107359.
-    testString: assert.strictEqual(euler59(), 107359, '<code>euler59()</code> should return 107359.');
+    testString: assert.strictEqual(euler59(), 107359);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-6-sum-square-difference.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-6-sum-square-difference.english.md
@@ -25,11 +25,11 @@ Find the difference between the sum of the squares of the first <code>n</code> n
 ```yml
 tests:
   - text: <code>sumSquareDifference(10)</code> should return 2640.
-    testString: assert.strictEqual(sumSquareDifference(10), 2640, '<code>sumSquareDifference(10)</code> should return 2640.');
+    testString: assert.strictEqual(sumSquareDifference(10), 2640);
   - text: <code>sumSquareDifference(20)</code> should return 41230.
-    testString: assert.strictEqual(sumSquareDifference(20), 41230, '<code>sumSquareDifference(20)</code> should return 41230.');
+    testString: assert.strictEqual(sumSquareDifference(20), 41230);
   - text: <code>sumSquareDifference(100)</code> should return 25164150.
-    testString: assert.strictEqual(sumSquareDifference(100), 25164150, '<code>sumSquareDifference(100)</code> should return 25164150.');
+    testString: assert.strictEqual(sumSquareDifference(100), 25164150);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-60-prime-pair-sets.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-60-prime-pair-sets.english.md
@@ -21,7 +21,7 @@ Find the lowest sum for a set of five primes for which any two primes concatenat
 ```yml
 tests:
   - text: <code>euler60()</code> should return 26033.
-    testString: assert.strictEqual(euler60(), 26033, '<code>euler60()</code> should return 26033.');
+    testString: assert.strictEqual(euler60(), 26033);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-61-cyclical-figurate-numbers.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-61-cyclical-figurate-numbers.english.md
@@ -55,7 +55,7 @@ Find the sum of the only ordered set of six cyclic 4-digit numbers for which eac
 ```yml
 tests:
   - text: <code>euler61()</code> should return 28684.
-    testString: assert.strictEqual(euler61(), 28684, '<code>euler61()</code> should return 28684.');
+    testString: assert.strictEqual(euler61(), 28684);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-62-cubic-permutations.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-62-cubic-permutations.english.md
@@ -21,7 +21,7 @@ Find the smallest cube for which exactly five permutations of its digits are cub
 ```yml
 tests:
   - text: <code>euler62()</code> should return 127035954683.
-    testString: assert.strictEqual(euler62(), 127035954683, '<code>euler62()</code> should return 127035954683.');
+    testString: assert.strictEqual(euler62(), 127035954683);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-63-powerful-digit-counts.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-63-powerful-digit-counts.english.md
@@ -21,7 +21,7 @@ How many n-digit positive integers exist which are also an nth power?
 ```yml
 tests:
   - text: <code>euler63()</code> should return 49.
-    testString: assert.strictEqual(euler63(), 49, '<code>euler63()</code> should return 49.');
+    testString: assert.strictEqual(euler63(), 49);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-64-odd-period-square-roots.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-64-odd-period-square-roots.english.md
@@ -143,7 +143,7 @@ How many continued fractions for N ≤ 10000 have an odd period?
 ```yml
 tests:
   - text: <code>euler64()</code> should return 1322.
-    testString: assert.strictEqual(euler64(), 1322, '<code>euler64()</code> should return 1322.');
+    testString: assert.strictEqual(euler64(), 1322);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-65-convergents-of-e.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-65-convergents-of-e.english.md
@@ -109,7 +109,7 @@ Find the sum of digits in the numerator of the 100th convergent of the continued
 ```yml
 tests:
   - text: <code>euler65()</code> should return 272.
-    testString: assert.strictEqual(euler65(), 272, '<code>euler65()</code> should return 272.');
+    testString: assert.strictEqual(euler65(), 272);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-66-diophantine-equation.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-66-diophantine-equation.english.md
@@ -30,7 +30,7 @@ Find the value of D ≤ 1000 in minimal solutions of x for which the largest val
 ```yml
 tests:
   - text: <code>euler66()</code> should return 661.
-    testString: assert.strictEqual(euler66(), 661, '<code>euler66()</code> should return 661.');
+    testString: assert.strictEqual(euler66(), 661);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-67-maximum-path-sum-ii.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-67-maximum-path-sum-ii.english.md
@@ -26,7 +26,7 @@ NOTE: This is a much more difficult version of Problem 18. It is not possible to
 ```yml
 tests:
   - text: <code>euler67()</code> should return 7273.
-    testString: assert.strictEqual(euler67(), 7273, '<code>euler67()</code> should return 7273.');
+    testString: assert.strictEqual(euler67(), 7273);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-68-magic-5-gon-ring.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-68-magic-5-gon-ring.english.md
@@ -37,7 +37,7 @@ Using the numbers 1 to 10, and depending on arrangements, it is possible to form
 ```yml
 tests:
   - text: <code>euler68()</code> should return 6531031914842725.
-    testString: assert.strictEqual(euler68(), 6531031914842725, '<code>euler68()</code> should return 6531031914842725.');
+    testString: assert.strictEqual(euler68(), 6531031914842725);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-69-totient-maximum.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-69-totient-maximum.english.md
@@ -64,7 +64,7 @@ Find the value of n ≤ 1,000,000 for which n/φ(n) is a maximum.
 ```yml
 tests:
   - text: <code>euler69()</code> should return 510510.
-    testString: assert.strictEqual(euler69(), 510510, '<code>euler69()</code> should return 510510.');
+    testString: assert.strictEqual(euler69(), 510510);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-7-10001st-prime.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-7-10001st-prime.english.md
@@ -21,15 +21,15 @@ What is the <code>n</code>th prime number?
 ```yml
 tests:
   - text: <code>nthPrime(6)</code> should return 13.
-    testString: assert.strictEqual(nthPrime(6), 13, '<code>nthPrime(6)</code> should return 13.');
+    testString: assert.strictEqual(nthPrime(6), 13);
   - text: <code>nthPrime(10)</code> should return 29.
-    testString: assert.strictEqual(nthPrime(10), 29, '<code>nthPrime(10)</code> should return 29.');
+    testString: assert.strictEqual(nthPrime(10), 29);
   - text: <code>nthPrime(100)</code> should return 541.
-    testString: assert.strictEqual(nthPrime(100), 541, '<code>nthPrime(100)</code> should return 541.');
+    testString: assert.strictEqual(nthPrime(100), 541);
   - text: <code>nthPrime(1000)</code> should return 7919.
-    testString: assert.strictEqual(nthPrime(1000), 7919, '<code>nthPrime(1000)</code> should return 7919.');
+    testString: assert.strictEqual(nthPrime(1000), 7919);
   - text: <code>nthPrime(10001)</code> should return 104743.
-    testString: assert.strictEqual(nthPrime(10001), 104743, '<code>nthPrime(10001)</code> should return 104743.');
+    testString: assert.strictEqual(nthPrime(10001), 104743);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-70-totient-permutation.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-70-totient-permutation.english.md
@@ -22,7 +22,7 @@ Find the value of n, 1 < n < 107, for which φ(n) is a permutation of n and the 
 ```yml
 tests:
   - text: <code>euler70()</code> should return 8319823.
-    testString: assert.strictEqual(euler70(), 8319823, '<code>euler70()</code> should return 8319823.');
+    testString: assert.strictEqual(euler70(), 8319823);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-71-ordered-fractions.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-71-ordered-fractions.english.md
@@ -24,7 +24,7 @@ By listing the set of reduced proper fractions for d ≤ 1,000,000 in ascending 
 ```yml
 tests:
   - text: <code>euler71()</code> should return 428570.
-    testString: assert.strictEqual(euler71(), 428570, '<code>euler71()</code> should return 428570.');
+    testString: assert.strictEqual(euler71(), 428570);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-72-counting-fractions.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-72-counting-fractions.english.md
@@ -24,7 +24,7 @@ How many elements would be contained in the set of reduced proper fractions for 
 ```yml
 tests:
   - text: <code>euler72()</code> should return 303963552391.
-    testString: assert.strictEqual(euler72(), 303963552391, '<code>euler72()</code> should return 303963552391.');
+    testString: assert.strictEqual(euler72(), 303963552391);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-73-counting-fractions-in-a-range.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-73-counting-fractions-in-a-range.english.md
@@ -24,7 +24,7 @@ How many fractions lie between 1/3 and 1/2 in the sorted set of reduced proper f
 ```yml
 tests:
   - text: <code>euler73()</code> should return 7295372.
-    testString: assert.strictEqual(euler73(), 7295372, '<code>euler73()</code> should return 7295372.');
+    testString: assert.strictEqual(euler73(), 7295372);
 
 ```
 


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Related to issue #36400

This PR removes assert message arguments from `testString` for another 75 `Project Euler` challenges in the `Coding Interview Prep` curriculum section.
