### PR TITLE
fix: sync up client and server validation

### DIFF
--- a/api-server/server/boot/settings.js
+++ b/api-server/server/boot/settings.js
@@ -4,6 +4,7 @@ import { check } from 'express-validator/check';
 import { ifNoUser401, createValidatorErrorHandler } from '../utils/middleware';
 import { themes } from '../../common/utils/themes.js';
 import { alertTypes } from '../../common/utils/flash.js';
+import { validate } from '../../../utils/validate';
 
 const log = debug('fcc:boot:settings');
 
@@ -199,6 +200,15 @@ function createUpdateMyUsername(app) {
         message: 'Username is already associated with this account'
       });
     }
+    const validation = validate(username);
+
+    if (!validation.valid) {
+      return res.json({
+        type: 'info',
+        message: `Username ${username} ${validation.error}`
+      });
+    }
+
     const exists = await User.doesExist(username);
 
     if (exists) {

--- a/client/src/components/settings/Username.js
+++ b/client/src/components/settings/Username.js
@@ -101,7 +101,8 @@ class UsernameSettings extends Component {
       {
         formValue: newValue,
         isFormPristine: username === newValue,
-        characterValidation: this.validateFormInput(newValue)
+        characterValidation: this.validateFormInput(newValue),
+        submitClicked: false
       },
       () =>
         this.state.isFormPristine || this.state.characterValidation.error

--- a/client/src/components/settings/Username.js
+++ b/client/src/components/settings/Username.js
@@ -9,7 +9,6 @@ import {
   Alert,
   FormGroup
 } from '@freecodecamp/react-bootstrap';
-import isAscii from 'validator/lib/isAscii';
 
 import {
   validateUsername,
@@ -18,6 +17,7 @@ import {
 } from '../../redux/settings';
 import BlockSaveButton from '../helpers/form/BlockSaveButton';
 import FullWidthRow from '../helpers/FullWidthRow';
+import { validate } from '../../../../utils/validate';
 
 const propTypes = {
   isValidUsername: PropTypes.bool,
@@ -43,14 +43,6 @@ const mapDispatchToProps = dispatch =>
     },
     dispatch
   );
-
-const invalidCharsRE = /[/\s?:@=&"'<>#%{}|\\^~[\]`,.;!*()$]/;
-const invlaidCharError = {
-  valid: false,
-  error: 'Username contains invalid characters.'
-};
-const valididationSuccess = { valid: true, error: null };
-const usernameTooShort = { valid: false, error: 'Username is too short' };
 
 const hex = '[0-9a-f]';
 const tempUserRegex = new RegExp(`^fcc${hex}{8}-(${hex}{4}-){3}${hex}{12}$`);
@@ -119,24 +111,14 @@ class UsernameSettings extends Component {
   }
 
   validateFormInput(formValue) {
-    if (formValue.length < 3) {
-      return usernameTooShort;
-    }
-
-    if (!isAscii(formValue)) {
-      return invlaidCharError;
-    }
-    if (invalidCharsRE.test(formValue)) {
-      return invlaidCharError;
-    }
-    return valididationSuccess;
+    return validate(formValue);
   }
 
   renderAlerts(validating, error, isValidUsername) {
     if (!validating && error) {
       return (
         <FullWidthRow>
-          <Alert bsStyle='danger'>{error}</Alert>
+          <Alert bsStyle='danger'>{'Username ' + error}</Alert>
         </FullWidthRow>
       );
     }

--- a/utils/validate.js
+++ b/utils/validate.js
@@ -1,0 +1,13 @@
+const validCharsRE = /^[a-zA-Z0-9\-_+]+$/;
+const invalidCharError = {
+  valid: false,
+  error: 'contains invalid characters'
+};
+const validationSuccess = { valid: true, error: null };
+const usernameTooShort = { valid: false, error: 'is too short' };
+
+exports.validate = str => {
+  if (str.length < 3) return usernameTooShort;
+  if (!validCharsRE.test(str)) return invalidCharError;
+  return validationSuccess;
+};

--- a/utils/validate.test.js
+++ b/utils/validate.test.js
@@ -1,0 +1,54 @@
+/* global describe expect it */
+
+const { validate } = require('./validate');
+
+const invalidCharError = {
+  valid: false,
+  error: 'contains invalid characters'
+};
+const validationSuccess = { valid: true, error: null };
+const usernameTooShort = { valid: false, error: 'is too short' };
+
+function inRange(num, range) {
+  return num >= range[0] && num <= range[1];
+}
+
+describe('validate', () => {
+  it('rejects strings with less than 3 characters', () => {
+    expect(validate('')).toStrictEqual(usernameTooShort);
+    expect(validate('12')).toStrictEqual(usernameTooShort);
+    expect(validate('a')).toStrictEqual(usernameTooShort);
+    expect(validate('123')).toStrictEqual(validationSuccess);
+  });
+  it('rejects non-ASCII characters', () => {
+    expect(validate('👀👂👄')).toStrictEqual(invalidCharError);
+  });
+  it('accepts alphanumeric characters', () => {
+    expect(validate('abcdefghijklmnopqrstuvwxyz0123456789')).toStrictEqual(
+      validationSuccess
+    );
+  });
+  it('accepts hyphens and underscores', () => {
+    expect(validate('a-b')).toStrictEqual(validationSuccess);
+    expect(validate('a_b')).toStrictEqual(validationSuccess);
+  });
+
+  it('rejects all other ASCII characters', () => {
+    const whiteList = ['-', '_', '+'];
+    const numbers = [48, 57];
+    const upperCase = [65, 90];
+    const lowerCase = [97, 122];
+    const base = 'user';
+    const finalCode = 127;
+
+    for (let code = 0; code <= finalCode; code++) {
+      let char = String.fromCharCode(code);
+      let expected = invalidCharError;
+      if (whiteList.includes(char)) expected = validationSuccess;
+      if (inRange(code, numbers)) expected = validationSuccess;
+      if (inRange(code, upperCase)) expected = validationSuccess;
+      if (inRange(code, lowerCase)) expected = validationSuccess;
+      expect(validate(base + char)).toStrictEqual(expected);
+    }
+  });
+});


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This makes the api-server and client use a common `validate` function to check usernames.  It also whitelists allowed characters rather than blacklists invalid ones, in part to make it easier to understand what is and is not 

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/37714.

The problem that urls with spaces render blank pages is due to a problem with Gatsby's routing, discussed here: https://github.com/gatsbyjs/gatsby/issues/19462.  I don't think we need do anything other than keep Gatsby up to date.
