### PR TITLE
fix(curriculum): correct function name in test text for Create a Priority Queue Class challenge

### DIFF
--- a/curriculum/challenges/english/08-coding-interview-prep/data-structures/create-a-priority-queue-class.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/data-structures/create-a-priority-queue-class.english.md
@@ -26,15 +26,15 @@ The <code>enqueue</code> should accept items with the format shown above (<code>
 
 ```yml
 tests:
-  - text: Your <code>Queue</code> class should have a <code>enqueue</code> method.
+  - text: Your <code>PriorityQueue</code> class should have a <code>enqueue</code> method.
     testString: assert((function(){var test = new PriorityQueue();  return (typeof test.enqueue === 'function')}()));
-  - text: Your <code>Queue</code> class should have a <code>dequeue</code> method.
+  - text: Your <code>PriorityQueue</code> class should have a <code>dequeue</code> method.
     testString: assert((function(){var test = new PriorityQueue();  return (typeof test.dequeue === 'function')}()));
-  - text: Your <code>Queue</code> class should have a <code>size</code> method.
+  - text: Your <code>PriorityQueue</code> class should have a <code>size</code> method.
     testString: assert((function(){var test = new PriorityQueue();  return (typeof test.size === 'function')}()));
-  - text: Your <code>Queue</code> class should have an <code>isEmpty</code> method.
+  - text: Your <code>PriorityQueue</code> class should have an <code>isEmpty</code> method.
     testString: assert((function(){var test = new PriorityQueue();  return (typeof test.isEmpty === 'function')}()));
-  - text: Your PriorityQueue should correctly keep track of the current number of items using the <code>size</code> method as items are enqueued and dequeued.
+  - text: Your <code>PriorityQueue</code> class should correctly keep track of the current number of items using the <code>size</code> method as items are enqueued and dequeued.
     testString: assert((function(){var test = new PriorityQueue(); test.enqueue(['David Brown', 2]); test.enqueue(['Jon Snow', 1]); var size1 = test.size(); test.dequeue(); var size2 = test.size(); test.enqueue(['A', 3]); test.enqueue(['B', 3]); test.enqueue(['C', 3]); return (size1 === 2 && size2 === 1 && test.size() === 4)}()));
   - text: The <code>isEmpty</code> method should return <code>true</code> when the queue is empty.
     testString: assert((function(){var test = new PriorityQueue(); test.enqueue(['A', 1]); test.enqueue(['B', 1]); test.dequeue(); var first = test.isEmpty(); test.dequeue(); return (!first && test.isEmpty()); }()));


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

This PR fixes a typo in the text of several tests for this challenge.  The challenge seed and tests expect the name of the function/class to be `PriorityQueue`, but the tests' text referenced `Queue` instead.
