### PR TITLE
fix: make info tab default on mobile challenges

### DIFF
--- a/client/src/templates/Challenges/classic/MobileLayout.js
+++ b/client/src/templates/Challenges/classic/MobileLayout.js
@@ -33,6 +33,9 @@ const propTypes = {
 };
 
 class MobileLayout extends Component {
+  componentDidMount() {
+    if (this.props.currentTab !== 1) this.props.moveToTab(1);
+  }
   render() {
     const {
       currentTab,


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Currently on mobile when you submit a correct solution and move to the next challenge, it opens on the 'Tests' tab.  This PR makes challenges always open on the 'Info' tab as that is typically where you're going to want to start.