### PR TITLE
Move the comment on line 71 to its own line

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-pass-an-object-as-a-functions-parameters.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-pass-an-object-as-a-functions-parameters.english.md
@@ -67,8 +67,8 @@ const stats = {
   average: 35.85
 };
 
-// change code below this line
 // use function argument destructuring
+// change code below this line
 const half = (stats) => (stats.max + stats.min) / 2.0; 
 // change code above this line
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-pass-an-object-as-a-functions-parameters.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-pass-an-object-as-a-functions-parameters.english.md
@@ -68,7 +68,8 @@ const stats = {
 };
 
 // change code below this line
-const half = (stats) => (stats.max + stats.min) / 2.0; // use function argument destructuring
+// use function argument destructuring
+const half = (stats) => (stats.max + stats.min) / 2.0; 
 // change code above this line
 
 console.log(stats); // should be object


### PR DESCRIPTION
The comment "use function argument destructuring" was on the same line as some code, and when displayed as a challenge it returned to a new line and was not commented out.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-pass-an-object-as-a-functions-parameters
