### PR TITLE
fix(donate): handle missing stripe keys

### DIFF
--- a/client/gatsby-node.js
+++ b/client/gatsby-node.js
@@ -51,6 +51,19 @@ exports.createPages = function createPages({ graphql, actions, reporter }) {
       );
     }
   }
+
+  if (!env.stripePublicKey || !env.servicebotId) {
+    if (process.env.FREECODECAMP_NODE_ENV === 'production') {
+      throw new Error(
+        'Stripe public key and Servicebot id are required to start the client!'
+      );
+    } else {
+      reporter.info(
+        'Stripe public key or Servicebot id missing or invalid. Required for' +
+          ' donations.'
+      );
+    }
+  }
   const { createPage } = actions;
 
   return new Promise((resolve, reject) => {

--- a/client/src/components/Donation/components/DonateFormChildViewForHOC.js
+++ b/client/src/components/Donation/components/DonateFormChildViewForHOC.js
@@ -60,6 +60,7 @@ class DonateFormChildViewForHOC extends Component {
     this.handleSubmit = this.handleSubmit.bind(this);
     this.postDonation = this.postDonation.bind(this);
     this.resetDonation = this.resetDonation.bind(this);
+    this.hideAmountOptions(false);
   }
 
   getUserEmail() {
@@ -226,7 +227,6 @@ class DonateFormChildViewForHOC extends Component {
         reset: this.resetDonation
       });
     }
-    this.hideAmountOptions(false);
     return this.renderDonateForm();
   }
 }

--- a/client/src/pages/donate.js
+++ b/client/src/pages/donate.js
@@ -61,11 +61,12 @@ export class DonatePage extends Component {
 
   handleStripeLoad() {
     // Create Stripe instance once Stripe.js loads
-    console.info('stripe has loaded');
-    this.setState(state => ({
-      ...state,
-      stripe: window.Stripe(stripePublicKey)
-    }));
+    if (stripePublicKey) {
+      this.setState(state => ({
+        ...state,
+        stripe: window.Stripe(stripePublicKey)
+      }));
+    }
   }
 
   enableDonationSettingsPage(enableSettings = true) {

--- a/config/env.js
+++ b/config/env.js
@@ -30,8 +30,14 @@ const locations = {
 
 module.exports = Object.assign(locations, {
   locale,
-  stripePublicKey,
-  servicebotId,
+  stripePublicKey:
+    !stripePublicKey || stripePublicKey === 'pk_from_stripe_dashboard'
+      ? null
+      : stripePublicKey,
+  servicebotId:
+    !servicebotId || servicebotId === 'servicebot_id_from_servicebot_dashboard'
+      ? null
+      : servicebotId,
   algoliaAppId:
     !algoliaAppId || algoliaAppId === 'Algolia app id from dashboard'
       ? null


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The first commit prevents production from starting with missing keys while allowing development to start with a warning.  If the keys are still missing when the donate page is rendered it handles it gracefully.

The second commit makes sure the flow is `state -> render` not `render -> state`.  @raisedadead I went through the logic and I'm reasonably confident it's correct i.e. in this PR `this.hideAmountOptions();` will now have been called by a handler before `render` so that we will end up with the same `processing` state as before.