### PR TITLE
fix(curriculum): make last test more robust for Uncomment HTML challenge

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/uncomment-html.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/uncomment-html.english.md
@@ -30,7 +30,7 @@ tests:
   - text: Your <code>p</code> element should be visible on the page by uncommenting it.
     testString: assert($("p").length > 0);
   - text: No trailing comment tags should be visible on the page (i.e. <code>--></code>).
-    testString: console.log($('*:contains("-->")')[1]);assert(!$('*:contains("-->")')[1]);
+    testString: assert(!$('*:contains("-->")')[1]);
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/uncomment-html.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/uncomment-html.english.md
@@ -23,14 +23,14 @@ Uncomment your <code>h1</code>, <code>h2</code> and <code>p</code> elements.
 
 ```yml
 tests:
-  - text: Your <code>h1</code> element should be visible on your page by uncommenting it.
+  - text: Your <code>h1</code> element should be visible on the page by uncommenting it.
     testString: assert($("h1").length > 0);
-  - text: Your <code>h2</code> element should be visible on your page by uncommenting it.
+  - text: Your <code>h2</code> element should be visible on the page by uncommenting it.
     testString: assert($("h2").length > 0);
-  - text: Your <code>p</code> element should be visible on your page by uncommenting it.
+  - text: Your <code>p</code> element should be visible on the page by uncommenting it.
     testString: assert($("p").length > 0);
-  - text: All trailing comment tags should be deleted&#44; i.e. <code>--&#62;</code>.
-    testString: assert(!/[^fc]-->/gi.test(code.replace(/ *<!--[^fc]*\n/g,'')));
+  - text: No trailing comment tags should be visible on the page (i.e. <code>--></code>).
+    testString: console.log($('*:contains("-->")')[1]);assert(!$('*:contains("-->")')[1]);
 
 ```
 


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

In [this forum topic](https://www.freecodecamp.org/forum/t/frist-day-learning-code-ask-for-help/328668/2) a user pointed out a case where technically there were no trailing comment tags visible, but the test incorrectly stated there were.  This PR fixes the last test to allow the main objective of removing all comment syntax and cases where a user still adds extra valid comment syntax which does not prevent the other 3 tests from passing.
