### PR TITLE
fix: make public certs always viewable

### DIFF
--- a/api-server/server/middlewares/request-authorization.js
+++ b/api-server/server/middlewares/request-authorization.js
@@ -16,8 +16,9 @@ import { wrapHandledError } from '../utils/create-handled-error';
 const apiProxyRE = /^\/internal\/|^\/external\//;
 const newsShortLinksRE = /^\/internal\/n\/|^\/internal\/p\?/;
 const loopbackAPIPathRE = /^\/internal\/api\//;
+const showCertRe = /^\/internal\/certificate\/showCert\//;
 
-const _whiteListREs = [newsShortLinksRE, loopbackAPIPathRE];
+const _whiteListREs = [newsShortLinksRE, loopbackAPIPathRE, showCertRe];
 
 export function isWhiteListedPath(path, whiteListREs = _whiteListREs) {
   return whiteListREs.some(re => re.test(path));


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I'm not sure if there are security ramifications to whitelisting this path, but doing so makes the certificates visible to unauthenticated users, i.e. the people you might want to show them to.

The users privacy settings are still respected though.

Closes #36460
