### PR TITLE
fix: add SENTRY_ENVIRONMENT variable

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -52,3 +52,4 @@ DOCKER_HOST_LOCATION=localhost
 GHOST_CLIENT_KEY=123abc
 
 SENTRY_DSN=dsn_from_sentry_dashboard
+SENTRY_ENVIRONMENT='staging'


### PR DESCRIPTION
Adds a tag to group Sentry events
