### PR TITLE
fix(challenge): account for browser zoom, add note to challenge (for width challenge)

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/adjust-the-width-of-an-element-using-the-width-property.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/adjust-the-width-of-an-element-using-the-width-property.english.md
@@ -21,6 +21,7 @@ img {
 ## Instructions
 <section id='instructions'>
 Add a <code>width</code> property to the entire card and set it to an absolute value of 245px. Use the <code>fullCard</code> class to select the element.
+<strong>Note:</strong> You may need to be at 100% zoom to pass the test on this challenge.
 </section>
 
 ## Tests
@@ -29,7 +30,7 @@ Add a <code>width</code> property to the entire card and set it to an absolute v
 ```yml
 tests:
   - text: Your code should change the <code>width</code> property of the card to 245 pixels by using the <code>fullCard</code> class selector.
-    testString: assert($('.fullCard').css('width') === '245px' && /\.fullCard{\S*width:245px(;\S*}|})/.test($('style').text().replace(/\s/g ,'')));
+    testString: assert(Math.round(document.querySelector('.fullCard').getBoundingClientRect().width) - 10 === 245 && /\.fullCard{\S*width:245px(;\S*}|})/.test($('style').text().replace(/\s/g ,'')));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/adjust-the-width-of-an-element-using-the-width-property.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/adjust-the-width-of-an-element-using-the-width-property.english.md
@@ -21,7 +21,6 @@ img {
 ## Instructions
 <section id='instructions'>
 Add a <code>width</code> property to the entire card and set it to an absolute value of 245px. Use the <code>fullCard</code> class to select the element.
-<strong>Note:</strong> You may need to be at 100% zoom to pass the test on this challenge.
 </section>
 
 ## Tests
@@ -30,7 +29,7 @@ Add a <code>width</code> property to the entire card and set it to an absolute v
 ```yml
 tests:
   - text: Your code should change the <code>width</code> property of the card to 245 pixels by using the <code>fullCard</code> class selector.
-    testString: assert(Math.round(document.querySelector('.fullCard').getBoundingClientRect().width) - 10 === 245 && /\.fullCard{\S*width:245px(;\S*}|})/.test($('style').text().replace(/\s/g ,'')));
+    testString: const fullCard = code.match(/\.fullCard\s*{[\s\S]+?[^}]}/g); assert(fullCard && /width\s*:\s*245px\s*(;|})/gi.test(fullCard[0]) && $('.fullCard').css('maxWidth') === 'none');
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/adjust-the-width-of-an-element-using-the-width-property.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/adjust-the-width-of-an-element-using-the-width-property.english.md
@@ -30,7 +30,7 @@ Add a <code>width</code> property to the entire card and set it to an absolute v
 ```yml
 tests:
   - text: Your code should change the <code>width</code> property of the card to 245 pixels by using the <code>fullCard</code> class selector.
-    testString: assert(Math.round(document.querySelector('.fullCard').getBoundingClientRect().width) - 10 === 245 && /\.fullCard{\S*width:245px(;\S*}|})/.test($('style').text().replace(/\s/g ,'')));
+    testString: assert(/\.fullCard{\S*width:245px(;\S*}|})/.test($('style').text().replace(/\s/g ,'')));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/adjust-the-width-of-an-element-using-the-width-property.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/adjust-the-width-of-an-element-using-the-width-property.english.md
@@ -21,7 +21,6 @@ img {
 ## Instructions
 <section id='instructions'>
 Add a <code>width</code> property to the entire card and set it to an absolute value of 245px. Use the <code>fullCard</code> class to select the element.
-<strong>Note:</strong> You may need to be at 100% zoom to pass the test on this challenge.
 </section>
 
 ## Tests

--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/adjust-the-width-of-an-element-using-the-width-property.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/adjust-the-width-of-an-element-using-the-width-property.english.md
@@ -21,6 +21,7 @@ img {
 ## Instructions
 <section id='instructions'>
 Add a <code>width</code> property to the entire card and set it to an absolute value of 245px. Use the <code>fullCard</code> class to select the element.
+<strong>Note:</strong> You may need to be at 100% zoom to pass the test on this challenge.
 </section>
 
 ## Tests
@@ -29,7 +30,7 @@ Add a <code>width</code> property to the entire card and set it to an absolute v
 ```yml
 tests:
   - text: Your code should change the <code>width</code> property of the card to 245 pixels by using the <code>fullCard</code> class selector.
-    testString: assert(/\.fullCard{\S*width:245px(;\S*}|})/.test($('style').text().replace(/\s/g ,'')));
+    testString: assert(Math.round(document.querySelector('.fullCard').getBoundingClientRect().width) - 10 === 245 && /\.fullCard{\S*width:245px(;\S*}|})/.test($('style').text().replace(/\s/g ,'')));
 
 ```
 


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

This is the same fix as for the [height challenge](https://github.com/freeCodeCamp/freeCodeCamp/pull/37687). I do not have any confirmation for this fix yet ([forum post](https://www.freecodecamp.org/forum/t/is-the-adjust-the-width-lesson-in-the-applied-vis-design-course-broken/324794) showing the issue). We may or may not want to wait for one.

I thought about wrapping this in a function to add a variable explaining the `- 10` part, just to avoid any "magic" numbers. But that just makes the assert really long and without proper formatting it gets hard to read in my opinion.

The `- 10` is subtracting the padding and border of the `.fullCard` element to get the "true" width.
