### PR TITLE
fix: enable search in dev mode

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -5,8 +5,8 @@ ROLLBAR_APP_ID='my-rollbar-app-id'
 ROLLBAR_CLIENT_ID='post_client_id from rollbar dashboard'
 
 ALGOLIA_ADMIN_KEY=123abc
-ALGOLIA_APP_ID='Algolia app id from dashboard'
-ALGOLIA_API_KEY='Algolia api key from dashboard'
+ALGOLIA_APP_ID=X5V7KWJ4RB
+ALGOLIA_API_KEY=a45d2b80c97479bbda5cf5c55914230f
 
 AUTH0_CLIENT_ID=stuff
 AUTH0_CLIENT_SECRET=stuff


### PR DESCRIPTION
Added id and API key for the Algolia dev instance to sample.env. This will enable search while developing locally without affecting the main Algolia index we use for News.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #37115 
