### PR TITLE
fix: fetch CSRF cookie and set headers

### DIFF
--- a/client/src/redux/cookieValues.js
+++ b/client/src/redux/cookieValues.js
@@ -1,5 +1,4 @@
 import cookies from 'browser-cookies';
 
-export const _csrf = typeof window !== 'undefined' && cookies.get('_csrf');
 export const jwt =
   typeof window !== 'undefined' && cookies.get('jwt_access_token');

--- a/client/src/utils/ajax.js
+++ b/client/src/utils/ajax.js
@@ -10,19 +10,11 @@ axios.defaults.withCredentials = true;
 
 // _csrf is passed to the client as a cookie. Tokens are sent back to the server
 // via headers:
-
-let csrfSet = false;
-
-// lazily get _csrf and set headers
 function setCSRFTokens() {
-  if (csrfSet) return;
-
   const _csrf = typeof window !== 'undefined' && cookies.get('_csrf');
-  // TODO add client Sentry logging to check if this is the culprit
   if (!_csrf) return;
   axios.defaults.headers.post['CSRF-Token'] = tokens.create(_csrf);
   axios.defaults.headers.put['CSRF-Token'] = tokens.create(_csrf);
-  csrfSet = true;
 }
 
 function get(path) {

--- a/client/src/utils/ajax.js
+++ b/client/src/utils/ajax.js
@@ -1,7 +1,7 @@
 import { apiLocation } from '../../config/env.json';
-import { _csrf } from '../redux/cookieValues';
 import axios from 'axios';
 import Tokens from 'csrf';
+import cookies from 'browser-cookies';
 
 const base = apiLocation;
 const tokens = new Tokens();
@@ -10,9 +10,19 @@ axios.defaults.withCredentials = true;
 
 // _csrf is passed to the client as a cookie. Tokens are sent back to the server
 // via headers:
-if (_csrf) {
+
+let csrfSet = false;
+
+// lazily get _csrf and set headers
+function setCSRFTokens() {
+  if (csrfSet) return;
+
+  const _csrf = typeof window !== 'undefined' && cookies.get('_csrf');
+  // TODO add client Sentry logging to check if this is the culprit
+  if (!_csrf) return;
   axios.defaults.headers.post['CSRF-Token'] = tokens.create(_csrf);
   axios.defaults.headers.put['CSRF-Token'] = tokens.create(_csrf);
+  csrfSet = true;
 }
 
 function get(path) {
@@ -20,10 +30,12 @@ function get(path) {
 }
 
 export function post(path, body) {
+  setCSRFTokens();
   return axios.post(`${base}${path}`, body);
 }
 
 function put(path, body) {
+  setCSRFTokens();
   return axios.put(`${base}${path}`, body);
 }
 


### PR DESCRIPTION
It seems that the CSRF cookie is not always set by the time `ajax` tries to get it.  This attempts to mitigate that by checking the cookie before each PUT or POST.

This error can be replicated by going to a challenge, deleting  `_csrf` and navigating (escape + n/p) to other challenges.  Without this PR this each new page visited should trigger a CSRF error.  With it, the error should only appear once after which the new cookie gets used.

If the cookie is deleted and the page reloaded, CSRF errors should not appear.