### PR TITLE
fix: improve challenge layout on mobile

### DIFF
--- a/client/src/templates/Challenges/classic/MobileLayout.js
+++ b/client/src/templates/Challenges/classic/MobileLayout.js
@@ -59,7 +59,7 @@ class MobileLayout extends Component {
           id='challenge-page-tabs'
           onSelect={moveToTab}
         >
-          <TabPane eventKey={1} title='Instructions'>
+          <TabPane eventKey={1} title='Info'>
             {instructions}
           </TabPane>
           <TabPane eventKey={2} title='Code' {...editorTabPaneProps}>

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -23,6 +23,8 @@
 
 #challenge-page-tabs .nav-tabs > li > a {
   padding: 5px 10px;
+  text-decoration: none;
+  font-size: 0.8em;
 }
 
 #challenge-page-tabs .tab-content {
@@ -34,9 +36,8 @@
   height: 100%;
   overflow: hidden;
 }
-#challenge-page-tabs a {
-  text-decoration: none;
-}
-#challenge-page-tabs a:hover {
-  color: var(--secondary-background);
+
+#challenge-page-tabs .nav-tabs > li.active > a {
+  color: var(--quaternary-color);
+  background-color: var(--quaternary-background);
 }

--- a/client/src/templates/Challenges/components/tool-panel.css
+++ b/client/src/templates/Challenges/components/tool-panel.css
@@ -5,7 +5,7 @@
 
 .tool-panel-group-mobile button,
 .tool-panel-group-mobile a {
-  font-size: 16px;
+  font-size: 0.8rem;
 }
 
 .tool-panel-group-mobile {
@@ -16,4 +16,6 @@
 
 .tool-panel-group-mobile .btn-block + .btn-block {
   margin: 0 2px 0 0;
+  padding-left: 8px;
+  padding-right: 8px;
 }


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #36825

This PR makes the challenges viewable down to 320px width.  Using 'Info' instead of 'Instructions' was a compromise, the other option would be a smaller font. 