### PR TITLE
fix: news search redirects and loading indicator

### DIFF
--- a/client/src/components/search/searchBar/SearchBar.js
+++ b/client/src/components/search/searchBar/SearchBar.js
@@ -115,7 +115,7 @@ export class SearchBar extends Component {
     // when non-empty search input submitted
     return query
       ? window.location.assign(
-          `https://freecodecamp.org/news/search/?query=${encodeURIComponent(
+          `https://www.freecodecamp.org/news/search/?query=${encodeURIComponent(
             query
           )}`
         )
@@ -188,7 +188,7 @@ export class SearchBar extends Component {
                 onChange={this.handleChange}
                 onFocus={this.handleFocus}
                 onSubmit={this.handleSearch}
-                showLoadingIndicator={true}
+                showLoadingIndicator={false}
                 translations={{ placeholder }}
               />
             </ObserveKeys>

--- a/client/src/components/search/searchBar/SearchHits.js
+++ b/client/src/components/search/searchBar/SearchHits.js
@@ -17,7 +17,7 @@ const CustomHits = connectHits(
       {
         objectID: `default-hit-${searchQuery}`,
         query: searchQuery,
-        url: `https://freecodecamp.org/news/search/?query=${encodeURIComponent(
+        url: `https://www.freecodecamp.org/news/search/?query=${encodeURIComponent(
           searchQuery
         )}`,
         title: `See all results for ${searchQuery}`,

--- a/client/src/components/search/searchBar/SearchSuggestion.js
+++ b/client/src/components/search/searchBar/SearchSuggestion.js
@@ -14,7 +14,7 @@ const Suggestion = ({ hit, handleMouseEnter, handleMouseLeave }) => {
       }
       href={
         dropdownFooter
-          ? `https://freecodecamp.org/news/search/?query=${encodeURIComponent(
+          ? `https://www.freecodecamp.org/news/search/?query=${encodeURIComponent(
               hit.query
             )}`
           : hit.url


### PR DESCRIPTION
Disable loading indicator and redirect to full news search page url so NGINX no longer redirects to ../news/news/search?query=...

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #38039
