### PR TITLE
feat(client): helper functions for challenge tests across curriculum

### DIFF
--- a/client/src/client/frame-runner.js
+++ b/client/src/client/frame-runner.js
@@ -1,5 +1,6 @@
 import '@babel/polyfill';
 import jQuery from 'jquery';
+import testHelpers from '../utils/curriculum-test-helpers';
 
 window.$ = jQuery;
 
@@ -34,6 +35,7 @@ async function initTestFrame(e = {}) {
   // eslint-disable-next-line no-inline-comments
   const { default: chai } = await import(/* webpackChunkName: "chai" */ 'chai');
   const assert = chai.assert;
+  const __testHelpers = testHelpers;
   /* eslint-enable no-unused-vars */
 
   let Enzyme;

--- a/client/src/client/workers/test-evaluator.js
+++ b/client/src/client/workers/test-evaluator.js
@@ -2,6 +2,7 @@ import chai from 'chai';
 import '@babel/polyfill';
 import __toString from 'lodash/toString';
 import { format as __format } from '../../utils/format';
+import testHelpers from '../../utils/curriculum-test-helpers';
 
 const __utils = (() => {
   const MAX_LOGS_SIZE = 64 * 1024;
@@ -57,6 +58,7 @@ self.onmessage = async e => {
   /* eslint-disable no-unused-vars */
   const { code = '' } = e.data;
   const assert = chai.assert;
+  const __testHelpers = testHelpers;
   // Fake Deep Equal dependency
   const DeepEqual = (a, b) => JSON.stringify(a) === JSON.stringify(b);
 

--- a/client/src/utils/__fixtures/curriculum-test-helpers-css.js
+++ b/client/src/utils/__fixtures/curriculum-test-helpers-css.js
@@ -1,0 +1,49 @@
+const cssFullExample = `
+a {
+  color: green;
+  display: flex;
+}
+
+.aClass {
+  font-size: 32px;
+  /* the property below should not appear in final css string
+  width: 400px;
+  height: 200px;
+  */
+  flex: 1;
+  flex-direction: row;
+}
+
+/* Set the background color to blue for screens that are 300px or less */
+@media screen and (max-width: 300px) {
+  body {
+    background-color: blue;
+  }
+}`;
+
+const cssCodeWithCommentsRemoved = `
+a {
+  color: green;
+  display: flex;
+}
+
+.aClass {
+  font-size: 32px;
+  
+  flex: 1;
+  flex-direction: row;
+}
+
+
+@media screen and (max-width: 300px) {
+  body {
+    background-color: blue;
+  }
+}`;
+
+const testValues = {
+  cssFullExample,
+  cssCodeWithCommentsRemoved
+};
+
+export default testValues;

--- a/client/src/utils/__fixtures/curriculum-test-helpers-javascript.js
+++ b/client/src/utils/__fixtures/curriculum-test-helpers-javascript.js
@@ -1,0 +1,44 @@
+const jsCodeWithSingleAndMultLineComments = `
+function nonMutatingPush(original, newItem) {
+  /* This is a 
+    multi-line comment 
+    that should be removed. */
+  return original.push(newItem);
+}
+var first = [1, 2, 3];
+// This is a single line comment
+var second = [4, 5];
+nonMutatingPush(first, second);`;
+
+const jsCodeWithSingleAndMultLineCommentsRemoved = `
+function nonMutatingPush(original, newItem) {
+
+
+
+  return original.push(newItem);
+}
+var first = [1, 2, 3];
+
+var second = [4, 5];
+nonMutatingPush(first, second);`;
+
+const jsCodeWithUrl = `
+function nonMutatingPush(original, newItem) {
+  var url = 'https://freecodecamp.org'; // this comment should vanish
+  return original.push(newItem);
+}`;
+
+const jsCodeWithUrlUnchanged = `
+function nonMutatingPush(original, newItem) {
+  var url = 'https://freecodecamp.org';
+  return original.push(newItem);
+}`;
+
+const testValues = {
+  jsCodeWithSingleAndMultLineComments,
+  jsCodeWithSingleAndMultLineCommentsRemoved,
+  jsCodeWithUrl,
+  jsCodeWithUrlUnchanged
+};
+
+export default testValues;

--- a/client/src/utils/__fixtures/curriculum-test-helpers-remove-white-space.js
+++ b/client/src/utils/__fixtures/curriculum-test-helpers-remove-white-space.js
@@ -1,0 +1,19 @@
+const stringWithWhiteSpaceChars = `
+This string sentence has various white spaces characters:
+\t* This line starts with a tab character.
+
+
+
+\t* This line has several preceding white space characters.`;
+
+/* eslint-disable max-len */
+const stringWithWhiteSpaceCharsRemoved =
+  'Thisstringsentencehasvariouswhitespacescharacters:*Thislinestartswithatabcharacter.*Thislinehasseveralprecedingwhitespacecharacters.';
+/* esline-enable max-len */
+
+const testValues = {
+  stringWithWhiteSpaceChars,
+  stringWithWhiteSpaceCharsRemoved
+};
+
+export default testValues;

--- a/client/src/utils/curriculum-test-helpers.js
+++ b/client/src/utils/curriculum-test-helpers.js
@@ -1,0 +1,34 @@
+import { parse } from '@babel/parser';
+import generate from '@babel/generator';
+
+const removeCssComments = str => str.replace(/\/\*[\s\S]+?\*\//g, '');
+
+const removeJSComments = codeStr => {
+  // Note: removes trailing new lines and tailing spaces at end of lines
+  const options = {
+    comments: false,
+    retainLines: true,
+    compact: false,
+    concise: false,
+    minified: false
+  };
+  try {
+    const ast = parse(codeStr);
+    const { code } = generate(ast, options, codeStr);
+    return code;
+  } catch (err) {
+    return codeStr;
+  }
+};
+
+const removeWhiteSpace = (str = '') => {
+  return str.replace(/\s/g, '');
+};
+
+const helperFunctions = {
+  removeCssComments,
+  removeJSComments,
+  removeWhiteSpace
+};
+
+export default helperFunctions;

--- a/client/src/utils/curriculum-test-helpers.test.js
+++ b/client/src/utils/curriculum-test-helpers.test.js
@@ -1,0 +1,67 @@
+/* global describe it expect */
+
+import __testHelpers from './curriculum-test-helpers';
+import jsTestValues from './__fixtures/curriculum-test-helpers-javascript';
+import cssTestValues from './__fixtures/curriculum-test-helpers-css';
+/* eslint-disable max-len */
+import whiteSpaceTestValues from './__fixtures/curriculum-test-helpers-remove-white-space';
+/* eslint-enable max-len */
+
+const {
+  stringWithWhiteSpaceChars,
+  stringWithWhiteSpaceCharsRemoved
+} = whiteSpaceTestValues;
+
+const { cssFullExample, cssCodeWithCommentsRemoved } = cssTestValues;
+
+const {
+  jsCodeWithSingleAndMultLineComments,
+  jsCodeWithSingleAndMultLineCommentsRemoved,
+  jsCodeWithUrl,
+  jsCodeWithUrlUnchanged
+} = jsTestValues;
+
+describe('removeWhiteSpace', () => {
+  const { removeWhiteSpace } = __testHelpers;
+  it('returns a string', () => {
+    expect(typeof removeWhiteSpace('This should return a string')).toBe(
+      'string'
+    );
+  });
+
+  it('returns a string with no white space characters', () => {
+    expect(removeWhiteSpace(stringWithWhiteSpaceChars)).toBe(
+      stringWithWhiteSpaceCharsRemoved
+    );
+  });
+});
+
+describe('removeJSComments', () => {
+  const { removeJSComments } = __testHelpers;
+  it('returns a string', () => {
+    expect(typeof removeJSComments('const should = "return a string"')).toBe(
+      'string'
+    );
+  });
+
+  it('returns a string with no single or multi-line comments', () => {
+    expect(removeJSComments(jsCodeWithSingleAndMultLineComments)).toBe(
+      jsCodeWithSingleAndMultLineCommentsRemoved
+    );
+  });
+
+  it('does not remove a url found in JS code', () => {
+    expect(removeJSComments(jsCodeWithUrl)).toBe(jsCodeWithUrlUnchanged);
+  });
+});
+
+describe('removeCssComments', () => {
+  const { removeCssComments } = __testHelpers;
+  it('returns a string', () => {
+    expect(typeof removeCssComments('.aClass: { color: red; }')).toBe('string');
+  });
+
+  it('returns a CSS string with no single or multi-line comments', () => {
+    expect(removeCssComments(cssFullExample)).toBe(cssCodeWithCommentsRemoved);
+  });
+});

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-clockwise-notation-to-specify-the-margin-of-an-element.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-clockwise-notation-to-specify-the-margin-of-an-element.english.md
@@ -33,7 +33,7 @@ tests:
   - text: Your <code>blue-box</code> class should give the left of elements <code>40px</code> of <code>margin</code>.
     testString: assert($(".blue-box").css("margin-left") === "40px");
   - text: You should use the clockwise notation to set the margin of <code>blue-box</code> class.
-    testString: const removeCssComments = str => str.replace(/\/\*[\s\S]+?\*\//g, '');assert(/\.blue-box\s*{[\s\S]*margin[\s]*:\s*\d+px\s+\d+px\s+\d+px\s+\d+px(;\s*[^}]+\s*}|;?\s*})/.test(removeCssComments($('style').text())));
+    testString: assert(/\.blue-box\s*{[\s\S]*margin[\s]*:\s*\d+px\s+\d+px\s+\d+px\s+\d+px(;\s*[^}]+\s*}|;?\s*})/.test(__testHelpers.removeCssComments($('style').text())));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-clockwise-notation-to-specify-the-padding-of-an-element.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-clockwise-notation-to-specify-the-padding-of-an-element.english.md
@@ -32,7 +32,7 @@ tests:
   - text: Your <code>blue-box</code> class should give the left of elements <code>40px</code> of <code>padding</code>.
     testString: assert($(".blue-box").css("padding-left") === "40px");
   - text: You should use the clockwise notation to set the padding of <code>blue-box</code> class.
-    testString: const removeCssComments = str => str.replace(/\/\*[\s\S]+?\*\//g, '');assert(/\.blue-box\s*{[\s\S]*padding[\s]*:\s*\d+px\s+\d+px\s+\d+px\s+\d+px(;\s*[^}]+\s*}|;?\s*})/.test(removeCssComments($('style').text())));
+    testString: assert(/\.blue-box\s*{[\s\S]*padding[\s]*:\s*\d+px\s+\d+px\s+\d+px\s+\d+px(;\s*[^}]+\s*}|;?\s*})/.test(__testHelpers.removeCssComments($('style').text())));
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/copy-an-array-with-the-spread-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/copy-an-array-with-the-spread-operator.english.md
@@ -38,7 +38,7 @@ tests:
   - text: <code>copyMachine(["it works"], 3)</code> should return <code>[["it works"], ["it works"], ["it works"]]</code>
     testString: assert.deepEqual(copyMachine(['it works'], 3), [['it works'], ['it works'], ['it works']]);
   - text: The <code>copyMachine</code> function should utilize the <code>spread operator</code> with array <code>arr</code>
-    testString: assert(removeJSComments(code).match(/\.\.\.arr/));
+    testString: assert(__testHelpers.removeJSComments(code).match(/\.\.\.arr/));
 
 ```
 
@@ -62,15 +62,6 @@ function copyMachine(arr, num) {
 }
 
 console.log(copyMachine([true, false, true], 2));
-```
-
-</div>
-
-### After Test
-<div id='js-teardown'>
-
-```js
-const removeJSComments = str => str.replace(/\/\*[\s\S]*?\*\/|\/\/.*$/gm, '');
 ```
 
 </div>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/replace-loops-using-recursion.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/replace-loops-using-recursion.english.md
@@ -57,9 +57,9 @@ tests:
   - text: <code>sum([2, 3, 4, 5], 3)</code> should equal 9.
     testString: assert.equal(sum([2, 3, 4, 5], 3), 9);
   - text: Your code should not rely on any kind of loops (<code>for</code> or <code>while</code> or higher order functions such as <code>forEach</code>, <code>map</code>, <code>filter</code>, or <code>reduce</code>.).
-    testString: assert(!removeJSComments(code).match(/for|while|forEach|map|filter|reduce/g));
+    testString: assert(!__testHelpers.removeJSComments(code).match(/for|while|forEach|map|filter|reduce/g));
   - text: You should use recursion to solve this problem.
-    testString: assert(removeJSComments(sum.toString()).match(/sum\(.*\)/g).length > 1);
+    testString: assert(__testHelpers.removeJSComments(sum.toString()).match(/sum\(.*\)/g).length > 1);
 ```
 
 </section>
@@ -75,16 +75,6 @@ function sum(arr, n) {
 
   // Only change code above this line
 }
-
-```
-
-</div>
-
-### After Test
-<div id='js-teardown'>
-
-```js
-const removeJSComments = str => str.replace(/\/\*[\s\S]*?\*\/|\/\/.*$/gm, '');
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/use-recursion-to-create-a-countdown.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/use-recursion-to-create-a-countdown.english.md
@@ -52,9 +52,9 @@ tests:
   - text: <code>countdown(5)</code> should return <code>[5, 4, 3, 2, 1]</code>
     testString: assert.deepStrictEqual(countdown(5), [5, 4, 3, 2, 1]);
   - text: Your code should not rely on any kind of loops (<code>for</code>, <code>while</code> or higher order functions such as <code>forEach</code>, <code>map</code>, <code>filter</code>, and <code>reduce</code>).
-    testString: assert(!removeJSComments(code).match(/for|while|forEach|map|filter|reduce/g));
+    testString: assert(!__testHelpers.removeJSComments(code).match(/for|while|forEach|map|filter|reduce/g));
   - text: You should use recursion to solve this problem.
-    testString: assert(removeJSComments(countdown.toString()).match(/countdown\s*\(.+\)/));
+    testString: assert(__testHelpers.removeJSComments(countdown.toString()).match(/countdown\s*\(.+\)/));
 ```
 
 </section>
@@ -73,15 +73,6 @@ function countdown(n){
 }
 // Only change code above this line
 console.log(countdown(5)); // [5, 4, 3, 2, 1]
-```
-
-</div>
-
-### After Test
-<div id='js-teardown'>
-
-```js
-const removeJSComments = str => str.replace(/\/\*[\s\S]*?\*\/|\/\/.*$/gm, '');
 ```
 
 </div>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/use-recursion-to-create-a-range-of-numbers.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/use-recursion-to-create-a-range-of-numbers.english.md
@@ -25,9 +25,9 @@ tests:
   - text: Your function should return an array.
     testString: assert(Array.isArray(rangeOfNumbers(5, 10)));
   - text: Your code should not use any loop syntax (<code>for</code> or <code>while</code> or higher order functions such as <code>forEach</code>, <code>map</code>, <code>filter</code>, or <code>reduce</code>).
-    testString: assert(!removeJSComments(code).match(/for|while|forEach|map|filter|reduce/g));
+    testString: assert(!__testHelpers.removeJSComments(code).match(/for|while|forEach|map|filter|reduce/g));
   - text: <code>rangeOfNumbers</code> should use recursion (call itself) to solve this challenge.
-    testString: assert(removeJSComments(rangeOfNumbers.toString()).match(/rangeOfNumbers\s*\(.+\)/));
+    testString: assert(__testHelpers.removeJSComments(rangeOfNumbers.toString()).match(/rangeOfNumbers\s*\(.+\)/));
   - text: <code>rangeOfNumbers(1, 5)</code> should return <code>[1, 2, 3, 4, 5]</code>.
     testString: assert.deepStrictEqual(rangeOfNumbers(1, 5), [1, 2, 3, 4, 5]);
   - text: <code>rangeOfNumbers(6, 9)</code> should return <code>[6, 7, 8, 9]</code>.
@@ -47,15 +47,6 @@ tests:
 function rangeOfNumbers(startNum, endNum) {
   return [];
 };
-```
-
-</div>
-
-### After Test
-<div id='js-teardown'>
-
-```js
-const removeJSComments = str => str.replace(/\/\*[\s\S]*?\*\/|\/\/.*$/gm, '');
 ```
 
 </div>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/debugging/understanding-the-differences-between-the-freecodecamp-and-browser-console.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/debugging/understanding-the-differences-between-the-freecodecamp-and-browser-console.english.md
@@ -26,9 +26,9 @@ First, use <code>console.clear()</code> to clear the browser console. After that
 ```yml
 tests:
   - text: You should use <code>console.clear()</code> to clear the browser console.
-    testString: const removeJSComments = code.replace(/\/\*[\s\S]*?\*\/|\/\/.*$/gm, ''); const noSpaces = removeJSComments.replace(/\s/g, ''); assert(noSpaces.match(/console.clear\(\)/));
+    testString: const { removeWhiteSpace, removeJSComments } = __testHelpers; assert(removeWhiteSpace(removeJSComments(code)).match(/console.clear\(\)/));
   - text: You should use <code>console.log()</code> to print the <code>output</code> variable.
-    testString: const noSpaces = code.replace(/\s/g, ''); assert(noSpaces.match(/console\.log\(output\)/));
+    testString: assert(__testHelpers.removeWhiteSpace(code).match(/console\.log\(output\)/));
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/complete-a-promise-with-resolve-and-reject.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/complete-a-promise-with-resolve-and-reject.english.md
@@ -33,9 +33,9 @@ Make the promise handle success and failure.  If <code>responseFromServer</code>
 ```yml
 tests:
   - text: <code>resolve</code> should be executed when the <code>if</code> condition is <code>true</code>.
-    testString: assert(removeJSComments(code).match(/if\s*\(\s*responseFromServer\s*\)\s*{\s*resolve\s*\(\s*('|"|`)We got the data\1\s*\)(\s*|\s*;\s*)}/g));
+    testString: assert(__testHelpers.removeJSComments(code).match(/if\s*\(\s*responseFromServer\s*\)\s*{\s*resolve\s*\(\s*('|"|`)We got the data\1\s*\)(\s*|\s*;\s*)}/g));
   - text: <code>reject</code> should be executed when the <code>if</code> condition is <code>false</code>.
-    testString: assert(removeJSComments(code).match(/}\s*else\s*{\s*reject\s*\(\s*('|"|`)Data not received\1\s*\)(\s*|\s*;\s*)}/g));
+    testString: assert(__testHelpers.removeJSComments(code).match(/}\s*else\s*{\s*reject\s*\(\s*('|"|`)Data not received\1\s*\)(\s*|\s*;\s*)}/g));
 ```
 
 </section>
@@ -59,14 +59,6 @@ const makeServerRequest = new Promise((resolve, reject) => {
 
 </div>
 
-### After Test
-<div id='js-teardown'>
-
-```js
-const removeJSComments = str => str.replace(/\/\*[\s\S]*?\*\/|\/\/.*$/gm, '');
-```
-
-</div>
 </section>
 
 ## Solution

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/write-concise-declarative-functions-with-es6.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/write-concise-declarative-functions-with-es6.english.md
@@ -42,7 +42,7 @@ Refactor the function <code>setGear</code> inside the object <code>bicycle</code
 ```yml
 tests:
   - text: Traditional function expression should not be used.
-    testString: getUserInput => assert(!removeJSComments(code).match(/function/));
+    testString: getUserInput => assert(!__testHelpers.removeJSComments(code).match(/function/));
   - text: <code>setGear</code> should be a declarative function.
     testString: assert(typeof bicycle.setGear === 'function' && code.match(/setGear\s*\(.+\)\s*\{/));
   - text: <code>bicycle.setGear(48)</code> should change the <code>gear</code> value to 48.
@@ -68,15 +68,6 @@ const bicycle = {
 // Only change code above this line
 bicycle.setGear(3);
 console.log(bicycle.gear);
-```
-
-</div>
-
-### After Test
-<div id='js-teardown'>
-
-```js
-const removeJSComments = str => str.replace(/\/\*[\s\S]*?\*\/|\/\/.*$/gm, '');
 ```
 
 </div>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/use-higher-order-functions-map-filter-or-reduce-to-solve-a-complex-problem.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/use-higher-order-functions-map-filter-or-reduce-to-solve-a-complex-problem.english.md
@@ -24,9 +24,9 @@ tests:
   - text: <code>squareList</code> should be a <code>function</code>.
     testString: assert.typeOf(squareList, 'function'), '<code>squareList</code> should be a <code>function</code>';
   - text: for or while loops or forEach should not be used.
-    testString: assert(!removeJSComments(code).match(/for|while|forEach/g));
+    testString: assert(!__testHelpers.removeJSComments(code).match(/for|while|forEach/g));
   - text: <code>map</code>, <code>filter</code>, or <code>reduce</code> should be used.
-    testString: assert(removeJSComments(code).match(/\.(map|filter|reduce)\s*\(/g));
+    testString: assert(__testHelpers.removeJSComments(code).match(/\.(map|filter|reduce)\s*\(/g));
   - text: The function should return an <code>array</code>.
     testString: assert(Array.isArray(squareList([4, 5.6, -9.8, 3.14, 42, 6, 8.34, -2])));
   - text: <code>squareList([4, 5.6, -9.8, 3.14, 42, 6, 8.34, -2])</code> should return <code>[16, 1764, 36]</code>.
@@ -51,14 +51,6 @@ const squareList = (arr) => {
 
 const squaredIntegers = squareList([-3, 4.8, 5, 3, -3.2]);
 console.log(squaredIntegers);
-```
-
-</div>
-
-<div id='js-teardown'>
-
-```js
-const removeJSComments = str => str.replace(/\/\*[\s\S]*?\*\/|\/\/.*$/gm, '');
 ```
 
 </div>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/use-the-map-method-to-extract-data-from-an-array.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/use-the-map-method-to-extract-data-from-an-array.english.md
@@ -41,7 +41,7 @@ tests:
   - text: The <code>watchList</code> variable should not change.
     testString: assert(watchList[0].Title === "Inception" && watchList[4].Director == "James Cameron");
   - text: Your code should not use a <code>for</code> loop.
-    testString: assert(!removeJSComments(code).match(/for\s*?\([\s\S]*?\)/));
+    testString: assert(!__testHelpers.removeJSComments(code).match(/for\s*?\([\s\S]*?\)/));
   - text: Your code should use the <code>map</code> method.
     testString: assert(code.match(/\.map/g));
   - text: <code>ratings</code> should equal <code>[{"title":"Inception","rating":"8.8"},{"title":"Interstellar","rating":"8.6"},{"title":"The Dark Knight","rating":"9.0"},{"title":"Batman Begins","rating":"8.3"},{"title":"Avatar","rating":"7.9"}]</code>.
@@ -181,15 +181,6 @@ for(var i=0; i < watchList.length; i++){
 // Only change code above this line
 
 console.log(JSON.stringify(ratings));
-```
-
-</div>
-
-### After Test
-<div id='js-teardown'>
-
-```js
-const removeJSComments = str => str.replace(/\/\*[\s\S]*?\*\/|\/\/.*$/gm, '');
 ```
 
 </div>

--- a/curriculum/challenges/english/03-front-end-libraries/react-and-redux/getting-started-with-react-redux.english.md
+++ b/curriculum/challenges/english/03-front-end-libraries/react-and-redux/getting-started-with-react-redux.english.md
@@ -26,7 +26,7 @@ tests:
   - text: The <code>DisplayMessages</code> component should render an empty <code>div</code> element.
     testString: assert((function() { const mockedComponent = Enzyme.mount(React.createElement(DisplayMessages)); return mockedComponent.find('div').text() === '' })());
   - text: The <code>DisplayMessages</code> constructor should be called properly with <code>super</code>, passing in <code>props</code>.
-    testString: getUserInput => assert((function() { const noWhiteSpace = getUserInput('index').replace(/\s/g,''); return noWhiteSpace.includes('constructor(props)') && noWhiteSpace.includes('super(props'); })());
+    testString: assert((function() { const noWhiteSpace = __testHelpers.removeWhiteSpace(code); return noWhiteSpace.includes('constructor(props)') && noWhiteSpace.includes('super(props'); })());
   - text: 'The <code>DisplayMessages</code> component should have an initial state equal to <code>{input: "", messages: []}</code>.'
     testString: "assert((function() { const mockedComponent = Enzyme.mount(React.createElement(DisplayMessages)); const initialState = mockedComponent.state(); return typeof initialState === 'object' && initialState.input === '' && Array.isArray(initialState.messages) && initialState.messages.length === 0; })());"
 

--- a/curriculum/challenges/english/03-front-end-libraries/react/use-proptypes-to-define-the-props-you-expect.english.md
+++ b/curriculum/challenges/english/03-front-end-libraries/react/use-proptypes-to-define-the-props-you-expect.english.md
@@ -33,7 +33,7 @@ tests:
   - text: The <code>Items</code> component should render.
     testString: assert((function() { const mockedComponent = Enzyme.mount(React.createElement(ShoppingCart)); return mockedComponent.find('Items').length === 1; })());
   - text: The <code>Items</code> component should include a <code>propTypes</code> check that requires <code>quantity</code> to be a <code>number</code>.
-    testString: getUserInput => assert((function() { const noWhiteSpace = getUserInput('index').replace(/ /g, ''); return noWhiteSpace.includes('quantity:PropTypes.number.isRequired') && noWhiteSpace.includes('Items.propTypes='); })());
+    testString: assert((function() { const noWhiteSpace = __testHelpers.removeWhiteSpace(code); return noWhiteSpace.includes('quantity:PropTypes.number.isRequired') && noWhiteSpace.includes('Items.propTypes='); })());
 
 ```
 

--- a/curriculum/challenges/english/03-front-end-libraries/react/use-state-to-toggle-an-element.english.md
+++ b/curriculum/challenges/english/03-front-end-libraries/react/use-state-to-toggle-an-element.english.md
@@ -55,7 +55,7 @@ tests:
   - text: Clicking the button element should toggle the <code>visibility</code> property in state between <code>true</code> and <code>false</code>.
     testString: 'async () => { const waitForIt = (fn) => new Promise((resolve, reject) => setTimeout(() => resolve(fn()), 250)); const mockedComponent = Enzyme.mount(React.createElement(MyComponent)); const first = () => { mockedComponent.setState({ visibility: false }); return waitForIt(() => mockedComponent.state(''visibility'')); }; const second = () => { mockedComponent.find(''button'').simulate(''click''); return waitForIt(() => mockedComponent.state(''visibility'')); }; const third = () => { mockedComponent.find(''button'').simulate(''click''); return waitForIt(() => mockedComponent.state(''visibility'')); }; const firstValue = await first(); const secondValue = await second(); const thirdValue = await third(); assert(!firstValue && secondValue && !thirdValue); }; '
   - text: An anonymous function should be passed to <code>setState</code>.
-    testString: const paramRegex = '[a-zA-Z$_]\\w*(,[a-zA-Z$_]\\w*)?'; const noSpaces = code.replace(/\s/g, ''); assert(new RegExp('this\\.setState\\((function\\(' + paramRegex + '\\){|([a-zA-Z$_]\\w*|\\(' + paramRegex + '\\))=>)').test(noSpaces));
+    testString: const paramRegex = '[a-zA-Z$_]\\w*(,[a-zA-Z$_]\\w*)?'; assert(new RegExp('this\\.setState\\((function\\(' + paramRegex + '\\){|([a-zA-Z$_]\\w*|\\(' + paramRegex + '\\))=>)').test(__testHelpers.removeWhiteSpace(code)));
   - text: <code>this</code> should not be used inside <code>setState</code>
     testString: assert(!/this\.setState\([^}]*this/.test(code));
 

--- a/curriculum/challenges/english/03-front-end-libraries/redux/combine-multiple-reducers.english.md
+++ b/curriculum/challenges/english/03-front-end-libraries/redux/combine-multiple-reducers.english.md
@@ -39,7 +39,7 @@ tests:
   - text: 'The store <code>state</code> should have two keys: <code>count</code>, which holds a number, and <code>auth</code>, which holds an object. The <code>auth</code> object should have a property of <code>authenticated</code>, which holds a boolean.'
     testString: "assert((function() { const state = store.getState(); return typeof state.auth === 'object' && typeof state.auth.authenticated === 'boolean' && typeof state.count === 'number' })());"
   - text: The <code>rootReducer</code> should be a function that combines the <code>counterReducer</code> and the <code>authReducer</code>.
-    testString: getUserInput => assert((function() {  const noWhiteSpace = getUserInput('index').replace(/\s/g,''); return typeof rootReducer === 'function' && noWhiteSpace.includes('Redux.combineReducers')  })());
+    testString: assert((function() {  return typeof rootReducer === 'function' && __testHelpers.removeWhiteSpace(code).includes('Redux.combineReducers')  })());
 
 ```
 

--- a/curriculum/challenges/english/03-front-end-libraries/redux/dispatch-an-action-event.english.md
+++ b/curriculum/challenges/english/03-front-end-libraries/redux/dispatch-an-action-event.english.md
@@ -33,7 +33,7 @@ tests:
   - text: The store should be initialized with an object with property <code>login</code> set to <code>false</code>.
     testString: assert(store.getState().login === false);
   - text: The <code>store.dispatch()</code> method should be used to dispatch an action of type <code>LOGIN</code>.
-    testString: "getUserInput => assert((function() {  let noWhiteSpace = getUserInput('index').replace(/\\s/g,''); return noWhiteSpace.includes('store.dispatch(loginAction())') || noWhiteSpace.includes('store.dispatch({type: \\'LOGIN\\'})') === true })());"
+    testString: "assert((function() {  const noWhiteSpace = __testHelpers.removeWhiteSpace(code); return noWhiteSpace.includes('store.dispatch(loginAction())') || noWhiteSpace.includes('store.dispatch({type: \\'LOGIN\\'})') === true })());"
 
 ```
 

--- a/curriculum/challenges/english/03-front-end-libraries/redux/use-const-for-action-types.english.md
+++ b/curriculum/challenges/english/03-front-end-libraries/redux/use-const-for-action-types.english.md
@@ -35,9 +35,9 @@ tests:
   - text: The <code>authReducer</code> function should handle multiple action types with a switch statement.
     testString: getUserInput => assert((function() { return typeof authReducer === 'function' && getUserInput('index').toString().includes('switch') && getUserInput('index').toString().includes('case') && getUserInput('index').toString().includes('default') })());
   - text: <code>LOGIN</code> and <code>LOGOUT</code> should be declared as <code>const</code> values and should be assigned strings of <code>LOGIN</code>and <code>LOGOUT</code>.
-    testString: const noWhiteSpace = code.replace(/\s/g, ''); assert(/constLOGIN=(['"`])LOGIN\1/.test(noWhiteSpace) && /constLOGOUT=(['"`])LOGOUT\1/.test(noWhiteSpace));
+    testString: const noWhiteSpace = __testHelpers.removeWhiteSpace(code); assert(/constLOGIN=(['"`])LOGIN\1/.test(noWhiteSpace) && /constLOGOUT=(['"`])LOGOUT\1/.test(noWhiteSpace));
   - text: The action creators and the reducer should reference the <code>LOGIN</code> and <code>LOGOUT</code> constants.
-    testString: getUserInput => assert((function() { const noWhiteSpace = getUserInput('index').toString().replace(/\s/g,''); return noWhiteSpace.includes('caseLOGIN:') && noWhiteSpace.includes('caseLOGOUT:') && noWhiteSpace.includes('type:LOGIN') && noWhiteSpace.includes('type:LOGOUT') })());
+    testString: assert((function() { const noWhiteSpace = __testHelpers.removeWhiteSpace(code); return noWhiteSpace.includes('caseLOGIN:') && noWhiteSpace.includes('caseLOGOUT:') && noWhiteSpace.includes('type:LOGIN') && noWhiteSpace.includes('type:LOGOUT') })());
 
 ```
 

--- a/curriculum/challenges/english/03-front-end-libraries/redux/use-middleware-to-handle-asynchronous-actions.english.md
+++ b/curriculum/challenges/english/03-front-end-libraries/redux/use-middleware-to-handle-asynchronous-actions.english.md
@@ -33,7 +33,7 @@ tests:
   - text: Dispatching the requestingData action creator should update the store <code>state</code> property of fetching to <code>true</code>.
     testString: assert((function() { const initialState = store.getState(); store.dispatch(requestingData()); const reqState = store.getState(); return initialState.fetching === false && reqState.fetching === true })());
   - text: Dispatching <code>handleAsync</code> should dispatch the data request action and then dispatch the received data action after a delay.
-    testString: assert((function() { const noWhiteSpace = handleAsync.toString().replace(/\s/g,''); return noWhiteSpace.includes('dispatch(requestingData())') === true && noWhiteSpace.includes('dispatch(receivedData(data))') === true })());
+    testString: assert((function() { const noWhiteSpace = __testHelpers.removeWhiteSpace(handleAsync.toString()); return noWhiteSpace.includes('dispatch(requestingData())') === true && noWhiteSpace.includes('dispatch(receivedData(data))') === true })());
 
 ```
 


### PR DESCRIPTION
Checklist:
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

This PR attempts to create a set of utility functions that can be used across all curriculum tests. 

Goals Achieved:
 * Able to get rid of all of the `Before / After Test` sections that only existed for the sole purpose of using in a curriculum file's tests.
* Create tested functions that test writer's can trust will work when ever used.
* Clean up existing `textString`s in tests by not having to define the functions within the `textString`s

To Do Before Merging:
- [ ] Conclude if where I currently stored these helper functions (`client/src/utils`) is the best place for them.
- [ ] Need to figure out how to use `@babel/standalone` instead of `@babel/parse` and `@babel/generate`.  (@ojeytonwilliams to help here)
- [ ] Figure out if this needs to be lazy-loaded (@ojeytonwilliams to help here)
- [ ] Update the existing [documentation](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/docs/how-to-work-on-coding-challenges.md) to include a reference to trying to use the helper functions whenever possible.