### PR TITLE
fix: flush logs straight after evaluation

### DIFF
--- a/client/src/client/workers/test-evaluator.js
+++ b/client/src/client/workers/test-evaluator.js
@@ -47,7 +47,8 @@ const __utils = (() => {
   return {
     postResult,
     log,
-    toggleProxyLogger
+    toggleProxyLogger,
+    flushLogs
   };
 })();
 
@@ -71,6 +72,7 @@ self.onmessage = async e => {
       // generated during testing.
       testResult = eval(`
         ${e.data.build}
+        __utils.flushLogs();
         __userCodeWasExecuted = true;
         __utils.toggleProxyLogger(true);
         ${e.data.testString}


### PR DESCRIPTION


<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

As discussed in https://github.com/freeCodeCamp/freeCodeCamp/pull/37979#pullrequestreview-337534003 if test evaluation takes too long the worker can timeout and any logs will be lost.  Flushing the logs before test evaluation avoids this.
