### PR TITLE
fix(curriculum): added new test to Give Links Meaning by Using Descriptive Link Text challenge to specifically for href attribute

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/applied-accessibility/give-links-meaning-by-using-descriptive-link-text.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-accessibility/give-links-meaning-by-using-descriptive-link-text.english.md
@@ -26,7 +26,7 @@ tests:
     testString: assert($('a').text().match(/^(information about batteries)$/g));
   - text: Your <code>a</code> element should have a <code>href</code> attribute with a value of an empty string <code>""</code>.
     testString: assert($('a').attr('href') === '');
-  - text: You <code>a</code> element should have a closing tag.
+  - text: Your <code>a</code> element should have a closing tag.
     testString: assert($('a').length === code.match(/<\/a>/g).length);
 
 ```

--- a/curriculum/challenges/english/01-responsive-web-design/applied-accessibility/give-links-meaning-by-using-descriptive-link-text.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-accessibility/give-links-meaning-by-using-descriptive-link-text.english.md
@@ -24,8 +24,10 @@ The link text that Camper Cat is using is not very descriptive without the surro
 tests:
   - text: Your code should move the anchor <code>a</code> tags from around the words "Click here" to wrap around the words "information about batteries".
     testString: assert($('a').text().match(/^(information about batteries)$/g));
-  - text: Make sure your <code>a</code> element has a closing tag.
-    testString: assert(code.match(/<\/a>/g) && code.match(/<\/a>/g).length === code.match(/<a href=(''|"")>/g).length);
+  - text: Your <code>a</code> element should have a <code>href</code> attribute with a value of an empty string <code>""</code>.
+    testString: assert($('a').attr('href') === '');
+  - text: You <code>a</code> element should have a closing tag.
+    testString: assert($('a').length === code.match(/<\/a>/g).length);
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/applied-accessibility/give-links-meaning-by-using-descriptive-link-text.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-accessibility/give-links-meaning-by-using-descriptive-link-text.english.md
@@ -24,7 +24,7 @@ The link text that Camper Cat is using is not very descriptive without the surro
 tests:
   - text: Your code should move the anchor <code>a</code> tags from around the words "Click here" to wrap around the words "information about batteries".
     testString: assert($('a').text().match(/^(information about batteries)$/g));
-  - text: Your <code>a</code> element should have a <code>href</code> attribute with a value of an empty string <code>""</code>.
+  - text: Your <code>a</code> element should have an <code>href</code> attribute with a value of an empty string <code>""</code>.
     testString: assert($('a').attr('href') === '');
   - text: Your <code>a</code> element should have a closing tag.
     testString: assert($('a').length === code.match(/<\/a>/g).length);


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x]  My changes do not use shortened URLs or affiliate links.

The original last test for the challenge was testing more than just if the `a` element was missing a closing tag.  This PR changes the last test to only validate the a tag has a matching closing tag and adds another test which validates the `href` attribute value remains an empty string.

[Here is a forum topic](https://www.freecodecamp.org/forum/t/applied-accessibility-give-links-meaning-by-using-descriptive-link-text-make-sure-your-a-element-has-a-closing-tag-issues/325606) which shows how the current tests can confuse a user.
