### PR TITLE
fix: added white space checks including newlines to ensure proper validation of trim method

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/remove-whitespace-from-start-and-end.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/remove-whitespace-from-start-and-end.english.md
@@ -13,7 +13,7 @@ Sometimes whitespace characters around strings are not wanted but are there. Typ
 ## Instructions
 <section id='instructions'>
 Write a regex and use the appropriate string methods to remove whitespace at the beginning and end of strings.
-<strong>Note</strong><br>The <code>.trim()</code> method would work here, but you'll need to complete this challenge using regular expressions.
+<strong>Note:</strong> The <code>String.prototype.trim()</code> method would work here, but you'll need to complete this challenge using regular expressions.
 </section>
 
 ## Tests

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/remove-whitespace-from-start-and-end.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/remove-whitespace-from-start-and-end.english.md
@@ -23,8 +23,8 @@ Write a regex and use the appropriate string methods to remove whitespace at the
 tests:
   - text: <code>result</code> should equal to <code>"Hello, World!"</code>
     testString: assert(result == "Hello, World!");
-  - text: You should not use the <code>.trim()</code> method.
-    testString: assert(!code.match(/\.trim\(.*?\)/));
+  - text: Your solution should not use the <code>String.prototype.trim()</code> method.
+    testString: assert(!code.match(/\.trim\([\s\S]*?\)/));
   - text: The <code>result</code> variable should not be set equal to a string.
     testString: assert(!code.match(/result\s*=\s*".*?"/));
 


### PR DESCRIPTION
Fixed the trim method validation by adding checks for newlines for the regex challenge [remove whitespaces from start and end](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/regular-expressions/remove-whitespace-from-start-and-end).

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #38165
