### PR TITLE
fix: make fcc console log undefined

### DIFF
--- a/client/src/client/workers/test-evaluator.js
+++ b/client/src/client/workers/test-evaluator.js
@@ -18,7 +18,7 @@ const __utils = (() => {
 
   const oldLog = self.console.log.bind(self.console);
   self.console.log = function proxyConsole(...args) {
-    logs.push(args.map(arg => JSON.stringify(arg)).join(' '));
+    logs.push(args.map(arg => '' + JSON.stringify(arg)).join(' '));
     if (logs.join('\n').length > MAX_LOGS_SIZE) {
       flushLogs();
     }

--- a/client/src/templates/Challenges/utils/frame.js
+++ b/client/src/templates/Challenges/utils/frame.js
@@ -83,7 +83,7 @@ const mountFrame = document => ({ element, ...rest }) => {
 const buildProxyConsole = proxyLogger => ctx => {
   const oldLog = ctx.window.console.log.bind(ctx.window.console);
   ctx.window.console.log = function proxyConsole(...args) {
-    proxyLogger(args.map(arg => JSON.stringify(arg)).join(' '));
+    proxyLogger(args.map(arg => '' + JSON.stringify(arg)).join(' '));
     return oldLog(...args);
   };
   return ctx;


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Handles the case where `arg` is undefined by forcing it to be a string.

Closes #36864
