### PR TITLE
fix: Modify challenge test suite for project based curriculum

### DIFF
--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -184,9 +184,11 @@ function populateTestsForLang({ lang, challenges }) {
           if (challenge.challengeType !== 7 && invalidBlock) {
             throw new Error(invalidBlock);
           }
-          const { id, title } = challenge;
+          const { id, title, block, dashedName } = challenge;
+          const dashedBlock = dasherize(block);
+          const pathAndTitle = `${dashedBlock}/${dashedName}`;
           mongoIds.check(id, title);
-          challengeTitles.check(title);
+          challengeTitles.check(title, pathAndTitle);
         });
 
         const { challengeType } = challenge;

--- a/curriculum/test/utils/challengeTitles.js
+++ b/curriculum/test/utils/challengeTitles.js
@@ -2,7 +2,7 @@ class ChallengeTitles {
   constructor() {
     this.knownTitles = [];
   }
-  check(title) {
+  check(title, pathAndTitle) {
     if (typeof title !== 'string') {
       throw new Error(
         `Expected a valid string for ${title}, but got a(n) ${typeof title}`
@@ -12,15 +12,19 @@ class ChallengeTitles {
     if (titleToCheck.length === 0) {
       throw new Error('Expected a title length greater than 0');
     }
-    const isKnown = this.knownTitles.includes(titleToCheck);
+    const isProjectCurriculumChallenge = title.match(/^Part\s*\d+/);
+    const titleToAdd = isProjectCurriculumChallenge
+      ? pathAndTitle
+      : titleToCheck;
+    const isKnown = this.knownTitles.includes(titleToAdd);
     if (isKnown) {
       throw new Error(`
-    All challenges must have a unique title.
+    All current curriculum challenges must have a unique title.
 
-    The title ${title} is already assigned
+    The title ${title} (at ${pathAndTitle}) is already assigned
     `);
     }
-    this.knownTitles = [...this.knownTitles, titleToCheck];
+    this.knownTitles = [...this.knownTitles, titleToAdd];
   }
 }
 


### PR DESCRIPTION
Modified challenge test suite so it does not throw an error if two steps for the project based curriculum have the same title.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to https://github.com/freeCodeCamp/freeCodeCamp/pull/37792.