### PR TITLE
Provide sign in link when user completes a challenge

### DIFF
--- a/client/src/components/Header/components/Login.js
+++ b/client/src/components/Header/components/Login.js
@@ -35,11 +35,11 @@ function Login(props) {
   const { children, navigate, isSignedIn, ...restProps } = props;
   return (
     <Button
+      bsStyle='default'
+      className={(restProps.block ? 'btn-cta-big' : '') + ' signup-btn btn-cta'}
       href='/signin'
       onClick={createOnClick(navigate, isSignedIn)}
       {...restProps}
-      bsStyle='default'
-      className={(restProps.block ? 'btn-cta-big' : '') + ' signup-btn btn-cta'}
     >
       {children || 'Sign In'}
     </Button>

--- a/client/src/templates/Challenges/components/CompletionModal.js
+++ b/client/src/templates/Challenges/components/CompletionModal.js
@@ -40,6 +40,9 @@ const mapDispatchToProps = function(dispatch) {
     handleKeypress: e => {
       if (e.keyCode === 13 && (e.ctrlKey || e.metaKey)) {
         e.preventDefault();
+        // Since Hotkeys also listens to Ctrl + Enter we have to stop this event
+        // getting to it.
+        e.stopPropagation();
         dispatch(submitChallenge());
       }
     },

--- a/client/src/templates/Challenges/components/CompletionModal.js
+++ b/client/src/templates/Challenges/components/CompletionModal.js
@@ -6,6 +6,7 @@ import { createSelector } from 'reselect';
 import { Button, Modal } from '@freecodecamp/react-bootstrap';
 
 import ga from '../../../analytics';
+import Login from '../../../components/Header/components/Login';
 import GreenPass from '../../../assets/icons/GreenPass';
 
 import { dasherize } from '../../../../../utils/slugs';
@@ -21,15 +22,19 @@ import {
   challengeMetaSelector
 } from '../redux';
 
+import { isSignedInSelector } from '../../../redux';
+
 const mapStateToProps = createSelector(
   challengeFilesSelector,
   challengeMetaSelector,
   isCompletionModalOpenSelector,
+  isSignedInSelector,
   successMessageSelector,
-  (files, { title }, isOpen, message) => ({
+  (files, { title }, isOpen, isSignedIn, message) => ({
     files,
     title,
     isOpen,
+    isSignedIn,
     message
   })
 );
@@ -58,6 +63,7 @@ const propTypes = {
   files: PropTypes.object.isRequired,
   handleKeypress: PropTypes.func.isRequired,
   isOpen: PropTypes.bool,
+  isSignedIn: PropTypes.bool.isRequired,
   message: PropTypes.string,
   submitChallenge: PropTypes.func.isRequired,
   title: PropTypes.string
@@ -107,6 +113,7 @@ export class CompletionModal extends Component {
     const {
       close,
       isOpen,
+      isSignedIn,
       submitChallenge,
       handleKeypress,
       message,
@@ -144,9 +151,19 @@ export class CompletionModal extends Component {
             bsStyle='primary'
             onClick={submitChallenge}
           >
-            Submit and go to next challenge{' '}
+            {isSignedIn ? 'Submit and g' : 'G'}o to next challenge{' '}
             <span className='hidden-xs'>(Ctrl + Enter)</span>
           </Button>
+          {isSignedIn ? null : (
+            <Login
+              block={true}
+              bsSize='lg'
+              bsStyle='primary'
+              className='btn-invert'
+            >
+              Sign in to save your progress
+            </Login>
+          )}
           {this.state.downloadURL ? (
             <Button
               block={true}


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The completion model now reflects if the user is signed in or not and provides a sign in button if they are not.

Also prevents the `Hotkeys` component from triggering when the completion modal is already handling `Ctrl + enter` 

Closes #37131
