### PR TITLE
Corrected declaration of integer array.

### DIFF
--- a/guide/english/csharp/array/index.md
+++ b/guide/english/csharp/array/index.md
@@ -90,7 +90,7 @@ You can declare, initialize and assign values in the array all at once by using 
 or simply:
 
 ```csharp
-int [] nameOfArray = new nameOfArray[4] {2,9,56,1280};
+int [] nameOfArray = new int[4] {2,9,56,1280};
 int [] nameOfSecondArray = nameOfArray;
 ```
 


### PR DESCRIPTION
To declare an integer array, the correct way is:

int[] name = new int[] {1, 2, 3};

and not

int[] name = new name[] {1, 2, 3};

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX
