### PR TITLE
fix(docs): render navbar in mobile view when sidebar is open

### DIFF
--- a/docs/components/theme.css
+++ b/docs/components/theme.css
@@ -259,6 +259,12 @@ body .sidebar-toggle span:nth-child(3) {
   }
 }
 
+body.close .app-nav,
+body.close .github-corner {
+  display: block !important;
+  text-align: center;
+}
+
 /****** Markdown General ******/
 .markdown-section {
   padding: 30px 30px 40px;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #38568

<!-- Feel free to add any addtional description of changes below this line -->

CSS was coming from the theme `vue.css`
