### PR TITLE
fix: stop quotes reloading

### DIFF
--- a/client/src/components/welcome/index.js
+++ b/client/src/components/welcome/index.js
@@ -7,8 +7,12 @@ import { randomQuote } from '../../utils/get-words';
 
 import './welcome.css';
 
+// created outside the function, so that the quotes don't change unless the
+// page is reloaded.
+
+const { quote, author } = randomQuote();
+
 function Welcome({ name }) {
-  const { quote, author } = randomQuote();
   return (
     <Fragment>
       <Row>


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Currently the quotes refresh whenever you visit learn, including when you navigate from learn (i.e. you click on the nav).  Also, when the server cannot be reached, clicking anywhere on the page triggers a refresh - though I don't know why.  This ensures that they only change when the page is reloaded.

Closes #37341