### PR TITLE
Fix/night mode by default

### DIFF
--- a/client/src/html.js
+++ b/client/src/html.js
@@ -4,7 +4,12 @@ import PropTypes from 'prop-types';
 export default class HTML extends React.Component {
   render() {
     return (
-      <html id='__fcc-html' {...this.props.htmlAttributes} lang='en'>
+      <html
+        className='night'
+        id='__fcc-html'
+        {...this.props.htmlAttributes}
+        lang='en'
+      >
         <head>
           <meta charSet='utf-8' />
           <meta content='ie=edge' httpEquiv='x-ua-compatible' />

--- a/client/src/redux/night-mode-saga.js
+++ b/client/src/redux/night-mode-saga.js
@@ -2,12 +2,13 @@
 
 import { takeEvery } from 'redux-saga/effects';
 import store from 'store';
+import { isEmpty } from 'lodash';
 
 const themeKey = 'fcc-theme';
 const defaultTheme = 'default';
 const nightTheme = 'night';
 
-function setTheme(currentTheme = defaultTheme, theme) {
+function setTheme(currentTheme = nightTheme, theme = nightTheme) {
   if (currentTheme !== theme) {
     store.set(themeKey, theme);
   }
@@ -17,9 +18,9 @@ function setTheme(currentTheme = defaultTheme, theme) {
 }
 
 function* updateLocalThemeSaga({ payload: { user, theme } }) {
-  const currentTheme = store.get(themeKey) || defaultTheme;
-  if (user) {
-    const { theme = defaultTheme } = user;
+  const currentTheme = store.get(themeKey) || nightTheme;
+  if (!isEmpty(user)) {
+    const { theme = nightTheme } = user;
     return setTheme(currentTheme, theme);
   }
   if (theme) {


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

On .dev, when not logged in code blocks look like this:

![DevCodeBlock](https://user-images.githubusercontent.com/15801806/63596661-03377380-c5bc-11e9-8b52-93df258dbac8.png)

These changes make sure that page displays code as night mode by default.
