### PR TITLE
fix: allow more space for map challenge titles

### DIFF
--- a/client/src/components/Map/map.css
+++ b/client/src/components/Map/map.css
@@ -50,7 +50,7 @@ li.open > .map-title svg:first-child {
 
 .map-challenge-title {
   margin-bottom: 0.25rem;
-  max-width: 28rem;
+  max-width: calc(100% - 80px);
 }
 
 .block a {


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The width is set at `100% - 80pt`  since the titles are pushed 40pt to the right with respect to the enclosing box.  This is discussed a little further in the issue.

Closes #36676
