### PR TITLE
fix: display current progress in single line

### DIFF
--- a/client/src/components/Map/map.css
+++ b/client/src/components/Map/map.css
@@ -33,7 +33,7 @@ button.map-title:hover {
 
 .map-title-completed {
   margin-left: auto;
-  width: 100px;
+  min-width: 100px;
   padding-left: 20px;
 }
 


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This fixes the wrapping issue when five or more digits are displayed but also keeps the circles in line when browsing the site on smaller screens.

Closes #37415
