### PR TITLE
fix: Improve landing page

### DIFF
--- a/client/src/components/landing/index.js
+++ b/client/src/components/landing/index.js
@@ -22,39 +22,41 @@ function Landing() {
         <title>Learn to code | freeCodeCamp.org</title>
       </Helmet>
       <main className='index-page'>
-        <Spacer size={2} />
+        <Spacer size={1} />
         <Grid>
           <Row>
             <Col sm={10} smOffset={1} xs={12}>
               <h1 className='big-heading text-center'>
                 Welcome to freeCodeCamp.org
               </h1>
-              <Spacer />
-              <h2 className='medium-heading'>Learn to code.</h2>
-              <h2 className='medium-heading'>
+              <Spacer size={0.8} />
+              <h2 className='medium-heading text-shift'>Learn to code.</h2>
+              <h2 className='medium-heading text-shift'>
                 Build projects and earn certifications.
               </h2>
-              <h2 className='medium-heading'>
+              <h2 className='medium-heading text-shift'>
                 Grow your portfolio and get a developer job.
               </h2>
-              <h2 className='medium-heading'>
+              <h2 className='medium-heading text-shift'>
                 It's all 100% free thanks to our nonprofit's donors.
               </h2>
             </Col>
           </Row>
-          <Spacer />
+          <Spacer size={0.7} />
           <BigCallToAction />
-          <Spacer size={2} />
+          <Spacer size={0.8} />
+          <h2 className='medium-heading text-center'>As seen in:</h2>
+          <Spacer size={0.7} />
           <Image
             alt='companies featuring freeCodeCamp.org'
             className='img-center'
             responsive={true}
             src='https://cdn-media-1.freecodecamp.org/learn/as-seen-on.png'
           />
-          <Spacer />
+          <Spacer size={0.8} />
           <Row>
             <Col sm={10} smOffset={1} xs={12}>
-              <h2 className='medium-heading'>
+              <h2 className='medium-heading text-shift'>
                 Since 2014, more than 40,000 freeCodeCamp.org graduates have
                 gotten jobs in tech.
               </h2>

--- a/client/src/components/landing/landing.css
+++ b/client/src/components/landing/landing.css
@@ -42,6 +42,10 @@
   text-decoration: underline;
 }
 
+.text-shift {
+  margin-left: 110px;
+}
+
 /* Buttons with a lot of text can overflow and mess up formatting on small
    screens, this stops that unless the word itself is too large. */
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-equality-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparison-with-the-equality-operator.english.md
@@ -9,7 +9,7 @@ forumTopicId: 16784
 ## Description
 <section id='description'>
 There are many <dfn>Comparison Operators</dfn> in JavaScript. All of these operators return a boolean <code>true</code> or <code>false</code> value.
-The most basic operator is the equality operator <code>==</code>. The equality operator compares two values and returns <code>true</code> if they're equivalent or <code>false</code> if they are not. Note that equality is different from assignment (<code>=</code>), which assigns the value at the right of the operator to a variable in the left.
+The most basic operator is the equality operator <code>==</code>. The equality operator compares two values and returns <code>true</code> if they're equivalent or <code>false</code> if they are not. Note that equality is different from assignment (<code>=</code>), which assigns the value at the right of the operator to a variable on the left.
 
 ```js
 function equalityTest(myVal) {
@@ -34,7 +34,7 @@ In order for JavaScript to compare two different <code>data types</code> (for ex
 
 ## Instructions
 <section id='instructions'>
-Add the <code>equality operator</code> to the indicated line so that the function will return "Equal" when <code>val</code> is equivalent to <code>12</code>
+Add the <code>equality operator</code> to the indicated line so that the function will return "Equal" when <code>val</code> is equivalent to <code>12</code>.
 </section>
 
 ## Tests


### PR DESCRIPTION
I add these changes to the landing page :

    whitespace should be managed in a way that the last bullet point stays above fold.

    add the text "As seen in:" centered and above the logos image

    give margin/padding to the bullet points so they are vertically aligned with the title of the page to be as same as the CTA button.

Closes #36775 

