### PR TITLE
fix(curriculum): use object.assign to prevent overwriting prototypes if user uses class instead of function

### DIFF
--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/add-a-new-element-to-a-binary-search-tree.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/add-a-new-element-to-a-binary-search-tree.english.md
@@ -60,50 +60,41 @@ function BinarySearchTree() {
 <div id='js-teardown'>
 
 ```js
-BinarySearchTree.prototype = {
-  isBinarySearchTree() {
-    if (this.root == null) {
-      return null;
-    } else {
-      var check = true;
-      function checkTree(node) {
-        if (node.left != null) {
-          var left = node.left;
-          if (left.value > node.value) {
-            check = false;
-          } else {
-            checkTree(left);
-          }
-        }
-        if (node.right != null) {
-          var right = node.right;
-          if (right.value < node.value) {
-            check = false;
-          } else {
-            checkTree(right);
-          }
-        }
+BinarySearchTree.prototype = Object.assign(
+  BinarySearchTree.prototype,
+  {
+    isBinarySearchTree(node = this.root, min = null, max = null) {
+      if (!node) return true;
+      if (node.left != null && node.left.value > node.value) {
+        return false;
       }
-      checkTree(this.root);
-      return check;
+
+      if (node.right != null && node.right.value < node.value) {
+        return false;
+      }
+
+      if (!isBST(node.left) || !isBST(node.right)) {
+        return false;
+      }
+
+      return true;
+    },
+
+    inOrder() {
+      if (!this.root) {
+        return null;
+      }
+      var result = new Array();
+      function traverseInOrder(node) {
+        node.left && traverseInOrder(node.left);
+        result.push(node.value);
+        node.right && traverseInOrder(node.right);
+      }
+      traverseInOrder(this.root);
+      return result;
     }
   }
-};
-BinarySearchTree.prototype = {
-  inOrder() {
-    if (!this.root) {
-      return null;
-    }
-    var result = new Array();
-    function traverseInOrder(node) {
-      node.left && traverseInOrder(node.left);
-      result.push(node.value);
-      node.right && traverseInOrder(node.right);
-    }
-    traverseInOrder(this.root);
-    return result;
-  }
-};
+);
 ```
 
 </div>
@@ -129,7 +120,6 @@ function BinarySearchTree() {
       const searchTree = function(current) {
         if (current.value > element) {
           if (current.left) {
-            //si existe
             return searchTree(current.left);
           } else {
             current.left = new Node(element);

--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/add-a-new-element-to-a-binary-search-tree.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/add-a-new-element-to-a-binary-search-tree.english.md
@@ -63,23 +63,6 @@ function BinarySearchTree() {
 BinarySearchTree.prototype = Object.assign(
   BinarySearchTree.prototype,
   {
-    isBinarySearchTree(node = this.root, min = null, max = null) {
-      if (!node) return true;
-      if (node.left != null && node.left.value > node.value) {
-        return false;
-      }
-
-      if (node.right != null && node.right.value < node.value) {
-        return false;
-      }
-
-      if (!isBST(node.left) || !isBST(node.right)) {
-        return false;
-      }
-
-      return true;
-    },
-
     inOrder() {
       if (!this.root) {
         return null;

--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/check-if-an-element-is-present-in-a-binary-search-tree.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/check-if-an-element-is-present-in-a-binary-search-tree.english.md
@@ -61,36 +61,39 @@ function BinarySearchTree() {
 <div id='js-teardown'>
 
 ```js
-BinarySearchTree.prototype = {
-  add: function(value) {
-    var node = this.root;
-    if (node == null) {
-      this.root = new Node(value);
-      return;
-    } else {
-      function searchTree(node) {
-        if (value < node.value) {
-          if (node.left == null) {
-            node.left = new Node(value);
-            return;
-          } else if (node.left != null) {
-            return searchTree(node.left);
+BinarySearchTree.prototype = Object.assign(
+  BinarySearchTree.prototype,
+  {
+    add: function(value) {
+      var node = this.root;
+      if (node == null) {
+        this.root = new Node(value);
+        return;
+      } else {
+        function searchTree(node) {
+          if (value < node.value) {
+            if (node.left == null) {
+              node.left = new Node(value);
+              return;
+            } else if (node.left != null) {
+              return searchTree(node.left);
+            }
+          } else if (value > node.value) {
+            if (node.right == null) {
+              node.right = new Node(value);
+              return;
+            } else if (node.right != null) {
+              return searchTree(node.right);
+            }
+          } else {
+            return null;
           }
-        } else if (value > node.value) {
-          if (node.right == null) {
-            node.right = new Node(value);
-            return;
-          } else if (node.right != null) {
-            return searchTree(node.right);
-          }
-        } else {
-          return null;
         }
+        return searchTree(node);
       }
-      return searchTree(node);
     }
   }
-};
+);
 ```
 
 </div>

--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/create-a-doubly-linked-list.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/create-a-doubly-linked-list.english.md
@@ -68,7 +68,11 @@ var DoublyLinkedList = function() {
 <div id='js-teardown'>
 
 ```js
-DoublyLinkedList.prototype = {
+
+DoublyLinkedList.prototype = Object.assign(
+  DoublyLinkedList.prototype,
+  {
+  
   print() {
     if (this.head == null) {
       return null;
@@ -96,8 +100,8 @@ DoublyLinkedList.prototype = {
       result.push(node.data);
       return result;
     };
-  } 
-};
+  }
+});
 ```
 
 </div>

--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/delete-a-leaf-node-in-a-binary-search-tree.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/delete-a-leaf-node-in-a-binary-search-tree.english.md
@@ -116,33 +116,6 @@ BinarySearchTree.prototype = Object.assign(
         traverseInOrder(this.root);
         return result;
       }
-    },
-    isBinarySearchTree() {
-      if (this.root == null) {
-        return null;
-      } else {
-        var check = true;
-        function checkTree(node) {
-          if (node.left != null) {
-            var left = node.left;
-            if (left.value > node.value) {
-              check = false;
-            } else {
-              checkTree(left);
-            }
-          }
-          if (node.right != null) {
-            var right = node.right;
-            if (right.value < node.value) {
-              check = false;
-            } else {
-              checkTree(right);
-            }
-          }
-        }
-        checkTree(this.root);
-        return check;
-      }
     }
   }
 );

--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/delete-a-leaf-node-in-a-binary-search-tree.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/delete-a-leaf-node-in-a-binary-search-tree.english.md
@@ -68,81 +68,84 @@ function BinarySearchTree() {
 <div id='js-teardown'>
 
 ```js
-BinarySearchTree.prototype = {
-  add: function(value) {
-    var node = this.root;
-    if (node == null) {
-      this.root = new Node(value);
-      return;
-    } else {
-      function searchTree(node) {
-        if (value < node.value) {
-          if (node.left == null) {
-            node.left = new Node(value);
-            return;
-          } else if (node.left != null) {
-            return searchTree(node.left);
-          }
-        } else if (value > node.value) {
-          if (node.right == null) {
-            node.right = new Node(value);
-            return;
-          } else if (node.right != null) {
-            return searchTree(node.right);
-          }
-        } else {
-          return null;
-        }
-      }
-      return searchTree(node);
-    }
-  },
-  inorder: function() {
-    if (this.root == null) {
-      return null;
-    } else {
-      var result = new Array();
-      function traverseInOrder(node) {
-        if (node.left != null) {
-          traverseInOrder(node.left);
-        }
-        result.push(node.value);
-        if (node.right != null) {
-          traverseInOrder(node.right);
-        }
-      }
-      traverseInOrder(this.root);
-      return result;
-    }
-  },
-  isBinarySearchTree() {
-    if (this.root == null) {
-      return null;
-    } else {
-      var check = true;
-      function checkTree(node) {
-        if (node.left != null) {
-          var left = node.left;
-          if (left.value > node.value) {
-            check = false;
+BinarySearchTree.prototype = Object.assign(
+  BinarySearchTree.prototype,
+  {
+    add: function(value) {
+      var node = this.root;
+      if (node == null) {
+        this.root = new Node(value);
+        return;
+      } else {
+        function searchTree(node) {
+          if (value < node.value) {
+            if (node.left == null) {
+              node.left = new Node(value);
+              return;
+            } else if (node.left != null) {
+              return searchTree(node.left);
+            }
+          } else if (value > node.value) {
+            if (node.right == null) {
+              node.right = new Node(value);
+              return;
+            } else if (node.right != null) {
+              return searchTree(node.right);
+            }
           } else {
-            checkTree(left);
+            return null;
           }
         }
-        if (node.right != null) {
-          var right = node.right;
-          if (right.value < node.value) {
-            check = false;
-          } else {
-            checkTree(right);
-          }
-        }
+        return searchTree(node);
       }
-      checkTree(this.root);
-      return check;
+    },
+    inorder: function() {
+      if (this.root == null) {
+        return null;
+      } else {
+        var result = new Array();
+        function traverseInOrder(node) {
+          if (node.left != null) {
+            traverseInOrder(node.left);
+          }
+          result.push(node.value);
+          if (node.right != null) {
+            traverseInOrder(node.right);
+          }
+        }
+        traverseInOrder(this.root);
+        return result;
+      }
+    },
+    isBinarySearchTree() {
+      if (this.root == null) {
+        return null;
+      } else {
+        var check = true;
+        function checkTree(node) {
+          if (node.left != null) {
+            var left = node.left;
+            if (left.value > node.value) {
+              check = false;
+            } else {
+              checkTree(left);
+            }
+          }
+          if (node.right != null) {
+            var right = node.right;
+            if (right.value < node.value) {
+              check = false;
+            } else {
+              checkTree(right);
+            }
+          }
+        }
+        checkTree(this.root);
+        return check;
+      }
     }
   }
-};
+);
 ```
 
 </div>

--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/delete-a-node-with-one-child-in-a-binary-search-tree.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/delete-a-node-with-one-child-in-a-binary-search-tree.english.md
@@ -154,33 +154,6 @@ BinarySearchTree.prototype = Object.assign(
         traverseInOrder(this.root);
         return result;
       }
-    },
-    isBinarySearchTree() {
-      if (this.root == null) {
-        return null;
-      } else {
-        var check = true;
-        function checkTree(node) {
-          if (node.left != null) {
-            var left = node.left;
-            if (left.value > node.value) {
-              check = false;
-            } else {
-              checkTree(left);
-            }
-          }
-          if (node.right != null) {
-            var right = node.right;
-            if (right.value < node.value) {
-              check = false;
-            } else {
-              checkTree(right);
-            }
-          }
-        }
-        checkTree(this.root);
-        return check;
-      }
     }
   }
 );

--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/delete-a-node-with-one-child-in-a-binary-search-tree.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/delete-a-node-with-one-child-in-a-binary-search-tree.english.md
@@ -106,81 +106,84 @@ function BinarySearchTree() {
 <div id='js-teardown'>
 
 ```js
-BinarySearchTree.prototype = {
-  add: function(value) {
-    var node = this.root;
-    if (node == null) {
-      this.root = new Node(value);
-      return;
-    } else {
-      function searchTree(node) {
-        if (value < node.value) {
-          if (node.left == null) {
-            node.left = new Node(value);
-            return;
-          } else if (node.left != null) {
-            return searchTree(node.left);
-          }
-        } else if (value > node.value) {
-          if (node.right == null) {
-            node.right = new Node(value);
-            return;
-          } else if (node.right != null) {
-            return searchTree(node.right);
-          }
-        } else {
-          return null;
-        }
-      }
-      return searchTree(node);
-    }
-  },
-  inorder: function() {
-    if (this.root == null) {
-      return null;
-    } else {
-      var result = new Array();
-      function traverseInOrder(node) {
-        if (node.left != null) {
-          traverseInOrder(node.left);
-        }
-        result.push(node.value);
-        if (node.right != null) {
-          traverseInOrder(node.right);
-        }
-      }
-      traverseInOrder(this.root);
-      return result;
-    }
-  },
-  isBinarySearchTree() {
-    if (this.root == null) {
-      return null;
-    } else {
-      var check = true;
-      function checkTree(node) {
-        if (node.left != null) {
-          var left = node.left;
-          if (left.value > node.value) {
-            check = false;
+BinarySearchTree.prototype = Object.assign(
+  BinarySearchTree.prototype,
+  {
+    add: function(value) {
+      var node = this.root;
+      if (node == null) {
+        this.root = new Node(value);
+        return;
+      } else {
+        function searchTree(node) {
+          if (value < node.value) {
+            if (node.left == null) {
+              node.left = new Node(value);
+              return;
+            } else if (node.left != null) {
+              return searchTree(node.left);
+            }
+          } else if (value > node.value) {
+            if (node.right == null) {
+              node.right = new Node(value);
+              return;
+            } else if (node.right != null) {
+              return searchTree(node.right);
+            }
           } else {
-            checkTree(left);
+            return null;
           }
         }
-        if (node.right != null) {
-          var right = node.right;
-          if (right.value < node.value) {
-            check = false;
-          } else {
-            checkTree(right);
-          }
-        }
+        return searchTree(node);
       }
-      checkTree(this.root);
-      return check;
+    },
+    inorder: function() {
+      if (this.root == null) {
+        return null;
+      } else {
+        var result = new Array();
+        function traverseInOrder(node) {
+          if (node.left != null) {
+            traverseInOrder(node.left);
+          }
+          result.push(node.value);
+          if (node.right != null) {
+            traverseInOrder(node.right);
+          }
+        }
+        traverseInOrder(this.root);
+        return result;
+      }
+    },
+    isBinarySearchTree() {
+      if (this.root == null) {
+        return null;
+      } else {
+        var check = true;
+        function checkTree(node) {
+          if (node.left != null) {
+            var left = node.left;
+            if (left.value > node.value) {
+              check = false;
+            } else {
+              checkTree(left);
+            }
+          }
+          if (node.right != null) {
+            var right = node.right;
+            if (right.value < node.value) {
+              check = false;
+            } else {
+              checkTree(right);
+            }
+          }
+        }
+        checkTree(this.root);
+        return check;
+      }
     }
   }
-};
+);
 ```
 
 </div>

--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/delete-a-node-with-two-children-in-a-binary-search-tree.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/delete-a-node-with-two-children-in-a-binary-search-tree.english.md
@@ -125,81 +125,84 @@ function BinarySearchTree() {
 <div id='js-teardown'>
 
 ```js
-BinarySearchTree.prototype = {
-  add: function(value) {
-    var node = this.root;
-    if (node == null) {
-      this.root = new Node(value);
-      return;
-    } else {
-      function searchTree(node) {
-        if (value < node.value) {
-          if (node.left == null) {
-            node.left = new Node(value);
-            return;
-          } else if (node.left != null) {
-            return searchTree(node.left);
-          }
-        } else if (value > node.value) {
-          if (node.right == null) {
-            node.right = new Node(value);
-            return;
-          } else if (node.right != null) {
-            return searchTree(node.right);
-          }
-        } else {
-          return null;
-        }
-      }
-      return searchTree(node);
-    }
-  },
-  inorder: function() {
-    if (this.root == null) {
-      return null;
-    } else {
-      var result = new Array();
-      function traverseInOrder(node) {
-        if (node.left != null) {
-          traverseInOrder(node.left);
-        }
-        result.push(node.value);
-        if (node.right != null) {
-          traverseInOrder(node.right);
-        }
-      }
-      traverseInOrder(this.root);
-      return result;
-    }
-  },
-  isBinarySearchTree() {
-    if (this.root == null) {
-      return null;
-    } else {
-      var check = true;
-      function checkTree(node) {
-        if (node.left != null) {
-          var left = node.left;
-          if (left.value > node.value) {
-            check = false;
+BinarySearchTree.prototype = Object.assign(
+  BinarySearchTree.prototype,
+  {
+    add: function(value) {
+      var node = this.root;
+      if (node == null) {
+        this.root = new Node(value);
+        return;
+      } else {
+        function searchTree(node) {
+          if (value < node.value) {
+            if (node.left == null) {
+              node.left = new Node(value);
+              return;
+            } else if (node.left != null) {
+              return searchTree(node.left);
+            }
+          } else if (value > node.value) {
+            if (node.right == null) {
+              node.right = new Node(value);
+              return;
+            } else if (node.right != null) {
+              return searchTree(node.right);
+            }
           } else {
-            checkTree(left);
+            return null;
           }
         }
-        if (node.right != null) {
-          var right = node.right;
-          if (right.value < node.value) {
-            check = false;
-          } else {
-            checkTree(right);
-          }
-        }
+        return searchTree(node);
       }
-      checkTree(this.root);
-      return check;
+    },
+    inorder: function() {
+      if (this.root == null) {
+        return null;
+      } else {
+        var result = new Array();
+        function traverseInOrder(node) {
+          if (node.left != null) {
+            traverseInOrder(node.left);
+          }
+          result.push(node.value);
+          if (node.right != null) {
+            traverseInOrder(node.right);
+          }
+        }
+        traverseInOrder(this.root);
+        return result;
+      }
+    },
+    isBinarySearchTree() {
+      if (this.root == null) {
+        return null;
+      } else {
+        var check = true;
+        function checkTree(node) {
+          if (node.left != null) {
+            var left = node.left;
+            if (left.value > node.value) {
+              check = false;
+            } else {
+              checkTree(left);
+            }
+          }
+          if (node.right != null) {
+            var right = node.right;
+            if (right.value < node.value) {
+              check = false;
+            } else {
+              checkTree(right);
+            }
+          }
+        }
+        checkTree(this.root);
+        return check;
+      }
     }
   }
-};
+);
 ```
 
 </div>

--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/find-the-minimum-and-maximum-height-of-a-binary-search-tree.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/find-the-minimum-and-maximum-height-of-a-binary-search-tree.english.md
@@ -66,13 +66,10 @@ function BinarySearchTree() {
 <div id='js-teardown'>
 
 ```js
-BinarySearchTree.prototype = {
-  add: function(value) {
-    var node = this.root;
-    if (node == null) {
-      this.root = new Node(value);
-      return;
-    } else {
+BinarySearchTree.prototype = Object.assign(
+  BinarySearchTree.prototype,
+  {
+    add: function(value) {
       function searchTree(node) {
         if (value < node.value) {
           if (node.left == null) {
@@ -92,10 +89,17 @@ BinarySearchTree.prototype = {
           return null;
         }
       }
-      return searchTree(node);
+
+      var node = this.root;
+      if (node == null) {
+        this.root = new Node(value);
+        return;
+      } else {
+        return searchTree(node);
+      }
     }
   }
-};
+);
 ```
 
 </div>

--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/find-the-minimum-and-maximum-value-in-a-binary-search-tree.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/find-the-minimum-and-maximum-value-in-a-binary-search-tree.english.md
@@ -66,13 +66,10 @@ function BinarySearchTree() {
 <div id='js-teardown'>
 
 ```js
-BinarySearchTree.prototype = {
-  add: function(value) {
-    var node = this.root;
-    if (node == null) {
-      this.root = new Node(value);
-      return;
-    } else {
+BinarySearchTree.prototype = Object.assign(
+  BinarySearchTree.prototype,
+  {
+    add: function(value) {
       function searchTree(node) {
         if (value < node.value) {
           if (node.left == null) {
@@ -92,10 +89,17 @@ BinarySearchTree.prototype = {
           return null;
         }
       }
-      return searchTree(node);
+
+      var node = this.root;
+      if (node == null) {
+        this.root = new Node(value);
+        return;
+      } else {
+        return searchTree(node);
+      }
     }
   }
-};
+);
 ```
 
 </div>

--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/invert-a-binary-tree.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/invert-a-binary-tree.english.md
@@ -58,54 +58,58 @@ function BinarySearchTree() {
 <div id='js-teardown'>
 
 ```js
-BinarySearchTree.prototype = {
+BinarySearchTree.prototype = Object.assign(
+  BinarySearchTree.prototype,
+  {
     add: function(value) {
-        var node = this.root;
-        if (node == null) {
-          this.root = new Node(value);
-          return;
+      function searchTree(node) {
+        if (value < node.value) {
+          if (node.left == null) {
+            node.left = new Node(value);
+            return;
+          } else if (node.left != null) {
+            return searchTree(node.left)
+          };
+        } else if (value > node.value) {
+          if (node.right == null) {
+            node.right = new Node(value);
+            return;
+          } else if (node.right != null) {
+            return searchTree(node.right);
+          };
         } else {
-            function searchTree(node) {
-                if (value < node.value) {
-                    if (node.left == null) {
-                        node.left = new Node(value);
-                        return;
-                    } else if (node.left != null) {
-                        return searchTree(node.left)
-                    };
-                } else if (value > node.value) {
-                    if (node.right == null) {
-                        node.right = new Node(value);
-                        return;
-                    } else if (node.right != null) {
-                        return searchTree(node.right);
-                    };
-                } else {
-                    return null;
-                };
-            };
-            return searchTree(node);
+          return null;
         };
+      }
+
+      var node = this.root;
+      if (node == null) {
+        this.root = new Node(value);
+        return;
+      } else {
+        return searchTree(node);
+      };
     },
     inorder: function() {
-        if (this.root == null) {
-          return null;
-        } else {
-          var result = new Array();
-          function traverseInOrder(node) {
-              if (node.left != null) {
-                  traverseInOrder(node.left);
-              };
-              result.push(node.value);
-              if (node.right != null) {
-                  traverseInOrder(node.right);
-              };
-          }
-          traverseInOrder(this.root);
-          return result;
-        };
+      if (this.root == null) {
+        return null;
+      } else {
+        var result = new Array();
+        function traverseInOrder(node) {
+          if (node.left != null) {
+            traverseInOrder(node.left);
+          };
+          result.push(node.value);
+          if (node.right != null) {
+            traverseInOrder(node.right);
+          };
+        }
+        traverseInOrder(this.root);
+        return result;
+      };
     }
-};
+  }
+);
 ```
 
 </div>

--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/reverse-a-doubly-linked-list.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/reverse-a-doubly-linked-list.english.md
@@ -63,52 +63,55 @@ var DoublyLinkedList = function() {
 <div id='js-teardown'>
 
 ```js
-DoublyLinkedList.prototype = {
-  add(data) {
-    if (this.head == null) {
-      this.head = new Node(data, null);
-      this.tail = this.head;
-    } else {
-      var node = this.head;
-      var prev = null;
-      while (node.next != null) {
-        prev = node;
-        node = node.next;
+DoublyLinkedList.prototype = Object.assign(
+  DoublyLinkedList.prototype,
+  {
+    add(data) {
+      if (this.head == null) {
+        this.head = new Node(data, null);
+        this.tail = this.head;
+      } else {
+        var node = this.head;
+        var prev = null;
+        while (node.next != null) {
+          prev = node;
+          node = node.next;
+        };
+        var newNode = new Node(data, node);
+        node.next = newNode;
+        this.tail = newNode;
       };
-      var newNode = new Node(data, node);
-      node.next = newNode;
-      this.tail = newNode;
-    };
-  },
-  print() {
-    if (this.head == null) {
-      return null;
-    } else {
-      var result = new Array();
-      var node = this.head;
-      while (node.next != null) {
+    },
+    print() {
+      if (this.head == null) {
+        return null;
+      } else {
+        var result = new Array();
+        var node = this.head;
+        while (node.next != null) {
+          result.push(node.data);
+          node = node.next;
+        };
         result.push(node.data);
-        node = node.next;
+        return result;
       };
-      result.push(node.data);
-      return result;
-    };
-  },
-  printReverse() {
-    if (this.tail == null) {
-      return null;
-    } else {
-      var result = new Array();
-      var node = this.tail;
-      while (node.prev != null) {
+    },
+    printReverse() {
+      if (this.tail == null) {
+        return null;
+      } else {
+        var result = new Array();
+        var node = this.tail;
+        while (node.prev != null) {
+          result.push(node.data);
+          node = node.prev;
+        };
         result.push(node.data);
-        node = node.prev;
+        return result;
       };
-      result.push(node.data);
-      return result;
-    };
+    }
   }
-};
+);
 ```
 
 </div>

--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/use-breadth-first-search-in-a-binary-search-tree.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/use-breadth-first-search-in-a-binary-search-tree.english.md
@@ -64,13 +64,10 @@ function BinarySearchTree() {
 <div id='js-teardown'>
 
 ```js
-BinarySearchTree.prototype = {
-  add: function(value) {
-    var node = this.root;
-    if (node == null) {
-      this.root = new Node(value);
-      return;
-    } else {
+BinarySearchTree.prototype = Object.assign(
+  BinarySearchTree.prototype,
+  {
+    add: function(value) {
       function searchTree(node) {
         if (value < node.value) {
           if (node.left == null) {
@@ -90,10 +87,16 @@ BinarySearchTree.prototype = {
           return null;
         }
       }
-      return searchTree(node);
+      var node = this.root;
+      if (node == null) {
+        this.root = new Node(value);
+        return;
+      } else {
+        return searchTree(node);
+      }
     }
   }
-};
+);
 ```
 
 </div>

--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/use-depth-first-search-in-a-binary-search-tree.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/use-depth-first-search-in-a-binary-search-tree.english.md
@@ -76,13 +76,10 @@ function BinarySearchTree() {
 <div id='js-teardown'>
 
 ```js
-BinarySearchTree.prototype = {
-  add: function(value) {
-    var node = this.root;
-    if (node == null) {
-      this.root = new Node(value);
-      return;
-    } else {
+BinarySearchTree.prototype = Object.assign(
+  BinarySearchTree.prototype,
+  {
+    add: function(value) {
       function searchTree(node) {
         if (value < node.value) {
           if (node.left == null) {
@@ -102,10 +99,18 @@ BinarySearchTree.prototype = {
           return null;
         }
       }
-      return searchTree(node);
+
+      var node = this.root;
+      if (node == null) {
+        this.root = new Node(value);
+        return;
+      } else {
+        return searchTree(node);
+      }
     }
   }
-};
+);
+
 ```
 
 </div>


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x]  My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

**Issue:**
I noticed for 12 challenges in the `Data Structures` section of `Coding Interview Prep` that in the `After Test`, the function prototype was defined and would be fine as long as the user did not use the `class` syntax (which defines a prototype under the hood).  If a user used the `class` in a solution, the test would fail.  After discussing the issue with @ojeytonwilliams, he realized the `After Test` prototype reassignment was inadvertently wiping out the user's defined class methods, causing the solution to fail most if not all the tests. 

An example of what the problem is can be found be testing the working solution (seen below) for ``
```js
var displayTree = (tree) => console.log(JSON.stringify(tree, null, 2));
function Node(value) {
  this.value = value;
  this.left = null;
  this.right = null;
}
function BinarySearchTree() {
  this.root = null;
  this.isPresent = function (value) {
    var current = this.root
    while (current) {
      if (value === current.value) {
        return true;
      }
      current = value < current.value ? current.left : current.right;
    }
    return false;
  }
}
```
This will pass the current tests without a problem, but if you rewrite the solution using `class` syntax (see below), it will fail (before the changes introduced in this PR).
```js
var displayTree = (tree) => console.log(JSON.stringify(tree, null, 2));
function Node(value) {
  this.value = value;
  this.left = null;
  this.right = null;
}
class BinarySearchTree {
  constructor() {
    this.root = null;
  }
  isPresent(value) {
    var current = this.root
    while (current) {
      if (value === current.value) {
        return true;
      }
      current = value < current.value ? current.left : current.right;
    }
    return false;
  }
};
```
**Solution:**
This PR uses `Object.assign` in the `After Test` to make sure to preserve any existing prototype definition created by the user.  With this change, both the function syntax or class syntax can be use to solve the problem.

I also noticed in the `Add a New Element to a Binary Search Tree` challenge `After Test` section, that there was `isBinarySearchTree` method defined in a prototype for the BinarySearchTree function and then wiped out by reassignment with just an `inOrder` method.  If rewrote the `isBinarySearchTree` method and added it to the prototype definition and call it in the first test.
