### PR TITLE
fix: color for button and input visibility

### DIFF
--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -131,6 +131,10 @@ a:focus {
   border-color: var(--secondary-color);
 }
 
+button {
+  background-color: var(--secondary-background);
+}
+
 /* button */
 .btn {
   background-color: var(--quaternary-background);
@@ -245,6 +249,7 @@ input {
   -moz-box-shadow: none !important;
   box-shadow: none !important;
   border-radius: 0px;
+  background-color: var(--secondary-background);
 }
 
 form {


### PR DESCRIPTION
Reviewed buttons and input in dark mode and looks like it is set to inherit nothing, so it defaults to browser choice. Added default background-colors based on variables already given for both input and button.