### PR TITLE
feat: Code saveing to localStorage on Cmd/Ctrl + S

### DIFF
--- a/client/src/templates/Challenges/classic/Editor.js
+++ b/client/src/templates/Challenges/classic/Editor.js
@@ -7,6 +7,7 @@ import {
   canFocusEditorSelector,
   executeChallenge,
   inAccessibilityModeSelector,
+  saveEditorContent,
   setEditorFocusability,
   setAccessibilityMode,
   updateFile
@@ -25,6 +26,7 @@ const propTypes = {
   ext: PropTypes.string,
   fileKey: PropTypes.string,
   inAccessibilityMode: PropTypes.bool.isRequired,
+  saveEditorContent: PropTypes.func.isRequired,
   setAccessibilityMode: PropTypes.func.isRequired,
   setEditorFocusability: PropTypes.func,
   theme: PropTypes.string,
@@ -44,9 +46,10 @@ const mapStateToProps = createSelector(
 );
 
 const mapDispatchToProps = {
-  setEditorFocusability,
-  setAccessibilityMode,
   executeChallenge,
+  saveEditorContent,
+  setAccessibilityMode,
+  setEditorFocusability,
   updateFile
 };
 
@@ -149,6 +152,14 @@ class Editor extends Component {
         this.focusOnHotkeys();
         this.props.setEditorFocusability(false);
       }
+    });
+    this._editor.addAction({
+      id: 'save-editor-content',
+      label: 'Save editor content to localStorage',
+      keybindings: [
+        monaco.KeyMod.chord(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_S)
+      ],
+      run: this.props.saveEditorContent
     });
     this._editor.addAction({
       id: 'toggle-accessibility',

--- a/client/src/templates/Challenges/redux/code-storage-epic.js
+++ b/client/src/templates/Challenges/redux/code-storage-epic.js
@@ -101,8 +101,9 @@ function saveCodeEpic(action$, state$) {
         createFlashMessage({
           type: error ? 'warning' : 'success',
           message: error
-            ? 'Oops, your code did not save, local storage may be full'
-            : 'Saved! Your code was saved to local storage'
+            ? // eslint-disable-next-line max-len
+              "Oops, your code did not save, your browser's local storage may be full"
+            : "Saved! Your code was saved to your browser's local storage"
         })
       )
     )

--- a/client/src/templates/Challenges/redux/code-storage-epic.js
+++ b/client/src/templates/Challenges/redux/code-storage-epic.js
@@ -102,8 +102,8 @@ function saveCodeEpic(action$, state$) {
           type: error ? 'warning' : 'success',
           message: error
             ? // eslint-disable-next-line max-len
-              "Oops, your code did not save, your browser's local storage may be full"
-            : "Saved! Your code was saved to your browser's local storage"
+              "Oops, your code did not save, your browser's local storage may be full."
+            : "Saved! Your code was saved to your browser's local storage."
         })
       )
     )

--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -70,6 +70,7 @@ export const types = createTypes(
     'disableBuildOnError',
     'storedCodeFound',
     'noStoredCodeFound',
+    'saveEditorContent',
 
     'closeModal',
     'openModal',
@@ -147,6 +148,7 @@ export const unlockCode = createAction(types.unlockCode);
 export const disableBuildOnError = createAction(types.disableBuildOnError);
 export const storedCodeFound = createAction(types.storedCodeFound);
 export const noStoredCodeFound = createAction(types.noStoredCodeFound);
+export const saveEditorContent = createAction(types.saveEditorContent);
 
 export const closeModal = createAction(types.closeModal);
 export const openModal = createAction(types.openModal);


### PR DESCRIPTION
Had to reopen this PR please see (#37011) for more information.  The flash message right now overlays the editor contents a little bit.  Those changes have been moved to #38327

Right now this is showing a flash message to alert the user that their code was saved.

Before this, the users code was getting saved to localStorage when they attempted to submit the challenge. I've just changed it so that they can manually do it as well. I kept pressing ctrl+s accidently so I thought it would be cool to add this feature. Please let me know if this can be improved in any way.

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.
