### PR TITLE
fix: division operator in the beginning code is interfering with the …

### DIFF
--- a/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/divide-one-decimal-by-another-with-javascript.arabic.md
+++ b/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/divide-one-decimal-by-another-with-javascript.arabic.md
@@ -34,7 +34,7 @@ tests:
 <div id='js-seed'>
 
 ```js
-var quotient = 0.0 / 2.0; // Fix this line
+var quotient = 0.0 / 2.0; /* Fix this line */
 
 ```
 

--- a/curriculum/challenges/chinese/02-javascript-algorithms-and-data-structures/basic-javascript/divide-one-decimal-by-another-with-javascript.chinese.md
+++ b/curriculum/challenges/chinese/02-javascript-algorithms-and-data-structures/basic-javascript/divide-one-decimal-by-another-with-javascript.chinese.md
@@ -34,7 +34,7 @@ tests:
 <div id='js-seed'>
 
 ```js
-var quotient = 0.0 / 2.0; // Fix this line
+var quotient = 0.0 / 2.0; /* Fix this line */
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/divide-one-decimal-by-another-with-javascript.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/divide-one-decimal-by-another-with-javascript.english.md
@@ -38,7 +38,7 @@ tests:
 <div id='js-seed'>
 
 ```js
-var quotient = 0.0 / 2.0; // Change this line
+var quotient = 0.0 / 2.0; /* Change this line */
 ```
 
 </div>

--- a/curriculum/challenges/portuguese/02-javascript-algorithms-and-data-structures/basic-javascript/divide-one-decimal-by-another-with-javascript.portuguese.md
+++ b/curriculum/challenges/portuguese/02-javascript-algorithms-and-data-structures/basic-javascript/divide-one-decimal-by-another-with-javascript.portuguese.md
@@ -34,7 +34,7 @@ tests:
 <div id='js-seed'>
 
 ```js
-var quotient = 0.0 / 2.0; // Fix this line
+var quotient = 0.0 / 2.0; /* Fix this line */
 
 ```
 

--- a/curriculum/challenges/russian/02-javascript-algorithms-and-data-structures/basic-javascript/divide-one-decimal-by-another-with-javascript.russian.md
+++ b/curriculum/challenges/russian/02-javascript-algorithms-and-data-structures/basic-javascript/divide-one-decimal-by-another-with-javascript.russian.md
@@ -39,7 +39,7 @@ tests:
 <div id='js-seed'>
 
 ```js
-var quotient = 0.0 / 2.0; // Fix this line
+var quotient = 0.0 / 2.0; /* Fix this line */
 
 ```
 

--- a/curriculum/challenges/spanish/02-javascript-algorithms-and-data-structures/basic-javascript/divide-one-decimal-by-another-with-javascript.spanish.md
+++ b/curriculum/challenges/spanish/02-javascript-algorithms-and-data-structures/basic-javascript/divide-one-decimal-by-another-with-javascript.spanish.md
@@ -34,7 +34,7 @@ tests:
 <div id='js-seed'>
 
 ```js
-var quotient = 0.0 / 2.0; // Fix this line
+var quotient = 0.0 / 2.0; /* Fix this line */
 
 ```
 


### PR DESCRIPTION
When viewing the following lesson: Basic JavaScript: Divide One Decimal by Another with JavaScript
You can observe the division operator in the beginning code is interfering with the single line comment at the end of the line. Now the single line comment is replaced with mutliline comment hence it is not interfering with division operator.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the 38403 below with the issue number.-->

Closes #38403 

<!-- Feel free to add any addtional description of changes below this line -->
