### PR TITLE
refactor: update trivial regex capture group find and replace challenge

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/use-capture-groups-to-search-and-replace.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/use-capture-groups-to-search-and-replace.english.md
@@ -28,7 +28,7 @@ You can also access capture groups in the replacement string with dollar signs (
 
 ## Instructions
 <section id='instructions'>
-Write a regex using three capture groups that will replace the string "one two three" with the string "three two one" and assign the result to the <code>result</code> variable.
+Write a regex <code>fixRegex</code> using three capture groups that will search for each word in the string "one two three". Then update the <code>replaceText</code> variable to replace "one two three" with the string "three two one" and assign the result to the <code>result</code> variable. Make sure you utilizing your capture groups in the replacement string using the dollar sign (<code>$</code>) syntax.
 </section>
 
 ## Tests

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/use-capture-groups-to-search-and-replace.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/use-capture-groups-to-search-and-replace.english.md
@@ -28,7 +28,7 @@ You can also access capture groups in the replacement string with dollar signs (
 
 ## Instructions
 <section id='instructions'>
-Write a regex using capture groups that will search for the words <code>"one"</code>, <code>"two"</code>, and <code>"three"</code>. Then update the <code>replaceText</code> variable to replace <code>"one two three"</code> with <code>"three two one"</code>.
+Write a regex using three capture groups that will replace the string "one two three" with the string "three two one" and assign the result to the <code>replaceText</code> variable.
 </section>
 
 ## Tests
@@ -42,6 +42,8 @@ tests:
     testString: assert(result === "three two one");
   - text: You should not change the last line.
     testString: assert(code.match(/result\s*=\s*huhText\.replace\(.*?\)/));
+  - text: <code>fixRegex</code> should use at least three capture groups.
+    testString: assert((new RegExp(fixRegex.source + '|')).exec('').length - 1 >= 3);
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/use-capture-groups-to-search-and-replace.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/use-capture-groups-to-search-and-replace.english.md
@@ -28,7 +28,7 @@ You can also access capture groups in the replacement string with dollar signs (
 
 ## Instructions
 <section id='instructions'>
-Write a regex using three capture groups that will replace the string "one two three" with the string "three two one" and assign the result to the <code>replaceText</code> variable.
+Write a regex using three capture groups that will replace the string "one two three" with the string "three two one" and assign the result to the <code>result</code> variable.
 </section>
 
 ## Tests
@@ -47,7 +47,7 @@ tests:
   - text: <code>replaceText</code> should use parenthesized submatch string(s).
     testString: '{
       const re = /(\$\d{1,2})+(?:[\D]|\b)/g;
-      assert(replaceText.match(re));
+      assert(replaceText.match(re).length >= 3);
     }'
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/use-capture-groups-to-search-and-replace.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/use-capture-groups-to-search-and-replace.english.md
@@ -41,7 +41,7 @@ tests:
   - text: Your regex should change <code>"one two three"</code> to <code>"three two one"</code>
     testString: assert(result === "three two one");
   - text: You should not change the last line.
-    testString: assert(code.match(/result\s*=\s*huhText\.replace\(.*?\)/));
+    testString: assert(code.match(/result\s*=\s*str\.replace\(.*?\)/));
   - text: <code>fixRegex</code> should use at least three capture groups.
     testString: assert((new RegExp(fixRegex.source + '|')).exec('').length - 1 >= 3);
 
@@ -55,10 +55,10 @@ tests:
 <div id='js-seed'>
 
 ```js
-let huhText = "one two three";
+let str = "one two three";
 let fixRegex = /change/; // Change this line
 let replaceText = ""; // Change this line
-let result = huhText.replace(fixRegex, replaceText);
+let result = str.replace(fixRegex, replaceText);
 ```
 
 </div>
@@ -71,10 +71,10 @@ let result = huhText.replace(fixRegex, replaceText);
 <section id='solution'>
 
 ```js
-let huhText = "one two three";
+let str = "one two three";
 let fixRegex = /(\w+) (\w+) (\w+)/g; // Change this line
 let replaceText = "$3 $2 $1"; // Change this line
-let result = huhText.replace(fixRegex, replaceText);
+let result = str.replace(fixRegex, replaceText);
 ```
 
 </section>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/use-capture-groups-to-search-and-replace.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/use-capture-groups-to-search-and-replace.english.md
@@ -44,7 +44,7 @@ tests:
     testString: assert(code.match(/result\s*=\s*str\.replace\(.*?\)/));
   - text: <code>fixRegex</code> should use at least three capture groups.
     testString: assert((new RegExp(fixRegex.source + '|')).exec('').length - 1 >= 3);
-  - text: <code>replaceText</code> should use parenthesized submatch string(s).
+  - text: <code>replaceText</code> should use parenthesized submatch string(s) (i.e. the nth parenthesized submatch string, $n, corresponds to the nth capture group).
     testString: '{
       const re = /(\$\d{1,2})+(?:[\D]|\b)/g;
       assert(replaceText.match(re).length >= 3);

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/use-capture-groups-to-search-and-replace.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/use-capture-groups-to-search-and-replace.english.md
@@ -28,7 +28,7 @@ You can also access capture groups in the replacement string with dollar signs (
 
 ## Instructions
 <section id='instructions'>
-Write a regex <code>fixRegex</code> using three capture groups that will search for each word in the string "one two three". Then update the <code>replaceText</code> variable to replace "one two three" with the string "three two one" and assign the result to the <code>result</code> variable. Make sure you utilizing your capture groups in the replacement string using the dollar sign (<code>$</code>) syntax.
+Write a regex <code>fixRegex</code> using three capture groups that will search for each word in the string "one two three". Then update the <code>replaceText</code> variable to replace "one two three" with the string "three two one" and assign the result to the <code>result</code> variable. Make sure you are utilizing capture groups in the replacement string using the dollar sign (<code>$</code>) syntax.
 </section>
 
 ## Tests

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/use-capture-groups-to-search-and-replace.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/use-capture-groups-to-search-and-replace.english.md
@@ -44,6 +44,11 @@ tests:
     testString: assert(code.match(/result\s*=\s*str\.replace\(.*?\)/));
   - text: <code>fixRegex</code> should use at least three capture groups.
     testString: assert((new RegExp(fixRegex.source + '|')).exec('').length - 1 >= 3);
+  - text: <code>replaceText</code> should use parenthesized submatch string(s).
+    testString: '{
+      const re = /(\$\d{1,2})+(?:[\D]|\b)/g;
+      assert(replaceText.match(re));
+    }'
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/use-capture-groups-to-search-and-replace.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/use-capture-groups-to-search-and-replace.english.md
@@ -28,7 +28,7 @@ You can also access capture groups in the replacement string with dollar signs (
 
 ## Instructions
 <section id='instructions'>
-Write a regex so that it will search for the string <code>"good"</code>. Then update the <code>replaceText</code> variable to replace <code>"good"</code> with <code>"okey-dokey"</code>.
+Write a regex using capture groups that will search for the words <code>"one"</code>, <code>"two"</code>, and <code>"three"</code>. Then update the <code>replaceText</code> variable to replace <code>"one two three"</code> with <code>"three two one"</code>.
 </section>
 
 ## Tests
@@ -38,8 +38,8 @@ Write a regex so that it will search for the string <code>"good"</code>. Then up
 tests:
   - text: You should use <code>.replace()</code> to search and replace.
     testString: assert(code.match(/\.replace\(.*\)/));
-  - text: Your regex should change <code>"This sandwich is good."</code> to <code>"This sandwich is okey-dokey."</code>
-    testString: assert(result == "This sandwich is okey-dokey." && replaceText === "okey-dokey");
+  - text: Your regex should change <code>"one two three"</code> to <code>"three two one"</code>
+    testString: assert(result === "three two one");
   - text: You should not change the last line.
     testString: assert(code.match(/result\s*=\s*huhText\.replace\(.*?\)/));
 
@@ -53,7 +53,7 @@ tests:
 <div id='js-seed'>
 
 ```js
-let huhText = "This sandwich is good.";
+let huhText = "one two three";
 let fixRegex = /change/; // Change this line
 let replaceText = ""; // Change this line
 let result = huhText.replace(fixRegex, replaceText);
@@ -69,9 +69,9 @@ let result = huhText.replace(fixRegex, replaceText);
 <section id='solution'>
 
 ```js
-let huhText = "This sandwich is good.";
-let fixRegex = /good/g; // Change this line
-let replaceText = "okey-dokey"; // Change this line
+let huhText = "one two three";
+let fixRegex = /(\w+) (\w+) (\w+)/g; // Change this line
+let replaceText = "$3 $2 $1"; // Change this line
 let result = huhText.replace(fixRegex, replaceText);
 ```
 


### PR DESCRIPTION
Implements the fixes provided by @alanpaulprice in pull #36925 with
the changes requested by maintainers. Previous challenge could be
completed without any capture groups. New challenge rectifies this
behavior.

resolves #17645

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
   Note: as the commit text says, this is the pull referenced above with the requested corrections. Not my work, basically.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #17645
