### PR TITLE
feat: render profile preview on my private profile + change verbiage

### DIFF
--- a/client/src/client-only-routes/ShowUser.js
+++ b/client/src/client-only-routes/ShowUser.js
@@ -10,7 +10,8 @@ import {
   FormGroup,
   ControlLabel,
   Button,
-  Col
+  Col,
+  Row
 } from '@freecodecamp/react-bootstrap';
 import Helmet from 'react-helmet';
 
@@ -142,41 +143,45 @@ class ShowUser extends Component {
     }
 
     const { textarea } = this.state;
-
+    const placeholderText = `Please provide as much detail as possible about the account or behavior you are reporting.`;
     return (
       <Fragment>
         <Helmet>
           <title>Report a users profile | freeCodeCamp.org</title>
         </Helmet>
-        <FullWidthRow>
-          <Spacer size={2} />
-          <Col md={8} mdOffset={2}>
+        <Spacer size={2} />
+        <Row className='text-center'>
+          <Col sm={8} smOffset={2} xs={12}>
             <h2>
               Do you want to report {username}
               's profile for abuse?
             </h2>
+          </Col>
+        </Row>
+        <Row>
+          <Col sm={6} smOffset={3} xs={12}>
             <p>
               We will notify the community moderators' team, and a send copy of
-              this report to your email:{' '}
-              <span className='green-text'>{email}</span>.
+              this report to your email: <strong>{email}</strong>
             </p>
             <p>We may get back to you for more information, if required.</p>
             <form onSubmit={this.handleSubmit}>
               <FormGroup controlId='report-user-textarea'>
-                <ControlLabel>Additional Information</ControlLabel>
+                <ControlLabel>What would you like to report?</ControlLabel>
                 <FormControl
                   componentClass='textarea'
                   onChange={this.handleChange}
-                  placeholder=''
+                  placeholder={placeholderText}
                   value={textarea}
                 />
               </FormGroup>
               <Button block={true} bsStyle='primary' type='submit'>
                 Submit the report
               </Button>
+              <Spacer />
             </form>
           </Col>
-        </FullWidthRow>
+        </Row>
       </Fragment>
     );
   }

--- a/client/src/components/profile/Profile.js
+++ b/client/src/components/profile/Profile.js
@@ -50,78 +50,46 @@ const propTypes = {
   })
 };
 
-function TakeMeToTheChallenges() {
-  return <CurrentChallengeLink>Take me to the Challenges</CurrentChallengeLink>;
-}
-
-function renderIsLocked(username, isSessionUser) {
-  return (
+function renderMessage(isSessionUser, username) {
+  return isSessionUser ? (
     <Fragment>
-      <Helmet>
-        <title>Profile | freeCodeCamp.org</title>
-      </Helmet>
-      <Spacer size={2} />
-      <Grid>
-        {isSessionUser
-          ? renderSettingsButton()
-          : renderReportUserButton(username)}
-        <FullWidthRow>
-          <h2 className='text-center'>
-            {username} has not made their profile public.
-          </h2>
-        </FullWidthRow>
-        <FullWidthRow>
-          <p className='alert alert-info'>
-            {username} needs to change their privacy setting in order for you to
-            view their profile
-          </p>
-        </FullWidthRow>
-        <FullWidthRow>
-          <TakeMeToTheChallenges />
-          <Spacer />
-        </FullWidthRow>
-      </Grid>
+      <FullWidthRow>
+        <h2 className='text-center'>You have not made your profile public.</h2>
+      </FullWidthRow>
+      <FullWidthRow>
+        <p className='alert alert-info'>
+          You need to change your privacy setting in order for your profile to
+          be seen by others. This is a preview of how your profile will look
+          when made public.
+        </p>
+      </FullWidthRow>
+      <Spacer />
+    </Fragment>
+  ) : (
+    <Fragment>
+      <FullWidthRow>
+        <h2 className='text-center'>
+          {username} has not made their profile public.
+        </h2>
+      </FullWidthRow>
+      <FullWidthRow>
+        <p className='alert alert-info'>
+          {username} needs to change their privacy setting in order for you to
+          view their profile.
+        </p>
+      </FullWidthRow>
+      <Spacer />
+      <FullWidthRow>
+        <CurrentChallengeLink>Take me to the Challenges</CurrentChallengeLink>
+      </FullWidthRow>
+      <Spacer />
     </Fragment>
   );
 }
 
-function renderSettingsButton() {
-  return (
-    <Fragment>
-      <Row>
-        <Col sm={4} smOffset={4}>
-          <Link className='btn btn-lg btn-primary btn-block' to='/settings'>
-            Update my settings
-          </Link>
-        </Col>
-      </Row>
-      <Spacer size={2} />
-    </Fragment>
-  );
-}
-
-function renderReportUserButton(username) {
-  return (
-    <Fragment>
-      <Row>
-        <Col sm={4} smOffset={4}>
-          <Link
-            className='btn btn-lg btn-primary btn-block'
-            to={`/user/${username}/report-user`}
-          >
-            Report This User
-          </Link>
-        </Col>
-      </Row>
-      <Spacer size={2} />
-    </Fragment>
-  );
-}
-
-function Profile({ user, isSessionUser }) {
+function renderProfile(user) {
   const {
     profileUI: {
-      isLocked = true,
       showAbout = false,
       showCerts = false,
       showHeatMap = false,
@@ -152,42 +120,67 @@ function Profile({ user, isSessionUser }) {
     yearsTopContributor
   } = user;
 
-  if (isLocked) {
-    return renderIsLocked(username, isSessionUser);
-  }
+  return (
+    <Fragment>
+      <Camper
+        about={showAbout ? about : null}
+        githubProfile={githubProfile}
+        isGithub={isGithub}
+        isLinkedIn={isLinkedIn}
+        isTwitter={isTwitter}
+        isWebsite={isWebsite}
+        linkedin={linkedin}
+        location={showLocation ? location : null}
+        name={showName ? name : null}
+        picture={picture}
+        points={showPoints ? points : null}
+        twitter={twitter}
+        username={username}
+        website={website}
+        yearsTopContributor={yearsTopContributor}
+      />
+      {showHeatMap ? <HeatMap calendar={calendar} streak={streak} /> : null}
+      {showCerts ? <Certifications username={username} /> : null}
+      {showPortfolio ? <Portfolio portfolio={portfolio} /> : null}
+      {showTimeLine ? (
+        <Timeline completedMap={completedChallenges} username={username} />
+      ) : null}
+      <Spacer />
+    </Fragment>
+  );
+}
+
+function Profile({ user, isSessionUser }) {
+  const {
+    profileUI: { isLocked = true },
+    username
+  } = user;
+
   return (
     <Fragment>
       <Helmet>
         <title>Profile | freeCodeCamp.org</title>
       </Helmet>
-      <Spacer size={2} />
+      <Spacer />
       <Grid>
-        {isSessionUser
-          ? renderSettingsButton()
-          : renderReportUserButton(username)}
-        <Camper
-          about={showAbout ? about : null}
-          githubProfile={githubProfile}
-          isGithub={isGithub}
-          isLinkedIn={isLinkedIn}
-          isTwitter={isTwitter}
-          isWebsite={isWebsite}
-          linkedin={linkedin}
-          location={showLocation ? location : null}
-          name={showName ? name : null}
-          picture={picture}
-          points={showPoints ? points : null}
-          twitter={twitter}
-          username={username}
-          website={website}
-          yearsTopContributor={yearsTopContributor}
-        />
-        {showHeatMap ? <HeatMap calendar={calendar} streak={streak} /> : null}
-        {showCerts ? <Certifications username={username} /> : null}
-        {showPortfolio ? <Portfolio portfolio={portfolio} /> : null}
-        {showTimeLine ? (
-          <Timeline completedMap={completedChallenges} username={username} />
+        {isSessionUser ? (
+          <Row>
+            <Col sm={4} smOffset={4}>
+              <Link className='btn btn-lg btn-primary btn-block' to='/settings'>
+                Update my settings
+              </Link>
+            </Col>
+          </Row>
         ) : null}
+        <Spacer />
+        {isLocked ? renderMessage(isSessionUser, username) : null}
+        {!isLocked || isSessionUser ? renderProfile(user) : null}
+        {isSessionUser ? null : (
+          <Row className='text-center'>
+            <Link to={`/user/${username}/report-user`}>Report This User</Link>
+          </Row>
+        )}
+        <Spacer />
       </Grid>
     </Fragment>
   );

--- a/client/src/components/profile/__snapshots__/Profile.test.js.snap
+++ b/client/src/components/profile/__snapshots__/Profile.test.js.snap
@@ -12,40 +12,8 @@ Array [
     }
   />,
   <div
-    className="spacer"
-    style={
-      Object {
-        "height": "1px",
-        "padding": "15px 0",
-      }
-    }
-  />,
-  <div
     className="container"
   >
-    <div
-      className="row"
-    >
-      <div
-        className="col-sm-4 col-sm-offset-4"
-      >
-        <a
-          className="btn btn-lg btn-primary btn-block"
-          href="/user/string/report-user"
-        >
-          Report This User
-        </a>
-      </div>
-    </div>
-    <div
-      className="spacer"
-      style={
-        Object {
-          "height": "1px",
-          "padding": "15px 0",
-        }
-      }
-    />
     <div
       className="spacer"
       style={
@@ -182,6 +150,33 @@ Array [
       </h2>
       <br />
     </div>
+    <div
+      className="spacer"
+      style={
+        Object {
+          "height": "1px",
+          "padding": "15px 0",
+        }
+      }
+    />
+    <div
+      className="text-center row"
+    >
+      <a
+        href="/user/string/report-user"
+      >
+        Report This User
+      </a>
+    </div>
+    <div
+      className="spacer"
+      style={
+        Object {
+          "height": "1px",
+          "padding": "15px 0",
+        }
+      }
+    />
   </div>,
 ]
 `;


### PR DESCRIPTION
I had to rework this component pretty significantly to give it this functionality without making things too cluttered. This is what I came up with. If it looks good, I can write some tests. 

I made this little table for what I expected to see if anyone wants to use it for testing reference...
```
          |  Public         | Private
===================================================
Mine      | settings btn    | settings btn
          | + no message    | + you not public message 
          | + profile       | + profile
          | + no take btn   | + no take btn
          | + no report btn | + no report btn
===================================================
Not Mine  | no settings btn | no settings btn
          | + no message    | + @mot not public message 
          | + profile       | + no profile
          | + no take btn   | + take btn
          | + report btn    | + report btn
```


Closes #36928 
