### PR TITLE
fix: added forumTopicId to recently added Rosetta Code challenges

### DIFF
--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/knapsack-problem-0-1.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/knapsack-problem-0-1.md
@@ -2,6 +2,7 @@
 id: 5a23c84252665b21eecc7ed1
 title: Knapsack problem/0-1
 challengeType: 5
+forumTopicId: 323649
 ---
 
 ## Description

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/knapsack-problem-bounded.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/knapsack-problem-bounded.md
@@ -2,6 +2,7 @@
 id: 5a23c84252665b21eecc7ed2
 title: Knapsack problem/Bounded
 challengeType: 5
+forumTopicId: 323652
 ---
 
 ## Description

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/knapsack-problem-continuous.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/knapsack-problem-continuous.md
@@ -2,6 +2,7 @@
 id: 5a23c84252665b21eecc7ed3
 title: Knapsack problem/Continuous
 challengeType: 5
+forumTopicId: 323654
 ---
 
 ## Description

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/knapsack-problem-unbounded.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/knapsack-problem-unbounded.md
@@ -2,6 +2,7 @@
 id: 5a23c84252665b21eecc7ed4
 title: Knapsack problem/Unbounded
 challengeType: 5
+forumTopicId: 323655
 ---
 
 ## Description


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Related to #35770

I have created forum topics for the recently merged challenges of PR #35770 and added the corresponding solution in the challenge files to the topics.  This PR adds the corresponding `forumTopicId` to the challenge file, so the `Get a Hint` links to something.
