### PR TITLE
Improve viewport unit readability

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/responsive-web-design-principles/make-typography-responsive.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/responsive-web-design-principles/make-typography-responsive.english.md
@@ -10,7 +10,7 @@ forumTopicId: 301141
 <section id='description'>
 Instead of using <code>em</code> or <code>px</code> to size text, you can use viewport units for responsive typography. Viewport units, like percentages, are relative units, but they are based off different items. Viewport units are relative to the viewport dimensions (width or height) of a device, and percentages are relative to the size of the parent container element.
 The four different viewport units are:
-  <ul><li><code>width: 10vw</code> would be 10% of the viewport's width.</li><li><code>height: 3vh</code> would be 3% of the viewport's height.</li><li><code>width: 70vmin</code> or <code>height: 70vmin</code>would be 70% of the viewport's smaller dimension (height vs. width).</li><li><code>width:100vmax</code> or <code>height:100vmax</code> would be 100% of the viewport's bigger dimension (height vs. width).</li></ul>
+<ul><li><code>width: 10vw</code> would be 10% of the viewport's width.</li><li><code>height: 3vh</code> would be 3% of the viewport's height.</li><li><code>width: 70vmin</code> or <code>height: 70vmin</code>would be 70% of the viewport's smaller dimension (height vs. width).</li><li><code>width:100vmax</code> or <code>height:100vmax</code> would be 100% of the viewport's bigger dimension (height vs. width).</li></ul>
 Here is an example that sets a body tag to 30% of the viewport's width.
 <code>body { width: 30vw; }</code>
 </section>

--- a/curriculum/challenges/english/01-responsive-web-design/responsive-web-design-principles/make-typography-responsive.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/responsive-web-design-principles/make-typography-responsive.english.md
@@ -10,7 +10,7 @@ forumTopicId: 301141
 <section id='description'>
 Instead of using <code>em</code> or <code>px</code> to size text, you can use viewport units for responsive typography. Viewport units, like percentages, are relative units, but they are based off different items. Viewport units are relative to the viewport dimensions (width or height) of a device, and percentages are relative to the size of the parent container element.
 The four different viewport units are:
-<ul><li><code>vw: 10vw</code> would be 10% of the viewport's width.</li><li><code>vh: 3vh</code> would be 3% of the viewport's height.</li><li><code>vmin: 70vmin</code> would be 70% of the viewport's smaller dimension (height vs. width).</li><li><code>vmax: 100vmax</code> would be 100% of the viewport's bigger dimension (height vs. width).</li></ul>
+  <ul><li><code>width: 10vw</code> would be 10% of the viewport's width.</li><li><code>height: 3vh</code> would be 3% of the viewport's height.</li><li><code>width: 70vmin</code> or <code>height: 70vmin</code>would be 70% of the viewport's smaller dimension (height vs. width).</li><li><code>width:100vmax</code> or <code>height:100vmax</code> would be 100% of the viewport's bigger dimension (height vs. width).</li></ul>
 Here is an example that sets a body tag to 30% of the viewport's width.
 <code>body { width: 30vw; }</code>
 </section>

--- a/curriculum/challenges/english/01-responsive-web-design/responsive-web-design-principles/make-typography-responsive.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/responsive-web-design-principles/make-typography-responsive.english.md
@@ -10,7 +10,7 @@ forumTopicId: 301141
 <section id='description'>
 Instead of using <code>em</code> or <code>px</code> to size text, you can use viewport units for responsive typography. Viewport units, like percentages, are relative units, but they are based off different items. Viewport units are relative to the viewport dimensions (width or height) of a device, and percentages are relative to the size of the parent container element.
 The four different viewport units are:
-<ul><li><code>width: 10vw</code> would be 10% of the viewport's width.</li><li><code>height: 3vh</code> would be 3% of the viewport's height.</li><li><code>width: 70vmin</code> or <code>height: 70vmin</code>would be 70% of the viewport's smaller dimension (height vs. width).</li><li><code>width:100vmax</code> or <code>height:100vmax</code> would be 100% of the viewport's bigger dimension (height vs. width).</li></ul>
+<ul><li><code>vw</code>(viewport width): <code>10vw</code> would be 10% of the viewport's width.</li><li><code>vh</code>(viewport height): <code>3vh</code> would be 3% of the viewport's height.</li><li><code>vmin</code>(viewport minimum): <code>70vmin</code> would be 70% of the viewport's smaller dimension (height or width).</li><li><code>vmax</code> (viewport maximum): <code>100vmax</code> would be 100% of the viewport's bigger dimension (height or width).</li></ul>
 Here is an example that sets a body tag to 30% of the viewport's width.
 <code>body { width: 30vw; }</code>
 </section>

--- a/curriculum/challenges/english/01-responsive-web-design/responsive-web-design-principles/make-typography-responsive.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/responsive-web-design-principles/make-typography-responsive.english.md
@@ -10,7 +10,7 @@ forumTopicId: 301141
 <section id='description'>
 Instead of using <code>em</code> or <code>px</code> to size text, you can use viewport units for responsive typography. Viewport units, like percentages, are relative units, but they are based off different items. Viewport units are relative to the viewport dimensions (width or height) of a device, and percentages are relative to the size of the parent container element.
 The four different viewport units are:
-<ul><li><code>vw</code>(viewport width): <code>10vw</code> would be 10% of the viewport's width.</li><li><code>vh</code>(viewport height): <code>3vh</code> would be 3% of the viewport's height.</li><li><code>vmin</code>(viewport minimum): <code>70vmin</code> would be 70% of the viewport's smaller dimension (height or width).</li><li><code>vmax</code> (viewport maximum): <code>100vmax</code> would be 100% of the viewport's bigger dimension (height or width).</li></ul>
+<ul><li><code>vw</code> (viewport width): <code>10vw</code> would be 10% of the viewport's width.</li><li><code>vh</code> (viewport height): <code>3vh</code> would be 3% of the viewport's height.</li><li><code>vmin</code> (viewport minimum): <code>70vmin</code> would be 70% of the viewport's smaller dimension (height or width).</li><li><code>vmax</code> (viewport maximum): <code>100vmax</code> would be 100% of the viewport's bigger dimension (height or width).</li></ul>
 Here is an example that sets a body tag to 30% of the viewport's width.
 <code>body { width: 30vw; }</code>
 </section>


### PR DESCRIPTION
Ran into a readability issue when trying to complete challenge. Instead of using `width: 80vw` was attempting `vw: 80vw` based on the initial layout. I believe either this change or the example that was added but doesn't seem to be pushed yet will help.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x ] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x ] My pull request targets the `master` branch of freeCodeCamp.
- [x ] None of my changes are plagiarized from another source without proper attribution.
- [x ] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x ] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX
