### PR TITLE
fix: improve map responsiveness

### DIFF
--- a/client/src/components/Map/components/SuperBlock.js
+++ b/client/src/components/Map/components/SuperBlock.js
@@ -50,7 +50,7 @@ const codingPrepRE = new RegExp('Interview Prep');
 function createSuperBlockTitle(str) {
   return codingPrepRE.test(str)
     ? `${str} (Thousands of hours of challenges)`
-    : `${str} Certification (300 hours)`;
+    : `${str} Certification (300\xa0hours)`;
 }
 
 export class SuperBlock extends Component {

--- a/client/src/components/Map/components/SuperBlock.test.js
+++ b/client/src/components/Map/components/SuperBlock.test.js
@@ -61,7 +61,7 @@ test('<SuperBlock should handle toggle clicks correctly', () => {
       .find('.map-title')
       .find('h4')
       .text()
-  ).toBe('Super Block One Certification (300 hours)');
+  ).toBe('Super Block One Certification (300\xa0hours)');
   expect(enzymeWrapper.find('ul').length).toBe(0);
 
   enzymeWrapper.find('.map-title').simulate('click');
@@ -76,6 +76,6 @@ test('<SuperBlock should handle toggle clicks correctly', () => {
       .find('.map-title')
       .find('h4')
       .text()
-  ).toBe('Super Block One Certification (300 hours)');
+  ).toBe('Super Block One Certification (300\xa0hours)');
   expect(enzymeWrapper.find('ul').length).toBe(1);
 });

--- a/client/src/components/Map/components/__snapshots__/SuperBlock.test.js.snap
+++ b/client/src/components/Map/components/__snapshots__/SuperBlock.test.js.snap
@@ -11,7 +11,7 @@ exports[`<SuperBlock /> expanded snapshot: superBlock-expanded 1`] = `
   >
     <Caret />
     <h4>
-      Super Block One Certification (300 hours)
+      Super Block One Certification (300 hours)
     </h4>
   </button>
   <ul>
@@ -149,7 +149,7 @@ exports[`<SuperBlock /> not expanded snapshot: superBlock-not-expanded 1`] = `
   >
     <Caret />
     <h4>
-      Super Block One Certification (300 hours)
+      Super Block One Certification (300 hours)
     </h4>
   </button>
 </li>

--- a/client/src/components/Map/map.css
+++ b/client/src/components/Map/map.css
@@ -19,6 +19,7 @@ button.map-title {
   padding-bottom: 18px;
   background: transparent;
   border: none;
+  text-align: left;
 }
 
 button.map-title:hover {
@@ -49,10 +50,39 @@ li.open > .map-title svg:first-child {
 }
 
 .map-challenge-title {
+  display: flex;
   margin-bottom: 0.25rem;
-  max-width: calc(100% - 80px);
+  max-width: calc(100% - 105px);
+}
+
+@media (max-width: 640px) {
+  .map-ui .block ul {
+    padding-inline-start: 6px;
+    font-size: 0.9rem;
+  }
+  button.map-title {
+    width: 100%;
+  }
+  .map-ui ul {
+    padding-inline-start: 15px;
+  }
+  .map-ui > ul {
+    padding-inline-start: 0;
+  }
+  .map-challenge-title {
+    max-width: 100%;
+  }
+  .map-title-completed {
+    flex-shrink: 0;
+    padding-left: 15px;
+  }
 }
 
 .block a {
   text-decoration: none;
+}
+
+/* 14px is the width of the expansion arrow */
+.superblock {
+  max-width: calc(100% - 14px);
 }


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This makes the challenge map look reasonable on tablets and mobile.  It's designed to work with the changes in https://github.com/freeCodeCamp/freeCodeCamp/pull/36822, but should look good on its own.

Also, it stops `300 hours` from wrapping. 

Closes #36824
