### PR TITLE
fix: prevent 403 reporting

### DIFF
--- a/api-server/server/middlewares/sentry-error-handler.js
+++ b/api-server/server/middlewares/sentry-error-handler.js
@@ -17,10 +17,7 @@ export default function sentryErrorHandler() {
         shouldHandleError(err) {
           // CSRF errors have status 403, consider ignoring them once csurf is
           // no longer rejecting people incorrectly.
-          return (
-            !isHandledError(err) &&
-            (!err.status || err.status === 403 || err.status >= 500)
-          );
+          return !isHandledError(err) && (!err.status || err.status >= 500);
         }
       });
 }


### PR DESCRIPTION
Just to avoid overloading Sentry while I figure out what's actually going on.
