### PR TITLE
fix(curriculum): make test more flexible for 

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/applied-accessibility/give-links-meaning-by-using-descriptive-link-text.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-accessibility/give-links-meaning-by-using-descriptive-link-text.english.md
@@ -27,7 +27,7 @@ tests:
   - text: The <code>a</code> element should have an <code>href</code> attribute with a value of an empty string <code>""</code>.
     testString: assert($('a').attr('href') === '');
   - text: The <code>a</code> element should have a closing tag.
-    testString: assert(code.match(/<\/a>/g) && code.match(/<\/a>/g).length === code.match(/<a href=(''|"")>/g).length);
+    testString: assert((code.match(/<\/a>/g) || []).length === (code.match(/<a[^>] href=(''|"")>/g).length);
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/applied-accessibility/give-links-meaning-by-using-descriptive-link-text.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-accessibility/give-links-meaning-by-using-descriptive-link-text.english.md
@@ -27,7 +27,7 @@ tests:
   - text: The <code>a</code> element should have an <code>href</code> attribute with a value of an empty string <code>""</code>.
     testString: assert($('a').attr('href') === '');
   - text: The <code>a</code> element should have a closing tag.
-    testString: assert((code.match(/<\/a>/g) || []).length === (code.match(/<a[^>] href=(''|"")>/g).length);
+    testString: assert(code.match(/<\/a>/g) && code.match(/<\/a>/g).length === code.match(/<a href=(''|"")>/g).length);
 
 ```
 

--- a/curriculum/challenges/english/03-front-end-libraries/react/render-a-class-component-to-the-dom.english.md
+++ b/curriculum/challenges/english/03-front-end-libraries/react/render-a-class-component-to-the-dom.english.md
@@ -30,7 +30,7 @@ tests:
   - text: The <code>TypesOfFood</code> component should render the <code>Vegetables</code> component after <code>Fruits</code>.
     testString: assert((function() { const mockedComponent = Enzyme.mount(React.createElement(TypesOfFood)); return mockedComponent.children().childAt(2).name() === 'Vegetables'; })());
   - text: The <code>TypesOfFood</code> component should render to the DOM within the <code>div</code> with the id <code>challenge-node</code>.
-    testString: assert((function() { const html = document.getElementById('challenge-node').childNodes[0].innerHTML; return (html === '<h1>Types of Food:</h1><div><h2>Fruits:</h2><h4>Non-Citrus:</h4><ul><li>Apples</li><li>Blueberries</li><li>Strawberries</li><li>Bananas</li></ul><h4>Citrus:</h4><ul><li>Lemon</li><li>Lime</li><li>Orange</li><li>Grapefruit</li></ul></div><div><h2>Vegetables:</h2><ul><li>Brussel Sprouts</li><li>Broccoli</li><li>Squash</li></ul></div>'); })());
+    testString: assert((function() { const html = document.getElementById('challenge-node').childNodes[0].innerHTML; return html.includes('<div><h2>Fruits:</h2><h4>Non-Citrus:</h4><ul><li>Apples</li><li>Blueberries</li><li>Strawberries</li><li>Bananas</li></ul><h4>Citrus:</h4><ul><li>Lemon</li><li>Lime</li><li>Orange</li><li>Grapefruit</li></ul></div>') && html.includes('<div><h2>Vegetables:</h2><ul><li>Brussel Sprouts</li><li>Broccoli</li><li>Squash</li></ul></div>'); })());
 
 ```
 


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

After a forum [posted this](https://www.freecodecamp.org/forum/t/issue-with-react-dont-know-whats-not-working/331692), I realized the test does not deal with valid code.  The last test only should care that the html of the Fruits and Vegetables components render in the DOM.  React adds spaces in the overall HTML if the user puts spaces on the same line as a comment or another component, even though technically the components would still show the same. 

This PR just checks that the html in the Fruits and Vegetables components is included in the final rendering and ignores if there happens to be extra space before, between, or after the components' html. 