### PR TITLE
fix(curriculum): Allow leading to zero before decimal point to be optional for opacity value

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/decrease-the-opacity-of-an-element.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/decrease-the-opacity-of-an-element.english.md
@@ -24,7 +24,7 @@ Set the <code>opacity</code> of the anchor tags to 0.7 using <code>links</code> 
 ```yml
 tests:
   - text: Your code should set the <code>opacity</code> property to 0.7 on the anchor tags by selecting the class of <code>links</code>.
-    testString: assert(/\.links\s*\{[^}]+opacity\s*:\s*0?\.7;/.test(code));
+    testString: assert(getComputedStyle($('.links')[0]).opacity == '0.7');
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/decrease-the-opacity-of-an-element.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/decrease-the-opacity-of-an-element.english.md
@@ -24,7 +24,7 @@ Set the <code>opacity</code> of the anchor tags to 0.7 using <code>links</code> 
 ```yml
 tests:
   - text: Your code should set the <code>opacity</code> property to 0.7 on the anchor tags by selecting the class of <code>links</code>.
-    testString: assert(/\.links\s*\{[^}]+opacity\s*:\s*0.7;/.test(code));
+    testString: assert(/\.links\s*\{[^}]+opacity\s*:\s*0?\.7;/.test(code));
 
 ```
 


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Per discussion in [this forum topic](https://www.freecodecamp.org/forum/t/applied-visual-design-tutorial-bug-w-opacity/325805), I have modified the test to accept the opacity value with or without the leading zero before the decimal point.  They are both functionality valid syntax.

[Applied Visual Design: Decrease the Opacity of an ElementPassed](https://www.freecodecamp.org/learn/responsive-web-design/applied-visual-design/decrease-the-opacity-of-an-element)

