### PR TITLE
fix(client): disable intellisense in editor

### DIFF
--- a/client/src/templates/Challenges/classic/Editor.js
+++ b/client/src/templates/Challenges/classic/Editor.js
@@ -109,19 +109,9 @@ class Editor extends Component {
         useShadows: false,
         verticalScrollbarSize: 5
       },
-      quickSuggestions: {
-        other: false,
-        comments: false,
-        strings: false
-      },
       parameterHints: {
         enabled: false
-      },
-      ordBasedSuggestions: false,
-      suggestOnTriggerCharacters: false,
-      acceptSuggestionOnEnter: 'off',
-      tabCompletion: 'off',
-      wordBasedSuggestions: false
+      }
     };
 
     this._editor = null;

--- a/client/src/templates/Challenges/classic/Editor.js
+++ b/client/src/templates/Challenges/classic/Editor.js
@@ -108,7 +108,20 @@ class Editor extends Component {
         verticalHasArrows: false,
         useShadows: false,
         verticalScrollbarSize: 5
-      }
+      },
+      quickSuggestions: {
+        other: false,
+        comments: false,
+        strings: false
+      },
+      parameterHints: {
+        enabled: false
+      },
+      ordBasedSuggestions: false,
+      suggestOnTriggerCharacters: false,
+      acceptSuggestionOnEnter: 'off',
+      tabCompletion: 'off',
+      wordBasedSuggestions: false
     };
 
     this._editor = null;


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This is a first stab at disabling intellisense in client editor. Meanwhile, I'm still looking for a more concise way to turn off intellisense completely, without requiring as many commands as are on here, if possible.

@raisedadead When you have a moment, could you please test this out to make sure things are working as expected.

Closes #37740 
