### PR TITLE
fix(curriculum): changed test text to use should for Coding Interview Prep - part 2 of 2

### DIFF
--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-1-multiples-of-3-and-5.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-1-multiples-of-3-and-5.english.md
@@ -27,7 +27,7 @@ tests:
     testString: assert.strictEqual(multiplesOf3and5(49), 543);
   - text: <code>multiplesOf3and5(19564)</code> should return 89301183.
     testString: assert.strictEqual(multiplesOf3and5(19564), 89301183);
-  - text: Your function is not returning the correct result using our tests values.
+  - text: <code>multiplesOf3and5(8456)</code> should return 16687353.
     testString: assert.strictEqual(multiplesOf3and5(8456), 16687353);
 
 ```

--- a/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-32-pandigital-products.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/project-euler/problem-32-pandigital-products.english.md
@@ -26,7 +26,7 @@ HINT: Some products can be obtained in more than one way so be sure to only incl
 
 ```yml
 tests:
-  - text: <code>pandigitalProducts()</code> is a function.
+  - text: <code>pandigitalProducts()</code> should be a function.
     testString: assert(typeof pandigitalProducts === 'function');
   - text: <code>pandigitalProducts()</code> should return 45228.
     testString: assert.strictEqual(pandigitalProducts(), 45228);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/100-doors.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/100-doors.english.md
@@ -20,11 +20,11 @@ Implement a function to determine the state of the doors after the last pass. Re
 
 ```yml
 tests:
-  - text: <code>getFinalOpenedDoors</code> is a function.
+  - text: <code>getFinalOpenedDoors</code> should be a function.
     testString: assert(typeof getFinalOpenedDoors === 'function');
   - text: <code>getFinalOpenedDoors</code> should return an array.
     testString: assert(Array.isArray(getFinalOpenedDoors(100)));
-  - text: <code>getFinalOpenedDoors</code> did not produce the correct results.
+  - text: <code>getFinalOpenedDoors</code> should produce the correct result.
     testString: assert.deepEqual(getFinalOpenedDoors(100), solution);
 
 ```

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/24-game.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/24-game.english.md
@@ -36,7 +36,7 @@ Implement a function that takes a string of four digits as its argument, with ea
 
 ```yml
 tests:
-  - text: <code>solve24</code> is a function.
+  - text: <code>solve24</code> should be a function.
     testString: assert(typeof solve24 === 'function');
   - text: <code>solve24("4878")</code> should return <code>(7-8/8)*4</code> or <code>4*(7-8/8)</code>
     testString: assert(include(answers[0], solve24(testCases[0])));

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/9-billion-names-of-god-the-integer.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/9-billion-names-of-god-the-integer.english.md
@@ -40,7 +40,7 @@ Implement a function that returns the sum of the  $n$-th  row.
 
 ```yml
 tests:
-  - text: <code>numberOfNames</code> is a function.
+  - text: <code>numberOfNames</code> should be function.
     testString: assert(typeof numberOfNames === 'function');
   - text: <code>numberOfNames(5)</code> should equal 7.
     testString: assert.equal(numberOfNames(5), 7);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/abc-problem.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/abc-problem.english.md
@@ -47,7 +47,7 @@ Some rules to keep in mind:
 
 ```yml
 tests:
-  - text: <code>canMakeWord</code> is a function.
+  - text: <code>canMakeWord</code> should be a function.
     testString: assert(typeof canMakeWord === 'function');
   - text: <code>canMakeWord</code> should return a boolean.
     testString: assert(typeof canMakeWord('hi') === 'boolean');

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/abundant-deficient-and-perfect-number-classifications.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/abundant-deficient-and-perfect-number-classifications.english.md
@@ -31,7 +31,7 @@ Implement a function that calculates how many of the integers from <code>1</code
 
 ```yml
 tests:
-  - text: <code>getDPA</code> is a function.
+  - text: <code>getDPA</code> should be a function.
     testString: assert(typeof getDPA === 'function');
   - text: <code>getDPA</code> should return an array.
     testString: assert(Array.isArray(getDPA(100)));

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/accumulator-factory.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/accumulator-factory.english.md
@@ -24,7 +24,7 @@ Closures save outer state.
 
 ```yml
 tests:
-  - text: <code>accumulator</code> is a function.
+  - text: <code>accumulator</code> should be a function.
     testString: assert(typeof accumulator === 'function');
   - text: <code>accumulator(0)</code> should return a function.
     testString: assert(typeof accumulator(0) === 'function');

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/ackermann-function.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/ackermann-function.english.md
@@ -23,7 +23,7 @@ Write a function which returns the value of $A(m, n)$. Arbitrary precision is pr
 
 ```yml
 tests:
-  - text: <code>ack</code> is a function.
+  - text: <code>ack</code> should be a function.
     testString: assert(typeof ack === 'function');
   - text: <code>ack(0, 0)</code> should return 1.
     testString: assert(ack(0, 0) === 1);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/align-columns.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/align-columns.english.md
@@ -43,7 +43,7 @@ or$center$justified$within$its$column.
 
 ```yml
 tests:
-  - text: <code>formatText</code> is a function.
+  - text: <code>formatText</code> should be a function.
     testString: assert(typeof formatText === 'function');
   - text: '<code>formatText</code> with the above input and "right" justification should produce the following: '
     testString: 'assert.strictEqual(formatText(testInput, ''right''), rightAligned);'

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/amicable-pairs.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/amicable-pairs.english.md
@@ -26,7 +26,7 @@ Calculate and show here the Amicable pairs below 20,000 (there are eight).
 
 ```yml
 tests:
-  - text: <code>amicablePairsUpTo</code> is a function.
+  - text: <code>amicablePairsUpTo</code> should be a function.
     testString: assert(typeof amicablePairsUpTo === 'function');
   - text: <code>amicablePairsUpTo(300)</code> should return <code>[[220,284]]</code>.
     testString: assert.deepEqual(amicablePairsUpTo(300), answer300);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/averages-mode.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/averages-mode.english.md
@@ -22,7 +22,7 @@ If it is not appropriate or possible to support a general collection, use a vect
 
 ```yml
 tests:
-  - text: <code>mode</code> is a function.
+  - text: <code>mode</code> should be a function.
     testString: assert(typeof mode === 'function');
   - text: <code>mode([1, 3, 6, 6, 6, 6, 7, 7, 12, 12, 17])</code> should equal <code>[6]</code>
     testString: assert.deepEqual(mode(arr1), [6]);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/averages-pythagorean-means.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/averages-pythagorean-means.english.md
@@ -42,7 +42,7 @@ For the answer, please output an object in the following format:
 
 ```yml
 tests:
-  - text: <code>pythagoreanMeans</code> is a function.
+  - text: <code>pythagoreanMeans</code> should be a function.
     testString: assert(typeof pythagoreanMeans === 'function');
   - text: <code>pythagoreanMeans([1, 2, ..., 10])</code> should equal the same output above.
     testString: assert.deepEqual(pythagoreanMeans(range1), answer1);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/averages-root-mean-square.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/averages-root-mean-square.english.md
@@ -23,7 +23,7 @@ The RMS is calculated as the mean of the squares of the numbers, square-rooted:
 
 ```yml
 tests:
-  - text: <code>rms</code> is a function.
+  - text: <code>rms</code> should be a function.
     testString: assert(typeof rms === 'function');
   - text: <code>rms([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])</code> should equal <code>6.2048368229954285</code>.
     testString: assert.equal(rms(arr1), answer1);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/babbage-problem.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/babbage-problem.english.md
@@ -26,7 +26,7 @@ Implement a function to return the lowest integer that satisfies the Babbage pro
 
 ```yml
 tests:
-  - text: <code>babbage</code> is a function.
+  - text: <code>babbage</code> should be a function.
     testString: assert(typeof babbage === 'function');
   - text: <code>babbage(99736, 269696)</code> should not return 99736 (there is a smaller answer).
     testString: assert.equal(babbage(babbageAns, endDigits), answer);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/balanced-brackets.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/balanced-brackets.english.md
@@ -30,7 +30,7 @@ Determine whether a generated string of brackets is balanced; that is, whether i
 
 ```yml
 tests:
-  - text: <code>isBalanced</code> is a function.
+  - text: <code>isBalanced</code> should be a function.
     testString: assert(typeof isBalanced === 'function');
   - text: <code>isBalanced("[]")</code> should return true.
     testString: assert(isBalanced(testCases[0]));

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/circles-of-given-radius-through-two-points.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/circles-of-given-radius-through-two-points.english.md
@@ -42,7 +42,7 @@ Implement a function that takes two points and a radius and returns the two circ
 
 ```yml
 tests:
-  - text: <code>getCircles</code> is a function.
+  - text: <code>getCircles</code> should be a function.
     testString: assert(typeof getCircles === 'function');
   - text: <code>getCircles([0.1234, 0.9876], [0.8765, 0.2345], 2.0)</code> should return <code>[[1.8631, 1.9742], [-0.8632, -0.7521]]</code>.
     testString: assert.deepEqual(getCircles(...testCases[0]), answers[0]);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/closest-pair-problem.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/closest-pair-problem.english.md
@@ -81,7 +81,7 @@ For the input, expect the argument to be an array of objects (points) with <code
 
 ```yml
 tests:
-  - text: <code>getClosestPair</code> is a function.
+  - text: <code>getClosestPair</code> should be a function.
     testString: assert(typeof getClosestPair === 'function');
   - text: Distance should be the following.
     testString: assert.equal(getClosestPair(points1).distance, answer1.distance);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/combinations.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/combinations.english.md
@@ -34,7 +34,7 @@ Given non-negative integers <code>m</code> and <code>n</code>, generate all size
 
 ```yml
 tests:
-  - text: <code>combinations</code> is a function.
+  - text: <code>combinations</code> should be a function.
     testString: assert(typeof combinations === 'function');
   - text: <code>combinations(3, 5)</code> should return <code>[[0, 1, 2], [0, 1, 3], [0, 1, 4], [0, 2, 3], [0, 2, 4], [0, 3, 4], [1, 2, 3], [1, 2, 4], [1, 3, 4], [2, 3, 4]]</code>.
     testString: assert.deepEqual(combinations(testInput1[0], testInput1[1]), testOutput1);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/comma-quibbling.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/comma-quibbling.english.md
@@ -34,7 +34,7 @@ Test your function with the following series of inputs showing your output here 
 
 ```yml
 tests:
-  - text: <code>quibble</code> is a function.
+  - text: <code>quibble</code> should be a function.
     testString: assert(typeof quibble === 'function');
   - text: <code>quibble(["ABC"])</code> should return a string.
     testString: assert(typeof quibble(["ABC"]) === 'string');

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/compare-a-list-of-strings.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/compare-a-list-of-strings.english.md
@@ -24,29 +24,29 @@ Given a <a href="https://en.wikipedia.org/wiki/List_(abstract_data_type)" title=
 
 ```yml
 tests:
-  - text: <code>allEqual</code> is a function.
+  - text: <code>allEqual</code> should be a function.
     testString: assert(typeof allEqual === 'function');
-  - text: <code>azSorted</code> is a function.
+  - text: <code>azSorted</code> should be a function.
     testString: assert(typeof azSorted === 'function');
-  - text: <code>allEqual(["AA", "AA", "AA", "AA"])</code> returns true.
+  - text: <code>allEqual(["AA", "AA", "AA", "AA"])</code> should return true.
     testString: assert(allEqual(testCases[0]));
-  - text: <code>azSorted(["AA", "AA", "AA", "AA"])</code> returns false.
+  - text: <code>azSorted(["AA", "AA", "AA", "AA"])</code> should return false.
     testString: assert(!azSorted(testCases[0]));
-  - text: <code>allEqual(["AA", "ACB", "BB", "CC"])</code> returns false.
+  - text: <code>allEqual(["AA", "ACB", "BB", "CC"])</code> should return false.
     testString: assert(!allEqual(testCases[1]));
-  - text: <code>azSorted(["AA", "ACB", "BB", "CC"])</code> returns true.
+  - text: <code>azSorted(["AA", "ACB", "BB", "CC"])</code> should return true.
     testString: assert(azSorted(testCases[1]));
-  - text: <code>allEqual([])</code> returns true.
+  - text: <code>allEqual([])</code> should return true.
     testString: assert(allEqual(testCases[2]));
-  - text: <code>azSorted([])</code> returns true.
+  - text: <code>azSorted([])</code> should return true.
     testString: assert(azSorted(testCases[2]));
-  - text: <code>allEqual(["AA"])</code> returns true.
+  - text: <code>allEqual(["AA"])</code> should return true.
     testString: assert(allEqual(testCases[3]));
-  - text: <code>azSorted(["AA"])</code> returns true.
+  - text: <code>azSorted(["AA"])</code> should return true.
     testString: assert(azSorted(testCases[3]));
-  - text: <code>allEqual(["BB", "AA"])</code> returns false.
+  - text: <code>allEqual(["BB", "AA"])</code> should return false.
     testString: assert(!allEqual(testCases[4]));
-  - text: <code>azSorted(["BB", "AA"])</code> returns false.
+  - text: <code>azSorted(["BB", "AA"])</code> should return false.
     testString: assert(!azSorted(testCases[4]));
 
 ```

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/convert-seconds-to-compound-duration.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/convert-seconds-to-compound-duration.english.md
@@ -55,7 +55,7 @@ Demonstrate that it passes the following three test-cases:
 
 ```yml
 tests:
-  - text: <code>convertSeconds</code> is a function.
+  - text: <code>convertSeconds</code> should be a function.
     testString: assert(typeof convertSeconds === 'function');
   - text: <code>convertSeconds(7259)</code> should return <code>2 hr, 59 sec</code>.
     testString: assert.equal(convertSeconds(testCases[0]), results[0]);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/count-occurrences-of-a-substring.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/count-occurrences-of-a-substring.english.md
@@ -28,7 +28,7 @@ In general, this essentially means matching from left-to-right or right-to-left.
 
 ```yml
 tests:
-  - text: <code>countSubstring</code> is a function.
+  - text: <code>countSubstring</code> should be a function.
     testString: assert(typeof countSubstring === 'function');
   - text: <code>countSubstring("the three truths", "th")</code> should return <code>3</code>.
     testString: assert.equal(countSubstring(testCases[0], searchString[0]), results[0]);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/count-the-coins.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/count-the-coins.english.md
@@ -35,7 +35,7 @@ Implement a function to determine how many ways there are to make change for a d
 
 ```yml
 tests:
-  - text: <code>countCoins</code> is a function.
+  - text: <code>countCoins</code> should be a function.
     testString: assert(typeof countCoins === 'function');
   - text: <code>countCoints()</code> should return 242.
     testString: assert.equal(countCoins(), 242);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/cramers-rule.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/cramers-rule.english.md
@@ -41,7 +41,7 @@ solve for <big>$w$, $x$, $y$</big> and <big>$z$</big>, using Cramer's rule.
 
 ```yml
 tests:
-  - text: <code>cramersRule</code> is a function.
+  - text: <code>cramersRule</code> should be a function.
     testString: assert(typeof cramersRule === 'function');
   - text: <code>cramersRule([[2, -1, 5, 1], [3, 2, 2, -6], [1, 3, 3, -1], [5, -2, -3, 3]], [-3, -32, -47, 49])</code> should return <code>[2, -12, -4, 1]</code>.
     testString: assert.deepEqual(cramersRule(matrices[0], freeTerms[0]), answers[0]);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/date-format.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/date-format.english.md
@@ -25,13 +25,13 @@ Example output: <code>['2007-11-23', 'Sunday, November 23, 2007']</code>
 
 ```yml
 tests:
-  - text: <code>getDateFormats</code> is a function.
+  - text: <code>getDateFormats</code> should be a function.
     testString: assert(typeof getDateFormats === 'function');
-  - text: Should return an object.
+  - text: <code>getDateFormats</code> should return an object.
     testString: assert(typeof getDateFormats() === 'object');
-  - text: Should returned an array with 2 elements.
+  - text: <code>getDateFormats</code> should returned an array with 2 elements.
     testString: assert(getDateFormats().length === 2);
-  - text: Should return the correct date in the right format
+  - text: <code>getDateFormats</code> should return the correct date in the right format
     testString: assert.deepEqual(getDateFormats(), dates, equalsMessage);
 
 ```

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/date-format.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/date-format.english.md
@@ -29,7 +29,7 @@ tests:
     testString: assert(typeof getDateFormats === 'function');
   - text: <code>getDateFormats</code> should return an object.
     testString: assert(typeof getDateFormats() === 'object');
-  - text: <code>getDateFormats</code> should returned an array with 2 elements.
+  - text: <code>getDateFormats</code> should return an array with 2 elements.
     testString: assert(getDateFormats().length === 2);
   - text: <code>getDateFormats</code> should return the correct date in the right format
     testString: assert.deepEqual(getDateFormats(), dates, equalsMessage);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/date-manipulation.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/date-manipulation.english.md
@@ -22,7 +22,7 @@ Example output: <code>"March 8 2009 7:30am EST"</code>
 
 ```yml
 tests:
-  - text: <code>add12Hours</code> is a function.
+  - text: <code>add12Hours</code> should be a function.
     testString: assert(typeof add12Hours === 'function');
   - text: <code>add12Hours(dateString)</code> should return a string.
     testString: assert(typeof add12Hours('January 17 2017 11:43am EST') === 'string');

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/day-of-the-week.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/day-of-the-week.english.md
@@ -20,7 +20,7 @@ Write a function that takes a start year and an end year and return an array of 
 
 ```yml
 tests:
-  - text: <code>findXmasSunday</code> is a function.
+  - text: <code>findXmasSunday</code> should be a function.
     testString: assert(typeof findXmasSunday === 'function');
   - text: <code>findChristmasSunday(2000, 2100)</code> should return an array.
     testString: assert(typeof findXmasSunday(2000, 2100) === 'object');

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/deal-cards-for-freecell.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/deal-cards-for-freecell.english.md
@@ -78,7 +78,7 @@ Deals can also be checked against <a href="https://freecellgamesolutions.com/" t
 
 ```yml
 tests:
-  - text: <code>dealFreeCell</code> is a function.
+  - text: <code>dealFreeCell</code> should be a function.
     testString: assert(typeof dealFreeCell === 'function');
   - text: <code>dealFreeCell(seed)</code> should return an object.
     testString: assert(typeof dealFreeCell(1) === 'object');

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/deepcopy.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/deepcopy.english.md
@@ -31,11 +31,11 @@ tests:
     testString: assert(typeof deepcopy === 'function');
   - text: '<code>deepcopy({test: "test"})</code> should return an object.'
     testString: 'assert(typeof deepcopy(obj1) === ''object'');'
-  - text: Should not return the same object that was provided.
+  - text: <code>deepcopy</code> should not return the same object that was provided.
     testString: assert(deepcopy(obj2) != obj2);
-  - text: When passed an object containing an array, should return a deep copy of the object.
+  - text: When passed an object containing an array, <code>deepcopy</code> should return a deep copy of the object.
     testString: assert.deepEqual(deepcopy(obj2), obj2);
-  - text: When passed an object containing another object, should return a deep copy of the object.
+  - text: When passed an object containing another object, <code>deepcopy</code>  should return a deep copy of the object.
     testString: assert.deepEqual(deepcopy(obj3), obj3);
 
 ```

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/discordian-date.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/discordian-date.english.md
@@ -20,7 +20,7 @@ Convert a given date from the  <a href="https://en.wikipedia.org/wiki/Gregorian 
 
 ```yml
 tests:
-  - text: <code>discordianDate</code> is a function.
+  - text: <code>discordianDate</code> should be a function.
     testString: assert(typeof discordianDate === 'function');
   - text: <code>discordianDate(new Date(2010, 6, 22))</code> should return <code>"Pungenday, the 57th day of Confusion in the YOLD 3176"</code>.
     testString: assert(discordianDate(new Date(2010, 6, 22)) === 'Pungenday, the 57th day of Confusion in the YOLD 3176');

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/element-wise-operations.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/element-wise-operations.english.md
@@ -29,7 +29,7 @@ The first parameter will be the operation to be performed, for example, "m_add" 
 
 ```yml
 tests:
-  - text: <code>operation</code> is a function.
+  - text: <code>operation</code> should be a function.
     testString: assert(typeof operation === 'function');
   - text: <code>operation("m_add",[[1,2],[3,4]],[[1,2],[3,4]])</code> should return <code>[[2,4],[6,8]]</code>.
     testString: assert.deepEqual(operation('m_add', [[1, 2], [3, 4]], [[1, 2], [3, 4]]), [[2, 4], [6, 8]]);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/emirp-primes.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/emirp-primes.english.md
@@ -27,7 +27,7 @@ The function should accept two parameters. The first will receive <code>n</code>
 
 ```yml
 tests:
-  - text: <code>emirps</code> is a function.
+  - text: <code>emirps</code> should be a function.
     testString: assert(typeof emirps === 'function');
   - text: <code>emirps(20,true)</code> should return <code>[13,17,31,37,71,73,79,97,107,113,149,157,167,179,199,311,337,347,359,389]</code>
     testString: assert.deepEqual(emirps(20, true), [13, 17, 31, 37, 71, 73, 79, 97, 107, 113, 149, 157, 167, 179, 199, 311, 337, 347, 359, 389]);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/entropy.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/entropy.english.md
@@ -23,7 +23,7 @@ where $count_i$ is the count of character $n_i$.
 
 ```yml
 tests:
-  - text: <code>entropy</code> is a function.
+  - text: <code>entropy</code> should be a function.
     testString: assert(typeof entropy === 'function');
   - text: <code>entropy("0")</code> should return <code>0</code>
     testString: assert.equal(entropy('0'), 0);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/equilibrium-index.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/equilibrium-index.english.md
@@ -41,7 +41,7 @@ Assume that the sequence may be very long.
 
 ```yml
 tests:
-  - text: <code>equilibrium</code> is a function.
+  - text: <code>equilibrium</code> should be a function.
     testString: assert(typeof equilibrium === 'function');
   - text: <code>equilibrium([-7, 1, 5, 2, -4, 3, 0])</code> should return <code>[3,6]</code>.
     testString: assert.deepEqual(equilibrium(equilibriumTests[0]), ans[0]);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/ethiopian-multiplication.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/ethiopian-multiplication.english.md
@@ -73,7 +73,7 @@ Use these functions to create a function that does Ethiopian multiplication.
 
 ```yml
 tests:
-  - text: <code>eth_mult</code> is a function.
+  - text: <code>eth_mult</code> should be a function.
     testString: assert(typeof eth_mult === 'function');
   - text: <code>eth_mult(17,34)</code> should return <code>578</code>.
     testString: assert.equal(eth_mult(17, 34), 578);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/euler-method.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/euler-method.english.md
@@ -72,7 +72,7 @@ and to compare with the analytical solution.
 
 ```yml
 tests:
-  - text: <code>eulersMethod</code> is a function.
+  - text: <code>eulersMethod</code> should be a function.
     testString: assert(typeof eulersMethod === 'function');
   - text: <code>eulersMethod(0, 100, 100, 10)</code> should return a number.
     testString: assert(typeof eulersMethod(0, 100, 100, 10) === 'number');

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/evaluate-binomial-coefficients.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/evaluate-binomial-coefficients.english.md
@@ -22,7 +22,7 @@ $\binom{n}{k} = \frac{n!}{(n-k)!k!} = \frac{n(n-1)(n-2)\ldots(n-k+1)}{k(k-1)(k-2
 
 ```yml
 tests:
-  - text: <code>binom</code> is a function.
+  - text: <code>binom</code> should be a function.
     testString: assert(typeof binom === 'function');
   - text: <code>binom(5,3)</code> should return 10.
     testString: assert.equal(binom(5, 3), 10);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/execute-a-markov-algorithm.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/execute-a-markov-algorithm.english.md
@@ -142,7 +142,7 @@ into
 
 ```yml
 tests:
-  - text: <code>markov</code> is a function.
+  - text: <code>markov</code> should be a function.
     testString: assert(typeof markov === 'function');
   - text: <code>markov(["A -> apple","B -> bag","S -> shop","T -> the","the shop -> my brother","a never used -> .terminating rule"],"I bought a B of As from T S.")</code> should return "I bought a bag of apples from my brother.".
     testString: assert.deepEqual(markov(rules[0],tests[0]),outputs[0]);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/extensible-prime-generator.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/extensible-prime-generator.english.md
@@ -28,15 +28,15 @@ The function should have two parameters. The first will receive <code>n</code> o
 
 ```yml
 tests:
-  - text: <code>primeGenerator</code> is a function.
+  - text: <code>primeGenerator</code> should be a function.
     testString: assert(typeof primeGenerator === 'function');
-  - text: <code>primeGenerator</code> is a function.
+  - text: <code>primeGenerator</code> should be a function.
     testString: assert.deepEqual(primeGenerator(20, true), [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71]);
-  - text: <code>primeGenerator</code> is a function.
+  - text: <code>primeGenerator</code> should be a function.
     testString: assert.deepEqual(primeGenerator([100, 150], true), [101, 103, 107, 109, 113, 127, 131, 137, 139, 149]);
-  - text: <code>primeGenerator</code> is a function.
+  - text: <code>primeGenerator</code> should be a function.
     testString: assert.equal(primeGenerator([7700, 8000], false), 30);
-  - text: <code>primeGenerator</code> is a function.
+  - text: <code>primeGenerator</code> should be a function.
     testString: assert.equal(primeGenerator(10000, false), 104729);
 
 ```

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/factorial.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/factorial.english.md
@@ -30,7 +30,7 @@ For example:
 
 ```yml
 tests:
-  - text: <code>factorial</code> is a function.
+  - text: <code>factorial</code> should be a function.
     testString: assert(typeof factorial === 'function');
   - text: <code>factorial(2)</code> should return a number.
     testString: assert(typeof factorial(2) === 'number');

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/factors-of-a-mersenne-number.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/factors-of-a-mersenne-number.english.md
@@ -46,7 +46,7 @@ Using the above method find a factor of  <code>2<sup>929</sup>-1</code> (aka M92
 
 ```yml
 tests:
-  - text: <code>check_mersenne</code> is a function.
+  - text: <code>check_mersenne</code> should be a function.
     testString: assert(typeof check_mersenne === 'function');
   - text: <code>check_mersenne(3)</code> should return a string.
     testString: assert(typeof check_mersenne(3) == 'string');

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/factors-of-an-integer.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/factors-of-an-integer.english.md
@@ -21,7 +21,7 @@ These factors are the positive integers by which the number being factored can b
 
 ```yml
 tests:
-  - text: <code>factors</code> is a function.
+  - text: <code>factors</code> should be a function.
     testString: assert(typeof factors === 'function');
   - text: <code>factors(45)</code> should return <code>[1,3,5,9,15,45]</code>.
     testString: assert.deepEqual(factors(45), ans[0]);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/farey-sequence.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/farey-sequence.english.md
@@ -34,7 +34,7 @@ Write a function that returns the Farey sequence of order <code>n</code>. The fu
 
 ```yml
 tests:
-  - text: <code>farey</code> is a function.
+  - text: <code>farey</code> should be a function.
     testString: assert(typeof farey === 'function');
   - text: <code>farey(3)</code> should return an array
     testString: assert(Array.isArray(farey(3)));

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/fibonacci-n-step-number-sequences.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/fibonacci-n-step-number-sequences.english.md
@@ -42,7 +42,7 @@ Write a function to generate Fibonacci $n$-step number sequences and Lucas seque
 
 ```yml
 tests:
-  - text: <code>fib_luc</code> is a function.
+  - text: <code>fib_luc</code> should be a function.
     testString: assert(typeof fib_luc === 'function');
   - text: <code>fib_luc(2,10,"f")</code> should return <code>[1,1,2,3,5,8,13,21,34,55]</code>.
     testString: assert.deepEqual(fib_luc(2,10,"f"),ans[0]);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/fibonacci-sequence.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/fibonacci-sequence.english.md
@@ -24,7 +24,7 @@ Hence, the series is: 0, 1, 1, 2, 3, 5, 8, 13...
 
 ```yml
 tests:
-  - text: <code>fibonacci</code> is a function.
+  - text: <code>fibonacci</code> should be a function.
     testString: assert(typeof fibonacci === 'function');
   - text: <code>fibonacci(2)</code> should return a number.
     testString: assert(typeof fibonacci(2) == 'number');

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/fibonacci-word.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/fibonacci-word.english.md
@@ -26,7 +26,7 @@ Write a function to return the Fibonacci Words up to <code>n</code>. <code>n</co
 
 ```yml
 tests:
-  - text: <code>fibWord</code> is a function.
+  - text: <code>fibWord</code> should be a function.
     testString: assert(typeof fibWord === 'function');
   - text: <code>fibWord(5)</code> should return an array.
     testString: assert(Array.isArray(fibWord(5)));

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/hailstone-sequence.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/hailstone-sequence.english.md
@@ -35,7 +35,7 @@ The hailstone sequence is also known as hailstone numbers (because the values ar
 
 ```yml
 tests:
-  - text: <code>hailstoneSequence</code> is a function.
+  - text: <code>hailstoneSequence</code> should be a function.
     testString: assert(typeof hailstoneSequence === 'function');
   - text: <code>hailstoneSequence()</code> should return <code>[[27,82,41,124,8,4,2,1], [351, 77031]]</code>
     testString: assert.deepEqual(hailstoneSequence(), res);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/happy-numbers.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/happy-numbers.english.md
@@ -21,7 +21,7 @@ Implement a function that returns true if the number is happy, or false if not.
 
 ```yml
 tests:
-  - text: <code>happy</code> is a function.
+  - text: <code>happy</code> should be a function.
     testString: assert(typeof happy === 'function');
   - text: <code>happy(1)</code> should return a boolean.
     testString: assert(typeof happy(1) === 'boolean');

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/harshad-or-niven-series.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/harshad-or-niven-series.english.md
@@ -23,7 +23,7 @@ Use it to list the first twenty members of the sequence and list the first Harsh
 
 ```yml
 tests:
-  - text: <code>isHarshadOrNiven</code> is a function.
+  - text: <code>isHarshadOrNiven</code> should be a function.
     testString: assert(typeof isHarshadOrNiven === 'function');
   - text: '<code>isHarshadOrNiven()</code> should return <code>{"firstTwenty": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 18, 20, 21, 24, 27, 30, 36, 40, 42],"firstOver1000": 1002}</code>'
     testString: assert.deepEqual(isHarshadOrNiven(), res);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/hash-from-two-arrays.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/hash-from-two-arrays.english.md
@@ -24,7 +24,7 @@ Using two Arrays of equal length, create a Hash object where the elements from o
 
 ```yml
 tests:
-  - text: <code>arrToObj</code> is a function.
+  - text: <code>arrToObj</code> should be a function.
     testString: assert(typeof arrToObj === 'function');
   - text: '<code>arrToObj([1, 2, 3, 4, 5], ["a", "b", "c", "d", "e"])</code> should return <code>{ 1: "a", 2: "b", 3: "c", 4: "d", 5: "e" }</code>'
     testString: assert.deepEqual(arrToObj(...testCases[0]), res[0]);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/hash-join.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/hash-join.english.md
@@ -173,7 +173,7 @@ The order of the rows in the output table is not significant.
 
 ```yml
 tests:
-  - text: <code>hashJoin</code> is a function.
+  - text: <code>hashJoin</code> should be a function.
     testString: assert(typeof hashJoin === 'function');
   - text: '<code>hashJoin([{ age: 27, name: "Jonah" }, { age: 18, name: "Alan" }, { age: 28, name: "Glory" }, { age: 18, name: "Popeye" }, { age: 28, name: "Alan" }], [{ character: "Jonah", nemesis: "Whales" }, { character: "Jonah", nemesis: "Spiders" }, { character: "Alan", nemesis: "Ghosts" }, { character:"Alan", nemesis: "Zombies" }, { character: "Glory", nemesis: "Buffy" }, { character: "Bob", nemesis: "foo" }])</code> should return <code>[{"A_age": 27,"A_name": "Jonah", "B_character": "Jonah", "B_nemesis": "Whales"}, {"A_age": 27,"A_name": "Jonah", "B_character": "Jonah", "B_nemesis": "Spiders"}, {"A_age": 18,"A_name": "Alan", "B_character": "Alan", "B_nemesis": "Ghosts"}, {"A_age": 18,"A_name": "Alan", "B_character": "Alan", "B_nemesis": "Zombies"}, {"A_age": 28,"A_name": "Glory", "B_character": "Glory", "B_nemesis": "Buffy"}, {"A_age": 28,"A_name": "Alan", "B_character": "Alan", "B_nemesis": "Ghosts"}, {"A_age": 28,"A_name": "Alan", "B_character": "Alan", "B_nemesis": "Zombies"}]</code>'
     testString: assert.deepEqual(hashJoin(hash1, hash2), res);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/heronian-triangles.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/heronian-triangles.english.md
@@ -29,7 +29,7 @@ Implement a function based on Hero's formula that returns the first <code>n<sub>
 
 ```yml
 tests:
-  - text: <code>heronianTriangle</code> is a function.
+  - text: <code>heronianTriangle</code> should be a function.
     testString: assert(typeof heronianTriangle === 'function');
   - text: <code>heronianTriangle()</code> should return <code>[[3, 4, 5], [5, 5, 6], [5, 5, 8], [4, 13, 15], [5, 12, 13], [9, 10, 17], [3, 25, 26], [7, 15, 20], [10, 13, 13], [8, 15, 17]]</code>
     testString: assert.deepEqual(heronianTriangle(testCases[0]), res[0]);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/hofstadter-figure-figure-sequences.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/hofstadter-figure-figure-sequences.english.md
@@ -36,9 +36,9 @@ No maximum value for <code>n</code> should be assumed.
 
 ```yml
 tests:
-  - text: <code>ffr</code> is a function.
+  - text: <code>ffr</code> should be a function.
     testString: assert(typeof ffr === 'function');
-  - text: <code>ffs</code> is a function.
+  - text: <code>ffs</code> should be a function.
     testString: assert(typeof ffs === 'function');
   - text: <code>ffr</code> should return integer.
     testString: assert(Number.isInteger(ffr(1)));

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/hofstadter-q-sequence.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/hofstadter-q-sequence.english.md
@@ -22,7 +22,7 @@ Implement the Hofstadter Q Sequence equation as a function. The function should 
 
 ```yml
 tests:
-  - text: <code>hofstadterQ</code> is a function.
+  - text: <code>hofstadterQ</code> should be a function.
     testString: assert(typeof hofstadterQ === 'function');
   - text: <code>hofstadterQ()</code> should return <code>integer</code>
     testString: assert(Number.isInteger(hofstadterQ(1000)));

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/jortsort.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/jortsort.english.md
@@ -8,7 +8,7 @@ forumTopicId: 302293
 ## Description
 <section id='description'>
 jortSort is a sorting toolset that makes the user do the work and guarantees efficiency because you don't have to sort ever again. It was originally presented by Jenn "Moneydollars" Schiffer at the prestigious <a href="https://www.youtube.com/watch?v=pj4U_W0OFoE" target="_blank">JSConf</a>.
-jortSort is a function that takes a single array of comparable objects as its argument. It then sorts the array in ascending order and compares the sorted array to the originally provided array. If the arrays match (i.e. the original array was already sorted), the function returns true. If the arrays do not match (i.e. the original array was not sorted), the function returns false.
+jortSort should be a function that takes a single array of comparable objects as its argument. It then sorts the array in ascending order and compares the sorted array to the originally provided array. If the arrays match (i.e. the original array was already sorted), the function returns true. If the arrays do not match (i.e. the original array was not sorted), the function returns false.
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/s-expressions.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/s-expressions.english.md
@@ -32,7 +32,7 @@ and turn it into a native data structure. (See the <a href="https://rosettacode.
 
 ```yml
 tests:
-  - text: <code>parseSexpr</code> is a function.
+  - text: <code>parseSexpr</code> should be a function.
     testString: assert(typeof parseSexpr === 'function');
   - text: <code>parseSexpr('(data1 data2 data3)')</code> should return <code>['data1', 'data2', 'data3']</code>
     testString: assert.deepEqual(parseSexpr(simpleSExpr), simpleSolution);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/sailors-coconuts-and-a-monkey-problem.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/sailors-coconuts-and-a-monkey-problem.english.md
@@ -32,7 +32,7 @@ Of course the tale is told in a world where the collection of any amount of coco
 
 ```yml
 tests:
-  - text: <code>splitCoconuts</code> is a function.
+  - text: <code>splitCoconuts</code> should be a function.
     testString: assert(typeof splitCoconuts === 'function');
   - text: <code>splitCoconuts(5)</code> should return 3121.
     testString: assert(splitCoconuts(5) === 3121);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/sedols.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/sedols.english.md
@@ -36,7 +36,7 @@ Check that each input is correctly formed, especially with respect to valid char
 
 ```yml
 tests:
-  - text: <code>sedol</code> is a function.
+  - text: <code>sedol</code> should be a function.
     testString: assert(typeof sedol === 'function');
   - text: <code>sedol('a')</code> should return null.
     testString: assert(sedol('a') === null);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/taxicab-numbers.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/taxicab-numbers.english.md
@@ -35,13 +35,13 @@ Write a function that returns the lowest <code>n</code> taxicab numbers. For eac
 
 ```yml
 tests:
-  - text: <code>taxicabNumbers</code> is a function.
+  - text: <code>taxicabNumbers</code> should be a function.
     testString: assert(typeof taxicabNumbers === 'function');
   - text: <code>taxicabNumbers</code> should return an array.
     testString: assert(typeof taxicabNumbers(2) === 'object');
   - text: <code>taxicabNumbers</code> should return an array of numbers.
     testString: assert(typeof taxicabNumbers(100)[0] === 'number');
-  - text: <code>taxicabNumbers(4)</code> must return [1729, 4104, 13832, 20683].
+  - text: <code>taxicabNumbers(4)</code> should return [1729, 4104, 13832, 20683].
     testString: assert.deepEqual(taxicabNumbers(4), res4);
   - text: <code>taxicabNumbers(25)</code> should return [1729, 4104, 13832, 20683, 32832, 39312, 40033, 46683, 64232, 65728, 110656, 110808, 134379, 149389, 165464, 171288, 195841, 216027, 216125, 262656, 314496, 320264, 327763, 373464, 402597]
     testString: assert.deepEqual(taxicabNumbers(25), res25);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/tokenize-a-string-with-escaping.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/tokenize-a-string-with-escaping.english.md
@@ -45,7 +45,7 @@ and using <code>|</code> as a separator and <code>^</code> as escape character, 
 
 ```yml
 tests:
-  - text: <code>tokenize</code> is a function.
+  - text: <code>tokenize</code> should be a function.
     testString: assert(typeof tokenize === 'function');
   - text: <code>tokenize</code> should return an array.
     testString: assert(typeof tokenize('a', 'b', 'c') === 'object');

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/top-rank-per-group.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/top-rank-per-group.english.md
@@ -52,19 +52,19 @@ one could rank the top-rated movie in each genre by calling
 
 ```yml
 tests:
-  - text: <code>topRankPerGroup</code> is a function.
+  - text: <code>topRankPerGroup</code> should be a function.
     testString: assert(typeof topRankPerGroup === 'function');
-  - text: <code>topRankPerGroup</code> returns undefined on negative n values.
+  - text: <code>topRankPerGroup</code> should return undefined on negative n values.
     testString: assert(typeof topRankPerGroup(-1, []) === 'undefined');
-  - text: First department must be D050
+  - text: First department should be D050
     testString: assert.equal(res1[0][0].dept, 'D050');
-  - text: First department must be D050
+  - text: First department should be D050
     testString: assert.equal(res1[0][1].salary, 21900);
-  - text: The last department must be D202
+  - text: The last department should be D202
     testString: assert.equal(res1[3][3].dept, 'D202');
-  - text: <code>topRankPerGroup(1, ...)</code> must return only top ranking result per group.
+  - text: <code>topRankPerGroup(1, ...)</code> should return only top ranking result per group.
     testString: assert.equal(res2[2].length, 1);
-  - text: <code>topRankPerGroup(1, ...)</code> must return only top ranking result per group.
+  - text: <code>topRankPerGroup(1, ...)</code> should return only top ranking result per group.
     testString: assert.equal(res3[2][1].name, 'Maze Runner');
 
 ```

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/topological-sort.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/topological-sort.english.md
@@ -61,7 +61,7 @@ tests:
     testString: assert(typeof topologicalSort === 'function');
   - text: <code>topologicalSort</code> should return correct library order.
     testString: assert.deepEqual(topologicalSort(libsSimple), ['bbb', 'aaa']);
-  - text: <code>topologicalSort</code> should return correct library order..
+  - text: <code>topologicalSort</code> should return correct library order.
     testString: assert.deepEqual(topologicalSort(libsVHDL), solutionVHDL);
   - text: <code>topologicalSort</code> should return correct library order..
     testString: assert.deepEqual(topologicalSort(libsCustom), solutionCustom);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/topological-sort.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/topological-sort.english.md
@@ -65,7 +65,7 @@ tests:
     testString: assert.deepEqual(topologicalSort(libsVHDL), solutionVHDL);
   - text: <code>topologicalSort</code> should return correct library order.
     testString: assert.deepEqual(topologicalSort(libsCustom), solutionCustom);
-  - text: <code>topologicalSort</code> should ignore unorderable dependencies..
+  - text: <code>topologicalSort</code> should ignore unorderable dependencies.
     testString: assert.deepEqual(topologicalSort(libsUnorderable), solutionUnorderable);
 
 ```

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/topological-sort.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/topological-sort.english.md
@@ -63,7 +63,7 @@ tests:
     testString: assert.deepEqual(topologicalSort(libsSimple), ['bbb', 'aaa']);
   - text: <code>topologicalSort</code> should return correct library order.
     testString: assert.deepEqual(topologicalSort(libsVHDL), solutionVHDL);
-  - text: <code>topologicalSort</code> should return correct library order..
+  - text: <code>topologicalSort</code> should return correct library order.
     testString: assert.deepEqual(topologicalSort(libsCustom), solutionCustom);
   - text: <code>topologicalSort</code> should ignore unorderable dependencies..
     testString: assert.deepEqual(topologicalSort(libsUnorderable), solutionUnorderable);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/topological-sort.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/topological-sort.english.md
@@ -57,15 +57,15 @@ There are two popular algorithms for topological sorting:
 
 ```yml
 tests:
-  - text: <code>topologicalSort</code> is a function.
+  - text: <code>topologicalSort</code> should be a function.
     testString: assert(typeof topologicalSort === 'function');
-  - text: <code>topologicalSort</code> must return correct library order..
+  - text: <code>topologicalSort</code> should return correct library order..
     testString: assert.deepEqual(topologicalSort(libsSimple), ['bbb', 'aaa']);
-  - text: <code>topologicalSort</code> must return correct library order..
+  - text: <code>topologicalSort</code> should return correct library order..
     testString: assert.deepEqual(topologicalSort(libsVHDL), solutionVHDL);
-  - text: <code>topologicalSort</code> must return correct library order..
+  - text: <code>topologicalSort</code> should return correct library order..
     testString: assert.deepEqual(topologicalSort(libsCustom), solutionCustom);
-  - text: <code>topologicalSort</code> must ignore unorderable dependencies..
+  - text: <code>topologicalSort</code> should ignore unorderable dependencies..
     testString: assert.deepEqual(topologicalSort(libsUnorderable), solutionUnorderable);
 
 ```

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/topological-sort.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/topological-sort.english.md
@@ -59,7 +59,7 @@ There are two popular algorithms for topological sorting:
 tests:
   - text: <code>topologicalSort</code> should be a function.
     testString: assert(typeof topologicalSort === 'function');
-  - text: <code>topologicalSort</code> should return correct library order..
+  - text: <code>topologicalSort</code> should return correct library order.
     testString: assert.deepEqual(topologicalSort(libsSimple), ['bbb', 'aaa']);
   - text: <code>topologicalSort</code> should return correct library order..
     testString: assert.deepEqual(topologicalSort(libsVHDL), solutionVHDL);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/towers-of-hanoi.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/towers-of-hanoi.english.md
@@ -23,7 +23,7 @@ For example, the array <code>[['A', 'C'], ['B', 'A']]</code> indicates that the 
 
 ```yml
 tests:
-  - text: <code>towerOfHanoi</code> is a function.
+  - text: <code>towerOfHanoi</code> should be a function.
     testString: assert(typeof towerOfHanoi === 'function');
   - text: <code>towerOfHanoi(3, ...)</code> should return 7 moves.
     testString: assert(res3.length === 7);
@@ -31,7 +31,7 @@ tests:
     testString: assert.deepEqual(towerOfHanoi(3, 'A', 'B', 'C'), res3Moves);
   - text: <code>towerOfHanoi(5, "X", "Y", "Z")</code> 10th move should be Y -> X.
     testString: assert.deepEqual(res5[9], ['Y', 'X']);
-  - text: <code>towerOfHanoi(7, 'A', 'B', 'C')</code> first ten moves are <code>[['A','B'], ['A','C'], ['B','C'], ['A','B'], ['C','A'], ['C','B'], ['A','B'], ['A','C'], ['B','C'], ['B','A']]</code>
+  - text: <code>towerOfHanoi(7, 'A', 'B', 'C')</code> first ten moves should be <code>[['A','B'], ['A','C'], ['B','C'], ['A','B'], ['C','A'], ['C','B'], ['A','B'], ['A','C'], ['B','C'], ['B','A']]</code>
     testString: assert.deepEqual(towerOfHanoi(7, 'A', 'B', 'C').slice(0, 10), res7First10Moves);
 
 ```

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/vector-cross-product.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/vector-cross-product.english.md
@@ -22,11 +22,11 @@ Write a function that takes two vectors (arrays) as input and computes their cro
 
 ```yml
 tests:
-  - text: dotProduct must be a function
+  - text: dotProduct should be a function.
     testString: assert.equal(typeof crossProduct, 'function');
-  - text: dotProduct() must return null
+  - text: dotProduct() should return null.
     testString: assert.equal(crossProduct(), null);
-  - text: crossProduct([1, 2, 3], [4, 5, 6]) must return [-3, 6, -3].
+  - text: crossProduct([1, 2, 3], [4, 5, 6]) should return [-3, 6, -3].
     testString: assert.deepEqual(res12, exp12);
 
 ```

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/vector-dot-product.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/vector-dot-product.english.md
@@ -22,17 +22,17 @@ Write a function that takes any numbers of vectors (arrays) as input and compute
 
 ```yml
 tests:
-  - text: dotProduct must be a function
+  - text: dotProduct should be a function.
     testString: assert.equal(typeof dotProduct, 'function');
-  - text: dotProduct() must return null
+  - text: dotProduct() should return null.
     testString: assert.equal(dotProduct(), null);
-  - text: dotProduct([[1], [1]]) must return 1.
+  - text: dotProduct([[1], [1]]) should return 1.
     testString: assert.equal(dotProduct([1], [1]), 1);
-  - text: dotProduct([[1], [1, 2]]) must return null.
+  - text: dotProduct([[1], [1, 2]]) should return null.
     testString: assert.equal(dotProduct([1], [1, 2]), null);
-  - text: dotProduct([1, 3, -5], [4, -2, -1]) must return 3.
+  - text: dotProduct([1, 3, -5], [4, -2, -1]) should return 3.
     testString: assert.equal(dotProduct([1, 3, -5], [4, -2, -1]), 3);
-  - text: <code>dotProduct(...nVectors)</code> should return 156000
+  - text: <code>dotProduct(...nVectors)</code> should return 156000.
     testString: assert.equal(dotProduct([ 0, 1, 2, 3, 4 ], [ 0, 2, 4, 6, 8 ], [ 0, 3, 6, 9, 12 ], [ 0, 4, 8, 12, 16 ], [ 0, 5, 10, 15, 20 ]), 156000);
 
 ```

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/word-wrap.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/word-wrap.english.md
@@ -28,17 +28,17 @@ than a simple minimum length algorithm.
 
 ```yml
 tests:
-  - text: wrap must be a function.
+  - text: wrap should be a function.
     testString: assert.equal(typeof wrap, 'function');
-  - text: wrap must return a string.
+  - text: wrap should return a string.
     testString: assert.equal(typeof wrap('abc', 10), 'string');
-  - text: wrap(80) must return 4 lines.
+  - text: wrap(80) should return 4 lines.
     testString: assert(wrapped80.split('\n').length === 4);
-  - text: Your <code>wrap</code> function should return our expected text
+  - text: Your <code>wrap</code> function should return our expected text.
     testString: assert.equal(wrapped80.split('\n')[0], firstRow80);
-  - text: wrap(42) must return 7 lines.
+  - text: wrap(42) should return 7 lines.
     testString: assert(wrapped42.split('\n').length === 7);
-  - text: Your <code>wrap</code> function should return our expected text
+  - text: Your <code>wrap</code> function should return our expected text.
     testString: assert.equal(wrapped42.split('\n')[0], firstRow42);
 
 ```

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/y-combinator.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/y-combinator.english.md
@@ -27,17 +27,17 @@ Define the stateless Y combinator function and use it to compute <a href="https:
 
 ```yml
 tests:
-  - text: Y must return a function
+  - text: Y mushouldst return a function.
     testString: assert.equal(typeof Y(f => n => n), 'function');
-  - text: factorial(1) must return 1.
+  - text: factorial(1) should return 1.
     testString: assert.equal(factorial(1), 1);
-  - text: factorial(2) must return 2.
+  - text: factorial(2) should return 2.
     testString: assert.equal(factorial(2), 2);
-  - text: factorial(3) must return 6.
+  - text: factorial(3) should return 6.
     testString: assert.equal(factorial(3), 6);
-  - text: factorial(4) must return 24.
+  - text: factorial(4) should return 24.
     testString: assert.equal(factorial(4), 24);
-  - text: factorial(10) must return 3628800.
+  - text: factorial(10) should return 3628800.
     testString: assert.equal(factorial(10), 3628800);
 
 ```

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/y-combinator.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/y-combinator.english.md
@@ -27,7 +27,7 @@ Define the stateless Y combinator function and use it to compute <a href="https:
 
 ```yml
 tests:
-  - text: Y mushouldst return a function.
+  - text: Y should return a function.
     testString: assert.equal(typeof Y(f => n => n), 'function');
   - text: factorial(1) should return 1.
     testString: assert.equal(factorial(1), 1);

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/zeckendorf-number-representation.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/zeckendorf-number-representation.english.md
@@ -21,9 +21,9 @@ Write a function that generates and returns an array of the first <code>n</code>
 
 ```yml
 tests:
-  - text: zeckendorf must be function
+  - text: zeckendorf should be function.
     testString: assert.equal(typeof zeckendorf, 'function');
-  - text: Your <code>zeckendorf</code> function should return the correct answer
+  - text: Your <code>zeckendorf</code> function should return the correct answer.
     testString: assert.deepEqual(answer, solution20);
 
 ```

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/zhang-suen-thinning-algorithm.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/zhang-suen-thinning-algorithm.english.md
@@ -101,13 +101,13 @@ Write a routine to perform Zhang-Suen thinning on the provided image matrix.
 
 ```yml
 tests:
-  - text: <code>thinImage</code> must be a function
+  - text: <code>thinImage</code> should be a function.
     testString: assert.equal(typeof thinImage, 'function');
-  - text: <code>thinImage</code> must return an array
+  - text: <code>thinImage</code> should return an array.
     testString: assert(Array.isArray(result));
-  - text: <code>thinImage</code> must return an array of strings
+  - text: <code>thinImage</code> should return an array of strings.
     testString: assert.equal(typeof result[0], 'string');
-  - text: <code>thinImage</code> must return an array of strings
+  - text: <code>thinImage</code> should return an array of strings.
     testString: assert.deepEqual(result, expected);
 
 ```

--- a/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/zig-zag-matrix.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/rosetta-code/zig-zag-matrix.english.md
@@ -29,17 +29,17 @@ Write a function that takes the size of the zig-zag matrix, and returns the corr
 
 ```yml
 tests:
-  - text: ZigZagMatrix must be a function
+  - text: ZigZagMatrix should be a function.
     testString: assert.equal(typeof ZigZagMatrix, 'function');
-  - text: ZigZagMatrix should return array
+  - text: ZigZagMatrix should return array.
     testString: assert.equal(typeof ZigZagMatrix(1), 'object');
-  - text: ZigZagMatrix should return an array of nested arrays
+  - text: ZigZagMatrix should return an array of nested arrays.
     testString: assert.equal(typeof ZigZagMatrix(1)[0], 'object');
-  - text: ZigZagMatrix(1) should return [[0]]
+  - text: ZigZagMatrix(1) should return [[0]].
     testString: assert.deepEqual(ZigZagMatrix(1), zm1);
-  - text: ZigZagMatrix(2) should return [[0, 1], [2, 3]]
+  - text: ZigZagMatrix(2) should return [[0, 1], [2, 3]].
     testString: assert.deepEqual(ZigZagMatrix(2), zm2);
-  - text: ZigZagMatrix(5) must return specified matrix
+  - text: ZigZagMatrix(5) should return specified matrix.
     testString: assert.deepEqual(ZigZagMatrix(5), zm5);
 
 ```


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

Related to PR #36860 

This PR makes sure all challenges' tests in the following sections of the `Coding Interview Prep` section use "should " or "should not".

* Project Euler
* Rosetta Code