### PR TITLE
fix: use gatsby link where applicable

### DIFF
--- a/client/src/client-only-routes/ShowSettings.js
+++ b/client/src/client-only-routes/ShowSettings.js
@@ -16,9 +16,7 @@ import {
 import { submitNewAbout, updateUserFlag, verifyCert } from '../redux/settings';
 import { createFlashMessage } from '../components/Flash/redux';
 
-import Spacer from '../components/helpers/Spacer';
-import Loader from '../components/helpers/Loader';
-import FullWidthRow from '../components/helpers/FullWidthRow';
+import { FullWidthRow, Link, Loader, Spacer } from '../components/helpers';
 import About from '../components/settings/About';
 import Privacy from '../components/settings/Privacy';
 import Email from '../components/settings/Email';
@@ -184,15 +182,12 @@ export function ShowSettings(props) {
         <main>
           <Spacer size={2} />
           <FullWidthRow>
-            <Button
-              block={true}
-              bsSize='lg'
-              bsStyle='primary'
-              className='btn-invert'
-              href={`/${username}`}
+            <Link
+              className='btn-invert btn btn-lg btn-primary btn-block'
+              to={`/${username}`}
             >
               Show me my public portfolio
-            </Button>
+            </Link>
             <Button
               block={true}
               bsSize='lg'


### PR DESCRIPTION
I found a few spots we could probably use gatsby-link to speed things up and limit requests. I focused on these because fixing them provides the most benefit. If I don't get around to changing the `<a>` tags, this would be beneficial to add as-is.

I'm assuming we want to keep footer and nav links opening in their own tabs, but using gatsby-link on many of those could speed things up as well.

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #36711
