### PR TITLE
[docs] Updated How to Work on Challenge Files to explain how to test individual challenges

### DIFF
--- a/docs/how-to-work-on-coding-challenges.md
+++ b/docs/how-to-work-on-coding-challenges.md
@@ -306,7 +306,7 @@ function myFunc() {
 
 ## Testing Challenges
 
-Before you [create a pull request](how-to-open-a-pull-request) for your changes, you need to validate the changes you have made do not inadvertently cause problems with the challenge working correctly.  You do this by performing the following steps:
+Before you [create a pull request](how-to-open-a-pull-request.md) for your changes, you need to validate that the changes you have made do not inadvertently cause problems with the challenge.  You do this by performing the following steps:
 
 1. In the `.env` file, set the environment variable `TEST_CHALLENGES_FOR_LANGS` to the language of the challenge(s) you need to test.  The currently accepted values are `english`, `arabic`, `chinese`, `portuguese`, `russian` and `spanish`.
 

--- a/docs/how-to-work-on-coding-challenges.md
+++ b/docs/how-to-work-on-coding-challenges.md
@@ -316,7 +316,7 @@ Before you [create a pull request](how-to-open-a-pull-request.md) for your chang
   cd curriculum
 ```
 
-3. Run the following for each challenge file for which you have added solution:
+3. Run the following for each challenge file for which you have changed any `testString`s or added solutions:
 
 ```
 npm run test -- -g 'the full English title of the challenge'

--- a/docs/how-to-work-on-coding-challenges.md
+++ b/docs/how-to-work-on-coding-challenges.md
@@ -308,7 +308,7 @@ function myFunc() {
 
 Before you [create a pull request](how-to-open-a-pull-request) for your changes, you need to validate the changes you have made do not inadvertently cause problems with the challenge working correctly.  You do this by performing the following steps:
 
-1. In the `.env` file, set the environment variable `TEST_CHALLENGES_FOR_LANGS` to the language of the challange(s) you are needing to test.  The currently accepted values are `english`, `arabic`, `chinese`, `portuguese`, `russian` and `spanish`.
+1. In the `.env` file, set the environment variable `TEST_CHALLENGES_FOR_LANGS` to the language of the challenge(s) you need to test.  The currently accepted values are `english`, `arabic`, `chinese`, `portuguese`, `russian` and `spanish`.
 
 2.  Switch to the `curriculum` directory:
 

--- a/docs/how-to-work-on-coding-challenges.md
+++ b/docs/how-to-work-on-coding-challenges.md
@@ -306,7 +306,7 @@ function myFunc() {
 
 ## Testing Challenges
 
-Before you [create a pull request](how-to-open-a-pull-request.md) for your changes, you need to validate that the changes you have made do not inadvertently cause problems with the challenge.  You do this by performing the following steps:
+Before you [create a pull request](how-to-open-a-pull-request.md) for your changes, you need to validate that the changes you have made do not inadvertently cause problems with the challenge.  To test all challenges run `npm run test:curriculum`. To save time you can limit the tests to one challenge by performing the following steps:
 
 1. In the `.env` file, set the environment variable `TEST_CHALLENGES_FOR_LANGS` to the language of the challenge(s) you need to test.  The currently accepted values are `english`, `arabic`, `chinese`, `portuguese`, `russian` and `spanish`.
 

--- a/docs/how-to-work-on-coding-challenges.md
+++ b/docs/how-to-work-on-coding-challenges.md
@@ -304,6 +304,26 @@ function myFunc() {
 </details>
 ````
 
+## Testing Challenges
+
+Before you [create a pull request](how-to-open-a-pull-request) for your changes, you need to validate the changes you have made do not inadvertently cause problems with the challenge working correctly.  You do this by performing the following steps:
+
+1. In the `.env` file, set the environment variable `TEST_CHALLENGES_FOR_LANGS` to the language of the challange(s) you are needing to test.  The currently accepted values are `english`, `arabic`, `chinese`, `portuguese`, `russian` and `spanish`.
+
+2.  Switch to the `curriculum` directory:
+
+```
+  cd curriculum
+```
+
+3. Run the following for each challenge file for which you have added solution:
+
+```
+npm run test -- -g 'the full English title of the challenge'
+```
+    
+Once you tested each applicable challenge file using the syntax above and the test results show all tests pass, then you can create a pull request.
+
 ### Useful Links
 
 Creating and Editing Challenges:

--- a/docs/how-to-work-on-coding-challenges.md
+++ b/docs/how-to-work-on-coding-challenges.md
@@ -322,7 +322,7 @@ Before you [create a pull request](how-to-open-a-pull-request) for your changes,
 npm run test -- -g 'the full English title of the challenge'
 ```
     
-Once you tested each applicable challenge file using the syntax above and the test results show all tests pass, then you can create a pull request.
+Once you have verified that each challenge you've worked on passes the tests, please create a pull request.
 
 ### Useful Links
 


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Related to discussion in PR #37161

This PR adds important information on how to test individual challenges (regardless of language) instead of using `npm run test:curriculum` to make the testing faster due to not having to test all the challenges of a particular language.
