### PR TITLE
fix(learn): Added code tags to translated texts

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/applied-accessibility/standardize-times-with-the-html5-datetime-attribute.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-accessibility/standardize-times-with-the-html5-datetime-attribute.english.md
@@ -24,13 +24,13 @@ Camper Cat's Mortal Kombat survey results are in! Wrap a <code>time</code> tag a
 
 ```yml
 tests:
-  - text: Your code should have a <code>p</code> element which includes the text "Thank you to everyone for responding to Master Camper Cat's survey." and include a <code>time</code> element.
+  - text: Your code should have a <code>p</code> element which includes the text <code>Thank you to everyone for responding to Master Camper Cat's survey.</code> and include a <code>time</code> element.
     testString: assert(timeElement.length);
-  - text: Your added <code>time</code> tags should wrap around the text "Thursday, September 15&lt;sup&gt;th&lt;/sup&gt;".
+  - text: Your added <code>time</code> tags should wrap around the text <code>Thursday, September 15&lt;sup&gt;th&lt;/sup&gt;</code>.
     testString: assert(timeElement.length && $(timeElement).html().trim() === "Thursday, September 15<sup>th</sup>");
   - text: Your added <code>time</code> tag should have a <code>datetime</code> attribute that is not empty.
     testString: assert(datetimeAttr && datetimeAttr.length);
-  - text: Your added <code>datetime</code> attribute should be set to a value of 2016-09-15.
+  - text: Your added <code>datetime</code> attribute should be set to a value of <code>2016-09-15</code>.
     testString: assert(datetimeAttr === "2016-09-15");
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/use-the-strong-tag-to-make-text-bold.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/use-the-strong-tag-to-make-text-bold.english.md
@@ -26,7 +26,7 @@ tests:
     testString: assert($('strong').length == 1);
   - text: The <code>strong</code> tag should be inside the <code>p</code> tag.
     testString: assert($('p').children('strong').length == 1);
-  - text: The <code>strong</code> tag should wrap around the words "Stanford University".
+  - text: The <code>strong</code> tag should wrap around the words <code>Stanford University</code>.
     testString: assert($('strong').text().match(/^Stanford University\.?$/gi));
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/use-the-u-tag-to-underline-text.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/use-the-u-tag-to-underline-text.english.md
@@ -25,7 +25,7 @@ Wrap the <code>u</code> tag only around the text "Ph.D. students".
 tests:
   - text: Your code should add a <code>u</code> tag to the markup.
     testString: assert($('u').length === 1);
-  - text: The <code>u</code> tag should wrap around the text "Ph.D. students".
+  - text: The <code>u</code> tag should wrap around the text <code>Ph.D. students</code>.
     testString: assert($('u').text() === 'Ph.D. students');
 
 ```

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/add-a-submit-button-to-a-form.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/add-a-submit-button-to-a-form.english.md
@@ -28,7 +28,7 @@ tests:
     testString: assert($("form").children("button").length > 0);
   - text: Your submit button should have the attribute <code>type</code> set to <code>submit</code>.
     testString: assert($("button").attr("type") === "submit");
-  - text: Your submit button should only have the text "Submit".
+  - text: Your submit button should only have the text <code>Submit</code>.
     testString: assert($("button").text().match(/^\s*submit\s*$/gi));
   - text: Your <code>button</code> element should have a closing tag.
     testString: assert(code.match(/<\/button>/g) && code.match(/<button/g) && code.match(/<\/button>/g).length === code.match(/<button/g).length);

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/add-placeholder-text-to-a-text-field.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/add-placeholder-text-to-a-text-field.english.md
@@ -27,7 +27,7 @@ Set the <code>placeholder</code> value of your text <code>input</code> to "cat p
 tests:
   - text: You should add a <code>placeholder</code> attribute to the existing text <code>input</code> element.
     testString: assert($("input[placeholder]").length > 0);
-  - text: You should set the value of your placeholder attribute to "cat photo URL".
+  - text: You should set the value of your placeholder attribute to <code>cat photo URL</code>.
     testString: assert($("input") && $("input").attr("placeholder") && $("input").attr("placeholder").match(/cat\s+photo\s+URL/gi));
   - text: The finished <code>input</code> element should not have a closing tag.
     testString: assert(!code.match(/<input.*\/?>.*<\/input>/gi));

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/create-an-ordered-list.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/create-an-ordered-list.english.md
@@ -34,9 +34,9 @@ Create an ordered list of the top 3 things cats hate the most.
 
 ```yml
 tests:
-  - text: You should have an ordered list for "Top 3 things cats hate:"
+  - text: You should have an ordered list for <code>Top 3 things cats hate:</code>
     testString: assert((/Top 3 things cats hate:/i).test($("ol").prev().text()));
-  - text: You should have an unordered list for "Things cats love:"
+  - text: You should have an unordered list for <code>Things cats love:</code>
     testString: assert((/Things cats love:/i).test($("ul").prev().text()));
   - text: You should have only one <code>ul</code> element.
     testString: assert.equal($("ul").length, 1);

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/headline-with-the-h2-element.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/headline-with-the-h2-element.english.md
@@ -28,9 +28,9 @@ tests:
     testString: assert(($("h2").length > 0));
   - text: Your <code>h2</code> element should have a closing tag.
     testString: assert(code.match(/<\/h2>/g) && code.match(/<\/h2>/g).length === code.match(/<h2>/g).length);
-  - text: Your <code>h2</code> element should have the text "CatPhotoApp".
+  - text: Your <code>h2</code> element should have the text <code>CatPhotoApp</code>.
     testString: assert.isTrue((/cat(\s)?photo(\s)?app/gi).test($("h2").text()));
-  - text: Your <code>h1</code> element should have the text "Hello World".
+  - text: Your <code>h1</code> element should have the text <code>Hello World</code>.
     testString: assert.isTrue((/hello(\s)+world/gi).test($("h1").text()));
 
 ```

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/inform-with-the-paragraph-element.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/inform-with-the-paragraph-element.english.md
@@ -27,7 +27,7 @@ Create a <code>p</code> element below your <code>h2</code> element, and give it 
 tests:
   - text: Your code should have a valid <code>p</code> element.
     testString: assert(($("p").length > 0));
-  - text: Your <code>p</code> element should have the text "Hello Paragraph".
+  - text: Your <code>p</code> element should have the text <code>Hello Paragraph</code>.
     testString: assert.isTrue((/hello(\s)+paragraph/gi).test($("p").text()));
   - text: Your <code>p</code> element should have a closing tag.
     testString: assert(code.match(/<\/p>/g) && code.match(/<\/p>/g).length === code.match(/<p/g).length);


### PR DESCRIPTION
Checklist:

- [X ] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [X ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `master` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

Closes #38312

Followed @RandellDawson detailed description of what test texts needed `code` tags, in order to fix a previous pull request.

`npm run test:curriculum` has been run, and all tests passed.
