### PR TITLE
fix: remove paypal credit button

### DIFF
--- a/client/src/components/Donation/PaypalButton.js
+++ b/client/src/components/Donation/PaypalButton.js
@@ -99,7 +99,7 @@ export class PaypalButton extends Component {
           }
           options={{
             vault: true,
-            disableFunding: 'card',
+            disableFunding: 'credit,card',
             clientId: paypalClientId
           }}
           style={{


### PR DESCRIPTION
Note: I have not been able to see the paypal credit button either locally or on production.
(probably because of regional paypal limitations)
but this fix should take care of removing the button.

This fix will remove the button but users will be able to use their paypal credit  after they sign in if they have it activated in paypal.

please test locally before merging. 