### PR TITLE
fix: disable button after submission

### DIFF
--- a/client/src/components/Donation/DonateFormChildViewForHOC.js
+++ b/client/src/components/Donation/DonateFormChildViewForHOC.js
@@ -92,7 +92,7 @@ class DonateFormChildViewForHOC extends Component {
   handleSubmit(e) {
     e.preventDefault();
 
-    const { isEmailValid, isFormValid } = this.state;
+    const { isEmailValid, isFormValid, donationState } = this.state;
 
     if ((!isEmailValid, !isFormValid)) {
       return this.setState({
@@ -100,9 +100,16 @@ class DonateFormChildViewForHOC extends Component {
       });
     }
 
-    this.setState({
-      isSubmissionValid: null
-    });
+    if (donationState.processing) {
+      return this.setState(state => ({
+        ...state,
+        donationState: {
+          ...state.donationState,
+          error:
+            'Another payment is being processed,' + ' Please try again later.'
+        }
+      }));
+    }
 
     const email = this.getUserEmail();
     if (!email || !isEmail(email)) {
@@ -228,7 +235,12 @@ class DonateFormChildViewForHOC extends Component {
   }
 
   renderDonateForm() {
-    const { isEmailValid, isSubmissionValid, email } = this.state;
+    const {
+      isEmailValid,
+      isSubmissionValid,
+      email,
+      donationState
+    } = this.state;
     const { getDonationButtonLabel, theme, defaultTheme } = this.props;
 
     return (
@@ -257,6 +269,7 @@ class DonateFormChildViewForHOC extends Component {
           block={true}
           bsStyle='primary'
           className='btn-cta'
+          disabled={donationState.processing}
           id='confirm-donation-btn'
           type='submit'
         >

--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -238,6 +238,9 @@ fieldset[disabled] .btn-primary.focus {
   background-image: none;
   box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.3);
 }
+.btn-cta[disabled] {
+  background-image: none;
+}
 .btn-link,
 .btn-link:focus,
 .btn-link:active {


### PR DESCRIPTION
<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

This pr will disable the submission button after the form is submitted and enable it during the donation processing.

Closes #38052
