### PR TITLE
Issued Date visibility fix

### DIFF
--- a/client/src/client-only-routes/ShowCertification.js
+++ b/client/src/client-only-routes/ShowCertification.js
@@ -42,6 +42,10 @@ const propTypes = {
   validCertName: PropTypes.bool
 };
 
+const whiteTextStyle = {
+  color: 'white'
+}
+
 const mapStateToProps = (state, { certName }) => {
   const validCertName = validCertNames.some(name => name === certName);
   return createSelector(
@@ -123,7 +127,7 @@ class ShowCertification extends Component {
               <Col md={7} sm={12}>
                 <div className='issue-date'>
                   Issued&nbsp;
-                  <strong>{issueDate}</strong>
+                  <strong style={whiteTextStyle}>{issueDate}</strong>
                 </div>
               </Col>
             </header>


### PR DESCRIPTION
I added an inline style for now because the Certificate Issued Date is invisible with the current theme of the site. Tested Issue on multiple devices, and found that no matter how I navigated to it, the certifications page shows a black-on-black font for the issued date. This is hopefully a temporary fix.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #37378 
