### PR TITLE
Fix broken contributing link in line 16

### DIFF
--- a/docs/i18n-languages/portuguese/how-to-work-on-coding-challenges.md
+++ b/docs/i18n-languages/portuguese/how-to-work-on-coding-challenges.md
@@ -13,7 +13,7 @@ Você pode fazer mudanças sem ter nada rodando em seu sistema local.
 
 Depois que encontrar o arquivo que deseja modificar pela interface do GitHub, clique no ícone de lápis para começar a editar. Isto ira criar um fork do projeto automaticamente, se você já não tem um.
 
-Você também pode clonar o projeto e editar localmente no seu computador. Para ajuda com isso, leia o artigo [Orientações de Contribuição](/docs/portuguese/CONTRIBUTING.md).
+Você também pode clonar o projeto e editar localmente no seu computador. Para ajuda com isso, leia o artigo [Orientações de Contribuição](/docs/i18n-languages/portuguese/CONTRIBUTING.md).
 
 ### Modelo de Desafio
 


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

The repository's folder hierarchy had been updated but the relative path wasn't, resulting on a broken link.

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX
