### PR TITLE
fix(curriculum): changed test text to use should for JavaScript Algorithms and Data Structures

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-algorithm-scripting/confirm-the-ending.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-algorithm-scripting/confirm-the-ending.english.md
@@ -43,7 +43,7 @@ tests:
     testString: assert(confirmEnding("If you want to save our world, you must hurry. We dont know how much longer we can withstand the nothing", "mountain") === false);
   - text: <code>confirmEnding("Abstraction", "action")</code> should return true.
     testString: assert(confirmEnding("Abstraction", "action") === true);
-  - text: Do not use the built-in method <code>.endsWith()</code> to solve the challenge.
+  - text: Your code should not use the built-in method <code>.endsWith()</code> to solve the challenge.
     testString: assert(!(/\.endsWith\(.*?\)\s*?;?/.test(code)) && !(/\['endsWith'\]/.test(code)));
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/access-an-arrays-contents-using-bracket-notation.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/access-an-arrays-contents-using-bracket-notation.english.md
@@ -43,13 +43,13 @@ In order to complete this challenge, set the 2nd position (index <code>1</code>)
 
 ```yml
 tests:
-  - text: <code>myArray[0]</code> is equal to <code>"a"</code>
+  - text: <code>myArray[0]</code> should be equal to <code>"a"</code>
     testString: assert.strictEqual(myArray[0], "a");
-  - text: <code>myArray[1]</code> is no longer set to <code>"b"</code>
+  - text: <code>myArray[1]</code> should not be equal to <code>"b"</code>
     testString: assert.notStrictEqual(myArray[1], "b");
-  - text: <code>myArray[2]</code> is equal to <code>"c"</code>
+  - text: <code>myArray[2]</code> should be equal to <code>"c"</code>
     testString: assert.strictEqual(myArray[2], "c");
-  - text: <code>myArray[3]</code> is equal to <code>"d"</code>
+  - text: <code>myArray[3]</code> should be equal to <code>"d"</code>
     testString: assert.strictEqual(myArray[3], "d");
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/access-property-names-with-bracket-notation.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/access-property-names-with-bracket-notation.english.md
@@ -27,15 +27,15 @@ We've defined a function, <code>checkInventory</code>, which receives a scanned 
 
 ```yml
 tests:
-  - text: <code>checkInventory</code> is a function
+  - text: <code>checkInventory</code> should be a function.
     testString: assert.strictEqual(typeof checkInventory, 'function');
-  - text: 'The <code>foods</code> object should have only the following key-value pairs: <code>apples: 25</code>, <code>oranges: 32</code>, <code>plums: 28</code>, <code>bananas: 13</code>, <code>grapes: 35</code>, <code>strawberries: 27</code>'
+  - text: 'The <code>foods</code> object should have only the following key-value pairs: <code>apples: 25</code>, <code>oranges: 32</code>, <code>plums: 28</code>, <code>bananas: 13</code>, <code>grapes: 35</code>, <code>strawberries: 27</code>.'
     testString: 'assert.deepEqual(foods, {apples: 25, oranges: 32, plums: 28, bananas: 13, grapes: 35, strawberries: 27});'
-  - text: <code>checkInventory("apples")</code> should return <code>25</code>
+  - text: <code>checkInventory("apples")</code> should return <code>25</code>.
     testString: assert.strictEqual(checkInventory('apples'), 25);
-  - text: <code>checkInventory("bananas")</code> should return <code>13</code>
+  - text: <code>checkInventory("bananas")</code> should return <code>13</code>.
     testString: assert.strictEqual(checkInventory('bananas'), 13);
-  - text: <code>checkInventory("strawberries")</code> should return <code>27</code>
+  - text: <code>checkInventory("strawberries")</code> should return <code>27</code>.
     testString: assert.strictEqual(checkInventory('strawberries'), 27);
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/add-key-value-pairs-to-javascript-objects.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/add-key-value-pairs-to-javascript-objects.english.md
@@ -45,15 +45,15 @@ Using the same syntax, we can also <em><strong>add new</strong></em> key-value p
 
 ```yml
 tests:
-  - text: <code>foods</code> is an object
+  - text: <code>foods</code> should be an object.
     testString: assert(typeof foods === 'object');
-  - text: The <code>foods</code> object has a key <code>"bananas"</code> with a value of <code>13</code>
+  - text: The <code>foods</code> object should have a key <code>"bananas"</code> with a value of <code>13</code>.
     testString: assert(foods.bananas === 13);
-  - text: The <code>foods</code> object has a key <code>"grapes"</code> with a value of <code>35</code>
+  - text: The <code>foods</code> object should have a key <code>"grapes"</code> with a value of <code>35</code>.
     testString: assert(foods.grapes === 35);
-  - text: The <code>foods</code> object has a key <code>"strawberries"</code> with a value of <code>27</code>
+  - text: The <code>foods</code> object should have a key <code>"strawberries"</code> with a value of <code>27</code>.
     testString: assert(foods.strawberries === 27);
-  - text: The key-value pairs should be set using dot or bracket notation
+  - text: The key-value pairs should be set using dot or bracket notation.
     testString: assert(code.search(/bananas:/) === -1 && code.search(/grapes:/) === -1 && code.search(/strawberries:/) === -1);
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/generate-an-array-of-all-object-keys-with-object.keys.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/generate-an-array-of-all-object-keys-with-object.keys.english.md
@@ -20,9 +20,9 @@ Finish writing the <code>getArrayOfUsers</code> function so that it returns an a
 
 ```yml
 tests:
-  - text: The <code>users</code> object only contains the keys <code>Alan</code>, <code>Jeff</code>, <code>Sarah</code>, and <code>Ryan</code>
+  - text: The <code>users</code> object should only contain the keys <code>Alan</code>, <code>Jeff</code>, <code>Sarah</code>, and <code>Ryan</code>
     testString: assert('Alan' in users && 'Jeff' in users && 'Sarah' in users && 'Ryan' in users && Object.keys(users).length === 4);
-  - text: The <code>getArrayOfUsers</code> function returns an array which contains all the keys in the <code>users</code> object
+  - text: The <code>getArrayOfUsers</code> function should return an array which contains all the keys in the <code>users</code> object
     testString: assert((function() { users.Sam = {}; users.Lewis = {}; let R = getArrayOfUsers(users); return (R.indexOf('Alan') !== -1 && R.indexOf('Jeff') !== -1 && R.indexOf('Sarah') !== -1 && R.indexOf('Ryan') !== -1 && R.indexOf('Sam') !== -1 && R.indexOf('Lewis') !== -1); })() === true);
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/modify-an-array-stored-in-an-object.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/modify-an-array-stored-in-an-object.english.md
@@ -22,7 +22,7 @@ Take a look at the object we've provided in the code editor. The <code>user</cod
 tests:
   - text: The <code>user</code> object should have <code>name</code>, <code>age</code>, and <code>data</code> keys.
     testString: assert('name' in user && 'age' in user && 'data' in user);
-  - text: The <code>addFriend</code> function should accept a <code>user</code> object and a <code>friend</code> string as arguments and adds the friend to the array of <code>friends</code> in the <code>user</code> object.
+  - text: The <code>addFriend</code> function should accept a <code>user</code> object and a <code>friend</code> string as arguments and add the friend to the array of <code>friends</code> in the <code>user</code> object.
     testString: assert((function() { let L1 = user.data.friends.length; addFriend(user, 'Sean'); let L2 = user.data.friends.length; return (L2 === L1 + 1); })());
   - text: <code>addFriend(user, "Pete")</code> should return <code>["Sam", "Kira", "Tomo", "Pete"]</code>.
     testString: assert.deepEqual((function() { delete user.data.friends; user.data.friends = ['Sam', 'Kira', 'Tomo']; return addFriend(user, 'Pete') })(), ['Sam', 'Kira', 'Tomo', 'Pete']);

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/modify-an-array-stored-in-an-object.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/modify-an-array-stored-in-an-object.english.md
@@ -20,11 +20,11 @@ Take a look at the object we've provided in the code editor. The <code>user</cod
 
 ```yml
 tests:
-  - text: The <code>user</code> object has <code>name</code>, <code>age</code>, and <code>data</code> keys
+  - text: The <code>user</code> object should have <code>name</code>, <code>age</code>, and <code>data</code> keys.
     testString: assert('name' in user && 'age' in user && 'data' in user);
-  - text: The <code>addFriend</code> function accepts a <code>user</code> object and a <code>friend</code> string as arguments and adds the friend to the array of <code>friends</code> in the <code>user</code> object
+  - text: The <code>addFriend</code> function should accept a <code>user</code> object and a <code>friend</code> string as arguments and adds the friend to the array of <code>friends</code> in the <code>user</code> object.
     testString: assert((function() { let L1 = user.data.friends.length; addFriend(user, 'Sean'); let L2 = user.data.friends.length; return (L2 === L1 + 1); })());
-  - text: <code>addFriend(user, "Pete")</code> should return <code>["Sam", "Kira", "Tomo", "Pete"]</code>
+  - text: <code>addFriend(user, "Pete")</code> should return <code>["Sam", "Kira", "Tomo", "Pete"]</code>.
     testString: assert.deepEqual((function() { delete user.data.friends; user.data.friends = ['Sam', 'Kira', 'Tomo']; return addFriend(user, 'Pete') })(), ['Sam', 'Kira', 'Tomo', 'Pete']);
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/modify-an-object-nested-within-an-object.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/modify-an-object-nested-within-an-object.english.md
@@ -37,13 +37,13 @@ Here we've defined an object, <code>userActivity</code>, which includes another 
 
 ```yml
 tests:
-  - text: <code>userActivity</code> has <code>id</code>, <code>date</code> and <code>data</code> properties
+  - text: <code>userActivity</code> should have <code>id</code>, <code>date</code> and <code>data</code> properties
     testString: assert('id' in userActivity && 'date' in userActivity && 'data' in userActivity);
-  - text: <code>userActivity</code> has a <code>data</code> key set to an object with keys <code>totalUsers</code> and <code>online</code>
+  - text: <code>userActivity</code> should have a <code>data</code> key set to an object with keys <code>totalUsers</code> and <code>online</code>
     testString: assert('totalUsers' in userActivity.data && 'online' in userActivity.data);
   - text: The <code>online</code> property nested in the <code>data</code> key of <code>userActivity</code> should be set to <code>45</code>
     testString: assert(userActivity.data.online === 45);
-  - text: The <code>online</code> property is set using dot or bracket notation
+  - text: The <code>online</code> property should be set using dot or bracket notation
     testString: 'assert.strictEqual(code.search(/online: 45/), -1);'
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/modify-an-object-nested-within-an-object.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/modify-an-object-nested-within-an-object.english.md
@@ -37,7 +37,7 @@ Here we've defined an object, <code>userActivity</code>, which includes another 
 
 ```yml
 tests:
-  - text: <code>userActivity</code> should have <code>id</code>, <code>date</code> and <code>data</code> properties
+  - text: <code>userActivity</code> should have <code>id</code>, <code>date</code> and <code>data</code> properties.
     testString: assert('id' in userActivity && 'date' in userActivity && 'data' in userActivity);
   - text: <code>userActivity</code> should have a <code>data</code> key set to an object with keys <code>totalUsers</code> and <code>online</code>
     testString: assert('totalUsers' in userActivity.data && 'online' in userActivity.data);

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/modify-an-object-nested-within-an-object.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/modify-an-object-nested-within-an-object.english.md
@@ -39,7 +39,7 @@ Here we've defined an object, <code>userActivity</code>, which includes another 
 tests:
   - text: <code>userActivity</code> should have <code>id</code>, <code>date</code> and <code>data</code> properties.
     testString: assert('id' in userActivity && 'date' in userActivity && 'data' in userActivity);
-  - text: <code>userActivity</code> should have a <code>data</code> key set to an object with keys <code>totalUsers</code> and <code>online</code>
+  - text: <code>userActivity</code> should have a <code>data</code> key set to an object with keys <code>totalUsers</code> and <code>online</code>.
     testString: assert('totalUsers' in userActivity.data && 'online' in userActivity.data);
   - text: The <code>online</code> property nested in the <code>data</code> key of <code>userActivity</code> should be set to <code>45</code>
     testString: assert(userActivity.data.online === 45);

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/modify-an-object-nested-within-an-object.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/modify-an-object-nested-within-an-object.english.md
@@ -43,7 +43,7 @@ tests:
     testString: assert('totalUsers' in userActivity.data && 'online' in userActivity.data);
   - text: The <code>online</code> property nested in the <code>data</code> key of <code>userActivity</code> should be set to <code>45</code>
     testString: assert(userActivity.data.online === 45);
-  - text: The <code>online</code> property should be set using dot or bracket notation
+  - text: The <code>online</code> property should be set using dot or bracket notation.
     testString: 'assert.strictEqual(code.search(/online: 45/), -1);'
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/use-an-array-to-store-a-collection-of-data.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/use-an-array-to-store-a-collection-of-data.english.md
@@ -55,15 +55,15 @@ We have defined a variable called <code>yourArray</code>. Complete the statement
 
 ```yml
 tests:
-  - text: yourArray is an array
+  - text: <code>yourArray</code> should be an array.
     testString: assert.strictEqual(Array.isArray(yourArray), true);
-  - text: <code>yourArray</code> is at least 5 elements long
+  - text: <code>yourArray</code> should be at least 5 elements long.
     testString: assert.isAtLeast(yourArray.length, 5);
-  - text: <code>yourArray</code> contains at least one <code>boolean</code>
+  - text: <code>yourArray</code> should contain at least one <code>boolean</code>.
     testString: assert(yourArray.filter( el => typeof el === 'boolean').length >= 1);
-  - text: <code>yourArray</code> contains at least one <code>number</code>
+  - text: <code>yourArray</code> should contain at least one <code>number</code>.
     testString: assert(yourArray.filter( el => typeof el === 'number').length >= 1);
-  - text: <code>yourArray</code> contains at least one <code>string</code>
+  - text: <code>yourArray</code> should contain at least one <code>string</code>.
     testString: assert(yourArray.filter( el => typeof el === 'string').length >= 1);
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/use-the-delete-keyword-to-remove-object-properties.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/use-the-delete-keyword-to-remove-object-properties.english.md
@@ -27,9 +27,9 @@ Use the delete keyword to remove the <code>oranges</code>, <code>plums</code>, a
 
 ```yml
 tests:
-  - text: 'The <code>foods</code> object only has three keys: <code>apples</code>, <code>grapes</code>, and <code>bananas</code>'
+  - text: 'The <code>foods</code> object should only have three keys: <code>apples</code>, <code>grapes</code>, and <code>bananas</code>.'
     testString: 'assert(!foods.hasOwnProperty(''oranges'') && !foods.hasOwnProperty(''plums'') && !foods.hasOwnProperty(''strawberries'') && Object.keys(foods).length === 3);'
-  - text: The <code>oranges</code>, <code>plums</code>, and <code>strawberries</code> keys are removed using <code>delete</code>
+  - text: The <code>oranges</code>, <code>plums</code>, and <code>strawberries</code> keys should be removed using <code>delete</code>.
     testString: assert(code.search(/oranges:/) !== -1 && code.search(/plums:/) !== -1 && code.search(/strawberries:/) !== -1);
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-arrays.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-arrays.english.md
@@ -46,9 +46,9 @@ Retrieve the second tree from the variable <code>myPlants</code> using object do
 
 ```yml
 tests:
-  - text: <code>secondTree</code> should equal "pine"
+  - text: <code>secondTree</code> should equal "pine".
     testString: assert(secondTree === "pine");
-  - text: Use dot and bracket notation to access <code>myPlants</code>
+  - text: Your code should use dot and bracket notation to access <code>myPlants</code>.
     testString: assert(/=\s*myPlants\[1\].list\[1\]/.test(code));
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-objects.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-objects.english.md
@@ -40,9 +40,9 @@ Access the <code>myStorage</code> object and assign the contents of the <code>gl
 
 ```yml
 tests:
-  - text: <code>gloveBoxContents</code> should equal "maps"
+  - text: <code>gloveBoxContents</code> should equal "maps".
     testString: assert(gloveBoxContents === "maps");
-  - text: Use dot and bracket notation to access <code>myStorage</code>
+  - text: Your code should use dot and bracket notation to access <code>myStorage</code>.
     testString: assert(/=\s*myStorage\.car\.inside\[\s*("|')glove box\1\s*\]/g.test(code));
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/add-new-properties-to-a-javascript-object.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/add-new-properties-to-a-javascript-object.english.md
@@ -26,9 +26,9 @@ Add a <code>"bark"</code> property to <code>myDog</code> and set it to a dog sou
 
 ```yml
 tests:
-  - text: Add the property <code>"bark"</code> to <code>myDog</code>.
+  - text: You should add the property <code>"bark"</code> to <code>myDog</code>.
     testString: assert(myDog.bark !== undefined);
-  - text: Do not add <code>"bark"</code> to the setup section
+  - text: You should not add <code>"bark"</code> to the setup section.
     testString: assert(!/bark[^\n]:/.test(code));
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/add-two-numbers-with-javascript.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/add-two-numbers-with-javascript.english.md
@@ -29,9 +29,9 @@ Change the <code>0</code> so that sum will equal <code>20</code>.
 
 ```yml
 tests:
-  - text: <code>sum</code> should equal <code>20</code>
+  - text: <code>sum</code> should equal <code>20</code>.
     testString: assert(sum === 20);
-  - text: Use the <code>+</code> operator
+  - text: You should use the <code>+</code> operator.
     testString: assert(/\+/.test(code));
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/appending-variables-to-strings.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/appending-variables-to-strings.english.md
@@ -21,9 +21,9 @@ Set <code>someAdjective</code> and append it to <code>myStr</code> using the <co
 
 ```yml
 tests:
-  - text: <code>someAdjective</code> should be set to a string at least 3 characters long
+  - text: <code>someAdjective</code> should be set to a string at least 3 characters long.
     testString: assert(typeof someAdjective !== 'undefined' && someAdjective.length > 2);
-  - text: Append <code>someAdjective</code> to <code>myStr</code> using the <code>+=</code> operator
+  - text: You should append <code>someAdjective</code> to <code>myStr</code> using the <code>+=</code> operator.
     testString: assert(code.match(/myStr\s*\+=\s*someAdjective\s*/).length > 0);
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comment-your-javascript-code.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comment-your-javascript-code.english.md
@@ -36,9 +36,9 @@ Try creating one of each type of comment.
 
 ```yml
 tests:
-  - text: Create a <code>//</code> style comment that contains at least five letters.
+  - text: You should create a <code>//</code> style comment that contains at least five letters.
     testString: assert(code.match(/(\/\/)...../g));
-  - text: Create a <code>/* */</code> style comment that contains at least five letters.
+  - text: You should create a <code>/* */</code> style comment that contains at least five letters.
     testString: assert(code.match(/(\/\*)([^\/]{5,})(?=\*\/)/gm));
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/compound-assignment-with-augmented-addition.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/compound-assignment-with-augmented-addition.english.md
@@ -31,15 +31,15 @@ Convert the assignments for <code>a</code>, <code>b</code>, and <code>c</code> t
 
 ```yml
 tests:
-  - text: <code>a</code> should equal <code>15</code>
+  - text: <code>a</code> should equal <code>15</code>.
     testString: assert(a === 15);
-  - text: <code>b</code> should equal <code>26</code>
+  - text: <code>b</code> should equal <code>26</code>.
     testString: assert(b === 26);
-  - text: <code>c</code> should equal <code>19</code>
+  - text: <code>c</code> should equal <code>19</code>.
     testString: assert(c === 19);
-  - text: You should use the <code>+=</code> operator for each variable
+  - text: You should use the <code>+=</code> operator for each variable.
     testString: assert(code.match(/\+=/g).length === 3);
-  - text: Do not modify the code above the line
+  - text: You should not modify the code above the specified comment.
     testString: assert(/var a = 3;/.test(code) && /var b = 17;/.test(code) && /var c = 12;/.test(code));
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/compound-assignment-with-augmented-division.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/compound-assignment-with-augmented-division.english.md
@@ -24,7 +24,7 @@ Convert the assignments for <code>a</code>, <code>b</code>, and <code>c</code> t
 
 ```yml
 tests:
-  - text: <code>a</code> should be equal <code>4</code>.
+  - text: <code>a</code> should equal <code>4</code>.
     testString: assert(a === 4);
   - text: <code>b</code> should be equal <code>27</code>.
     testString: assert(b === 27);

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/compound-assignment-with-augmented-division.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/compound-assignment-with-augmented-division.english.md
@@ -28,7 +28,7 @@ tests:
     testString: assert(a === 4);
   - text: <code>b</code> should be equal <code>27</code>.
     testString: assert(b === 27);
-  - text: <code>c</code> should be equal <code>3</code>.
+  - text: <code>c</code> should equal <code>3</code>.
     testString: assert(c === 3);
   - text: You should use the <code>/=</code> operator for each variable.
     testString: assert(code.match(/\/=/g).length === 3);

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/compound-assignment-with-augmented-division.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/compound-assignment-with-augmented-division.english.md
@@ -26,7 +26,7 @@ Convert the assignments for <code>a</code>, <code>b</code>, and <code>c</code> t
 tests:
   - text: <code>a</code> should equal <code>4</code>.
     testString: assert(a === 4);
-  - text: <code>b</code> should be equal <code>27</code>.
+  - text: <code>b</code> should equal <code>27</code>.
     testString: assert(b === 27);
   - text: <code>c</code> should equal <code>3</code>.
     testString: assert(c === 3);

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/compound-assignment-with-augmented-division.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/compound-assignment-with-augmented-division.english.md
@@ -24,15 +24,15 @@ Convert the assignments for <code>a</code>, <code>b</code>, and <code>c</code> t
 
 ```yml
 tests:
-  - text: <code>a</code> should equal <code>4</code>
+  - text: <code>a</code> should be equal <code>4</code>.
     testString: assert(a === 4);
-  - text: <code>b</code> should equal <code>27</code>
+  - text: <code>b</code> should be equal <code>27</code>.
     testString: assert(b === 27);
-  - text: <code>c</code> should equal <code>3</code>
+  - text: <code>c</code> should be equal <code>3</code>.
     testString: assert(c === 3);
-  - text: You should use the <code>/=</code> operator for each variable
+  - text: You should use the <code>/=</code> operator for each variable.
     testString: assert(code.match(/\/=/g).length === 3);
-  - text: Do not modify the code above the line
+  - text: You should not modify the code above the specified comment.
     testString: assert(/var a = 48;/.test(code) && /var b = 108;/.test(code) && /var c = 33;/.test(code));
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/compound-assignment-with-augmented-multiplication.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/compound-assignment-with-augmented-multiplication.english.md
@@ -24,15 +24,15 @@ Convert the assignments for <code>a</code>, <code>b</code>, and <code>c</code> t
 
 ```yml
 tests:
-  - text: <code>a</code> should equal <code>25</code>
+  - text: <code>a</code> should equal <code>25</code>.
     testString: assert(a === 25);
-  - text: <code>b</code> should equal <code>36</code>
+  - text: <code>b</code> should equal <code>36</code>.
     testString: assert(b === 36);
-  - text: <code>c</code> should equal <code>46</code>
+  - text: <code>c</code> should equal <code>46</code>.
     testString: assert(c === 46);
-  - text: You should use the <code>*=</code> operator for each variable
+  - text: You should use the <code>*=</code> operator for each variable.
     testString: assert(code.match(/\*=/g).length === 3);
-  - text: Do not modify the code above the line
+  - text: You should not modify the code above the specified comment.
     testString: assert(/var a = 5;/.test(code) && /var b = 12;/.test(code) && /var c = 4\.6;/.test(code));
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/compound-assignment-with-augmented-subtraction.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/compound-assignment-with-augmented-subtraction.english.md
@@ -24,15 +24,15 @@ Convert the assignments for <code>a</code>, <code>b</code>, and <code>c</code> t
 
 ```yml
 tests:
-  - text: <code>a</code> should equal <code>5</code>
+  - text: <code>a</code> should equal <code>5</code>.
     testString: assert(a === 5);
-  - text: <code>b</code> should equal <code>-6</code>
+  - text: <code>b</code> should equal <code>-6</code>.
     testString: assert(b === -6);
-  - text: <code>c</code> should equal <code>2</code>
+  - text: <code>c</code> should equal <code>2</code>.
     testString: assert(c === 2);
-  - text: You should use the <code>-=</code> operator for each variable
+  - text: You should use the <code>-=</code> operator for each variable.
     testString: assert(code.match(/-=/g).length === 3);
-  - text: Do not modify the code above the line
+  - text: You should not modify the code above the specified comment.
     testString: assert(/var a = 11;/.test(code) && /var b = 9;/.test(code) && /var c = 3;/.test(code));
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/concatenating-strings-with-plus-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/concatenating-strings-with-plus-operator.english.md
@@ -30,11 +30,11 @@ Build <code>myStr</code> from the strings <code>"This is the start. "</code> and
 tests:
   - text: <code>myStr</code> should have a value of <code>This is the start. This is the end.</code>
     testString: assert(myStr === "This is the start. This is the end.");
-  - text: Use the <code>+</code> operator to build <code>myStr</code>
+  - text: You should use the <code>+</code> operator to build <code>myStr</code>.
     testString: assert(code.match(/(["']).*(["'])\s*\+\s*(["']).*(["'])/g).length > 1);
   - text: <code>myStr</code> should be created using the <code>var</code> keyword.
     testString: assert(/var\s+myStr/.test(code));
-  - text: Make sure to assign the result to the <code>myStr</code> variable.
+  - text: You should assign the result to the <code>myStr</code> variable.
     testString: assert(/myStr\s*=/.test(code));
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/concatenating-strings-with-the-plus-equals-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/concatenating-strings-with-the-plus-equals-operator.english.md
@@ -24,7 +24,7 @@ Build <code>myStr</code> over several lines by concatenating these two strings: 
 tests:
   - text: <code>myStr</code> should have a value of <code>This is the first sentence. This is the second sentence.</code>
     testString: assert(myStr === "This is the first sentence. This is the second sentence.");
-  - text: Use the <code>+=</code> operator to build <code>myStr</code>
+  - text: You should use the <code>+=</code> operator to build <code>myStr</code>.
     testString: assert(code.match(/\w\s*\+=\s*["']/g).length > 1 && code.match(/\w\s*\=\s*["']/g).length > 1);
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/constructing-strings-with-variables.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/constructing-strings-with-variables.english.md
@@ -21,9 +21,9 @@ Set <code>myName</code> to a string equal to your name and build <code>myStr</co
 
 ```yml
 tests:
-  - text: <code>myName</code> should be set to a string at least 3 characters long
+  - text: <code>myName</code> should be set to a string at least 3 characters long.
     testString: assert(typeof myName !== 'undefined' && myName.length > 2);
-  - text: Use two <code>+</code> operators to build <code>myStr</code> with <code>myName</code> inside it
+  - text: You should use two <code>+</code> operators to build <code>myStr</code> with <code>myName</code> inside it.
     testString: assert(code.match(/["']\s*\+\s*myName\s*\+\s*["']/g).length > 0);
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/decrement-a-number-with-javascript.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/decrement-a-number-with-javascript.english.md
@@ -25,13 +25,13 @@ Change the code to use the <code>--</code> operator on <code>myVar</code>.
 
 ```yml
 tests:
-  - text: <code>myVar</code> should equal <code>10</code>
+  - text: <code>myVar</code> should equal <code>10</code>.
     testString: assert(myVar === 10);
-  - text: <code>myVar = myVar - 1;</code> should be changed
+  - text: <code>myVar = myVar - 1;</code> should be changed.
     testString: assert(/var\s*myVar\s*=\s*11;\s*\/*.*\s*([-]{2}\s*myVar|myVar\s*[-]{2});/.test(code));
-  - text: Use the <code>--</code> operator on <code>myVar</code>
+  - text: You should use the <code>--</code> operator on <code>myVar</code>.
     testString: assert(/[-]{2}\s*myVar|myVar\s*[-]{2}/.test(code));
-  - text: Do not change code above the line
+  - text: You should not change code above the specified comment.
     testString: assert(/var myVar = 11;/.test(code));
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/delete-properties-from-a-javascript-object.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/delete-properties-from-a-javascript-object.english.md
@@ -22,9 +22,9 @@ Delete the <code>"tails"</code> property from <code>myDog</code>. You may use ei
 
 ```yml
 tests:
-  - text: Delete the property <code>"tails"</code> from <code>myDog</code>.
+  - text: You should delete the property <code>"tails"</code> from <code>myDog</code>.
     testString: assert(typeof myDog === "object" && myDog.tails === undefined);
-  - text: Do not modify the <code>myDog</code> setup
+  - text: You should not modify the <code>myDog</code> setup.
     testString: 'assert(code.match(/"tails": 1/g).length > 1);'
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/divide-one-number-by-another-with-javascript.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/divide-one-number-by-another-with-javascript.english.md
@@ -30,9 +30,9 @@ Change the <code>0</code> so that the <code>quotient</code> is equal to <code>2<
 
 ```yml
 tests:
-  - text: Make the variable <code>quotient</code> equal to 2.
+  - text: The variable <code>quotient</code> should be equal to 2.
     testString: assert(quotient === 2);
-  - text: Use the <code>/</code> operator
+  - text: You should use the <code>/</code> operator.
     testString: assert(/\d+\s*\/\s*\d+/.test(code));
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/global-vs.-local-scope-in-functions.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/global-vs.-local-scope-in-functions.english.md
@@ -32,11 +32,11 @@ Add a local variable to <code>myOutfit</code> function to override the value of 
 
 ```yml
 tests:
-  - text: Do not change the value of the global <code>outerWear</code>
+  - text: You should not change the value of the global <code>outerWear</code>.
     testString: assert(outerWear === "T-Shirt");
-  - text: <code>myOutfit</code> should return <code>"sweater"</code>
+  - text: <code>myOutfit</code> should return <code>"sweater"</code>.
     testString: assert(myOutfit() === "sweater");
-  - text: Do not change the return statement
+  - text: You should not change the return statement.
     testString: assert(/return outerWear/.test(code));
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/increment-a-number-with-javascript.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/increment-a-number-with-javascript.english.md
@@ -28,7 +28,7 @@ Change the code to use the <code>++</code> operator on <code>myVar</code>.
 tests:
   - text: <code>myVar</code> should equal <code>88</code>.
     testString: assert(myVar === 88);
-  - text: <code>myVar = myVar + 1;</code> should be changed
+  - text: <code>myVar = myVar + 1;</code> should be changed.
     testString: assert(/var\s*myVar\s*=\s*87;\s*\/*.*\s*([+]{2}\s*myVar|myVar\s*[+]{2});/.test(code));
   - text: You should use the <code>++</code> operator.
     testString: assert(/[+]{2}\s*myVar|myVar\s*[+]{2}/.test(code));

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/increment-a-number-with-javascript.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/increment-a-number-with-javascript.english.md
@@ -26,13 +26,13 @@ Change the code to use the <code>++</code> operator on <code>myVar</code>.
 
 ```yml
 tests:
-  - text: <code>myVar</code> should equal <code>88</code>
+  - text: <code>myVar</code> should equal <code>88</code>.
     testString: assert(myVar === 88);
   - text: <code>myVar = myVar + 1;</code> should be changed
     testString: assert(/var\s*myVar\s*=\s*87;\s*\/*.*\s*([+]{2}\s*myVar|myVar\s*[+]{2});/.test(code));
-  - text: Use the <code>++</code> operator
+  - text: You should use the <code>++</code> operator.
     testString: assert(/[+]{2}\s*myVar|myVar\s*[+]{2}/.test(code));
-  - text: Do not change code above the line
+  - text: You should not change code above the specified comment.
     testString: assert(/var myVar = 87;/.test(code));
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/initializing-variables-with-the-assignment-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/initializing-variables-with-the-assignment-operator.english.md
@@ -23,7 +23,7 @@ Define a variable <code>a</code> with <code>var</code> and initialize it to a va
 
 ```yml
 tests:
-  - text: Initialize <code>a</code> to a value of <code>9</code>
+  - text: You should initialize <code>a</code> to a value of <code>9</code>.
     testString: assert(/var\s+a\s*=\s*9\s*/.test(code));
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/introducing-else-statements.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/introducing-else-statements.english.md
@@ -40,7 +40,7 @@ tests:
     testString: assert(testElse(5) === "5 or Smaller");
   - text: <code>testElse(6)</code> should return "Bigger than 5"
     testString: assert(testElse(6) === "Bigger than 5");
-  - text: <code>testElse(10)</code> should return "Bigger than 5"
+  - text: <code>testElse(10)</code> should return "Bigger than 5".
     testString: assert(testElse(10) === "Bigger than 5");
   - text: You should not change the code above or below the specified comments.
     testString: assert(/var result = "";/.test(code) && /return result;/.test(code));

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/introducing-else-statements.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/introducing-else-statements.english.md
@@ -42,7 +42,7 @@ tests:
     testString: assert(testElse(6) === "Bigger than 5");
   - text: <code>testElse(10)</code> should return "Bigger than 5"
     testString: assert(testElse(10) === "Bigger than 5");
-  - text: Do not change the code above or below the lines.
+  - text: You should not change the code above or below the specified comments.
     testString: assert(/var result = "";/.test(code) && /return result;/.test(code));
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/iterate-through-an-array-with-a-for-loop.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/iterate-through-an-array-with-a-for-loop.english.md
@@ -30,13 +30,13 @@ Declare and initialize a variable <code>total</code> to <code>0</code>. Use a <c
 
 ```yml
 tests:
-  - text: <code>total</code> should be declared and initialized to 0
+  - text: <code>total</code> should be declared and initialized to 0.
     testString: assert(code.match(/(var|let|const)\s*?total\s*=\s*0.*?;?/));
-  - text: <code>total</code> should equal 20
+  - text: <code>total</code> should equal 20.
     testString: assert(total === 20);
-  - text: You should use a <code>for</code> loop to iterate through <code>myArr</code>
+  - text: You should use a <code>for</code> loop to iterate through <code>myArr</code>.
     testString: assert(code.match(/for\s*\(/g).length > 1 && code.match(/myArr\s*\[/));
-  - text: Do not set <code>total</code> to 20 directly
+  - text: You should not set <code>total</code> to 20 directly.
     testString: assert(!code.match(/total[\s\+\-]*=\s*(0(?!\s*[;,]?$)|[1-9])/gm));
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/local-scope-and-functions.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/local-scope-and-functions.english.md
@@ -34,9 +34,9 @@ Declare a local variable <code>myVar</code> inside <code>myLocalScope</code>. Ru
 
 ```yml
 tests:
-  - text: No global <code>myVar</code> variable
+  - text: The code should not contain a global <code>myVar</code> variable.
     testString: assert(typeof myVar === 'undefined');
-  - text: Add a local <code>myVar</code> variable
+  - text: You should add a local <code>myVar</code> variable.
     testString: assert(/function\s+myLocalScope\s*\(\s*\)\s*\{\s[\s\S]+\s*var\s*myVar\s*(\s*|=[\s\S]+)\s*;[\s\S]+}/.test(code));
 
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/manipulate-arrays-with-pop.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/manipulate-arrays-with-pop.english.md
@@ -33,7 +33,7 @@ Use the <code>.pop()</code> function to remove the last item from <code>myArray<
 tests:
   - text: <code>myArray</code> should only contain <code>[["John", 23]]</code>.
     testString: assert((function(d){if(d[0][0] == 'John' && d[0][1] === 23 && d[1] == undefined){return true;}else{return false;}})(myArray));
-  - text: You should use <code>pop()</code> on <code>myArray</code>
+  - text: You should use <code>pop()</code> on <code>myArray</code>.
     testString: assert(/removedFromMyArray\s*=\s*myArray\s*.\s*pop\s*(\s*)/.test(code));
   - text: <code>removedFromMyArray</code> should only contain <code>["cat", 2]</code>.
     testString: assert((function(d){if(d[0] == 'cat' && d[1] === 2 && d[2] == undefined){return true;}else{return false;}})(removedFromMyArray));

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/manipulate-arrays-with-pop.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/manipulate-arrays-with-pop.english.md
@@ -33,7 +33,7 @@ Use the <code>.pop()</code> function to remove the last item from <code>myArray<
 tests:
   - text: <code>myArray</code> should only contain <code>[["John", 23]]</code>.
     testString: assert((function(d){if(d[0][0] == 'John' && d[0][1] === 23 && d[1] == undefined){return true;}else{return false;}})(myArray));
-  - text: Use <code>pop()</code> on <code>myArray</code>
+  - text: You should use <code>pop()</code> on <code>myArray</code>
     testString: assert(/removedFromMyArray\s*=\s*myArray\s*.\s*pop\s*(\s*)/.test(code));
   - text: <code>removedFromMyArray</code> should only contain <code>["cat", 2]</code>.
     testString: assert((function(d){if(d[0] == 'cat' && d[1] === 2 && d[2] == undefined){return true;}else{return false;}})(removedFromMyArray));

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/multiply-two-numbers-with-javascript.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/multiply-two-numbers-with-javascript.english.md
@@ -30,9 +30,9 @@ Change the <code>0</code> so that product will equal <code>80</code>.
 
 ```yml
 tests:
-  - text: Make the variable <code>product</code> equal 80
+  - text: The variable <code>product</code> should be equal to 80.
     testString: assert(product === 80);
-  - text: Use the <code>*</code> operator
+  - text: You should use the <code>*</code> operator.
     testString: assert(/\*/.test(code));
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/passing-values-to-functions-with-arguments.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/passing-values-to-functions-with-arguments.english.md
@@ -32,13 +32,13 @@ We have passed two arguments, <code>"Hello"</code> and <code>"World"</code>. Ins
 
 ```yml
 tests:
-  - text: <code>functionWithArgs</code> should be a function
+  - text: <code>functionWithArgs</code> should be a function.
     testString: assert(typeof functionWithArgs === 'function');
-  - text: <code>functionWithArgs(1,2)</code> should output <code>3</code>
+  - text: <code>functionWithArgs(1,2)</code> should output <code>3</code>.
     testString: if(typeof functionWithArgs === "function") { capture(); functionWithArgs(1,2); uncapture(); } assert(logOutput == 3);
-  - text: <code>functionWithArgs(7,9)</code> should output <code>16</code>
+  - text: <code>functionWithArgs(7,9)</code> should output <code>16</code>.
     testString: if(typeof functionWithArgs === "function") { capture(); functionWithArgs(7,9); uncapture(); } assert(logOutput == 16);
-  - text: Call <code>functionWithArgs</code> with two numbers after you define it.
+  - text: You should call <code>functionWithArgs</code> with two numbers after you define it.
     testString: assert(/^\s*functionWithArgs\s*\(\s*\d+\s*,\s*\d+\s*\)\s*/m.test(code));
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/quoting-strings-with-single-quotes.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/quoting-strings-with-single-quotes.english.md
@@ -45,7 +45,7 @@ Right now, the <code>&#60;a&#62;</code> tag in the string uses double quotes eve
 tests:
   - text: You should remove all the <code>backslashes</code> (<code>\</code>).
     testString: assert(!/\\/g.test(code) && myStr.match('\\s*<a href\\s*=\\s*"http://www.example.com"\\s*target\\s*=\\s*"_blank">\\s*Link\\s*</a>\\s*'));
-  - text: You should have two single quotes <code>&#39;</code> and four double quotes <code>&quot;</code>
+   - text: You should have two single quotes <code>&#39;</code> and four double quotes <code>&quot;</code>.
     testString: assert(code.match(/"/g).length === 4 && code.match(/'/g).length === 2);
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/quoting-strings-with-single-quotes.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/quoting-strings-with-single-quotes.english.md
@@ -43,7 +43,7 @@ Right now, the <code>&#60;a&#62;</code> tag in the string uses double quotes eve
 
 ```yml
 tests:
-  - text: Remove all the <code>backslashes</code> (<code>\</code>)
+  - text: You should remove all the <code>backslashes</code> (<code>\</code>).
     testString: assert(!/\\/g.test(code) && myStr.match('\\s*<a href\\s*=\\s*"http://www.example.com"\\s*target\\s*=\\s*"_blank">\\s*Link\\s*</a>\\s*'));
   - text: You should have two single quotes <code>&#39;</code> and four double quotes <code>&quot;</code>
     testString: assert(code.match(/"/g).length === 4 && code.match(/'/g).length === 2);

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/quoting-strings-with-single-quotes.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/quoting-strings-with-single-quotes.english.md
@@ -45,7 +45,7 @@ Right now, the <code>&#60;a&#62;</code> tag in the string uses double quotes eve
 tests:
   - text: You should remove all the <code>backslashes</code> (<code>\</code>).
     testString: assert(!/\\/g.test(code) && myStr.match('\\s*<a href\\s*=\\s*"http://www.example.com"\\s*target\\s*=\\s*"_blank">\\s*Link\\s*</a>\\s*'));
-   - text: You should have two single quotes <code>&#39;</code> and four double quotes <code>&quot;</code>.
+  - text: You should have two single quotes <code>&#39;</code> and four double quotes <code>&quot;</code>.
     testString: assert(code.match(/"/g).length === 4 && code.match(/'/g).length === 2);
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/shopping-list.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/shopping-list.english.md
@@ -24,13 +24,13 @@ There should be at least 5 sub-arrays in the list.
 
 ```yml
 tests:
-  - text: <code>myList</code> should be an array
+  - text: <code>myList</code> should be an array.
     testString: assert(isArray);
-  - text: The first elements in each of your sub-arrays must all be strings
+  - text: The first elements in each of your sub-arrays should all be strings.
     testString: assert(hasString);
-  - text: The second elements in each of your sub-arrays must all be numbers
+  - text: The second elements in each of your sub-arrays should all be numbers.
     testString: assert(hasNumber);
-  - text: You must have at least 5 items in your list
+  - text: You should have at least 5 items in your list.
     testString: assert(count > 4);
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/storing-values-with-the-assignment-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/storing-values-with-the-assignment-operator.english.md
@@ -32,13 +32,13 @@ Assign the contents of <code>a</code> to variable <code>b</code>.
 
 ```yml
 tests:
-  - text: Do not change code above the line
+  - text: You should not change code above the specified comment.
     testString: assert(/var a;/.test(code) && /var b = 2;/.test(code));
-  - text: <code>a</code> should have a value of 7
+  - text: <code>a</code> should have a value of 7.
     testString: assert(typeof a === 'number' && a === 7);
-  - text: <code>b</code> should have a value of 7
+  - text: <code>b</code> should have a value of 7.
     testString: assert(typeof b === 'number' && b === 7);
-  - text: <code>a</code> should be assigned to <code>b</code> with <code>=</code>
+  - text: <code>a</code> should be assigned to <code>b</code> with <code>=</code>.
     testString: assert(/b\s*=\s*a\s*;/g.test(code));
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/subtract-one-number-from-another-with-javascript.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/subtract-one-number-from-another-with-javascript.english.md
@@ -30,9 +30,9 @@ Change the <code>0</code> so the difference is <code>12</code>.
 
 ```yml
 tests:
-  - text: Make the variable <code>difference</code> equal 12.
+  - text: The variable <code>difference</code> should be equal to 12.
     testString: assert(difference === 12);
-  - text: Only subtract one number from 45.
+  - text: You should only subtract one number from 45.
     testString: assert(/var\s*difference\s*=\s*45\s*-\s*[0-9]*;(?!\s*[a-zA-Z0-9]+)/.test(code));
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/understand-string-immutability.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/understand-string-immutability.english.md
@@ -35,9 +35,9 @@ Correct the assignment to <code>myStr</code> so it contains the string value of 
 
 ```yml
 tests:
-  - text: <code>myStr</code> should have a value of <code>Hello World</code>
+  - text: <code>myStr</code> should have a value of <code>Hello World</code>.
     testString: assert(myStr === "Hello World");
-  - text: Do not change the code above the line
+  - text: You should not change the code above the specified comment.
     testString: assert(/myStr = "Jello World"/.test(code));
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/understanding-case-sensitivity-in-variables.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/understanding-case-sensitivity-in-variables.english.md
@@ -32,11 +32,11 @@ Modify the existing declarations and assignments so their names use <dfn>camelCa
 
 ```yml
 tests:
-  - text: <code>studlyCapVar</code> is defined and has a value of <code>10</code>
+  - text: <code>studlyCapVar</code> should be defined and have a value of <code>10</code>.
     testString: assert(typeof studlyCapVar !== 'undefined' && studlyCapVar === 10);
-  - text: <code>properCamelCase</code> is defined and has a value of <code>"A String"</code>
+  - text: <code>properCamelCase</code> should be defined and have a value of <code>"A String"</code>.
     testString: assert(typeof properCamelCase !== 'undefined' && properCamelCase === "A String");
-  - text: <code>titleCaseOver</code> is defined and has a value of <code>9000</code>
+  - text: <code>titleCaseOver</code> should be defined and have a value of <code>9000</code>.
     testString: assert(typeof titleCaseOver !== 'undefined' && titleCaseOver === 9000);
   - text: <code>studlyCapVar</code> should use camelCase in both declaration and assignment sections.
     testString: assert(code.match(/studlyCapVar/g).length === 2);

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/understanding-undefined-value-returned-from-a-function.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/understanding-undefined-value-returned-from-a-function.english.md
@@ -32,13 +32,13 @@ Create a function <code>addFive</code> without any arguments. This function adds
 
 ```yml
 tests:
-  - text: <code>addFive</code> should be a function
+  - text: <code>addFive</code> should be a function.
     testString: assert(typeof addFive === 'function');
-  - text: Once both functions have ran, the <code>sum</code> should be equal to 8
+  - text: Once both functions have ran, the <code>sum</code> should be equal to 8.
     testString: assert(sum === 8);
-  - text: Returned value from <code>addFive</code> should be <code>undefined</code>
+  - text: Returned value from <code>addFive</code> should be <code>undefined</code>.
     testString: assert(addFive() === undefined);
-  - text: Inside the <code>addFive</code> function, add <code>5</code> to the <code>sum</code> variable
+  - text: Inside the <code>addFive</code> function, you should add <code>5</code> to the <code>sum</code> variable.
     testString: assert(addFive.toString().replace(/\s/g, '').match(/sum=sum\+5|sum\+=5/));
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/understanding-uninitialized-variables.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/understanding-uninitialized-variables.english.md
@@ -21,13 +21,13 @@ Initialize the three variables <code>a</code>, <code>b</code>, and <code>c</code
 
 ```yml
 tests:
-  - text: <code>a</code> should be defined and evaluated to have the value of <code>6</code>
+  - text: <code>a</code> should be defined and evaluated to have the value of <code>6</code>.
     testString: assert(typeof a === 'number' && a === 6);
-  - text: <code>b</code> should be defined and evaluated to have the value of <code>15</code>
+  - text: <code>b</code> should be defined and evaluated to have the value of <code>15</code>.
     testString: assert(typeof b === 'number' && b === 15);
   - text: <code>c</code> should not contain <code>undefined</code> and should have a value of "I am a String!"
     testString: assert(!/undefined/.test(c) && c === "I am a String!");
-  - text: Do not change code below the line
+  - text: You should not change code below the specified comment.
     testString: assert(/a = a \+ 1;/.test(code) && /b = b \+ 5;/.test(code) && /c = c \+ " String!";/.test(code));
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/updating-object-properties.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/updating-object-properties.english.md
@@ -36,9 +36,9 @@ Update the <code>myDog</code> object's name property. Let's change her name from
 
 ```yml
 tests:
-  - text: Update <code>myDog</code>&apos;s <code>"name"</code> property to equal "Happy Coder".
+  - text: You should update <code>myDog</code>&apos;s <code>"name"</code> property to equal "Happy Coder".
     testString: assert(/happy coder/gi.test(myDog.name));
-  - text: Do not edit the <code>myDog</code> definition
+  - text: You should not edit the <code>myDog</code> definition.
     testString: 'assert(/"name": "Coder"/.test(code));'
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/use-bracket-notation-to-find-the-last-character-in-a-string.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/use-bracket-notation-to-find-the-last-character-in-a-string.english.md
@@ -25,7 +25,7 @@ Use <dfn>bracket notation</dfn> to find the last character in the <code>lastName
 tests:
   - text: <code>lastLetterOfLastName</code> should be "e".
     testString: assert(lastLetterOfLastName === "e");
-  - text: You have to use <code>.length</code> to get the last letter.
+  - text: You should use <code>.length</code> to get the last letter.
     testString: assert(code.match(/\.length/g).length === 2);
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/use-bracket-notation-to-find-the-nth-to-last-character-in-a-string.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/use-bracket-notation-to-find-the-nth-to-last-character-in-a-string.english.md
@@ -25,7 +25,7 @@ Use <dfn>bracket notation</dfn> to find the second-to-last character in the <cod
 tests:
   - text: <code>secondToLastLetterOfLastName</code> should be "c".
     testString: assert(secondToLastLetterOfLastName === 'c');
-  - text: You have to use <code>.length</code> to get the second last letter.
+  - text: You should use <code>.length</code> to get the second last letter.
     testString: assert(code.match(/\.length/g).length === 2);
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/write-reusable-javascript-with-functions.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/write-reusable-javascript-with-functions.english.md
@@ -32,11 +32,11 @@ Each time the function is called it will print out the message <code>"Hello Worl
 
 ```yml
 tests:
-  - text: <code>reusableFunction</code> should be a function
+  - text: <code>reusableFunction</code> should be a function.
     testString: assert(typeof reusableFunction === 'function');
-  - text: <code>reusableFunction</code> should output "Hi World" to the dev console
+  - text: <code>reusableFunction</code> should output "Hi World" to the dev console.
     testString: assert(hiWorldWasLogged);
-  - text: Call <code>reusableFunction</code> after you define it
+  - text: You should call <code>reusableFunction</code> after you define it.
     testString: assert(/^\s*reusableFunction\(\)\s*/m.test(code));
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/debugging/catch-use-of-assignment-operator-instead-of-equality-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/debugging/catch-use-of-assignment-operator-instead-of-equality-operator.english.md
@@ -36,7 +36,7 @@ Fix the condition so the program runs the right branch, and the appropriate valu
 tests:
   - text: Your code should fix the condition so it checks for equality, instead of using assignment.
     testString: assert(result == "Not equal!");
-  - text: The condition can use either <code>==</code> or <code>===</code> to test for equality.
+  - text: The condition should use either <code>==</code> or <code>===</code> to test for equality.
     testString: assert(code.match(/x\s*?===?\s*?y/g));
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/debugging/understanding-the-differences-between-the-freecodecamp-and-browser-console.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/debugging/understanding-the-differences-between-the-freecodecamp-and-browser-console.english.md
@@ -25,9 +25,9 @@ First, use <code>console.clear()</code> to clear the browser console. After that
 
 ```yml
 tests:
-  - text: Use <code>console.clear()</code> to clear the browser console.
+  - text: You should use <code>console.clear()</code> to clear the browser console.
     testString: const removeJSComments = code.replace(/\/\*[\s\S]*?\*\/|\/\/.*$/gm, ''); const noSpaces = removeJSComments.replace(/\s/g, ''); assert(noSpaces.match(/console.clear\(\)/));
-  - text: Use <code>console.log()</code> to print the <code>output</code> variable.
+  - text: You should use <code>console.log()</code> to print the <code>output</code> variable.
     testString: const noSpaces = code.replace(/\s/g, ''); assert(noSpaces.match(/console\.log\(output\)/));
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/create-strings-using-template-literals.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/create-strings-using-template-literals.english.md
@@ -47,11 +47,11 @@ Use an iterator method (any kind of loop) to get the desired output.
 tests:
   - text: <code>resultDisplayArray</code> should be an array containing <code>result failure</code> messages.
     testString: assert(typeof makeList(result.failure) === 'object' && resultDisplayArray.length === 3);
-  - text: <code>resultDisplayArray</code> is the desired output.
+  - text: <code>resultDisplayArray</code> should be equal to the specified output.
     testString: assert(makeList(result.failure).every((v, i) => v === `<li class="text-warning">${result.failure[i]}</li>` || v === `<li class='text-warning'>${result.failure[i]}</li>`));
-  - text: Template strings and expression interpolation should be used
+  - text: Template strings and expression interpolation should be used.
     testString: getUserInput => assert(getUserInput('index').match(/(`.*\${.*}.*`)/));
-  - text: An iterator should be used
+  - text: An iterator should be used.
     testString: getUserInput => assert(getUserInput('index').match(/for|map|reduce|forEach|while/));
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/declare-a-read-only-variable-with-the-const-keyword.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/declare-a-read-only-variable-with-the-const-keyword.english.md
@@ -31,7 +31,7 @@ Change the code so that all variables are declared using <code>let</code> or <co
 
 ```yml
 tests:
-  - text: <code>var</code> does not exist in your code.
+  - text: <code>var</code> should not exist in your code.
     testString: getUserInput => assert(!getUserInput('index').match(/var/g));
   - text: <code>SENTENCE</code> should be a constant variable declared with <code>const</code>.
     testString: getUserInput => assert(getUserInput('index').match(/(const SENTENCE)/g));

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/explore-differences-between-the-var-and-let-keywords.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/explore-differences-between-the-var-and-let-keywords.english.md
@@ -48,7 +48,7 @@ Update the code so it only uses the <code>let</code> keyword.
 
 ```yml
 tests:
-  - text: <code>var</code> does not exist in code.
+  - text: <code>var</code> should not exist in the code.
     testString: getUserInput => assert(!getUserInput('index').match(/var/g));
   - text: <code>catName</code> should be <code>Oliver</code>.
     testString: assert(catName === "Oliver");

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/mutate-an-array-declared-with-const.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/mutate-an-array-declared-with-const.english.md
@@ -32,11 +32,11 @@ An array is declared as <code>const s = [5, 7, 2]</code>. Change the array to <c
 
 ```yml
 tests:
-  - text: Do not replace <code>const</code> keyword.
+  - text: You should not replace <code>const</code> keyword.
     testString: getUserInput => assert(getUserInput('index').match(/const/g));
   - text: <code>s</code> should be a constant variable (by using <code>const</code>).
     testString: getUserInput => assert(getUserInput('index').match(/const\s+s/g));
-  - text: Do not change the original array declaration.
+  - text: You should not change the original array declaration.
     testString: getUserInput => assert(getUserInput('index').match(/const\s+s\s*=\s*\[\s*5\s*,\s*7\s*,\s*2\s*\]\s*;?/g));
   - text: <code>s</code> should be equal to <code>[2, 5, 7]</code>.
     testString: assert.deepEqual(s, [2, 5, 7]);

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/prevent-object-mutation.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/prevent-object-mutation.english.md
@@ -34,13 +34,13 @@ In this challenge you are going to use <code>Object.freeze</code> to prevent mat
 
 ```yml
 tests:
-  - text: Do not replace <code>const</code> keyword.
+  - text: You should not replace <code>const</code> keyword.
     testString: getUserInput => assert(getUserInput('index').match(/const/g));
   - text: <code>MATH_CONSTANTS</code> should be a constant variable (by using <code>const</code>).
     testString: getUserInput => assert(getUserInput('index').match(/const\s+MATH_CONSTANTS/g));
-  - text: Do not change original <code>MATH_CONSTANTS</code>.
+  - text: You should not change original <code>MATH_CONSTANTS</code>.
     testString: getUserInput => assert(getUserInput('index').match(/const\s+MATH_CONSTANTS\s+=\s+{\s+PI:\s+3.14\s+};/g));
-  - text: <code>PI</code> equals <code>3.14</code>.
+  - text: <code>PI</code> should equal <code>3.14</code>.
     testString: assert(PI === 3.14);
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/set-default-parameters-for-your-functions.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/set-default-parameters-for-your-functions.english.md
@@ -35,7 +35,7 @@ tests:
     testString: assert(increment(5, 2) === 7);
   - text: The result of <code>increment(5)</code> should be <code>6</code>.
     testString: assert(increment(5) === 6);
-  - text: Default parameter <code>1</code> was used for <code>value</code>.
+  - text: A default parameter value of <code>1</code> should be used for <code>value</code>.
     testString: assert(code.match(/value\s*=\s*1/g));
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use--to-import-everything-from-a-file.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use--to-import-everything-from-a-file.english.md
@@ -32,7 +32,7 @@ The code in this file requires the contents of the file: <code>string_functions.
 
 ```yml
 tests:
-  - text: Properly uses <code>import * as</code> syntax.
+  - text: Your code should properly use <code>import * as</code> syntax.
     testString: assert(code.match(/import\s*\*\s*as\s+stringFunctions\s+from\s*('|")\.\/string_functions\.js\1/g));
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-assign-variables-from-arrays.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-assign-variables-from-arrays.english.md
@@ -40,7 +40,7 @@ tests:
     testString: assert(a === 6);
   - text: Value of <code>b</code> should be 8, after swapping.
     testString: assert(b === 8);
-  - text: Should use array destructuring to swap a and b.
+  - text: You should use array destructuring to swap a and b.
     testString: assert(/\[\s*(\w)\s*,\s*(\w)\s*\]\s*=\s*\[\s*\2\s*,\s*\1\s*\]/g.test(code));
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-the-spread-operator-to-evaluate-arrays-in-place.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-the-spread-operator-to-evaluate-arrays-in-place.english.md
@@ -44,7 +44,7 @@ Copy all contents of <code>arr1</code> into another array <code>arr2</code> usin
 tests:
   - text: <code>arr2</code> should be correct copy of <code>arr1</code>.
     testString: assert(arr2.every((v, i) => v === arr1[i]));
-  - text: <code>...</code> spread operator was used to duplicate <code>arr1</code>.
+  - text: <code>...</code> spread operator should be used to duplicate <code>arr1</code>.
     testString: assert(code.match(/Array\(\s*\.\.\.arr1\s*\)|\[\s*\.\.\.arr1\s*\]/));
   - text: <code>arr2</code> should remain unchanged when <code>arr1</code> is changed.
     testString: assert((arr1, arr2) => {arr1.push('JUN'); return arr2.length < arr1.length});

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/write-arrow-functions-with-parameters.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/write-arrow-functions-with-parameters.english.md
@@ -40,15 +40,15 @@ Rewrite the <code>myConcat</code> function which appends contents of <code>arr2<
 
 ```yml
 tests:
-  - text: User did replace <code>var</code> keyword.
+  - text: You should replace the <code>var</code> keyword.
     testString: getUserInput => assert(!getUserInput('index').match(/var/g));
   - text: <code>myConcat</code> should be a constant variable (by using <code>const</code>).
     testString: getUserInput => assert(getUserInput('index').match(/const\s+myConcat/g));
-  - text: <code>myConcat</code> should be a function
+  - text: <code>myConcat</code> should be a function.
     testString: assert(typeof myConcat === 'function');
-  - text: <code>myConcat()</code> returns the correct <code>array</code>
+  - text: <code>myConcat()</code> should return <code>[1, 2, 3, 4, 5]</code>.
     testString: assert(() => { const a = myConcat([1], [2]); return a[0] == 1 && a[1] == 2; });
-  - text: <code>function</code> keyword was not used.
+  - text: <code>function</code> keyword should not be used.
     testString: getUserInput => assert(!getUserInput('index').match(/function/g));
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/iterate-over-all-properties.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/iterate-over-all-properties.english.md
@@ -53,7 +53,7 @@ tests:
     testString: assert(ownProps.indexOf('name') !== -1);
   - text: The <code>prototypeProps</code> array should include <code>"numLegs"</code>.
     testString: assert(prototypeProps.indexOf('numLegs') !== -1);
-  - text: Solve this challenge without using the built in method <code>Object.keys()</code>.
+  - text: You should solve this challenge without using the built in method <code>Object.keys()</code>.
     testString: assert(!/\Object.keys/.test(code));
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/understand-own-properties.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/understand-own-properties.english.md
@@ -49,9 +49,9 @@ Add the <code>own</code> properties of <code>canary</code> to the array <code>ow
 tests:
   - text: <code>ownProps</code> should include the values <code>"numLegs"</code> and <code>"name"</code>.
     testString: assert(ownProps.indexOf('name') !== -1 && ownProps.indexOf('numLegs') !== -1);
-  - text: Solve this challenge without using the built in method <code>Object.keys()</code>.
+  - text: You should solve this challenge without using the built in method <code>Object.keys()</code>.
     testString: assert(!/Object(\.keys|\[(['"`])keys\2\])/.test(code));
-  - text: Solve this challenge without hardcoding the <code>ownProps</code> array.
+  - text: You should solve this challenge without hardcoding the <code>ownProps</code> array.
     testString: assert(!/\[\s*(?:'|")(?:name|numLegs)|(?:push|concat)\(\s*(?:'|")(?:name|numLegs)/.test(code));
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/understand-where-an-objects-prototype-comes-from.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/understand-where-an-objects-prototype-comes-from.english.md
@@ -36,7 +36,7 @@ Use <code>isPrototypeOf</code> to check the <code>prototype</code> of <code>beag
 
 ```yml
 tests:
-  - text: Show that <code>Dog.prototype</code> is the <code>prototype</code> of <code>beagle</code>
+  - text: You should show that <code>Dog.prototype</code> is the <code>prototype</code> of <code>beagle</code>
     testString: assert(/Dog\.prototype\.isPrototypeOf\(beagle\)/.test(code));
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/verify-an-objects-constructor-with-instanceof.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/verify-an-objects-constructor-with-instanceof.english.md
@@ -47,7 +47,7 @@ Create a new instance of the <code>House</code> constructor, calling it <code>my
 tests:
   - text: <code>myHouse</code> should have a <code>numBedrooms</code> attribute set to a number.
     testString: assert(typeof myHouse.numBedrooms === 'number');
-  - text: Be sure to verify that <code>myHouse</code> is an instance of <code>House</code> using the <code>instanceof</code> operator.
+  - text: You should verify that <code>myHouse</code> is an instance of <code>House</code> using the <code>instanceof</code> operator.
     testString: assert(/myHouse\s*instanceof\s*House/.test(code));
 
 ```


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Related to PR #36860 

This PR makes sure all challenges' tests in the `JavaScript Algorithms and Data Structures" section use "should " or "should not".
