### PR TITLE
fix: Report build errors to dev console

### DIFF
--- a/client/src/client/workers/test-evaluator.js
+++ b/client/src/client/workers/test-evaluator.js
@@ -31,7 +31,8 @@ const __utils = (() => {
   }
 
   return {
-    postResult
+    postResult,
+    oldLog
   };
 })();
 
@@ -54,7 +55,12 @@ self.onmessage = async e => {
       `);
     } catch (err) {
       if (__userCodeWasExecuted) {
+        // rethrow error, since test failed.
         throw err;
+      } else {
+        // report errors to dev console (not the editor console, since the test
+        // may still pass)
+        __utils.oldLog(err);
       }
       testResult = eval(e.data.testString);
     }


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

If there is an error thrown while evaluating the user's code in a challenge that error will now get reported in their browser's dev console, but not in the editor's logs.

This should make it easier to debug those challenges, without cluttering the editor logs.

Closes  #36307