### PR TITLE
fix: timeline not showing when set to public

### DIFF
--- a/api-server/common/models/user.js
+++ b/api-server/common/models/user.js
@@ -797,14 +797,15 @@ export default function(User) {
       about: showAbout ? about : '',
       calendar: showHeatMap ? calendar : {},
       completedChallenges: (function() {
-        if (showCerts && showTimeLine) {
-          return completedChallenges;
-        } else if (showTimeLine) {
-          return completedChallenges.filter(
-            challenge => challenge.challengeType !== 7
-          );
+        if (showTimeLine) {
+          return showCerts
+            ? completedChallenges
+            : completedChallenges.filter(
+                challenge => challenge.challengeType !== 7
+              );
+        } else {
+          return [];
         }
-        return [];
       })(),
       isDonating: showDonation ? isDonating : null,
       location: showLocation ? location : '',

--- a/api-server/common/models/user.js
+++ b/api-server/common/models/user.js
@@ -792,7 +792,6 @@ export default function(User) {
         username
       };
     }
-
     return {
       ...user,
       about: showAbout ? about : '',

--- a/api-server/common/models/user.js
+++ b/api-server/common/models/user.js
@@ -792,11 +792,21 @@ export default function(User) {
         username
       };
     }
+
     return {
       ...user,
       about: showAbout ? about : '',
       calendar: showHeatMap ? calendar : {},
-      completedChallenges: showCerts && showTimeLine ? completedChallenges : [],
+      completedChallenges: (function() {
+        if (showCerts && showTimeLine) {
+          return completedChallenges;
+        } else if (showTimeLine) {
+          return completedChallenges.filter(
+            challenge => challenge.challengeType !== 7
+          );
+        }
+        return [];
+      })(),
       isDonating: showDonation ? isDonating : null,
       location: showLocation ? location : '',
       name: showName ? name : '',

--- a/api-server/common/models/user.js
+++ b/api-server/common/models/user.js
@@ -801,7 +801,7 @@ export default function(User) {
           return showCerts
             ? completedChallenges
             : completedChallenges.filter(
-                challenge => challenge.challengeType !== 7
+                ({ challengeType }) => challengeType !== 7
               );
         } else {
           return [];


### PR DESCRIPTION
So the problem here was that, when requesting another users profile (not your own), the `completedChallenges` array was only sent back if `showCerts` and `showTimeLine` were `true` - aka public. So I filtered out the cert challenges if `showCerts` was private and sent it back like that. I came up with a few iterations of this logic before landing on what's in the PR. Feel free to suggest something better.

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #37855
