### PR TITLE
Added new test cases and corrected the solution for positive and negative lookahead for ensuring that strings beginning with numbers are not accepted

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/positive-and-negative-lookahead.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/positive-and-negative-lookahead.english.md
@@ -58,6 +58,9 @@ tests:
     testString: assert(!pwRegex.test("123"));
   - text: Your regex should not match <code>"1234"</code>
     testString: assert(!pwRegex.test("1234"));
+  - text: Your regex should not match <code>"8pass99"</code>
+    testString: assert(!pwRegex.test("8pass99"));
+
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/positive-and-negative-lookahead.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/positive-and-negative-lookahead.english.md
@@ -60,6 +60,9 @@ tests:
     testString: assert(!pwRegex.test("1234"));
   - text: Your regex should not match <code>"8pass99"</code>
     testString: assert(!pwRegex.test("8pass99"));
+  - text: Your regex should not match <code>"12abcde"</code>
+    testString: assert(!pwRegex.test("12abcde"));
+
 
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/positive-and-negative-lookahead.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/positive-and-negative-lookahead.english.md
@@ -88,7 +88,7 @@ let result = pwRegex.test(sampleWord);
 
 
 ```js
-var pwRegex = /^(?=\w{6})(?=\D*\d{2})/;
+var pwRegex = /^(?=\w{6})(?=\D+\d{2})/;
 ```
 
 </section>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/positive-and-negative-lookahead.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/positive-and-negative-lookahead.english.md
@@ -88,7 +88,7 @@ let result = pwRegex.test(sampleWord);
 
 
 ```js
-var pwRegex = /(?=\w{6})(?=\D*\d{2})/;
+var pwRegex = /^(?=\w{6})(?=\D*\d{2})/;
 ```
 
 </section>


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #37481

Ran `npm run test:curriculum` and results:
![image](https://user-images.githubusercontent.com/28900975/67422624-7d05d080-f5f0-11e9-9a27-598418139f8d.png)

