### PR TITLE
fix: use flash before auth

### DIFF
--- a/api-server/server/middleware.json
+++ b/api-server/server/middleware.json
@@ -29,6 +29,8 @@
     "./middlewares/sessions.js": {}
   },
   "auth:before": {
+    "express-flash": {},
+    "./middlewares/express-extensions": {},
     "./middlewares/add-return-to": {},
     "./middlewares/cookie-parser": {},
     "./middlewares/request-authorization": {}
@@ -46,8 +48,6 @@
     "./middlewares/validator": {}
   },
   "routes:before": {
-    "./middlewares/express-extensions": {},
-    "express-flash": {},
     "helmet#xssFilter": {},
     "helmet#noSniff": {},
     "helmet#frameguard": {},


### PR DESCRIPTION
This makes sure `res.flash` and `res.redirectWithFlash` are defined before auth.  This is necessary as auth errors are reported with `res.redirectWithFlash`