### PR TITLE
Made description of logical operator under "or operator" challenge a little more intuitive.

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparisons-with-the-logical-or-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparisons-with-the-logical-or-operator.english.md
@@ -9,7 +9,7 @@ forumTopicId: 16800
 ## Description
 <section id='description'>
 The <dfn>logical or</dfn> operator (<code>||</code>) returns <code>true</code> if either of the <dfn>operands</dfn> is <code>true</code>. Otherwise, it returns <code>false</code>.
-The <dfn>logical or</dfn> operator is composed of two pipe symbols (<code>|</code>). This can typically be found between your Backspace and Enter keys.
+The <dfn>logical or</dfn> operator is composed of two pipe symbols (<code>||</code>). This can typically be found between your Backspace and Enter keys.
 The pattern below should look familiar from prior waypoints:
 
 ```js

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparisons-with-the-logical-or-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparisons-with-the-logical-or-operator.english.md
@@ -9,7 +9,7 @@ forumTopicId: 16800
 ## Description
 <section id='description'>
 The <dfn>logical or</dfn> operator (<code>||</code>) returns <code>true</code> if either of the <dfn>operands</dfn> is <code>true</code>. Otherwise, it returns <code>false</code>.
-The <dfn>logical or</dfn> operator is composed of two pipe symbols (<code>||</code>). This can typically be found between your Backspace and Enter keys.
+The <dfn>logical or</dfn> operator is composed of two pipe symbols, like this: (<code>||</code>). This can typically be found between your Backspace and Enter keys.
 The pattern below should look familiar from prior waypoints:
 
 ```js

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparisons-with-the-logical-or-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparisons-with-the-logical-or-operator.english.md
@@ -9,7 +9,7 @@ forumTopicId: 16800
 ## Description
 <section id='description'>
 The <dfn>logical or</dfn> operator (<code>||</code>) returns <code>true</code> if either of the <dfn>operands</dfn> is <code>true</code>. Otherwise, it returns <code>false</code>.
-The <dfn>logical or</dfn> operator is composed of two pipe symbols, like this: (<code>||</code>). This can typically be found between your Backspace and Enter keys.
+The <dfn>logical or</dfn> operator is composed of two pipe symbols: (<code>||</code>). This can typically be found between your Backspace and Enter keys.
 The pattern below should look familiar from prior waypoints:
 
 ```js


### PR DESCRIPTION
I think the description under the logical or operator [challenge](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/comparisons-with-the-logical-or-operator.english.md) is not too intuitive. The description had "The logical or operator is composed of two pipe symbols (|).". 
Personally, I thought it was a typo until I realized the sentence meant to show we need 2 pipes. 
I think it would be a little more clear and intuitive for the sentence to show the actual example of the two pipes.

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX
