### PR TITLE
fix(curriculum): use regex to avoid differences in how browsers calculate style property values for Decrease Opacity of an Element challenge

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/decrease-the-opacity-of-an-element.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/decrease-the-opacity-of-an-element.english.md
@@ -24,7 +24,7 @@ Set the <code>opacity</code> of the anchor tags to 0.7 using <code>links</code> 
 ```yml
 tests:
   - text: Your code should set the <code>opacity</code> property to 0.7 on the anchor tags by selecting the class of <code>links</code>.
-    testString: assert(getComputedStyle($('.links')[0]).opacity == '0.7');
+    testString: assert(/\.links{\S*opacity:0?\.70*(;\S*}|})/.test($('style').text().replace(/\s/g ,'')));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/decrease-the-opacity-of-an-element.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/decrease-the-opacity-of-an-element.english.md
@@ -24,7 +24,7 @@ Set the <code>opacity</code> of the anchor tags to 0.7 using <code>links</code> 
 ```yml
 tests:
   - text: Your code should set the <code>opacity</code> property to 0.7 on the anchor tags by selecting the class of <code>links</code>.
-    testString: assert(/\.links{\S*opacity:0?\.70*(;\S*}|})/.test($('style').text().replace(/\s/g ,'')));
+    testString: assert(/\.links\s*{([\s\S]*?;)*\s*opacity\s*:\s*0*\.70*\s*(;[\s\S]*?|\s*)}/.test($('style').text()));
 
 ```
 


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

The [Decrease Opacity of an Element](https://www.freecodecamp.org/learn/responsive-web-design/applied-visual-design/decrease-the-opacity-of-an-element) challenge tests have been changed before to address this same issue, but they do not work on all browsers (like Safari).  For example, the original test used the `getComputedStyle` method and would return values like 0.699999887 for opacity.  

This PR uses regex to check the opacity value. to protect against differences in how browsers calculate the styling of elements.

Closes #37856