### PR TITLE
fix(challenge): use offsetHeight to get height value

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/adjust-the-height-of-an-element-using-the-height-property.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/adjust-the-height-of-an-element-using-the-height-property.english.md
@@ -29,7 +29,7 @@ Add a <code>height</code> property to the <code>h4</code> tag and set it to 25px
 ```yml
 tests:
   - text: Your code should change the <code>h4</code> <code>height</code> property to a value of 25 pixels.
-    testString: assert($('h4').css('height') === '25px' && /h4{\S*height:25px(;\S*}|})/.test($('style').text().replace(/\s/g ,'')));
+    testString: assert(document.querySelector('h4').offsetHeight === 25 && /h4{\S*height:25px(;\S*}|})/.test($('style').text().replace(/\s/g ,'')));
 
 ```
 


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

The challenge test relies on getComputedStyle (jquery css() function) which, for `height` at least, may not return a reliable result. There are reported cases of this failing and returning decimal numbers. This fix replaces `css()` with `element.offsetHeight`.

I should note that as I can't reproduce this bug, I can't reliably test if this is a solution either. I believe it is very likely to be a fix but it would be nice to get some confirmation. I have [posted in the forum](https://www.freecodecamp.org/forum/t/help-to-adjust-the-height-of-an-element-using-the-height-property/319027/10) and may be able to get some data back.

Note: The challenge also has a `width` counterpart challenge, which is using the same reliance on getComputedStyle. I have not seen any bug reports for it. But that doesn't mean there aren't any and it may need the same fix.

Adjust the Width of an Element Using the width Property
https://learn.freecodecamp.org/responsive-web-design/applied-visual-design/adjust-the-width-of-an-element-using-the-width-property

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/18045
