### PR TITLE
fix: Global color vars

### DIFF
--- a/client/src/components/layouts/variables.css
+++ b/client/src/components/layouts/variables.css
@@ -1,21 +1,36 @@
 :root {
   --header-height: 38px;
   --theme-color: #0a0a23;
+  --gray-00: #ffffff;
   --gray-05: #f5f6f7;
+  --gray-10: #dfdfe2;
+  --gray-15: #d0d0d5;
+  --gray-75: #3b3b4f;
+  --gray-80: #2a2a40;
+  --gray-85: #1b1b32;
+  --gray-90: #0a0a23;
   --gray-mid: #858591;
+  --purple: #dbb8ff;
+  --yellow: #f1be32;
+  --blue: #99c9ff;
+  --light-green: #acd157;
+  --dark-purple: #5a01a7;
+  --dark-yellow: #4d3800;
+  --dark-blue: #002ead;
+  --dark-green: #00471b;
 }
 
 .dark-palette {
-  --primary-color: #ffffff;
-  --secondary-color: #f5f6f7;
-  --tertiary-color: #dfdfe2;
-  --quaternary-color: #d0d0d5;
-  --quaternary-background: #3b3b4f;
-  --tertiary-background: #2a2a40;
-  --secondary-background: #1b1b32;
-  --primary-background: #0a0a23;
-  --highlight-color: #99c9ff;
-  --highlight-background: #002ead;
+  --primary-color: var(--gray-00);
+  --secondary-color: var(--gray-05);
+  --tertiary-color: var(--gray-10);
+  --quaternary-color: var(--gray-15);
+  --quaternary-background: var(--gray-75);
+  --tertiary-background: var(--gray-80);
+  --secondary-background: var(--gray-85);
+  --primary-background: var(--gray-90);
+  --highlight-color: var(--blue);
+  --highlight-background: var(--dark-blue);
   --success-color: #87d98e;
   --success-background: #004d00;
   --danger-color: #ffadad;
@@ -23,16 +38,16 @@
 }
 
 .light-palette {
-  --primary-color: #0a0a23;
-  --secondary-color: #1b1b32;
-  --tertiary-color: #2a2a40;
-  --quaternary-color: #3b3b4f;
-  --quaternary-background: #d0d0d5;
-  --tertiary-background: #dfdfe2;
-  --secondary-background: #f5f6f7;
-  --primary-background: #ffffff;
-  --highlight-color: #002ead;
-  --highlight-background: #99c9ff;
+  --primary-color: var(--gray-90);
+  --secondary-color: var(--gray-85);
+  --tertiary-color: var(--gray-80);
+  --quaternary-color: var(--gray-75);
+  --quaternary-background: var(--gray-15);
+  --tertiary-background: var(--gray-10);
+  --secondary-background: var(--gray-05);
+  --primary-background: var(--gray-00);
+  --highlight-color: var(--dark-blue);
+  --highlight-background: var(--blue);
   --success-color: #004d00;
   --success-background: #87d98e;
   --danger-color: #850000;

--- a/client/src/components/layouts/variables.css
+++ b/client/src/components/layouts/variables.css
@@ -5,19 +5,21 @@
   --gray-05: #f5f6f7;
   --gray-10: #dfdfe2;
   --gray-15: #d0d0d5;
+  --gray-45: #858591;
   --gray-75: #3b3b4f;
   --gray-80: #2a2a40;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
-  --gray-mid: #858591;
-  --purple: #dbb8ff;
-  --yellow: #f1be32;
-  --blue: #99c9ff;
-  --light-green: #acd157;
-  --dark-purple: #5a01a7;
-  --dark-yellow: #4d3800;
-  --dark-blue: #002ead;
-  --dark-green: #00471b;
+  --purple-light: #dbb8ff;
+  --purple-dark: #5a01a7;
+  --yellow-light: #f1be32;
+  --yellow-dark: #4d3800;
+  --blue-light: #99c9ff;
+  --blue-dark: #002ead;
+  --green-light: #acd157;
+  --green-dark: #00471b;
+  --red-light: #ffadad;
+  --red-dark: #850000;
 }
 
 .dark-palette {
@@ -29,12 +31,12 @@
   --tertiary-background: var(--gray-80);
   --secondary-background: var(--gray-85);
   --primary-background: var(--gray-90);
-  --highlight-color: var(--blue);
-  --highlight-background: var(--dark-blue);
-  --success-color: #87d98e;
-  --success-background: #004d00;
-  --danger-color: #ffadad;
-  --danger-background: #850000;
+  --highlight-color: var(--blue-light);
+  --highlight-background: var(--blue-dark);
+  --success-color: var(--green-light);
+  --success-background: var(--green-dark);
+  --danger-color: var(--red-light);
+  --danger-background: var(--red-dark);
 }
 
 .light-palette {
@@ -46,10 +48,10 @@
   --tertiary-background: var(--gray-10);
   --secondary-background: var(--gray-05);
   --primary-background: var(--gray-00);
-  --highlight-color: var(--dark-blue);
-  --highlight-background: var(--blue);
-  --success-color: #004d00;
-  --success-background: #87d98e;
-  --danger-color: #850000;
-  --danger-background: #ffadad;
+  --highlight-color: var(--blue-dark);
+  --highlight-background: var(--blue-light);
+  --success-color: var(--green-dark);
+  --success-background: var(--green-light);
+  --danger-color: var(--red-dark);
+  --danger-background: var(--red-light);
 }


### PR DESCRIPTION
Added colors from the style guide to :root so they're available globally. Also switched out hex codes for named variables in .dark-palette and .light-palette wherever possible.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX
