### PR TITLE
fix(curriculum) - updated tests for the 3 challenges involving the animation-timing-function property to work with Edge browser

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/change-animation-timing-with-keywords.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/change-animation-timing-with-keywords.english.md
@@ -23,9 +23,9 @@ For the elements with id of <code>ball1</code> and <code>ball2</code>, add an <c
 ```yml
 tests:
   - text: The value of the <code>animation-timing-function</code> property for the element with the id <code>ball1</code> should be linear.
-    testString: assert($('#ball1').css('animation-timing-function') == 'linear');
+    testString: const ball1Animation = $('#ball1').css('animation-timing-function').replace(/\s/g, '');assert(ball1Animation == 'linear' || ball1Animation == 'cubic-bezier(0,0,1,1)');
   - text: The value of the <code>animation-timing-function</code> property for the element with the id <code>ball2</code> should be ease-out.
-    testString: assert($('#ball2').css('animation-timing-function') == 'ease-out');
+    testString: const ball2Animation = $('#ball2').css('animation-timing-function').replace(/\s/g, ''); assert(ball2Animation == 'ease-out' || ball2Animation == 'cubic-bezier(0,0,0.58,1)');
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/learn-how-bezier-curves-work.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/learn-how-bezier-curves-work.english.md
@@ -28,7 +28,7 @@ tests:
   - text: The value of the <code>animation-timing-function</code> property for the element with the id <code>ball1</code> should be the linear-equivalent cubic-bezier function.
     testString: assert($('#ball1').css('animation-timing-function') == 'cubic-bezier(0.25, 0.25, 0.75, 0.75)');
   - text: The value of the <code>animation-timing-function</code> property for the element with the id <code>ball2</code> should not change.
-    testString: assert($('#ball2').css('animation-timing-function') == 'ease-out');
+    testString: const ball2Animation = $('#ball2').css('animation-timing-function').replace(/\s/g, ''); assert(ball2Animation == 'ease-out' || ball2Animation == 'cubic-bezier(0,0,0.58,1)');
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/use-a-bezier-curve-to-move-a-graphic.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/use-a-bezier-curve-to-move-a-graphic.english.md
@@ -29,7 +29,7 @@ tests:
   - text: The element with the id <code>red</code> should no longer have the <code>animation-timing-function</code> property of linear.
     testString: assert($('#red').css('animation-timing-function') !== 'linear');
   - text: The value of the <code>animation-timing-function</code> property for the element with the id <code>blue</code> should not change.
-    testString: assert($('#blue').css('animation-timing-function') == 'ease-out');
+    testString: const blueBallAnimation = $('#blue').css('animation-timing-function').replace(/\s/g, ''); assert(blueBallAnimation == 'ease-out' || blueBallAnimation == 'cubic-bezier(0,0,0.58,1)');
 
 ```
 


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

After working through all the current Responsive Web Design challenges using a valid solution on the Edge browser, I discovered the following 3 challenges are the only ones that would not work.  It was related to the value returned by jQuery `css` method for the `animation-timing-function' property` when using Edge.  The string version values like "linear" and  "ease-out" get converted to the cubic-bezier equivalent, so the tests must consider those values also.

This PR makes the required changes to the tests.