### PR TITLE
fix: add close modal to keyboard navigation

### DIFF
--- a/client/src/components/Donation/Donation.css
+++ b/client/src/components/Donation/Donation.css
@@ -217,6 +217,11 @@ li.disabled > a {
   font-size: 1.5rem;
 }
 
+.donation-modal .btn-link:focus {
+  outline-width: 1px;
+  outline-style: solid;
+}
+
 @media screen and (max-width: 991px) {
   .donation-icon-container {
     margin: 30px;

--- a/client/src/components/Donation/components/DonationModal.js
+++ b/client/src/components/Donation/components/DonationModal.js
@@ -107,6 +107,7 @@ function DonateModal({ show, block, isBlockDonation, closeDonationModal }) {
               bsStyle='primary'
               className='btn-link'
               onClick={closeDonationModal}
+              tabIndex='0'
             >
               {closeLabel ? 'Close.' : 'Ask me later.'}
             </Button>


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This makes the 'Ask me later.' button reachable by tab navigation.  When focused it looks like this:
![image](https://user-images.githubusercontent.com/15801806/71070210-95bade80-217a-11ea-9b10-6d8ce55d0570.png)

Closes #37949
