### PR TITLE
fix: ignore input elements except in search

### DIFF
--- a/client/src/components/search/searchBar/SearchBar.js
+++ b/client/src/components/search/searchBar/SearchBar.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { createSelector } from 'reselect';
 import { SearchBox } from 'react-instantsearch-dom';
-import { HotKeys, configure } from 'react-hotkeys';
+import { HotKeys, ObserveKeys } from 'react-hotkeys';
 import { isEqual } from 'lodash';
 
 import {
@@ -18,9 +18,6 @@ import SearchHits from './SearchHits';
 
 import './searchbar-base.css';
 import './searchbar.css';
-
-// Configure react-hotkeys to work with the searchbar
-configure({ ignoreTags: ['select', 'textarea'] });
 
 const propTypes = {
   innerRef: PropTypes.object,
@@ -187,14 +184,16 @@ class SearchBar extends Component {
             <label className='fcc_sr_only' htmlFor='fcc_instantsearch'>
               Search
             </label>
-            <SearchBox
-              focusShortcuts={[83, 191]}
-              onChange={this.handleChange}
-              onFocus={this.handleFocus}
-              onSubmit={this.handleSearch}
-              showLoadingIndicator={true}
-              translations={{ placeholder }}
-            />
+            <ObserveKeys>
+              <SearchBox
+                focusShortcuts={[83, 191]}
+                onChange={this.handleChange}
+                onFocus={this.handleFocus}
+                onSubmit={this.handleSearch}
+                showLoadingIndicator={true}
+                translations={{ placeholder }}
+              />
+            </ObserveKeys>
             {isDropdownEnabled && isSearchFocused && (
               <SearchHits
                 handleHits={this.handleHits}


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Rather than listening to key events on all `input` and `select` elements, this opts into listening to the `SearchBox`

Closes #37142
