### PR TITLE
fix(curriculum): Remove additional unnecessary assert message argument wrapped in double quotes from various curriculum sections

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/applied-accessibility/use-headings-to-show-hierarchical-relationships-of-content.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-accessibility/use-headings-to-show-hierarchical-relationships-of-content.english.md
@@ -30,7 +30,7 @@ tests:
   - text: Your code should have 6 <code>h3</code> closing tags.
     testString: assert((code.match(/\/h3/g) || []).length===6,'Your code should have 6 <code>h3</code> closing tags.');
   - text: Your code should not have any <code>h5</code> tags.
-    testString: assert($("h5").length === 0, "Your code should not have any <code>h5</code> tags.");
+    testString: assert($("h5").length === 0);
   - text: Your code should not have any <code>h5</code> closing tags.
     testString: assert(/\/h5/.test(code)===false, 'Your code should not have any <code>h5</code> closing tags');
 ```

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/give-a-background-color-to-a-div-element.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/give-a-background-color-to-a-div-element.english.md
@@ -33,7 +33,7 @@ tests:
   - text: Your <code>div</code> element should have a silver background.
     testString: assert($("div").css("background-color") === "rgb(192, 192, 192)", 'Your <code>div</code> element should have a silver background.');
   - text: Define a class named <code>silver-background</code> within the <code>style</code> element and assign the value of <code>silver</code> to the <code>background-color</code> property.
-    testString: assert(code.match(/\.silver-background\s*{\s*background-color:\s*silver;\s*}/), "Define a class named <code>silver-background</code> within the <code>style</code> element and assign the value of <code>silver</code> to the <code>background-color</code> property.");
+    testString: assert(code.match(/\.silver-background\s*{\s*background-color:\s*silver;\s*}/));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/import-a-google-font.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/import-a-google-font.english.md
@@ -32,7 +32,7 @@ tests:
   - text: Your <code>h2</code> element should use the font <code>Lobster</code>.
     testString: assert($("h2").css("font-family").match(/lobster/i), 'Your <code>h2</code> element should use the font <code>Lobster</code>.');
   - text: Use an <code>h2</code> CSS selector to change the font.
-    testString: 'assert(/\s*h2\s*\{\s*font-family\:\s*(\"|")?Lobster(\"|")?(.{0,})\s*;\s*\}/gi.test(code), "Use an <code>h2</code> CSS selector to change the font.");'
+    testString: 'assert(/\s*h2\s*\{\s*font-family\:\s*(\"|")?Lobster(\"|")?(.{0,})\s*;\s*\}/gi.test(code));'
   - text: Your <code>p</code> element should still use the font <code>monospace</code>.
     testString: assert($("p").css("font-family").match(/monospace/i), 'Your <code>p</code> element should still use the font <code>monospace</code>.');
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/understand-the-prototype-chain.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/understand-the-prototype-chain.english.md
@@ -46,7 +46,7 @@ Modify the code to show the correct prototype chain.
 ```yml
 tests:
   - text: Your code should show that <code>Object.prototype</code> is the prototype of <code>Dog.prototype</code>
-    testString: assert(/Object\.prototype\.isPrototypeOf/.test(code), "Your code should show that <code>Object.prototype</code> is the prototype of <code>Dog.prototype</code>");
+    testString: assert(/Object\.prototype\.isPrototypeOf/.test(code));
 
 ```
 

--- a/curriculum/challenges/english/03-front-end-libraries/jquery/learn-how-script-tags-and-document-ready-work.english.md
+++ b/curriculum/challenges/english/03-front-end-libraries/jquery/learn-how-script-tags-and-document-ready-work.english.md
@@ -26,11 +26,11 @@ This is important because without your <code>document ready function</code>, you
 ```yml
 tests:
   - text: Create a <code>script</code> element making sure it is valid and has a closing tag.
-    testString: 'assert(code.match(/<\/script\s*>/g) && code.match(/<script(\sasync|\sdefer)*(\s(charset|src|type)\s*=\s*["\"]+[^"\"]*["\"]+)*(\sasync|\sdefer)*\s*>/g) && code.match(/<\/script\s*>/g).length === code.match(/<script(\sasync|\sdefer)*(\s(charset|src|type)\s*=\s*["\"]+[^"\"]*["\"]+)*(\sasync|\sdefer)*\s*>/g).length, "Create a <code>script</code> element making sure it is valid and has a closing tag.");'
+    testString: 'assert(code.match(/<\/script\s*>/g) && code.match(/<script(\sasync|\sdefer)*(\s(charset|src|type)\s*=\s*["\"]+[^"\"]*["\"]+)*(\sasync|\sdefer)*\s*>/g) && code.match(/<\/script\s*>/g).length === code.match(/<script(\sasync|\sdefer)*(\s(charset|src|type)\s*=\s*["\"]+[^"\"]*["\"]+)*(\sasync|\sdefer)*\s*>/g).length);'
   - text: 'You should add <code>$&#40;document&#41;.ready<wbr>&#40;function&#40;&#41; {</code> to the beginning of your <code>script</code> element.'
-    testString: 'assert(code.match(/\$\s*?\(\s*?document\s*?\)\.ready\s*?\(\s*?function\s*?\(\s*?\)\s*?\{/g), "You should add <code>$&#40;document&#41;.ready<wbr>&#40;function&#40;&#41; {</code> to the beginning of your <code>script</code> element.");'
+    testString: 'assert(code.match(/\$\s*?\(\s*?document\s*?\)\.ready\s*?\(\s*?function\s*?\(\s*?\)\s*?\{/g));'
   - text: 'Close your <code>$&#40;document&#41;.ready<wbr>&#40;function&#40;&#41; {</code> function with <code>}&#41;;</code>'
-    testString: 'assert(code.match(/\n*?\s*?\}\s*?\);/g), "Close your <code>$&#40;document&#41;.ready<wbr>&#40;function&#40;&#41; {</code> function with <code>}&#41;;</code>");'
+    testString: 'assert(code.match(/\n*?\s*?\}\s*?\);/g));'
 
 ```
 

--- a/curriculum/challenges/english/03-front-end-libraries/jquery/target-html-elements-with-selectors-using-jquery.english.md
+++ b/curriculum/challenges/english/03-front-end-libraries/jquery/target-html-elements-with-selectors-using-jquery.english.md
@@ -27,9 +27,9 @@ Note that we've already included both the jQuery library and the Animate.css lib
 ```yml
 tests:
   - text: 'Use the jQuery <code>addClass&#40&#41</code> function to give the classes <code>animated</code> and <code>bounce</code> to your <code>button</code> elements.'
-    testString: 'assert($("button").hasClass("animated") && $("button").hasClass("bounce"), "Use the jQuery <code>addClass&#40&#41</code> function to give the classes <code>animated</code> and <code>bounce</code> to your <code>button</code> elements.");'
+    testString: 'assert($("button").hasClass("animated") && $("button").hasClass("bounce"));'
   - text: Only use jQuery to add these classes to the element.
-    testString: 'assert(!code.match(/class.*animated/g), "Only use jQuery to add these classes to the element.");'
+    testString: 'assert(!code.match(/class.*animated/g));'
   - text: Your jQuery code should be within the <code>$(document).ready();</code> function.
     testString: assert(code.match(/\$\(document\)\.ready\(function.*(\s|\n)*.*button.*.addClass.*\);/g), 'Your jQuery code should be within the <code>$(document).ready();</code> function.');
 

--- a/curriculum/challenges/english/03-front-end-libraries/jquery/target-the-same-element-with-multiple-jquery-selectors.english.md
+++ b/curriculum/challenges/english/03-front-end-libraries/jquery/target-the-same-element-with-multiple-jquery-selectors.english.md
@@ -38,7 +38,7 @@ tests:
   - text: Your <code>#target1</code> element should have the classes <code>animated</code>&#130; <code>shake</code> and <code>btn-primary</code>.
     testString: assert($('#target1').hasClass('animated') && $('#target1').hasClass('shake') && $('#target1').hasClass('btn-primary'), 'Your <code>#target1</code> element should have the classes <code>animated</code>&#130; <code>shake</code> and <code>btn-primary</code>.');
   - text: Only use jQuery to add these classes to the element.
-    testString: 'assert(!code.match(/class.*animated/g), "Only use jQuery to add these classes to the element.");'
+    testString: 'assert(!code.match(/class.*animated/g));'
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/create-and-add-to-sets-in-es6.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/create-and-add-to-sets-in-es6.english.md
@@ -40,7 +40,7 @@ For this exercise, return a set with the following values: <code>1, 2, 3, 'Taco'
 ```yml
 tests:
   - text: 'Your <code>Set</code> should only contain the values <code>1, 2, 3, Taco, Cat, Awesome</code>.'
-    testString: 'assert((function(){var test = checkSet(); return (test.size == 6) && test.has(1) && test.has(2) && test.has(3) && test.has("Taco") && test.has("Cat") && test.has("Awesome");})(), "Your <code>Set</code> should only contain the values <code>1, 2, 3, Taco, Cat, Awesome</code>.");'
+    testString: 'assert((function(){var test = checkSet(); return (test.size == 6) && test.has(1) && test.has(2) && test.has(3) && test.has("Taco") && test.has("Cat") && test.has("Awesome");})());'
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/perform-a-subset-check-on-two-sets-of-data.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/perform-a-subset-check-on-two-sets-of-data.english.md
@@ -25,13 +25,13 @@ tests:
   - text: The first Set() was contained in the second Set
     testString: assert((function(){var setA = new Set(); var setB = new Set(); setA.add('a'); setB.add('b'); setB.add('c'); setB.add('a'); setB.add('d'); var subsetSetAB = setA.subset(setB);return (subsetSetAB === true)})(), 'The first Set() was contained in the second Set');
   - text: <code>['a', 'b'].subset(['a', 'b', 'c', 'd'])</code> should return <code>true</code>
-    testString: assert((function(){var setA = new Set(); var setB = new Set(); setA.add('a'); setA.add('b'); setB.add('a'); setB.add('b'); setB.add('c'); setB.add('d'); var subsetSetAB = setA.subset(setB); return (subsetSetAB === true)})(), "<code>['a', 'b'].subset(['a', 'b', 'c', 'd'])</code> should return <code>true</code>");
+    testString: assert((function(){var setA = new Set(); var setB = new Set(); setA.add('a'); setA.add('b'); setB.add('a'); setB.add('b'); setB.add('c'); setB.add('d'); var subsetSetAB = setA.subset(setB); return (subsetSetAB === true)})());
   - text: <code>['a', 'b', 'c'].subset(['a', 'b'])</code> should return <code>false</code>
-    testString: assert((function(){var setA = new Set(); var setB = new Set(); setA.add('a'); setA.add('b'); setA.add('c'); setB.add('a'); setB.add('b'); var subsetSetAB = setA.subset(setB); return (subsetSetAB === false)})(), "<code>['a', 'b', 'c'].subset(['a', 'b'])</code> should return <code>false</code>");
+    testString: assert((function(){var setA = new Set(); var setB = new Set(); setA.add('a'); setA.add('b'); setA.add('c'); setB.add('a'); setB.add('b'); var subsetSetAB = setA.subset(setB); return (subsetSetAB === false)})());
   - text: <code>[].subset([])</code> should return <code>true</code>
     testString: assert((function(){var setA = new Set(); var setB = new Set(); var subsetSetAB = setA.subset(setB); return (subsetSetAB === true)})(), '<code>[].subset([])</code> should return <code>true</code>');
   - text: <code>['a', 'b'].subset(['c', 'd'])</code> should return <code>false</code>
-    testString: assert((function(){var setA = new Set(); var setB = new Set(); setA.add('a'); setA.add('b'); setB.add('c'); setB.add('d'); var subsetSetAB = setA.subset(setB); return (subsetSetAB === false)})(), "<code>['a', 'b'].subset(['c', 'd'])</code> should return <code>false</code>");
+    testString: assert((function(){var setA = new Set(); var setB = new Set(); setA.add('a'); setA.add('b'); setB.add('c'); setB.add('d'); var subsetSetAB = setA.subset(setB); return (subsetSetAB === false)})());
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/use-.has-and-.size-on-an-es6-set.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/use-.has-and-.size-on-an-es6-set.english.md
@@ -26,7 +26,7 @@ In this exercise we will pass an array and a value to the checkSet() function. Y
 ```yml
 tests:
   - text: <code>checkSet([4, 5, 6], 3)</code> should return [ false, 3 ]
-    testString: 'assert((function(){var test = checkSet([4,5,6], 3); return DeepEqual(test, [ false, 3 ]);})(), "<code>checkSet([4, 5, 6], 3)</code> should return [ false, 3 ]");'
+    testString: 'assert((function(){var test = checkSet([4,5,6], 3); return DeepEqual(test, [ false, 3 ]);})());'
 ```
 
 </section>

--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/use-spread-and-notes-for-es5-set-integration.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/use-spread-and-notes-for-es5-set-integration.english.md
@@ -30,7 +30,7 @@ Now you've successfully learned how to use the ES6 <code>Set()</code> object, go
 ```yml
 tests:
   - text: Your Set was returned correctly!
-    testString: 'assert((function(){var test = checkSet(new Set([1,2,3,4,5,6,7])); return DeepEqual(test, [ 1, 2, 3, 4, 5, 6, 7 ]);})(), "Your Set was returned correctly!");'
+    testString: 'assert((function(){var test = checkSet(new Set([1,2,3,4,5,6,7])); return DeepEqual(test, [ 1, 2, 3, 4, 5, 6, 7 ]);})());'
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/factorial.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/factorial.english.md
@@ -34,11 +34,11 @@ tests:
   - text: <code>factorial(2)</code> should return a number.
     testString: assert(typeof factorial(2) === 'number', '<code>factorial(2)</code> should return a number.');
   - text: <code>factorial(3)</code> should return 6.
-    testString: assert.equal(factorial(3),results[0],"<code>factorial(3)</code> should return 6.");
+    testString: assert.equal(factorial(3),results[0]);
   - text: <code>factorial(3)</code> should return 120.
-    testString: assert.equal(factorial(5),results[1],"<code>factorial(3)</code> should return 120.");
+    testString: assert.equal(factorial(5),results[1]);
   - text: <code>factorial(3)</code> should return 3,628,800.
-    testString: assert.equal(factorial(10),results[2],"<code>factorial(3)</code> should return 3,628,800.");
+    testString: assert.equal(factorial(10),results[2]);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/fibonacci-sequence.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/fibonacci-sequence.english.md
@@ -28,11 +28,11 @@ tests:
   - text: <code>fibonacci(2)</code> should return a number.
     testString: assert(typeof fibonacci(2) == 'number', '<code>fibonacci(2)</code> should return a number.');
   - text: <code>fibonacci(3)</code> should return 1.
-    testString: assert.equal(fibonacci(3),1,"<code>fibonacci(3)</code> should return 1.");
+    testString: assert.equal(fibonacci(3),1);
   - text: <code>fibonacci(5)</code> should return 3.
-    testString: assert.equal(fibonacci(5),3,"<code>fibonacci(5)</code> should return 3.");
+    testString: assert.equal(fibonacci(5),3);
   - text: <code>fibonacci(10)</code> should return 34.
-    testString: assert.equal(fibonacci(10),34,"<code>fibonacci(10)</code> should return 34.");
+    testString: assert.equal(fibonacci(10),34);
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/sedols.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/sedols.english.md
@@ -37,13 +37,13 @@ tests:
   - text: <code>sedol</code> is a function.
     testString: assert(typeof sedol === 'function', '<code>sedol</code> is a function.');
   - text: <code>sedol('a')</code> should return null.
-    testString: assert(sedol('a') === null, "<code>sedol('a')</code> should return null.");
+    testString: assert(sedol('a') === null);
   - text: <code>sedol('710889')</code> should return '7108899'.
-    testString: assert(sedol('710889') === '7108899', "<code>sedol('710889')</code> should return '7108899'.");
+    testString: assert(sedol('710889') === '7108899');
   - text: <code>sedol('BOATER')</code> should return null.
-    testString: assert(sedol('BOATER') === null, "<code>sedol('BOATER')</code> should return null.");
+    testString: assert(sedol('BOATER') === null);
   - text: <code>sedol('228276')</code> should return '2282765'.
-    testString: assert(sedol('228276') === '2282765', "<code>sedol('228276')</code> should return '2282765'.");
+    testString: assert(sedol('228276') === '2282765');
 
 ```
 


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x]  My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Related to issue #36400

This PR is an additional PR in the series of PRs related to issue #36400.  This particular PR handles the case of removing assert message arguments from `testString` where the assert message argument is wrapped in double quotes instead of single quotes.  @thecodingaviator noticed that none of the other PRs were removing such arguments, which is how this PR came about.

The following sections were checked for the double quoted assert message arguments.  Some of the sections did not have such cases.

* JavaScript Algorithms and Data Structures
* Responsive Web Design
* Front End Libraries
* Data Visualization
* Coding Interview Prep
