### PR TITLE
fix: prevent duplication of Monaco webpack plugin

### DIFF
--- a/client/gatsby-node.js
+++ b/client/gatsby-node.js
@@ -161,25 +161,31 @@ exports.createPages = function createPages({ graphql, actions, reporter }) {
 
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
 
-exports.onCreateWebpackConfig = ({ plugins, actions }) => {
+exports.onCreateWebpackConfig = ({ stage, plugins, actions }) => {
+  const newPlugins = [
+    plugins.define({
+      HOME_PATH: JSON.stringify(
+        process.env.HOME_PATH || 'http://localhost:3000'
+      ),
+      STRIPE_PUBLIC_KEY: JSON.stringify(process.env.STRIPE_PUBLIC_KEY || ''),
+      ROLLBAR_CLIENT_ID: JSON.stringify(process.env.ROLLBAR_CLIENT_ID || ''),
+      ENVIRONMENT: JSON.stringify(
+        process.env.FREECODECAMP_NODE_ENV || 'development'
+      ),
+      PAYPAL_SUPPORTERS: JSON.stringify(process.env.PAYPAL_SUPPORTERS || 404)
+    })
+  ];
+  // The monaco editor relies on some browser only globals so should not be
+  // involved in SSR. Also, if the plugin is used during the 'build-html' stage
+  // it overwrites the minfied files with ordinary ones.
+  if (stage !== 'build-html') {
+    newPlugins.push(new MonacoWebpackPlugin());
+  }
   actions.setWebpackConfig({
     node: {
       fs: 'empty'
     },
-    plugins: [
-      plugins.define({
-        HOME_PATH: JSON.stringify(
-          process.env.HOME_PATH || 'http://localhost:3000'
-        ),
-        STRIPE_PUBLIC_KEY: JSON.stringify(process.env.STRIPE_PUBLIC_KEY || ''),
-        ROLLBAR_CLIENT_ID: JSON.stringify(process.env.ROLLBAR_CLIENT_ID || ''),
-        ENVIRONMENT: JSON.stringify(
-          process.env.FREECODECAMP_NODE_ENV || 'development'
-        ),
-        PAYPAL_SUPPORTERS: JSON.stringify(process.env.PAYPAL_SUPPORTERS || 404)
-      }),
-      new MonacoWebpackPlugin()
-    ]
+    plugins: newPlugins
   });
 };
 


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

It seems that adding it during the 'build-html' stage meant it was creating new, unminified, versions of the scripts and overwriting the existing, minified, ones.  I *guess* this is a peculiarity of that stage, though I'm not sure.

On my local tests it works for both `develop` and `build` so, all being well, it shouldn't break anything.

Related to #37742
