### PR TITLE
Fix typo on translation of "obtain" in line 12

### DIFF
--- a/docs/i18n-languages/portuguese/how-to-catch-outgoing-emails-locally.md
+++ b/docs/i18n-languages/portuguese/how-to-catch-outgoing-emails-locally.md
@@ -9,7 +9,7 @@
 
 ## Introdução
 
-Alguns do fluxos de email, como atualizar o email de um usuário, necessita de uma api e/ou um servidor back-end para enviar os emails. No ambiente de desenvolvimento, você pode usar uma ferramenta para obter esses emails localmente, em vez de ter que usar um provedor de email e efetivamente enviar o email. MailHog é uma dessas ferramentas para desenvolvedores fazerem testes com emails, ela vai oter os emails que sua instância local do freeCodeCamp mandar.
+Alguns do fluxos de email, como atualizar o email de um usuário, necessita de uma api e/ou um servidor back-end para enviar os emails. No ambiente de desenvolvimento, você pode usar uma ferramenta para obter esses emails localmente, em vez de ter que usar um provedor de email e efetivamente enviar o email. MailHog é uma dessas ferramentas para desenvolvedores fazerem testes com emails, ela vai obter os emails que sua instância local do freeCodeCamp mandar.
 
 ## Instando MailHog
 


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

The translation of "obtain" had a typo.

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX
