### PR TITLE
docs: update spelling on installation guide

### DIFF
--- a/docs/how-to-catch-outgoing-emails-locally.md
+++ b/docs/how-to-catch-outgoing-emails-locally.md
@@ -38,7 +38,7 @@ Download the latest version of MailHog from [MailHog's official repository](http
 
 When the download completes, click to open the file. A Windows firewall notification may appear, requesting access permission for MailHog. A standard Windows command line prompt will open where MailHog will be running once firewall access is granted.
 
-Close MailHog by closing the command prompt window. To start MailHog again, click on the MailHog executable (.exe) file that was downloaded initially - it is not necessary to download a new MailHog intallation file.
+Close MailHog by closing the command prompt window. To start MailHog again, click on the MailHog executable (.exe) file that was downloaded initially - it is not necessary to download a new MailHog installation file.
 
 Start [using MailHog](#using-mailhog).
 


### PR DESCRIPTION
The spelling of installation on line 41 was wrong

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ ] My pull request targets the `master` branch of freeCodeCamp.
- [ ] None of my changes are plagiarized from another source without proper attribution.
- [ ] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [ ] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX
