### PR TITLE
fix(curriculum): Add tests for setter, getter and setting a temperature (es6 tests)

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-getters-and-setters-to-control-access-to-an-object.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-getters-and-setters-to-control-access-to-an-object.english.md
@@ -63,7 +63,7 @@ tests:
   - text: A <code>setter</code> should  be defined.
     testString: assert((() => {const desc = Object.getOwnPropertyDescriptor(Thermostat.prototype, 'temperature');return !!desc && typeof desc.set === 'function';})());
   - text: Calling the <code>setter</code> should set the temperature.
-    testString: assert((() => {const t = new Thermostat(32); t.temperature(26);return t.temperature !== 0;})());
+    testString: assert((() => {const t = new Thermostat(32); t.temperature = 26;return t.temperature !== 0;})());
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-getters-and-setters-to-control-access-to-an-object.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-getters-and-setters-to-control-access-to-an-object.english.md
@@ -58,6 +58,12 @@ tests:
     testString: assert(code.match(/class/g));
   - text: <code>Thermostat</code> should be able to be instantiated.
     testString: assert((() => {const t = new Thermostat(32);return typeof t === 'object' && t.temperature === 0;})());
+  - text: A <code>getter</code> should be defined.
+    testString: assert((() => {const desc = Object.getOwnPropertyDescriptor(Thermostat.prototype, 'temperature');return !!desc && typeof desc.get === 'function';})());
+  - text: A <code>setter</code> should  be defined.
+    testString: assert((() => {const desc = Object.getOwnPropertyDescriptor(Thermostat.prototype, 'temperature');return !!desc && typeof desc.set === 'function';})());
+  - text: Calling the <code>setter</code> should set the temperature.
+    testString: assert((() => {const t = new Thermostat(32); t.temperature(26);return t.temperature !== 0;})());
 
 ```
 


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #17403

This PR is about the following curriculum:
javascript-algorithms-and-data-structures >  es6 >  use-getters-and-setters-to-control-access-to-an-object

As described in the issue #17403, and even if the test suite was modified since the last issue update, this current PR provides 3 new tests:
- test if a getter is declared
- test if a setter is declared
- test if setting the temperature updates the previous temperature as described [here](https://github.com/freeCodeCamp/freeCodeCamp/issues/17403#issuecomment-405969306)

Adding the 2 first tests is usefull to detect this type code snippet which passes the current test suite:
`
// my class
function Thermostat(fahrenheit) {
    this._tempInCelsius = 5/9 * (fahrenheit - 32);
    this.temperature = this._tempInCelsius    
}
`







