### PR TITLE
fix: make challenge test errors more informative

### DIFF
--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -257,7 +257,7 @@ function populateTestsForLang({ lang, challenges }) {
 
         describe('Check tests against solutions', function() {
           solutions.forEach((solution, index) => {
-            it(`Solution ${index + 1}`, async function() {
+            it(`Solution ${index + 1} must pass the tests`, async function() {
               this.timeout(5000 * tests.length + 1000);
               const testRunner = await createTestRunner(
                 { ...challenge, files },
@@ -311,13 +311,10 @@ async function createTestRunnerForDOMChallenge(
         }, testString)
       ]);
       if (!pass) {
-        throw AssertionError(`${text}\n${err.message}`);
+        throw new AssertionError(err.message);
       }
     } catch (err) {
-      throw typeof err === 'string'
-        ? `${text}\n${err}`
-        : (err.message = `${text}
-        ${err.message}`);
+      reThrow(err, text);
     }
   };
 }
@@ -338,13 +335,23 @@ async function createTestRunnerForJSChallenge({ files }, solution) {
         5000
       ).done;
       if (!pass) {
-        throw new AssertionError(`${text}\n${err.message}`);
+        throw new AssertionError(err.message);
       }
     } catch (err) {
-      throw typeof err === 'string'
-        ? `${text}\n${err}`
-        : (err.message = `${text}
-        ${err.message}`);
+      reThrow(err, text);
     }
   };
+}
+
+function reThrow(err, text) {
+  if (typeof err === 'string') {
+    throw new AssertionError(
+      `${text}
+         ${err}`
+    );
+  } else {
+    err.message = `${text}
+       ${err.message}`;
+    throw err;
+  }
 }


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

On master, if a DOM challenge test fails, then `npm test` reports:
![OldError](https://user-images.githubusercontent.com/15801806/66198056-e81c5100-e69b-11e9-8ce8-6e7558afbc51.png)
which isn't helpful.

JavaScript challenges do report errors, but the message gets duplicated:
![image](https://user-images.githubusercontent.com/15801806/66198451-c079b880-e69c-11e9-8bfd-99ce129c7c12.png)

This PR cleans up the reporting and makes sure both DOM and js challenges give meaningful reports.  For example:
![NewErrorMessage](https://user-images.githubusercontent.com/15801806/66198231-434e4380-e69c-11e9-9ea8-f9f898e97608.png)



