### PR TITLE
fix: escape HTML entities in code editor log

### DIFF
--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -9,6 +9,7 @@ import {
   getContext
 } from 'redux-saga/effects';
 import { channel } from 'redux-saga';
+import escape from 'lodash/escape';
 
 import {
   challengeDataSelector,
@@ -73,7 +74,7 @@ export function* executeChallengeSaga() {
 
 function* logToConsole(channel) {
   yield takeEvery(channel, function*(args) {
-    yield put(updateLogs(args));
+    yield put(updateLogs(escape(args)));
   });
 }
 


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Escape `console.log` output as it is expected to be text, not HTML.  

Before: 
![image](https://user-images.githubusercontent.com/15801806/67700524-64116c80-f9ae-11e9-8644-b7d5cd7d2204.png)

After:
![image](https://user-images.githubusercontent.com/15801806/67700465-48a66180-f9ae-11e9-995e-aa45c7d746fc.png)

Closes #37598

This will also make `console.log('<code>hi</code>')` output `"<code>hi</code>"` instead of "`hi`".