### PR TITLE
fix(client):remove hyperlink from flash message

### DIFF
--- a/client/src/utils/reallyWeirdErrorMessage.js
+++ b/client/src/utils/reallyWeirdErrorMessage.js
@@ -2,5 +2,5 @@ export default {
   type: 'danger',
   message:
     'Something really weird happened, if it happens again, please consider ' +
-    'raising an issue on github.com/freeCodeCamp/freeCodeCamp/issues/new'
+    'raising an issue on https://github.com/freeCodeCamp/freeCodeCamp/issues/new'
 };

--- a/client/src/utils/reallyWeirdErrorMessage.js
+++ b/client/src/utils/reallyWeirdErrorMessage.js
@@ -2,7 +2,5 @@ export default {
   type: 'danger',
   message:
     'Something really weird happened, if it happens again, please consider ' +
-    "raising an issue on <a href='https://github.com/freeCodeCamp" +
-    "/freeCodeCamp/issues/new' target='_blank' rel='nofollow " +
-    "noreferrer'>GitHub</a>."
+    'raising an issue on github.com/freeCodeCamp/freeCodeCamp/issues/new'
 };


### PR DESCRIPTION
The anchor tag in this flash message is just displayed as a string.  So I replaced it with just the url so it looks a bit better and the user can copy and paste it.

- [ x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [ x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ x] My pull request targets the `master` branch of freeCodeCamp.
- [ x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.
