### PR TITLE
fix(client): use JSON.stringify replacer function for NaN

### DIFF
--- a/client/src/client/workers/test-evaluator.js
+++ b/client/src/client/workers/test-evaluator.js
@@ -16,9 +16,16 @@ const __utils = (() => {
     }
   }
 
+  function replacer(key, value) {
+    if (Number.isNaN(value)) {
+      return 'NaN';
+    }
+    return value;
+  }
+
   const oldLog = self.console.log.bind(self.console);
   self.console.log = function proxyConsole(...args) {
-    logs.push(args.map(arg => '' + JSON.stringify(arg)).join(' '));
+    logs.push(args.map(arg => '' + JSON.stringify(arg, replacer)).join(' '));
     if (logs.join('\n').length > MAX_LOGS_SIZE) {
       flushLogs();
     }


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Passing `NaN` to `JSON.stringify()` returns "null", causing the test output to be incorrect. The second parameter to stringify accepts an array or a [replacer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#The_replacer_parameter) function. We can use the replacer function to catch when `NaN` is passed to stringify and return the string 'NaN'.

Tested on a handful of challenges, some debugging challenges and the [Falsy Bouncer](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-algorithm-scripting/falsy-bouncer) challenge from the [related issue](https://github.com/freeCodeCamp/freeCodeCamp/issues/37674).

1. Not sure if we should handle other cases like `Infinity` and `-Infinity` as well? I don't really think we need to but I'm not sure.

2. I didn't add the replacer function to the stringify calls in the `DeepEqual` function (is it used?). If I need to add it just let me know.

Closes #37674
