### PR TITLE
fix(test): make less strict about whitespace

### DIFF
--- a/curriculum/challenges/english/04-data-visualization/json-apis-and-ajax/access-the-json-data-from-an-api.english.md
+++ b/curriculum/challenges/english/04-data-visualization/json-apis-and-ajax/access-the-json-data-from-an-api.english.md
@@ -35,7 +35,7 @@ For the cat with the "id" of 2, print to the console the second value in the <co
 ```yml
 tests:
   - text: Your code should use bracket and dot notation to access the proper code name, and print "Loki" to the console.
-    testString: assert(code.match(/(?:json\[2\]\.codeNames\[1\]|json\[2\]\[('|")codeNames\1\]\[1\])/g));
+    testString: assert(code.match(/console\s*\.\s*log\s*\(\s*json\s*\[2\]\s*(\.\s*codeNames|\[\s*('|`|")codeNames\2\s*\])\s*\[\s*1\s*\]\s*\)/g));
 
 ```
 


### PR DESCRIPTION
The test for the first challenge in the issue should now accept any valid syntax.
I didn't change any tests in the second challenge in the issue because the instructions explicitly say to "add the example code" - so none of the syntax should be changed.
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #35368
