### PR TITLE
fix(client): report cross origin errors

### DIFF
--- a/client/src/templates/Challenges/utils/frame.js
+++ b/client/src/templates/Challenges/utils/frame.js
@@ -12,13 +12,19 @@ const testId = 'fcc-test-frame';
 // this also allows in-page anchors to work properly
 // rather than load another instance of the learn
 
-// window.onerror is added here to catch any errors thrown during the building
-// of the frame.
+// window.onerror is added here to report any errors thrown during the building
+// of the frame.  React dom errors already appear in the console, so onerror
+// does not need to pass them on to the default error handler.
 const createHeader = (id = mainId) => `
   <base href='' />
   <script>
     window.__frameId = '${id}';
     window.onerror = function(msg) {
+      var string = msg.toLowerCase();
+      var substring = 'script error';
+      if (string.indexOf(substring) > -1) {
+        msg = 'Build error, open your browser console to learn more.';
+      }
       console.log(msg);
       return true;
     };
@@ -107,11 +113,17 @@ const initMainFrame = (frameReady, proxyLogger) => ctx => {
     // after the frame is ready. It has to be overwritten, as proxyLogger cannot
     // be added as part of createHeader.
     ctx.window.onerror = function(msg) {
-      console.log(msg);
+      var string = msg.toLowerCase();
+      var substring = 'script error';
+      if (string.indexOf(substring) > -1) {
+        msg = 'Error, open your browser console to learn more.';
+      }
       if (proxyLogger) {
         proxyLogger(msg);
       }
-      return true;
+      // let the error propagate so it appears in the browser console, otherwise
+      // an error from a cross origin script just appears as 'Script error.'
+      return false;
     };
     frameReady();
   });

--- a/client/src/templates/Challenges/utils/frame.js
+++ b/client/src/templates/Challenges/utils/frame.js
@@ -21,8 +21,7 @@ const createHeader = (id = mainId) => `
     window.__frameId = '${id}';
     window.onerror = function(msg) {
       var string = msg.toLowerCase();
-      var substring = 'script error';
-      if (string.indexOf(substring) > -1) {
+      if (string.includes('script error')) {
         msg = 'Build error, open your browser console to learn more.';
       }
       console.log(msg);
@@ -114,8 +113,7 @@ const initMainFrame = (frameReady, proxyLogger) => ctx => {
     // be added as part of createHeader.
     ctx.window.onerror = function(msg) {
       var string = msg.toLowerCase();
-      var substring = 'script error';
-      if (string.indexOf(substring) > -1) {
+      if (string.includes('script error')) {
         msg = 'Error, open your browser console to learn more.';
       }
       if (proxyLogger) {


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I noticed that the React challenges were reporting just 'Script error.' when a component throws an error.  For example

```jsx
class MyComponent extends React.Component {
  constructor(props) {
    throw Error('err')
  }
};
```
produces `"Script error."` in the fcc console (the dev console reports the actual error).

If the error occurs during execution (i.e. if a click handler throws an error) then both consoles reported "Script error."

This PR makes it so errors generated in cross origin scripts are always reported to the dev console and lets the user know via the fcc console.