### PR TITLE
Fix: Reduce the number of db calls for getSessionUser

### DIFF
--- a/api-server/common/models/user.js
+++ b/api-server/common/models/user.js
@@ -983,6 +983,12 @@ export default function(User) {
   });
 
   User.prototype.getPoints$ = function getPoints$() {
+    if (
+      Array.isArray(this.progressTimestamps) &&
+      this.progressTimestamps.length
+    ) {
+      return Observable.of(this.progressTimestamps);
+    }
     const id = this.getId();
     const filter = {
       where: { id },
@@ -994,6 +1000,12 @@ export default function(User) {
     });
   };
   User.prototype.getCompletedChallenges$ = function getCompletedChallenges$() {
+    if (
+      Array.isArray(this.completedChallenges) &&
+      this.completedChallenges.length
+    ) {
+      return Observable.of(this.completedChallenges);
+    }
     const id = this.getId();
     const filter = {
       where: { id },

--- a/api-server/server/boot_tests/challenge.test.js
+++ b/api-server/server/boot_tests/challenge.test.js
@@ -28,7 +28,7 @@ import {
 } from './fixtures';
 
 describe('boot/challenge', () => {
-  xdescribe('backendChallengeCompleted');
+  xdescribe('backendChallengeCompleted', () => {});
 
   describe('buildUserUpdate', () => {
     it('returns an Object with a nested "completedChallenges" property', () => {
@@ -332,9 +332,9 @@ describe('boot/challenge', () => {
     });
   });
 
-  xdescribe('modernChallengeCompleted');
+  xdescribe('modernChallengeCompleted', () => {});
 
-  xdescribe('projectCompleted');
+  xdescribe('projectCompleted', () => {});
 
   describe('redirectToCurrentChallenge', () => {
     const mockHomeLocation = 'https://www.example.com';

--- a/api-server/server/utils/user-stats.js
+++ b/api-server/server/utils/user-stats.js
@@ -110,9 +110,7 @@ export function getUserById(id, User = loopback.getModelByType('User')) {
       if (err || isEmpty(instance)) {
         return reject(err || 'No user instance found');
       }
-      instance.points =
-        (instance.progressTimestamps && instance.progressTimestamps.length) ||
-        1;
+
       let completedChallengeCount = 0;
       let completedProjectCount = 0;
       if ('completedChallenges' in instance) {
@@ -126,12 +124,14 @@ export function getUserById(id, User = loopback.getModelByType('User')) {
           }
         });
       }
+
       instance.completedChallengeCount = completedChallengeCount;
       instance.completedProjectCount = completedProjectCount;
       instance.completedCertCount = getCompletedCertCount(instance);
       instance.completedLegacyCertCount = getLegacyCertCount(instance);
-      instance.completedChallenges = [];
-      delete instance.progressTimestamps;
+      instance.points =
+        (instance.progressTimestamps && instance.progressTimestamps.length) ||
+        1;
       return resolve(instance);
     })
   );

--- a/api-server/server/utils/user-stats.test.js
+++ b/api-server/server/utils/user-stats.test.js
@@ -599,13 +599,12 @@ describe('user stats', () => {
         .then(user => {
           expect(user).toEqual(mockUser);
 
-          // fields added or removed by getUserById
-          expect(user).not.toHaveProperty('progressTimestamps');
+          expect(user).toHaveProperty('progressTimestamps');
           expect(user).toHaveProperty('completedChallengeCount');
           expect(user).toHaveProperty('completedProjectCount');
           expect(user).toHaveProperty('completedCertCount');
           expect(user).toHaveProperty('completedLegacyCertCount');
-          expect(user.completedChallenges).toEqual([]);
+          expect(user).toHaveProperty('completedChallenges');
         })
         .then(done)
         .catch(done);


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.

Only call the db if we have missing data for the current user.

This is achieved through early returns in `User` methods when the data already exists on the user (`req.user`).