### PR TITLE
fix: use single quotes as required by prettier

### DIFF
--- a/client/src/templates/Guide/components/calculators/CodingBootcampCostCalculator/CodingBootcampCostCalculator.css
+++ b/client/src/templates/Guide/components/calculators/CodingBootcampCostCalculator/CodingBootcampCostCalculator.css
@@ -1,8 +1,8 @@
-.article .d3-chart {	
+.article .d3-chart {
   position: relative;
 }
 
-.article div.tooltip {	
+.article div.tooltip {
   position: absolute;
   text-align: center;
   width: 80px;
@@ -27,7 +27,7 @@
   width: 100%;
   line-height: 1;
   color: rgba(0, 0, 0, 0.8);
-  content: "\25BC";
+  content: '\25BC';
   position: absolute;
   text-align: center;
   bottom: -9px;


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Instead of reverting #35278, this just fixes the quotes in the css, so it stops breaking builds.

@raisedadead just close this if you'd rather revert.