### PR TITLE
fix(curriculum): correct typo - change rating to ratings in console.log statement

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/use-the-map-method-to-extract-data-from-an-array.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/use-the-map-method-to-extract-data-from-an-array.english.md
@@ -180,7 +180,7 @@ for(var i=0; i < watchList.length; i++){
 
 // Add your code above this line
 
-console.log(JSON.stringify(rating));
+console.log(JSON.stringify(ratings));
 ```
 
 </div>


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

User in [this forum post](https://www.freecodecamp.org/forum/t/how-to-remove-backlashes-from-output/330020/3) pointed out a typo in the [Use the map Method to Extract Data from an Array](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/functional-programming/use-the-map-method-to-extract-data-from-an-array) challenge.  This PR fixes the typo that was causing a reference error to show in the FCC console.
