### PR TITLE
fix: update timeline without reload

### DIFF
--- a/client/src/redux/index.js
+++ b/client/src/redux/index.js
@@ -311,9 +311,11 @@ export const reducer = handleActions(
       }
     }),
     [types.submitComplete]: (state, { payload: { id, challArray } }) => {
-      let submitedchallneges = [{ id }];
+      // TODO: possibly more of the payload (files?) should be added
+      // to the completedChallenges array.
+      let submittedchallenges = [{ id, completedDate: Date.now() }];
       if (challArray) {
-        submitedchallneges = challArray;
+        submittedchallenges = challArray;
       }
       const { appUsername } = state;
       return {
@@ -325,7 +327,7 @@ export const reducer = handleActions(
             ...state.user[appUsername],
             completedChallenges: uniqBy(
               [
-                ...submitedchallneges,
+                ...submittedchallenges,
                 ...state.user[appUsername].completedChallenges
               ],
               'id'


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Now the timeline will immediately update with the date a user submits a challenge.

Rather than pinging the server, this uses the current time.  It should almost always be the same and only lasts until reload.

Related to #37279, but may not fix all those problems.
