### PR TITLE
Double quotes is added for a Word since it was Confusing without the Quotes

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/use-the-s-tag-to-strikethrough-text.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/use-the-s-tag-to-strikethrough-text.english.md
@@ -13,7 +13,7 @@ To strikethrough text, which is when a horizontal line cuts across the character
 
 ## Instructions
 <section id='instructions'>
-Wrap the <code>s</code> tag around "Google" inside the <code>h4</code> tag and then add the word Alphabet beside it, which should not have the strikethrough formatting.
+Wrap the <code>s</code> tag around "Google" inside the <code>h4</code> tag and then add the word "Alphabet" beside it, which should not have the strikethrough formatting.
 </section>
 
 ## Tests


### PR DESCRIPTION
Alphabet word is not wrapped inside double quotes

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any addtional description of changes below this line -->
