### PR TITLE
fix: added cross-env before api-server package.json scripts

### DIFF
--- a/api-server/package.json
+++ b/api-server/package.json
@@ -4,11 +4,11 @@
   "version": "0.0.1",
   "repository": "freecodecamp/freecodecamp",
   "scripts": {
-    "develop": "DEBUG=fcc* node development-start.js",
+    "develop": "cross-env DEBUG=fcc* node development-start.js",
     "babel-dev-server": "babel-node --inspect=0.0.0.0 ./server/index.js",
     "build": "babel server --out-dir lib --ignore 'node_modules /**/*','/**/*.test.js' --copy-files",
     "ensure-env": "node ../tools/scripts/build/ensure-env.js",
-    "start": "DEBUG=fcc* node production-start.js",
+    "start": "cross-env DEBUG=fcc* node production-start.js",
     "test": "jest"
   },
   "license": "BSD-3-Clause",


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Quick fix to keep Windows users happy.