### PR TITLE
fix: add more tests for curriclum testing

### DIFF
--- a/curriculum/challenges/_meta/applied-accessibility/meta.json
+++ b/curriculum/challenges/_meta/applied-accessibility/meta.json
@@ -86,7 +86,7 @@
     ],
     [
       "587d7790367417b2b2512aaf",
-      "Make Links Navigatable with HTML Access Keys"
+      "Make Links Navigable with HTML Access Keys"
     ],
     [
       "587d7790367417b2b2512ab0",

--- a/curriculum/getChallenges.js
+++ b/curriculum/getChallenges.js
@@ -2,6 +2,7 @@ const path = require('path');
 const { findIndex } = require('lodash');
 const readDirP = require('readdirp-walk');
 const { parseMarkdown } = require('@freecodecamp/challenge-md-parser');
+const fs = require('fs');
 
 const { dasherize } = require('../utils/slugs');
 
@@ -14,7 +15,15 @@ function getChallengesDirForLang(lang) {
   return path.resolve(challengesDir, `./${lang}`);
 }
 
+function getMetaForBlock(block) {
+  const meta = JSON.parse(
+    fs.readFileSync(path.resolve(metaDir, `./${block}/meta.json`), 'utf8')
+  );
+  return meta;
+}
+
 exports.getChallengesDirForLang = getChallengesDirForLang;
+exports.getMetaForBlock = getMetaForBlock;
 
 exports.getChallengesForLang = function getChallengesForLang(lang) {
   let curriculum = {};

--- a/curriculum/getChallenges.js
+++ b/curriculum/getChallenges.js
@@ -16,10 +16,9 @@ function getChallengesDirForLang(lang) {
 }
 
 function getMetaForBlock(block) {
-  const meta = JSON.parse(
+  return JSON.parse(
     fs.readFileSync(path.resolve(metaDir, `./${block}/meta.json`), 'utf8')
   );
-  return meta;
 }
 
 exports.getChallengesDirForLang = getChallengesDirForLang;

--- a/curriculum/package-lock.json
+++ b/curriculum/package-lock.json
@@ -5575,8 +5575,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5597,14 +5596,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5619,20 +5616,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5749,8 +5743,7 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5762,7 +5755,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5777,7 +5769,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5785,14 +5776,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5811,7 +5800,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5901,8 +5889,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5914,7 +5901,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6000,8 +5986,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6037,7 +6022,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6057,7 +6041,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6101,14 +6084,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -14672,6 +14653,12 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.0.2.tgz",
       "integrity": "sha1-2sMECGkMIfPDYwo/86BYd73L1zY=",
+      "dev": true
+    },
+    "string-similarity": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/string-similarity/-/string-similarity-4.0.1.tgz",
+      "integrity": "sha512-v36MJzloekKVvKAsYi6O/qpn2mIuvwEFIT9Gx3yg4spkNjXYsk7yxc37g4ZTyMVIBvt/9PZGxnqEtme8XHK+Mw==",
       "dev": true
     },
     "string-width": {

--- a/curriculum/package.json
+++ b/curriculum/package.json
@@ -60,6 +60,7 @@
     "readdirp-walk": "^1.7.0",
     "rx": "^4.1.0",
     "semantic-release": "^15.13.24",
+    "string-similarity": "^4.0.1",
     "validator": "^10.4.0"
   },
   "keywords": [

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -160,7 +160,7 @@ async function setup() {
       challenge => challenge.superBlock === filter
     );
 
-    if (challengesForLang[0].challenges.length === 0) {
+    if (!challengesForLang[0].challenges.length) {
       throw new Error(`No challenges found with superBlock "${filter}"`);
     }
   }
@@ -176,7 +176,7 @@ async function setup() {
       challenge => challenge.block === filter
     );
 
-    if (challengesForLang[0].challenges.length === 0) {
+    if (!challengesForLang[0].challenges.length) {
       throw new Error(`No challenges found with block "${filter}"`);
     }
   }

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -165,7 +165,7 @@ please change the TEST_CHALLENGES_FOR_LANGS env variable to a single language`
   if (process.env.npm_config_block) {
     const filter = stringSimilarity.findBestMatch(
       process.env.npm_config_block,
-      filters.blocks
+      targetBlockStrings
     ).bestMatch.target;
 
     console.log(`\nblock being tested: ${filter}`);

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -127,6 +127,11 @@ async function setup() {
   page = await newPageContext(browser);
   await page.setViewport({ width: 300, height: 150 });
   const testLangs = testedLangs();
+  if (testLangs.length > 1)
+    throw Error(
+      `Testing more than one language at once is not currently supported
+please change the TEST_CHALLENGES_FOR_LANGS env variable to a single language`
+    );
   const challengesForLang = await Promise.all(
     testLangs.map(lang => getChallenges(lang))
   );

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -122,11 +122,11 @@ async function setup() {
   page = await newPageContext(browser);
   await page.setViewport({ width: 300, height: 150 });
   const testLangs = testedLangs();
-  const langAndChallenges = await Promise.all(
+  const challengesForLang = await Promise.all(
     testLangs.map(lang => getChallenges(lang))
   );
   const meta = {};
-  for (const { lang, challenges } of langAndChallenges) {
+  for (const { lang, challenges } of challengesForLang) {
     meta[lang] = {};
     for (const challenge of challenges) {
       const dashedBlockName = dasherize(challenge.block);
@@ -139,7 +139,7 @@ async function setup() {
   }
   return {
     meta,
-    langAndChallenges
+    challengesForLang
   };
 }
 
@@ -153,7 +153,7 @@ function cleanup() {
   spinner.stop();
 }
 
-function runTests({ langAndChallenges, meta }) {
+function runTests({ challengesForLang, meta }) {
   process.on('unhandledRejection', err => {
     throw new Error(`unhandledRejection: ${err.name}, ${err.message}`);
   });
@@ -164,11 +164,11 @@ function runTests({ langAndChallenges, meta }) {
 
   // the next few statements will filter challenges based on command variables
   if (process.env.npm_config_superblock) {
-    langAndChallenges[0].challenges = langAndChallenges[0].challenges.filter(
+    challengesForLang[0].challenges = challengesForLang[0].challenges.filter(
       challenge => challenge.superBlock === process.env.npm_config_superblock
     );
 
-    if (langAndChallenges[0].challenges.length === 0) {
+    if (challengesForLang[0].challenges.length === 0) {
       throw new Error(
         `"${process.env.npm_config_superblock}" superblock not found. Input needs to be in dasherized form. e.g. "front-end-libraries"`
       );
@@ -176,11 +176,11 @@ function runTests({ langAndChallenges, meta }) {
   }
 
   if (process.env.npm_config_block) {
-    langAndChallenges[0].challenges = langAndChallenges[0].challenges.filter(
+    challengesForLang[0].challenges = challengesForLang[0].challenges.filter(
       challenge => challenge.block === process.env.npm_config_block
     );
 
-    if (langAndChallenges[0].challenges.length === 0) {
+    if (challengesForLang[0].challenges.length === 0) {
       throw new Error(
         `"${process.env.npm_config_block}" block not found. Input should be as shown on /learn. e.g. "Basic HTML and HTML5"`
       );
@@ -191,7 +191,7 @@ function runTests({ langAndChallenges, meta }) {
     after(function() {
       cleanup();
     });
-    for (const challenge of langAndChallenges) {
+    for (const challenge of challengesForLang) {
       populateTestsForLang(challenge, meta);
     }
   });

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -138,20 +138,12 @@ please change the TEST_CHALLENGES_FOR_LANGS env variable to a single language`
 
   // the next few statements create a list of all blocks and superblocks
   // as they appear in the list of challenges
-  const filters = {
-    blocks: [],
-    superBlocks: []
-  };
-
-  challengesForLang[0].challenges.forEach(chal => {
-    if (filters.blocks.indexOf(chal.block) < 0) {
-      filters.blocks.push(chal.block);
-    }
-
-    if (filters.superBlocks.indexOf(chal.superBlock) < 0) {
-      filters.superBlocks.push(chal.superBlock);
-    }
-  });
+  const blocks = challengesForLang[0].challenges.map(({ block }) => block);
+  const superBlocks = challengesForLang[0].challenges.map(
+    ({ superBlock }) => superBlock
+  );
+  const targetBlockStrings = [...new Set(blocks)];
+  const targetSuperBlockStrings = [...new Set(superBlocks)];
 
   // the next few statements will filter challenges based on command variables
   if (process.env.npm_config_superblock) {

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -149,7 +149,7 @@ please change the TEST_CHALLENGES_FOR_LANGS env variable to a single language`
   if (process.env.npm_config_superblock) {
     const filter = stringSimilarity.findBestMatch(
       process.env.npm_config_superblock,
-      filters.superBlocks
+      targetSuperBlockStrings
     ).bestMatch.target;
 
     console.log(`\nsuperBlock being tested: ${filter}`);

--- a/docs/how-to-setup-freecodecamp-locally.md
+++ b/docs/how-to-setup-freecodecamp-locally.md
@@ -305,7 +305,6 @@ A quick reference to the commands that you will need when working locally.
 
 **Local Build:**
 
-<<<<<<< HEAD
 | command                                                        | description                                                                         |
 | -------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
 | `npm ci`                                                       | Installs / re-install all dependencies and bootstraps the different services.       |

--- a/docs/how-to-setup-freecodecamp-locally.md
+++ b/docs/how-to-setup-freecodecamp-locally.md
@@ -305,16 +305,18 @@ A quick reference to the commands that you will need when working locally.
 
 **Local Build:**
 
-| command                   | description                                                                         |
-| ------------------------- | ----------------------------------------------------------------------------------- |
-| `npm ci`                  | Installs / re-install all dependencies and bootstraps the different services.       |
-| `npm run seed`            | Parses all the challenge markdown files and inserts them into MongoDB.              |
-| `npm run develop`         | Starts the freeCodeCamp API Server and Client Applications.                         |
-| `npm test`                | Run all JS tests in the system, including client, server, lint and challenge tests. |
-| `npm run test:client`     | Run the client test suite.                                                          |
-| `npm run test:curriculum` | Run the curriculum test suite.                                                      |
-| `npm run test:server`     | Run the server test suite.                                                          |
-| `npm run clean`           | Uninstalls all dependencies and cleans up caches.                                   |
+| command                                                        | description                                                                         |
+| -------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `npm ci`                                                       | Installs / re-install all dependencies and bootstraps the different services.       |
+| `npm run seed`                                                 | Parses all the challenge markdown files and inserts them into MongoDB.              |
+| `npm run develop`                                              | Starts the freeCodeCamp API Server and Client Applications.                         |
+| `npm test`                                                     | Run all JS tests in the system, including client, server, lint and challenge tests. |
+| `npm run test:client`                                          | Run the client test suite.                                                          |
+| `npm run test:curriculum`                                      | Run the curriculum test suite.                                                      |
+| `npm run test:curriculum --block='Basic HTML and HTML5'`       | Test a specific Block.                                                              |
+| `npm run test:curriculum --superblock='responsive-web-design'` | Test a specific SuperBlock.                                                         |
+| `npm run test:server`                                          | Run the server test suite.                                                          |
+| `npm run clean`                                                | Uninstalls all dependencies and cleans up caches.                                   |
 
 ## Making changes locally
 

--- a/docs/how-to-setup-freecodecamp-locally.md
+++ b/docs/how-to-setup-freecodecamp-locally.md
@@ -305,6 +305,7 @@ A quick reference to the commands that you will need when working locally.
 
 **Local Build:**
 
+<<<<<<< HEAD
 | command                                                        | description                                                                         |
 | -------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
 | `npm ci`                                                       | Installs / re-install all dependencies and bootstraps the different services.       |


### PR DESCRIPTION
PR for https://github.com/freeCodeCamp/freeCodeCamp/pull/38456#issuecomment-604825040

Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.


This PR adds two tests to check that a challenge title and id are found in their meta.json files.
In making these tests, I found one challenge where a title didn't match.
It also adds some options to test a specific block or superblock of the curriculum...
`npm run test:curriculum --block='Basic HTML and HTML5'`
`npm run test:curriculum --superblock=responsive-web-design`
These commands will do that.

The lines I actually changed in `test-challenges.js` are 35, 103-131, & 205-238. The rest of the diff wasn't changed other than some indentation. 

The code feels a little sloppy, but it looks like it's working. Any suggestions are welcome.
