### PR TITLE
fix(curriculum): removed semi-colon from regex to allow other solutions for the Use Recursion to Create a Countdown challenge

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/use-recursion-to-create-a-countdown.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/use-recursion-to-create-a-countdown.md
@@ -54,7 +54,7 @@ tests:
   - text: Your code should not rely on any kind of loops (<code>for</code>, <code>while</code> or higher order functions such as <code>forEach</code>, <code>map</code>, <code>filter</code>, and <code>reduce</code>).
     testString: assert(!removeJSComments(code).match(/for|while|forEach|map|filter|reduce/g));
   - text: You should use recursion to solve this problem.
-    testString: assert(removeJSComments(countdown.toString()).match(/countdown\s*\(.+\)\;/));
+    testString: assert(removeJSComments(countdown.toString()).match(/countdown\s*\(.+\)/));
 ```
 
 </section>


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

User in [this forum post](https://www.freecodecamp.org/forum/t/recursion-to-create-a-countdown-problem/331281) had a valid solution that was not passing due to the regex requiring a semi-colon directly after the closing parentheses of the recursive call.  This PR removes the semi-colon from the regex to allow the following solution valid to pass the tests:

```javascript
function countdown(n){
  return n > 0 ? [n].concat(countdown(n - 1)) : [];
}
```
