### PR TITLE
fix: restrict markdown linting to curriculum files

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
         "eslint --fix",
         "git add"
       ],
-      "*.md": "node ./tools/scripts/lint/index.js",
+      "./curriculum/challenges/**/*.md": "node ./tools/scripts/lint/index.js",
       "*.css": [
         "prettier --write",
         "git add"


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


