### PR TITLE
feat(curriculum): download solution as non-json text file

### DIFF
--- a/client/src/templates/Challenges/components/CompletionModal.js
+++ b/client/src/templates/Challenges/components/CompletionModal.js
@@ -87,14 +87,14 @@ export class CompletionModal extends Component {
     if (Object.keys(files).length) {
       const filesForDownload = Object.keys(files)
         .map(key => files[key])
-        .reduce(
-          (allFiles, { path, contents }) => ({
-            ...allFiles,
-            [path]: contents
-          }),
-          {}
-        );
-      const blob = new Blob([JSON.stringify(filesForDownload, null, 2)], {
+        .reduce((allFiles, { path, contents }) => {
+          const beforeText = `** start of ${path} **\n\n`;
+          const afterText = `\n** end of ${path} **\n\n`;
+          allFiles +=
+            files.length > 1 ? beforeText + contents + afterText : contents;
+          return allFiles;
+        }, '');
+      const blob = new Blob([filesForDownload], {
         type: 'text/json'
       });
       newURL = URL.createObjectURL(blob);
@@ -170,7 +170,7 @@ export class CompletionModal extends Component {
               bsSize='lg'
               bsStyle='primary'
               className='btn-invert'
-              download={`${dashedName}.json`}
+              download={`${dashedName}.txt`}
               href={this.state.downloadURL}
             >
               Download my solution

--- a/client/src/templates/Challenges/components/CompletionModal.js
+++ b/client/src/templates/Challenges/components/CompletionModal.js
@@ -89,7 +89,7 @@ export class CompletionModal extends Component {
         .map(key => files[key])
         .reduce((allFiles, { path, contents }) => {
           const beforeText = `** start of ${path} **\n\n`;
-          const afterText = `\n** end of ${path} **\n\n`;
+          const afterText = `\n\n** end of ${path} **\n\n`;
           allFiles +=
             files.length > 1 ? beforeText + contents + afterText : contents;
           return allFiles;


### PR DESCRIPTION
We get tons of complaints about the fact that solutions can only be downloaded in a json formatted file which has to be "cleaned up".  There may be edge cases I am overlooking, but it seems the solution could be downloaded as a plain text file which looks like the following:
```
function chunkArrayInGroups(arr, size) {
  var groupsArr = [];
  for (var arrIdx = 0; arrIdx < arr.length; arrIdx += size){
    var group = [];
    var groupIdx = arrIdx;
    while (groupIdx < arrIdx + size && groupIdx < arr.length) {
      group.push(arr[groupIdx++]);
    }

    groupsArr.push(group);
  }
  return groupsArr;
}

chunkArrayInGroups(["a", "b", "c", "d"], 2);
```
instead of the current json version:
```
{
  "index.js": "function chunkArrayInGroups(arr, size) {\n  var groupsArr = [];\n  for (var arrIdx = 0; arrIdx < arr.length; arrIdx += size){\n    var group = [];\n    var groupIdx = arrIdx;\n    while (groupIdx < arrIdx + size && groupIdx < arr.length) {\n      group.push(arr[groupIdx++]);\n    }\n\n    groupsArr.push(group);\n  }\n  return groupsArr;\n}\n\nchunkArrayInGroups([\"a\", \"b\", \"c\", \"d\"], 2);\nchunkArrayInGroups([\"a\", \"b\", \"c\", \"d\"], 2);\n"
}
```
I have never noticed more than one file in a solution file, but just in case there are such chalelnges, I have made it so separate files are surround by `** start of xxxxxx.xxxx **` and `** end of xxxxxxx.xxxx **` lines.  If there is only a single file, then it does not include this separator text.