### PR TITLE
fix: make donate modal scrollable

### DIFF
--- a/client/src/components/Donation/Donation.css
+++ b/client/src/components/Donation/Donation.css
@@ -1,5 +1,6 @@
 .donation-modal {
   font-size: 0.8rem;
+  overflow-y: auto;
 }
 
 .donation-modal p {

--- a/client/src/components/Donation/Donation.css
+++ b/client/src/components/Donation/Donation.css
@@ -1,5 +1,4 @@
 .donation-modal {
-  font-size: 0.8rem;
   overflow-y: auto;
 }
 
@@ -17,15 +16,29 @@
   font-size: 1.2rem;
 }
 
-.donation-modal .donation-form {
-  width: 60%;
-}
 .donation-form {
   display: flex;
   flex-direction: column;
   width: 80%;
   justify-content: center;
   margin: 0 auto;
+}
+
+@media (max-width: 500px) {
+  .donation-form {
+    width: 100%;
+  }
+}
+
+.donation-modal .btn-link {
+  border: none;
+  text-decoration: underline;
+  background: transparent;
+}
+.donation-modal .btn-link:hover {
+  background: var(--tertiary-background);
+  text-decoration: none;
+  color: inherit;
 }
 
 .donation-elements {

--- a/client/src/components/Donation/components/DonateForm.js
+++ b/client/src/components/Donation/components/DonateForm.js
@@ -8,7 +8,9 @@ import {
   ControlLabel,
   Form,
   FormControl,
-  FormGroup
+  FormGroup,
+  Row,
+  Col
 } from '@freecodecamp/react-bootstrap';
 import { injectStripe } from 'react-stripe-elements';
 
@@ -162,34 +164,35 @@ class DonateForm extends Component {
   renderDonateForm() {
     const { isFormValid } = this.state;
     return (
-      <div>
-        <Form className='donation-form' onSubmit={this.handleSubmit}>
-          <FormGroup className='donation-email-container'>
-            <ControlLabel>
-              Email (we'll send you a tax-deductible donation receipt):
-            </ControlLabel>
-            <FormControl
-              onChange={this.handleEmailChange}
-              placeholder='me@example.com'
-              required={true}
-              type='text'
-              value={this.getUserEmail()}
-            />
-          </FormGroup>
-          <StripeCardForm getValidationState={this.getValidationState} />
-          <Button
-            block={true}
-            bsSize='lg'
-            bsStyle='primary'
-            disabled={!isFormValid}
-            id='confirm-donation-btn'
-            type='submit'
-          >
-            Confirm your donation of $5 / month
-          </Button>
-          <Spacer />
-        </Form>
-      </div>
+      <Row>
+        <Col sm={10} smOffset={1} xs={12}>
+          <Form className='donation-form' onSubmit={this.handleSubmit}>
+            <FormGroup className='donation-email-container'>
+              <ControlLabel>
+                Email (we'll send you a tax-deductible donation receipt):
+              </ControlLabel>
+              <FormControl
+                onChange={this.handleEmailChange}
+                placeholder='me@example.com'
+                required={true}
+                type='text'
+                value={this.getUserEmail()}
+              />
+            </FormGroup>
+            <StripeCardForm getValidationState={this.getValidationState} />
+            <Button
+              block={true}
+              bsStyle='primary'
+              disabled={!isFormValid}
+              id='confirm-donation-btn'
+              type='submit'
+            >
+              Confirm your donation of $5 / month
+            </Button>
+            <Spacer />
+          </Form>
+        </Col>
+      </Row>
     );
   }
 

--- a/client/src/components/Donation/components/DonateModal.js
+++ b/client/src/components/Donation/components/DonateModal.js
@@ -75,7 +75,7 @@ class DonateModal extends Component {
     };
     return (
       <div className='modal-close-btn-container'>
-        <Button className='btn btn-lg btn-primary' onClick={handleClick}>
+        <Button bsStyle='link' onClick={handleClick}>
           Close
         </Button>
       </div>

--- a/client/src/components/Donation/components/DonateModal.js
+++ b/client/src/components/Donation/components/DonateModal.js
@@ -75,7 +75,7 @@ class DonateModal extends Component {
     };
     return (
       <div className='modal-close-btn-container'>
-        <Button bsStyle='link' onClick={handleClick}>
+        <Button className='btn btn-lg btn-primary' onClick={handleClick}>
           Close
         </Button>
       </div>

--- a/client/src/components/Donation/components/DonateText.js
+++ b/client/src/components/Donation/components/DonateText.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
+import { Row, Col } from '@freecodecamp/react-bootstrap';
 
 import { activeDonationsSelector } from '../../../redux';
 
@@ -17,18 +18,20 @@ const mapStateToProps = createSelector(
 const DonateText = ({ activeDonations }) => {
   const donationsLocale = activeDonations.toLocaleString();
   return (
-    <div className='text-center'>
-      <p>
-        freeCodeCamp.org is a tiny nonprofit that's helping millions of people
-        learn to code for free.
-      </p>
-      <p>
-        Join <strong>{donationsLocale}</strong> supporters.
-      </p>
-      <p>
-        Your $5 / month donation will help keep tech education free and open.
-      </p>
-    </div>
+    <Row>
+      <Col sm={10} smOffset={1} xs={12}>
+        <p>
+          freeCodeCamp.org is a tiny nonprofit that's helping millions of people
+          learn to code for free.
+        </p>
+        <p>
+          Join <strong>{donationsLocale}</strong> supporters.
+        </p>
+        <p>
+          Your $5 / month donation will help keep tech education free and open.
+        </p>
+      </Col>
+    </Row>
   );
 };
 


### PR DESCRIPTION
I'm not quite sure what you all had in mind for this @raisedadead - but this seems like a quick and easy fix to the scrolling issue - which allows you to get to the `close` button.

Also, the `close` button text was underlined - so I got rid of that.

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Closes #36756
