### PR TITLE
fix: use arrow function syntax

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/set-default-parameters-for-your-functions.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/set-default-parameters-for-your-functions.english.md
@@ -11,9 +11,8 @@ In order to help us create more flexible functions, ES6 introduces <dfn>default 
 Check out this code:
 
 ```js
-function greeting(name = "Anonymous") {
-  return "Hello " + name;
-}
+const greeting = (name = "Anonymous") => "Hello " + name;
+
 console.log(greeting("John")); // Hello John
 console.log(greeting()); // Hello Anonymous
 ```


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

A user brought up the fact that the challenge seed code used arrow function syntax but the example did not.  This PR changes the example to use arrow function syntax.
