### PR TITLE
fix: separate certs from interview prep on landing page

### DIFF
--- a/client/src/components/landing/index.js
+++ b/client/src/components/landing/index.js
@@ -24,6 +24,7 @@ const BigCallToAction = () => (
 
 export const Landing = ({ edges }) => {
   const superBlocks = uniq(edges.map(element => element.node.superBlock));
+  const interviewPrep = superBlocks.splice(6, 1);
   return (
     <Fragment>
       <Helmet>
@@ -68,6 +69,15 @@ export const Landing = ({ edges }) => {
                     </Link>
                   </li>
                 ))}
+              </ul>
+              <Spacer />
+              <h2 className='medium-heading'>Additional Learning:</h2>
+              <ul>
+                <li>
+                  <Link state={{ superBlock: interviewPrep }} to={`/learn`}>
+                    <h2 className='medium-heading'>{interviewPrep}</h2>
+                  </Link>
+                </li>
               </ul>
             </Col>
           </Row>


### PR DESCRIPTION
This is what I came up with, let me know if we want some different....

<img width="497" alt="Screen Shot 2019-10-22 at 12 42 31 PM" src="https://user-images.githubusercontent.com/20648924/67313921-73357d80-f4c9-11e9-94c3-24b61bf8ae79.png">

Closes #37340
