### PR TITLE
fix(client): Header and buttons text made smaller

### DIFF
--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -33,7 +33,7 @@ h1 {
 h2 {
   color: var(--secondary-color);
   font-weight: 700;
-  font-size: 1.1rem;
+  font-size: 1.25rem;
   font-family: 'Roboto Mono', monospace;
   margin: 0.6rem 0;
 }
@@ -68,7 +68,7 @@ p {
 }
 
 .medium-heading {
-  font-size: 1.1rem !important;
+  font-size: 1.25rem !important;
   font-weight: normal;
 }
 
@@ -81,16 +81,16 @@ p {
     font-size: 1.2rem !important;
   }
   .medium-heading {
-    font-size: 1rem !important;
+    font-size: 1.1rem !important;
   }
   h1 {
-    font-size: 1.2rem;
+    font-size: 1.3rem;
   }
   h2 {
-    font-size: 1rem;
+    font-size: 1.2rem;
   }
   h3 {
-    font-size: 0.8rem;
+    font-size: 1.1rem;
   }
   .btn-cta {
     font-size: 1rem;

--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -10,7 +10,7 @@ body {
 
 .btn-cta-big {
   max-height: 100%;
-  font-size: 27px;
+  font-size: 1rem;
   white-space: normal;
   width: 100%;
 }
@@ -28,21 +28,21 @@ h1 {
   font-weight: 700;
   font-size: 1.5rem;
   font-family: 'Roboto Mono', monospace;
-  margin: 1.2rem 0 1.2rem;
+  margin: 0.6rem 0;
 }
 h2 {
   color: var(--secondary-color);
   font-weight: 700;
-  font-size: 1.2rem;
+  font-size: 1.1rem;
   font-family: 'Roboto Mono', monospace;
-  margin: 1.2rem 0 1.2rem;
+  margin: 0.6rem 0;
 }
 h3 {
   color: var(--secondary-color);
   font-weight: 700;
   font-size: 1.1rem;
   font-family: 'Roboto Mono', monospace;
-  margin: 0 0 1.2rem;
+  margin: 0 0 0.6rem;
 }
 
 h4,
@@ -63,12 +63,12 @@ p {
 }
 
 .big-heading {
-  font-size: 2.5rem !important;
+  font-size: 1.5rem !important;
   overflow-wrap: break-word;
 }
 
 .medium-heading {
-  font-size: 1.5rem !important;
+  font-size: 1.1rem !important;
   font-weight: normal;
 }
 
@@ -78,22 +78,22 @@ p {
 
 @media (max-width: 500px) {
   .big-heading {
-    font-size: 1.6rem !important;
+    font-size: 1.2rem !important;
   }
   .medium-heading {
-    font-size: 1.4rem !important;
+    font-size: 1rem !important;
   }
   h1 {
     font-size: 1.2rem;
   }
   h2 {
-    font-size: 1.1rem;
-  }
-  h3 {
     font-size: 1rem;
   }
+  h3 {
+    font-size: 0.8rem;
+  }
   .btn-cta {
-    font-size: 1.2rem;
+    font-size: 1rem;
   }
 }
 


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This is a suggestion to make header and button fonts smaller and their margins smaller too, especially on front page and learn page. This is because on smaller screens it is easier to read everything without so much scrolling. 
