### PR TITLE
fix: handle invalid Algolia keys gracefully in dev

### DIFF
--- a/client/gatsby-node.js
+++ b/client/gatsby-node.js
@@ -1,4 +1,4 @@
-require('dotenv').config();
+const env = require('../config/env');
 
 const { createFilePath } = require('gatsby-source-filesystem');
 
@@ -39,7 +39,18 @@ exports.onCreateNode = function onCreateNode({ node, actions, getNode }) {
   }
 };
 
-exports.createPages = function createPages({ graphql, actions }) {
+exports.createPages = function createPages({ graphql, actions, reporter }) {
+  if (!env.algoliaAPIKey || !env.algoliaAppId) {
+    if (process.env.FREECODECAMP_NODE_ENV === 'production') {
+      throw new Error(
+        'Algolia App id and API key are required to start the client!'
+      );
+    } else {
+      reporter.info(
+        'Algolia keys missing or invalid. Required for search to yield results.'
+      );
+    }
+  }
   const { createPage } = actions;
 
   return new Promise((resolve, reject) => {

--- a/client/src/components/search/WithInstantSearch.js
+++ b/client/src/components/search/WithInstantSearch.js
@@ -20,7 +20,11 @@ import { createSelector } from 'reselect';
 
 const DEBOUNCE_TIME = 100;
 
-const searchClient = algoliasearch(algoliaAppId, algoliaAPIKey);
+// If a key is missing, searches will fail, but the client will still render.
+const searchClient =
+  algoliaAppId && algoliaAPIKey
+    ? algoliasearch(algoliaAppId, algoliaAPIKey)
+    : {};
 
 const propTypes = {
   children: PropTypes.any,

--- a/config/env.js
+++ b/config/env.js
@@ -26,6 +26,12 @@ const locations = {
 module.exports = Object.assign(locations, {
   locale,
   stripePublicKey,
-  algoliaAppId,
-  algoliaAPIKey
+  algoliaAppId:
+    !algoliaAppId || algoliaAppId === 'Algolia app id from dashboard'
+      ? null
+      : algoliaAppId,
+  algoliaAPIKey:
+    !algoliaAPIKey || algoliaAPIKey === 'Algolia api key from dashboard'
+      ? null
+      : algoliaAPIKey
 });

--- a/sample.env
+++ b/sample.env
@@ -5,8 +5,8 @@ ROLLBAR_APP_ID='my-rollbar-app-id'
 ROLLBAR_CLIENT_ID='post_client_id from rollbar dashboard'
 
 ALGOLIA_ADMIN_KEY=123abc
-ALGOLIA_APP_ID=ACDEFG
-ALGOLIA_API_KEY=123abc
+ALGOLIA_APP_ID='Algolia app id from dashboard'
+ALGOLIA_API_KEY='Algolia api key from dashboard'
 
 AUTH0_CLIENT_ID=stuff
 AUTH0_CLIENT_SECRET=stuff


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Invalid keys throw an error during a production build, but just cause invalid PropTypes and build warnings in development.

@raisedadead I wasn't sure precisely how the environment variables are set in production, so I made the assumption that it wasn't by a `.env` file.  Hence the replacement of `require('dotenv').config();` in `gatsby-node`.

Closes #37076
