### PR TITLE
fix(client): wrap editor in span with "notranslate"

### DIFF
--- a/client/src/templates/Challenges/classic/Editor.js
+++ b/client/src/templates/Challenges/classic/Editor.js
@@ -216,16 +216,18 @@ class Editor extends Component {
     const editorTheme = theme === 'night' ? 'vs-dark-custom' : 'vs-custom';
     return (
       <Suspense fallback={<Loader timeout={600} />}>
-        <MonacoEditor
-          editorDidMount={this.editorDidMount}
-          editorWillMount={this.editorWillMount}
-          key={`${editorTheme}-${fileKey}`}
-          language={modeMap[ext]}
-          onChange={this.onChange}
-          options={this.options}
-          theme={editorTheme}
-          value={contents}
-        />
+        <span className="notranslate">
+          <MonacoEditor
+            editorDidMount={this.editorDidMount}
+            editorWillMount={this.editorWillMount}
+            key={`${editorTheme}-${fileKey}`}
+            language={modeMap[ext]}
+            onChange={this.onChange}
+            options={this.options}
+            theme={editorTheme}
+            value={contents}
+          />
+        </span>
       </Suspense>
     );
   }

--- a/client/src/templates/Challenges/classic/Editor.js
+++ b/client/src/templates/Challenges/classic/Editor.js
@@ -216,7 +216,7 @@ class Editor extends Component {
     const editorTheme = theme === 'night' ? 'vs-dark-custom' : 'vs-custom';
     return (
       <Suspense fallback={<Loader timeout={600} />}>
-        <span className="notranslate">
+        <span className='notranslate'>
           <MonacoEditor
             editorDidMount={this.editorDidMount}
             editorWillMount={this.editorWillMount}

--- a/client/src/templates/Challenges/classic/Show.js
+++ b/client/src/templates/Challenges/classic/Show.js
@@ -251,10 +251,7 @@ class ShowClassic extends Component {
 
   renderPreview() {
     return (
-      <Preview
-        className='full-height notranslate'
-        disableIframe={this.state.resizing}
-      />
+      <Preview className='full-height' disableIframe={this.state.resizing} />
     );
   }
 

--- a/client/src/templates/Challenges/classic/Show.js
+++ b/client/src/templates/Challenges/classic/Show.js
@@ -251,7 +251,10 @@ class ShowClassic extends Component {
 
   renderPreview() {
     return (
-      <Preview className='full-height' disableIframe={this.state.resizing} />
+      <Preview
+        className='full-height notranslate'
+        disableIframe={this.state.resizing}
+      />
     );
   }
 

--- a/client/src/templates/Challenges/components/Preview.js
+++ b/client/src/templates/Challenges/components/Preview.js
@@ -46,7 +46,7 @@ class Preview extends Component {
   render() {
     const iframeToggle = this.state.iframeStatus ? 'disable' : 'enable';
     return (
-      <div className={`challenge-preview ${iframeToggle}-iframe`}>
+      <div className={`notranslate challenge-preview ${iframeToggle}-iframe`}>
         <iframe
           className={'challenge-preview-frame'}
           id={mainId}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!-- Feel free to add any addtional description of changes below this line -->
Wraps `react-monaco-editor` into a span with class `notranslate` to avoid translating it when using Google Translate.

### References:
[Why wrapping](https://github.com/react-monaco-editor/react-monaco-editor/issues/93)
[Why notranslate](https://stackoverflow.com/questions/9628507/how-can-i-tell-google-translate-to-not-translate-a-section-of-a-website/41855529)