### PR TITLE
fix(curriculum): Remove additional unnecessary assert message argument from English Responsive Web Design challenges

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/adjust-the-color-of-various-elements-to-complementary-colors.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/adjust-the-color-of-various-elements-to-complementary-colors.english.md
@@ -21,13 +21,13 @@ This page will use a shade of teal (<code>#09A7A1</code>) as the dominant color,
 ```yml
 tests:
   - text: 'The <code>header</code> element should have a <code>background-color</code> of #09A7A1.'
-    testString: "assert($('header').css('background-color') == 'rgb(9, 167, 161)', 'The <code>header</code> element should have a <code>background-color</code> of #09A7A1.');"
+    testString: "assert($('header').css('background-color') == 'rgb(9, 167, 161)');"
   - text: 'The <code>footer</code> element should have a <code>background-color</code> of #09A7A1.'
-    testString: "assert($('footer').css('background-color') == 'rgb(9, 167, 161)', 'The <code>footer</code> element should have a <code>background-color</code> of #09A7A1.');"
+    testString: "assert($('footer').css('background-color') == 'rgb(9, 167, 161)');"
   - text: 'The <code>h2</code> element should have a <code>color</code> of #09A7A1.'
-    testString: "assert($('h2').css('color') == 'rgb(9, 167, 161)', 'The <code>h2</code> element should have a <code>color</code> of #09A7A1.');"
+    testString: "assert($('h2').css('color') == 'rgb(9, 167, 161)');"
   - text: 'The <code>button</code> element should have a <code>background-color</code> of #FF790E.'
-    testString: "assert($('button').css('background-color') == 'rgb(255, 121, 14)', 'The <code>button</code> element should have a <code>background-color</code> of #FF790E.');"
+    testString: "assert($('button').css('background-color') == 'rgb(255, 121, 14)');"
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/import-a-google-font.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/import-a-google-font.english.md
@@ -32,7 +32,7 @@ tests:
   - text: Your <code>h2</code> element should use the font <code>Lobster</code>.
     testString: assert($("h2").css("font-family").match(/lobster/i), 'Your <code>h2</code> element should use the font <code>Lobster</code>.');
   - text: Use an <code>h2</code> CSS selector to change the font.
-    testString: 'assert(/\s*h2\s*\{\s*font-family\:\s*(\"|")?Lobster(\"|")?(.{0,})\s*;\s*\}/gi.test(code), "Use an <code>h2</code> CSS selector to change the font.");'
+    testString: 'assert(/\s*h2\s*\{\s*font-family\:\s*(\"|")?Lobster(\"|")?(.{0,})\s*;\s*\}/gi.test(code));'
   - text: Your <code>p</code> element should still use the font <code>monospace</code>.
     testString: assert($("p").css("font-family").match(/monospace/i), 'Your <code>p</code> element should still use the font <code>monospace</code>.');
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/uncomment-html.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/uncomment-html.english.md
@@ -29,7 +29,7 @@ tests:
   - text: Make your <code>p</code> element visible on your page by uncommenting it.
     testString: assert($("p").length > 0, 'Make your <code>p</code> element visible on your page by uncommenting it.');
   - text: Be sure to delete all trailing comment tags&#44; i.e. <code>--&#62;</code>.
-    testString: assert(!/[^fc]-->/gi.test(code.replace(/ *<!--[^fc]*\n/g,'')), 'Be sure to delete all trailing comment tags&#44; i.e. <code>--&#62;</code>.');
+    testString: assert(!/[^fc]-->/gi.test(code.replace(/ *<!--[^fc]*\n/g,'')));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-justify-content-property-in-the-tweet-embed.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-justify-content-property-in-the-tweet-embed.english.md
@@ -21,7 +21,7 @@ Add the CSS property <code>justify-content</code> to the header's <code>.profile
 ```yml
 tests:
   - text: 'The <code>.profile-name</code> element should have the <code>justify-content</code> property set to any of these values: <code>center</code>, <code>flex-start</code>, <code>flex-end</code>, <code>space-between</code>, or <code>space-around</code>.'
-    testString: 'assert(code.match(/header\s.profile-name\s*{\s*?.*?\s*?.*?\s*?\s*?.*?\s*?justify-content\s*:\s*(center|flex-start|flex-end|space-between|space-around)\s*;/g), ''The <code>.profile-name</code> element should have the <code>justify-content</code> property set to any of these values: center, flex-start, flex-end, space-between, or space-around.'');'
+    testString: 'assert(code.match(/header\s.profile-name\s*{\s*?.*?\s*?.*?\s*?\s*?.*?\s*?justify-content\s*:\s*(center|flex-start|flex-end|space-between|space-around)\s*;/g));'
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-grid/use-css-grid-units-to-change-the-size-of-columns-and-rows.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-grid/use-css-grid-units-to-change-the-size-of-columns-and-rows.english.md
@@ -31,7 +31,7 @@ Make a grid with three columns whose widths are as follows: 1fr, 100px, and 2fr.
 ```yml
 tests:
   - text: '<code>container</code> class should have a <code>grid-template-columns</code> property that has three columns with the following widths: <code>1fr, 100px, and 2fr</code>.'
-    testString: 'assert(code.match(/.container\s*?{[\s\S]*grid-template-columns\s*?:\s*?1fr\s*?100px\s*?2fr\s*?;[\s\S]*}/gi), ''<code>container</code> class should have a <code>grid-template-columns</code> property that has three columns with the following widths: <code>1fr, 100px, and 2fr</code>.'');'
+    testString: 'assert(code.match(/.container\s*?{[\s\S]*grid-template-columns\s*?:\s*?1fr\s*?100px\s*?2fr\s*?;[\s\S]*}/gi));'
 
 ```
 


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x]  My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Related to issue #36400

This PR removes assert message arguments from `testString` for the `Responsive Web Design` curriculum section.  This PR was created to remove assert message arguments which were wrapped in two single quotes instead of single quotes.  [See this discussion for more information](https://github.com/freeCodeCamp/freeCodeCamp/pull/36409#issuecomment-510219004)