### PR TITLE
fix: bind handleStripeLoad in constructor

### DIFF
--- a/client/src/components/Donation/components/DonateModal.js
+++ b/client/src/components/Donation/components/DonateModal.js
@@ -48,6 +48,7 @@ class DonateModal extends Component {
       stripe: null
     };
     this.renderMaybe = this.renderMaybe.bind(this);
+    this.handleStripeLoad = this.handleStripeLoad.bind(this);
   }
   componentDidMount() {
     if (window.Stripe) {
@@ -63,7 +64,6 @@ class DonateModal extends Component {
 
   handleStripeLoad() {
     // Create Stripe instance once Stripe.js loads
-    console.info('stripe has loaded');
     this.setState(state => ({
       ...state,
       stripe: window.Stripe(stripePublicKey)


### PR DESCRIPTION
Bound handleStripeLoad to this in the constructor to prevent "setState is not a function" errors.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX
