### PR TITLE
chore(client): add tests for search bar

### DIFF
--- a/client/src/components/search/searchBar/SearchBar.js
+++ b/client/src/components/search/searchBar/SearchBar.js
@@ -45,7 +45,7 @@ const mapDispatchToProps = dispatch =>
 
 const placeholder = 'Search 5,000+ tutorials';
 
-class SearchBar extends Component {
+export class SearchBar extends Component {
   constructor(props) {
     super(props);
 
@@ -62,8 +62,6 @@ class SearchBar extends Component {
   }
 
   componentDidMount() {
-    const searchInput = document.querySelector('.ais-SearchBox-input');
-    searchInput.id = 'fcc_instantsearch';
     document.addEventListener('click', this.handleFocus);
   }
 

--- a/client/src/components/search/searchBar/SearchBar.test.js
+++ b/client/src/components/search/searchBar/SearchBar.test.js
@@ -1,68 +1,27 @@
 /* global jest, expect */
-import 'jest-dom/extend-expect';
 import React from 'react';
-import Enzyme, { shallow } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import 'jest-dom/extend-expect';
+import ShallowRenderer from 'react-test-renderer/shallow';
+
 import { SearchBar } from './SearchBar';
 
-Enzyme.configure({ adapter: new Adapter() });
+describe('<SearchBar />', () => {
+  it('renders to the DOM', () => {
+    const shallow = new ShallowRenderer();
+    shallow.render(<SearchBar {...searchBarProps} />);
+    const result = shallow.getRenderOutput();
+    expect(result).toBeTruthy();
+  });
 
-const mockProps = {
+  /* Todo: When e2e testing is in place,
+  add tests to check that the search bar
+  resets to -1 on change/input, redirects to a
+  selected hit, and redirects to dev news if
+  there's a query and no hit is selected */
+});
+
+const searchBarProps = {
   toggleSearchDropdown: jest.fn(),
   toggleSearchFocused: jest.fn(),
   updateSearchQuery: jest.fn()
 };
-
-const mockHits = [
-  {
-    objectID: '1',
-    url: 'Test URL 1'
-  },
-  {
-    objectID: '2',
-    url: 'Test URL 2'
-  },
-  {
-    objectID: '3',
-    url: 'Test URL 3'
-  }
-];
-
-describe('<SearchBar />', () => {
-  it('Renders to the DOM', () => {
-    const wrapper = shallow(<SearchBar {...mockProps} />);
-    expect(wrapper.find(`[data-testid='fcc_searchBar']`)).toHaveLength(1);
-  });
-
-  it('Rests index to -1 on change / input', () => {
-    const wrapper = shallow(<SearchBar {...mockProps} />);
-    const searchBox = wrapper.find('AlgoliaSearchBox(Translatable(SearchBox))');
-    wrapper.setState({ index: 3 });
-    searchBox.prop('onChange')();
-    expect(wrapper.state().index).toEqual(-1);
-  });
-
-  it('Redirects to the selected hit', () => {
-    const wrapper = shallow(<SearchBar {...mockProps} />);
-    const searchBox = wrapper.find('AlgoliaSearchBox(Translatable(SearchBox))');
-    const fakeEvent = { preventDefault: jest.fn() };
-    // Prep mock window
-    window.location.assign = jest.fn();
-    wrapper.setState({ index: 2, hits: mockHits });
-    searchBox.prop('onSubmit')(fakeEvent);
-    expect(window.location.assign).toBeCalledWith('Test URL 3');
-  });
-
-  it(`Redirects to the Developer News if there's a query and no hit is selected`, () => {
-    const wrapper = shallow(<SearchBar {...mockProps} />);
-    const searchBox = wrapper.find('AlgoliaSearchBox(Translatable(SearchBox))');
-    const fakeEvent = { preventDefault: jest.fn() };
-    // Prep mock window
-    window.location.assign = jest.fn();
-    wrapper.setState({ index: -1, hits: mockHits });
-    searchBox.prop('onSubmit')(fakeEvent, 'test');
-    expect(window.location.assign).toBeCalledWith(
-      'https://freecodecamp.org/news/search/?query=test'
-    );
-  });
-});

--- a/client/src/components/search/searchBar/SearchBar.test.js
+++ b/client/src/components/search/searchBar/SearchBar.test.js
@@ -1,0 +1,68 @@
+/* global jest, expect */
+import 'jest-dom/extend-expect';
+import React from 'react';
+import Enzyme, { shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import { SearchBar } from './SearchBar';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+const mockProps = {
+  toggleSearchDropdown: jest.fn(),
+  toggleSearchFocused: jest.fn(),
+  updateSearchQuery: jest.fn()
+};
+
+const mockHits = [
+  {
+    objectID: '1',
+    url: 'Test URL 1'
+  },
+  {
+    objectID: '2',
+    url: 'Test URL 2'
+  },
+  {
+    objectID: '3',
+    url: 'Test URL 3'
+  }
+];
+
+describe('<SearchBar />', () => {
+  it('Renders to the DOM', () => {
+    const wrapper = shallow(<SearchBar {...mockProps} />);
+    expect(wrapper.find(`[data-testid='fcc_searchBar']`)).toHaveLength(1);
+  });
+
+  it('Rests index to -1 on change / input', () => {
+    const wrapper = shallow(<SearchBar {...mockProps} />);
+    const searchBox = wrapper.find('AlgoliaSearchBox(Translatable(SearchBox))');
+    wrapper.setState({ index: 3 });
+    searchBox.prop('onChange')();
+    expect(wrapper.state().index).toEqual(-1);
+  });
+
+  it('Redirects to the selected hit', () => {
+    const wrapper = shallow(<SearchBar {...mockProps} />);
+    const searchBox = wrapper.find('AlgoliaSearchBox(Translatable(SearchBox))');
+    const fakeEvent = { preventDefault: jest.fn() };
+    // Prep mock window
+    window.location.assign = jest.fn();
+    wrapper.setState({ index: 2, hits: mockHits });
+    searchBox.prop('onSubmit')(fakeEvent);
+    expect(window.location.assign).toBeCalledWith('Test URL 3');
+  });
+
+  it(`Redirects to the Developer News if there's a query and no hit is selected`, () => {
+    const wrapper = shallow(<SearchBar {...mockProps} />);
+    const searchBox = wrapper.find('AlgoliaSearchBox(Translatable(SearchBox))');
+    const fakeEvent = { preventDefault: jest.fn() };
+    // Prep mock window
+    window.location.assign = jest.fn();
+    wrapper.setState({ index: -1, hits: mockHits });
+    searchBox.prop('onSubmit')(fakeEvent, 'test');
+    expect(window.location.assign).toBeCalledWith(
+      'https://freecodecamp.org/news/search/?query=test'
+    );
+  });
+});


### PR DESCRIPTION
Basic tests for the search bar and minor changes to `SearchBar.js` like exporting the `SearchBar` class and removing the lines that set its id to `fcc_instantsearch`.