### PR TITLE
fix(curriculum): remove setup code not needed anymore from Testing Objects for Properties challenge

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/testing-objects-for-properties.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/testing-objects-for-properties.english.md
@@ -52,13 +52,6 @@ tests:
 <div id='js-seed'>
 
 ```js
-// Setup
-var myObj = {
-  gift: "pony",
-  pet: "kitten",
-  bed: "sleigh"
-};
-
 function checkObj(obj, checkProp) {
   // Only change code below this line
   return "Change Me!";
@@ -70,20 +63,12 @@ checkObj(myObj, "gift");
 
 </div>
 
-
-
 </section>
 
 ## Solution
 <section id='solution'>
 
-
 ```js
-var myObj = {
-  gift: "pony",
-  pet: "kitten",
-  bed: "sleigh"
-};
 function checkObj(obj, checkProp) {
   if(obj.hasOwnProperty(checkProp)) {
     return obj[checkProp];

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/testing-objects-for-properties.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/testing-objects-for-properties.english.md
@@ -58,7 +58,6 @@ function checkObj(obj, checkProp) {
   // Only change code above this line
 }
 
-checkObj(myObj, "gift");
 ```
 
 </div>


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

Due to the confusion discussed in [this forum thread](https://www.freecodecamp.org/forum/t/testing-object-for-properties-exercise-2020/364001) this PR removes the setup code from the seed code and solution that is no longer relevant due to changes in a [recently merged PR](https://github.com/freeCodeCamp/freeCodeCamp/pull/38414).

