### PR TITLE
ISSUE #37480 - isLinkedIn flag was being incorrectly set

### DIFF
--- a/api-server/common/models/user.js
+++ b/api-server/common/models/user.js
@@ -822,7 +822,7 @@ export default function(User) {
         const allUser = {
           ..._.pick(user, publicUserProps),
           isGithub: !!user.githubProfile,
-          isLinkedIn: !!user.linkedIn,
+          isLinkedIn: !!user.linkedin,
           isTwitter: !!user.twitter,
           isWebsite: !!user.website,
           points: progressTimestamps.length,


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Had a small investigation to work out why the linkedIn flag was not working, It appears the get-public-profile endpoint was using `linkedIn` instead of `linkedin` This could probably do with a test to for the functionality, but not sure what the testing structure is for this app.

Closes #37480
