### PR TITLE
fix: remove useless logging

### DIFF
--- a/client/src/templates/Challenges/rechallenge/transformers.js
+++ b/client/src/templates/Challenges/rechallenge/transformers.js
@@ -194,7 +194,6 @@ async function transformScript(element) {
     script.innerHTML = tryTransform(babelTransformCode(babelOptionsJS))(
       script.innerHTML
     );
-    console.log('transformed:', script.innerHTML);
   });
 }
 


### PR DESCRIPTION
Removes a console.log that I should have removed before.  There's still too many messages coming out of Webpack, but this deals with the biggest mess.

Closes #38242