### PR TITLE
fix(settings): Add method to user to update email

### DIFF
--- a/api-server/common/models/user.js
+++ b/api-server/common/models/user.js
@@ -437,6 +437,22 @@ export default function(User) {
 
   User.prototype.requestCompletedChallenges = requestCompletedChallenges;
 
+  User.prototype.requestUpdateEmail = function requestUpdateEmail(email) {
+    const userUpdate = new Promise((resolve, reject) =>
+      this.updateAttribute('email', email, err => {
+        if (err) {
+          return reject(err);
+        }
+        return resolve();
+      })
+    );
+    return Observable.fromPromise(userUpdate).map(
+      () => dedent`
+          Your email has been updated.
+        `
+    );
+  }
+
   User.prototype.requestUpdateFlags = async function requestUpdateFlags(
     values
   ) {

--- a/api-server/server/boot/settings.js
+++ b/api-server/server/boot/settings.js
@@ -88,9 +88,16 @@ function updateMyEmail(req, res, next) {
     user,
     body: { email }
   } = req;
-  return user
-    .requestUpdateEmail(email)
-    .subscribe(message => res.json({ message }), next);
+  if (email === user.email) {
+    return res.status(400).json({
+      type: 'danger',
+      message: 'This email is already associated with this account.'
+    });
+  } else {
+    return user
+      .requestUpdateEmail(email)
+      .subscribe(message => res.json({ message }), next);
+  }
 }
 
 const updateMyCurrentChallengeValidators = [

--- a/client/src/redux/index.js
+++ b/client/src/redux/index.js
@@ -348,7 +348,17 @@ export const reducer = handleActions(
     [settingsTypes.submitNewAboutComplete]: (state, { payload }) =>
       payload ? spreadThePayloadOnUser(state, payload) : state,
     [settingsTypes.updateMyEmailComplete]: (state, { payload }) =>
-      payload ? spreadThePayloadOnUser(state, payload) : state,
+      payload 
+      ? {
+          ...state,
+          user: {
+            ...state.user,
+            [state.appUsername]: {
+              ...state.user[state.appUsername],
+              email: payload
+            }
+          }
+      }: state,
     [settingsTypes.updateUserFlagComplete]: (state, { payload }) =>
       payload ? spreadThePayloadOnUser(state, payload) : state,
     [settingsTypes.verifyCertComplete]: (state, { payload }) =>


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `master` branch of freeCodeCamp.
- [X] None of my changes are plagiarized from another source without proper attribution.
- [X] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [X] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #36604

Note: when a user updates his or her email, that goes through on the server and the put is successful. However, I still need to figure out how to get the new email to render on the settings page upon success. Working on that now.
