### PR TITLE
feat(client): Added tweet sharing ability for a certification.

### DIFF
--- a/client/src/client-only-routes/ShowCertification.js
+++ b/client/src/client-only-routes/ShowCertification.js
@@ -4,10 +4,10 @@ import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
-import { Grid, Row, Col, Image, Button } from '@freecodecamp/react-bootstrap';
-import FreeCodeCampLogo from '../assets/icons/freeCodeCampLogo';
+import { Grid, Row, Col, Button } from '@freecodecamp/react-bootstrap';
 // eslint-disable-next-line max-len
 import MinimalDonateForm from '../components/Donation/MinimalDonateForm';
+import Certificate from '../components/profile/components/Certificate';
 
 import {
   showCertSelector,
@@ -186,14 +186,6 @@ class ShowCertification extends Component {
       return <RedirectHome />;
     }
 
-    const {
-      date: issueDate,
-      name: userFullName,
-      username,
-      certTitle,
-      completionTime
-    } = cert;
-
     const donationCloseBtn = (
       <div>
         <Button
@@ -237,62 +229,7 @@ class ShowCertification extends Component {
     return (
       <div className='certificate-outer-wrapper'>
         {isDonationDisplayed && !isDonationClosed ? donationSection : ''}
-        <Grid className='certificate-wrapper certification-namespace'>
-          <Row>
-            <header>
-              <Col md={5} sm={12}>
-                <div className='logo'>
-                  <FreeCodeCampLogo />
-                </div>
-              </Col>
-              <Col md={7} sm={12}>
-                <div className='issue-date'>
-                  Issued&nbsp;
-                  <strong>{issueDate}</strong>
-                </div>
-              </Col>
-            </header>
-
-            <main className='information'>
-              <div className='information-container'>
-                <h3>This certifies that</h3>
-                <h1>
-                  <strong>{userFullName}</strong>
-                </h1>
-                <h3>has successfully completed the freeCodeCamp.org</h3>
-                <h1>
-                  <strong>{certTitle}</strong>
-                </h1>
-                <h4>
-                  Developer Certification, representing approximately{' '}
-                  {completionTime} hours of coursework
-                </h4>
-              </div>
-            </main>
-            <footer>
-              <div className='row signatures'>
-                <Image
-                  alt="Quincy Larson's Signature"
-                  src={
-                    'https://cdn.freecodecamp.org' +
-                    '/platform/english/images/quincy-larson-signature.svg'
-                  }
-                />
-                <p>
-                  <strong>Quincy Larson</strong>
-                </p>
-                <p>Executive Director, freeCodeCamp.org</p>
-              </div>
-              <Row>
-                <p className='verify'>
-                  Verify this certification at:
-                  https://www.freecodecamp.org/certification/
-                  {username}/{certName}
-                </p>
-              </Row>
-            </footer>
-          </Row>
-        </Grid>
+        <Certificate {...cert} certName={certName} />
       </div>
     );
   }

--- a/client/src/components/profile/components/Certificate.js
+++ b/client/src/components/profile/components/Certificate.js
@@ -1,0 +1,104 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Grid, Row, Col, Image } from '@freecodecamp/react-bootstrap';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTwitter } from '@fortawesome/free-brands-svg-icons';
+import FreeCodeCampLogo from '../../../assets/icons/freeCodeCampLogo';
+
+const propTypes = {
+  certName: PropTypes.string,
+  certTitle: PropTypes.string,
+  completionTime: PropTypes.number,
+  date: PropTypes.string,
+  name: PropTypes.string,
+  username: PropTypes.string
+};
+
+const CERT_URL = ' https://www.freecodecamp.org/certification';
+const TWITTER_URL = 'https://twitter.com/intent/tweet';
+const TWEET = `${TWITTER_URL}?text=After 100's of hours of learning, I've earned the @freeCodeCamp`;
+
+const Certificate = ({
+  certName,
+  certTitle,
+  completionTime,
+  date,
+  name,
+  username
+}) => (
+  <Grid className='certificate-wrapper certification-namespace'>
+    <Row>
+      <header>
+        <Col md={5} sm={12}>
+          <div className='logo'>
+            <FreeCodeCampLogo />
+          </div>
+        </Col>
+        <Col className='right' md={7} sm={12}>
+          <div className='issue-date'>
+            Issued&nbsp;
+            <strong>{date}</strong>
+          </div>
+
+          <div className='share'>
+            <span>Share Certification</span>
+
+            <a
+              aria-label={`Tweet your certification`}
+              href={`${TWEET} ${certTitle} Certification. ${CERT_URL}/${username}/${certName}`}
+              rel='noopener noreferrer'
+              target='_blank'
+            >
+              <FontAwesomeIcon icon={faTwitter} />
+            </a>
+          </div>
+        </Col>
+      </header>
+
+      <main className='information'>
+        <div className='information-container'>
+          <h3>This certifies that</h3>
+          <h1>
+            <strong>{name}</strong>
+          </h1>
+          <h3>has successfully completed the freeCodeCamp.org</h3>
+          <h1>
+            <strong>{certTitle}</strong>
+          </h1>
+          <h4>
+            Developer Certification, representing approximately
+            {` ${completionTime} hours of coursework`}
+          </h4>
+        </div>
+      </main>
+
+      <footer>
+        <div className='row signatures'>
+          <Image
+            alt="Quincy Larson's Signature"
+            src={
+              'https://cdn.freecodecamp.org' +
+              '/platform/english/images/quincy-larson-signature.svg'
+            }
+          />
+          <p>
+            <strong>Quincy Larson</strong>
+          </p>
+          <p>Executive Director, freeCodeCamp.org</p>
+        </div>
+
+        <Row>
+          <p className='verify'>
+            Verify this certification at:
+            https://www.freecodecamp.org/certification/
+            {username}/{certName}
+          </p>
+        </Row>
+      </footer>
+    </Row>
+  </Grid>
+);
+
+Certificate.propTypes = propTypes;
+
+export default Certificate;

--- a/client/src/pages/certification.css
+++ b/client/src/pages/certification.css
@@ -7,9 +7,11 @@
   margin: 0;
   padding: 0;
 }
+
 .certification-namespace h1 {
   margin: 12px 0;
 }
+
 .certification-namespace.container {
   max-width: 1500px;
   width: 100%;
@@ -77,11 +79,21 @@
   position: relative;
 }
 
+.certification-namespace header > .right {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: center;
+  height: 100%;
+  padding-right: 40px;
+  color: white;
+}
+
 .certification-namespace .logo {
   display: flex;
   align-items: center;
   height: 140px;
-  margin-left: 100px;
+  margin-left: 60px;
 }
 
 .certification-namespace .logo svg {
@@ -90,16 +102,23 @@
   max-width: 500px;
 }
 
-.certification-namespace .issue-date {
-  line-height: 140px;
-  font-size: 20px;
-  text-align: right;
-  margin-right: 100px;
+.certification-namespace .right > .issue-date {
+  margin-bottom: 2px;
+}
+
+.certification-namespace .right > .issue-date > strong {
   color: var(--gray-00);
 }
 
-.certification-namespace .issue-date strong {
-  color: var(--gray-00);
+.certification-namespace .right > .share > span {
+  margin-right: 10px;
+}
+
+.certification-namespace .right > .share > a {
+  background: #1a91da;
+  padding: 2px 3px;
+  border-radius: 4px;
+  cursor: pointer;
 }
 
 .certification-namespace .information {
@@ -207,18 +226,11 @@
     margin-top: 20px;
   }
 
-  .certification-namespace .issue-date {
-    margin-top: 10px;
-    margin-right: 0;
-    text-align: center;
-    line-height: 0px;
-    word-wrap: break-word;
-  }
-
-  .certification-namespace .issue-date strong {
-    display: block;
-    margin-top: 15px;
-    line-height: 25px;
+  .certification-namespace header > .right {
+    align-items: center;
+    justify-content: center;
+    height: unset;
+    padding: 0;
   }
 
   .certification-namespace .information {


### PR DESCRIPTION
Checklist:
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

Closes #38194

I have added a Twitter icon that allows a user to tweet their certification. I decided to break down the initial `ShowCertification` client route by extracting the code to display an individual certification into a separate component named `Certificate`.

You'll see in the updated `ShowCertifications` file that I attach the props to the `Certificate` component via:
- `<Certificate {...cert} certName={certName} />`

The reason why I added the certName prop explicitly is because in the `ShowCertifications` file we have the following props:

```
const {
  cert,
  fetchState,
  validCertName,
  createFlashMessage,
  certName
} = this.props;
```

According to the propTypes, `cert` should have a certName property on it, but it was not being utilized. I figured there must be something I am not privy to, so I decided to make sure that I used all props in the same manner they were implemented in the prior version.

P.S. _I changed the wording a tiny bit, because perhaps a Facebook Icon could be added as well?_

Here are two screenshots of the twitter button for desktop and mobile.

![tweet-cert-desktop](https://user-images.githubusercontent.com/19492185/77425025-76020a80-6da8-11ea-85fc-d714ede9e3bd.jpg)

![tweet-cert-mobile](https://user-images.githubusercontent.com/19492185/77425028-769aa100-6da8-11ea-9bd2-c6e83579cb55.jpg)





