### PR TITLE
Work on the space-evenly option for flexbox justify-content

### DIFF
--- a/curriculum/challenges/arabic/01-responsive-web-design/css-flexbox/use-the-justify-content-property-in-the-tweet-embed.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/css-flexbox/use-the-justify-content-property-in-the-tweet-embed.arabic.md
@@ -18,7 +18,7 @@ localeTitle: استخدم خاصية theify-content في تطبيق Tweet Tweet
 ```yml
 tests:
   - text: 'يجب أن يكون لعنصر <code>.profile-name</code> خاصية ضبط <code>justify-content</code> المضبوطة على أي من هذه القيم: مركز ، أو بداية مرنة ، أو نهاية مرنة ، أو مسافة بينية ، أو مسافة.'
-    testString: 'assert(code.match(/header\s.profile-name\s*{\s*?.*?\s*?.*?\s*?\s*?.*?\s*?justify-content\s*:\s*(center|flex-start|flex-end|space-between|space-around)\s*;/g), "The <code>.profile-name</code> element should have the <code>justify-content</code> property set to any of these values: center, flex-start, flex-end, space-between, or space-around.");'
+    testString: 'assert(code.match(/header\s.profile-name\s*{\s*?.*?\s*?.*?\s*?\s*?.*?\s*?justify-content\s*:\s*(center|flex-start|flex-end|space-between|space-around|space-evenly)\s*;/g), "The <code>.profile-name</code> element should have the <code>justify-content</code> property set to any of these values: center, flex-start, flex-end, space-between, space-around, or space-evenly.");'
 
 ```
 

--- a/curriculum/challenges/chinese/01-responsive-web-design/css-flexbox/use-the-justify-content-property-in-the-tweet-embed.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/css-flexbox/use-the-justify-content-property-in-the-tweet-embed.chinese.md
@@ -17,8 +17,8 @@ localeTitle: 在Tweet Embed中使用justify-content属性
 
 ```yml
 tests:
-  - text: <code>.profile-name</code>元素应将<code>justify-content</code>属性设置为以下任何值：center，flex-start，flex-end，space-between或space-around。
-    testString: 'assert(code.match(/header\s.profile-name\s*{\s*?.*?\s*?.*?\s*?\s*?.*?\s*?justify-content\s*:\s*(center|flex-start|flex-end|space-between|space-around)\s*;/g), "The <code>.profile-name</code> element should have the <code>justify-content</code> property set to any of these values: center, flex-start, flex-end, space-between, or space-around.");'
+  - text: <code>.profile-name</code>元素应将<code>justify-content</code>属性设置为以下任何值：center，flex-start，flex-end，space-between，space-around或space-evenly。
+    testString: 'assert(code.match(/header\s.profile-name\s*{\s*?.*?\s*?.*?\s*?\s*?.*?\s*?justify-content\s*:\s*(center|flex-start|flex-end|space-between|space-around|space-evenly)\s*;/g), "The <code>.profile-name</code> element should have the <code>justify-content</code> property set to any of these values: center, flex-start, flex-end, space-between, space-around, or space-evenly.");'
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-justify-content-property-in-the-tweet-embed.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-justify-content-property-in-the-tweet-embed.english.md
@@ -21,8 +21,8 @@ Add the CSS property <code>justify-content</code> to the header's <code>.profile
 
 ```yml
 tests:
-  - text: 'The <code>.profile-name</code> element should have the <code>justify-content</code> property set to any of these values: <code>center</code>, <code>flex-start</code>, <code>flex-end</code>, <code>space-between</code>, or <code>space-around</code>.'
-    testString: 'assert(code.match(/header\s.profile-name\s*{\s*?.*?\s*?.*?\s*?\s*?.*?\s*?justify-content\s*:\s*(center|flex-start|flex-end|space-between|space-around)\s*;/g));'
+  - text: 'The <code>.profile-name</code> element should have the <code>justify-content</code> property set to any of these values: <code>center</code>, <code>flex-start</code>, <code>flex-end</code>, <code>space-between</code>, <code>space-around</code>, or <code>space-evenly</code>.'
+    testString: 'assert(code.match(/header\s.profile-name\s*{\s*?.*?\s*?.*?\s*?\s*?.*?\s*?justify-content\s*:\s*(center|flex-start|flex-end|space-between|space-around|space-evenly)\s*;/g));'
 
 ```
 

--- a/curriculum/challenges/portuguese/01-responsive-web-design/css-flexbox/use-the-justify-content-property-in-the-tweet-embed.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/css-flexbox/use-the-justify-content-property-in-the-tweet-embed.portuguese.md
@@ -18,7 +18,7 @@ localeTitle: Use a propriedade justify-content no Tweet Incorporar
 ```yml
 tests:
   - text: 'O elemento <code>.profile-name</code> deve ter a propriedade <code>justify-content</code> definida para qualquer um desses valores: center, flex-start, flex-end, espaço-entre ou espaço-around.'
-    testString: 'assert(code.match(/header\s.profile-name\s*{\s*?.*?\s*?.*?\s*?\s*?.*?\s*?justify-content\s*:\s*(center|flex-start|flex-end|space-between|space-around)\s*;/g), "The <code>.profile-name</code> element should have the <code>justify-content</code> property set to any of these values: center, flex-start, flex-end, space-between, or space-around.");'
+    testString: 'assert(code.match(/header\s.profile-name\s*{\s*?.*?\s*?.*?\s*?\s*?.*?\s*?justify-content\s*:\s*(center|flex-start|flex-end|space-between|space-around|space-evenly)\s*;/g), "The <code>.profile-name</code> element should have the <code>justify-content</code> property set to any of these values: center, flex-start, flex-end, space-between, space-around, or space-evenly.");'
 
 ```
 

--- a/curriculum/challenges/russian/01-responsive-web-design/css-flexbox/use-the-justify-content-property-in-the-tweet-embed.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/css-flexbox/use-the-justify-content-property-in-the-tweet-embed.russian.md
@@ -22,8 +22,8 @@ localeTitle: Используйте свойство justify-content в Tweet Em
 
 ```yml
 tests:
-  - text: 'The <code>.profile-name</code> element should have the <code>justify-content</code> property set to any of these values: <code>center</code>, <code>flex-start</code>, <code>flex-end</code>, <code>space-between</code>, or <code>space-around</code>.'
-    testString: assert(code.match(/header\s.profile-name\s*{\s*?.*?\s*?.*?\s*?\s*?.*?\s*?justify-content\s*:\s*(center|flex-start|flex-end|space-between|space-around)\s*;/g));
+  - text: 'The <code>.profile-name</code> element should have the <code>justify-content</code> property set to any of these values: <code>center</code>, <code>flex-start</code>, <code>flex-end</code>, <code>space-between</code>, <code>space-around</code>, or <code>space-evenly</code>.'
+    testString: assert(code.match(/header\s.profile-name\s*{\s*?.*?\s*?.*?\s*?\s*?.*?\s*?justify-content\s*:\s*(center|flex-start|flex-end|space-between|space-around|space-evenly)\s*;/g));
 
 ```
 

--- a/curriculum/challenges/spanish/01-responsive-web-design/css-flexbox/use-the-justify-content-property-in-the-tweet-embed.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/css-flexbox/use-the-justify-content-property-in-the-tweet-embed.spanish.md
@@ -18,7 +18,7 @@ localeTitle: Use la propiedad justify-content en el Tweet Insertar
 ```yml
 tests:
   - text: 'El elemento <code>.profile-name</code> debe tener la propiedad <code>.profile-name</code> <code>justify-content</code> establecida en cualquiera de estos valores: centro, inicio flexible, final flexible, espacio intermedio o espacio-alrededor.'
-    testString: 'assert(code.match(/header\s.profile-name\s*{\s*?.*?\s*?.*?\s*?\s*?.*?\s*?justify-content\s*:\s*(center|flex-start|flex-end|space-between|space-around)\s*;/g), "The <code>.profile-name</code> element should have the <code>justify-content</code> property set to any of these values: center, flex-start, flex-end, space-between, or space-around.");'
+    testString: 'assert(code.match(/header\s.profile-name\s*{\s*?.*?\s*?.*?\s*?\s*?.*?\s*?justify-content\s*:\s*(center|flex-start|flex-end|space-between|space-around|space-evenly)\s*;/g), "The <code>.profile-name</code> element should have the <code>justify-content</code> property set to any of these values: center, flex-start, flex-end, space-between, space-around, or space-evenly.");'
 
 ```
 


### PR DESCRIPTION
This challenge requests setting the justify-content attribute to one of the possible values shown in the previous challenge. One of these values - space-evenly - doesn't actually work (at least for the English version).

In this commit I fix the space-evenly issues to some extent.

I cannot tick the box saying that all files changed are in the same world language. However, the changes made should be understandable in all languages.

There still is more to be done for languages other than English, like adding to the test text for Arabic, Portuguese, and Spanish, and adding descriptions for space-evenly in the previous challenge.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [ ] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX
