### PR TITLE
fix(style): rework color scheme for icons

### DIFF
--- a/client/src/assets/icons/Caret.js
+++ b/client/src/assets/icons/Caret.js
@@ -5,7 +5,11 @@ function Caret() {
     <svg viewBox='0 0 100 100' width='25px'>
       <polygon
         points='-6.04047,17.1511 81.8903,58.1985 -3.90024,104.196'
-        style={{ stroke: '#858591', fill: '#858591', strokeWidth: '1px' }}
+        style={{
+          stroke: 'var(--primary-color)',
+          fill: 'var(--primary-color)',
+          strokeWidth: '1px'
+        }}
         transform={
           'matrix(0.999729, 0.023281, -0.023281, 0.999729, 7.39321, -10.0425)'
         }

--- a/client/src/assets/icons/Fail.js
+++ b/client/src/assets/icons/Fail.js
@@ -13,17 +13,17 @@ function RedFail() {
         <circle
           cx='100'
           cy='99'
-          fill='#858591'
+          fill='var(--primary-color)'
           r='95'
-          stroke='#858591'
+          stroke='(var--primary-color)'
           strokeDasharray='null'
           strokeLinecap='null'
           strokeLinejoin='null'
         />
         <rect
-          fill='#ffffff'
+          fill='var(--primary-background)'
           height='30'
-          stroke='#ffffff'
+          stroke='var(--primary-background)'
           strokeDasharray='null'
           strokeLinecap='null'
           strokeLinejoin='null'
@@ -33,9 +33,9 @@ function RedFail() {
           y='88'
         />
         <rect
-          fill='#ffffff'
+          fill='var(--primary-background)'
           height='30'
-          stroke='#ffffff'
+          stroke='var(--primary-background)'
           strokeDasharray='null'
           strokeLinecap='null'
           strokeLinejoin='null'

--- a/client/src/assets/icons/GreenNotCompleted.js
+++ b/client/src/assets/icons/GreenNotCompleted.js
@@ -18,13 +18,13 @@ function GreenNotCompleted(props) {
           <circle
             cx='100'
             cy='99'
-            fill='#FFFFFF'
+            fill='var(--primary-background)'
             r='95'
-            stroke='#858591'
+            stroke='var(--primary-color)'
             strokeDasharray='null'
             strokeLinecap='null'
             strokeLinejoin='null'
-            strokeWidth='5'
+            strokeWidth='10'
           />
         </g>
       </svg>

--- a/client/src/assets/icons/GreenPass.js
+++ b/client/src/assets/icons/GreenPass.js
@@ -16,17 +16,17 @@ function GreenPass(props) {
           <circle
             cx='100'
             cy='99'
-            fill='#858591'
+            fill='var(--primary-color)'
             r='95'
-            stroke='#858591'
+            stroke='var(--primary-color)'
             strokeDasharray='null'
             strokeLinecap='null'
             strokeLinejoin='null'
           />
           <rect
-            fill='#ffffff'
+            fill='var(--primary-background)'
             height='30'
-            stroke='#ffffff'
+            stroke='var(--primary-background)'
             strokeDasharray='null'
             strokeLinecap='null'
             strokeLinejoin='null'
@@ -36,9 +36,9 @@ function GreenPass(props) {
             y='91.32089'
           />
           <rect
-            fill='#ffffff'
+            fill='var(--primary-background)'
             height='30'
-            stroke='#ffffff'
+            stroke='var(--primary-background)'
             strokeDasharray='null'
             strokeLinecap='null'
             strokeLinejoin='null'

--- a/client/src/assets/icons/Initial.js
+++ b/client/src/assets/icons/Initial.js
@@ -14,9 +14,9 @@ function Initial(props) {
         <circle
           cx='100'
           cy='99'
-          fill='#858591'
+          fill='var(--primary-color)'
           r='95'
-          stroke='#858591'
+          stroke='var(--primary-color)'
           strokeDasharray='null'
           strokeLinecap='null'
           strokeLinejoin='null'
@@ -42,7 +42,7 @@ function Initial(props) {
               '447 1-1zm3 3c0-.552-.448-1-1-1s-1 .448-1 1 .448 1 1 1 1-.448 ' +
               '1-1z'
             }
-            fill='#fff'
+            fill='var(--primary-background)'
           />
         </svg>
       </g>

--- a/client/src/templates/Challenges/components/__snapshots__/ChallengeTitle.test.js.snap
+++ b/client/src/templates/Challenges/components/__snapshots__/ChallengeTitle.test.js.snap
@@ -40,17 +40,17 @@ exports[`<ChallengeTitle/> renders correctly 1`] = `
         <circle
           cx="100"
           cy="99"
-          fill="#858591"
+          fill="var(--primary-color)"
           r="95"
-          stroke="#858591"
+          stroke="var(--primary-color)"
           strokeDasharray="null"
           strokeLinecap="null"
           strokeLinejoin="null"
         />
         <rect
-          fill="#ffffff"
+          fill="var(--primary-background)"
           height="30"
-          stroke="#ffffff"
+          stroke="var(--primary-background)"
           strokeDasharray="null"
           strokeLinecap="null"
           strokeLinejoin="null"
@@ -60,9 +60,9 @@ exports[`<ChallengeTitle/> renders correctly 1`] = `
           y="91.32089"
         />
         <rect
-          fill="#ffffff"
+          fill="var(--primary-background)"
           height="30"
-          stroke="#ffffff"
+          stroke="var(--primary-background)"
           strokeDasharray="null"
           strokeLinecap="null"
           strokeLinejoin="null"

--- a/client/src/templates/Challenges/components/test-suite.css
+++ b/client/src/templates/Challenges/components/test-suite.css
@@ -16,7 +16,7 @@
 }
 
 .test-output {
-  padding: 10px;
+  padding: 5px 10px;
 }
 
 .test-status-icon {

--- a/client/src/templates/Challenges/components/test-suite.css
+++ b/client/src/templates/Challenges/components/test-suite.css
@@ -2,7 +2,7 @@
   display: flex;
   justify-content: flex-start;
   flex-direction: column;
-  margin-top: 15px;
+  margin: 15px 0;
 }
 
 .test-result {
@@ -16,16 +16,18 @@
 }
 
 .test-output {
-  margin-left: 15px;
+  padding: 10px;
 }
 
 .test-status-icon {
   display: flex;
   align-items: center;
-  margin-left: 3px;
+  justify-content: center;
+  min-width: 60px;
+  min-height: 60px;
 }
 
 .test-status-icon > svg {
-  width: 50px;
-  height: 50px;
+  width: 40px;
+  height: 40px;
 }


### PR DESCRIPTION
I reworked the colors of our icons to go with the new theme. I'm not sure if that was wanted - I think they look pretty good - see photos.

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #36666


<img width="354" alt="Screen Shot 2019-09-05 at 7 57 37 AM" src="https://user-images.githubusercontent.com/20648924/64345350-d1f47580-cfb5-11e9-826d-e9d51056cefc.png">
<img width="504" alt="Screen Shot 2019-09-05 at 7 57 55 AM" src="https://user-images.githubusercontent.com/20648924/64345377-dcaf0a80-cfb5-11e9-825e-39bbe0b64e8f.png">
<img width="501" alt="Screen Shot 2019-09-05 at 7 58 13 AM" src="https://user-images.githubusercontent.com/20648924/64345382-de78ce00-cfb5-11e9-8b0b-c614bf643f5e.png">
<img width="379" alt="Screen Shot 2019-09-05 at 7 56 16 AM" src="https://user-images.githubusercontent.com/20648924/64345386-e0429180-cfb5-11e9-965d-1a1a2abf6e27.png">
<img width="490" alt="Screen Shot 2019-09-05 at 7 56 34 AM" src="https://user-images.githubusercontent.com/20648924/64345388-e173be80-cfb5-11e9-8351-97889479e106.png">
<img width="500" alt="Screen Shot 2019-09-05 at 7 56 57 AM" src="https://user-images.githubusercontent.com/20648924/64345392-e33d8200-cfb5-11e9-8990-8ff4515c1400.png">