### PR TITLE
fix(client): border visibility for form control in nightmode

### DIFF
--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -248,9 +248,10 @@ strong {
 }
 
 .form-control {
-  color: var(--theme-color);
+  color: var(--primary-color);
   outline: none;
   border-color: var(--quaternary-background);
+  background-color: var(--primary-background);
   -webkit-box-shadow: none !important;
   -moz-box-shadow: none !important;
   box-shadow: none !important;


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x ] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x ] My pull request targets the `master` branch of freeCodeCamp.
- [x ] None of my changes are plagiarized from another source without proper attribution.
- [x ] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x ] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #37375

**What has been done**
I took a look at #37375 issue. Like @ojeytonwilliams suggested, I'm throwing little dark background (#0a0a23) and light text (#ffffff) on form control elements. Also the border color during focus is now visible in night mode. 

I tried to attach the screenshot of the webpage in night mode. But unfortunately github has some issues in uploading it. Please take a look and any suggestions are welcomed. :)