### PR TITLE
feat: remove protection from interview prep

### DIFF
--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -21,6 +21,7 @@ const initialState = {
   canFocusEditor: true,
   challengeFiles: {},
   challengeMeta: {
+    superBlock: '',
     block: '',
     id: '',
     nextChallengePath: '/',

--- a/client/src/templates/Challenges/utils/build.js
+++ b/client/src/templates/Challenges/utils/build.js
@@ -1,4 +1,4 @@
-import { transformers, transformersPreview } from '../rechallenge/transformers';
+import { getTransformers } from '../rechallenge/transformers';
 import { cssToHtml, jsToHtml, concatHtml } from '../rechallenge/builders.js';
 import { challengeTypes } from '../../../../utils/challengeTypes';
 import createWorker from './worker-executor';
@@ -76,11 +76,11 @@ export function canBuildChallenge(challengeData) {
   return buildFunctions.hasOwnProperty(challengeType);
 }
 
-export async function buildChallenge(challengeData, preview = false) {
+export async function buildChallenge(challengeData, options) {
   const { challengeType } = challengeData;
   let build = buildFunctions[challengeType];
   if (build) {
-    return build(challengeData, preview);
+    return build(challengeData, options);
   }
   throw new Error(`Cannot build challenge of type ${challengeType}`);
 }
@@ -123,7 +123,7 @@ export function buildDOMChallenge({ files, required = [], template = '' }) {
   const finalRequires = [...globalRequires, ...required, ...frameRunner];
   const loadEnzyme = Object.keys(files).some(key => files[key].ext === 'jsx');
   const toHtml = [jsToHtml, cssToHtml];
-  const pipeLine = composeFunctions(...transformers, ...toHtml);
+  const pipeLine = composeFunctions(...getTransformers(), ...toHtml);
   const finalFiles = Object.keys(files)
     .map(key => files[key])
     .map(pipeLine);
@@ -137,10 +137,9 @@ export function buildDOMChallenge({ files, required = [], template = '' }) {
     }));
 }
 
-export function buildJSChallenge({ files }, preview = false) {
-  const pipeLine = preview
-    ? composeFunctions(...transformersPreview)
-    : composeFunctions(...transformers);
+export function buildJSChallenge({ files }, options) {
+  const pipeLine = composeFunctions(...getTransformers(options));
+
   const finalFiles = Object.keys(files)
     .map(key => files[key])
     .map(pipeLine);
@@ -190,4 +189,8 @@ export function isJavaScriptChallenge({ challengeType }) {
     challengeType === challengeTypes.js ||
     challengeType === challengeTypes.bonfire
   );
+}
+
+export function isLoopProtected(challengeMeta) {
+  return challengeMeta.superBlock !== 'Coding Interview Prep';
 }

--- a/client/utils/gatsby/challengePageCreator.js
+++ b/client/utils/gatsby/challengePageCreator.js
@@ -61,6 +61,7 @@ const getIntroIfRequired = (node, index, nodeArray) => {
 
 exports.createChallengePages = createPage => ({ node }, index, thisArray) => {
   const {
+    superBlock,
     block,
     fields: { slug },
     required = [],
@@ -77,6 +78,7 @@ exports.createChallengePages = createPage => ({ node }, index, thisArray) => {
     component: getTemplateComponent(challengeType),
     context: {
       challengeMeta: {
+        superBlock,
         block: block,
         introPath: getIntroIfRequired(node, index, thisArray),
         template,


### PR DESCRIPTION
The interview prep section includes many challenges that require long running calculations which can be mistaken for infinite loops. This removes the loop protection from those challenges, while the tests are being evaluated.

It keeps the protection for the preview, since it is easy to create broken code while working on a challenge and that should not crash the site.
