### PR TITLE
fix(curriculum): change debugging console lesson

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/debugging/understanding-the-differences-between-the-freecodecamp-and-browser-console.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/debugging/understanding-the-differences-between-the-freecodecamp-and-browser-console.english.md
@@ -9,15 +9,15 @@ forumTopicId: 301193
 <section id='description'>
 You may have noticed that some freeCodeCamp JavaScript challenges include their own console. This console behaves a little differently than the browser console you used in the last challenge.
 The following challenge is meant to highlight the main difference between the freeCodeCamp console and your browser console.
-When you run ordinary JavaScript, the browsers console will display your <code>console.log()</code> statements the exact number of times you requested.
-The freeCodeCamp console will print your <code>console.log()</code> statements for each test of that challenge, as well as one more time for any function calls that you have in your code.
-This lends itself to some interesting behavior and might trip you up in the beginning, because a logged value that you expect to see only once may print out many more times.
-If you would like to see only your single output and not have to worry about running through the test cycles, you can use <code>console.clear()</code> and check the browsers console.
+When you run ordinary JavaScript, the browser's console will display your <code>console.log()</code> statements the exact number of times it is called.
+The freeCodeCamp console will print your <code>console.log()</code> statements a short time after the editor detects a change in the script, as well as during every test.
+The freeCodeCamp console is cleared before every test. So, you may miss a log, if the tests finish too quickly.
+If you would like to see every log for every test, run the tests, and open the browser console. If you would like to use the browser console, and want it to operate the same as the freeCodeCamp console, place <code>console.clear()</code> before any other <code>console</code> calls, to clear the browser console.
 </section>
 
 ## Instructions
 <section id='instructions'>
-First, use <code>console.clear()</code> to clear the browser console. After that, use <code>console.log</code> to log the <code>output</code> variable.
+First, use <code>console.log</code> to log the <code>output</code> variable. Then, use <code>console.clear</code> to clear the browser console.
 </section>
 
 ## Tests
@@ -41,14 +41,12 @@ tests:
 
 ```js
 // Open your browser console.
-let output = "Get this to log once in the browser console and twice in the freeCodeCamp console";
-// Use console.clear() on the next line to clear the browser console.
-
-
+let output = "Get this to log once in the freeCodeCamp console and twice in the browser console";
 // Use console.log() to print the output variable.
 
+// Run the tests to see the difference between the two consoles.
 
-// Check the two consoles to see the difference. The freeCodeCamp console should have printed the variable twice, once for each test of this challenge. The browser console should only print the variable once because you cleared it first.
+// Now, add console.clear() before your console.log() to clear the browser console, and pass the tests.
 ```
 
 </div>
@@ -63,14 +61,14 @@ let output = "Get this to log once in the browser console and twice in the freeC
 
 ```js
 // Open your browser console.
-let output = "Get this to log once in the browser console and twice in the freeCodeCamp console";
-// Use console.clear() on the next line to clear the browser console.
-console.clear();
-
+let output = "Get this to log once in the freeCodeCamp console and twice in the browser console";
 // Use console.log() to print the output variable.
+console.clear();
 console.log(output);
 
-// Check the two consoles to see the difference. The freeCodeCamp console should have printed the variable twice, one for each test of this challenge. The browser console should only print the variable once because you cleared it first.
+// Run the tests to see the difference between the two consoles.
+
+// Now, add console.clear() before your console.log() to clear the browser console, and pass the tests.
 ```
 
 </section>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/debugging/understanding-the-differences-between-the-freecodecamp-and-browser-console.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/debugging/understanding-the-differences-between-the-freecodecamp-and-browser-console.english.md
@@ -10,7 +10,7 @@ forumTopicId: 301193
 You may have noticed that some freeCodeCamp JavaScript challenges include their own console. This console behaves a little differently than the browser console you used in the last challenge.
 The following challenge is meant to highlight the main difference between the freeCodeCamp console and your browser console.
 When you run ordinary JavaScript, the browser's console will display your <code>console.log()</code> statements the exact number of times it is called.
-The freeCodeCamp console will print your <code>console.log()</code> statements a short time after the editor detects a change in the script, as well as during every test.
+The freeCodeCamp console will print your <code>console.log()</code> statements a short time after the editor detects a change in the script, as well as during testing.
 The freeCodeCamp console is cleared before every test. So, you may miss a log, if the tests finish too quickly.
 If you would like to see every log for every test, run the tests, and open the browser console. If you would like to use the browser console, and want it to operate the same as the freeCodeCamp console, place <code>console.clear()</code> before any other <code>console</code> calls, to clear the browser console.
 </section>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/debugging/understanding-the-differences-between-the-freecodecamp-and-browser-console.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/debugging/understanding-the-differences-between-the-freecodecamp-and-browser-console.english.md
@@ -12,7 +12,7 @@ The following challenge is meant to highlight the main difference between the fr
 When you run ordinary JavaScript, the browser's console will display your <code>console.log()</code> statements the exact number of times it is called.
 The freeCodeCamp console will print your <code>console.log()</code> statements a short time after the editor detects a change in the script, as well as during testing.
 The freeCodeCamp console is cleared before every test. So, you may miss a log, if the tests finish too quickly.
-If you would like to see every log for every test, run the tests, and open the browser console. If you would like to use the browser console, and want it to operate the same as the freeCodeCamp console, place <code>console.clear()</code> before any other <code>console</code> calls, to clear the browser console.
+If you would like to see every log for every test, run the tests, and open the browser console. If you prefer to use the browser console, and want it to mimic the freeCodeCamp console, place <code>console.clear()</code> before any other <code>console</code> calls, to clear the browser console.
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/debugging/understanding-the-differences-between-the-freecodecamp-and-browser-console.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/debugging/understanding-the-differences-between-the-freecodecamp-and-browser-console.english.md
@@ -13,7 +13,8 @@ When you run ordinary JavaScript, the browser's console will display your <code>
 The freeCodeCamp console will print your <code>console.log()</code> statements a short time after the editor detects a change in the script, as well as during testing.
 The freeCodeCamp console is cleared before the tests are run and, to avoid spam, only prints the logs during the first test (see the note below for exceptions).
 If you would like to see every log for every test, run the tests, and open the browser console. If you prefer to use the browser console, and want it to mimic the freeCodeCamp console, place <code>console.clear()</code> before any other <code>console</code> calls, to clear the browser console.
-**Note:** <code>console.log</code>s inside functions are printed to the freeCodeCamp console whenever those functions are called, this can help debugging functions that are called during testing.
+
+**Note:** `console.log`s inside functions are printed to the freeCodeCamp console whenever those functions are called, this can help debugging functions that are called during testing.
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/debugging/understanding-the-differences-between-the-freecodecamp-and-browser-console.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/debugging/understanding-the-differences-between-the-freecodecamp-and-browser-console.english.md
@@ -11,8 +11,9 @@ You may have noticed that some freeCodeCamp JavaScript challenges include their 
 The following challenge is meant to highlight the main difference between the freeCodeCamp console and your browser console.
 When you run ordinary JavaScript, the browser's console will display your <code>console.log()</code> statements the exact number of times it is called.
 The freeCodeCamp console will print your <code>console.log()</code> statements a short time after the editor detects a change in the script, as well as during testing.
-The freeCodeCamp console is cleared before every test. So, you may miss a log, if the tests finish too quickly.
+The freeCodeCamp console is cleared before the tests are run and, to avoid spam, only prints the logs during the first test (see the note below for exceptions).
 If you would like to see every log for every test, run the tests, and open the browser console. If you prefer to use the browser console, and want it to mimic the freeCodeCamp console, place <code>console.clear()</code> before any other <code>console</code> calls, to clear the browser console.
+**Note:** <code>console.log</code>s inside functions are printed to the freeCodeCamp console whenever those functions are called, this can help debugging functions that are called during testing.
 </section>
 
 ## Instructions


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

Linked to #38474

This pull-request changes this lesson to match the expected behaviour of the built-in console: https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/debugging/understanding-the-differences-between-the-freecodecamp-and-browser-console