### PR TITLE
fix(curriculum): Portuguese challenge tests

### DIFF
--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/add-rounded-corners-with-border-radius.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/add-rounded-corners-with-border-radius.portuguese.md
@@ -18,9 +18,9 @@ localeTitle: Adicionar cantos arredondados com raio de borda
 ```yml
 tests:
   - text: Seu elemento de imagem deve ter a classe "borda verde espessa".
-    testString: 'assert($("img").hasClass("thick-green-border"), "Your image element should have the class "thick-green-border".");'
+    testString: assert($("img").hasClass("thick-green-border"));
   - text: Sua imagem deve ter um raio de 10 <code>10px</code>
-    testString: 'assert(parseInt($("img").css("border-top-left-radius")) > 8, "Your image should have a border radius of <code>10px</code>");'
+    testString: assert(parseInt($("img").css("border-top-left-radius")) > 8);
 
 ```
 
@@ -104,4 +104,5 @@ tests:
 ```js
 // solution required
 ```
+
 </section>

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/add-rounded-corners-with-border-radius.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/add-rounded-corners-with-border-radius.portuguese.md
@@ -17,9 +17,9 @@ localeTitle: Adicionar cantos arredondados com raio de borda
 
 ```yml
 tests:
-  - text: Seu elemento de imagem deve ter a classe "borda verde espessa".
+  - text: Seu elemento de imagem deve ter a classe "thick-green-border".
     testString: assert($("img").hasClass("thick-green-border"));
-  - text: Sua imagem deve ter um raio de 10 <code>10px</code>
+  - text: Sua imagem deve ter uma borda com raio de <code>10px</code>
     testString: assert(parseInt($("img").css("border-top-left-radius")) > 8);
 
 ```

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/size-your-images.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/size-your-images.portuguese.md
@@ -18,9 +18,9 @@ localeTitle: Tamanho suas imagens
 ```yml
 tests:
   - text: Seu elemento <code>img</code> deve ter a classe <code>smaller-image</code> .
-    testString: 'assert($("img[src="https://bit.ly/fcc-relaxing-cat"]").attr("class") === "smaller-image", "Your <code>img</code> element should have the class <code>smaller-image</code>.");'
+    testString: assert($("img[src='https://bit.ly/fcc-relaxing-cat']").attr('class') === "smaller-image");
   - text: Sua imagem deve ter 100 pixels de largura. O zoom do navegador deve estar em 100%.
-    testString: 'assert($("img").width() === 100, "Your image should be 100 pixels wide. Browser zoom should be at 100%.");'
+    testString: assert($("img").width() === 100);
 
 ```
 
@@ -94,4 +94,5 @@ tests:
 ```js
 // solution required
 ```
+
 </section>

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/size-your-images.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/size-your-images.portuguese.md
@@ -17,7 +17,7 @@ localeTitle: Tamanho suas imagens
 
 ```yml
 tests:
-  - text: Seu elemento <code>img</code> deve ter a classe <code>smaller-image</code> .
+  - text: Seu elemento <code>img</code> deveria ter a classe <code>smaller-image</code>.
     testString: assert($("img[src='https://bit.ly/fcc-relaxing-cat']").attr('class') === "smaller-image");
   - text: Sua imagem deve ter 100 pixels de largura. O zoom do navegador deve estar em 100%.
     testString: assert($("img").width() === 100);

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/use-a-css-class-to-style-an-element.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/use-a-css-class-to-style-an-element.portuguese.md
@@ -17,13 +17,13 @@ localeTitle: Use uma classe CSS para estilizar um elemento
 
 ```yml
 tests:
-  - text: Seu elemento <code>h2</code> deve estar vermelho.
+  - text: Seu elemento <code>h2</code> deve ser vermelho.
     testString: assert($("h2").css("color") === "rgb(255, 0, 0)");
-  - text: Seu elemento <code>h2</code> deve ter a classe <code>red-text</code> .
+  - text: Seu elemento <code>h2</code> deveria ter a classe <code>red-text</code>.
     testString: assert($("h2").hasClass("red-text"));
-  - text: Sua folha de estilo deve declarar uma classe de <code>red-text</code> e ter sua cor definida como vermelha.
+  - text: Sua folha de estilo deve declarar uma classe <code>red-text</code> e tenha a cor definida em vermelho.
     testString: assert(code.match(/\.red-text\s*\{\s*color\s*:\s*red;\s*\}/g));
-  - text: 'Não use declarações de estilo inline como <code>style=&quot;color: red&quot;</code> em seu elemento <code>h2</code> .'
+  - text: Não use declarações de estilo embutido como <code>style="color&#58; red"</code> em seu elemento <code>h2</code>.
     testString: assert($("h2").attr("style") === undefined);
 
 ```

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/use-a-css-class-to-style-an-element.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/use-a-css-class-to-style-an-element.portuguese.md
@@ -18,13 +18,13 @@ localeTitle: Use uma classe CSS para estilizar um elemento
 ```yml
 tests:
   - text: Seu elemento <code>h2</code> deve estar vermelho.
-    testString: 'assert($("h2").css("color") === "rgb(255, 0, 0)", "Your <code>h2</code> element should be red.");'
+    testString: assert($("h2").css("color") === "rgb(255, 0, 0)");
   - text: Seu elemento <code>h2</code> deve ter a classe <code>red-text</code> .
-    testString: 'assert($("h2").hasClass("red-text"), "Your <code>h2</code> element should have the class <code>red-text</code>.");'
+    testString: assert($("h2").hasClass("red-text"));
   - text: Sua folha de estilo deve declarar uma classe de <code>red-text</code> e ter sua cor definida como vermelha.
-    testString: 'assert(code.match(/\.red-text\s*\{\s*color\s*:\s*red;\s*\}/g), "Your stylesheet should declare a <code>red-text</code> class and have its color set to red.");'
+    testString: assert(code.match(/\.red-text\s*\{\s*color\s*:\s*red;\s*\}/g));
   - text: 'Não use declarações de estilo inline como <code>style=&quot;color: red&quot;</code> em seu elemento <code>h2</code> .'
-    testString: 'assert($("h2").attr("style") === undefined, "Do not use inline style declarations like <code>style="color&#58; red"</code> in your <code>h2</code> element.");'
+    testString: assert($("h2").attr("style") === undefined);
 
 ```
 
@@ -88,4 +88,5 @@ tests:
 ```js
 // solution required
 ```
+
 </section>

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/use-attribute-selectors-to-style-elements.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/use-attribute-selectors-to-style-elements.portuguese.md
@@ -18,11 +18,11 @@ localeTitle: Use Seletores de Atributo para Elementos de Estilo
 ```yml
 tests:
   - text: O seletor de atributo de <code>type</code> deve ser usado para selecionar as caixas de seleção.
-    testString: 'assert(code.match(/<style>[\s\S]*?\[type=("|")checkbox\1\]\s*?{[\s\S]*?}[\s\S]*?<\/style>/gi),"The <code>type</code> attribute selector should be used to select the checkboxes.");'
+    testString: assert(code.match(/<style>[\s\S]*?\[type=("|")checkbox\1\]\s*?{[\s\S]*?}[\s\S]*?<\/style>/gi));
   - text: As margens superiores das caixas de seleção devem ser 10px.
-    testString: 'assert((function() {var count=0; $("[type="checkbox"]").each(function() { if($(this).css("marginTop") === "10px") {count++;}});return (count===3)}()),"The top margins of the checkboxes should be 10px.");'
+    testString: assert((function() {var count=0; $("[type=\"checkbox\"]").each(function() { if($(this).css("marginTop") === "10px") {count++;}});return (count===3)}()));
   - text: As margens inferiores das caixas de seleção devem ser de 15px.
-    testString: 'assert((function() {var count=0; $("[type="checkbox"]").each(function() { if($(this).css("marginBottom") === "15px") {count++;}});return (count===3)}()),"The bottom margins of the checkboxes should be 15px.");'
+    testString: assert((function() {var count=0; $("[type=\"checkbox\"]").each(function() { if($(this).css("marginBottom") === "15px") {count++;}});return (count===3)}()));
 
 ```
 
@@ -111,4 +111,5 @@ tests:
 ```js
 // solution required
 ```
+
 </section>

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/use-attribute-selectors-to-style-elements.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/use-attribute-selectors-to-style-elements.portuguese.md
@@ -17,11 +17,11 @@ localeTitle: Use Seletores de Atributo para Elementos de Estilo
 
 ```yml
 tests:
-  - text: O seletor de atributo de <code>type</code> deve ser usado para selecionar as caixas de seleção.
+  - text: O seletor de atributo <code>type</code> deve ser usado para selecionar as caixas de seleção.
     testString: assert(code.match(/<style>[\s\S]*?\[type=("|")checkbox\1\]\s*?{[\s\S]*?}[\s\S]*?<\/style>/gi));
   - text: As margens superiores das caixas de seleção devem ser 10px.
     testString: assert((function() {var count=0; $("[type=\"checkbox\"]").each(function() { if($(this).css("marginTop") === "10px") {count++;}});return (count===3)}()));
-  - text: As margens inferiores das caixas de seleção devem ser de 15px.
+  - text: As margens inferiores das caixas de seleção devem ser 15px.
     testString: assert((function() {var count=0; $("[type=\"checkbox\"]").each(function() { if($(this).css("marginBottom") === "15px") {count++;}});return (count===3)}()));
 
 ```

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/use-css-selectors-to-style-elements.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/use-css-selectors-to-style-elements.portuguese.md
@@ -18,15 +18,15 @@ localeTitle: Use seletores CSS para elementos de estilo
 ```yml
 tests:
   - text: Remova o atributo style do seu elemento <code>h2</code> .
-    testString: 'assert(!$("h2").attr("style"), "Remove the style attribute from your <code>h2</code> element.");'
+    testString: assert(!$("h2").attr("style"));
   - text: Crie um elemento de <code>style</code> .
-    testString: 'assert($("style") && $("style").length > 1, "Create a <code>style</code> element.");'
+    testString: assert($("style") && $("style").length >= 1);
   - text: Seu elemento <code>h2</code> deve ser azul.
-    testString: 'assert($("h2").css("color") === "rgb(0, 0, 255)", "Your <code>h2</code> element should be blue.");'
+    testString: assert($("h2").css("color") === "rgb(0, 0, 255)");
   - text: Certifique-se de que a declaração <code>h2</code> sua folha de estilo seja válida com um ponto-e-vírgula e uma chave de fechamento.
-    testString: 'assert(code.match(/h2\s*\{\s*color\s*:.*;\s*\}/g), "Ensure that your stylesheet <code>h2</code> declaration is valid with a semicolon and closing brace.");'
+    testString: assert(code.match(/h2\s*\{\s*color\s*:.*;\s*\}/g));
   - text: Certifique-se de que todos os seus elementos de <code>style</code> sejam válidos e tenham uma tag de fechamento.
-    testString: 'assert(code.match(/<\/style>/g) && code.match(/<\/style>/g).length === (code.match(/<style((\s)*((type|media|scoped|title|disabled)="[^"]*")?(\s)*)*>/g) || []).length, "Make sure all your <code>style</code> elements are valid and have a closing tag.");'
+    testString: assert(code.match(/<\/style>/g) && code.match(/<\/style>/g).length === (code.match(/<style((\s)*((type|media|scoped|title|disabled)="[^"]*")?(\s)*)*>/g) || []).length);
 
 ```
 
@@ -120,4 +120,5 @@ tests:
   </form>
 </main>
 ```
+
 </section>

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/use-css-selectors-to-style-elements.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/use-css-selectors-to-style-elements.portuguese.md
@@ -17,15 +17,15 @@ localeTitle: Use seletores CSS para elementos de estilo
 
 ```yml
 tests:
-  - text: Remova o atributo style do seu elemento <code>h2</code> .
+  - text: Remova o atributo style do seu elemento <code>h2</code>.
     testString: assert(!$("h2").attr("style"));
-  - text: Crie um elemento de <code>style</code> .
+  - text: Crie um elemento <code>style</code>.
     testString: assert($("style") && $("style").length >= 1);
-  - text: Seu elemento <code>h2</code> deve ser azul.
+  - text: Seu elemento <code>h2</code> deveria ser azul.
     testString: assert($("h2").css("color") === "rgb(0, 0, 255)");
-  - text: Certifique-se de que a declaração <code>h2</code> sua folha de estilo seja válida com um ponto-e-vírgula e uma chave de fechamento.
+  - text: Certifique-se de que sua declaração <code> h2 </code> da folha de estilo seja válida com um ponto-e-vírgula e uma chave de fechamento.
     testString: assert(code.match(/h2\s*\{\s*color\s*:.*;\s*\}/g));
-  - text: Certifique-se de que todos os seus elementos de <code>style</code> sejam válidos e tenham uma tag de fechamento.
+  - text: Verifique se todos os seus elementos <code> style </code> são válidos e têm uma tag de fechamento.
     testString: assert(code.match(/<\/style>/g) && code.match(/<\/style>/g).length === (code.match(/<style((\s)*((type|media|scoped|title|disabled)="[^"]*")?(\s)*)*>/g) || []).length);
 
 ```


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Fixes the failing test caused by PR #36970.

I didn't want to dismiss the author's contribution, so I decided to fix the tests instead of reverting the changes. I fixed them by removing all the assert message arguments, following a Randell's comment in another PR https://github.com/freeCodeCamp/freeCodeCamp/pull/37161#issuecomment-540704059.

The changes were tested locally using the following commands:
```
cd curriculum

npm run test -- -g "Use CSS Selectors to Style Elements"
``` 
With `TEST_CHALLENGES_FOR_LANGS=portuguese`