### PR TITLE
docs: fix link path to other translations in document-quick-reference

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,14 +2,17 @@
     <tr>
         <!-- Do not translate this table -->
         <td> Read these guidelines in </td>
-        <td><a href="/CONTRIBUTING.md"> English </a></td>
-        <td><a href="/docs/arabic/README.md"> عربي </a></td>
-        <td><a href="/docs/chinese/README.md"> 中文 </a></td>
-        <td><a href="/docs/russian/README.md"> русский </a></td>
-        <td><a href="/docs/portuguese/README.md"> Português </a></td>
-        <td><a href="/docs/spanish/README.md"> Español </a></td>
-        <td><a href="/docs/german/README.md"> Deutsch </a></td>
-        <td><a href="/docs/greek/README.md"> Ελληνικά </a></td>
+        <td><a href="/docs/README.md"> English </a></td>
+        <td><a href="/docs/arabic/document-quick-reference.md"> عربي </a></td>
+        <td><a href="/docs/chinese/document-quick-reference.md"> 中文 </a></td>
+        <td><a href="/docs/french/README.md"> Français </a></td>
+        <td><a href="/docs/german/document-quick-reference.md"> Deutsch </a></td>
+        <td><a href="/docs/greek/document-quick-reference.md"> Ελληνικά </a></td>
+        <td><a href="/docs/japanese/document-quick-reference.md"> 日本語 </a></td>
+        <td><a href="/docs/korean/document-quick-reference.md"> 한국어 </a></td>
+        <td><a href="/docs/portuguese/document-quick-reference.md"> Português </a></td>
+        <td><a href="/docs/russian/document-quick-reference.md"> русский </a></td>
+        <td><a href="/docs/spanish/document-quick-reference.md"> Español </a></td>
     </tr>
 </table>
 

--- a/docs/arabic/document-quick-reference.md
+++ b/docs/arabic/document-quick-reference.md
@@ -1,14 +1,17 @@
-
 <table>
     <tr>
         <td> Read these guidelines in </td>
-        <td><a href="/CONTRIBUTING.md"> English </a></td>
-        <td><a href="/docs/chinese/README.md"> 中文 </a></td>
-        <td><a href="/docs/russian/README.md"> русский </a></td>
-        <td><a href="/docs/arabic/README.md"> عربي </a></td>
-        <td><a href="/docs/spanish/README.md"> Español </a></td>
-        <td><a href="/docs/portuguese/README.md"> Português </a></td>
-        <td><a href="/docs/german/README.md"> Deutsch </a></td>
+        <td><a href="/docs/README.md"> English </a></td>
+        <td><a href="/docs/arabic/document-quick-reference.md"> عربي </a></td>
+        <td><a href="/docs/chinese/document-quick-reference.md"> 中文 </a></td>
+        <td><a href="/docs/french/README.md"> Français </a></td>
+        <td><a href="/docs/german/document-quick-reference.md"> Deutsch </a></td>
+        <td><a href="/docs/greek/document-quick-reference.md"> Ελληνικά </a></td>
+        <td><a href="/docs/japanese/document-quick-reference.md"> 日本語 </a></td>
+        <td><a href="/docs/korean/document-quick-reference.md"> 한국어 </a></td>
+        <td><a href="/docs/portuguese/document-quick-reference.md"> Português </a></td>
+        <td><a href="/docs/russian/document-quick-reference.md"> русский </a></td>
+        <td><a href="/docs/spanish/document-quick-reference.md"> Español </a></td>
     </tr>
 </table>
 

--- a/docs/chinese/document-quick-reference.md
+++ b/docs/chinese/document-quick-reference.md
@@ -2,12 +2,16 @@
     <tr>
         <td>  此指南可阅读的语言版本 </td>
         <td><a href="/docs/README.md"> English </a></td>
-        <td><a href="/docs/chinese/README.md"> 中文 </a></td>
-        <td><a href="/docs/russian/README.md"> русский </a></td>
-        <td><a href="/docs/arabic/README.md"> عربي </a></td>
-        <td><a href="/docs/spanish/README.md"> Español </a></td>
-        <td><a href="/docs/portuguese/README.md"> Português </a></td>
-        <td><a href="/docs/german/README.md"> Deutsch </a></td>
+        <td><a href="/docs/arabic/document-quick-reference.md"> عربي </a></td>
+        <td><a href="/docs/chinese/document-quick-reference.md"> 中文 </a></td>
+        <td><a href="/docs/french/README.md"> Français </a></td>
+        <td><a href="/docs/german/document-quick-reference.md"> Deutsch </a></td>
+        <td><a href="/docs/greek/document-quick-reference.md"> Ελληνικά </a></td>
+        <td><a href="/docs/japanese/document-quick-reference.md"> 日本語 </a></td>
+        <td><a href="/docs/korean/document-quick-reference.md"> 한국어 </a></td>
+        <td><a href="/docs/portuguese/document-quick-reference.md"> Português </a></td>
+        <td><a href="/docs/russian/document-quick-reference.md"> русский </a></td>
+        <td><a href="/docs/spanish/document-quick-reference.md"> Español </a></td>
     </tr>
 </table>
 

--- a/docs/french/document-quick-reference.md
+++ b/docs/french/document-quick-reference.md
@@ -2,14 +2,17 @@
     <tr>
         <!-- Do not translate this table -->
         <td> Read these guidelines in </td>
-        <td><a href="/CONTRIBUTING.md"> English </a></td>
-        <td><a href="/docs/arabic/README.md"> عربى </a></td>
-        <td><a href="/docs/chinese/README.md"> 中文 </a></td>
-        <td><a href="/docs/russian/README.md"> русский </a></td>
-        <td><a href="/docs/portuguese/README.md"> Português </a></td>
-        <td><a href="/docs/spanish/README.md"> Español </a></td>
-        <td><a href="/docs/german/README.md"> Deutsch </a></td>
+        <td><a href="/docs/README.md"> English </a></td>
+        <td><a href="/docs/arabic/document-quick-reference.md"> عربي </a></td>
+        <td><a href="/docs/chinese/document-quick-reference.md"> 中文 </a></td>
         <td><a href="/docs/french/README.md"> Français </a></td>
+        <td><a href="/docs/german/document-quick-reference.md"> Deutsch </a></td>
+        <td><a href="/docs/greek/document-quick-reference.md"> Ελληνικά </a></td>
+        <td><a href="/docs/japanese/document-quick-reference.md"> 日本語 </a></td>
+        <td><a href="/docs/korean/document-quick-reference.md"> 한국어 </a></td>
+        <td><a href="/docs/portuguese/document-quick-reference.md"> Português </a></td>
+        <td><a href="/docs/russian/document-quick-reference.md"> русский </a></td>
+        <td><a href="/docs/spanish/document-quick-reference.md"> Español </a></td>
     </tr>
 </table>
 

--- a/docs/german/document-quick-reference.md
+++ b/docs/german/document-quick-reference.md
@@ -2,13 +2,17 @@
     <tr>
         <!-- Do not translate this table -->
         <td> Read these guidelines in </td>
-        <td><a href="/CONTRIBUTING.md"> English </a></td>
-        <td><a href="/docs/arabic/README.md"> عربى </a></td>
-        <td><a href="/docs/chinese/README.md"> 中文 </a></td>
-        <td><a href="/docs/russian/README.md"> русский </a></td>
-        <td><a href="/docs/portuguese/README.md"> Português </a></td>
-        <td><a href="/docs/spanish/README.md"> Español </a></td>
-        <td><a href="/docs/german/README.md"> Deutsch </a></td>
+        <td><a href="/docs/README.md"> English </a></td>
+        <td><a href="/docs/arabic/document-quick-reference.md"> عربي </a></td>
+        <td><a href="/docs/chinese/document-quick-reference.md"> 中文 </a></td>
+        <td><a href="/docs/french/README.md"> Français </a></td>
+        <td><a href="/docs/german/document-quick-reference.md"> Deutsch </a></td>
+        <td><a href="/docs/greek/document-quick-reference.md"> Ελληνικά </a></td>
+        <td><a href="/docs/japanese/document-quick-reference.md"> 日本語 </a></td>
+        <td><a href="/docs/korean/document-quick-reference.md"> 한국어 </a></td>
+        <td><a href="/docs/portuguese/document-quick-reference.md"> Português </a></td>
+        <td><a href="/docs/russian/document-quick-reference.md"> русский </a></td>
+        <td><a href="/docs/spanish/document-quick-reference.md"> Español </a></td>
     </tr>
 </table>
 

--- a/docs/greek/document-quick-reference.md
+++ b/docs/greek/document-quick-reference.md
@@ -2,14 +2,17 @@
     <tr>
         <!-- Do not translate this table -->
         <td> Read these guidelines in </td>
-        <td><a href="/CONTRIBUTING.md"> English </a></td>
-        <td><a href="/docs/arabic/README.md"> عربى </a></td>
-        <td><a href="/docs/chinese/README.md"> 中文 </a></td>
-        <td><a href="/docs/russian/README.md"> русский </a></td>
-        <td><a href="/docs/portuguese/README.md"> Português </a></td>
-        <td><a href="/docs/spanish/README.md"> Español </a></td>
-        <td><a href="/docs/german/README.md"> Deutsch </a></td>
-        <td><a href="/docs/greek/README.md"> Ελληνικά </a></td>
+        <td><a href="/docs/README.md"> English </a></td>
+        <td><a href="/docs/arabic/document-quick-reference.md"> عربي </a></td>
+        <td><a href="/docs/chinese/document-quick-reference.md"> 中文 </a></td>
+        <td><a href="/docs/french/README.md"> Français </a></td>
+        <td><a href="/docs/german/document-quick-reference.md"> Deutsch </a></td>
+        <td><a href="/docs/greek/document-quick-reference.md"> Ελληνικά </a></td>
+        <td><a href="/docs/japanese/document-quick-reference.md"> 日本語 </a></td>
+        <td><a href="/docs/korean/document-quick-reference.md"> 한국어 </a></td>
+        <td><a href="/docs/portuguese/document-quick-reference.md"> Português </a></td>
+        <td><a href="/docs/russian/document-quick-reference.md"> русский </a></td>
+        <td><a href="/docs/spanish/document-quick-reference.md"> Español </a></td>
     </tr>
 </table>
 

--- a/docs/japanese/document-quick-reference.md
+++ b/docs/japanese/document-quick-reference.md
@@ -2,14 +2,17 @@
     <tr>
         <!-- Do not translate this table -->
         <td> Read these guidelines in </td>
-        <td><a href="/CONTRIBUTING.md"> English </a></td>
-        <td><a href="/docs/arabic/README.md"> عربي </a></td>
-        <td><a href="/docs/chinese/README.md"> 中文 </a></td>
-        <td><a href="/docs/russian/README.md"> русский </a></td>
-        <td><a href="/docs/portuguese/README.md"> Português </a></td>
-        <td><a href="/docs/spanish/README.md"> Español </a></td>
-        <td><a href="/docs/german/README.md"> Deutsch </a></td>
-        <td><a href="/docs/greek/README.md"> Ελληνικά </a></td>
+        <td><a href="/docs/README.md"> English </a></td>
+        <td><a href="/docs/arabic/document-quick-reference.md"> عربي </a></td>
+        <td><a href="/docs/chinese/document-quick-reference.md"> 中文 </a></td>
+        <td><a href="/docs/french/README.md"> Français </a></td>
+        <td><a href="/docs/german/document-quick-reference.md"> Deutsch </a></td>
+        <td><a href="/docs/greek/document-quick-reference.md"> Ελληνικά </a></td>
+        <td><a href="/docs/japanese/document-quick-reference.md"> 日本語 </a></td>
+        <td><a href="/docs/korean/document-quick-reference.md"> 한국어 </a></td>
+        <td><a href="/docs/portuguese/document-quick-reference.md"> Português </a></td>
+        <td><a href="/docs/russian/document-quick-reference.md"> русский </a></td>
+        <td><a href="/docs/spanish/document-quick-reference.md"> Español </a></td>
     </tr>
 </table>
 

--- a/docs/korean/document-quick-reference.md
+++ b/docs/korean/document-quick-reference.md
@@ -2,15 +2,17 @@
     <tr>
         <!-- Do not translate this table -->
         <td> Read these guidelines in </td>
-        <td><a href="/CONTRIBUTING.md"> English </a></td>
-        <td><a href="/docs/arabic/README.md"> عربي </a></td>
-        <td><a href="/docs/chinese/README.md"> 中文 </a></td>
-        <td><a href="/docs/russian/README.md"> русский </a></td>
-        <td><a href="/docs/portuguese/README.md"> Português </a></td>
-        <td><a href="/docs/spanish/README.md"> Español </a></td>
-        <td><a href="/docs/german/README.md"> Deutsch </a></td>
-        <td><a href="/docs/greek/README.md"> Ελληνικά </a></td>
-        <td><a href="/docs/korean/README.md"> 한국어 </a></td>
+        <td><a href="/docs/README.md"> English </a></td>
+        <td><a href="/docs/arabic/document-quick-reference.md"> عربي </a></td>
+        <td><a href="/docs/chinese/document-quick-reference.md"> 中文 </a></td>
+        <td><a href="/docs/french/README.md"> Français </a></td>
+        <td><a href="/docs/german/document-quick-reference.md"> Deutsch </a></td>
+        <td><a href="/docs/greek/document-quick-reference.md"> Ελληνικά </a></td>
+        <td><a href="/docs/japanese/document-quick-reference.md"> 日本語 </a></td>
+        <td><a href="/docs/korean/document-quick-reference.md"> 한국어 </a></td>
+        <td><a href="/docs/portuguese/document-quick-reference.md"> Português </a></td>
+        <td><a href="/docs/russian/document-quick-reference.md"> русский </a></td>
+        <td><a href="/docs/spanish/document-quick-reference.md"> Español </a></td>
     </tr>
 </table>
 

--- a/docs/macedonian/document-quick-reference.md
+++ b/docs/macedonian/document-quick-reference.md
@@ -2,12 +2,17 @@
     <tr>
         <!-- Do not translate this table -->
         <td> Read these guidelines in </td>
-        <td><a href="/CONTRIBUTING.md"> English </a></td>
-        <td><a href="/docs/arabic/README.md"> عربى </a></td>
-        <td><a href="/docs/chinese/README.md"> 中文 </a></td>
-        <td><a href="/docs/russian/README.md"> русский </a></td>
-        <td><a href="/docs/portuguese/README.md"> Português </a></td>
-        <td><a href="/docs/spanish/README.md"> Español </a></td>
+        <td><a href="/docs/README.md"> English </a></td>
+        <td><a href="/docs/arabic/document-quick-reference.md"> عربي </a></td>
+        <td><a href="/docs/chinese/document-quick-reference.md"> 中文 </a></td>
+        <td><a href="/docs/french/README.md"> Français </a></td>
+        <td><a href="/docs/german/document-quick-reference.md"> Deutsch </a></td>
+        <td><a href="/docs/greek/document-quick-reference.md"> Ελληνικά </a></td>
+        <td><a href="/docs/japanese/document-quick-reference.md"> 日本語 </a></td>
+        <td><a href="/docs/korean/document-quick-reference.md"> 한국어 </a></td>
+        <td><a href="/docs/portuguese/document-quick-reference.md"> Português </a></td>
+        <td><a href="/docs/russian/document-quick-reference.md"> русский </a></td>
+        <td><a href="/docs/spanish/document-quick-reference.md"> Español </a></td>
     </tr>
 </table>
 

--- a/docs/portuguese/document-quick-reference.md
+++ b/docs/portuguese/document-quick-reference.md
@@ -1,13 +1,17 @@
 <table>
     <tr>
         <td> Ler estes guias em </td>
-        <td><a href="/CONTRIBUTING.md"> English </a></td>
-        <td><a href="/docs/chinese/README.md"> 中文 </a></td>
-        <td><a href="/docs/russian/README.md"> русский </a></td>
-        <td><a href="/docs/arabic/README.md"> عربي </a></td>
-        <td><a href="/docs/spanish/README.md"> Español </a></td>
-        <td><a href="/docs/portuguese/README.md"> Português </a></td>
-        <td><a href="/docs/german/README.md"> Deutsch </a></td>
+        <td><a href="/docs/README.md"> English </a></td>
+        <td><a href="/docs/arabic/document-quick-reference.md"> عربي </a></td>
+        <td><a href="/docs/chinese/document-quick-reference.md"> 中文 </a></td>
+        <td><a href="/docs/french/README.md"> Français </a></td>
+        <td><a href="/docs/german/document-quick-reference.md"> Deutsch </a></td>
+        <td><a href="/docs/greek/document-quick-reference.md"> Ελληνικά </a></td>
+        <td><a href="/docs/japanese/document-quick-reference.md"> 日本語 </a></td>
+        <td><a href="/docs/korean/document-quick-reference.md"> 한국어 </a></td>
+        <td><a href="/docs/portuguese/document-quick-reference.md"> Português </a></td>
+        <td><a href="/docs/russian/document-quick-reference.md"> русский </a></td>
+        <td><a href="/docs/spanish/document-quick-reference.md"> Español </a></td>
     </tr>
 </table>
 

--- a/docs/russian/document-quick-reference.md
+++ b/docs/russian/document-quick-reference.md
@@ -2,13 +2,17 @@
     <tr>
         <!-- Do not translate this table -->
         <td> Read these guidelines in </td>
-        <td><a href="/CONTRIBUTING.md"> English </a></td>
-        <td><a href="/docs/chinese/README.md"> 中文 </a></td>
-        <td><a href="/docs/russian/README.md"> русский </a></td>
-        <td><a href="/docs/arabic/README.md"> عربي </a></td>
-        <td><a href="/docs/spanish/README.md"> Español </a></td>
-        <td><a href="/docs/portuguese/README.md"> Português </a></td>
-        <td><a href="/docs/german/README.md"> Deutsch </a></td>
+        <td><a href="/docs/README.md"> English </a></td>
+        <td><a href="/docs/arabic/document-quick-reference.md"> عربي </a></td>
+        <td><a href="/docs/chinese/document-quick-reference.md"> 中文 </a></td>
+        <td><a href="/docs/french/README.md"> Français </a></td>
+        <td><a href="/docs/german/document-quick-reference.md"> Deutsch </a></td>
+        <td><a href="/docs/greek/document-quick-reference.md"> Ελληνικά </a></td>
+        <td><a href="/docs/japanese/document-quick-reference.md"> 日本語 </a></td>
+        <td><a href="/docs/korean/document-quick-reference.md"> 한국어 </a></td>
+        <td><a href="/docs/portuguese/document-quick-reference.md"> Português </a></td>
+        <td><a href="/docs/russian/document-quick-reference.md"> русский </a></td>
+        <td><a href="/docs/spanish/document-quick-reference.md"> Español </a></td>
     </tr>
 </table>
 

--- a/docs/spanish/document-quick-reference.md
+++ b/docs/spanish/document-quick-reference.md
@@ -1,13 +1,17 @@
 <table>
     <tr>
         <td> Read these guidelines in </td>
-        <td><a href="/CONTRIBUTING.md"> English </a></td>
-        <td><a href="/docs/chinese/README.md"> 中文 </a></td>
-        <td><a href="/docs/russian/README.md"> русский </a></td>
-        <td><a href="/docs/arabic/README.md"> عربي </a></td>
-        <td><a href="/docs/spanish/README.md"> Español </a></td>
-        <td><a href="/docs/portuguese/README.md"> Português </a></td>
-        <td><a href="/docs/german/README.md"> Deutsch </a></td>
+        <td><a href="/docs/README.md"> English </a></td>
+        <td><a href="/docs/arabic/document-quick-reference.md"> عربي </a></td>
+        <td><a href="/docs/chinese/document-quick-reference.md"> 中文 </a></td>
+        <td><a href="/docs/french/README.md"> Français </a></td>
+        <td><a href="/docs/german/document-quick-reference.md"> Deutsch </a></td>
+        <td><a href="/docs/greek/document-quick-reference.md"> Ελληνικά </a></td>
+        <td><a href="/docs/japanese/document-quick-reference.md"> 日本語 </a></td>
+        <td><a href="/docs/korean/document-quick-reference.md"> 한국어 </a></td>
+        <td><a href="/docs/portuguese/document-quick-reference.md"> Português </a></td>
+        <td><a href="/docs/russian/document-quick-reference.md"> русский </a></td>
+        <td><a href="/docs/spanish/document-quick-reference.md"> Español </a></td>
     </tr>
 </table>
 


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [ ] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

## Description
### Fix link path
https://github.com/freeCodeCamp/freeCodeCamp/pull/36716 renames `docs/lang/README.md` to `docs/lang/document-quick-reference.md`.
But links to other translations seems to be not changed and broken.
So, I fixed that.

### Fix link to english version
Some translations has link to `<td><a href="/CONTRIBUTING.md"> English </a></td>`.
But I think this is wrong, so I fixed that.

### Add all the translation
Since some `document-quick-reference` do not have links to all the translated `document-quick-reference`, I added the links.
