### PR TITLE
feat: SSR MathJax and Stripe on routes using them

### DIFF
--- a/client/gatsby-ssr.js
+++ b/client/gatsby-ssr.js
@@ -17,28 +17,73 @@ wrapRootElement.propTypes = {
   element: PropTypes.any
 };
 
+// TODO: put these in a common utils file.
+const mathJaxCdn = {
+  address:
+    'https://cdnjs.cloudflare.com/ajax/libs/mathjax/' +
+    '2.7.4/MathJax.js?config=TeX-AMS_HTML',
+  key: 'mathjax',
+  type: 'text/javascript'
+};
+
+const stripeScript = {
+  address: 'https://js.stripe.com/v3/',
+  id: 'stripe-js',
+  key: 'stripe-js',
+  type: 'text/javascript'
+};
+
+const challengeRE = new RegExp('/learn/[^/]+/[^/]+/[^/]+/?$');
+const donateRE = new RegExp('/donate/?$');
+
 export const wrapPageElement = layoutSelector;
 
-export const onRenderBody = ({ setHeadComponents, setPostBodyComponents }) => {
+export const onRenderBody = ({
+  pathname,
+  setHeadComponents,
+  setPostBodyComponents
+}) => {
   setHeadComponents([...headComponents]);
-  setPostBodyComponents(
-    [
+  const scripts = [
+    <script
+      async={true}
+      key='gtag-script'
+      src='https://www.googletagmanager.com/gtag/js?id=AW-795617839'
+    />,
+    <script
+      dangerouslySetInnerHTML={{
+        __html: `
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-795617839');
+      `
+      }}
+      key='gtag-dataLayer'
+    />
+  ];
+
+  if (pathname.includes('/learn/coding-interview-prep/rosetta-code/')) {
+    scripts.push(
       <script
         async={true}
-        key='gtag-script'
-        src='https://www.googletagmanager.com/gtag/js?id=AW-795617839'
-      />,
-      <script
-        dangerouslySetInnerHTML={{
-          __html: `
-          window.dataLayer = window.dataLayer || [];
-          function gtag(){dataLayer.push(arguments);}
-          gtag('js', new Date());
-          gtag('config', 'AW-795617839');
-        `
-        }}
-        key='gtag-dataLayer'
+        key={mathJaxCdn.key}
+        src={mathJaxCdn.address}
+        type={mathJaxCdn.type}
       />
-    ].filter(Boolean)
-  );
+    );
+  }
+
+  if (challengeRE.test(pathname) || donateRE.test(pathname)) {
+    scripts.push(
+      <script
+        async={true}
+        id={stripeScript.id}
+        key={stripeScript.key}
+        src={stripeScript.address}
+      />
+    );
+  }
+
+  setPostBodyComponents(scripts.filter(Boolean));
 };

--- a/client/src/head/index.js
+++ b/client/src/head/index.js
@@ -1,8 +1,7 @@
 import meta from './meta';
-import mathjax from './mathjax';
 import scripts from './scripts';
 
-const metaAndStyleSheets = meta.concat(mathjax, scripts).map((element, i) => ({
+const metaAndStyleSheets = meta.concat(scripts).map((element, i) => ({
   ...element,
   key: `meta-stylesheet-${i}`,
   props: { ...element.props, key: `meta-stylesheet-${i}` }

--- a/client/src/head/index.js
+++ b/client/src/head/index.js
@@ -1,7 +1,6 @@
 import meta from './meta';
-import scripts from './scripts';
 
-const metaAndStyleSheets = meta.concat(scripts).map((element, i) => ({
+const metaAndStyleSheets = meta.map((element, i) => ({
   ...element,
   key: `meta-stylesheet-${i}`,
   props: { ...element.props, key: `meta-stylesheet-${i}` }

--- a/client/src/head/mathjax.js
+++ b/client/src/head/mathjax.js
@@ -1,9 +1,0 @@
-import React from 'react';
-
-const cdnAddr =
-  'https://cdnjs.cloudflare.com/ajax/libs/mathjax/' +
-  '2.7.4/MathJax.js?config=TeX-AMS_HTML';
-
-const mathjax = [<script key='mathjax' src={cdnAddr} type='text/javascript' />];
-
-export default mathjax;

--- a/client/src/head/scripts.js
+++ b/client/src/head/scripts.js
@@ -1,3 +1,0 @@
-const scripts = [];
-
-export default scripts;


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Attaches scripts to the body if they're needed.  Stripe for `/donate` and challenges and MathJax for the rosetta code challenges.  This should be faster than waiting for `componentDidMount` before starting.

Related to #37360