### PR TITLE
feat(client): add space for flash message

### DIFF
--- a/client/src/components/Flash/index.js
+++ b/client/src/components/Flash/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Alert } from '@freecodecamp/react-bootstrap';
 import { TransitionGroup, CSSTransition } from 'react-transition-group';
@@ -7,14 +7,44 @@ import './flash.css';
 
 function Flash({ flashMessage, onClose }) {
   const { type, message, id } = flashMessage;
+  const [flashMessageHeight, setFlashMessageHeight] = useState(null);
+
+  useEffect(() => {
+    setFlashMessageHeight(
+      document.querySelector('.flash-message').offsetHeight
+    );
+    document.documentElement.style.setProperty(
+      '--flash-message-height',
+      flashMessageHeight + 'px'
+    );
+  }, [flashMessageHeight]);
+
+  function handleClose() {
+    document.documentElement.style.setProperty('--flash-message-height', '0px');
+    onClose();
+  }
+
   return (
-    <TransitionGroup>
-      <CSSTransition classNames='flash-message' key={id} timeout={500}>
-        <Alert bsStyle={type} className='flash-message' onDismiss={onClose}>
-          {message}
-        </Alert>
-      </CSSTransition>
-    </TransitionGroup>
+    <>
+      <TransitionGroup>
+        <CSSTransition classNames='flash-message' key={id} timeout={500}>
+          <Alert
+            bsStyle={type}
+            className='flash-message'
+            onDismiss={handleClose}
+          >
+            {message}
+          </Alert>
+        </CSSTransition>
+      </TransitionGroup>
+      {flashMessage && (
+        <div
+          style={{
+            height: flashMessageHeight + 'px'
+          }}
+        ></div>
+      )}
+    </>
   );
 }
 

--- a/client/src/components/layouts/learn.css
+++ b/client/src/components/layouts/learn.css
@@ -1,5 +1,7 @@
 #learn-app-wrapper .desktop-layout {
-  height: calc(100vh - var(--header-height, 0px));
+  height: calc(
+    100vh - var(--header-height, 0px) - var(--flash-message-height, 0px)
+  );
 }
 
 #learn-app-wrapper .reflex-container.vertical > .reflex-splitter,

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -32,7 +32,9 @@
 }
 
 #challenge-page-tabs .tab-content {
-  height: calc(100vh - var(--header-height, 0px) - 69px);
+  height: calc(
+    100vh - var(--header-height, 0px) - var(--flash-message-height, 0px) - 69px
+  );
   overflow-y: auto;
 }
 


### PR DESCRIPTION
The current behavior of flash messages is that they are 'position: fixed'.  All the pages have room at the top for the flash message (besides the lessons pages).  This update changes the flash message file so that the amount of space needed is rendered for each flash message.  

For more context please see #37011 and [this conversation](https://github.com/freeCodeCamp/freeCodeCamp/pull/37011#discussion_r344171692)

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.
