### PR TITLE
fix: change test-evaluator hash to refresh cache

### DIFF
--- a/client/src/client/workers/test-evaluator.js
+++ b/client/src/client/workers/test-evaluator.js
@@ -70,13 +70,11 @@ self.onmessage = async e => {
     try {
       // Logging is proxyed after the build to catch console.log messages
       // generated during testing.
-      testResult = eval(`
-        ${e.data.build}
-        __utils.flushLogs();
-        __userCodeWasExecuted = true;
-        __utils.toggleProxyLogger(true);
-        ${e.data.testString}
-      `);
+      testResult = eval(`${e.data.build}
+__utils.flushLogs();
+__userCodeWasExecuted = true;
+__utils.toggleProxyLogger(true);
+${e.data.testString}`);
     } catch (err) {
       if (__userCodeWasExecuted) {
         // rethrow error, since test failed.


### PR DESCRIPTION
This should not affect how test-evaluator behaves, just what Webpack outputs as a content hash.  Hopefully this will deal with the issues in https://github.com/freeCodeCamp/freeCodeCamp/issues/38044