### PR TITLE
fix: intermediate js calorie counter challengeType

### DIFF
--- a/client/utils/challengeTypes.js
+++ b/client/utils/challengeTypes.js
@@ -115,7 +115,6 @@ exports.helpCategory = {
   'css-variables-skyline': 'HTML-CSS',
   'basic-javascript-rpg-game': 'JavaScript',
   'functional-programming-spreadsheet': 'JavaScript',
-  'intermediate-javascript-calorie-counter':
-    'Intermediate JavaScript Calorie Counter',
+  'intermediate-javascript-calorie-counter': 'JavaScript',
   'd3-dashboard-project': 'JavaScript'
 };


### PR DESCRIPTION
This fixes a mistake in `client/utils/challengeTypes.js` where the Intermediate JS Calorie Counter project should be listed as a JS challenge.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ ] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any addtional description of changes below this line -->
