### PR TITLE
fix: make redirect timer count down to zero

### DIFF
--- a/client/src/client-only-routes/ShowUser.js
+++ b/client/src/client-only-routes/ShowUser.js
@@ -64,7 +64,8 @@ class ShowUser extends Component {
 
     this.timer = null;
     this.state = {
-      textarea: ''
+      textarea: '',
+      time: 5
     };
     this.handleChange = this.handleChange.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
@@ -72,7 +73,7 @@ class ShowUser extends Component {
 
   componentWillUnmount() {
     if (this.timer) {
-      clearTimeout(this.timer);
+      clearInterval(this.timer);
     }
   }
 
@@ -92,7 +93,12 @@ class ShowUser extends Component {
 
   setNavigationTimer(navigate) {
     if (!this.timer) {
-      this.timer = setTimeout(() => navigate(`${apiLocation}/signin`), 5000);
+      this.timer = setInterval(() => {
+        if (this.state.time <= 0) {
+          navigate(`${apiLocation}/signin`);
+        }
+        this.setState({ time: this.state.time - 1 });
+      }, 1000);
     }
   }
 
@@ -120,7 +126,7 @@ class ShowUser extends Component {
                 <Spacer />
                 <p>
                   You will be redirected to sign in to freeCodeCamp.org
-                  automatically in 5 seconds
+                  automatically in {this.state.time} seconds
                 </p>
                 <p>
                   <Button


### PR DESCRIPTION
I didn't create an issue for this.

When you go to report a user while not authenticated; you get this screen...
<img width="714" alt="Screen Shot 2019-10-09 at 8 15 15 AM" src="https://user-images.githubusercontent.com/20648924/66484684-14a1e580-ea6d-11e9-8044-025a9f1a1d99.png">
While working on another PR I noticed that it just stays at 5 for the 5 seconds and then redirects. This PR will make the 5 count down to 0 before the redirect

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX
