### PR TITLE
Update test output default text to help reduce confusion

### DIFF
--- a/client/src/templates/Challenges/classic/Show.js
+++ b/client/src/templates/Challenges/classic/Show.js
@@ -237,7 +237,7 @@ class ShowClassic extends Component {
       <Output
         defaultOutput={`
 /**
-* Your test output will go here.
+* Your unit test output will go here.
 */
 `}
         output={output}


### PR DESCRIPTION

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

I often see confusion, nearly everyday from either posts on Reddit or in the forum wondering why the console.log output does not show in the "test output" box below the editor. I wanted to propose this change to try and clear up some confusion to new students. I'm not sure if this is the best way to word it and would appreciate any feedback from those with more experience in UX.

I also considered adding an extra sentence along the lines of "Open your Developer Tools to check console.log output" but that seemed a bit too long.