### PR TITLE
fix: return the loader after redirect

### DIFF
--- a/client/src/client-only-routes/ShowSettings.js
+++ b/client/src/client-only-routes/ShowSettings.js
@@ -168,9 +168,7 @@ export function ShowSettings(props) {
 
   return (
     <Fragment>
-      <Helmet>
-        <title>Settings | freeCodeCamp.org</title>
-      </Helmet>
+      <Helmet title='Settings | freeCodeCamp.org'></Helmet>
       <Grid>
         <main>
           <Spacer size={2} />

--- a/client/src/client-only-routes/ShowSettings.js
+++ b/client/src/client-only-routes/ShowSettings.js
@@ -162,7 +162,8 @@ export function ShowSettings(props) {
   }
 
   if (!showLoading && !isSignedIn) {
-    return navigate(`${apiLocation}/signin?returnTo=settings`);
+    navigate(`${apiLocation}/signin?returnTo=settings`);
+    return <Loader fullScreen={true} />;
   }
 
   return (

--- a/client/src/client-only-routes/ShowSettings.test.js
+++ b/client/src/client-only-routes/ShowSettings.test.js
@@ -14,7 +14,8 @@ describe('<ShowSettings />', () => {
     expect(navigate).toHaveBeenCalledWith(
       `${apiLocation}/signin?returnTo=settings`
     );
-    expect(true).toBeTruthy();
+    const result = shallow.getRenderOutput();
+    expect(result.type.displayName).toBe('Loader');
   });
 });
 

--- a/client/src/client-only-routes/ShowSettings.test.js
+++ b/client/src/client-only-routes/ShowSettings.test.js
@@ -7,7 +7,19 @@ import { apiLocation } from '../../config/env.json';
 import { ShowSettings } from './ShowSettings';
 
 describe('<ShowSettings />', () => {
-  it('redirects to signin page when user not logged in', () => {
+  it('renders to the DOM when user is logged in', () => {
+    const shallow = new ShallowRenderer();
+    shallow.render(<ShowSettings {...loggedInProps} />);
+    expect(navigate).toHaveBeenCalledTimes(0);
+    const result = shallow.getRenderOutput();
+    expect(result.type.toString()).toBe('Symbol(react.fragment)');
+    // Renders Helmet component rather than Loader
+    expect(result.props.children[0].props.title).toEqual(
+      'Settings | freeCodeCamp.org'
+    );
+  });
+
+  it('redirects to sign in page when user is not logged in', () => {
     const shallow = new ShallowRenderer();
     shallow.render(<ShowSettings {...loggedOutProps} />);
     expect(navigate).toHaveBeenCalledTimes(1);
@@ -15,15 +27,16 @@ describe('<ShowSettings />', () => {
       `${apiLocation}/signin?returnTo=settings`
     );
     const result = shallow.getRenderOutput();
+    // Renders Loader rather than ShowSettings
     expect(result.type.displayName).toBe('Loader');
   });
 });
 
 const navigate = jest.fn();
-const loggedOutProps = {
+const loggedInProps = {
   createFlashMessage: jest.fn(),
   hardGoTo: jest.fn(),
-  isSignedIn: false,
+  isSignedIn: true,
   navigate: navigate,
   showLoading: false,
   submitNewAbout: jest.fn(),
@@ -38,3 +51,5 @@ const loggedOutProps = {
   },
   verifyCert: jest.fn()
 };
+const loggedOutProps = { ...loggedInProps };
+loggedOutProps.isSignedIn = false;

--- a/client/src/pages/donate.js
+++ b/client/src/pages/donate.js
@@ -91,7 +91,8 @@ export class DonatePage extends Component {
     }
 
     if (!showLoading && !isSignedIn) {
-      return navigate(`${apiLocation}/signin?returnTo=donate`);
+      navigate(`${apiLocation}/signin?returnTo=donate`);
+      return <Loader fullScreen={true} />;
     }
 
     return (

--- a/client/src/pages/donate.test.js
+++ b/client/src/pages/donate.test.js
@@ -6,7 +6,7 @@ import { apiLocation } from '../../config/env.json';
 
 import { DonatePage } from './donate';
 
-describe('<ShowSettings />', () => {
+describe('<DonatePage />', () => {
   it('redirects to signin page when user not logged in', () => {
     const shallow = new ShallowRenderer();
     shallow.render(<DonatePage {...loggedOutProps} />);
@@ -14,7 +14,8 @@ describe('<ShowSettings />', () => {
     expect(navigate).toHaveBeenCalledWith(
       `${apiLocation}/signin?returnTo=donate`
     );
-    expect(true).toBeTruthy();
+    const result = shallow.getRenderOutput();
+    expect(result.type.displayName).toBe('Loader');
   });
 });
 

--- a/client/src/pages/donate.test.js
+++ b/client/src/pages/donate.test.js
@@ -7,7 +7,19 @@ import { apiLocation } from '../../config/env.json';
 import { DonatePage } from './donate';
 
 describe('<DonatePage />', () => {
-  it('redirects to signin page when user not logged in', () => {
+  it('renders to the DOM when user is logged in', () => {
+    const shallow = new ShallowRenderer();
+    shallow.render(<DonatePage {...loggedInProps} />);
+    expect(navigate).toHaveBeenCalledTimes(0);
+    const result = shallow.getRenderOutput();
+    expect(result.type.toString()).toBe('Symbol(react.fragment)');
+    // Renders Helmet component rather than Loader
+    expect(result.props.children[0].props.title).toEqual(
+      'Support our nonprofit | freeCodeCamp.org'
+    );
+  });
+
+  it('redirects to sign in page when user is not logged in', () => {
     const shallow = new ShallowRenderer();
     shallow.render(<DonatePage {...loggedOutProps} />);
     expect(navigate).toHaveBeenCalledTimes(1);
@@ -15,14 +27,17 @@ describe('<DonatePage />', () => {
       `${apiLocation}/signin?returnTo=donate`
     );
     const result = shallow.getRenderOutput();
+    // Renders Loader rather than DonatePage
     expect(result.type.displayName).toBe('Loader');
   });
 });
 
 const navigate = jest.fn();
-const loggedOutProps = {
+const loggedInProps = {
   createFlashMessage: () => {},
-  isSignedIn: false,
+  isSignedIn: true,
   showLoading: false,
   navigate: navigate
 };
+const loggedOutProps = { ...loggedInProps };
+loggedOutProps.isSignedIn = false;

--- a/client/src/pages/portfolio.js
+++ b/client/src/pages/portfolio.js
@@ -50,7 +50,8 @@ function ProfilePage(props) {
     return <Loader fullScreen={true} />;
   }
   if (!showLoading && !isSignedIn) {
-    return navigate(`${apiLocation}/signin?returnTo=portfolio`);
+    navigate(`${apiLocation}/signin?returnTo=portfolio`);
+    return <Loader fullScreen={true} />;
   }
   const RedirecUser = createRedirect('/' + username);
   return <RedirecUser />;


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

react errors when when returning a function, 
we could return a loader while the redirection happens in the background.

Thanks to @scissorsneedfoodtoo for the investigation

