### PR TITLE
feat: donate page update

### DIFF
--- a/api-server/server/boot/donate.js
+++ b/api-server/server/boot/donate.js
@@ -3,6 +3,11 @@ import debug from 'debug';
 import crypto from 'crypto';
 import { isEmail, isNumeric } from 'validator';
 
+import {
+  durationKeysConfig,
+  donationOneTimeConfig,
+  donationSubscriptionConfig
+} from '../../../config/donation-settings';
 import keys from '../../../config/secrets';
 
 const log = debug('fcc:boot:donate');
@@ -11,19 +16,6 @@ export default function donateBoot(app, done) {
   let stripe = false;
   const api = app.loopback.Router();
   const donateRouter = app.loopback.Router();
-
-  const durationKeys = ['year', 'month', 'onetime'];
-  const donationOneTimeConfig = [100000, 25000, 3500];
-  const donationSubscriptionConfig = {
-    duration: {
-      year: 'Yearly',
-      month: 'Monthly'
-    },
-    plans: {
-      year: [100000, 25000, 3500],
-      month: [5000, 3500, 500]
-    }
-  };
 
   const subscriptionPlans = Object.keys(
     donationSubscriptionConfig.plans
@@ -62,7 +54,7 @@ export default function donateBoot(app, done) {
   function validStripeForm(amount, duration, email) {
     return isEmail('' + email) &&
       isNumeric('' + amount) &&
-      durationKeys.includes(duration) &&
+      durationKeysConfig.includes(duration) &&
       duration === 'onetime'
       ? donationOneTimeConfig.includes(amount)
       : donationSubscriptionConfig.plans[duration];

--- a/api-server/server/boot/donate.js
+++ b/api-server/server/boot/donate.js
@@ -78,13 +78,17 @@ export default function donateBoot(app, done) {
         }
         const requiredPlans = subscriptionPlans.map(plan => plan.id);
         const availablePlans = stripePlans.data.map(plan => plan.id);
-        requiredPlans.forEach(requiredPlan => {
-          if (!availablePlans.includes(requiredPlan)) {
-            createStripePlan(
-              subscriptionPlans.find(plan => plan.id === requiredPlan)
-            );
-          }
-        });
+        if (process.env.STRIPE_CREATE_PLANS === 'true') {
+          requiredPlans.forEach(requiredPlan => {
+            if (!availablePlans.includes(requiredPlan)) {
+              createStripePlan(
+                subscriptionPlans.find(plan => plan.id === requiredPlan)
+              );
+            }
+          });
+        } else {
+          log(`Skipping plan creation`);
+        }
       });
       resolve();
     });

--- a/api-server/server/models/donation.json
+++ b/api-server/server/models/donation.json
@@ -28,6 +28,9 @@
       "required": true,
       "description": "The donation amount in cents"
     },
+    "duration": {
+      "type": "string"
+    },
     "startDate": {
       "type": "DateString",
       "required": true

--- a/api-server/server/utils/publicUserProps.js
+++ b/api-server/server/utils/publicUserProps.js
@@ -51,7 +51,8 @@ export const userPropsForSession = [
   'completedProjectCount',
   'completedCertCount',
   'completedLegacyCertCount',
-  'acceptedPrivacyTerms'
+  'acceptedPrivacyTerms',
+  'donationEmails'
 ];
 
 export function normaliseUserFields(user) {

--- a/client/src/components/Donation/Donation.css
+++ b/client/src/components/Donation/Donation.css
@@ -153,3 +153,9 @@ li.disabled > a {
   border: 2px solid var(--gray-15) !important;
   color: var(--gray-15) !important;
 }
+
+.donate-text p,
+.donation-description,
+[name='payment-method'] {
+  font-family: 'Lato', sans-serif;
+}

--- a/client/src/components/Donation/Donation.css
+++ b/client/src/components/Donation/Donation.css
@@ -1,21 +1,3 @@
-.donation-modal {
-  overflow-y: auto;
-}
-
-.donation-modal p {
-  margin-left: auto;
-  margin-right: auto;
-}
-
-.donation-modal .alert {
-  width: 60%;
-  margin: 0 auto 0;
-}
-
-.donation-modal .modal-title {
-  font-size: 1.2rem;
-}
-
 .donation-form {
   display: flex;
   flex-direction: column;
@@ -63,21 +45,6 @@
   white-space: normal;
 }
 
-.modal-close-btn-container {
-  display: flex;
-  justify-content: center;
-}
-
-.modal-close-btn-container a {
-  font-size: 18px;
-}
-
-.modal-close-btn-container a:hover {
-  text-decoration: none;
-  font-size: 18px;
-  cursor: pointer;
-}
-
 .donate-input-element {
   padding-top: 8px;
 }
@@ -97,6 +64,92 @@
   color: inherit;
 }
 
-.donate-other .btn-cta {
-  margin: 7px 0px;
+.donate-tabs > .nav-pills {
+  display: flex;
+  align-content: space-between;
+}
+
+.donate-tabs > .nav-pills > li {
+  width: 100%;
+  text-align: center;
+}
+
+.donate-tabs > .nav-pills > li > a {
+  text-transform: capitalize;
+  text-decoration: none;
+  border: 2px solid var(--yellow-light);
+  border-radius: 0px;
+  color: var(--gray-85);
+  margin: 0 1px;
+}
+
+.donate-tabs > .nav-pills > li > a:hover,
+.donate-tabs > .nav-pills > li > a:focus {
+  background-color: #ffe18f;
+  cursor: pointer;
+}
+
+.donate-tabs > .nav-pills > li.active > a,
+.donate-tabs > .nav-pills > li.active > a:hover,
+.donate-tabs > .nav-pills > li.active > a:focus {
+  color: var(--gray-85);
+  background-color: var(--yellow-light);
+  border: 2px solid var(--yellow-light);
+  text-decoration: none;
+  border-radius: 0px;
+  box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+}
+
+.amount-values {
+  display: flex;
+  align-content: space-between;
+}
+
+.amount-value {
+  width: 100%;
+}
+
+.amount-values > label {
+  margin: 0 2px !important;
+  color: var(--gray-85);
+  border: 2px solid var(--yellow-light);
+  border-radius: 0px;
+  background-color: transparent;
+}
+
+.amount-values > label:hover,
+.amount-values > label:focus,
+.amount-values > label:active:hover {
+  background-color: #ffe18f;
+  cursor: pointer;
+  color: var(--gray-85);
+  border-color: var(--yellow-light);
+}
+
+.amount-values > label:focus,
+.amount-values > label:active:hover {
+  outline: 5px auto -webkit-focus-ring-color;
+  outline-color: -webkit-focus-ring-color;
+  outline-style: auto;
+  outline-width: 5px;
+  outline-offset: -2px;
+}
+
+.amount-values > label.active,
+.amount-values > label.active:hover,
+.amount-values > label.active:focus {
+  color: var(--gray-85);
+  background-color: var(--yellow-light);
+  border: 2px solid var(--yellow-light);
+  border-radius: 0px;
+  box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+}
+
+li.disabled {
+  cursor: not-allowed;
+}
+
+li.disabled > a {
+  border: 2px solid var(--gray-15) !important;
+  color: var(--gray-15) !important;
 }

--- a/client/src/components/Donation/components/DonateCompletion.js
+++ b/client/src/components/Donation/components/DonateCompletion.js
@@ -18,7 +18,7 @@ function DonateCompletion({ processing, reset, success, error = null }) {
   const heading = processing
     ? 'We are processing your donation.'
     : success
-    ? 'Your donation was successful.'
+    ? 'Thank you for being a supporter.'
     : 'Something went wrong with your donation.';
   return (
     <Alert bsStyle={style} className='donation-completion'>
@@ -37,12 +37,12 @@ function DonateCompletion({ processing, reset, success, error = null }) {
         {success && (
           <div>
             <p>
-              You can update your supporter status at any time from your account
-              settings.
+              Your donation will support free technology education for people
+              all over the world.
             </p>
             <p>
-              Thank you for supporting free technology education for people all
-              over the world.
+              You can update your supporter status at any time from the 'manage
+              your existing donation' section on this page.
             </p>
           </div>
         )}

--- a/client/src/components/Donation/components/DonateCompletion.js
+++ b/client/src/components/Donation/components/DonateCompletion.js
@@ -42,7 +42,7 @@ function DonateCompletion({ processing, reset, success, error = null }) {
             </p>
             <p>
               You can update your supporter status at any time from the 'manage
-              your existing donation' section on this page.
+              your existing donation' section below on this page.
             </p>
           </div>
         )}

--- a/client/src/components/Donation/components/DonateForm.js
+++ b/client/src/components/Donation/components/DonateForm.js
@@ -184,7 +184,7 @@ class DonateForm extends Component {
                   {this.renderAmountButtons(duration)}
                 </ToggleButtonGroup>
                 <Spacer />
-                <p>
+                <p className='donation-description'>
                   {`Your `}
                   {this.getFormatedAmountLabel(donationAmount)}
                   {` donation will provide `}

--- a/client/src/components/Donation/components/DonateForm.js
+++ b/client/src/components/Donation/components/DonateForm.js
@@ -96,8 +96,12 @@ class DonateForm extends Component {
       : this.amounts[durationSelected][0];
   }
 
-  convertToTimeContributed(amount) {
-    return `${numToCommas((amount / 100) * 50 * 60)} minutes`;
+  convertToTimeContributed(amount, duration) {
+    const timeContributed =
+      duration === 'month'
+        ? Math.round(((amount / 100) * 50) / 12)
+        : (amount / 100) * 50;
+    return `${numToCommas(timeContributed)} hours`;
   }
 
   getFormatedAmountLabel(amount) {
@@ -183,10 +187,9 @@ class DonateForm extends Component {
                   {`Your `}
                   {this.getFormatedAmountLabel(donationAmount)}
                   {` donation will provide `}
-                  {this.convertToTimeContributed(donationAmount)}
-                  {` of learning to people around the world `}
-                  {duration === 'one-time' ? `for one ` : `each `}
-                  {duration === 'monthly' ? `month.` : `year.`}
+                  {this.convertToTimeContributed(donationAmount, duration)}
+                  {` of learning to people around the world`}
+                  {duration === 'onetime' ? `.` : ` each ${duration}.`}
                 </p>
               </div>
             </Tab>

--- a/client/src/components/Donation/components/DonateForm.js
+++ b/client/src/components/Donation/components/DonateForm.js
@@ -30,6 +30,7 @@ const numToCommas = num =>
   num.toString().replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,');
 
 const propTypes = {
+  enableDonationSettingsPage: PropTypes.func.isRequired,
   isDonating: PropTypes.bool,
   isSignedIn: PropTypes.bool,
   navigate: PropTypes.func.isRequired,
@@ -204,7 +205,7 @@ class DonateForm extends Component {
   }
 
   renderDonationOptions() {
-    const { stripe } = this.props;
+    const { stripe, enableDonationSettingsPage } = this.props;
     const {
       donationAmount,
       donationDuration,
@@ -242,6 +243,7 @@ class DonateForm extends Component {
               <DonateFormChildViewForHOC
                 donationAmount={donationAmount}
                 donationDuration={donationDuration}
+                enableDonationSettingsPage={enableDonationSettingsPage}
                 getDonationButtonLabel={this.getDonationButtonLabel}
                 hideAmountOptionsCB={this.hideAmountOptionsCB}
               />
@@ -287,18 +289,6 @@ class DonateForm extends Component {
           ) : (
             this.renderDonationOptions()
           )}
-        </Col>
-        <Col sm={10} smOffset={1} xs={12}>
-          <Spacer size={2} />
-          <h3 className='text-center'>Manage your existing donation</h3>
-          <Button block={true} bsStyle='primary' disabled={true}>
-            Update your existing donation
-          </Button>
-          <Spacer />
-          <Button block={true} bsStyle='primary' disabled={true}>
-            Download donation receipts
-          </Button>
-          <Spacer />
         </Col>
       </Row>
     );

--- a/client/src/components/Donation/components/DonateForm.js
+++ b/client/src/components/Donation/components/DonateForm.js
@@ -73,9 +73,9 @@ class DonateForm extends Component {
     this.amounts = amountsConfig;
 
     this.state = {
+      ...defaultStateConfig,
       processing: false,
-      isDonating: this.props.isDonating,
-      ...defaultStateConfig
+      isDonating: this.props.isDonating
     };
 
     this.getActiveDonationAmount = this.getActiveDonationAmount.bind(this);

--- a/client/src/components/Donation/components/DonateForm.js
+++ b/client/src/components/Donation/components/DonateForm.js
@@ -13,6 +13,12 @@ import {
   Radio
 } from '@freecodecamp/react-bootstrap';
 import { StripeProvider, Elements } from 'react-stripe-elements';
+
+import {
+  amountsConfig,
+  durationsConfig,
+  defaultStateConfig
+} from '../../../../../config/donation-settings';
 import { apiLocation } from '../../../../config/env.json';
 import Spacer from '../../helpers/Spacer';
 import DonateFormChildViewForHOC from './DonateFormChildViewForHOC';
@@ -64,23 +70,13 @@ class DonateForm extends Component {
   constructor(...args) {
     super(...args);
 
+    this.durations = durationsConfig;
+    this.amounts = amountsConfig;
+
     this.state = {
       processing: false,
       isDonating: this.props.isDonating,
-      donationAmount: 5000,
-      donationDuration: 'month',
-      paymentType: 'Card'
-    };
-
-    this.durations = {
-      year: 'yearly',
-      month: 'monthly',
-      onetime: 'one-time'
-    };
-    this.amounts = {
-      year: [100000, 25000, 3500],
-      month: [5000, 3500, 500],
-      onetime: [100000, 25000, 3500]
+      ...defaultStateConfig
     };
 
     this.getActiveDonationAmount = this.getActiveDonationAmount.bind(this);

--- a/client/src/components/Donation/components/DonateForm.js
+++ b/client/src/components/Donation/components/DonateForm.js
@@ -9,8 +9,7 @@ import {
   Row,
   Col,
   ToggleButtonGroup,
-  ToggleButton,
-  Radio
+  ToggleButton
 } from '@freecodecamp/react-bootstrap';
 import { StripeProvider, Elements } from 'react-stripe-elements';
 
@@ -202,37 +201,9 @@ class DonateForm extends Component {
 
   renderDonationOptions() {
     const { stripe, enableDonationSettingsPage } = this.props;
-    const {
-      donationAmount,
-      donationDuration,
-      paymentType,
-      processing
-    } = this.state;
+    const { donationAmount, donationDuration, paymentType } = this.state;
     return (
       <div>
-        {!processing ? (
-          <div>
-            <Radio
-              checked={paymentType === 'Card'}
-              name='payment-method'
-              onChange={this.handleSelectPaymentType}
-              value='Card'
-            >
-              Donate using a Credit/Debit Card.
-            </Radio>
-            <Radio
-              checked={paymentType === 'PayPal'}
-              // disable the paypal integration for now
-              disabled={true}
-              name='payment-method'
-              onChange={this.handleSelectPaymentType}
-              value='PayPal'
-            >
-              Donate using PayPal. (Coming soon)
-            </Radio>
-            <Spacer />
-          </div>
-        ) : null}
         {paymentType === 'Card' ? (
           <StripeProvider stripe={stripe}>
             <Elements>

--- a/client/src/components/Donation/components/DonateFormChildViewForHOC.js
+++ b/client/src/components/Donation/components/DonateFormChildViewForHOC.js
@@ -15,7 +15,7 @@ import { injectStripe } from 'react-stripe-elements';
 import StripeCardForm from './StripeCardForm';
 import DonateCompletion from './DonateCompletion';
 import { postChargeStripe } from '../../../utils/ajax';
-import { userSelector, isSignedInSelector } from '../../../redux';
+import { userSelector } from '../../../redux';
 
 const propTypes = {
   donationAmount: PropTypes.number.isRequired,
@@ -39,8 +39,7 @@ const initialState = {
 
 const mapStateToProps = createSelector(
   userSelector,
-  isSignedInSelector,
-  ({ email, theme }, isSignedIn) => ({ email, theme, isSignedIn })
+  ({ email, theme }) => ({ email, theme })
 );
 
 class DonateFormChildViewForHOC extends Component {
@@ -122,7 +121,6 @@ class DonateFormChildViewForHOC extends Component {
 
   postDonation(token) {
     const { donationAmount: amount, donationDuration: duration } = this.state;
-    const { isSignedIn } = this.props;
     this.setState(state => ({
       ...state,
       donationState: {
@@ -131,7 +129,7 @@ class DonateFormChildViewForHOC extends Component {
       }
     }));
 
-    return postChargeStripe(isSignedIn, {
+    return postChargeStripe({
       token,
       amount,
       duration

--- a/client/src/components/Donation/components/DonateFormChildViewForHOC.js
+++ b/client/src/components/Donation/components/DonateFormChildViewForHOC.js
@@ -85,7 +85,6 @@ class DonateFormChildViewForHOC extends Component {
 
   handleSubmit(e) {
     e.preventDefault();
-    this.hideAmountOptions(true);
     const email = this.getUserEmail();
     if (!email || !isEmail(email)) {
       return this.setState(state => ({
@@ -129,6 +128,10 @@ class DonateFormChildViewForHOC extends Component {
         processing: true
       }
     }));
+
+    // hide the donation options on the parent and scroll to top
+    this.hideAmountOptions(true);
+    window.scrollTo(0, 0);
 
     return postChargeStripe({
       token,

--- a/client/src/components/Donation/components/DonateFormChildViewForHOC.js
+++ b/client/src/components/Donation/components/DonateFormChildViewForHOC.js
@@ -26,8 +26,7 @@ const propTypes = {
   isSignedIn: PropTypes.bool,
   stripe: PropTypes.shape({
     createToken: PropTypes.func.isRequired
-  }),
-  theme: PropTypes.string
+  })
 };
 const initialState = {
   donationState: {
@@ -39,7 +38,7 @@ const initialState = {
 
 const mapStateToProps = createSelector(
   userSelector,
-  ({ email, theme }) => ({ email, theme })
+  ({ email }) => ({ email })
 );
 
 class DonateFormChildViewForHOC extends Component {
@@ -176,7 +175,7 @@ class DonateFormChildViewForHOC extends Component {
 
   renderDonateForm() {
     const { isFormValid } = this.state;
-    const { theme, getDonationButtonLabel } = this.props;
+    const { getDonationButtonLabel } = this.props;
     return (
       <Form className='donation-form' onSubmit={this.handleSubmit}>
         <FormGroup className='donation-email-container'>
@@ -191,10 +190,7 @@ class DonateFormChildViewForHOC extends Component {
             value={this.getUserEmail()}
           />
         </FormGroup>
-        <StripeCardForm
-          getValidationState={this.getValidationState}
-          theme={theme}
-        />
+        <StripeCardForm getValidationState={this.getValidationState} />
         <Button
           block={true}
           bsStyle='primary'

--- a/client/src/components/Donation/components/DonateFormChildViewForHOC.js
+++ b/client/src/components/Donation/components/DonateFormChildViewForHOC.js
@@ -21,6 +21,7 @@ const propTypes = {
   donationAmount: PropTypes.number.isRequired,
   donationDuration: PropTypes.string.isRequired,
   email: PropTypes.string,
+  enableDonationSettingsPage: PropTypes.func.isRequired,
   getDonationButtonLabel: PropTypes.func.isRequired,
   hideAmountOptionsCB: PropTypes.func.isRequired,
   isSignedIn: PropTypes.bool,
@@ -119,6 +120,7 @@ class DonateFormChildViewForHOC extends Component {
   }
 
   postDonation(token) {
+    const { enableDonationSettingsPage } = this.props;
     const { donationAmount: amount, donationDuration: duration } = this.state;
     this.setState(state => ({
       ...state,
@@ -144,6 +146,7 @@ class DonateFormChildViewForHOC extends Component {
             error: data.error ? data.error : null
           }
         }));
+        enableDonationSettingsPage();
       })
       .catch(error => {
         const data =

--- a/client/src/components/Donation/components/DonateServicebotEmbed.js
+++ b/client/src/components/Donation/components/DonateServicebotEmbed.js
@@ -1,0 +1,71 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import { servicebotId } from '../../../../config/env.json';
+import { servicebotScriptLoader } from '../../../utils/scriptLoaders';
+
+import '../Donation.css';
+
+const propTypes = {
+  email: PropTypes.string.isRequired,
+  hash: PropTypes.string.isRequired
+};
+
+export class DonationServicebotEmbed extends Component {
+  constructor(...props) {
+    super(...props);
+
+    this.state = {
+      email: this.props.email,
+      hash: this.props.hash
+    };
+
+    this.setServiceBotConfig = this.setServiceBotConfig.bind(this);
+  }
+
+  setServiceBotConfig() {
+    const { email, hash } = this.state;
+    /* eslint-disable camelcase */
+    window.servicebotSettings = {
+      type: 'portal',
+      servicebot_id: servicebotId,
+      service: 'freeCodeCamp.org',
+      email,
+      hash,
+      options: {
+        cancel_now: true,
+        disableCoupon: true,
+        forceCard: true,
+        disableTiers: [
+          'Monthly $10 Donation  - Unavailable',
+          'Monthly $3 Donation - Unavailable'
+        ],
+        card: {
+          hideName: true,
+          hideAddress: true,
+          hideCountryPostal: true
+        },
+        messageOnCancel: `Thanks again for supporting our tiny nonprofit. We are helping millions of people around the world learn to code for free. Please confirm: are you certain you want to stop your donation?`
+      }
+    };
+    /* eslint-enable camelcase */
+  }
+
+  componentDidMount() {
+    servicebotScriptLoader();
+  }
+
+  render() {
+    this.setServiceBotConfig();
+    return (
+      <div className='fcc-servicebot-embed-portal'>
+        <div id='servicebot-subscription-portal'></div>
+      </div>
+    );
+  }
+}
+
+DonationServicebotEmbed.displayName = 'DonationServicebotEmbed';
+DonationServicebotEmbed.propTypes = propTypes;
+
+export default DonationServicebotEmbed;

--- a/client/src/components/Donation/components/DonateServicebotEmbed.js
+++ b/client/src/components/Donation/components/DonateServicebotEmbed.js
@@ -37,7 +37,7 @@ export class DonationServicebotEmbed extends Component {
         disableCoupon: true,
         forceCard: true,
         disableTiers: [
-          'Monthly $10 Donation  - Unavailable',
+          'Monthly $10 Donation - Unavailable',
           'Monthly $3 Donation - Unavailable'
         ],
         card: {

--- a/client/src/components/Donation/components/DonateText.js
+++ b/client/src/components/Donation/components/DonateText.js
@@ -3,7 +3,7 @@ import { Row, Col } from '@freecodecamp/react-bootstrap';
 
 const DonateText = () => {
   return (
-    <Row>
+    <Row className='donate-text'>
       <Col sm={10} smOffset={1} xs={12}>
         <p>freeCodeCamp is a highly efficient education nonprofit.</p>
         <p>

--- a/client/src/components/Donation/components/DonateText.js
+++ b/client/src/components/Donation/components/DonateText.js
@@ -7,7 +7,7 @@ const DonateText = () => {
       <Col sm={10} smOffset={1} xs={12}>
         <p>freeCodeCamp is a highly efficient education nonprofit.</p>
         <p>
-          In 2019 alone, we provided 1,100,000,000 minutes of free education to
+          In 2019 alone, we provided 18 million hours of free education to
           people around the world.
         </p>
         <p>

--- a/client/src/components/Donation/components/DonateText.js
+++ b/client/src/components/Donation/components/DonateText.js
@@ -1,27 +1,30 @@
 import React from 'react';
+import { Row, Col } from '@freecodecamp/react-bootstrap';
 
 const DonateText = () => {
   return (
-    <>
-      <p>freeCodeCamp is a highly efficient education nonprofit.</p>
-      <p>
-        In 2019 alone, we provided 1,100,000,000 minutes of free education to
-        people around the world.
-      </p>
-      <p>
-        Since freeCodeCamp's total budget is only $373,000, that means every
-        dollar you donate to freeCodeCamp translates into 50 hours worth of
-        technology education.
-      </p>
-      <p>
-        When you donate to freeCodeCamp, you help people learn new skills and
-        provide for their families.
-      </p>
-      <p>
-        You also help us create new resources for you to use to expand your own
-        technology skills.
-      </p>
-    </>
+    <Row>
+      <Col sm={10} smOffset={1} xs={12}>
+        <p>freeCodeCamp is a highly efficient education nonprofit.</p>
+        <p>
+          In 2019 alone, we provided 1,100,000,000 minutes of free education to
+          people around the world.
+        </p>
+        <p>
+          Since freeCodeCamp's total budget is only $373,000, that means every
+          dollar you donate to freeCodeCamp translates into 50 hours worth of
+          technology education.
+        </p>
+        <p>
+          When you donate to freeCodeCamp, you help people learn new skills and
+          provide for their families.
+        </p>
+        <p>
+          You also help us create new resources for you to use to expand your
+          own technology skills.
+        </p>
+      </Col>
+    </Row>
   );
 };
 

--- a/client/src/components/layouts/Default.js
+++ b/client/src/components/layouts/Default.js
@@ -81,7 +81,8 @@ const propTypes = {
   pathname: PropTypes.string.isRequired,
   removeFlashMessage: PropTypes.func.isRequired,
   showFooter: PropTypes.bool,
-  theme: PropTypes.string
+  theme: PropTypes.string,
+  useTheme: PropTypes.bool
 };
 
 const mapStateToProps = createSelector(
@@ -145,13 +146,16 @@ class DefaultLayout extends Component {
       isSignedIn,
       removeFlashMessage,
       showFooter = true,
-      theme = 'default'
+      theme = 'default',
+      useTheme = true
     } = this.props;
     return (
       <Fragment>
         <Helmet
           bodyAttributes={{
-            class: `${theme === 'default' ? 'light-palette' : 'dark-palette'}`
+            class: useTheme
+              ? `${theme === 'default' ? 'light-palette' : 'dark-palette'}`
+              : 'light-palette'
           }}
           meta={[
             {

--- a/client/src/pages/donate.js
+++ b/client/src/pages/donate.js
@@ -72,21 +72,19 @@ export class DonatePage extends Component {
       <Fragment>
         <Helmet title='Support our nonprofit | freeCodeCamp.org' />
         <Grid>
+          <Spacer />
           <Row>
             <Col sm={10} smOffset={1} xs={12}>
-              <Spacer />
-              <h2 className='text-center'>Become a Supporter</h2>
+              <h1 className='text-center'>Become a Supporter</h1>
               <Spacer />
             </Col>
           </Row>
           <Row>
-            <Col sm={8} smOffset={2} xs={12}>
-              <DonateText />
-              <Spacer />
-            </Col>
-            <Col sm={6} smOffset={3} xs={12}>
+            <Col md={6}>
               <DonateForm stripe={stripe} />
-              <Spacer />
+            </Col>
+            <Col md={6}>
+              <DonateText />
             </Col>
           </Row>
         </Grid>

--- a/client/src/pages/donate.js
+++ b/client/src/pages/donate.js
@@ -3,32 +3,40 @@ import Helmet from 'react-helmet';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
-import { Grid, Row, Col } from '@freecodecamp/react-bootstrap';
+import { Grid, Row, Col, Button } from '@freecodecamp/react-bootstrap';
 
 import { stripePublicKey } from '../../config/env.json';
 import { Spacer, Loader } from '../components/helpers';
 import DonateForm from '../components/Donation/components/DonateForm';
 import DonateText from '../components/Donation/components/DonateText';
-import { signInLoadingSelector } from '../redux';
+import { signInLoadingSelector, userSelector } from '../redux';
 import { stripeScriptLoader } from '../utils/scriptLoaders';
 
+const propTypes = {
+  isDonating: PropTypes.bool,
+  showLoading: PropTypes.bool.isRequired
+};
+
 const mapStateToProps = createSelector(
+  userSelector,
   signInLoadingSelector,
-  showLoading => ({
+  ({ isDonating }, showLoading) => ({
+    isDonating,
     showLoading
   })
 );
-
-const propTypes = {
-  showLoading: PropTypes.bool.isRequired
-};
 
 export class DonatePage extends Component {
   constructor(...props) {
     super(...props);
     this.state = {
-      stripe: null
+      stripe: null,
+      enableSettings: false
     };
+
+    this.enableDonationSettingsPage = this.enableDonationSettingsPage.bind(
+      this
+    );
     this.handleStripeLoad = this.handleStripeLoad.bind(this);
   }
 
@@ -60,9 +68,14 @@ export class DonatePage extends Component {
     }));
   }
 
+  enableDonationSettingsPage(enableSettings = true) {
+    this.setState({ enableSettings });
+  }
+
   render() {
     const { stripe } = this.state;
-    const { showLoading } = this.props;
+    const { showLoading, isDonating } = this.props;
+    const { enableSettings } = this.state;
 
     if (showLoading) {
       return <Loader fullScreen={true} />;
@@ -81,7 +94,32 @@ export class DonatePage extends Component {
           </Row>
           <Row>
             <Col md={6}>
-              <DonateForm stripe={stripe} />
+              <DonateForm
+                enableDonationSettingsPage={this.enableDonationSettingsPage}
+                stripe={stripe}
+              />
+              <Row>
+                <Col sm={10} smOffset={1} xs={12}>
+                  <Spacer size={2} />
+                  <h3 className='text-center'>Manage your existing donation</h3>
+                  {[
+                    `Update your existing donation`,
+                    `Download donation receipts`
+                  ].map(donationSettingOps => (
+                    <div key={donationSettingOps}>
+                      <Button
+                        block={true}
+                        bsStyle='primary'
+                        disabled={!isDonating && !enableSettings}
+                        href='/donation/settings'
+                      >
+                        {donationSettingOps}
+                      </Button>
+                      <Spacer />
+                    </div>
+                  ))}
+                </Col>
+              </Row>
             </Col>
             <Col md={6}>
               <DonateText />

--- a/client/src/pages/donation/settings.js
+++ b/client/src/pages/donation/settings.js
@@ -85,7 +85,7 @@ export class DonationSettingsPage extends Component {
 
   renderServicebotEmbed() {
     const { currentSettingsEmail, hash } = this.state;
-    if (!hash && !currentSettingsEmail) {
+    if (!hash || !currentSettingsEmail) {
       return null;
     }
     return (
@@ -100,8 +100,8 @@ export class DonationSettingsPage extends Component {
     const { donationEmails } = this.props;
     return (
       <div>
-        {uniq(donationEmails).map((email, index) => (
-          <div key={email + '-' + index}>
+        {uniq(donationEmails).map(email => (
+          <div key={email}>
             <Button
               bsStyle='primary'
               className='btn btn-block'
@@ -124,12 +124,12 @@ export class DonationSettingsPage extends Component {
       return <Loader fullScreen={true} />;
     }
 
-    if (!showLoading && !isSignedIn) {
+    if (!isSignedIn) {
       navigate(`${apiLocation}/signin?returnTo=donation/settings`);
       return <Loader fullScreen={true} />;
     }
 
-    if (!showLoading && !isDonating) {
+    if (!isDonating) {
       navigate(`/donate`);
       return <Loader fullScreen={true} />;
     }

--- a/client/src/pages/donation/settings.js
+++ b/client/src/pages/donation/settings.js
@@ -1,0 +1,209 @@
+import React, { Component, Fragment } from 'react';
+import Helmet from 'react-helmet';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { createSelector } from 'reselect';
+import { Grid, Row, Col, Button } from '@freecodecamp/react-bootstrap';
+import { uniq } from 'lodash';
+
+import { apiLocation } from '../../../config/env.json';
+import { postCreateHmacHash } from '../../utils/ajax';
+import {
+  signInLoadingSelector,
+  userSelector,
+  hardGoTo as navigate,
+  isSignedInSelector
+} from '../../redux';
+// eslint-disable-next-line max-len
+import DonateServicebotEmbed from '../../components/Donation/components/DonateServicebotEmbed';
+import { Loader, Spacer, Link } from '../../components/helpers';
+
+const propTypes = {
+  donationEmails: PropTypes.array,
+  email: PropTypes.string,
+  isDonating: PropTypes.bool,
+  isSignedIn: PropTypes.bool,
+  navigate: PropTypes.func.isRequired,
+  showLoading: PropTypes.bool.isRequired
+};
+
+const mapStateToProps = createSelector(
+  isSignedInSelector,
+  userSelector,
+  signInLoadingSelector,
+  (isSignedIn, { email, isDonating, donationEmails }, showLoading) => ({
+    isSignedIn,
+    email,
+    isDonating,
+    donationEmails,
+    showLoading
+  })
+);
+
+const mapDispatchToProps = {
+  navigate
+};
+
+export class DonationSettingsPage extends Component {
+  constructor(...props) {
+    super(...props);
+
+    this.state = {
+      hash: null,
+      currentSettingsEmail: null
+    };
+
+    this.getEmailHmacHash = this.getEmailHmacHash.bind(this);
+    this.handleSelectDonationEmail = this.handleSelectDonationEmail.bind(this);
+  }
+
+  getEmailHmacHash(currentSettingsEmail) {
+    return postCreateHmacHash({
+      email: currentSettingsEmail
+    })
+      .then(response => {
+        const data = response && response.data;
+        this.setState({ hash: '' + data.hash, currentSettingsEmail });
+      })
+      .catch(error => {
+        const data =
+          error.response && error.response.data
+            ? error.response.data
+            : {
+                error:
+                  'Something is not right. Please contact team@freecodecamp.org'
+              };
+        console.error(data.error);
+      });
+  }
+
+  handleSelectDonationEmail(e) {
+    e.preventDefault();
+    this.setState({ hash: null, currentSettingsEmail: null });
+    this.getEmailHmacHash(e.currentTarget.value);
+  }
+
+  renderServicebotEmbed() {
+    const { currentSettingsEmail, hash } = this.state;
+    if (!hash && !currentSettingsEmail) {
+      return null;
+    }
+    return (
+      <div>
+        <Spacer />
+        <DonateServicebotEmbed email={currentSettingsEmail} hash={hash} />
+      </div>
+    );
+  }
+
+  renderDonationEmailsList() {
+    const { donationEmails } = this.props;
+    return (
+      <div>
+        {uniq(donationEmails).map((email, index) => (
+          <div key={email + '-' + index}>
+            <Button
+              bsStyle='primary'
+              className='btn btn-block'
+              onClick={this.handleSelectDonationEmail}
+              value={email}
+            >
+              {`Show donations for your ${email} email address`}
+            </Button>
+            <Spacer />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  render() {
+    const { showLoading, isSignedIn, isDonating, navigate } = this.props;
+
+    if (showLoading) {
+      return <Loader fullScreen={true} />;
+    }
+
+    if (!showLoading && !isSignedIn) {
+      navigate(`${apiLocation}/signin?returnTo=donation/settings`);
+      return <Loader fullScreen={true} />;
+    }
+
+    if (!showLoading && !isDonating) {
+      navigate(`/donate`);
+      return <Loader fullScreen={true} />;
+    }
+
+    return (
+      <Fragment>
+        <Helmet title='Manage your donation | freeCodeCamp.org' />
+        <Grid>
+          <Row>
+            <Col sm={6} smOffset={3} xs={12}>
+              <Spacer size={2} />
+              <Button block={true} bsStyle='primary' href='/donate'>
+                Go to donate page
+              </Button>
+            </Col>
+          </Row>
+          <Row>
+            <Col sm={8} smOffset={2} xs={12}>
+              <Spacer />
+              <h1 className='text-center'>Manage your donations</h1>
+              <Spacer />
+              <h3 className='text-center'>
+                Donations made using a credit or debit card
+              </h3>
+            </Col>
+          </Row>
+          <Row>
+            <Col sm={6} smOffset={3} xs={12}>
+              {this.renderDonationEmailsList()}
+            </Col>
+          </Row>
+          <Row>
+            <Col sm={8} smOffset={2} xs={12}>
+              {this.renderServicebotEmbed()}
+            </Col>
+          </Row>
+          <Row>
+            <Col sm={8} smOffset={2} xs={12}>
+              <hr />
+              <h3 className='text-center'>Donations made using PayPal</h3>
+              <p className='text-center'>
+                You can update your PayPal donation{' '}
+                <Link
+                  external={true}
+                  to='https://www.paypal.com/cgi-bin/webscr?cmd=_manage-paylist'
+                >
+                  directly on PayPal
+                </Link>
+                .
+              </p>
+            </Col>
+          </Row>
+          <Row>
+            <Col sm={8} smOffset={2} xs={12}>
+              <hr />
+              <h3 className='text-center'>Still need help?</h3>
+              <p>
+                If you can't see your donation here, forward a donation receipt
+                you have recieved in your email to team@freeCodeCamp.org and
+                tell us how we can help you with it.
+              </p>
+              <Spacer />
+            </Col>
+          </Row>
+        </Grid>
+      </Fragment>
+    );
+  }
+}
+
+DonationSettingsPage.displayName = 'DonationSettingsPage';
+DonationSettingsPage.propTypes = propTypes;
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(DonationSettingsPage);

--- a/client/src/utils/ajax.js
+++ b/client/src/utils/ajax.js
@@ -54,6 +54,10 @@ export function postChargeStripe(body) {
   return post(`/donate/charge-stripe`, body);
 }
 
+export function postCreateHmacHash(body) {
+  return post(`/donate/create-hmac-hash`, body);
+}
+
 export function putUpdateLegacyCert(body) {
   return post('/update-my-projects', body);
 }

--- a/client/src/utils/ajax.js
+++ b/client/src/utils/ajax.js
@@ -50,11 +50,8 @@ export function getArticleById(shortId) {
 }
 
 /** POST **/
-export function postChargeStripe(isSignedIn, body) {
-  const donatePath = '/donate/charge-stripe';
-  return isSignedIn
-    ? post(donatePath, body)
-    : postUnauthenticated(donatePath, body);
+export function postChargeStripe(body) {
+  return post(`/donate/charge-stripe`, body);
 }
 
 export function putUpdateLegacyCert(body) {

--- a/client/src/utils/scriptLoaders.js
+++ b/client/src/utils/scriptLoaders.js
@@ -19,6 +19,14 @@ export const stripeScriptLoader = onload =>
     onload
   );
 
+export const servicebotScriptLoader = () =>
+  scriptLoader(
+    'servicebot-billing-settings-embed.js',
+    'servicebot-billing-settings-embed.js',
+    true,
+    'https://js.servicebot.io/embeds/servicebot-billing-settings-embed.js'
+  );
+
 export const mathJaxScriptLoader = () =>
   scriptLoader(
     'mathjax',

--- a/client/utils/gatsby/layoutSelector.js
+++ b/client/utils/gatsby/layoutSelector.js
@@ -27,6 +27,13 @@ export default function layoutSelector({ element, props }) {
       </DefaultLayout>
     );
   }
+  if (/^\/donation(\/.*)*|^\/donate(\/.*)*/.test(pathname)) {
+    return (
+      <DefaultLayout pathname={pathname} useTheme={false}>
+        {element}
+      </DefaultLayout>
+    );
+  }
   return <DefaultLayout pathname={pathname}>{element}</DefaultLayout>;
 }
 

--- a/config/donation-settings.js
+++ b/config/donation-settings.js
@@ -1,0 +1,39 @@
+// Configuration for client side
+const durationsConfig = {
+  year: 'yearly',
+  month: 'monthly',
+  onetime: 'one-time'
+};
+const amountsConfig = {
+  year: [100000, 25000, 3500],
+  month: [5000, 3500, 500],
+  onetime: [100000, 25000, 3500]
+};
+const defaultStateConfig = {
+  donationAmount: 5000,
+  donationDuration: 'month',
+  paymentType: 'Card'
+};
+
+// Configuration for server side
+const durationKeysConfig = ['year', 'month', 'onetime'];
+const donationOneTimeConfig = [100000, 25000, 3500];
+const donationSubscriptionConfig = {
+  duration: {
+    year: 'Yearly',
+    month: 'Monthly'
+  },
+  plans: {
+    year: [100000, 25000, 3500],
+    month: [5000, 3500, 500]
+  }
+};
+
+module.exports = {
+  durationsConfig,
+  amountsConfig,
+  defaultStateConfig,
+  durationKeysConfig,
+  donationOneTimeConfig,
+  donationSubscriptionConfig
+};

--- a/config/env.js
+++ b/config/env.js
@@ -13,7 +13,8 @@ const {
   FORUM_PROXY: forumProxy,
   NEWS_PROXY: newsProxy,
   LOCALE: locale,
-  STRIPE_PUBLIC: stripePublicKey,
+  STRIPE_PUBLIC_KEY: stripePublicKey,
+  SERVICEBOT_ID: servicebotId,
   ALGOLIA_APP_ID: algoliaAppId,
   ALGOLIA_API_KEY: algoliaAPIKey
 } = process.env;
@@ -30,6 +31,7 @@ const locations = {
 module.exports = Object.assign(locations, {
   locale,
   stripePublicKey,
+  servicebotId,
   algoliaAppId:
     !algoliaAppId || algoliaAppId === 'Algolia app id from dashboard'
       ? null

--- a/config/secrets.js
+++ b/config/secrets.js
@@ -30,8 +30,10 @@ const {
   ROLLBAR_APP_ID,
   ROLLBAR_CLIENT_ID,
 
-  STRIPE_PUBLIC,
-  STRIPE_SECRET
+  STRIPE_PUBLIC_KEY,
+  STRIPE_SECRET_KEY,
+  SERVICEBOT_ID,
+  SERVICEBOT_HMAC_SECRET_KEY
 } = process.env;
 
 module.exports = {
@@ -92,7 +94,12 @@ module.exports = {
   },
 
   stripe: {
-    public: STRIPE_PUBLIC,
-    secret: STRIPE_SECRET
+    public: STRIPE_PUBLIC_KEY,
+    secret: STRIPE_SECRET_KEY
+  },
+
+  servicebot: {
+    servicebotId: SERVICEBOT_ID,
+    hmacKey: SERVICEBOT_HMAC_SECRET_KEY
   }
 };

--- a/sample.env
+++ b/sample.env
@@ -16,8 +16,11 @@ SESSION_SECRET=secretstuff
 COOKIE_SECRET='this is a secret'
 JWT_SECRET='a very long secret'
 
-STRIPE_PUBLIC=pk_from_stipe_dashboard
-STRIPE_SECRET=sk_from_stipe_dashboard
+STRIPE_CREATE_PLANS=true
+STRIPE_PUBLIC_KEY=pk_from_stripe_dashboard
+STRIPE_SECRET_KEY=sk_from_stripe_dashboard
+SERVICEBOT_ID=servicebot_id_from_servicebot_dashboard
+SERVICEBOT_HMAC_SECRET_KEY=secret_key_from_servicebot_dashboard
 
 PAYPAL_SUPPORTERS=1703
 


### PR DESCRIPTION
This pull-request addresses several new updates to our donation infrastructure:

- [x] two column layout for the page.
- [x] amount to learning minutes mapping for contribution impact.
- [x] handle one-time and recurring stripe subscription charges.
- [x] server side validation of donate forms.
- [x] prevent multiple subscriptions and onetime donations per user.

Via Servicebot
- [x] change stripe subscription plan?
- [x] cancel a subscription plan programatically?
- [x] download invoices from Stripe.
- [x] update card on Stripe.


WIP:
- [ ] PayPal integration for subscription and onetime donations.

Planned:
- [ ] normalize non-donors (canceled subscriptions) in the database?
- [ ] Send a plan id instead of amount and duration to the API.
