### PR TITLE
fix: make fcc console dynamic and more informative

### DIFF
--- a/client/src/client/workers/test-evaluator.js
+++ b/client/src/client/workers/test-evaluator.js
@@ -43,6 +43,7 @@ const __utils = (() => {
   };
 })();
 
+/* Run the test if there is one.  If not just evaluate the user code */
 self.onmessage = async e => {
   /* eslint-disable no-unused-vars */
   const { code = '' } = e.data;
@@ -64,10 +65,13 @@ self.onmessage = async e => {
       if (__userCodeWasExecuted) {
         // rethrow error, since test failed.
         throw err;
-      } else {
-        // report errors to dev console (not the editor console, since the test
-        // may still pass)
+      } else if (e.data.testString) {
+        // report errors to dev console if tests are running (since some
+        // challenges should pass with code that throws errors)
         __utils.oldLog(err);
+      } else {
+        // user is editing code, so both consoles should report errors
+        console.log(err.toString());
       }
       testResult = eval(e.data.testString);
     }

--- a/client/src/client/workers/test-evaluator.js
+++ b/client/src/client/workers/test-evaluator.js
@@ -24,22 +24,37 @@ const __utils = (() => {
   }
 
   const oldLog = self.console.log.bind(self.console);
-  self.console.log = function proxyConsole(...args) {
+  function proxyLog(...args) {
     logs.push(args.map(arg => '' + JSON.stringify(arg, replacer)).join(' '));
     if (logs.join('\n').length > MAX_LOGS_SIZE) {
       flushLogs();
     }
     return oldLog(...args);
-  };
+  }
 
+  // unless data.type is truthy, this sends data out to the testRunner
   function postResult(data) {
     flushLogs();
     self.postMessage(data);
   }
 
+  function logToBoth(err) {
+    if (!(err instanceof chai.AssertionError)) {
+      // report to both the browser and the fcc consoles, discarding the
+      // stack trace via toString as it only useful to debug the site, not a
+      // specific challenge.
+      console.log(err.toString());
+    }
+  }
+
+  const toggleLogging = on => {
+    self.console.log = on ? proxyLog : () => {};
+  };
+
   return {
     postResult,
-    oldLog
+    logToBoth,
+    toggleLogging
   };
 })();
 
@@ -50,6 +65,8 @@ self.onmessage = async e => {
   const assert = chai.assert;
   // Fake Deep Equal dependency
   const DeepEqual = (a, b) => JSON.stringify(a) === JSON.stringify(b);
+
+  __utils.toggleLogging(e.data.firstTest);
   /* eslint-enable no-unused-vars */
   try {
     let testResult;
@@ -65,14 +82,11 @@ self.onmessage = async e => {
       if (__userCodeWasExecuted) {
         // rethrow error, since test failed.
         throw err;
-      } else if (e.data.testString) {
-        // report errors to dev console if tests are running (since some
-        // challenges should pass with code that throws errors)
-        __utils.oldLog(err);
-      } else {
-        // user is editing code, so both consoles should report errors
-        console.log(err.toString());
       }
+      // log build errors
+      __utils.logToBoth(err);
+      // the tests may not require working code, so they are evaluated even if
+      // the user code does not get executed.
       testResult = eval(e.data.testString);
     }
     /* eslint-enable no-eval */
@@ -83,15 +97,17 @@ self.onmessage = async e => {
       pass: true
     });
   } catch (err) {
+    // report errors that happened during testing, so the user learns of
+    // execution errors and not just build errors.
+    __utils.toggleLogging(true);
+    __utils.logToBoth(err);
+    // postResult flushes the logs and must be called after logging is finished.
     __utils.postResult({
       err: {
         message: err.message,
         stack: err.stack
       }
     });
-    if (!(err instanceof chai.AssertionError)) {
-      console.error(err);
-    }
   }
 };
 

--- a/client/src/templates/Challenges/components/output.css
+++ b/client/src/templates/Challenges/components/output.css
@@ -1,5 +1,5 @@
 .output-text {
-  white-space: pre-line;
+  white-space: pre-wrap;
   word-break: normal;
   padding-top: 0;
   height: 100%;

--- a/client/src/templates/Challenges/rechallenge/transformers.js
+++ b/client/src/templates/Challenges/rechallenge/transformers.js
@@ -55,7 +55,6 @@ function tryTransform(wrap = identity) {
   return function transformWrappedPoly(source) {
     const result = attempt(wrap, source);
     if (isError(result)) {
-      console.error(result);
       // note(Bouncey): Error thrown here to collapse the build pipeline
       // At the minute, it will not bubble up
       // We collapse the pipeline so the app doesn't fall over trying

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -92,10 +92,18 @@ function* buildChallengeData(challengeData) {
 
 function* executeTests(testRunner, tests, testTimeout = 5000) {
   const testResults = [];
-  for (const { text, testString } of tests) {
+  for (let i = 0; i < tests.length; i++) {
+    const { text, testString } = tests[i];
     const newTest = { text, testString };
+    // only the last test outputs console.logs to avoid log duplication.
+    const firstTest = i === 1;
     try {
-      const { pass, err } = yield call(testRunner, testString, testTimeout);
+      const { pass, err } = yield call(
+        testRunner,
+        testString,
+        testTimeout,
+        firstTest
+      );
       if (pass) {
         newTest.pass = true;
       } else {

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -125,13 +125,15 @@ function* previewChallengeSaga() {
     return;
   }
   const challengeData = yield select(challengeDataSelector);
-  if (!challengeHasPreview(challengeData)) {
-    return;
-  }
 
   try {
     yield put(initConsole(''));
+    // try to build even if there's no preview so build errors will be reported.
     const ctx = yield buildChallengeData(challengeData);
+    // then only continue if there is a preview.
+    if (!challengeHasPreview(challengeData)) {
+      return;
+    }
     const document = yield getContext('document');
     yield call(updatePreview, ctx, document);
   } catch (err) {

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -26,6 +26,7 @@ import {
 
 import {
   buildChallenge,
+  canBuildChallenge,
   getTestRunner,
   challengeHasPreview,
   updatePreview,
@@ -153,15 +154,17 @@ function* previewChallengeSaga() {
     yield fork(takeEveryConsole, logProxy);
 
     const challengeData = yield select(challengeDataSelector);
-    const buildData = yield buildChallengeData(challengeData);
-    // evaluate the user code in the preview frame or in the worker
-    if (challengeHasPreview(challengeData)) {
-      const document = yield getContext('document');
-      yield call(updatePreview, buildData, document, proxyLogger);
-    } else if (isJavaScriptChallenge(challengeData)) {
-      const runUserCode = getTestRunner(buildData, { proxyLogger });
-      // without a testString the testRunner just evaluates the user's code
-      yield call(runUserCode, null, 5000);
+    if (canBuildChallenge(challengeData)) {
+      const buildData = yield buildChallengeData(challengeData);
+      // evaluate the user code in the preview frame or in the worker
+      if (challengeHasPreview(challengeData)) {
+        const document = yield getContext('document');
+        yield call(updatePreview, buildData, document, proxyLogger);
+      } else if (isJavaScriptChallenge(challengeData)) {
+        const runUserCode = getTestRunner(buildData, { proxyLogger });
+        // without a testString the testRunner just evaluates the user's code
+        yield call(runUserCode, null, 5000);
+      }
     }
   } catch (err) {
     console.log(err);

--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -324,9 +324,8 @@ export const reducer = handleActions(
       isBuildEnabled: true,
       isCodeLocked: false
     }),
-    [types.disableBuildOnError]: (state, { payload }) => ({
+    [types.disableBuildOnError]: state => ({
       ...state,
-      consoleOut: state.consoleOut + ' \n' + payload,
       isBuildEnabled: false
     }),
 

--- a/client/src/templates/Challenges/utils/build.js
+++ b/client/src/templates/Challenges/utils/build.js
@@ -79,7 +79,7 @@ const testRunners = {
   [challengeTypes.html]: getDOMTestRunner,
   [challengeTypes.backend]: getDOMTestRunner
 };
-export function getTestRunner(buildData, proxyLogger, document) {
+export function getTestRunner(buildData, { proxyLogger }, document) {
   const { challengeType } = buildData;
   const testRunner = testRunners[challengeType];
   if (testRunner) {

--- a/client/src/templates/Challenges/utils/build.js
+++ b/client/src/templates/Challenges/utils/build.js
@@ -171,3 +171,7 @@ export function challengeHasPreview({ challengeType }) {
     challengeType === challengeTypes.modern
   );
 }
+
+export function isJavaScriptChallenge({ challengeType }) {
+  return challengeType === challengeTypes.js;
+}

--- a/client/src/templates/Challenges/utils/build.js
+++ b/client/src/templates/Challenges/utils/build.js
@@ -65,6 +65,11 @@ const buildFunctions = {
   [challengeTypes.backEndProject]: buildBackendChallenge
 };
 
+export function canBuildChallenge(challengeData) {
+  const { challengeType } = challengeData;
+  return buildFunctions.hasOwnProperty(challengeType);
+}
+
 export async function buildChallenge(challengeData) {
   const { challengeType } = challengeData;
   let build = buildFunctions[challengeType];

--- a/client/src/templates/Challenges/utils/build.js
+++ b/client/src/templates/Challenges/utils/build.js
@@ -173,5 +173,8 @@ export function challengeHasPreview({ challengeType }) {
 }
 
 export function isJavaScriptChallenge({ challengeType }) {
-  return challengeType === challengeTypes.js;
+  return (
+    challengeType === challengeTypes.js ||
+    challengeType === challengeTypes.bonfire
+  );
 }

--- a/client/src/templates/Challenges/utils/build.js
+++ b/client/src/templates/Challenges/utils/build.js
@@ -93,9 +93,9 @@ function getJSTestRunner({ build, sources }, proxyLogger) {
 
   const testWorker = createWorker('test-evaluator', { terminateWorker: true });
 
-  return (testString, testTimeout) => {
+  return (testString, testTimeout, firstTest = true) => {
     return testWorker
-      .execute({ build, testString, code, sources }, testTimeout)
+      .execute({ build, testString, code, sources, firstTest }, testTimeout)
       .on('LOG', proxyLogger).done;
   };
 }

--- a/client/src/templates/Challenges/utils/build.js
+++ b/client/src/templates/Challenges/utils/build.js
@@ -153,10 +153,13 @@ export function buildBackendChallenge({ url }) {
   };
 }
 
-export function updatePreview(buildData, document) {
+export async function updatePreview(buildData, document, proxyLogger) {
   const { challengeType } = buildData;
+
   if (challengeType === challengeTypes.html) {
-    createMainFramer(document)(buildData);
+    await new Promise(resolve =>
+      createMainFramer(document, resolve, proxyLogger)(buildData)
+    );
   } else {
     throw new Error(`Cannot show preview for challenge type ${challengeType}`);
   }

--- a/client/src/templates/Challenges/utils/frame.js
+++ b/client/src/templates/Challenges/utils/frame.js
@@ -101,15 +101,15 @@ const initTestFrame = frameReady => ctx => {
   return ctx;
 };
 
-const initMainFrame = (frameReady, proxyUpdateConsole) => ctx => {
+const initMainFrame = (frameReady, proxyLogger) => ctx => {
   waitForFrame(ctx).then(() => {
     // Overwriting the onerror added by createHeader to catch any errors thrown
     // after the frame is ready. It has to be overwritten, as proxyUpdateConsole
     // cannot be added as part of createHeader.
     ctx.window.onerror = function(msg) {
       console.log(msg);
-      if (proxyUpdateConsole) {
-        proxyUpdateConsole(msg);
+      if (proxyLogger) {
+        proxyLogger(msg);
       }
       return true;
     };
@@ -140,23 +140,17 @@ const writeContentToFrame = ctx => {
   return ctx;
 };
 
-export const createMainFramer = (document, frameReady, proxy) =>
-  createFramer(document, frameReady, proxy, mainId, initMainFrame);
+export const createMainFramer = (document, frameReady, proxyLogger) =>
+  createFramer(document, frameReady, proxyLogger, mainId, initMainFrame);
 
-export const createTestFramer = (document, frameReady, proxy) =>
-  createFramer(document, frameReady, proxy, testId, initTestFrame);
+export const createTestFramer = (document, frameReady, proxyLogger) =>
+  createFramer(document, frameReady, proxyLogger, testId, initTestFrame);
 
-const createFramer = (
-  document,
-  frameReady,
-  { proxyLogger, proxyUpdateConsole },
-  id,
-  init
-) =>
+const createFramer = (document, frameReady, proxyLogger, id, init) =>
   flow(
     createFrame(document, id),
     mountFrame(document),
     buildProxyConsole(proxyLogger),
     writeContentToFrame,
-    init(frameReady, proxyUpdateConsole)
+    init(frameReady, proxyLogger)
   );

--- a/client/src/templates/Challenges/utils/frame.js
+++ b/client/src/templates/Challenges/utils/frame.js
@@ -104,8 +104,8 @@ const initTestFrame = frameReady => ctx => {
 const initMainFrame = (frameReady, proxyLogger) => ctx => {
   waitForFrame(ctx).then(() => {
     // Overwriting the onerror added by createHeader to catch any errors thrown
-    // after the frame is ready. It has to be overwritten, as proxyUpdateConsole
-    // cannot be added as part of createHeader.
+    // after the frame is ready. It has to be overwritten, as proxyLogger cannot
+    // be added as part of createHeader.
     ctx.window.onerror = function(msg) {
       console.log(msg);
       if (proxyLogger) {

--- a/client/src/templates/Challenges/utils/frame.js
+++ b/client/src/templates/Challenges/utils/frame.js
@@ -22,6 +22,7 @@ const createHeader = (id = mainId) => `
     window.__frameId = '${id}';
     window.onerror = function(msg, url, ln, col, err) {
       window.__err = err;
+      console.log(msg);
       return true;
     };
     document.addEventListener('click', function(e) {


### PR DESCRIPTION
Previously only challenges with previews would inform the user of syntax errors.  This extends that to all challenges and corrects the output format so all errors are clearer.

Before css change:
![image](https://user-images.githubusercontent.com/15801806/67878230-458cac00-fb3b-11e9-937a-46d6aa20edc0.png)
and after
![image](https://user-images.githubusercontent.com/15801806/67878163-255ced00-fb3b-11e9-8001-a4a82ceb9f55.png)


One side-effect is that this makes the debugging challenges even easier - possibly too easy.  I'm not sure how to avoid that, though.

---

Errors thrown during execution will appear in both consoles.  JS: errors and logs from evaluating the user's code will only be reported during the first test, but non-assertion errors thrown during testing will also appear in both consoles.  

---

Now both html and js challenges output console logs and error messages to the fcc console as the user types.

---

Any errors generated once the preview frame has been created will also be logged (if a click listener throws an error, for example).  ~~Console logs are still ignored after the frame is ready~~.