### PR TITLE
fix(curriculum): changed test text to use should for Information Security and Quality Assurance

### DIFF
--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/announce-new-users.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/announce-new-users.english.md
@@ -39,9 +39,9 @@ Submit your page when you think you've got it right.
 
 ```yml
 tests:
-  - text: Event 'user' is emitted with name, currentUsers, and connected
+  - text: Event 'user' should be emitted with name, currentUsers, and connected.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /io.emit.*('|")user('|").*name.*currentUsers.*connected/gi, 'You should have an event emitted named user sending name, currentUsers, and connected'); }, xhr => { throw new Error(xhr.statusText); })
-  - text: Client properly handling and displaying the new data from event 'user'
+  - text: Client should properly handlle and display the new data from event 'user'.
     testString: "getUserInput => $.get(getUserInput('url')+ '/public/client.js') .then(data => { assert.match(data, /socket.on.*('|\")user('|\")[^]*num-users/gi, 'You should change the text of #num-users within on your client within the \"user\" even listener to show the current users connected'); assert.match(data, /socket.on.*('|\")user('|\")[^]*messages.*li/gi, 'You should append a list item to #messages on your client within the \"user\" event listener to annouce a user came or went'); }, xhr => { throw new Error(xhr.statusText); })"
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/authentication-strategies.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/authentication-strategies.english.md
@@ -41,9 +41,9 @@ In the next step we will set up how to actually call the authentication strategy
 
 ```yml
 tests:
-  - text: Passport-local is a dependency
+  - text: Passport-local should be a dependency.
     testString:  getUserInput => $.get(getUserInput('url')+ '/_api/package.json') .then(data => { var packJson = JSON.parse(data); assert.property(packJson.dependencies, 'passport-local', 'Your project should list "passport-local " as a dependency'); }, xhr => { throw new Error(xhr.statusText); })
-  - text: Passport-local correctly required and setup
+  - text: Passport-local should be correctly required and setup.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /require.*("|')passport-local("|')/gi, 'You should have required passport-local'); assert.match(data, /new LocalStrategy/gi, 'You should have told passport to use a new strategy'); assert.match(data, /findOne/gi, 'Your new local strategy should use the findOne query to find a username based on the inputs'); }, xhr => { throw new Error(xhr.statusText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/authentication-with-socket.io.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/authentication-with-socket.io.english.md
@@ -36,11 +36,11 @@ Submit your page when you think you've got it right. If you're running into erro
 
 ```yml
 tests:
-  - text: passportSocketIo is a dependency
+  - text: passportSocketIo should be a dependency.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/package.json') .then(data => { var packJson = JSON.parse(data); assert.property(packJson.dependencies, 'passport.socketio', 'Your project should list "passport.socketio" as a dependency'); }, xhr => { throw new Error(xhr.statusText); })
-  - text: passportSocketIo is properly required
+  - text: passportSocketIo should be properly required.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js').then(data => { assert.match(data, /require\((['"])passport\.socketio\1\)/gi, 'You should correctly require and instantiate "passport.socketio"');}, xhr => { throw new Error(xhr.statusText); })
-  - text: passportSocketIo is properly setup
+  - text: passportSocketIo should be properly setup.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /io\.use\(.+\.authorize\(/gi, 'You should register "passport.socketio" as socket.io middleware and provide it correct options'); }, xhr => { throw new Error(xhr.statusText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/clean-up-your-project-with-modules.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/clean-up-your-project-with-modules.english.md
@@ -36,7 +36,7 @@ Congratulations- you're at the end of this section of Advanced Node and Express 
 
 ```yml
 tests:
-  - text: Modules present
+  - text: Modules should be present.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /require\s*\(('|")\.\/routes(\.js)?\1\)/gi, 'You should have required your new files'); assert.match(data, /mongo.connect[^]*routes/gi, 'Your new modules should be called after your connection to the database'); }, xhr => { throw new Error(xhr.statusText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/communicate-by-emitting.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/communicate-by-emitting.english.md
@@ -34,11 +34,11 @@ Submit your page when you think you've got it right.
 
 ```yml
 tests:
-  - text: currentUsers is defined
+  - text: currentUsers should be defined.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js').then(data => {assert.match(data, /currentUsers/gi, 'You should have variable currentUsers defined');}, xhr => { throw new Error(xhr.statusText); })
-  - text: Server emits the current user count at each new connection
+  - text: Server should emit the current user count at each new connection.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /io.emit.*('|")user count('|").*currentUsers/gi, 'You should emit "user count" with data currentUsers'); }, xhr => { throw new Error(xhr.statusText); })
-  - text: Your client is listening for 'user count' event
+  - text: Your client should be listening for 'user count' event.
     testString: getUserInput => $.get(getUserInput('url')+ '/public/client.js') .then(data => { assert.match(data, /socket.on.*('|")user count('|")/gi, 'Your client should be connection to server with the connection defined as socket'); }, xhr => { throw new Error(xhr.statusText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/create-new-middleware.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/create-new-middleware.english.md
@@ -43,9 +43,9 @@ Submit your page when you think you've got it right.
 
 ```yml
 tests:
-  - text: Middleware ensureAuthenticated should be implemented and on our /profile route
+  - text: Middleware ensureAuthenticated should be implemented and on our /profile route.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /ensureAuthenticated[^]*req.isAuthenticated/gi, 'Your ensureAuthenticated middleware should be defined and utilize the req.isAuthenticated function'); assert.match(data, /profile[^]*get[^]*ensureAuthenticated/gi, 'Your ensureAuthenticated middleware should be attached to the /profile route'); }, xhr => { throw new Error(xhr.statusText); })
-  - text: A Get request to /profile correctly redirects to / since we are not authenticated
+  - text: A Get request to /profile should correctly redirect to / since we are not authenticated.
     testString: getUserInput => $.get(getUserInput('url')+ '/profile') .then(data => { assert.match(data, /Home page/gi, 'An attempt to go to the profile at this point should redirect to the homepage since we are not logged in'); }, xhr => { throw new Error(xhr.statusText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/handle-a-disconnect.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/handle-a-disconnect.english.md
@@ -25,9 +25,9 @@ Submit your page when you think you've got it right.
 
 ```yml
 tests:
-  - text: Server handles the event disconnect from a socket
+  - text: Server should handle the event disconnect from a socket.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /socket.on.*('|")disconnect('|")/gi, ''); }, xhr => { throw new Error(xhr.statusText); })
-  - text: Your client is listening for 'user count' event
+  - text: Your client should be listening for 'user count' event.
     testString: getUserInput => $.get(getUserInput('url')+ '/public/client.js') .then(data => { assert.match(data, /socket.on.*('|")user count('|")/gi, 'Your client should be connection to server with the connection defined as socket'); }, xhr => { throw new Error(xhr.statusText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/hashing-your-passwords.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/hashing-your-passwords.english.md
@@ -25,9 +25,9 @@ That is all it takes to implement one of the most important security features wh
 
 ```yml
 tests:
-  - text: BCrypt is a dependency
+  - text: BCrypt should be a dependency.
     testString:  getUserInput => $.get(getUserInput('url')+ '/_api/package.json') .then(data => { var packJson = JSON.parse(data); assert.property(packJson.dependencies, 'bcrypt', 'Your project should list "bcrypt" as a dependency'); }, xhr => { throw new Error(xhr.statusText); })
-  - text: BCrypt correctly required and implemented
+  - text: BCrypt should be correctly required and implemented.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /require.*("|')bcrypt("|')/gi, 'You should have required bcrypt'); assert.match(data, /bcrypt.hashSync/gi, 'You should use hash the password in the registration'); assert.match(data, /bcrypt.compareSync/gi, 'You should compare the password to the hash in your strategy'); }, xhr => { throw new Error(xhr.statusText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/how-to-put-a-profile-together.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/how-to-put-a-profile-together.english.md
@@ -24,7 +24,7 @@ Submit your page when you think you've got it right.
 
 ```yml
 tests:
-  - text: Correctly added a Pug render variable to /profile
+  - text: You should correctly add a Pug render variable to /profile.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /\/views\/pug\/profile[^]*username:( |)req.user.username/gi, 'You should be passing the variable username with req.user.username into the render function of the profile page'); }, xhr => { throw new Error(xhr.statusText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/how-to-use-passport-strategies.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/how-to-use-passport-strategies.english.md
@@ -26,9 +26,9 @@ Submit your page when you think you've got it right. If you're running into erro
 
 ```yml
 tests:
-  - text: All steps correctly implemented in the server.js
+  - text: All steps should be correctly implemented in the server.js.
     testString:  getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /showLogin:( |)true/gi, 'You should be passing the variable "showLogin" as true to your render function for the homepage'); assert.match(data, /failureRedirect:( |)('|")\/('|")/gi, 'Your code should include a failureRedirect to the "/" route'); assert.match(data, /login[^]*post[^]*local/gi, 'You should have a route for login which accepts a POST and passport.authenticates local'); }, xhr => { throw new Error(xhr.statusText); })
-  - text: A POST request to /login correctly redirects to /
+  - text: A POST request to /login should correctly redirect to /
     testString: getUserInput => $.post(getUserInput('url')+ '/login') .then(data => { assert.match(data, /Looks like this page is being rendered from Pug into HTML!/gi, 'A login attempt at this point should redirect to the homepage since we do not have any registered users'); }, xhr => { throw new Error(xhr.statusText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/how-to-use-passport-strategies.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/how-to-use-passport-strategies.english.md
@@ -28,7 +28,7 @@ Submit your page when you think you've got it right. If you're running into erro
 tests:
   - text: All steps should be correctly implemented in the server.js.
     testString:  getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /showLogin:( |)true/gi, 'You should be passing the variable "showLogin" as true to your render function for the homepage'); assert.match(data, /failureRedirect:( |)('|")\/('|")/gi, 'Your code should include a failureRedirect to the "/" route'); assert.match(data, /login[^]*post[^]*local/gi, 'You should have a route for login which accepts a POST and passport.authenticates local'); }, xhr => { throw new Error(xhr.statusText); })
-  - text: A POST request to /login should correctly redirect to /
+  - text: A POST request to /login should correctly redirect to /.
     testString: getUserInput => $.post(getUserInput('url')+ '/login') .then(data => { assert.match(data, /Looks like this page is being rendered from Pug into HTML!/gi, 'A login attempt at this point should redirect to the homepage since we do not have any registered users'); }, xhr => { throw new Error(xhr.statusText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/implement-the-serialization-of-a-passport-user.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/implement-the-serialization-of-a-passport-user.english.md
@@ -38,9 +38,9 @@ Submit your page when you think you've got it right. If you're running into erro
 
 ```yml
 tests:
-  - text: Database connection is present
+  - text: Database connection should be present.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /mongo.connect/gi, 'You should have created a connection to your database'); assert.match(data, /mongo.connect[^]*app.listen[^]*}[^]*}/gi, 'You should have your app.listen nested at within your database connection at the bottom'); }, xhr => { throw new Error(xhr.statusText); })
-  - text: Deserialization is now correctly using the DB and <code>done(null, null)</code> is erased
+  - text: Deserialization should now be correctly using the DB and <code>done(null, null)</code> should be erased.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.notMatch(data, /null,( |)null/gi, 'The callback in deserializeUser of (null, null) should be completely removed for the db block uncommented out'); }, xhr => { throw new Error(xhr.statusText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/implementation-of-social-authentication-ii.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/implementation-of-social-authentication-ii.english.md
@@ -39,11 +39,11 @@ Submit your page when you think you've got it right.
 
 ```yml
 tests:
-  - text: Dependency added
+  - text: passport-github dependency should be added.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/package.json') .then(data => { var packJson = JSON.parse(data); assert.property(packJson.dependencies, 'passport-github', 'Your project should list "passport-github" as a dependency'); }, xhr => { throw new Error(xhr.statusText); })
-  - text: Dependency required
+  - text: passport-github should be required.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /require.*("|')passport-github("|')/gi, 'You should have required passport-github'); }, xhr => { throw new Error(xhr.statusText); })
-  - text: GitHub strategy setup correctly thus far
+  - text: GitHub strategy should be setup correctly thus far.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /passport.use.*new GitHubStrategy/gi, 'Passport should use a new GitHubStrategy'); assert.match(data, /callbackURL:( |)("|').*("|')/gi, 'You should have a callbackURL'); assert.match(data, /process.env.GITHUB_CLIENT_SECRET/g, 'You should use process.env.GITHUB_CLIENT_SECRET'); assert.match(data, /process.env.GITHUB_CLIENT_ID/g, 'You should use process.env.GITHUB_CLIENT_ID'); }, xhr => { throw new Error(xhr.statusText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/implementation-of-social-authentication-iii.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/implementation-of-social-authentication-iii.english.md
@@ -47,7 +47,7 @@ You should be able to login to your app now- try it! Submit your page when you t
 
 ```yml
 tests:
-  - text: GitHub strategy setup complete
+  - text: GitHub strategy setup should be complete.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /GitHubStrategy[^]*db.collection/gi, 'Strategy should use now use the database to search for the user'); assert.match(data, /GitHubStrategy[^]*socialusers/gi, 'Strategy should use "socialusers" as db collection'); assert.match(data, /GitHubStrategy[^]*return cb/gi, 'Strategy should return the callback function "cb"'); }, xhr => { throw new Error(xhr.statusText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/implementation-of-social-authentication.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/implementation-of-social-authentication.english.md
@@ -34,9 +34,9 @@ Submit your page when you think you've got it right. If you're running into erro
 
 ```yml
 tests:
-  - text: Route /auth/github correct
+  - text: Route /auth/github should be correct.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /('|")\/auth\/github('|")[^]*get.*passport.authenticate.*github/gi, 'Route auth/github should only call passport.authenticate with github'); }, xhr => { throw new Error(xhr.statusText); })
-  - text: Route /auth/github/callback correct
+  - text: Route /auth/github/callback should be correct.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /('|")\/auth\/github\/callback('|")[^]*get.*passport.authenticate.*github.*failureRedirect:( |)("|')\/("|')/gi, 'Route auth/github/callback should accept a get request and call passport.authenticate for github with a failure redirect to home'); }, xhr => { throw new Error(xhr.statusText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/logging-a-user-out.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/logging-a-user-out.english.md
@@ -42,9 +42,9 @@ Submit your page when you think you've got it right.
 
 ```yml
 tests:
-  - text: Logout route
-    testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /req.logout/gi, 'You should be call req.logout() in youre /logout route'); }, xhr => { throw new Error(xhr.statusText); })
-  - text: Logout should redirect to the home page /
+  - text: <code>req.Logout</code> should be called in your <code>\/logout</code> route.
+    testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /req.logout/gi, 'You should be calling req.logout() in your /logout route'); }, xhr => { throw new Error(xhr.statusText); })
+  - text: Logout should redirect to the home page \/.
     testString: getUserInput => $.get(getUserInput('url')+ '/logout') .then(data => { assert.match(data, /Home page/gi, 'When a user logs out they should be redirected to the homepage'); }, xhr => { throw new Error(xhr.statusText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/logging-a-user-out.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/logging-a-user-out.english.md
@@ -42,7 +42,7 @@ Submit your page when you think you've got it right.
 
 ```yml
 tests:
-  - text: <code>req.Logout</code> should be called in your <code>\/logout</code> route.
+  - text: <code>req.Logout</code> should be called in your <code>/logout</code> route.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /req.logout/gi, 'You should be calling req.logout() in your /logout route'); }, xhr => { throw new Error(xhr.statusText); })
   - text: Logout should redirect to the home page \/.
     testString: getUserInput => $.get(getUserInput('url')+ '/logout') .then(data => { assert.match(data, /Home page/gi, 'When a user logs out they should be redirected to the homepage'); }, xhr => { throw new Error(xhr.statusText); })

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/logging-a-user-out.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/logging-a-user-out.english.md
@@ -44,7 +44,7 @@ Submit your page when you think you've got it right.
 tests:
   - text: <code>req.Logout</code> should be called in your <code>/logout</code> route.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /req.logout/gi, 'You should be calling req.logout() in your /logout route'); }, xhr => { throw new Error(xhr.statusText); })
-  - text: Logout should redirect to the home page \/.
+  - text: Logout should redirect to the home page.
     testString: getUserInput => $.get(getUserInput('url')+ '/logout') .then(data => { assert.match(data, /Home page/gi, 'When a user logs out they should be redirected to the homepage'); }, xhr => { throw new Error(xhr.statusText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/registration-of-new-users.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/registration-of-new-users.english.md
@@ -56,15 +56,15 @@ Submit your page when you think you've got it right. If you're running into erro
 
 ```yml
 tests:
-  - text: Register route and display on home
+  - text: You should register route and display on home.
     testString: 'getUserInput => $.get(getUserInput(''url'')+ ''/_api/server.js'') .then(data => { assert.match(data, /showRegistration:( |)true/gi, ''You should be passing the variable "showRegistration" as true to your render function for the homepage''); assert.match(data, /register[^]*post[^]*findOne[^]*username:( |)req.body.username/gi, ''You should have a route accepted a post request on register that querys the db with findone and the query being "username: req.body.username"''); }, xhr => { throw new Error(xhr.statusText); })'
-  - text: Registering should work
+  - text: Registering should work.
     testString: 'getUserInput => $.ajax({url: getUserInput(''url'')+ ''/register'',data: {username: ''freeCodeCampTester'', password: ''freeCodeCampTester''},crossDomain: true, type: ''POST'', xhrFields: { withCredentials: true }}) .then(data => { assert.match(data, /Profile/gi, ''I should be able to register and it direct me to my profile. CLEAR YOUR DATABASE if this test fails (each time until its right!)''); }, xhr => { throw new Error(xhr.statusText); })'
-  - text: Login should work
+  - text: Login should work.
     testString: 'getUserInput => $.ajax({url: getUserInput(''url'')+ ''/login'',data: {username: ''freeCodeCampTester'', password: ''freeCodeCampTester''}, type: ''POST'', xhrFields: { withCredentials: true }}) .then(data => { assert.match(data, /Profile/gi, ''Login should work if previous test was done successfully and redirect successfully to the profile. Check your work and clear your DB''); assert.match(data, /freeCodeCampTester/gi, ''The profile should properly display the welcome to the user logged in''); }, xhr => { throw new Error(xhr.statusText); })'
-  - text: Logout should work
+  - text: Logout should work.
     testString: 'getUserInput => $.ajax({url: getUserInput(''url'')+ ''/logout'', type: ''GET'', xhrFields: { withCredentials: true }}) .then(data => { assert.match(data, /Home/gi, ''Logout should redirect to home''); }, xhr => { throw new Error(xhr.statusText); })'
-  - text: Profile should no longer work after logout
+  - text: Profile should no longer work after logout.
     testString: 'getUserInput => $.ajax({url: getUserInput(''url'')+ ''/profile'', type: ''GET'', crossDomain: true, xhrFields: { withCredentials: true }}) .then(data => { assert.match(data, /Home/gi, ''Profile should redirect to home when we are logged out now again''); }, xhr => { throw new Error(xhr.statusText); })'
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/send-and-display-chat-messages.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/send-and-display-chat-messages.english.md
@@ -25,9 +25,9 @@ At this point the chat should be fully functional and sending messages across al
 
 ```yml
 tests:
-  - text: Server listens for 'chat message' then emits it properly
+  - text: Server should listen for 'chat message' and then emit it properly.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /socket.on.*('|")chat message('|")[^]*io.emit.*('|")chat message('|").*name.*message/gi, 'Your server should listen to the socket for "chat message" then emit to all users "chat message" with name and message in the data object'); }, xhr => { throw new Error(xhr.statusText); })
-  - text: Client properly handling and displaying the new data from event 'chat message'
+  - text: Client should properly handle and display the new data from event 'chat message'.
     testString: "getUserInput => $.get(getUserInput('url')+ '/public/client.js') .then(data => { assert.match(data, /socket.on.*('|\")chat message('|\")[^]*messages.*li/gi, 'You should append a list item to #messages on your client within the \"chat message\" event listener to display the new message'); }, xhr => { throw new Error(xhr.statusText); })"
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/serialization-of-a-user-object.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/serialization-of-a-user-object.english.md
@@ -40,13 +40,13 @@ Submit your page when you think you've got it right.
 
 ```yml
 tests:
-  - text: Serialize user function correct
+  - text: You should serialize user function correctly.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /passport.serializeUser/gi, 'You should have created your passport.serializeUser function'); assert.match(data, /null, user._id/gi, 'There should be a callback in your serializeUser with (null, user._id)'); }, xhr => { throw new Error(xhr.statusText); })
-  - text: Deserialize user function correct
+  - text: YOu should deserialize user function correctly.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /passport.deserializeUser/gi, 'You should have created your passport.deserializeUser function'); assert.match(data, /null,( |)null/gi, 'There should be a callback in your deserializeUser with (null, null) for now'); }, xhr => { throw new Error(xhr.statusText); })
-  - text: MongoDB is a dependency
+  - text: MongoDB should be a dependency.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/package.json') .then(data => { var packJson = JSON.parse(data); assert.property(packJson.dependencies, 'mongodb', 'Your project should list "mongodb" as a dependency'); }, xhr => { throw new Error(xhr.statusText); })
-  - text: Mongodb properly required including the ObjectId
+  - text: Mongodb should be properly required including the ObjectId.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /require.*("|')mongodb("|')/gi, 'You should have required mongodb'); assert.match(data, /new ObjectID.*id/gi, 'Even though the block is commented out, you should use new ObjectID(id) for when we add the database'); }, xhr => { throw new Error(xhr.statusText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/set-up-a-template-engine.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/set-up-a-template-engine.english.md
@@ -25,11 +25,11 @@ If all went as planned, you should refresh your apps home page and see a small m
 
 ```yml
 tests:
-  - text: Pug is a dependency
+  - text: Pug should be a dependency.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/package.json') .then(data => { var packJson = JSON.parse(data); assert.property(packJson.dependencies, 'pug', 'Your project should list "pug" as a dependency'); }, xhr => { throw new Error(xhr.statusText); })
-  - text: View engine is Pug
+  - text: View engine should be Pug.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /('|")view engine('|"),( |)('|")pug('|")/gi, 'Your project should set Pug as a view engine'); }, xhr => { throw new Error(xhr.statusText); })
-  - text: Pug is working
+  - text: Pug should be working.
     testString: getUserInput => $.get(getUserInput('url')+ '/') .then(data => { assert.match(data, /pug-success-message/gi, 'Your projects home page should now be rendered by pug with the projects .pug file unaltered'); }, xhr => { throw new Error(xhr.statusText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/set-up-passport.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/set-up-passport.english.md
@@ -36,13 +36,13 @@ Submit your page when you think you've got it right. If you're running into erro
 
 ```yml
 tests:
-  - text: Passort and Express-session are dependencies
+  - text: Passort and Express-session should be dependencies.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/package.json') .then(data => { var packJson = JSON.parse(data); assert.property(packJson.dependencies, 'passport', 'Your project should list "passport" as a dependency'); assert.property(packJson.dependencies, 'express-session', 'Your project should list "express-session" as a dependency'); }, xhr => { throw new Error(xhr.statusText); })
-  - text: Dependencies correctly required
+  - text: Dependencies should be correctly required.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /require.*("|')passport("|')/gi, 'You should have required passport'); assert.match(data, /require.*("|')express-session("|')/gi, 'You should have required express-session'); }, xhr => { throw new Error(xhr.statusText); })
-  - text: Express app uses new dependencies
+  - text: Express app should use new dependencies.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /passport.initialize/gi, 'Your express app should use "passport.initialize()"'); assert.match(data, /passport.session/gi, 'Your express app should use "passport.session()"'); }, xhr => { throw new Error(xhr.statusText); })
-  - text: Session and session secret correctly set up
+  - text: Session and session secret should be correctly set up.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /secret:( |)process.env.SESSION_SECRET/gi, 'Your express app should have express-session set up with your secret as process.env.SESSION_SECRET'); }, xhr => { throw new Error(xhr.statusText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/set-up-the-environment.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/set-up-the-environment.english.md
@@ -41,13 +41,13 @@ Submit your page when you think you've got it right.
 
 ```yml
 tests:
-  - text: Socket.IO is a dependency
+  - text: Socket.IO should be a dependency.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/package.json') .then(data => { var packJson = JSON.parse(data); assert.property(packJson.dependencies, 'socket.io', 'Your project should list "socket.io" as a dependency'); }, xhr => { throw new Error(xhr.statusText); })
   - text: You should correctly require and instantiate <code>socket.io</code> as <code>io</code>.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js').then(data => {assert.match(data, /io.*=.*require.*('|")socket.io('|").*http/gi, 'You should correctly require and instantiate socket.io as io.');}, xhr => { throw new Error(xhr.statusText); })
-  - text: Socket.IO should be listening for connections
+  - text: Socket.IO should be listening for connections.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /io.on.*('|")connection('|").*socket/gi, 'io should listen for "connection" and socket should be the 2nd arguments variable'); }, xhr => { throw new Error(xhr.statusText); })
-  - text: Your client should connect to your server
+  - text: Your client should connect to your server.
     testString: getUserInput => $.get(getUserInput('url')+ '/public/client.js') .then(data => { assert.match(data, /socket.*=.*io/gi, 'Your client should be connection to server with the connection defined as socket'); }, xhr => { throw new Error(xhr.statusText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/use-a-template-engines-powers.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/use-a-template-engines-powers.english.md
@@ -27,7 +27,7 @@ Now refresh your page and you should see those values rendered in your view in t
 
 ```yml
 tests:
-  - text: Pug render variables correct
+  - text: Pug should correctly render variables.
     testString: getUserInput => $.get(getUserInput('url')+ '/') .then(data => { assert.match(data, /pug-variable("|')>Please login/gi, 'Your projects home page should now be rendered by pug with the projects .pug file unaltered'); }, xhr => { throw new Error(xhr.statusText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/information-security-with-helmetjs/hash-and-compare-passwords-asynchronously.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/information-security-with-helmetjs/hash-and-compare-passwords-asynchronously.english.md
@@ -50,7 +50,7 @@ Submit your page when you think you've got it right.
 
 ```yml
 tests:
-  - text: Async hash generated and correctly compared
+  - text: Async hash should be generated and correctly compared.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /START_ASYNC[^]*bcrypt.hash.*myPlaintextPassword( |),( |)saltRounds( |),( |).*err( |),( |)hash[^]*END_ASYNC/gi, 'You should call bcrypt.hash on myPlaintextPassword and saltRounds and handle err and hash as a result in the callback'); assert.match(data, /START_ASYNC[^]*bcrypt.hash[^]*bcrypt.compare.*myPlaintextPassword( |),( |)hash( |),( |).*err( |),( |)res[^]*}[^]*}[^]*END_ASYNC/gi, 'Nested within the hash function should be the compare function comparing myPlaintextPassword to hash'); }, xhr => { throw new Error(xhr.statusText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/information-security-with-helmetjs/hash-and-compare-passwords-synchronously.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/information-security-with-helmetjs/hash-and-compare-passwords-synchronously.english.md
@@ -35,7 +35,7 @@ Submit your page when you think you've got it right.
 
 ```yml
 tests:
-  - text: Sync hash generated and correctly compared
+  - text: Sync hash should be generated and correctly compared.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /START_SYNC[^]*hash.*=.*bcrypt.hashSync.*myPlaintextPassword( |),( |)saltRounds[^]*END_SYNC/gi, 'You should call bcrypt.hashSync on myPlaintextPassword with saltRounds'); assert.match(data, /START_SYNC[^]*result.*=.*bcrypt.compareSync.*myPlaintextPassword( |),( |)hash[^]*END_SYNC/gi, 'You should call bcrypt.compareSync on myPlaintextPassword with the hash generated in the last line'); }, xhr => { throw new Error(xhr.statusText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/information-security-with-helmetjs/understand-bcrypt-hashes.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/information-security-with-helmetjs/understand-bcrypt-hashes.english.md
@@ -23,9 +23,9 @@ Submit your page when you think you've got it right.
 
 ```yml
 tests:
-  - text: BCrypt is a dependency
+  - text: BCrypt should be a dependency.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/package.json') .then(data => { var packJson = JSON.parse(data); assert.property(packJson.dependencies, 'bcrypt', 'Your project should list "bcrypt" as a dependency'); }, xhr => { throw new Error(xhr.statusText); })
-  - text: BCrypt has been properly required
+  - text: BCrypt should be properly required.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js').then(data => {assert.match(data, /bcrypt.*=.*require.*('|")bcrypt('|")/gi, 'You should correctly require and instantiate socket.io as io.');}, xhr => { throw new Error(xhr.statusText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/assert-deep-equality-with-.deepequal-and-.notdeepequal.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/assert-deep-equality-with-.deepequal-and-.notdeepequal.english.md
@@ -22,11 +22,11 @@ Use <code>assert.deepEqual()</code> or <code>assert.notDeepEqual()</code> to mak
 
 ```yml
 tests:
-  - text: All tests should pass
+  - text: All tests should pass.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=6').then(data => {assert.equal(data.state,'passed'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - deepEqual vs. notDeepEqual
+  - text: You should choose the right assertion - deepEqual vs. notDeepEqual.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=6').then(data => {  assert.equal(data.assertions[0].method, 'deepEqual', 'The order of the keys does not matter'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - deepEqual vs. notDeepEqual
+  - text: You should choose the right assertion - deepEqual vs. notDeepEqual.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=6').then(data => {  assert.equal(data.assertions[1].method, 'notDeepEqual', 'The position of elements within an array does matter'); }, xhr => { throw new Error(xhr.responseText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/compare-the-properties-of-two-elements.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/compare-the-properties-of-two-elements.english.md
@@ -21,15 +21,15 @@ Use <code>assert.isAbove()</code>(i.e. greater) or <code>assert.isAtMost()</code
 
 ```yml
 tests:
-  - text: All tests should pass
+  - text: All tests should pass.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=7').then(data => {assert.equal(data.state,'passed'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - isAbove vs. isAtMost
+  - text: You should choose the right assertion - isAbove vs. isAtMost.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=7').then(data => {  assert.equal(data.assertions[0].method, 'isAtMost', '5 is at most (<=) 5'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - isAbove vs. isAtMost
+  - text:  You should choose the right assertion - isAbove vs. isAtMost.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=7').then(data => {  assert.equal(data.assertions[1].method, 'isAbove', '1 is greater than 0'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - isAbove vs. isAtMost
+  - text: You should choose the right assertion - isAbove vs. isAtMost.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=7').then(data => {  assert.equal(data.assertions[2].method, 'isAbove', 'Math.PI = 3.14159265 is greater than 3'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - isAbove vs. isAtMost
+  - text: You should choose the right assertion - isAbove vs. isAtMost.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=7').then(data => {  assert.equal(data.assertions[3].method, 'isAtMost', '1 - Math.random() is > 0 and <= 1. It is atMost 1 !'); }, xhr => { throw new Error(xhr.responseText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/learn-how-javascript-assertions-work.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/learn-how-javascript-assertions-work.english.md
@@ -21,11 +21,11 @@ Use <code>assert.isNull()</code> or <code>assert.isNotNull()</code> to make the 
 
 ```yml
 tests:
-  - text: All tests should pass
+  - text: All tests should pass.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=0').then(data => {assert.equal(data.state,'passed'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - isNull vs. isNotNull
+  - text: You should choose the right assertion - isNull vs. isNotNull.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=0').then(data => {  assert.equal(data.assertions[0].method, 'isNull', 'Null is null'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - isNull vs. isNotNull
+  - text: You should choose the right assertion - isNull vs. isNotNull.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=0').then(data => {  assert.equal(data.assertions[1].method, 'isNotNull', '1 is not null'); }, xhr => { throw new Error(xhr.responseText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/run-functional-tests-on-an-api-response-using-chai-http-iii---put-method.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/run-functional-tests-on-an-api-response-using-chai-http-iii---put-method.english.md
@@ -49,15 +49,15 @@ Follow the assertion order above, We rely on it.
 
 ```yml
 tests:
-  - text: All tests should pass
+  - text: All tests should pass.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=2').then(data => { assert.equal(data.state,'passed'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: You should test for 'res.status' to be 200
+  - text: You should test for 'res.status' to be 200.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=2').then(data => { assert.equal(data.assertions[0].method, 'equal'); assert.equal(data.assertions[0].args[0], 'res.status'); assert.equal(data.assertions[0].args[1], '200');}, xhr => { throw new Error(xhr.responseText); })
-  - text: You should test for 'res.type' to be 'application/json'
+  - text: You should test for 'res.type' to be 'application/json'.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=2').then(data => { assert.equal(data.assertions[1].method, 'equal'); assert.equal(data.assertions[1].args[0], 'res.type'); assert.equal(data.assertions[1].args[1], '\'application/json\'');}, xhr => { throw new Error(xhr.responseText); })
-  - text: You should test for 'res.body.name' to be 'Cristoforo'
+  - text: You should test for 'res.body.name' to be 'Cristoforo'.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=2').then(data => { assert.equal(data.assertions[2].method, 'equal'); assert.equal(data.assertions[2].args[0], 'res.body.name'); assert.equal(data.assertions[2].args[1], '\'Cristoforo\'');}, xhr => { throw new Error(xhr.responseText); })
-  - text: You should test for 'res.body.surname' to be 'Colombo'
+  - text: You should test for 'res.body.surname' to be 'Colombo'.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=2').then(data => { assert.equal(data.assertions[3].method, 'equal'); assert.equal(data.assertions[3].args[0], 'res.body.surname'); assert.equal(data.assertions[3].args[1], '\'Colombo\'');}, xhr => { throw new Error(xhr.responseText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/run-functional-tests-using-a-headless-browser-ii.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/run-functional-tests-using-a-headless-browser-ii.english.md
@@ -22,15 +22,15 @@ Look at the code for directions. Follow the assertions order, We rely on it.
 
 ```yml
 tests:
-  - text: All tests should pass
+  - text: All tests should pass.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=5').then(data => { assert.equal(data.state,'passed'); }, xhr => { throw new Error(xhr.responseText); })
-  - text:  assert that the headless browser request succeeded
+  - text:  You should assert that the headless browser request succeeded.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=5').then(data => { assert.equal(data.assertions[0].method, 'browser.success'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: assert that the text inside the element 'span#name' is 'Amerigo'
+  - text: You should assert that the text inside the element 'span#name' is 'Amerigo'.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=5').then(data => { assert.equal(data.assertions[1].method, 'browser.text'); assert.equal(data.assertions[1].args[0], '\'span#name\''); assert.equal(data.assertions[1].args[1], '\'Amerigo\'');}, xhr => { throw new Error(xhr.responseText); })
-  - text: assert that the text inside the element 'span#surname' is 'Vespucci'
+  - text: You should assert that the text inside the element 'span#surname' is 'Vespucci'.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=5').then(data => { assert.equal(data.assertions[2].method, 'browser.text'); assert.equal(data.assertions[2].args[0], '\'span#surname\''); assert.equal(data.assertions[2].args[1], '\'Vespucci\'');}, xhr => { throw new Error(xhr.responseText); })
-  - text: assert that the element 'span#dates' exist and its count is 1
+  - text: You should assert that the element 'span#dates' exist and its count is 1.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=5').then(data => { assert.equal(data.assertions[3].method, 'browser.element'); assert.equal(data.assertions[3].args[0], '\'span#dates\''); assert.equal(data.assertions[3].args[1], 1);}, xhr => { throw new Error(xhr.responseText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/run-functional-tests-using-a-headless-browser.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/run-functional-tests-using-a-headless-browser.english.md
@@ -24,15 +24,15 @@ Look at the examples in the code for the exercise directions Follow the assertio
 
 ```yml
 tests:
-  - text: All tests should pass
+  - text: All tests should pass.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=4').then(data => { assert.equal(data.state,'passed'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: assert that the headless browser request succeeded
+  - text: You should assert that the headless browser request succeeded.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=4').then(data => { assert.equal(data.assertions[0].method, 'browser.success'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: assert that the text inside the element 'span#name' is 'Cristoforo'
+  - text: You should assert that the text inside the element 'span#name' is 'Cristoforo'.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=4').then(data => { assert.equal(data.assertions[1].method, 'browser.text'); assert.equal(data.assertions[1].args[0], '\'span#name\''); assert.equal(data.assertions[1].args[1], '\'Cristoforo\'');}, xhr => { throw new Error(xhr.responseText); })
-  - text: assert that the text inside the element 'span#surname' is 'Colombo'
+  - text: You should assert that the text inside the element 'span#surname' is 'Colombo'.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=4').then(data => { assert.equal(data.assertions[2].method, 'browser.text'); assert.equal(data.assertions[2].args[0], '\'span#surname\''); assert.equal(data.assertions[2].args[1], '\'Colombo\'');}, xhr => { throw new Error(xhr.responseText); })
-  - text: assert that the element 'span#dates' exist and its count is 1
+  - text: You should assert that the element 'span#dates' exist and its count is 1.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=functional&n=4').then(data => { assert.equal(data.assertions[3].method, 'browser.element'); assert.equal(data.assertions[3].args[0], '\'span#dates\''); assert.equal(data.assertions[3].args[1], 1);}, xhr => { throw new Error(xhr.responseText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/test-for-truthiness.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/test-for-truthiness.english.md
@@ -31,13 +31,13 @@ Use <code>assert.isTrue()</code> or <code>assert.isNotTrue()</code> to make the 
 
 ```yml
 tests:
-  - text: All tests should pass
+  - text: All tests should pass.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=3').then(data => {assert.equal(data.state,'passed'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - isTrue vs. isNotTrue
+  - text: You should choose the right assertion - isTrue vs. isNotTrue.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=3').then(data => {  assert.equal(data.assertions[0].method, 'isTrue', 'True is true'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - isTrue vs. isNotTrue
+  - text: You should choose the right assertion - isTrue vs. isNotTrue.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=3').then(data => {  assert.equal(data.assertions[1].method, 'isTrue', 'Double negation of a truthy value is true'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - isTrue vs. isNotTrue
+  - text: You should choose the right assertion - isTrue vs. isNotTrue.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=3').then(data => {  assert.equal(data.assertions[2].method, 'isNotTrue', 'A truthy object is not true - neither is a false one'); }, xhr => { throw new Error(xhr.responseText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/test-if-a-string-contains-a-substring.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/test-if-a-string-contains-a-substring.english.md
@@ -25,11 +25,11 @@ Use <code>assert.include()</code> or <code>assert.notInclude()</code> to make th
 
 ```yml
 tests:
-  - text: All tests should pass
+  - text: All tests should pass.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=13').then(data => { assert.equal(data.state,'passed'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - include vs. notInclude
+  - text: You should choose the right assertion - include vs. notInclude.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=13').then(data => {  assert.equal(data.assertions[0].method, 'include', '\'Arrow\' contains \'row\'...'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - include vs. notInclude
+  - text: You should choose the right assertion - include vs. notInclude.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=13').then(data => {  assert.equal(data.assertions[1].method, 'notInclude', '... a \'dart\' doesn\'t contain a \'queue\''); }, xhr => { throw new Error(xhr.responseText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/test-if-a-value-falls-within-a-specific-range.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/test-if-a-value-falls-within-a-specific-range.english.md
@@ -24,11 +24,11 @@ Choose the minimum range (3rd parameter) to make the test always pass. It should
 
 ```yml
 tests:
-  - text: All tests should pass
+  - text: All tests should pass.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=9').then(data => {assert.equal(data.state,'passed'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Use approximately(actual, expected, range) - Chose the correct range
+  - text: You should use approximately(actual, expected, range) - You should Chose the correct range.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=9').then(data => {  assert.equal(data.assertions[0].method, 'approximately');  assert.equal(data.assertions[0].args[2], 0.5, 'weirdNumbers(0.5) is in the range (0.5, 1.5]. It\'s within 1 +/- 0.5'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Use approximately(actual, expected, range) - Chose the correct range
+  - text: You should use approximately(actual, expected, range) - You should chose the correct range.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=9').then(data => {  assert.equal(data.assertions[1].method, 'approximately');  assert.equal(data.assertions[1].args[2], 0.8, 'weirdNumbers(0.2) is in the range (0.2, 1.2]. It\'s within 1 +/- 0.8'); }, xhr => { throw new Error(xhr.responseText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/test-if-a-value-falls-within-a-specific-range.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/test-if-a-value-falls-within-a-specific-range.english.md
@@ -28,7 +28,7 @@ tests:
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=9').then(data => {assert.equal(data.state,'passed'); }, xhr => { throw new Error(xhr.responseText); })
   - text: You should use approximately(actual, expected, range) - You should Chose the correct range.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=9').then(data => {  assert.equal(data.assertions[0].method, 'approximately');  assert.equal(data.assertions[0].args[2], 0.5, 'weirdNumbers(0.5) is in the range (0.5, 1.5]. It\'s within 1 +/- 0.5'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: You should use approximately(actual, expected, range) - You should chose the correct range.
+  - text: You should use approximately(actual, expected, range) - You should choose the correct range.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=9').then(data => {  assert.equal(data.assertions[1].method, 'approximately');  assert.equal(data.assertions[1].args[2], 0.8, 'weirdNumbers(0.2) is in the range (0.2, 1.2]. It\'s within 1 +/- 0.8'); }, xhr => { throw new Error(xhr.responseText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/test-if-a-value-falls-within-a-specific-range.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/test-if-a-value-falls-within-a-specific-range.english.md
@@ -26,7 +26,7 @@ Choose the minimum range (3rd parameter) to make the test always pass. It should
 tests:
   - text: All tests should pass.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=9').then(data => {assert.equal(data.state,'passed'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: You should use approximately(actual, expected, range) - You should Chose the correct range.
+  - text: You should use approximately(actual, expected, range) - You should choose the correct range.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=9').then(data => {  assert.equal(data.assertions[0].method, 'approximately');  assert.equal(data.assertions[0].args[2], 0.5, 'weirdNumbers(0.5) is in the range (0.5, 1.5]. It\'s within 1 +/- 0.5'); }, xhr => { throw new Error(xhr.responseText); })
   - text: You should use approximately(actual, expected, range) - You should choose the correct range.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=9').then(data => {  assert.equal(data.assertions[1].method, 'approximately');  assert.equal(data.assertions[1].args[2], 0.8, 'weirdNumbers(0.2) is in the range (0.2, 1.2]. It\'s within 1 +/- 0.8'); }, xhr => { throw new Error(xhr.responseText); })

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/test-if-a-value-is-a-string.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/test-if-a-value-is-a-string.english.md
@@ -21,13 +21,13 @@ Use <code>assert.isString()</code> or <code>assert.isNotString()</code> to make 
 
 ```yml
 tests:
-  - text: All tests should pass
+  - text: All tests should pass.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=12').then(data => { assert.equal(data.state,'passed'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - isString vs. isNotString
+  - text: You should choose the right assertion - isString vs. isNotString.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=12').then(data => {  assert.equal(data.assertions[0].method, 'isNotString', 'A float number is not a string'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - isString vs. isNotString
+  - text: You should choose the right assertion - isString vs. isNotString.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=12').then(data => {  assert.equal(data.assertions[1].method, 'isString', 'environment vars are strings (or undefined)'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - isString vs. isNotString
+  - text: You should choose the right assertion - isString vs. isNotString.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=12').then(data => {  assert.equal(data.assertions[2].method, 'isString', 'A JSON is a string'); }, xhr => { throw new Error(xhr.responseText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/test-if-a-value-is-an-array.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/test-if-a-value-is-an-array.english.md
@@ -20,11 +20,11 @@ Use <code>assert.isArray()</code> or <code>assert.isNotArray()</code> to make th
 
 ```yml
 tests:
-  - text: All tests should pass
+  - text: All tests should pass.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=10').then(data => {assert.equal(data.state,'passed'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - isArray vs. isNotArray
+  - text: You should choose the right assertion - isArray vs. isNotArray.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=10').then(data => {  assert.equal(data.assertions[0].method, 'isArray', 'String.prototype.split() returns an Array'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - isArray vs. isNotArray
+  - text: You should choose the right assertion - isArray vs. isNotArray.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=10').then(data => {  assert.equal(data.assertions[1].method, 'isNotArray', 'Array.prototype.indexOf() returns a number'); }, xhr => { throw new Error(xhr.responseText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/test-if-a-value-is-of-a-specific-data-structure-type.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/test-if-a-value-is-of-a-specific-data-structure-type.english.md
@@ -22,17 +22,17 @@ Use <code>assert.typeOf()</code> or <code>assert.notTypeOf()</code> to make the 
 
 ```yml
 tests:
-  - text: All tests should pass
+  - text: All tests should pass.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=16').then(data => { assert.equal(data.state,'passed'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - typeOf vs. notTypeOf
+  - text: You should choose the right assertion - typeOf vs. notTypeOf.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=16').then(data => { assert.equal(data.assertions[0].method, 'typeOf', 'myCar is typeOf Object'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - typeOf vs. notTypeOf
+  - text: You should choose the right assertion - typeOf vs. notTypeOf.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=16').then(data => { assert.equal(data.assertions[1].method, 'typeOf', 'Car.model is a String'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - typeOf vs. notTypeOf
+  - text: You should choose the right assertion - typeOf vs. notTypeOf.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=16').then(data => { assert.equal(data.assertions[2].method, 'notTypeOf', 'Plane.wings is a Number (not a String)'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - typeOf vs. notTypeOf
+  - text: You should choose the right assertion - typeOf vs. notTypeOf.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=16').then(data => { assert.equal(data.assertions[3].method, 'typeOf', 'Plane.engines is an Array'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - typeOf vs. notTypeOf
+  - text: You should choose the right assertion - typeOf vs. notTypeOf.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=16').then(data => { assert.equal(data.assertions[4].method, 'typeOf', 'Car.wheels is a Number'); }, xhr => { throw new Error(xhr.responseText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/test-if-a-variable-or-function-is-defined.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/test-if-a-variable-or-function-is-defined.english.md
@@ -21,13 +21,13 @@ Use <code>assert.isDefined()</code> or <code>assert.isUndefined()</code> to make
 
 ```yml
 tests:
-  - text: All tests should pass
+  - text: All tests should pass.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=1').then(data => {assert.equal(data.state,'passed'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - isDefined vs. isUndefined
+  - text: You should choose the right assertion - isDefined vs. isUndefined.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=1').then(data => {  assert.equal(data.assertions[0].method, 'isDefined', 'Null is not undefined'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - isDefined vs. isUndefined
+  - text: You should choose the right assertion - isDefined vs. isUndefined.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=1').then(data => {  assert.equal(data.assertions[1].method, 'isUndefined', 'Undefined is undefined'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - isDefined vs. isUndefined
+  - text: You should choose the right assertion - isDefined vs. isUndefined.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=1').then(data => {  assert.equal(data.assertions[2].method, 'isDefined', 'A string is not undefined'); }, xhr => { throw new Error(xhr.responseText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/test-if-an-array-contains-an-item.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/test-if-an-array-contains-an-item.english.md
@@ -20,11 +20,11 @@ Use <code>assert.include()</code> or <code>assert.notInclude()</code> to make th
 
 ```yml
 tests:
-  - text: All tests should pass
+  - text: All tests should pass.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=11').then(data => { assert.equal(data.state,'passed'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - include vs. notInclude
+  - text: You should choose the right assertion - include vs. notInclude.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=11').then(data => {  assert.equal(data.assertions[0].method, 'notInclude', 'It\'s summer in july...'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - include vs. notInclude
+  - text: You should choose the right assertion - include vs. notInclude.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=11').then(data => {  assert.equal(data.assertions[1].method, 'include', 'JavaScript is a backend language !!'); }, xhr => { throw new Error(xhr.responseText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/test-if-an-object-has-a-property.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/test-if-an-object-has-a-property.english.md
@@ -22,13 +22,13 @@ Use <code>assert.property()</code> or <code>assert.notProperty()</code> to make 
 
 ```yml
 tests:
-  - text: All tests should pass
+  - text: All tests should pass.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=15').then(data => { assert.equal(data.state,'passed'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - property vs. notProperty
+  - text: You should choose the right assertion - property vs. notProperty.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=15').then(data => { assert.equal(data.assertions[0].method, 'notProperty', 'A car has not wings'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - property vs. notProperty
+  - text: You should choose the right assertion - property vs. notProperty.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=15').then(data => { assert.equal(data.assertions[1].method, 'property', 'planes have engines'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - property vs. notProperty
+  - text: You should choose the right assertion - property vs. notProperty.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=15').then(data => { assert.equal(data.assertions[2].method, 'property', 'Cars have wheels'); }, xhr => { throw new Error(xhr.responseText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/test-if-an-object-is-an-instance-of-a-constructor.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/test-if-an-object-is-an-instance-of-a-constructor.english.md
@@ -22,15 +22,15 @@ Use <code>assert.instanceOf()</code> or <code>assert.notInstanceOf()</code> to m
 
 ```yml
 tests:
-  - text: All tests should pass
+  - text: All tests should pass.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=17').then(data => { assert.equal(data.state,'passed'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - instanceOf vs. notInstanceOf
+  - text: You should choose the right assertion - instanceOf vs. notInstanceOf.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=17').then(data => { assert.equal(data.assertions[0].method, 'notInstanceOf', 'myCar is not an instance of Plane'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - instanceOf vs. notInstanceOf
+  - text: You should choose the right assertion - instanceOf vs. notInstanceOf.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=17').then(data => { assert.equal(data.assertions[1].method, 'instanceOf', 'airlinePlane is an instance of Plane'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - instanceOf vs. notInstanceOf
+  - text: You should choose the right assertion - instanceOf vs. notInstanceOf.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=17').then(data => { assert.equal(data.assertions[2].method, 'instanceOf', 'everything is an Object in JavaScript...'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - instanceOf vs. notInstanceOf
+  - text: You should choose the right assertion - instanceOf vs. notInstanceOf.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=17').then(data => { assert.equal(data.assertions[3].method, 'notInstanceOf', 'myCar.wheels is not an instance of String'); }, xhr => { throw new Error(xhr.responseText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/test-if-one-value-is-below-or-at-least-as-large-as-another.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/test-if-one-value-is-below-or-at-least-as-large-as-another.english.md
@@ -21,15 +21,15 @@ Use <code>assert.isBelow()</code> (i.e. less than) or <code>assert.isAtLeast()</
 
 ```yml
 tests:
-  - text: All tests should pass
+  - text: All tests should pass.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=8').then(data => {assert.equal(data.state,'passed'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - isBelow vs. isAtLeast
+  - text: You should choose the right assertion - isBelow vs. isAtLeast.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=8').then(data => {  assert.equal(data.assertions[0].method, 'isAtLeast', '5 is at least (>=) 5'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - isBelow vs. isAtLeast
+  - text: You should choose the right assertion - isBelow vs. isAtLeast.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=8').then(data => {  assert.equal(data.assertions[1].method, 'isAtLeast', '2 * Math.random() is at least 0'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - isBelow vs. isAtLeast
+  - text: You should choose the right assertion - isBelow vs. isAtLeast.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=8').then(data => {  assert.equal(data.assertions[2].method, 'isBelow', '1 is smaller than 2'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - isBelow vs. isAtLeast
+  - text: You should choose the right assertion - isBelow vs. isAtLeast.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=8').then(data => {  assert.equal(data.assertions[3].method, 'isBelow', '2/3 (0.6666) is smaller than 1'); }, xhr => { throw new Error(xhr.responseText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/use-assert.isok-and-assert.isnotok.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/use-assert.isok-and-assert.isnotok.english.md
@@ -26,13 +26,13 @@ Use <code>assert.isOk()</code> or <code>assert.isNotOk()</code> to make the test
 
 ```yml
 tests:
-  - text: All tests should pass
+  - text: All tests should pass.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=2').then(data => {assert.equal(data.state,'passed'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - isOk vs. isNotOk
+  - text: You should choose the right assertion - isOk vs. isNotOk.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=2').then(data => {  assert.equal(data.assertions[0].method, 'isNotOk', 'Null is falsey'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - isOk vs. isNotOk
+  - text: You should choose the right assertion - isOk vs. isNotOk.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=2').then(data => {  assert.equal(data.assertions[1].method, 'isOk','A string is truthy'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - isOk vs. isNotOk
+  - text: You should choose the right assertion - isOk vs. isNotOk.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=2').then(data => {  assert.equal(data.assertions[2].method, 'isOk', 'true is truthy'); }, xhr => { throw new Error(xhr.responseText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/use-regular-expressions-to-test-a-string.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/use-regular-expressions-to-test-a-string.english.md
@@ -22,11 +22,11 @@ Use <code>assert.match()</code> to make the tests pass.
 
 ```yml
 tests:
-  - text: All tests should pass
+  - text: All tests should pass.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=14').then(data => { assert.equal(data.state,'passed'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - match vs. notMatch
+  - text: You should choose the right assertion - match vs. notMatch.
     testString: 'getUserInput => $.get(getUserInput(''url'') + ''/_api/get-tests?type=unit&n=14'').then(data => {  assert.equal(data.assertions[0].method, ''match'', ''\''# name: John Doe, age: 35\'' matches the regex''); }, xhr => { throw new Error(xhr.responseText); })'
-  - text: Choose the right assertion - match vs. notMatch
+  - text: You should choose the right assertion - match vs. notMatch.
     testString: 'getUserInput => $.get(getUserInput(''url'') + ''/_api/get-tests?type=unit&n=14'').then(data => {  assert.equal(data.assertions[1].method, ''notMatch'', ''\''# name: Paul Smith III, age: twenty-four\'' does not match the regex (the age must be numeric)''); }, xhr => { throw new Error(xhr.responseText); })'
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/use-the-double-equals-to-assert-equality.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/use-the-double-equals-to-assert-equality.english.md
@@ -22,15 +22,15 @@ Use <code>assert.equal()</code> or <code>assert.notEqual()</code> to make the te
 
 ```yml
 tests:
-  - text: All tests should pass
+  - text: All tests should pass.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=4').then(data => {assert.equal(data.state,'passed'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - equal vs. notEqual
+  - text: You should choose the right assertion - equal vs. notEqual.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=4').then(data => {  assert.equal(data.assertions[0].method, 'equal', 'Numbers are coerced into strings with == '); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - equal vs. notEqual
+  - text: You should choose the right assertion - equal vs. notEqual.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=4').then(data => {  assert.equal(data.assertions[1].method, 'notEqual', ' == compares object references'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - equal vs. notEqual
+  - text: You should choose the right assertion - equal vs. notEqual.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=4').then(data => {  assert.equal(data.assertions[2].method, 'equal', '6 * \'2\' is 12 ! It should be equal to \'12\''); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - equal vs. notEqual
+  - text: You should choose the right assertion - equal vs. notEqual.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=4').then(data => {  assert.equal(data.assertions[3].method, 'notEqual', '6 + \'2\' is \'62\'...'); }, xhr => { throw new Error(xhr.responseText); })
 
 ```

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/use-the-triple-equals-to-assert-strict-equality.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/use-the-triple-equals-to-assert-strict-equality.english.md
@@ -22,15 +22,15 @@ Use <code>assert.strictEqual()</code> or <code>assert.notStrictEqual()</code> to
 
 ```yml
 tests:
-  - text: All tests should pass
+  - text: All tests should pass.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=5').then(data => {assert.equal(data.state,'passed'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - strictEqual vs. notStrictEqual
+  - text: You should choose the right assertion - strictEqual vs. notStrictEqual.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=5').then(data => {  assert.equal(data.assertions[0].method, 'notStrictEqual', 'with strictEqual the type must match'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - strictEqual vs. notStrictEqual
+  - text: You should choose the right assertion - strictEqual vs. notStrictEqual.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=5').then(data => {  assert.equal(data.assertions[1].method, 'strictEqual', '3*2 = 6...'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - strictEqual vs. notStrictEqual
+  - text: You should choose the right assertion - strictEqual vs. notStrictEqual.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=5').then(data => {  assert.equal(data.assertions[2].method, 'strictEqual', '6 * \'2\' is 12. Types match !'); }, xhr => { throw new Error(xhr.responseText); })
-  - text: Choose the right assertion - strictEqual vs. notStrictEqual
+  - text: You should choose the right assertion - strictEqual vs. notStrictEqual.
     testString: getUserInput => $.get(getUserInput('url') + '/_api/get-tests?type=unit&n=5').then(data => {  assert.equal(data.assertions[3].method, 'notStrictEqual', 'Even if they have the same elements, the Arrays are notStrictEqual'); }, xhr => { throw new Error(xhr.responseText); })
 
 ```


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Related to PR #36860 

This PR makes sure all challenges' tests in the `Information Security and Quality Assurance` section use "should " or "should not".