### PR TITLE
Gender fix and changing 'and' for 'but'

### DIFF
--- a/docs/i18n-languages/portuguese/how-to-setup-freecodecamp-locally.md
+++ b/docs/i18n-languages/portuguese/how-to-setup-freecodecamp-locally.md
@@ -29,7 +29,7 @@ Isso é essencial, pois assim você pode trabalhar com sua cópia do freeCodeCam
 
 ## Preparando o ambiente de desenvolvimento
 
-Uma vez que os pré-requisitos estão instaladas, você precisa preparar seu ambiente de desenvolvimento. Isso é comum para muitos _workflows_ de desenvolvimento, e você precisará fazer isso uma única vez.
+Uma vez que os pré-requisitos estão instalados, você precisa preparar seu ambiente de desenvolvimento. Isso é comum para muitos _workflows_ de desenvolvimento, mas você precisará fazer isso uma única vez.
 
 **Siga estes passos para preparar seu ambiente de desenvolvimento:**
 


### PR DESCRIPTION
In portuguese verbs can have gender, so I have changed to 'instalados' that refer to 'estão' witch is a masculine verb.
In addition we changed 'e' to 'mas', because is a negation adverb, witch improoves cohesion.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX
