### PR TITLE
fix(curriculum): simplify the Remove Items Using splice() challenge without using reduce

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/remove-items-using-splice.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/remove-items-using-splice.english.md
@@ -32,7 +32,7 @@ let newArray = array.splice(3, 2);
 ## Instructions
 <section id='instructions'>
 
-We've initialized an array `arr`. Use `splice()` to modify `arr`, so that it only contains elements that sum to the value of <code>10</code>.
+We've initialized an array `arr`. Use `splice()` to remove elements `arr`, so that it only contains elements that sum to the value of <code>10</code>.
 
 </section>
 
@@ -41,12 +41,14 @@ We've initialized an array `arr`. Use `splice()` to modify `arr`, so that it onl
 
 ```yml
 tests:
-  - text: You should not change the original line of <code>const arr = [2, 5, 1, 5, 2, 1];</code>.
-    testString: assert(code.replace(/\s/g, '').match(/constarr=\[2,5,1,5,2,1\];?/));
+  - text: You should not change the original line of <code>const arr = [2, 4, 5, 1, 7, 5, 2, 1];</code>.
+    testString: assert(code.replace(/\s/g, '').match(/constarr=\[2,4,5,1,7,5,2,1\];?/));
   - text: <code>arr</code> should only contain elements that sum to <code>10</code>.
     testString: assert.strictEqual(arr.reduce((a, b) => a + b), 10);
   - text: Your code should utilize the <code>splice()</code> method on <code>arr</code>.
     testString: assert(code.replace(/\s/g, '').match(/arr\.splice\(/));
+  - text: The splice should only remove elements from <code>arr</code> and not add any additional elements to <code>arr</code>.
+    testString: assert(!code.replace(/\s/g, '').match(/arr\.splice\(\d+,\d+,\d+.*\)/g));
 ```
 
 </section>
@@ -57,8 +59,7 @@ tests:
 <div id='js-seed'>
 
 ```js
-
-const arr = [2, 5, 1, 5, 2, 1];
+const arr = [2, 4, 5, 1, 7, 5, 2, 1];
 // only change code below this line
 
 // only change code above this line
@@ -75,8 +76,8 @@ console.log(arr);
 <section id='solution'>
 
 ```js
-const arr = [2, 5, 1, 5, 2, 1];
-arr.splice(2, 2);
+const arr = [2, 4, 5, 1, 7, 5, 2, 1];
+arr.splice(1, 4);
 ```
 
 </section>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/remove-items-using-splice.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/remove-items-using-splice.english.md
@@ -31,7 +31,9 @@ let newArray = array.splice(3, 2);
 
 ## Instructions
 <section id='instructions'>
-We've defined a function, <code>sumOfTen</code>, which takes an array as an argument and returns the sum of that array's elements. Modify the function, using <code>splice()</code>, so that it returns a value of <code>10</code>.
+
+We've initialized an array `arr`. Use `splice()` to modify `arr`, so that it only contains elements that sum to the value of <code>10</code>.
+
 </section>
 
 ## Tests
@@ -39,11 +41,12 @@ We've defined a function, <code>sumOfTen</code>, which takes an array as an argu
 
 ```yml
 tests:
-  - text: <code>sumOfTen</code> should return 10
-    testString: assert.strictEqual(sumOfTen([2, 5, 1, 5, 2, 1]), 10);
-  - text: The <code>sumOfTen</code> function should utilize the <code>splice()</code> method
-    testString: assert.notStrictEqual(sumOfTen.toString().search(/\.splice\(/), -1);
-
+  - text: You should not change the original line of <code>const arr = [2, 5, 1, 5, 2, 1];</code>.
+    testString: assert(code.replace(/\s/g, '').match(/constarr=\[2,5,1,5,2,1\];?/));
+  - text: <code>arr</code> should only contain elements that sum to <code>10</code>.
+    testString: assert.strictEqual(arr.reduce((a, b) => a + b), 10);
+  - text: Your code should utilize the <code>splice()</code> method on <code>arr</code>.
+    testString: assert(code.replace(/\s/g, '').match(/arr\.splice\(/));
 ```
 
 </section>
@@ -54,15 +57,12 @@ tests:
 <div id='js-seed'>
 
 ```js
-function sumOfTen(arr) {
-  // change code below this line
 
-  // change code above this line
-  return arr.reduce((a, b) => a + b);
-}
+const arr = [2, 5, 1, 5, 2, 1];
+// only change code below this line
 
-// do not change code below this line
-console.log(sumOfTen([2, 5, 1, 5, 2, 1]));
+// only change code above this line
+console.log(arr);
 ```
 
 </div>
@@ -75,10 +75,8 @@ console.log(sumOfTen([2, 5, 1, 5, 2, 1]));
 <section id='solution'>
 
 ```js
-function sumOfTen(arr) {
-  arr.splice(2,2);
-  return arr.reduce((a, b) => a + b);
-}
+const arr = [2, 5, 1, 5, 2, 1];
+arr.splice(2, 2);
 ```
 
 </section>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/remove-items-using-splice.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/remove-items-using-splice.english.md
@@ -32,7 +32,7 @@ let newArray = array.splice(3, 2);
 ## Instructions
 <section id='instructions'>
 
-We've initialized an array `arr`. Use `splice()` to remove elements `arr`, so that it only contains elements that sum to the value of <code>10</code>.
+We've initialized an array `arr`. Use `splice()` to remove elements from `arr`, so that it only contains elements that sum to the value of <code>10</code>.
 
 </section>
 


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

After reading [this forum topic](https://www.freecodecamp.org/forum/t/understanding-the-reduce-method-in-splice-challenge/328194) regarding the use of the `reduce` method in the challenge seed code, I realized we should remove this from the code as the `reduce` method is not introduced until the `Functional Programming` section.   I kept the same idea behind the original challenge, but removed the function.

**NOTE:**  If this PR gets merged, the [corresponding forum topic](https://www.freecodecamp.org/forum/t/freecodecamp-challenge-guide-remove-items-using-splice/301166) hints/solution will need to be updated as well.
