### PR TITLE
fix: adding test to check if flat or flatMap method was used in the steamroller challenge

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/steamroller.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/steamroller.english.md
@@ -30,8 +30,8 @@ tests:
     testString: assert.deepEqual(steamrollArray([1, [], [3, [[4]]]]), [1, 3, 4]);
   - text: <code>steamrollArray([1, {}, [3, [[4]]]])</code> should return <code>[1, {}, 3, 4]</code>.
     testString: assert.deepEqual(steamrollArray([1, {}, [3, [[4]]]]), [1, {}, 3, 4]);
-  - text: You should not use the <code>.flat()</code> or <code>.flatMap()</code> methods.
-    testString: assert(!code.match(/\.flat\(.*?\)/)) || assert(!code.match(/\.flatMap\(.*?\)/));
+  - text: Your solution should not use the <code>Array.prototype.flat()</code> or <code>Array.prototype.flatMap()</code> methods.
+    testString: assert(!code.match(/\.flat\([\s\S]*?\)/) && !code.match(/\.flatMap\([\s\S]*?\)/));
 ```
 
 </section>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/steamroller.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/steamroller.english.md
@@ -30,7 +30,8 @@ tests:
     testString: assert.deepEqual(steamrollArray([1, [], [3, [[4]]]]), [1, 3, 4]);
   - text: <code>steamrollArray([1, {}, [3, [[4]]]])</code> should return <code>[1, {}, 3, 4]</code>.
     testString: assert.deepEqual(steamrollArray([1, {}, [3, [[4]]]]), [1, {}, 3, 4]);
-
+  - text: You should not use the <code>.flat()</code> or <code>.flatMap()</code> methods.
+    testString: assert(!code.match(/\.flat\(.*?\)/)) || assert(!code.match(/\.flatMap\(.*?\)/));
 ```
 
 </section>


### PR DESCRIPTION
The Steamroller Challenge in the Intermediate Algorithms section of the Javascript Algorithms and Data Structures course allowed using the methods `flat` and `flatMap`. This defeats the purpose of the challenge.

I have added a test that ensures that said methods are not allowed.
I have only added the test for the English language.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #38133

Tested and verified locally using the Docker build of the platform.