### PR TITLE
fix: Wrap `column` with <code> tags.

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-flex-direction-property-to-make-a-column.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-flex-direction-property-to-make-a-column.english.md
@@ -13,7 +13,7 @@ The last two challenges used the <code>flex-direction</code> property set to row
 
 ## Instructions
 <section id='instructions'>
-Add the CSS property <code>flex-direction</code> to the <code>#box-container</code> element, and give it a value of column.
+Add the CSS property <code>flex-direction</code> to the <code>#box-container</code> element, and give it a value of <code>column</code>.
 </section>
 
 ## Tests


### PR DESCRIPTION
## Checklist

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

## What
This is a tiny fix. Just wrap one value with `<code>` tag.

This is a URL of the challenge page: https://www.freecodecamp.org/learn/responsive-web-design/css-flexbox/use-the-flex-direction-property-to-make-a-column

## Why
The target challenge requires users to type `column` so the CSS value should be wrapped with `<code>` tag.