### PR TITLE
fix(curriculum): added additional test for Render Images from Data Sources challenge

### DIFF
--- a/curriculum/challenges/english/04-data-visualization/json-apis-and-ajax/render-images-from-data-sources.english.md
+++ b/curriculum/challenges/english/04-data-visualization/json-apis-and-ajax/render-images-from-data-sources.english.md
@@ -25,6 +25,8 @@ Add code to use the <code>imageLink</code> and <code>altText</code> properties i
 tests:
   - text: You should use the <code>imageLink</code> property to display the images.
     testString: assert(code.match(/val\.imageLink/g));
+  - text: You should use the <code>altText</code> for the alt attribute values of the images.
+    testString: assert(code.match(/val\.altText/g));
 
 ```
 


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #38394

This PR adds one additional test to validate the `alt` attribute's value actually uses `val.altText`.  As reported in the above issue, the test could pass without specifying `val.` in front of `atlText` which caused an error when the button was clicked yet the tests actually passed.
