### PR TITLE
fix: use bash -c to call jest utils when using Windows locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "test:search-indexing": "jest ./search-indexing",
     "test:server": "cd ./api-server && npm test && cd ../",
     "test:tools": "jest ./tools",
-    "test:utils": "bash -c 'jest ./utils/*.js'"
+    "test:utils": "jest --rootDir ./utils"
   },
   "devDependencies": {
     "@freecodecamp/eslint-config": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "test:search-indexing": "jest ./search-indexing",
     "test:server": "cd ./api-server && npm test && cd ../",
     "test:tools": "jest ./tools",
-    "test:utils": "jest ./utils/*.js"
+    "test:utils": "bash -c 'jest ./utils/*.js'"
   },
   "devDependencies": {
     "@freecodecamp/eslint-config": "^2.0.2",


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x]  My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x]  All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Closes #37610 

This PR implements to fix discovered by @ojeytonwilliams on issue #37610.  I can confirm it works for Windows 10.