### PR TITLE
fix(curriculum): Added test to Return a Sorted Array Without Changing the Original Array challenge to validate new array is returned

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/return-a-sorted-array-without-changing-the-original-array.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/return-a-sorted-array-without-changing-the-original-array.english.md
@@ -28,7 +28,7 @@ tests:
     testString: assert(JSON.stringify(nonMutatingSort(globalArray)) === JSON.stringify([2, 3, 5, 6, 9]));
   - text: <code>nonMutatingSort(globalArray)</code> should not be hard coded.
     testString: assert(!nonMutatingSort.toString().match(/[23569]/g));
-  - text: The function should return a new array, and not mutate the <code>globalArray</code> variable.
+  - text: The function should return a new array, not the array passed to it.
     testString: assert(nonMutatingSort(globalArray) !== globalArray);
 
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/return-a-sorted-array-without-changing-the-original-array.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/return-a-sorted-array-without-changing-the-original-array.english.md
@@ -27,7 +27,9 @@ tests:
   - text: <code>nonMutatingSort(globalArray)</code> should return <code>[2, 3, 5, 6, 9]</code>.
     testString: assert(JSON.stringify(nonMutatingSort(globalArray)) === JSON.stringify([2, 3, 5, 6, 9]));
   - text: <code>nonMutatingSort(globalArray)</code> should not be hard coded.
-    testString: assert(!nonMutatingSort.toString().match(/[23569]/g));    
+    testString: assert(!nonMutatingSort.toString().match(/[23569]/g));
+  - text: The function should return a new array, and not mutate the <code>globalArray</code> variable.
+    testString: assert(nonMutatingSort(globalArray) !== globalArray);
 
 ```
 


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

This PR adds a new test to the [Return a Sorted Array Without Changing the Original Array](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/functional-programming/return-a-sorted-array-without-changing-the-original-array) challenge.  The test validates the array returned by the `nonMutatingSort` function references a different array than the `globalArray` variable references.

Before adding the new test, the following code passes, which defeats the whole point of the challenge.
```javascript
var globalArray = [5, 6, 3, 2, 9];
function nonMutatingSort(arr) {
  // Add your code below this line  
  return arr.sort((a, b) => a - b);
  // Add your code above this line
}
```