### PR TITLE
fix: improve test regex to validate disallowed methods that can be bypassed by prototype reassignments and/or otherwise

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/add-elements-to-the-end-of-an-array-using-concat-instead-of-push.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/add-elements-to-the-end-of-an-array-using-concat-instead-of-push.english.md
@@ -33,7 +33,7 @@ tests:
   - text: Your code should use the <code>concat</code> method.
     testString: assert(code.match(/\.concat/g));
   - text: Your code should not use the <code>push</code> method.
-    testString: assert(!code.match(/\.push/g));
+    testString: assert(!code.match(/\.?[\s\S]*?push/g));
   - text: The <code>first</code> array should not change.
     testString: assert(JSON.stringify(first) === JSON.stringify([1, 2, 3]));
   - text: The <code>second</code> array should not change.

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/apply-functional-programming-to-convert-strings-to-url-slugs.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/apply-functional-programming-to-convert-strings-to-url-slugs.english.md
@@ -29,7 +29,7 @@ tests:
   - text: The <code>globalTitle</code> variable should not change.
     testString: assert(globalTitle === "Winter Is Coming");
   - text: Your code should not use the <code>replace</code> method for this challenge.
-    testString: assert(!code.match(/\.replace/g));
+    testString: assert(!code.match(/\.?[\s\S]*?replace/g));
   - text: <code>urlSlug("Winter Is Coming")</code> should return <code>"winter-is-coming"</code>.
     testString: assert(urlSlug("Winter Is Coming") === "winter-is-coming");
   - text: <code>urlSlug(" Winter Is  &nbsp;Coming")</code> should return <code>"winter-is-coming"</code>.

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/combine-an-array-into-a-string-using-the-join-method.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/combine-an-array-into-a-string-using-the-join-method.english.md
@@ -31,7 +31,7 @@ tests:
   - text: Your code should use the <code>join</code> method.
     testString: assert(code.match(/\.join/g));
   - text: Your code should not use the <code>replace</code> method.
-    testString: assert(!code.match(/\.replace/g));
+    testString: assert(!code.match(/\.?[\s\S]*?replace/g));
   - text: <code>sentensify("May-the-force-be-with-you")</code> should return a string.
     testString: assert(typeof sentensify("May-the-force-be-with-you") === "string");
   - text: <code>sentensify("May-the-force-be-with-you")</code> should return <code>"May the force be with you"</code>.

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/implement-map-on-a-prototype.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/implement-map-on-a-prototype.english.md
@@ -26,7 +26,7 @@ tests:
   - text: <code>new_s</code> should equal <code>[46, 130, 196, 10]</code>.
     testString: assert(JSON.stringify(new_s) === JSON.stringify([46, 130, 196, 10]));
   - text: Your code should not use the <code>map</code> method.
-    testString: assert(!code.match(/\.map/g));
+    testString: assert(!code.match(/\.?[\s\S]*?map/g));
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/implement-the-filter-method-on-a-prototype.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/implement-the-filter-method-on-a-prototype.english.md
@@ -24,7 +24,7 @@ tests:
   - text: <code>new_s</code> should equal <code>[23, 65, 5]</code>.
     testString: assert(JSON.stringify(new_s) === JSON.stringify([23, 65, 5]));
   - text: Your code should not use the <code>filter</code> method.
-    testString: assert(!code.match(/\.filter/g));
+    testString: assert(!code.match(/\.?[\s\S]*?filter/g));
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/remove-elements-from-an-array-using-slice-instead-of-splice.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/remove-elements-from-an-array-using-slice-instead-of-splice.english.md
@@ -32,7 +32,7 @@ tests:
   - text: Your code should use the <code>slice</code> method.
     testString: assert(code.match(/\.slice/g));
   - text: Your code should not use the <code>splice</code> method.
-    testString: assert(!code.match(/\.splice/g));
+    testString: assert(!code.match(/\.?[\s\S]*?splice/g));
   - text: The <code>inputCities</code> array should not change.
     testString: assert(JSON.stringify(inputCities) === JSON.stringify(["Chicago", "Delhi", "Islamabad", "London", "Berlin"]));
   - text: <code>nonMutatingSplice(["Chicago", "Delhi", "Islamabad", "London", "Berlin"])</code> should return <code>["Chicago", "Delhi", "Islamabad"]</code>.

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/steamroller.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/steamroller.english.md
@@ -33,7 +33,7 @@ tests:
   - text: <code>steamrollArray([1, {}, [3, [[4]]]])</code> should return <code>[1, {}, 3, 4]</code>.
     testString: assert.deepEqual(steamrollArray([1, {}, [3, [[4]]]]), [1, {}, 3, 4]);
   - text: Your solution should not use the <code>Array.prototype.flat()</code> or <code>Array.prototype.flatMap()</code> methods.
-    testString: assert(!code.match(/\.flat\([\s\S]*?\)/) && !code.match(/\.flatMap\([\s\S]*?\)/) && !code.match(/Array[\s\S]*?\.[\s\S]*?prototype[\s\S]*?\.[\s\S]*?flat));
+    testString: assert(!code.match(/\.?[\s\S]*?flat/) && !code.match(/\.?[\s\S]*?flatMap/));
 ```
 
 </section>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/steamroller.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/steamroller.english.md
@@ -7,16 +7,19 @@ forumTopicId: 16079
 ---
 
 ## Description
+
 <section id='description'>
 Flatten a nested array. You must account for varying levels of nesting.
 </section>
 
 ## Instructions
+
 <section id='instructions'>
 
 </section>
 
 ## Tests
+
 <section id='tests'>
 
 ```yml
@@ -30,12 +33,13 @@ tests:
   - text: <code>steamrollArray([1, {}, [3, [[4]]]])</code> should return <code>[1, {}, 3, 4]</code>.
     testString: assert.deepEqual(steamrollArray([1, {}, [3, [[4]]]]), [1, {}, 3, 4]);
   - text: Your solution should not use the <code>Array.prototype.flat()</code> or <code>Array.prototype.flatMap()</code> methods.
-    testString: assert(!code.match(/\.flat\([\s\S]*?\)/) && !code.match(/\.flatMap\([\s\S]*?\)/));
+    testString: assert(!code.match(/\.flat\([\s\S]*?\)/) && !code.match(/\.flatMap\([\s\S]*?\)/) && !code.match(/Array[\s\S]*?\.[\s\S]*?prototype[\s\S]*?\.[\s\S]*?flat));
 ```
 
 </section>
 
 ## Challenge Seed
+
 <section id='challengeSeed'>
 
 <div id='js-seed'>
@@ -51,13 +55,11 @@ steamrollArray([1, [2], [3, [[4]]]]);
 
 </div>
 
-
-
 </section>
 
 ## Solution
-<section id='solution'>
 
+<section id='solution'>
 
 ```js
 function steamrollArray(arr) {

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/remove-whitespace-from-start-and-end.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/remove-whitespace-from-start-and-end.english.md
@@ -24,7 +24,7 @@ tests:
   - text: <code>result</code> should equal to <code>"Hello, World!"</code>
     testString: assert(result == "Hello, World!");
   - text: Your solution should not use the <code>String.prototype.trim()</code> method.
-    testString: assert(!code.match(/\.trim\([\s\S]*?\)/));
+    testString: assert(!code.match(/\.?[\s\S]*?trim/));
   - text: The <code>result</code> variable should not be set equal to a string.
     testString: assert(!code.match(/result\s*=\s*".*?"/));
 

--- a/curriculum/challenges/english/08-coding-interview-prep/algorithms/implement-bubble-sort.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/algorithms/implement-bubble-sort.english.md
@@ -31,7 +31,7 @@ tests:
   - text: <code>bubbleSort</code> should return an array that is unchanged except for order.
     testString: assert.sameMembers(bubbleSort([1,4,2,8,345,123,43,32,5643,63,123,43,2,55,1,234,92]), [1,4,2,8,345,123,43,32,5643,63,123,43,2,55,1,234,92]);
   - text: <code>bubbleSort</code> should not use the built-in <code>.sort()</code> method.
-    testString: assert.strictEqual(code.search(/\.sort\(/), -1);
+    testString: assert(!code.match(/\.?[\s\S]*?sort/));
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/algorithms/implement-insertion-sort.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/algorithms/implement-insertion-sort.english.md
@@ -29,7 +29,7 @@ tests:
   - text: <code>insertionSort</code> should return an array that is unchanged except for order.
     testString: assert.sameMembers(insertionSort([1,4,2,8,345,123,43,32,5643,63,123,43,2,55,1,234,92]), [1,4,2,8,345,123,43,32,5643,63,123,43,2,55,1,234,92]);
   - text: <code>insertionSort</code> should not use the built-in <code>.sort()</code> method.
-    testString: assert.strictEqual(code.search(/\.sort\(/), -1);
+    testString: assert(!code.match(/\.?[\s\S]*?sort/));
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/algorithms/implement-merge-sort.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/algorithms/implement-merge-sort.english.md
@@ -33,7 +33,7 @@ tests:
   - text: <code>mergeSort</code> should return an array that is unchanged except for order.
     testString: assert.sameMembers(mergeSort([1,4,2,8,345,123,43,32,5643,63,123,43,2,55,1,234,92]), [1,4,2,8,345,123,43,32,5643,63,123,43,2,55,1,234,92]);
   - text: <code>mergeSort</code> should not use the built-in <code>.sort()</code> method.
-    testString: assert.strictEqual(code.search(/\.sort\(/), -1);
+    testString: assert(!code.match(/\.?[\s\S]*?sort/));
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/algorithms/implement-quick-sort.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/algorithms/implement-quick-sort.english.md
@@ -30,7 +30,7 @@ tests:
   - text: <code>quickSort</code> should return an array that is unchanged except for order.
     testString: assert.sameMembers(quickSort([1,4,2,8,345,123,43,32,5643,63,123,43,2,55,1,234,92]), [1,4,2,8,345,123,43,32,5643,63,123,43,2,55,1,234,92]);
   - text: <code>quickSort</code> should not use the built-in <code>.sort()</code> method.
-    testString: assert.strictEqual(code.search(/\.sort\(/), -1);
+    testString: assert(!code.match(/\.?[\s\S]*?sort/));
 
 ```
 

--- a/curriculum/challenges/english/08-coding-interview-prep/algorithms/implement-selection-sort.english.md
+++ b/curriculum/challenges/english/08-coding-interview-prep/algorithms/implement-selection-sort.english.md
@@ -29,7 +29,7 @@ tests:
   - text: <code>selectionSort</code> should return an array that is unchanged except for order.
     testString: assert.sameMembers(selectionSort([1,4,2,8,345,123,43,32,5643,63,123,43,2,55,1,234,92]), [1,4,2,8,345,123,43,32,5643,63,123,43,2,55,1,234,92]);
   - text: <code>selectionSort</code> should not use the built-in <code>.sort()</code> method.
-    testString: assert.strictEqual(code.search(/\.sort\(/), -1);
+    testString: assert(!code.match(/\.?[\s\S]*?sort/));
 
 ```
 


### PR DESCRIPTION
I went through the entire library of challenges and tested each to confirm if the disallowed methods could be bypassed by adding newlines/whitespaces or prototype reassignments.

I was able to fix the regex patterns to prevent those bypass scenarios. I have tested this on my local setup but it would be great if someone else can give it a spin as well.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #38204
