### PR TITLE
docs: fix unnecessary translation of strong tag

### DIFF
--- a/curriculum/challenges/spanish/01-responsive-web-design/applied-visual-design/use-the-strong-tag-to-make-text-bold.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/applied-visual-design/use-the-strong-tag-to-make-text-bold.spanish.md
@@ -3,7 +3,7 @@ id: 587d781a367417b2b2512ab7
 title: Use the strong Tag to Make Text Bold
 challengeType: 0
 videoUrl: ''
-localeTitle: Utilice la etiqueta fuerte para hacer el texto en negrita
+localeTitle: Utilice la etiqueta strong para hacer el texto en negrita
 ---
 
 ## Description


### PR DESCRIPTION
When translating to Spanish, the tag itself doesn't have to be translated, to avoid confusion. So, strong should be kept "strong" and not "fuerte".

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

