### PR TITLE
docs: add Japanese translation of README.md

### DIFF
--- a/docs/japanese/README.md
+++ b/docs/japanese/README.md
@@ -1,0 +1,155 @@
+![freeCodeCamp.org Social Banner](https://s3.amazonaws.com/freecodecamp/wide-social-banner.png)
+
+[![Pull Requests Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat)](http://makeapullrequest.com)
+[![first-timers-only Friendly](https://img.shields.io/badge/first--timers--only-friendly-blue.svg)](http://www.firsttimersonly.com/)
+[![Open Source Helpers](https://www.codetriage.com/freecodecamp/freecodecamp/badges/users.svg)](https://www.codetriage.com/freecodecamp/freecodecamp)
+[![Setup Automated](https://img.shields.io/badge/setup-automated-blue?logo=gitpod)](https://gitpod.io/from-referrer/)
+
+## freeCodeCamp.org のオープンソースコードベース、カリキュラムにようこそ！
+
+[freeCodeCamp.org](https://www.freecodecamp.org) は無料でプログラミングを学べるフレンドリーなコミュニティです。技術者になろうと忙しい何百万人もの人々を助けることを目的として、 [donor-supported 501(c)(3) nonprofit](https://donate.freecodecamp.org) により運営されています。このコミュニティはすでに10,000以上の人々に対し、初めての開発者の職につくことを助けてきました。
+
+私達のフルスタックのWeb開発のカリキュラムは完全に無料で、自分のペースで進められます。あなたのスキルを広げる何千ものインタラクティブなコーディング問題を用意しています。
+
+## 目次
+
+* [資格](#資格)
+* [学習プラットフォーム](#学習プラットフォーム)
+* [バグや問題を報告する](#バグや問題を報告する)
+* [セキュリティに関する問題を報告する](#セキュリティに関する問題を報告する)
+* [貢献する](#貢献する)
+* [ライセンス](#ライセンス)
+
+
+### 資格
+
+freeCodeCamp.org はいくつかの無料の開発に関する資格を提供しています。それぞれの資格は5つのWebアプリのプロジェクトを含んでいて、数百のコーディング問題に沿うことで、そのプロジェクトに対して準備ができるようになっています。それぞれの資格の取得には、初心者のプログラマーであれば300時間程度かかるような想定です。
+
+freeCodeCamp.org のカリキュラムにある30のプロジェクトそれぞれには、アジャイルなユーザーストーリーと自動化されたテストが含まれています。それはあなたがプロジェクトを徐々に開発していくのを助けるとともに、提出前にすべてのユーザーストーリーを満足するものにすることを保証します。
+
+それらのテストケースは [freeCodeCamp CDN](https://cdn.freecodecamp.org/testable-projects-fcc/v1/bundle.js) から取得することができます。つまり CodePen や Glitch を利用して、またはあなたのローカルの開発環境からそれらのプロジェクトをビルドすることが出来るということです。
+
+1度資格を取得したら、いつでもそれを利用できます。あなたはいつでも LinkedIn やレジュメから資格に対してリンクすることができます。将来の雇用主やフリーランスのクライアントがそのリンクをクリックすれば、あなたがその資格をもつと証明されていることを見られるでしょう。
+
+ただし、 [Academic Honesty ポリシー](https://www.freecodecamp.org/academic-honesty) に違反していることを私達が見つけた場合、これは例外となります。明確な盗用（引用なしに他人のコードやプロジェクトを用いて提出すること）行為をする人々を見つけた際には、厳正な学習の機関としてすべき対応、つまりその人々の資格を剥奪しBANを行います。
+
+以下は私達の提供する6つの資格です。
+
+#### 1. レスポンシブWebデザインに関する資格
+
+- [基本的なHTMLとHTML5](https://learn.freecodecamp.org/responsive-web-design/basic-html-and-html5)
+- [基本的なCSS](https://learn.freecodecamp.org/responsive-web-design/basic-css)
+- [応用的なビジュアルデザイン](https://learn.freecodecamp.org/responsive-web-design/applied-visual-design)
+- [応用的なアクセシビリティ](https://learn.freecodecamp.org/responsive-web-design/applied-accessibility)
+- [レスポンシブWebデザインの原則](https://learn.freecodecamp.org/responsive-web-design/responsive-web-design-principles)
+- [CSS Flexbox](https://learn.freecodecamp.org/responsive-web-design/css-flexbox)
+- [CSS Grid](https://learn.freecodecamp.org/responsive-web-design/css-grid)
+  <br />
+  <br />
+  **プロジェクト**: トリビュートページ、アンケートフォーム、ランディングページ、記述的なドキュメントページ、個人のポートフォリオページ
+
+#### 2. JavaScriptアルゴリズムとデータ構造に関する資格
+
+- [基本的なJavaScript](https://learn.freecodecamp.org/javascript-algorithms-and-data-structures/basic-javascript)
+- [ES6](https://learn.freecodecamp.org/javascript-algorithms-and-data-structures/es6)
+- [正規表現](https://learn.freecodecamp.org/javascript-algorithms-and-data-structures/regular-expressions)
+- [デバッグ](https://learn.freecodecamp.org/javascript-algorithms-and-data-structures/debugging)
+- [基本的なデータ構造](https://learn.freecodecamp.org/javascript-algorithms-and-data-structures/basic-data-structures)
+- [アルゴリズムスクリプティング](https://learn.freecodecamp.org/javascript-algorithms-and-data-structures/basic-algorithm-scripting)
+- [オブジェクト指向プログラミング](https://learn.freecodecamp.org/javascript-algorithms-and-data-structures/object-oriented-programming)
+- [関数プログラミング](https://learn.freecodecamp.org/javascript-algorithms-and-data-structures/functional-programming)
+- [中級アルゴリズムスクリプティング](https://learn.freecodecamp.org/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting)
+  <br />
+  <br />
+  **プロジェクト**: 回文チェッカー、ローマ数字変換器、シーザー暗号、電話番号バリデーター、レジ
+
+#### 3. フロントエンドライブラリに関する資格
+
+- [Bootstrap](https://learn.freecodecamp.org/front-end-libraries/bootstrap)
+- [jQuery](https://learn.freecodecamp.org/front-end-libraries/jquery)
+- [Sass](https://learn.freecodecamp.org/front-end-libraries/sass)
+- [React](https://learn.freecodecamp.org/front-end-libraries/react)
+- [Redux](https://learn.freecodecamp.org/front-end-libraries/redux)
+- [ReactとRedux](https://learn.freecodecamp.org/front-end-libraries/react-and-redux)
+  <br />
+  <br />
+  **プロジェクト**: ランダム引用マシーン、マークダウンプレビュー、ドラムマシーン、JavaScript計算機、ポモドーロタイマー
+
+#### 4. データビジュアライゼーションに関する資格
+
+- [D3でのデータビジュアライゼーション](https://learn.freecodecamp.org/data-visualization/data-visualization-with-d3)
+- [JSON APIとAjax](https://learn.freecodecamp.org/data-visualization/json-apis-and-ajax)
+  <br />
+  <br />
+  **プロジェクト**: 棒グラフ、散布図、ヒートマップ、階級区分図、ツリーマップ
+
+#### 5. APIとマイクロサービスに関する資格
+
+- [npmでのパッケージ管理](https://learn.freecodecamp.org/apis-and-microservices/managing-packages-with-npm)
+- [基本的なNodeとExpress](https://learn.freecodecamp.org/apis-and-microservices/basic-node-and-express)
+- [MongoDBとMongoose](https://learn.freecodecamp.org/apis-and-microservices/mongodb-and-mongoose)
+  <br />
+  <br />
+  **プロジェクト**: タイムスタンプマイクロサービス、リクエストヘッダーパーサー、URL短縮器、エクササイズトラッカー、ファイルメタデータマイクロサービス
+
+#### 6. 情報セキュリティと品質補償に関する資格
+
+- [HelmetJSでの情報セキュリティ](https://learn.freecodecamp.org/information-security-and-quality-assurance/information-security-with-helmetjs)
+- [品質保証とChaiでのテスト](https://learn.freecodecamp.org/information-security-and-quality-assurance/quality-assurance-and-testing-with-chai)
+- [発展的なNodeとExpress](https://learn.freecodecamp.org/information-security-and-quality-assurance/advanced-node-and-express)
+  <br />
+  <br />
+  **プロジェクト**: メートル/ヤード変換器、イシュートラッカー、個人ライブラリ、株価チェッカー、匿名掲示板
+
+#### フルスタック開発に関する資格
+
+6つすべての資格を取得したら、freeCodeCamp.orgのフルスタック開発に関する資格を請求することができます。この最後の栄誉は、さまざまなWeb開発ツールを用いて1800時間の開発を完遂したことを証明するものです。
+
+#### レガシーな資格
+
+他にも、2015年からのカリキュラムでまだ有効な3つの資格があります。freeCodeCamp.org では、それぞれのレガシーな資格に必要なすべてのプロジェクトは引き続き有効であるでしょう。
+
+- レガシーなフロントエンド開発に関する資格
+- レガシーなデータビジュアライゼーションに関する資格
+- レガシーなバックエンド開発に関する資格
+
+### 学習プラットフォーム
+
+このコードは [freeCodeCamp.org](https://www.freecodecamp.org) で実行されています。
+
+私達のコミュニティには他にも
+
+- [フォーラム](https://www.freecodecamp.org/forum) 通常数時間以内にプログラミングやプロジェクトに関するフィードバックが得られます。
+- [YouTube チャンネル](https://youtube.com/freecodecamp) Python、SQL、Android、その他いろいろな技術に関する無料のコース。
+- [ポッドキャスト](https://podcast.freecodecamp.org/) 開発者からの気づきや、刺激的なお話。
+- [ローカルの勉強会](https://study-group-directory.freecodecamp.org/) 世界中にあるコードを一緒に書ける人々の集まり。
+- 広汎的な [何千ものプログラミングトピックに対するガイド](https://guide.freecodecamp.org/)
+- [開発者ニュース](https://www.freecodecamp.org/news) 無料でオープンソース、かつ広告なしであなたのブログ記事をクロスポストできる場所。
+- [Facebook グループ](https://www.facebook.com/groups/freeCodeCampEarth/permalink/428140994253892/) 100,000以上の世界中のメンバー。
+
+> ### [こちらから私達のコミュニティに加わりましょう](https://www.freecodecamp.org/signin)。
+
+### バグや問題を報告する
+
+もしバグをを発見したときには、 [How to Report a Bug](https://www.freecodecamp.org/forum/t/how-to-report-a-bug/19543) の記事を閲覧し、その内容に従ってください。もしそのバグが新しいものであって同様の問題を他の誰かが直面していないと革新するのであれば、そのまま GitHub のイシューを作成してください。私達がバグを再現できるよう、必ず必要十分な情報を含めるようにしてください。
+
+### セキュリティに関する問題を報告する
+
+もし脆弱性を見つけたときには、責任を持って報告をお願いします。セキュリティの問題に関しては GitHub のイシューを作成しないでください。その代わりに、`security@freecodecamp.org`へのメールをお願いします。すぐにチェックをします。 
+
+### 貢献する
+
+> ### [貢献するには、こちらのステップに従ってください。](CONTRIBUTING.md)
+
+### プラットフォーム、ビルドとデプロイの状況
+
+ビルドやデプロイの状況に関しては [our DevOps Guide](/docs/devops.md) にて閲覧可能です。 このアプリコーションに関する一般的なプラットフォームの状態は [`status.freecodecamp.org`](https://status.freecodecamp.org) にて閲覧可能です。
+
+### ライセンス
+
+Copyright © 2019 freeCodeCamp.org
+
+このリポジトリの内容は以下のライセンスにより法的に拘束されてます。
+
+- コンピューターソフトウェアに関して、[BSD-3-Clause](LICENSE.md) ライセンス。
+- 教材のリソース（[`/curriculum`](/curriculum) とそのサブディレクトリ）は [CC-BY-SA-4.0](/curriculum/LICENSE.md) ライセンスの元に許可されています。


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

I just added Japanese translation of `README.md` file into `docs/japanese/README.md`.
