### PR TITLE
fix: stop wallets overflowing on mobile

### DIFF
--- a/client/src/components/Donation/Donation.css
+++ b/client/src/components/Donation/Donation.css
@@ -87,3 +87,7 @@
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075),
     0 0 8px rgba(102, 175, 233, 0.6);
 }
+
+.wallet {
+  overflow-wrap: break-word;
+}

--- a/client/src/components/Donation/components/DonateOther.js
+++ b/client/src/components/Donation/components/DonateOther.js
@@ -157,22 +157,30 @@ class DonateOther extends Component {
               <h4>Make a one-time Bitcoin donation</h4>
               <p className='negative-15'>
                 Our Bitcoin wallet is{' '}
-                <code>12skYi7aMCjDUdrVdoB3JjZ77ug8gxJfbL</code>
+                <code className='wallet'>
+                  12skYi7aMCjDUdrVdoB3JjZ77ug8gxJfbL
+                </code>
               </p>
               <h4>Make a one-time Ethereum donation</h4>
               <p className='negative-15'>
                 Our Ethereum wallet is{' '}
-                <code>0x0ADbEf2471416BD8732cf0f3944294eE393CcAF5</code>
+                <code className='wallet'>
+                  0x0ADbEf2471416BD8732cf0f3944294eE393CcAF5
+                </code>
               </p>
               <h4>Make a one-time Litecoin donation</h4>
               <p className='negative-15'>
                 Our Litecoin wallet is{' '}
-                <code>LKu8UG8Z1nbTxnq9Do96PsC3FwbNtycf3X</code>
+                <code className='wallet'>
+                  LKu8UG8Z1nbTxnq9Do96PsC3FwbNtycf3X
+                </code>
               </p>
               <h4>Make a one-time Bitcoin Cash donation</h4>
               <p className='negative-15'>
                 Our Bitcoin Cash wallet is{' '}
-                <code>1EBxPEJWrGZWxe2UayyAsnd5VsRg5H9xfu</code>
+                <code className='wallet'>
+                  1EBxPEJWrGZWxe2UayyAsnd5VsRg5H9xfu
+                </code>
               </p>
               <hr />
               <h3>Donate to freeCodeCamp by mailing us a check</h3>


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Large wallet keys were overflowing on the DonateOther page.  This allows them to wrap, preventing the overflow.

Closes #36603