### PR TITLE
fix: remove unnecessary stripe iframes

### DIFF
--- a/client/src/components/Header/index.js
+++ b/client/src/components/Header/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Helmet from 'react-helmet';
 
+import stripeObserver from './stripeIframesFix';
 import UniversalNav from './components/UniversalNav';
 
 import './header.css';
@@ -19,6 +20,10 @@ export class Header extends React.Component {
 
   componentDidMount() {
     document.addEventListener('click', this.handleClickOutside);
+
+    // Remove stacking Stripe iframes with each navigation
+    // after visiting /donate
+    stripeObserver();
   }
 
   componentWillUnmount() {

--- a/client/src/components/Header/stripeIframesFix.js
+++ b/client/src/components/Header/stripeIframesFix.js
@@ -1,0 +1,27 @@
+const stripeObserver = () => {
+  const config = { attributes: false, childList: true, subtree: false };
+
+  const filterNodes = nl =>
+    Array.from(nl)
+      .filter(b => b.nodeName === 'IFRAME')
+      .filter(
+        b =>
+          b.name !== '__privateStripeMetricsController0' &&
+          b.name !== '__privateStripeController1'
+      );
+
+  const mutationCallback = a =>
+    a
+      .reduce(
+        (acc, curr) =>
+          curr.type === 'childList'
+            ? [...acc, ...filterNodes(curr.addedNodes)]
+            : acc,
+        []
+      )
+      .forEach(a => a.remove());
+
+  return new MutationObserver(mutationCallback).observe(document.body, config);
+};
+
+export default stripeObserver;

--- a/client/src/components/Header/stripeIframesFix.js
+++ b/client/src/components/Header/stripeIframesFix.js
@@ -4,22 +4,25 @@ const stripeObserver = () => {
   const filterNodes = nl =>
     Array.from(nl)
       .filter(b => b.nodeName === 'IFRAME')
-      .filter(
-        b =>
-          b.name !== '__privateStripeMetricsController0' &&
-          b.name !== '__privateStripeController1'
-      );
+      .filter(b => /__privateStripeController/.test(b.name));
 
-  const mutationCallback = a =>
-    a
-      .reduce(
-        (acc, curr) =>
-          curr.type === 'childList'
-            ? [...acc, ...filterNodes(curr.addedNodes)]
-            : acc,
-        []
-      )
-      .forEach(a => a.remove());
+  const mutationCallback = a => {
+    const controllerAdded = a.reduce(
+      (acc, curr) =>
+        curr.type === 'childList'
+          ? [...acc, ...filterNodes(curr.addedNodes)]
+          : acc,
+      []
+    )[0];
+    if (controllerAdded) {
+      const allControllers = filterNodes(document.body.childNodes);
+      allControllers.forEach(controller => {
+        if (controller.name !== controllerAdded.name) {
+          controller.remove();
+        }
+      });
+    }
+  };
 
   return new MutationObserver(mutationCallback).observe(document.body, config);
 };

--- a/client/src/pages/donate.js
+++ b/client/src/pages/donate.js
@@ -65,29 +65,6 @@ export class DonatePage extends Component {
     const stripeMountPoint = document.querySelector('#stripe-js');
     if (stripeMountPoint) {
       stripeMountPoint.removeEventListener('load', this.handleStripeLoad);
-
-      // // Remove stacking Stripe iframes when navigating away from /donate
-      // const config = { attributes: false, childList: true, subtree: false };
-
-      // const filterNodes = nl =>
-      //   Array.from(nl)
-      //     .filter(b => b.nodeName === 'IFRAME')
-      //     .filter(b => b.name.match(/__privateStripe/g));
-
-      // const mutationCallback = a => {
-      //   console.log(a);
-      //   return a
-      //     .reduce(
-      //       (acc, curr) =>
-      //         curr.type === 'childList'
-      //           ? [...acc, ...filterNodes(curr.addedNodes)]
-      //           : acc,
-      //       []
-      //     )
-      //     .forEach(a => a.remove());
-      // }
-
-      // new MutationObserver(mutationCallback).observe(document.body, config);
     }
   }
 

--- a/client/src/pages/donate.js
+++ b/client/src/pages/donate.js
@@ -66,26 +66,28 @@ export class DonatePage extends Component {
     if (stripeMountPoint) {
       stripeMountPoint.removeEventListener('load', this.handleStripeLoad);
 
-      // Remove stacking Stripe iframes when navigating away from /donate
-      const config = { attributes: false, childList: true, subtree: false };
+      // // Remove stacking Stripe iframes when navigating away from /donate
+      // const config = { attributes: false, childList: true, subtree: false };
 
-      const filterNodes = nl =>
-        Array.from(nl)
-          .filter(b => b.nodeName === 'IFRAME')
-          .filter(b => b.name.match(/__privateStripe/g));
+      // const filterNodes = nl =>
+      //   Array.from(nl)
+      //     .filter(b => b.nodeName === 'IFRAME')
+      //     .filter(b => b.name.match(/__privateStripe/g));
 
-      const mutationCallback = a =>
-        a
-          .reduce(
-            (acc, curr) =>
-              curr.type === 'childList'
-                ? [...acc, ...filterNodes(curr.addedNodes)]
-                : acc,
-            []
-          )
-          .forEach(a => a.remove());
+      // const mutationCallback = a => {
+      //   console.log(a);
+      //   return a
+      //     .reduce(
+      //       (acc, curr) =>
+      //         curr.type === 'childList'
+      //           ? [...acc, ...filterNodes(curr.addedNodes)]
+      //           : acc,
+      //       []
+      //     )
+      //     .forEach(a => a.remove());
+      // }
 
-      new MutationObserver(mutationCallback).observe(document.body, config);
+      // new MutationObserver(mutationCallback).observe(document.body, config);
     }
   }
 

--- a/client/src/pages/donate.js
+++ b/client/src/pages/donate.js
@@ -48,6 +48,7 @@ export class DonatePage extends Component {
     this.handleStripeLoad = this.handleStripeLoad.bind(this);
     this.toggleOtherOptions = this.toggleOtherOptions.bind(this);
   }
+
   componentDidMount() {
     if (window.Stripe) {
       this.handleStripeLoad();
@@ -64,6 +65,27 @@ export class DonatePage extends Component {
     const stripeMountPoint = document.querySelector('#stripe-js');
     if (stripeMountPoint) {
       stripeMountPoint.removeEventListener('load', this.handleStripeLoad);
+
+      // Remove stacking Stripe iframes when navigating away from /donate
+      const config = { attributes: false, childList: true, subtree: false };
+
+      const filterNodes = nl =>
+        Array.from(nl)
+          .filter(b => b.nodeName === 'IFRAME')
+          .filter(b => b.name.match(/__privateStripe/g));
+
+      const mutationCallback = a =>
+        a
+          .reduce(
+            (acc, curr) =>
+              curr.type === 'childList'
+                ? [...acc, ...filterNodes(curr.addedNodes)]
+                : acc,
+            []
+          )
+          .forEach(a => a.remove());
+
+      new MutationObserver(mutationCallback).observe(document.body, config);
     }
   }
 


### PR DESCRIPTION
Remove stripe iframes that stack with each navigation after visiting /donate and loading Stripe. 

This method will still leave two iframes (`__privateStripeMetricsController0` and `__privateStripeController1`) as they may be necessary for Stripe to function normally. While it's possible to remove the previously mentioned iframes, Stripe seems to only load them once when first visiting /donate. Future visits to /donate only load iframes for each of the credit card inputs and not `__privateStripeMetricsControllerX` or `__privateStripeControllerX`.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/37387
