### PR TITLE
fix: force timezone to be UTC for tests

### DIFF
--- a/client/jest-timezone-setup.js
+++ b/client/jest-timezone-setup.js
@@ -1,0 +1,3 @@
+module.exports = async () => {
+  process.env.TZ = 'UTC';
+};

--- a/client/jest.config.js
+++ b/client/jest.config.js
@@ -12,6 +12,7 @@ module.exports = {
   globals: {
     __PATH_PREFIX__: ''
   },
+  globalSetup: './jest-timezone-setup.js',
   verbose: true,
   transform: {
     '^.+\\.js$': '<rootDir>/jest.transform.js'

--- a/client/jest.test.js
+++ b/client/jest.test.js
@@ -1,0 +1,6 @@
+/* global expect */
+describe('Timezones', () => {
+  it('should always be UTC', () => {
+    expect(new Date().getTimezoneOffset()).toBe(0);
+  });
+});


### PR DESCRIPTION
`react-calendar-heatmap`'s output depends on the timezone, which means that snapshots can fail if the timezone changes.  This sets the timezone to UTC during client tests to avoid that problem.