### PR TITLE
chore: extend linting to cover react hooks

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,13 +1,15 @@
 {
   "root": true,
   "extends": ["@freecodecamp/eslint-config", "prettier", "prettier/react"],
-  "plugins": ["prettier"],
+  "plugins": ["prettier", "react-hooks"],
   "rules": {
     "max-len": [
       "error",
       { "code": 80, "ignoreUrls": true, "ignoreTemplateLiterals": true }
     ],
-    "prettier/prettier": "error"
+    "prettier/prettier": "error",
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn"
   },
   "settings": {
     "react": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4640,6 +4640,12 @@
         }
       }
     },
+    "eslint-plugin-react-hooks": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.0.1.tgz",
+      "integrity": "sha512-xir+3KHKo86AasxlCV8AHRtIZPHljqCRRUYgASkbatmt0fad4+5GgC7zkT7o/06hdKM6MIwp8giHVXqBPaarHQ==",
+      "dev": true
+    },
     "eslint-rule-composer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "eslint-plugin-prefer-object-spread": "^1.2.1",
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-react": "^7.14.3",
+    "eslint-plugin-react-hooks": "^2.0.1",
     "faker": "^4.1.0",
     "gray-matter": "^4.0.2",
     "gulp": "^4.0.2",


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Since we're looking to start using React hooks in #36722, I figured we should lint them.
