### PR TITLE
fix/margins-on-buttons

### DIFF
--- a/client/src/templates/Challenges/components/challenge-title.css
+++ b/client/src/templates/Challenges/components/challenge-title.css
@@ -10,5 +10,6 @@
 }
 
 .challenge-title-wrap > a {
+  margin-top: 10px;
   align-self: flex-start;
 }


### PR DESCRIPTION
This moves the buttons down a little to align with the first sentence of the title.


<img width="398" alt="Screen Shot 2019-08-20 at 11 17 48 AM" src="https://user-images.githubusercontent.com/20648924/63364948-2ce26780-c33c-11e9-9248-5b1be121c9bf.png">


- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Closes #36648