### PR TITLE
fix: conditionally load MathJax

### DIFF
--- a/client/gatsby-ssr.js
+++ b/client/gatsby-ssr.js
@@ -20,8 +20,8 @@ wrapRootElement.propTypes = {
 // TODO: put these in a common utils file.
 const mathJaxCdn = {
   address:
-    'https://cdnjs.cloudflare.com/ajax/libs/mathjax/' +
-    '2.7.4/MathJax.js?config=TeX-AMS_HTML',
+    'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS_HTML',
+  id: 'mathjax',
   key: 'mathjax',
   type: 'text/javascript'
 };
@@ -63,10 +63,11 @@ export const onRenderBody = ({
     />
   ];
 
-  if (pathname.includes('/learn/coding-interview-prep/rosetta-code/')) {
+  if (pathname.includes('/learn/coding-interview-prep/rosetta-code')) {
     scripts.push(
       <script
-        async={true}
+        async={false}
+        id={mathJaxCdn.id}
         key={mathJaxCdn.key}
         src={mathJaxCdn.address}
         type={mathJaxCdn.type}
@@ -81,6 +82,7 @@ export const onRenderBody = ({
         id={stripeScript.id}
         key={stripeScript.key}
         src={stripeScript.address}
+        type={stripeScript.type}
       />
     );
   }

--- a/client/gatsby-ssr.js
+++ b/client/gatsby-ssr.js
@@ -20,7 +20,8 @@ wrapRootElement.propTypes = {
 // TODO: put these in a common utils file.
 const mathJaxCdn = {
   address:
-    'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS_HTML',
+    'https://cdnjs.cloudflare.com/ajax/libs/mathjax/' +
+    '2.7.4/MathJax.js?config=TeX-AMS_HTML',
   id: 'mathjax',
   key: 'mathjax',
   type: 'text/javascript'

--- a/client/src/components/layouts/Default.js
+++ b/client/src/components/layouts/Default.js
@@ -67,6 +67,7 @@ const metaKeywords = [
 ];
 
 const propTypes = {
+  cdnInfo: PropTypes.object,
   children: PropTypes.node.isRequired,
   fetchUser: PropTypes.func.isRequired,
   flashMessage: PropTypes.shape({
@@ -144,7 +145,8 @@ class DefaultLayout extends Component {
       isSignedIn,
       removeFlashMessage,
       showFooter = true,
-      theme = 'default'
+      theme = 'default',
+      cdnInfo
     } = this.props;
     return (
       <Fragment>

--- a/client/src/components/layouts/Default.js
+++ b/client/src/components/layouts/Default.js
@@ -104,14 +104,6 @@ const mapDispatchToProps = dispatch =>
     dispatch
   );
 
-const mathJaxCdn = {
-  address:
-    'https://cdnjs.cloudflare.com/ajax/libs/mathjax/' +
-    '2.7.4/MathJax.js?config=TeX-AMS_HTML',
-  key: 'mathjax',
-  type: 'text/javascript'
-};
-
 class DefaultLayout extends Component {
   componentDidMount() {
     const { isSignedIn, fetchUser, pathname } = this.props;
@@ -153,14 +145,8 @@ class DefaultLayout extends Component {
       isSignedIn,
       removeFlashMessage,
       showFooter = true,
-      theme = 'default',
-      pathname
+      theme = 'default'
     } = this.props;
-    const MathJax = global.MathJax;
-    const rosettaCodeChallenge = pathname.includes(
-      '/coding-interview-prep/rosetta-code/'
-    );
-    console.log(rosettaCodeChallenge);
     return (
       <Fragment>
         <Helmet
@@ -219,13 +205,6 @@ class DefaultLayout extends Component {
             rel='preload'
             type='font/woff'
           />
-          {!MathJax && rosettaCodeChallenge ? (
-            <script
-              key={mathJaxCdn.key}
-              src={mathJaxCdn.address}
-              type={mathJaxCdn.type}
-            ></script>
-          ) : null}
           <style>{fontawesome.dom.css()}</style>
         </Helmet>
         <WithInstantSearch>

--- a/client/src/components/layouts/Default.js
+++ b/client/src/components/layouts/Default.js
@@ -67,7 +67,6 @@ const metaKeywords = [
 ];
 
 const propTypes = {
-  cdnInfo: PropTypes.object,
   children: PropTypes.node.isRequired,
   fetchUser: PropTypes.func.isRequired,
   flashMessage: PropTypes.shape({
@@ -98,11 +97,20 @@ const mapStateToProps = createSelector(
     theme: user.theme
   })
 );
+
 const mapDispatchToProps = dispatch =>
   bindActionCreators(
     { fetchUser, removeFlashMessage, onlineStatusChange },
     dispatch
   );
+
+const mathJaxCdn = {
+  address:
+    'https://cdnjs.cloudflare.com/ajax/libs/mathjax/' +
+    '2.7.4/MathJax.js?config=TeX-AMS_HTML',
+  key: 'mathjax',
+  type: 'text/javascript'
+};
 
 class DefaultLayout extends Component {
   componentDidMount() {
@@ -137,7 +145,6 @@ class DefaultLayout extends Component {
   };
 
   render() {
-    const MathJax = global.MathJax;
     const {
       children,
       hasMessage,
@@ -147,8 +154,13 @@ class DefaultLayout extends Component {
       removeFlashMessage,
       showFooter = true,
       theme = 'default',
-      cdnInfo
+      pathname
     } = this.props;
+    const MathJax = global.MathJax;
+    const rosettaCodeChallenge = pathname.includes(
+      '/coding-interview-prep/rosetta-code/'
+    );
+    console.log(rosettaCodeChallenge);
     return (
       <Fragment>
         <Helmet
@@ -207,6 +219,13 @@ class DefaultLayout extends Component {
             rel='preload'
             type='font/woff'
           />
+          {!MathJax && rosettaCodeChallenge ? (
+            <script
+              key={mathJaxCdn.key}
+              src={mathJaxCdn.address}
+              type={mathJaxCdn.type}
+            ></script>
+          ) : null}
           <style>{fontawesome.dom.css()}</style>
         </Helmet>
         <WithInstantSearch>

--- a/client/src/components/layouts/Default.js
+++ b/client/src/components/layouts/Default.js
@@ -137,6 +137,7 @@ class DefaultLayout extends Component {
   };
 
   render() {
+    const MathJax = global.MathJax;
     const {
       children,
       hasMessage,

--- a/client/src/templates/Challenges/components/Side-Panel.js
+++ b/client/src/templates/Challenges/components/Side-Panel.js
@@ -20,8 +20,6 @@ const mapStateToProps = createSelector(
   })
 );
 
-const MathJax = global.MathJax;
-
 const propTypes = {
   description: PropTypes.string,
   guideUrl: PropTypes.string,
@@ -36,6 +34,7 @@ const propTypes = {
 
 export class SidePanel extends Component {
   componentDidMount() {
+    const MathJax = global.MathJax;
     if (MathJax) {
       MathJax.Hub.Config({
         tex2jax: {

--- a/client/src/templates/Challenges/components/Side-Panel.js
+++ b/client/src/templates/Challenges/components/Side-Panel.js
@@ -33,8 +33,8 @@ const propTypes = {
 };
 
 export class SidePanel extends Component {
-  componentDidMount() {
-    const MathJax = global.MathJax;
+  async componentDidMount() {
+    const MathJax = await global.MathJax;
     if (MathJax) {
       MathJax.Hub.Config({
         tex2jax: {

--- a/client/src/templates/Challenges/components/Side-Panel.js
+++ b/client/src/templates/Challenges/components/Side-Panel.js
@@ -55,7 +55,8 @@ export class SidePanel extends Component {
     const mathJaxMountPoint = document.querySelector('#mathjax');
     const rosettaCodeChallenge = this.props.section === 'rosetta-code';
     if (MathJax) {
-      // Configure MathJax loaded through Gatsby SSR
+      // Configure MathJax when it's loaded and
+      // users navigate from another challenge
       MathJax.Hub.Config({
         tex2jax: {
           inlineMath: [['$', '$'], ['\\(', '\\)']],

--- a/client/src/templates/Challenges/components/Side-Panel.js
+++ b/client/src/templates/Challenges/components/Side-Panel.js
@@ -34,24 +34,8 @@ const propTypes = {
 };
 
 export class SidePanel extends Component {
-  constructor(...props) {
-    super(...props);
-    this.state = {
-      MathJax: global.MathJax
-    };
-    this.handleMathJaxLoad = this.handleMathJaxLoad.bind(this);
-  }
-
-  handleMathJaxLoad() {
-    console.info('MathJax has loaded');
-    this.setState(state => ({
-      ...state,
-      MathJax: global.MathJax
-    }));
-  }
-
   componentDidMount() {
-    const { MathJax } = this.state;
+    const MathJax = global.MathJax;
     const mathJaxMountPoint = document.querySelector('#mathjax');
     const rosettaCodeChallenge = this.props.section === 'rosetta-code';
     if (MathJax) {
@@ -69,17 +53,8 @@ export class SidePanel extends Component {
         MathJax.Hub,
         document.querySelector('.rosetta-code')
       ]);
-    } else if (mathJaxMountPoint && rosettaCodeChallenge) {
-      mathJaxMountPoint.addEventListener('load', this.handleMathJaxLoad);
-    } else if (rosettaCodeChallenge) {
-      mathJaxScriptLoader(this.handleMathJaxLoad);
-    }
-  }
-
-  componentWillUnmount() {
-    const mathJaxMountPoint = document.querySelector('#mathjax');
-    if (mathJaxMountPoint) {
-      mathJaxMountPoint.removeEventListener('load', this.handleMathJaxLoad);
+    } else if (!mathJaxMountPoint && rosettaCodeChallenge) {
+      mathJaxScriptLoader();
     }
   }
 

--- a/client/src/utils/scriptLoaders.js
+++ b/client/src/utils/scriptLoaders.js
@@ -29,7 +29,7 @@ export const mathJaxScriptLoader = onload =>
     onload,
     `MathJax.Hub.Config({
       tex2jax: {
-        inlineMath: [['$', '$'], ['\\(', '\\)']],
+        inlineMath: [['$', '$'], ['\\\\(', '\\\\)']],
         processEscapes: true,
         processClass: 'rosetta-code'
       }

--- a/client/src/utils/scriptLoaders.js
+++ b/client/src/utils/scriptLoaders.js
@@ -19,14 +19,14 @@ export const stripeScriptLoader = onload =>
     onload
   );
 
-export const mathJaxScriptLoader = onload =>
+export const mathJaxScriptLoader = () =>
   scriptLoader(
     'mathjax',
     'mathjax',
     false,
     'https://cdnjs.cloudflare.com/ajax/libs/mathjax/' +
       '2.7.4/MathJax.js?config=TeX-AMS_HTML',
-    onload,
+    null,
     `MathJax.Hub.Config({
       tex2jax: {
         inlineMath: [['$', '$'], ['\\\\(', '\\\\)']],

--- a/client/src/utils/scriptLoaders.js
+++ b/client/src/utils/scriptLoaders.js
@@ -1,11 +1,12 @@
-export const scriptLoader = (id, key, async, src, onload) => {
-  var s = document.createElement('script');
+export const scriptLoader = (id, key, async, src, onload, text) => {
+  let s = document.createElement('script');
   s.type = 'text/javascript';
   s.id = id;
   s.key = key;
   s.async = async;
   s.onload = onload;
   s.src = src;
+  s.text = text;
   document.getElementsByTagName('head')[0].appendChild(s);
 };
 
@@ -16,4 +17,26 @@ export const stripeScriptLoader = onload =>
     false,
     'https://js.stripe.com/v3/',
     onload
+  );
+
+export const mathJaxScriptLoader = onload =>
+  scriptLoader(
+    'mathjax',
+    'mathjax',
+    false,
+    'https://cdnjs.cloudflare.com/ajax/libs/mathjax/' +
+      '2.7.4/MathJax.js?config=TeX-AMS_HTML',
+    onload,
+    `MathJax.Hub.Config({
+      tex2jax: {
+        inlineMath: [['$', '$'], ['\\(', '\\)']],
+        processEscapes: true,
+        processClass: 'rosetta-code'
+      }
+    });
+    MathJax.Hub.Queue([
+      'Typeset',
+      MathJax.Hub,
+      document.querySelector('.rosetta-code')
+    ]);`
   );

--- a/client/utils/gatsby/layoutSelector.js
+++ b/client/utils/gatsby/layoutSelector.js
@@ -20,6 +20,20 @@ export default function layoutSelector({ element, props }) {
   if (/^\/guide(\/.*)*/.test(pathname)) {
     console.log('Hitting guide for some reason. Need a redirect.');
   }
+  if (/^\/learn\/coding-interview-prep\/rosetta-code(\/.*)*/.test(pathname)) {
+    const mathjax = {
+      address:
+        'https://cdnjs.cloudflare.com/ajax/libs/mathjax/' +
+        '2.7.4/MathJax.js?config=TeX-AMS_HTML',
+      key: 'mathjax',
+      type: 'text/javascript'
+    };
+    return (
+      <DefaultLayout cdnInfo={mathjax} pathname={pathname} showFooter={false}>
+        {element}
+      </DefaultLayout>
+    );
+  }
   if (/^\/learn(\/.*)*/.test(pathname)) {
     return (
       <DefaultLayout pathname={pathname} showFooter={false}>

--- a/client/utils/gatsby/layoutSelector.js
+++ b/client/utils/gatsby/layoutSelector.js
@@ -20,20 +20,6 @@ export default function layoutSelector({ element, props }) {
   if (/^\/guide(\/.*)*/.test(pathname)) {
     console.log('Hitting guide for some reason. Need a redirect.');
   }
-  if (/^\/learn\/coding-interview-prep\/rosetta-code(\/.*)*/.test(pathname)) {
-    const cdnInfo = {
-      address:
-        'https://cdnjs.cloudflare.com/ajax/libs/mathjax/' +
-        '2.7.4/MathJax.js?config=TeX-AMS_HTML',
-      key: 'mathjax',
-      type: 'text/javascript'
-    };
-    return (
-      <DefaultLayout cdnInfo={cdnInfo} pathname={pathname} showFooter={false}>
-        {element}
-      </DefaultLayout>
-    );
-  }
   if (/^\/learn(\/.*)*/.test(pathname)) {
     return (
       <DefaultLayout pathname={pathname} showFooter={false}>

--- a/client/utils/gatsby/layoutSelector.js
+++ b/client/utils/gatsby/layoutSelector.js
@@ -21,7 +21,7 @@ export default function layoutSelector({ element, props }) {
     console.log('Hitting guide for some reason. Need a redirect.');
   }
   if (/^\/learn\/coding-interview-prep\/rosetta-code(\/.*)*/.test(pathname)) {
-    const mathjax = {
+    const cdnInfo = {
       address:
         'https://cdnjs.cloudflare.com/ajax/libs/mathjax/' +
         '2.7.4/MathJax.js?config=TeX-AMS_HTML',
@@ -29,7 +29,7 @@ export default function layoutSelector({ element, props }) {
       type: 'text/javascript'
     };
     return (
-      <DefaultLayout cdnInfo={mathjax} pathname={pathname} showFooter={false}>
+      <DefaultLayout cdnInfo={cdnInfo} pathname={pathname} showFooter={false}>
         {element}
       </DefaultLayout>
     );


### PR DESCRIPTION
Removed MathJax CDN from header and set it up to download whenever a user goes to a Rosetta Code challenge

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX
