### PR TITLE
fix: text overflow & portfolio hr

### DIFF
--- a/client/src/client-only-routes/ShowSettings.js
+++ b/client/src/client-only-routes/ShowSettings.js
@@ -200,7 +200,9 @@ export function ShowSettings(props) {
             </Button>
           </FullWidthRow>
           <Spacer />
-          <h1 className='text-center'>{`Account Settings for ${username}`}</h1>
+          <h1 className='text-center' style={{ overflowWrap: 'break-word' }}>
+            {`Account Settings for ${username}`}
+          </h1>
           <About
             about={about}
             currentTheme={theme}

--- a/client/src/components/Donation/Donation.css
+++ b/client/src/components/Donation/Donation.css
@@ -91,8 +91,7 @@
 }
 
 .wallet {
-  overflow-wrap: break-word;
-  white-space: normal;
+  word-break: break-all;
 }
 
 .alert p {

--- a/client/src/components/Flash/flash.css
+++ b/client/src/components/Flash/flash.css
@@ -8,6 +8,10 @@
   z-index: 1000;
 }
 
+.flash-message div {
+  max-width: 100%;
+}
+
 .flash-message-enter {
   opacity: 0;
 }

--- a/client/src/components/Flash/flash.css
+++ b/client/src/components/Flash/flash.css
@@ -10,6 +10,7 @@
 
 .flash-message div {
   max-width: 100%;
+  overflow-wrap: break-word;
 }
 
 .flash-message-enter {

--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -61,6 +61,19 @@ p {
   line-height: 1.5rem;
 }
 
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+a,
+span,
+div {
+  word-wrap: break-word;
+}
+
 .big-heading {
   font-size: 2.5rem !important;
 }
@@ -255,6 +268,10 @@ input {
   -moz-box-shadow: none !important;
   box-shadow: none !important;
   border-radius: 0px;
+}
+
+textarea {
+  resize: vertical;
 }
 
 form {

--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -61,22 +61,9 @@ p {
   line-height: 1.5rem;
 }
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-a,
-span,
-div,
-code {
-  word-break: break-word;
-}
-
 .big-heading {
   font-size: 2.5rem !important;
+  overflow-wrap: break-word;
 }
 
 .medium-heading {

--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -410,6 +410,7 @@ blockquote .small {
 
 .alert {
   border-radius: 0px;
+  overflow-wrap: break-word;
 }
 
 /* gatsby 404 */

--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -70,8 +70,9 @@ h6,
 p,
 a,
 span,
-div {
-  word-wrap: break-word;
+div,
+code {
+  word-break: break-word;
 }
 
 .big-heading {

--- a/client/src/components/profile/Profile.js
+++ b/client/src/components/profile/Profile.js
@@ -70,7 +70,7 @@ function renderMessage(isSessionUser, username) {
   ) : (
     <Fragment>
       <FullWidthRow>
-        <h2 className='text-center'>
+        <h2 className='text-center' style={{ overflowWrap: 'break-word' }}>
           {username} has not made their portfolio public.
         </h2>
       </FullWidthRow>

--- a/client/src/components/profile/components/camper.css
+++ b/client/src/components/profile/components/camper.css
@@ -6,3 +6,9 @@
   display: flex;
   justify-content: center;
 }
+
+.username,
+.name,
+.bio {
+  overflow-wrap: break-word;
+}

--- a/client/src/components/profile/components/camper.css
+++ b/client/src/components/profile/components/camper.css
@@ -9,6 +9,7 @@
 
 .username,
 .name,
-.bio {
+.bio,
+.location {
   overflow-wrap: break-word;
 }

--- a/client/src/components/profile/components/portfolio.css
+++ b/client/src/components/profile/components/portfolio.css
@@ -8,5 +8,5 @@
 }
 
 .media {
-  word-break: break-word;
+  word-break: break-all;
 }

--- a/client/src/components/profile/components/portfolio.css
+++ b/client/src/components/profile/components/portfolio.css
@@ -6,3 +6,7 @@
   width: 150px;
   min-width: 150px;
 }
+
+.media {
+  word-break: break-word;
+}

--- a/client/src/components/profile/components/portfolio.css
+++ b/client/src/components/profile/components/portfolio.css
@@ -1,5 +1,5 @@
 .portfolio-heading.media-heading {
-  border-bottom: 1px solid rgba(0, 100, 0, 0.6);
+  border-bottom: 1px solid var(--quaternary-background);
   padding-bottom: 10px;
 }
 .portfolio-screen-shot {


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Closes #37141 

**This PR addresses the following concerns:**
- [x] Now the word wraps at the boundary in portfolio title, description, username, name, about and flash messages.
- [x] Portfolio hr is now consistent with global hr.
- [x] Textarea horizontal resize has been disabled to prevent textarea horizontal overflow.


