### PR TITLE
feat: Escape hotkey enters 'navigation mode'

### DIFF
--- a/client/src/templates/Challenges/components/Hotkeys.js
+++ b/client/src/templates/Challenges/components/Hotkeys.js
@@ -2,8 +2,15 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { HotKeys, GlobalHotKeys } from 'react-hotkeys';
 import { navigate } from 'gatsby';
+import { connect } from 'react-redux';
+
+import { setEditorFocusability } from '../redux';
+import './hotkeys.css';
+
+const mapDispatchToProps = { setEditorFocusability };
 
 const keyMap = {
+  NAVIGATION_MODE: 'escape',
   EXECUTE_CHALLENGE: ['ctrl+enter', 'command+enter'],
   NAVIGATE_PREV: ['p'],
   NAVIGATE_NEXT: ['n']
@@ -15,7 +22,8 @@ const propTypes = {
   innerRef: PropTypes.any,
   introPath: PropTypes.string,
   nextChallengePath: PropTypes.string,
-  prevChallengePath: PropTypes.string
+  prevChallengePath: PropTypes.string,
+  setEditorFocusability: PropTypes.func.isRequired
 };
 
 function Hotkeys({
@@ -24,7 +32,8 @@ function Hotkeys({
   introPath,
   innerRef,
   nextChallengePath,
-  prevChallengePath
+  prevChallengePath,
+  setEditorFocusability
 }) {
   const handlers = {
     EXECUTE_CHALLENGE: e => {
@@ -35,6 +44,7 @@ function Hotkeys({
       e.preventDefault();
       if (executeChallenge) executeChallenge();
     },
+    NAVIGATION_MODE: () => setEditorFocusability(false),
     NAVIGATE_PREV: () => navigate(prevChallengePath),
     NAVIGATE_NEXT: () => navigate(introPath ? introPath : nextChallengePath)
   };
@@ -52,4 +62,7 @@ function Hotkeys({
 Hotkeys.displayName = 'Hotkeys';
 Hotkeys.propTypes = propTypes;
 
-export default Hotkeys;
+export default connect(
+  null,
+  mapDispatchToProps
+)(Hotkeys);

--- a/client/src/templates/Challenges/components/hotkeys.css
+++ b/client/src/templates/Challenges/components/hotkeys.css
@@ -1,0 +1,4 @@
+/* hide the outline for the HotKeys component */
+div[tabindex='-1']:focus {
+  outline: none;
+}


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Previously only 'escape'ing from the editor prevented auto focus on the editor, now you can 'escape' from anywhere that listens to Hotkeys.  Now, `n` and `p` can only be used to navigate after pressing `escape`, to prevent accidental navigation.

Also the outline for HotKeys is hidden as it is not used by tab navigation.

Closes #37146
