### PR TITLE
Enable newlines in Authentication with Socket.IO, test 3

### DIFF
--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/authentication-with-socket.io.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/authentication-with-socket.io.english.md
@@ -41,7 +41,7 @@ tests:
   - text: passportSocketIo should be properly required.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js').then(data => { assert.match(data, /require\((['"])passport\.socketio\1\)/gi, 'You should correctly require and instantiate "passport.socketio"');}, xhr => { throw new Error(xhr.statusText); })
   - text: passportSocketIo should be properly setup.
-    testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /io\.use\([^]+\.authorize\(/gi, 'You should register "passport.socketio" as socket.io middleware and provide it correct options'); }, xhr => { throw new Error(xhr.statusText); })
+    testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /io\.use\(\w*\s+\.authorize\(/, 'You should register "passport.socketio" as socket.io middleware and provide it correct options'); }, xhr => { throw new Error(xhr.statusText); })
 
 ```
 

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/authentication-with-socket.io.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/authentication-with-socket.io.english.md
@@ -41,7 +41,7 @@ tests:
   - text: passportSocketIo should be properly required.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js').then(data => { assert.match(data, /require\((['"])passport\.socketio\1\)/gi, 'You should correctly require and instantiate "passport.socketio"');}, xhr => { throw new Error(xhr.statusText); })
   - text: passportSocketIo should be properly setup.
-    testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /io\.use\(.+\.authorize\(/gi, 'You should register "passport.socketio" as socket.io middleware and provide it correct options'); }, xhr => { throw new Error(xhr.statusText); })
+    testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /io\.use\([^]+\.authorize\(/gi, 'You should register "passport.socketio" as socket.io middleware and provide it correct options'); }, xhr => { throw new Error(xhr.statusText); })
 
 ```
 

--- a/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/authentication-with-socket.io.english.md
+++ b/curriculum/challenges/english/06-information-security-and-quality-assurance/advanced-node-and-express/authentication-with-socket.io.english.md
@@ -41,7 +41,7 @@ tests:
   - text: passportSocketIo should be properly required.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js').then(data => { assert.match(data, /require\((['"])passport\.socketio\1\)/gi, 'You should correctly require and instantiate "passport.socketio"');}, xhr => { throw new Error(xhr.statusText); })
   - text: passportSocketIo should be properly setup.
-    testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /io\.use\(\w*\s+\.authorize\(/, 'You should register "passport.socketio" as socket.io middleware and provide it correct options'); }, xhr => { throw new Error(xhr.statusText); })
+    testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /io\.use\(\s*\w+\.authorize\(/, 'You should register "passport.socketio" as socket.io middleware and provide it correct options'); }, xhr => { throw new Error(xhr.statusText); })
 
 ```
 


### PR DESCRIPTION
Both my original formatting and glitch's "format this file" button add a newline between "io.use("  and  "passport.authorize"

`.+` catches one or more of anything that isn't a newline.
`[^]+` catches one or more of anything including newlines. 

This change updates the test accordingly so people who use glitch's formatting don't get left searching for assistance

With this change both:
```
io.use(
  passportSocketIo.authorize(
```

and

```
io.use(passportSocketIo.authorize(
```

will be caught

---
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.
