### PR TITLE
fix(curriculum): correct title of Averages/Mode challenge

### DIFF
--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/averages-mode.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/averages-mode.english.md
@@ -1,5 +1,5 @@
 ---
-title: Averages-Mode
+title: Averages/Mode
 id: 594d8d0ab97724821379b1e6
 challengeType: 5
 ---


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Noticed the challenge name is not the same as the Rosetta Code site's name for the same challenge.    I will correct the title in the Guide article in a separate PR.