### PR TITLE
fix(curriculum): added extra mongoose options to prevent log warnings

### DIFF
--- a/curriculum/challenges/english/05-apis-and-microservices/mongodb-and-mongoose/install-and-set-up-mongoose.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/mongodb-and-mongoose/install-and-set-up-mongoose.english.md
@@ -14,7 +14,7 @@ Add mongodb and mongoose to the project’s package.json. Then require mongoose.
 Add mongodb and mongoose to the project’s <code>package.json</code>. Then require mongoose. Store your mLab database URI in the private <code>.env</code> file as <code>MONGO_URI</code>. Connect to the database using the following syntax:
 
 ```js
-mongoose.connect(&lt;Your URI&gt;, { useNewUrlParser: true, useUnifiedTopology: true }); 
+mongoose.connect(<Your URI>, { useNewUrlParser: true, useUnifiedTopology: true }); 
 ```
 
 <section id='instructions'>

--- a/curriculum/challenges/english/05-apis-and-microservices/mongodb-and-mongoose/install-and-set-up-mongoose.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/mongodb-and-mongoose/install-and-set-up-mongoose.english.md
@@ -7,15 +7,13 @@ forumTopicId: 301540
 
 ## Description
 <section id='description'>
-Add mongodb and mongoose to the project’s package.json. Then require mongoose. Store your mLab database URI in the private <code>.env</code> file as MONGO_URI. Connect to the database using <code>mongoose.connect(&lt;Your URI&gt;)</code>
-</section>
-
-## Instructions
-Add mongodb and mongoose to the project’s <code>package.json</code>. Then require mongoose. Store your mLab database URI in the private <code>.env</code> file as <code>MONGO_URI</code>. Connect to the database using the following syntax:
+Add mongodb and mongoose to the project’s package.json. Then require mongoose. Store your mLab database URI in the private <code>.env</code> file as MONGO_URI. Connect to the database using the following syntax:
 
 ```js
 mongoose.connect(<Your URI>, { useNewUrlParser: true, useUnifiedTopology: true }); 
 ```
+
+</section>
 
 <section id='instructions'>
 

--- a/curriculum/challenges/english/05-apis-and-microservices/mongodb-and-mongoose/install-and-set-up-mongoose.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/mongodb-and-mongoose/install-and-set-up-mongoose.english.md
@@ -11,7 +11,12 @@ Add mongodb and mongoose to the project’s package.json. Then require mongoose.
 </section>
 
 ## Instructions
-Add mongodb and mongoose to the project’s <code>package.json</code>. Then require mongoose. Store your mLab database URI in the private <code>.env</code> file as <code>MONGO_URI</code>. Connect to the database using <code>mongoose.connect(&lt;Your URI&gt;)</code>
+Add mongodb and mongoose to the project’s <code>package.json</code>. Then require mongoose. Store your mLab database URI in the private <code>.env</code> file as <code>MONGO_URI</code>. Connect to the database using the following syntax:
+
+```js
+mongoose.connect(&lt;Your URI&gt;, { useNewUrlParser: true, useUnifiedTopology: true }); 
+```
+
 <section id='instructions'>
 
 </section>

--- a/curriculum/challenges/english/05-apis-and-microservices/mongodb-and-mongoose/install-and-set-up-mongoose.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/mongodb-and-mongoose/install-and-set-up-mongoose.english.md
@@ -7,7 +7,7 @@ forumTopicId: 301540
 
 ## Description
 <section id='description'>
-Add mongodb and mongoose to the project’s package.json. Then require mongoose. Store your mLab database URI in the private <code>.env</code> file as MONGO_URI. Connect to the database using the following syntax:
+Add mongodb and mongoose to the project’s package.json. Then require mongoose. Store your MongoDB Atlas database URI in the private <code>.env</code> file as MONGO_URI. Connect to the database using the following syntax:
 
 ```js
 mongoose.connect(<Your URI>, { useNewUrlParser: true, useUnifiedTopology: true }); 


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

To avoid the user seeing the following two deprecation warnings,
>(node:1436) DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. To use the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.
>
>🏐🛤 Your app is listening on port 3000
>
>(node:1436) DeprecationWarning: current Server Discovery and Monitoring engine is deprecated, and will be removed in a future version. To use the new Server Discover and Monitoring engine, pass option { useUnifiedTopology: true } to the MongoClient constructor.

this PR instructions the user to add the following options as the 2nd argument to the `mongoose.connect` call.

```js
{ useNewUrlParser: true, useUnifiedTopology: true }
```

I figured the user may have enough error messages showing that they do not need to see anything else to confuse them.
