### PR TITLE
fix(curriculum): added new test case to prevent invalid regex for Restrict Possible Usernames challenge

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/restrict-possible-usernames.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/restrict-possible-usernames.english.md
@@ -44,7 +44,9 @@ tests:
   - text: Your regex should not match <code>BadUs3rnam3</code>
     testString: assert(!userCheck.test("BadUs3rnam3"));
   - text: Your regex should match <code>Z97</code>
-    testString: assert(userCheck.test("Z97"));    
+    testString: assert(userCheck.test("Z97"));
+  - text: Your regex should not match <code>c57bT3</code>
+    testString: assert(!userCheck.test("c57bT3"));  
 
 ```
 


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

This PR adds a new test case which prevents the user's regex from incorrectly accepting a username which has numbers in the middle and at the end of the username.  The instructions state numbers should only (optionally) appear at the end of the username.  A user reported [on the forum](https://www.freecodecamp.org/forum/t/regex-solution-not-valid-why-from-regular-expressions-restrict-possible-usernames/326521/5) that the following regex allowed successful completion of the challenge, even though it allowed an invalid username like "c57bT3".
```js
/^[a-z]([a-z]|[\d][\d]+)[a-z]*[\d]*$/i
```
