### PR TITLE
fix: search bar hover and arrow select highlights

### DIFF
--- a/client/src/components/search/searchBar/searchbar.css
+++ b/client/src/components/search/searchBar/searchbar.css
@@ -72,7 +72,6 @@
 
 .fcc_suggestion_item:hover {
   cursor: pointer;
-  background-color: var(--blue-dark);
 }
 
 .fcc_sr_only {
@@ -93,6 +92,14 @@
 /* Hit selected with arrow keys or mouse */
 .selected {
   background-color: var(--blue-dark);
+}
+
+/* Override for rule in global.css to prevent
+multiple highlighted hits with the mouse
+and arrow keys */
+.fcc_suggestion_item:focus,
+.fcc_suggestion_item:hover {
+  background-color: transparent;
 }
 
 /* Dropdown footer */


### PR DESCRIPTION
Added link hover and focus override to searchBar.css so users cannot hover over a search hit and select another with the up and down keys

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX
