### PR TITLE
docs: fix dead link in Spanish guide article

### DIFF
--- a/docs/i18n-languages/spanish/how-to-work-on-guide-articles.md
+++ b/docs/i18n-languages/spanish/how-to-work-on-guide-articles.md
@@ -10,7 +10,7 @@ Con tu ayuda, podemos crear un herramienta de referencia accesible que ayudará 
 Puedes:
 
 
-- [Ayudarnos creando y editando articulos de la Guía](#steps-for-creating-and-editing-guide-articles).
+- [Ayudarnos creando y editando articulos de la Guía](#pasos-para-crear-y-editar-artículos-de-la-guía).
 - [Ayudarnos revisando Pull Requests para artículos de la Guía]()
 
 ## Pasos para crear y editar artículos de la Guía


### PR DESCRIPTION
Fix residual link from the original English version that doesn't work in the Spanish documentation.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

