### PR TITLE
fix(docs): npm run commit has been removed

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -41,7 +41,7 @@ A quick reference to the commands that you will need when working locally.
 
 | command | description |
 | ------- | ----------- |
-| `npm run bootstrap` | Bootstraps the different services. |
+| `npm ci` | Bootstraps the different services. |
 | `npm run seed` | Parse all the challenge markdown files and inserts them into MongoDB. |
 | `npm run develop` | Starts the freeCodeCamp API Server and Client Applications. |
 | `npm test` |  Run all JS tests in the system, including client, server, lint and challenge tests. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,4 +48,3 @@ A quick reference to the commands that you will need when working locally.
 | `npm run test:client` | Run the client test suite. |
 | `npm run test:curriculum` | Run the curriculum test suite. |
 | `npm run test:server` | Run the server test suite. |
-| `npm run commit` | An interactive tool to help you build a good commit message. |


### PR DESCRIPTION
The npm script `npm run commit` appears to have been removed.
Updating the docs accordingly.