### PR TITLE
Fix search bar vertical align

### DIFF
--- a/client/src/components/search/searchBar/searchbar.css
+++ b/client/src/components/search/searchBar/searchbar.css
@@ -20,6 +20,7 @@
   display: inline-block;
   margin-top: 6px;
   height: 26px;
+  line-height: 27px;
 }
 
 .ais-SearchBox-submit {


### PR DESCRIPTION
Closes #37778

<!-- Feel free to add any addtional description of changes below this line -->
It's a bit off a hacky solution in my opinion but it's the only fix I found to align the text properly. You could use something like padding as well but that will make the text look like it's pushed to high up in certain cases. 

The font itself will also make the text not look 100% vertical aligned in all cases. This happens even in an unstyled input field. In the issue (#37778 ), all lower case characters were used in the example so there is always going to be some space above the lower case characters. I would guess this is how text is just rendered to maintain a constant minimum height for both lowercase and uppercase inline. 

**Before fix in capital case**
<img width="228" alt="Screenshot 2020-03-19 at 21 49 22" src="https://user-images.githubusercontent.com/22411478/77222711-4cee3980-6b5e-11ea-8f68-1d9c415f195c.png">

**After fix in capital case**
<img width="249" alt="Screenshot 2020-03-19 at 21 49 16" src="https://user-images.githubusercontent.com/22411478/77222716-54154780-6b5e-11ea-9e9f-53ef4a3b13ad.png">

**Before fix in lower case**
<img width="278" alt="Screenshot 2020-03-21 at 10 26 57" src="https://user-images.githubusercontent.com/22411478/77222748-96d71f80-6b5e-11ea-9019-f57b1c0b7cde.png">

**After fix in lower case** 
You can see here there is still some space but this should be due to the font itself. Check the picture below for an example of an unstyled input with just some height and font size applied to it.
<img width="263" alt="Screenshot 2020-03-21 at 10 26 43" src="https://user-images.githubusercontent.com/22411478/77222757-b2422a80-6b5e-11ea-897c-e1f07332c067.png">

**Unstyled input field example**
<img width="340" alt="Screenshot 2020-03-19 at 21 23 46" src="https://user-images.githubusercontent.com/22411478/77222777-f46b6c00-6b5e-11ea-9e02-49333bc45fc4.png">

