### PR TITLE
fix(challenge): check inline style for color

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/change-the-color-of-text.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/change-the-color-of-text.english.md
@@ -29,7 +29,7 @@ tests:
   - text: Your <code>h2</code> element should have a <code>style</code> declaration.
     testString: assert($("h2").attr('style'));
   - text: Your <code>h2</code> element should be red.
-    testString: assert($("h2").css("color") === "rgb(255, 0, 0)");
+    testString: assert($("h2")[0].style.color === "red");
   - text: Your <code>style</code> declaration should end with a <code>;</code> .
     testString: assert($("h2").attr('style') && $("h2").attr('style').endsWith(';'));
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/change-the-color-of-text.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/change-the-color-of-text.english.md
@@ -28,7 +28,7 @@ Change your <code>h2</code> element's style so that its text color is red.
 tests:
   - text: Your <code>h2</code> element should have a <code>style</code> declaration.
     testString: assert($("h2").attr('style'));
-  - text: Your <code>h2</code> element should be red.
+  - text: Your <code>h2</code> element should have color set to <code>red</code>.
     testString: assert($("h2")[0].style.color === "red");
   - text: Your <code>style</code> declaration should end with a <code>;</code> .
     testString: assert($("h2").attr('style') && $("h2").attr('style').endsWith(';'));


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Fix for the challenge: https://www.freecodecamp.org/learn/responsive-web-design/basic-css/change-the-color-of-text

Switch the test to look at the style property for the color value to avoid issues with extensions that change the colors (like dark mode extensions).
