### PR TITLE
Update restrict-possible-usernames.english.md

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/restrict-possible-usernames.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/restrict-possible-usernames.english.md
@@ -43,8 +43,8 @@ tests:
     testString: assert(!userCheck.test("A1"));
   - text: Your regex should not match <code>BadUs3rnam3</code>
     testString: assert(!userCheck.test("BadUs3rnam3"));
-  - text: Your regex should match <code>Z97</code>
-    testString: assert(userCheck.test("Z97"));
+  - text: Your regex should not match <code>Z97</code>
+    testString: assert(!userCheck.test("Z97"));
   - text: Your regex should not match <code>c57bT3</code>
     testString: assert(!userCheck.test("c57bT3"));  
 


### PR DESCRIPTION
As per contraints the usernames have to be at least two characters long. A two-character username can only use alphabet letters as characters. Which makes testing Z97 to return false, but earlier it has been mentioned to return true

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX
