### PR TITLE
fix: make docs links relative

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,7 @@ All our coding challenges are curated by the community, bringing in expert knowl
 
 You can help expand them and make their wording better. You can also update the user stories to explain the concept better or remove redundant ones and improve the challenge tests to make them more accurately test people's code.
 
-**If you're interested in improving these coding challenges, here's [how to work on coding challenges](/how-to-work-on-coding-challenges.md).**
+**If you're interested in improving these coding challenges, here's [how to work on coding challenges](how-to-work-on-coding-challenges.md).**
 
 ### Learning Platform
 
@@ -51,7 +51,7 @@ Contributing to this requires some understanding of APIs, ES6 Syntax, and a lot 
 
 Essentially, we expect basic familiarity with some of the aforementioned technologies, tools, and libraries. With that being said, you are not required to be an expert on them to contribute.
 
-**If you want to help us improve our codebase, you can either [set up freeCodeCamp locally](/how-to-setup-freecodecamp-locally.md)**
+**If you want to help us improve our codebase, you can either [set up freeCodeCamp locally](how-to-setup-freecodecamp-locally.md)**
 
 OR
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

docsify has the base url of /docs/ while Github uses /
This makes the links relative so the links will work in both.

Closes #38532

<!-- Feel free to add any addtional description of changes below this line -->
