### PR TITLE
fix: remove Gatsby proxy

### DIFF
--- a/client/gatsby-config.js
+++ b/client/gatsby-config.js
@@ -6,18 +6,12 @@ const {
   localeChallengesRootDir
 } = require('./utils/buildChallenges');
 
-const { API_PROXY: proxyUrl = 'http://localhost:3000' } = process.env;
-
 const curriculumIntroRoot = path.resolve(__dirname, './src/pages');
 
 module.exports = {
   siteMetadata: {
     title: 'freeCodeCamp',
     siteUrl: 'https://www.freecodecamp.org'
-  },
-  proxy: {
-    prefix: '/internal',
-    url: proxyUrl
   },
   plugins: [
     'gatsby-plugin-react-helmet',

--- a/client/src/components/Donation/components/DonateForm.js
+++ b/client/src/components/Donation/components/DonateForm.js
@@ -124,7 +124,7 @@ class DonateForm extends Component {
     }));
 
     const chargeStripePath = isSignedIn
-      ? '/internal/donate/charge-stripe'
+      ? `${apiLocation}/internal/donate/charge-stripe`
       : `${apiLocation}/unauthenticated/donate/charge-stripe`;
     return postJSON$(chargeStripePath, {
       token,

--- a/client/src/utils/ajax.js
+++ b/client/src/utils/ajax.js
@@ -1,6 +1,9 @@
+import { apiLocation } from '../../config/env.json';
+
 import axios from 'axios';
 
-const base = '/internal';
+const base = apiLocation + '/internal';
+
 axios.defaults.withCredentials = true;
 
 function get(path) {


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Direct ajax calls to the server directly, rather than a proxy to reduce redirects while still allowing the server to be used in development.

The hope is that this will get api requests to the server quicker.