### PR TITLE
Typo whitespace fix in access-multi-dimensional-arrays-with-indexes.english.md

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/access-multi-dimensional-arrays-with-indexes.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/access-multi-dimensional-arrays-with-indexes.english.md
@@ -23,7 +23,7 @@ arr[3][0]; // equals [10,11,12]
 arr[3][0][1]; // equals 11
 ```
 
-<strong>Note</strong><br>There shouldn't be any spaces between the array name and the square brackets, like <code>array [0][0]</code> and even this <code>array [0] [0]</code> is not allowed. Although JavaScript is able to process this correctly, this may confuse other programmers reading your code.
+<strong>Note</strong><br>There shouldn't be any spaces between the array name and the square brackets, like <code>array&nbsp;[0][0]</code> and even this <code>array&nbsp;[0]&nbsp;[0]</code> is not allowed. Although JavaScript is able to process this correctly, this may confuse other programmers reading your code.
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/access-multi-dimensional-arrays-with-indexes.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/access-multi-dimensional-arrays-with-indexes.english.md
@@ -23,7 +23,7 @@ arr[3][0]; // equals [10,11,12]
 arr[3][0][1]; // equals 11
 ```
 
-<strong>Note</strong><br>There shouldn't be any spaces between the array name and the square brackets, like <code>array&nbsp;[0][0]</code> and even this <code>array&nbsp;[0]&nbsp;[0]</code> is not allowed. Although JavaScript is able to process this correctly, this may confuse other programmers reading your code.
+<strong>Note</strong><br>There shouldn't be any spaces between the array name and the square brackets, like `array [0][0]` and even this `array [0] [0]` is not allowed. Although JavaScript is able to process this correctly, this may confuse other programmers reading your code.
 </section>
 
 ## Instructions


### PR DESCRIPTION
Added non breaking space characters to display *Note* correct. 
* `myArray [0][0] changed to myArray&nbsp;[0][0]`
* `myArray [0] [0] changed to myArray&nbsp;[0]&nbsp;[0]`

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x ] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x ] My pull request has a descriptive title (not a vague title like `Update index.md`)

- [x ] My pull request targets the `master` branch of freeCodeCamp.
- [x ] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.


--- 
**Notes:**
 * This PR fixes the missing space when viewing [Basic JavaScript: Access Multi-Dimensional Arrays With Indexes](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-javascript/access-multi-dimensional-arrays-with-indexes) 
* The Notes section is currently incorrectly displaying the same example twice as the space shows up in the Markdown file, but is missing from the HTML course page.