### PR TITLE
fix(client): corrected guide url logic for backend challenges and projects

### DIFF
--- a/client/src/redux/propTypes.js
+++ b/client/src/redux/propTypes.js
@@ -20,6 +20,7 @@ export const MarkdownRemark = PropTypes.shape({
 
 export const ChallengeNode = PropTypes.shape({
   block: PropTypes.string,
+  challengeOrder: PropTypes.number,
   challengeType: PropTypes.number,
   dashedName: PropTypes.string,
   description: PropTypes.string,
@@ -31,9 +32,9 @@ export const ChallengeNode = PropTypes.shape({
     slug: PropTypes.string,
     blockName: PropTypes.string
   }),
+  forumTopicId: PropTypes.number,
   guideUrl: PropTypes.string,
   head: PropTypes.arrayOf(PropTypes.string),
-  challengeOrder: PropTypes.number,
   instructions: PropTypes.string,
   isBeta: PropTypes.bool,
   isComingSoon: PropTypes.bool,

--- a/client/src/templates/Challenges/backend/Show.js
+++ b/client/src/templates/Challenges/backend/Show.js
@@ -17,7 +17,7 @@ import {
   updateProjectFormValues,
   backendNS
 } from '../redux';
-import { createGuideUrl } from '../utils';
+import { getGuideUrl } from '../utils';
 
 import LearnLayout from '../../../components/layouts/Learn';
 import ChallengeTitle from '../components/Challenge-Title';
@@ -95,12 +95,6 @@ export class BackEnd extends Component {
     this.state = {};
     this.updateDimensions = this.updateDimensions.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
-  }
-
-  getGuideUrl({ forumTopicId, title }) {
-    return forumTopicId
-      ? 'https://www.freecodecamp.org/forum/t/' + forumTopicId
-      : createGuideUrl(title);
   }
 
   componentDidMount() {
@@ -219,7 +213,7 @@ export class BackEnd extends Component {
                 />
               )}
               <ProjectToolPanel
-                guideUrl={this.getGuideUrl({ forumTopicId, title })}
+                guideUrl={getGuideUrl({ forumTopicId, title })}
               />
               <br />
               <Output

--- a/client/src/templates/Challenges/backend/Show.js
+++ b/client/src/templates/Challenges/backend/Show.js
@@ -44,6 +44,7 @@ const propTypes = {
   }),
   description: PropTypes.string,
   executeChallenge: PropTypes.func.isRequired,
+  forumTopicId: PropTypes.number,
   id: PropTypes.string,
   initConsole: PropTypes.func.isRequired,
   initTests: PropTypes.func.isRequired,
@@ -94,6 +95,12 @@ export class BackEnd extends Component {
     this.state = {};
     this.updateDimensions = this.updateDimensions.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
+  }
+
+  getGuideUrl({ forumTopicId, title }) {
+    return forumTopicId
+      ? 'https://www.freecodecamp.org/forum/t/' + forumTopicId
+      : createGuideUrl(title);
   }
 
   componentDidMount() {
@@ -155,8 +162,9 @@ export class BackEnd extends Component {
     const {
       data: {
         challengeNode: {
-          fields: { blockName, slug },
+          fields: { blockName },
           challengeType,
+          forumTopicId,
           title,
           description,
           instructions
@@ -210,7 +218,9 @@ export class BackEnd extends Component {
                   updateProjectForm={updateProjectFormValues}
                 />
               )}
-              <ProjectToolPanel guideUrl={createGuideUrl(slug)} />
+              <ProjectToolPanel
+                guideUrl={this.getGuideUrl({ forumTopicId, title })}
+              />
               <br />
               <Output
                 defaultOutput={`/**
@@ -247,6 +257,7 @@ export default connect(
 export const query = graphql`
   query BackendChallenge($slug: String!) {
     challengeNode(fields: { slug: { eq: $slug } }) {
+      forumTopicId
       title
       description
       instructions

--- a/client/src/templates/Challenges/classic/Show.js
+++ b/client/src/templates/Challenges/classic/Show.js
@@ -20,7 +20,7 @@ import ResetModal from '../components/ResetModal';
 import MobileLayout from './MobileLayout';
 import DesktopLayout from './DesktopLayout';
 
-import { createGuideUrl } from '../utils';
+import { getGuideUrl } from '../utils';
 import { challengeTypes } from '../../../../utils/challengeTypes';
 import { ChallengeNode } from '../../../redux/propTypes';
 import { dasherize } from '../../../../utils';
@@ -166,13 +166,6 @@ class ShowClassic extends Component {
     return `${blockName}: ${title}`;
   }
 
-  getGuideUrl() {
-    const { forumTopicId, title } = this.getChallenge();
-    return forumTopicId
-      ? 'https://www.freecodecamp.org/forum/t/' + forumTopicId
-      : createGuideUrl(title);
-  }
-
   getVideoUrl = () => this.getChallenge().videoUrl;
 
   getChallengeFile() {
@@ -200,11 +193,13 @@ class ShowClassic extends Component {
       nextChallengePath,
       prevChallengePath
     } = this.props.pageContext.challengeMeta;
+
+    const { forumTopicId, title } = this.getChallenge();
     return (
       <SidePanel
         className='full-height'
         description={description}
-        guideUrl={this.getGuideUrl()}
+        guideUrl={getGuideUrl({ forumTopicId, title })}
         instructions={instructions}
         introPath={introPath}
         nextChallengePath={nextChallengePath}
@@ -247,6 +242,7 @@ class ShowClassic extends Component {
   }
 
   render() {
+    const { forumTopicId, title } = this.getChallenge();
     return (
       <LearnLayout>
         <Helmet
@@ -255,7 +251,7 @@ class ShowClassic extends Component {
         <Media maxWidth={MAX_MOBILE_WIDTH}>
           <MobileLayout
             editor={this.renderEditor()}
-            guideUrl={this.getGuideUrl()}
+            guideUrl={getGuideUrl({ forumTopicId, title })}
             hasPreview={this.hasPreview()}
             instructions={this.renderInstructionsPanel({
               showToolPanel: false

--- a/client/src/templates/Challenges/project/Show.js
+++ b/client/src/templates/Challenges/project/Show.js
@@ -13,7 +13,7 @@ import {
   updateProjectFormValues
 } from '../redux';
 import { frontEndProject } from '../../../../utils/challengeTypes';
-import { createGuideUrl } from '../utils';
+import { getGuideUrl } from '../utils';
 
 import LearnLayout from '../../../components/layouts/Learn';
 import Spacer from '../../../components/helpers/Spacer';
@@ -51,12 +51,6 @@ const propTypes = {
 };
 
 export class Project extends Component {
-  getGuideUrl({ forumTopicId, title }) {
-    return forumTopicId
-      ? 'https://www.freecodecamp.org/forum/t/' + forumTopicId
-      : createGuideUrl(title);
-  }
-
   componentDidMount() {
     const {
       challengeMounted,
@@ -134,7 +128,7 @@ export class Project extends Component {
             onSubmit={openCompletionModal}
             updateProjectForm={updateProjectFormValues}
           />
-          <ToolPanel guideUrl={this.getGuideUrl({ forumTopicId, title })} />
+          <ToolPanel guideUrl={getGuideUrl({ forumTopicId, title })} />
           <Spacer />
         </div>
         <CompletionModal />

--- a/client/src/templates/Challenges/project/Show.js
+++ b/client/src/templates/Challenges/project/Show.js
@@ -51,6 +51,12 @@ const propTypes = {
 };
 
 export class Project extends Component {
+  getGuideUrl({ forumTopicId, title }) {
+    return forumTopicId
+      ? 'https://www.freecodecamp.org/forum/t/' + forumTopicId
+      : createGuideUrl(title);
+  }
+
   componentDidMount() {
     const {
       challengeMounted,
@@ -93,7 +99,8 @@ export class Project extends Component {
       data: {
         challengeNode: {
           challengeType,
-          fields: { blockName, slug },
+          fields: { blockName },
+          forumTopicId,
           title,
           description,
           guideUrl
@@ -127,7 +134,7 @@ export class Project extends Component {
             onSubmit={openCompletionModal}
             updateProjectForm={updateProjectFormValues}
           />
-          <ToolPanel guideUrl={createGuideUrl(slug)} />
+          <ToolPanel guideUrl={this.getGuideUrl({ forumTopicId, title })} />
           <Spacer />
         </div>
         <CompletionModal />
@@ -148,6 +155,7 @@ export default connect(
 export const query = graphql`
   query ProjectChallenge($slug: String!) {
     challengeNode(fields: { slug: { eq: $slug } }) {
+      forumTopicId
       title
       description
       challengeType

--- a/client/src/templates/Challenges/utils/index.js
+++ b/client/src/templates/Challenges/utils/index.js
@@ -1,5 +1,11 @@
 const guideBase = 'https://www.freecodecamp.org/forum/search?q=';
 
+export function getGuideUrl({ forumTopicId, title }) {
+  return forumTopicId
+    ? 'https://www.freecodecamp.org/forum/t/' + forumTopicId
+    : createGuideUrl(title);
+}
+
 export function createGuideUrl(title = '') {
   return guideBase + title + '%20in%3Atitle%20order%3Aviews';
 }


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Closes #36596

The problem was the `Show.js` for the backend and `Show.js` for the projects were not using the challenge title and forumTopicId like the recent changes to `Show.js` for the classic challenges. 
 
These changes pass all existing tests with `npm run test`, but not sure if there needs to be any additional tests added or anything else in general.