### PR TITLE
Apply proper formatting on Note paragraph in the topic: "MongoDB and Mongoose - Perform Classic Updates by Running Find, Edit, then Save"

### DIFF
--- a/curriculum/challenges/english/05-apis-and-microservices/mongodb-and-mongoose/perform-classic-updates-by-running-find-edit-then-save.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/mongodb-and-mongoose/perform-classic-updates-by-running-find-edit-then-save.english.md
@@ -16,7 +16,7 @@ In the good old days this was what you needed to do if you wanted to edit a docu
 
 Find a person by <code>_id</code> ( use any of the above methods ) with the parameter <code>personId</code> as search key. Add &quot;hamburger&quot; to the list of the person&apos;s <code>favoriteFoods</code> (you can use <code>Array.push()</code>). Then - inside the find callback - <code>save()</code> the updated <code>Person</code>.
 
-<strong>Note:</strong> This may be tricky, if in your Schema, you declared <code>favoriteFoods</code> as an Array, without specifying the type (i.e. <code>[String]</code>). In that <code>casefavoriteFoods</code> defaults to Mixed type, and you have to manually mark it as edited using <code>document.markModified('edited-field')</code>. See [Mongoose documentation](https://mongoosejs.com/docs/schematypes.html#Mixed)
+<strong>Note:</strong> This may be tricky, if in your Schema, you declared <code>favoriteFoods</code> as an Array, without specifying the type (i.e. <code>[String]</code>). In that case, <code>favoriteFoods</code> defaults to Mixed type, and you have to manually mark it as edited using <code>document.markModified('edited-field')</code>. See [Mongoose documentation](https://mongoosejs.com/docs/schematypes.html#Mixed)
 
 </section>
 


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

## What was done

The current topic: `MongoDB and Mongoose - Perform Classic Updates by Running Find, Edit, then Save` contains a paragraph where *case* which is supposed to be a separate word followed by a comma, was written together with the formatted text as: `casefavoriteFoods` as shown in the image below:

![image](https://user-images.githubusercontent.com/14896918/73142317-8722e980-408d-11ea-9855-dec73693101d.png)

This Pull Request takes care of that by properly formatting the sentence in the paragraph. The paragraph would now appear like this:

> <strong>Note:</strong> This may be tricky, if in your Schema, you declared <code>favoriteFoods</code> as an Array, without specifying the type (i.e. <code>[String]</code>). In that case, <code>favoriteFoods</code> defaults to Mixed type, and you have to manually mark it as edited using <code>document.markModified('edited-field')</code>. See [Mongoose documentation](https://mongoosejs.com/docs/schematypes.html#Mixed)
