### PR TITLE
fix(curriculum): Remove unnecessary assert message argument from English Coding Interview Prep challenges - Project Euler - 07

### DIFF
--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-162-hexadecimal-numbers.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-162-hexadecimal-numbers.english.md
@@ -27,7 +27,7 @@ Give your answer as a hexadecimal number.
 ```yml
 tests:
   - text: <code>euler162()</code> should return 3D58725572C62302.
-    testString: assert.strictEqual(euler162(), '3D58725572C62302', '<code>euler162()</code> should return 3D58725572C62302.');
+    testString: assert.strictEqual(euler162(), '3D58725572C62302');
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-284-steady-squares.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-284-steady-squares.english.md
@@ -27,7 +27,7 @@ Find the sum of the digits of all the n-digit steady squares in the base 14 numb
 ```yml
 tests:
   - text: <code>euler284()</code> should return 5a411d7b.
-    testString: assert.strictEqual(euler284(), '5a411d7b', '<code>euler284()</code> should return 5a411d7b.');
+    testString: assert.strictEqual(euler284(), '5a411d7b');
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-74-digit-factorial-chains.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-74-digit-factorial-chains.english.md
@@ -31,7 +31,7 @@ How many chains, with a starting number below one million, contain exactly sixty
 ```yml
 tests:
   - text: <code>euler74()</code> should return 402.
-    testString: assert.strictEqual(euler74(), 402, '<code>euler74()</code> should return 402.');
+    testString: assert.strictEqual(euler74(), 402);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-75-singular-integer-right-triangles.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-75-singular-integer-right-triangles.english.md
@@ -24,7 +24,7 @@ Given that L is the length of the wire, for how many values of L ≤ 1,500,000 c
 ```yml
 tests:
   - text: <code>euler75()</code> should return 161667.
-    testString: assert.strictEqual(euler75(), 161667, '<code>euler75()</code> should return 161667.');
+    testString: assert.strictEqual(euler75(), 161667);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-76-counting-summations.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-76-counting-summations.english.md
@@ -27,7 +27,7 @@ How many different ways can one hundred be written as a sum of at least two posi
 ```yml
 tests:
   - text: <code>euler76()</code> should return 190569291.
-    testString: assert.strictEqual(euler76(), 190569291, '<code>euler76()</code> should return 190569291.');
+    testString: assert.strictEqual(euler76(), 190569291);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-77-prime-summations.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-77-prime-summations.english.md
@@ -26,7 +26,7 @@ What is the first value which can be written as the sum of primes in over five t
 ```yml
 tests:
   - text: <code>euler77()</code> should return 71.
-    testString: assert.strictEqual(euler77(), 71, '<code>euler77()</code> should return 71.');
+    testString: assert.strictEqual(euler77(), 71);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-78-coin-partitions.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-78-coin-partitions.english.md
@@ -30,7 +30,7 @@ Find the least value of n for which p(n) is divisible by one million.
 ```yml
 tests:
   - text: <code>euler78()</code> should return 55374.
-    testString: assert.strictEqual(euler78(), 55374, '<code>euler78()</code> should return 55374.');
+    testString: assert.strictEqual(euler78(), 55374);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-79-passcode-derivation.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-79-passcode-derivation.english.md
@@ -22,7 +22,7 @@ Given that the three characters are always asked for in order, analyse the file 
 ```yml
 tests:
   - text: <code>euler79()</code> should return 73162890.
-    testString: assert.strictEqual(euler79(), 73162890, '<code>euler79()</code> should return 73162890.');
+    testString: assert.strictEqual(euler79(), 73162890);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-8-largest-product-in-a-series.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-8-largest-product-in-a-series.english.md
@@ -42,9 +42,9 @@ Find the <code>n</code> adjacent digits in the 1000-digit number that have the g
 ```yml
 tests:
   - text: <code>largestProductinaSeries(4)</code> should return 5832.
-    testString: assert.strictEqual(largestProductinaSeries(4), 5832, '<code>largestProductinaSeries(4)</code> should return 5832.');
+    testString: assert.strictEqual(largestProductinaSeries(4), 5832);
   - text: <code>largestProductinaSeries(13)</code> should return 23514624000.
-    testString: assert.strictEqual(largestProductinaSeries(13), 23514624000, '<code>largestProductinaSeries(13)</code> should return 23514624000.');
+    testString: assert.strictEqual(largestProductinaSeries(13), 23514624000);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-80-square-root-digital-expansion.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-80-square-root-digital-expansion.english.md
@@ -22,7 +22,7 @@ For the first one hundred natural numbers, find the total of the digital sums of
 ```yml
 tests:
   - text: <code>euler80()</code> should return 40886.
-    testString: assert.strictEqual(euler80(), 40886, '<code>euler80()</code> should return 40886.');
+    testString: assert.strictEqual(euler80(), 40886);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-81-path-sum-two-ways.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-81-path-sum-two-ways.english.md
@@ -32,7 +32,7 @@ Find the minimal path sum, in matrix.txt (right click and "Save Link/Target As..
 ```yml
 tests:
   - text: <code>euler81()</code> should return 427337.
-    testString: assert.strictEqual(euler81(), 427337, '<code>euler81()</code> should return 427337.');
+    testString: assert.strictEqual(euler81(), 427337);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-82-path-sum-three-ways.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-82-path-sum-three-ways.english.md
@@ -33,7 +33,7 @@ Find the minimal path sum, in matrix.txt (right click and "Save Link/Target As..
 ```yml
 tests:
   - text: <code>euler82()</code> should return 260324.
-    testString: assert.strictEqual(euler82(), 260324, '<code>euler82()</code> should return 260324.');
+    testString: assert.strictEqual(euler82(), 260324);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-83-path-sum-four-ways.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-83-path-sum-four-ways.english.md
@@ -34,7 +34,7 @@ Find the minimal path sum, in matrix.txt (right click and
 ```yml
 tests:
   - text: <code>euler83()</code> should return 425185.
-    testString: assert.strictEqual(euler83(), 425185, '<code>euler83()</code> should return 425185.');
+    testString: assert.strictEqual(euler83(), 425185);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-84-monopoly-odds.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-84-monopoly-odds.english.md
@@ -94,7 +94,7 @@ If, instead of using two 6-sided dice, two 4-sided dice are used, find the six-d
 ```yml
 tests:
   - text: <code>euler84()</code> should return 101524.
-    testString: assert.strictEqual(euler84(), 101524, '<code>euler84()</code> should return 101524.');
+    testString: assert.strictEqual(euler84(), 101524);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-85-counting-rectangles.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-85-counting-rectangles.english.md
@@ -23,7 +23,7 @@ Although there exists no rectangular grid that contains exactly two million rect
 ```yml
 tests:
   - text: <code>euler85()</code> should return 2772.
-    testString: assert.strictEqual(euler85(), 2772, '<code>euler85()</code> should return 2772.');
+    testString: assert.strictEqual(euler85(), 2772);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-86-cuboid-route.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-86-cuboid-route.english.md
@@ -25,7 +25,7 @@ Find the least value of M such that the number of solutions first exceeds one mi
 ```yml
 tests:
   - text: <code>euler86()</code> should return 1818.
-    testString: assert.strictEqual(euler86(), 1818, '<code>euler86()</code> should return 1818.');
+    testString: assert.strictEqual(euler86(), 1818);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-87-prime-power-triples.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-87-prime-power-triples.english.md
@@ -25,7 +25,7 @@ How many numbers below fifty million can be expressed as the sum of a prime squa
 ```yml
 tests:
   - text: <code>euler87()</code> should return 1097343.
-    testString: assert.strictEqual(euler87(), 1097343, '<code>euler87()</code> should return 1097343.');
+    testString: assert.strictEqual(euler87(), 1097343);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-88-product-sum-numbers.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-88-product-sum-numbers.english.md
@@ -26,7 +26,7 @@ What is the sum of all the minimal product-sum numbers for 2≤k≤12000?
 ```yml
 tests:
   - text: <code>euler88()</code> should return 7587457.
-    testString: assert.strictEqual(euler88(), 7587457, '<code>euler88()</code> should return 7587457.');
+    testString: assert.strictEqual(euler88(), 7587457);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-89-roman-numerals.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-89-roman-numerals.english.md
@@ -31,7 +31,7 @@ Note: You can assume that all the Roman numerals in the file contain no more tha
 ```yml
 tests:
   - text: <code>euler89()</code> should return 743.
-    testString: assert.strictEqual(euler89(), 743, '<code>euler89()</code> should return 743.');
+    testString: assert.strictEqual(euler89(), 743);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-90-cube-digit-pairs.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-90-cube-digit-pairs.english.md
@@ -40,7 +40,7 @@ How many distinct arrangements of the two cubes allow for all of the square numb
 ```yml
 tests:
   - text: <code>euler90()</code> should return 1217.
-    testString: assert.strictEqual(euler90(), 1217, '<code>euler90()</code> should return 1217.');
+    testString: assert.strictEqual(euler90(), 1217);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-91-right-triangles-with-integer-coordinates.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-91-right-triangles-with-integer-coordinates.english.md
@@ -30,7 +30,7 @@ Given that 0 ≤ x1, y1, x2, y2 ≤ 50, how many right triangles can be formed?
 ```yml
 tests:
   - text: <code>euler91()</code> should return 14234.
-    testString: assert.strictEqual(euler91(), 14234, '<code>euler91()</code> should return 14234.');
+    testString: assert.strictEqual(euler91(), 14234);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-92-square-digit-chains.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-92-square-digit-chains.english.md
@@ -25,7 +25,7 @@ How many starting numbers below ten million will arrive at 89?
 ```yml
 tests:
   - text: <code>euler92()</code> should return 8581146.
-    testString: assert.strictEqual(euler92(), 8581146, '<code>euler92()</code> should return 8581146.');
+    testString: assert.strictEqual(euler92(), 8581146);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-93-arithmetic-expressions.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-93-arithmetic-expressions.english.md
@@ -28,7 +28,7 @@ Find the set of four distinct digits, a < b < c < d, for which the longest set o
 ```yml
 tests:
   - text: <code>euler93()</code> should return 1258.
-    testString: assert.strictEqual(euler93(), 1258, '<code>euler93()</code> should return 1258.');
+    testString: assert.strictEqual(euler93(), 1258);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-94-almost-equilateral-triangles.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-94-almost-equilateral-triangles.english.md
@@ -22,7 +22,7 @@ Find the sum of the perimeters of all almost equilateral triangles with integral
 ```yml
 tests:
   - text: <code>euler94()</code> should return 518408346.
-    testString: assert.strictEqual(euler94(), 518408346, '<code>euler94()</code> should return 518408346.');
+    testString: assert.strictEqual(euler94(), 518408346);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-95-amicable-chains.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-95-amicable-chains.english.md
@@ -25,7 +25,7 @@ Find the smallest member of the longest amicable chain with no element exceeding
 ```yml
 tests:
   - text: <code>euler95()</code> should return 14316.
-    testString: assert.strictEqual(euler95(), 14316, '<code>euler95()</code> should return 14316.');
+    testString: assert.strictEqual(euler95(), 14316);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-96-su-doku.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-96-su-doku.english.md
@@ -48,7 +48,7 @@ By solving all fifty puzzles find the sum of the 3-digit numbers found in the to
 ```yml
 tests:
   - text: <code>euler96()</code> should return 24702.
-    testString: assert.strictEqual(euler96(), 24702, '<code>euler96()</code> should return 24702.');
+    testString: assert.strictEqual(euler96(), 24702);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-97-large-non-mersenne-prime.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-97-large-non-mersenne-prime.english.md
@@ -22,7 +22,7 @@ Find the last ten digits of this prime number.
 ```yml
 tests:
   - text: <code>euler97()</code> should return 8739992577.
-    testString: assert.strictEqual(euler97(), 8739992577, '<code>euler97()</code> should return 8739992577.');
+    testString: assert.strictEqual(euler97(), 8739992577);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-98-anagramic-squares.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-98-anagramic-squares.english.md
@@ -23,7 +23,7 @@ NOTE: All anagrams formed must be contained in the given text file.
 ```yml
 tests:
   - text: <code>euler98()</code> should return 18769.
-    testString: assert.strictEqual(euler98(), 18769, '<code>euler98()</code> should return 18769.');
+    testString: assert.strictEqual(euler98(), 18769);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-99-largest-exponential.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-99-largest-exponential.english.md
@@ -23,7 +23,7 @@ NOTE: The first two lines in the file represent the numbers in the example given
 ```yml
 tests:
   - text: <code>euler99()</code> should return 709.
-    testString: assert.strictEqual(euler99(), 709, '<code>euler99()</code> should return 709.');
+    testString: assert.strictEqual(euler99(), 709);
 
 ```
 


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Related to issue #36400

This PR removes assert message arguments from `testString` for the remaining 27 `Project Euler` challenges in the `Coding Interview Prep` curriculum section.