### PR TITLE
fix: add cert redirect for Netlify

### DIFF
--- a/tools/scripts/build/__snapshots__/create-redirects.test.js.snap
+++ b/tools/scripts/build/__snapshots__/create-redirects.test.js.snap
@@ -48,6 +48,7 @@ https://freecodecamp-org.netlify.com/*        https://www.freecodecamp.org/:spla
 /:username/data-visualization-certification   /certification/:username/legacy-data-visualization 301
 /:username/back-end-certification             /certification/:username/legacy-back-end 301
 /:username/full-stack-certification           /certification/:username/full-stack 301
+/certification/*                              /certification/index.html 200
 
 # unsubscribe redirects
 /u/*                                          https://api.example.com/u/:splat 200!

--- a/tools/scripts/build/__snapshots__/create-redirects.test.js.snap
+++ b/tools/scripts/build/__snapshots__/create-redirects.test.js.snap
@@ -48,7 +48,7 @@ https://freecodecamp-org.netlify.com/*        https://www.freecodecamp.org/:spla
 /:username/data-visualization-certification   /certification/:username/legacy-data-visualization 301
 /:username/back-end-certification             /certification/:username/legacy-back-end 301
 /:username/full-stack-certification           /certification/:username/full-stack 301
-/certification/*                              /certification/index.html 200
+/certification/*                              /certification 200
 
 # unsubscribe redirects
 /u/*                                          https://api.example.com/u/:splat 200!

--- a/tools/scripts/build/create-redirects.js
+++ b/tools/scripts/build/create-redirects.js
@@ -69,7 +69,7 @@ https://freecodecamp-org.netlify.com/*        https://www.freecodecamp.org/:spla
 /:username/data-visualization-certification   /certification/:username/legacy-data-visualization 301
 /:username/back-end-certification             /certification/:username/legacy-back-end 301
 /:username/full-stack-certification           /certification/:username/full-stack 301
-/certification/*                              /certification/index.html 200
+/certification/*                              /certification 200
 
 # unsubscribe redirects
 /u/*                                          #{{API}}/u/:splat 200!

--- a/tools/scripts/build/create-redirects.js
+++ b/tools/scripts/build/create-redirects.js
@@ -69,6 +69,7 @@ https://freecodecamp-org.netlify.com/*        https://www.freecodecamp.org/:spla
 /:username/data-visualization-certification   /certification/:username/legacy-data-visualization 301
 /:username/back-end-certification             /certification/:username/legacy-back-end 301
 /:username/full-stack-certification           /certification/:username/full-stack 301
+/certification/*                              /certification/index.html 200
 
 # unsubscribe redirects
 /u/*                                          #{{API}}/u/:splat 200!


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Netlify does not automatically discover client only routes.  This PR creates a redirect telling it where to find the HTML for certifications.

Related to #37378, but only fixes the style issues that appear when the page is reloaded.