### PR TITLE
fix: rename tensorflow lessons

### DIFF
--- a/client/src/pages/learn/data-analysis-with-python/data-analysis-with-python-course/index.md
+++ b/client/src/pages/learn/data-analysis-with-python/data-analysis-with-python-course/index.md
@@ -5,4 +5,7 @@ superBlock: Data Analysis with Python
 ---
 ## Introduction to the Data Analysis with Python Course Challenges
 
-<dfn>Data Analysis with Python Course</dfn> Placeholder Introduction.
+Learn Data Analysis with Python in this comprehensive tutorial. Data Analysis has been around for a long time, but up until a few years ago, it was practiced using closed, expensive and limited tools like Excel or Tableau. Python, SQL and other open libraries have changed Data Analysis forever.
+
+In these lectures, create by Santiago Basulto from RMOTR, you will learn the whole process of Data Analysis: reading data from multiple sources (CSVs, SQL, Excel, etc), processing them using NumPy and Pandas, visualize them using Matplotlib and Seaborn and clean and process it to create reports.
+Additionally, we've included a thorough Jupyter Notebook tutorial, and a quick Python reference to refresh your programming skills.

--- a/client/src/pages/learn/data-analysis-with-python/numpy/index.md
+++ b/client/src/pages/learn/data-analysis-with-python/numpy/index.md
@@ -5,4 +5,4 @@ superBlock: Data Analysis with Python
 ---
 ## Introduction to the Numpy Challenges
 
-<dfn>Numpy</dfn> Placeholder Introduction.
+Learn the basics of the NumPy library with the following lectures created by Keith Galli. They provide background information on how NumPy works and how it compares to Python's Built-in lists. They go through how to write code with NumPy, creating arrays, indexing, math, statistics, reshaping, and more!

--- a/client/src/pages/learn/machine-learning-with-python/how-neural-networks-work/index.md
+++ b/client/src/pages/learn/machine-learning-with-python/how-neural-networks-work/index.md
@@ -5,4 +5,6 @@ superBlock: Data Analysis with Python
 ---
 ## Introduction to the How Neural Networks Work Challenges
 
-<dfn>How Neural Networks Work</dfn> Placeholder Introduction.
+Neural networks are at the core of what we are calling Artificial Intelligence today. They can seem impenetrable, and even mystical, if you are trying to understand them for the first time, but they don't have to.
+
+Even if you are completely new to neural networks, these lectures by Brandon Rohrer will get you comfortable with the concepts and math behind them.

--- a/client/src/pages/learn/machine-learning-with-python/tensorflow/index.md
+++ b/client/src/pages/learn/machine-learning-with-python/tensorflow/index.md
@@ -5,4 +5,6 @@ superBlock: Machine Learning with Python
 ---
 ## Introduction to the TensorFlow Challenges
 
-<dfn>TensorFlow</dfn> Placeholder Introduction.
+Tensorflow is an open source framework developed by the Google Brain team aimed to make the powers of machine learning and neural networking easier to use.
+
+The following lectures were created by Tim Ruscica, otherwise known as “Tech With Tim” from his educational programming YouTube channel. They will help you to understand Tensorflow and some of it's capabilities.

--- a/curriculum/challenges/_meta/tensorflow/meta.json
+++ b/curriculum/challenges/_meta/tensorflow/meta.json
@@ -8,127 +8,127 @@
   "challengeOrder": [
     [
       "5e8f2f13c4cdbe86b5c72d87",
-      "Intro to TensorFlow A"
+      "Introduction: Machine Learning Fundamentals"
     ],
     [
       "5e8f2f13c4cdbe86b5c72d88",
-      "Intro to TensorFlow B"
+      "Introduction to TensorFlow"
     ],
     [
       "5e8f2f13c4cdbe86b5c72d89",
-      "Core Learning Algorithms A"
+      "Core Learning Algorithms"
     ],
     [
       "5e8f2f13c4cdbe86b5c72d8a",
-      "Core Learning Algorithms B"
+      "Core Learning Algorithms: Working with Data"
     ],
     [
       "5e8f2f13c4cdbe86b5c72d8b",
-      "Core Learning Algorithms C"
+      "Core Learning Algorithms: Training and Testing Data"
     ],
     [
       "5e8f2f13c4cdbe86b5c72d8c",
-      "Core Learning Algorithms D"
+      "Core Learning Algorithms: The Training Process"
     ],
     [
       "5e8f2f13c4cdbe86b5c72d8d",
-      "Core Learning Algorithms E"
+      "Core Learning Algorithms: Classification"
     ],
     [
       "5e8f2f13c4cdbe86b5c72d8e",
-      "Core Learning Algorithms F"
+      "Core Learning Algorithms: Building the Model"
     ],
     [
       "5e8f2f13c4cdbe86b5c72d8f",
-      "Core Learning Algorithms G"
+      "Core Learning Algorithms: Clustering"
     ],
     [
       "5e8f2f13c4cdbe86b5c72d90",
-      "Core Learning Algorithms H"
+      "Core Learning Algorithms: Hidden Markov Models"
     ],
     [
       "5e8f2f13c4cdbe86b5c72d91",
-      "Core Learning Algorithms I"
+      "Core Learning Algorithms: Using Probabilities to make Predictions"
     ],
     [
       "5e8f2f13c4cdbe86b5c72d92",
-      "Neural Networks with TensorFlow A"
+      "Neural Networks with TensorFlow"
     ],
     [
       "5e8f2f13c4cdbe86b5c72d93",
-      "Neural Networks with TensorFlow B"
+      "Neural Networks: Activation Functions"
     ],
     [
       "5e8f2f13c4cdbe86b5c72d94",
-      "Neural Networks with TensorFlow C"
+      "Neural Networks: Optimizers"
     ],
     [
       "5e8f2f13c4cdbe86b5c72d95",
-      "Neural Networks with TensorFlow D"
+      "Neural Networks: Creating a Model"
     ],
     [
       "5e8f2f13c4cdbe86b5c72d96",
-      "Convolutional Neural Networks A"
+      "Convolutional Neural Networks"
     ],
     [
       "5e8f2f13c4cdbe86b5c72d97",
-      "Convolutional Neural Networks B"
+      "Convolutional Neural Networks: The Convolutional Layer"
     ],
     [
       "5e8f2f13c4cdbe86b5c72d98",
-      "Convolutional Neural Networks C"
+      "Creating a Convolutional Neural Network"
     ],
     [
       "5e8f2f13c4cdbe86b5c72d99",
-      "Convolutional Neural Networks D"
+      "Convolutional Neural Networks: Evaluating the Model"
     ],
     [
       "5e8f2f13c4cdbe86b5c72d9a",
-      "Convolutional Neural Networks E"
+      "Convolutional Neural Networks: Picking a Pretrained Model"
     ],
     [
       "5e8f2f13c4cdbe86b5c72d9b",
-      "Natural Language Processing With RNNs A"
+      "Natural Language Processing with RNNs"
     ],
     [
       "5e8f2f13c4cdbe86b5c72d9c",
-      "Natural Language Processing With RNNs B"
+      "Natural Language Processing With RNNs: Part 2"
     ],
     [
       "5e8f2f13c4cdbe86b5c72d9d",
-      "Natural Language Processing With RNNs C"
+      "Natural Language Processing With RNNs: Recurring Neural Networks"
     ],
     [
       "5e8f2f13c4cdbe86b5c72d9e",
-      "Natural Language Processing With RNNs D"
+      "Natural Language Processing With RNNs: Sentiment Analysis"
     ],
     [
       "5e8f2f13c4cdbe86b5c72d9f",
-      "Natural Language Processing With RNNs E"
+      "Natural Language Processing With RNNs: Making Predictions"
     ],
     [
       "5e8f2f13c4cdbe86b5c72da0",
-      "Natural Language Processing With RNNs F"
+      "Natural Language Processing With RNNs: Create a Play Generator"
     ],
     [
       "5e8f2f13c4cdbe86b5c72da1",
-      "Natural Language Processing With RNNs G"
+      "Natural Language Processing With RNNs: Building the Model"
     ],
     [
       "5e8f2f13c4cdbe86b5c72da2",
-      "Natural Language Processing With RNNs H"
+      "Natural Language Processing With RNNs: Training the Model"
     ],
     [
       "5e8f2f13c4cdbe86b5c72da3",
-      "Reinforcement Learning With Q-Learning A"
+      "Reinforcement Learning With Q-Learning"
     ],
     [
       "5e8f2f13c4cdbe86b5c72da4",
-      "Reinforcement Learning With Q-Learning B"
+      "Reinforcement Learning With Q-Learning: Part 2"
     ],
     [
       "5e8f2f13c4cdbe86b5c72da5",
-      "Reinforcement Learning With Q-Learning C"
+      "Reinforcement Learning With Q-Learning: Example"
     ],
     [
       "5e8f2f13c4cdbe86b5c72da6",

--- a/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/convolutional-neural-networks-evaluating-the-model.english.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/convolutional-neural-networks-evaluating-the-model.english.md
@@ -1,8 +1,8 @@
 ---
-id: 5e8f2f13c4cdbe86b5c72d9b
-title: Natural Language Processing With RNNs A
+id: 5e8f2f13c4cdbe86b5c72d99
+title: 'Convolutional Neural Networks: Evaluating the Model'
 challengeType: 11
-videoId: ZyCaF5S-lKg
+videoId: eCATNvwraXg
 ---
 
 ## Description

--- a/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/convolutional-neural-networks-picking-a-pretrained-model.english.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/convolutional-neural-networks-picking-a-pretrained-model.english.md
@@ -1,8 +1,8 @@
 ---
-id: 5e8f2f13c4cdbe86b5c72d91
-title: Core Learning Algorithms I
+id: 5e8f2f13c4cdbe86b5c72d9a
+title: 'Convolutional Neural Networks: Picking a Pretrained Model'
 challengeType: 11
-videoId: fYAYvLUawnc
+videoId: h1XUt1AgIOI
 ---
 
 ## Description

--- a/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/convolutional-neural-networks-the-convolutional-layer.english.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/convolutional-neural-networks-the-convolutional-layer.english.md
@@ -1,8 +1,8 @@
 ---
-id: 5e8f2f13c4cdbe86b5c72d96
-title: Convolutional Neural Networks A
+id: 5e8f2f13c4cdbe86b5c72d97
+title: 'Convolutional Neural Networks: The Convolutional Layer'
 challengeType: 11
-videoId: _1kTP7uoU9E
+videoId: LrdmcQpTyLw
 ---
 
 ## Description

--- a/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/convolutional-neural-networks.english.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/convolutional-neural-networks.english.md
@@ -1,8 +1,8 @@
 ---
-id: 5e8f2f13c4cdbe86b5c72d97
-title: Convolutional Neural Networks B
+id: 5e8f2f13c4cdbe86b5c72d96
+title: Convolutional Neural Networks
 challengeType: 11
-videoId: LrdmcQpTyLw
+videoId: _1kTP7uoU9E
 ---
 
 ## Description

--- a/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/core-learning-algorithms-building-the-model.english.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/core-learning-algorithms-building-the-model.english.md
@@ -1,8 +1,8 @@
 ---
-id: 5e8f2f13c4cdbe86b5c72da0
-title: Natural Language Processing With RNNs F
+id: 5e8f2f13c4cdbe86b5c72d8e
+title: 'Core Learning Algorithms: Building the Model'
 challengeType: 11
-videoId: j5xsxjq_Xk8
+videoId: 5wHw8BTd2ZQ
 ---
 
 ## Description

--- a/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/core-learning-algorithms-classification.english.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/core-learning-algorithms-classification.english.md
@@ -1,6 +1,6 @@
 ---
 id: 5e8f2f13c4cdbe86b5c72d8d
-title: Core Learning Algorithms E
+title: 'Core Learning Algorithms: Classification'
 challengeType: 11
 videoId: qFF7ZQNvK9E
 ---

--- a/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/core-learning-algorithms-clustering.english.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/core-learning-algorithms-clustering.english.md
@@ -1,8 +1,8 @@
 ---
-id: 5e8f2f13c4cdbe86b5c72d8b
-title: Core Learning Algorithms C
+id: 5e8f2f13c4cdbe86b5c72d8f
+title: 'Core Learning Algorithms: Clustering'
 challengeType: 11
-videoId: wz9J1slsi7I
+videoId: 8sqIaHc9Cz4
 ---
 
 ## Description

--- a/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/core-learning-algorithms-hidden-markov-models.english.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/core-learning-algorithms-hidden-markov-models.english.md
@@ -1,8 +1,8 @@
 ---
-id: 5e8f2f13c4cdbe86b5c72d94
-title: Neural Networks with TensorFlow C
+id: 5e8f2f13c4cdbe86b5c72d90
+title: 'Core Learning Algorithms: Hidden Markov Models'
 challengeType: 11
-videoId: hdOtRPQe1o4
+videoId: IZg24y4wEPY
 ---
 
 ## Description

--- a/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/core-learning-algorithms-the-training-process.english.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/core-learning-algorithms-the-training-process.english.md
@@ -1,8 +1,8 @@
 ---
-id: 5e8f2f13c4cdbe86b5c72d93
-title: Neural Networks with TensorFlow B
+id: 5e8f2f13c4cdbe86b5c72d8c
+title: 'Core Learning Algorithms: The Training Process'
 challengeType: 11
-videoId: S45tqW6BqRs
+videoId: _cEwvqVoBhI
 ---
 
 ## Description

--- a/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/core-learning-algorithms-training-and-testing-data.english.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/core-learning-algorithms-training-and-testing-data.english.md
@@ -1,8 +1,8 @@
 ---
-id: 5e8f2f13c4cdbe86b5c72d9c
-title: Natural Language Processing With RNNs B
+id: 5e8f2f13c4cdbe86b5c72d8b
+title: 'Core Learning Algorithms: Training and Testing Data'
 challengeType: 11
-videoId: mUU9YXOFbZg
+videoId: wz9J1slsi7I
 ---
 
 ## Description

--- a/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/core-learning-algorithms-using-probabilities-to-make-predictions.english.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/core-learning-algorithms-using-probabilities-to-make-predictions.english.md
@@ -1,8 +1,8 @@
 ---
-id: 5e8f2f13c4cdbe86b5c72d8a
-title: Core Learning Algorithms B
+id: 5e8f2f13c4cdbe86b5c72d91
+title: 'Core Learning Algorithms: Using Probabilities to make Predictions'
 challengeType: 11
-videoId: u85IOSsJsPI
+videoId: fYAYvLUawnc
 ---
 
 ## Description

--- a/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/core-learning-algorithms-working-with-data.english.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/core-learning-algorithms-working-with-data.english.md
@@ -1,8 +1,8 @@
 ---
-id: 5e8f2f13c4cdbe86b5c72da3
-title: Reinforcement Learning With Q-Learning A
+id: 5e8f2f13c4cdbe86b5c72d8a
+title: 'Core Learning Algorithms: Working with Data'
 challengeType: 11
-videoId: Cf7DSU0gVb4
+videoId: u85IOSsJsPI
 ---
 
 ## Description

--- a/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/core-learning-algorithms.english.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/core-learning-algorithms.english.md
@@ -1,8 +1,8 @@
 ---
-id: 5e8f2f13c4cdbe86b5c72da4
-title: Reinforcement Learning With Q-Learning B
+id: 5e8f2f13c4cdbe86b5c72d89
+title: Core Learning Algorithms
 challengeType: 11
-videoId: DX7hJuaUZ7o
+videoId: u5lZURgcWnU
 ---
 
 ## Description

--- a/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/creating-a-convolutional-neural-network.english.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/creating-a-convolutional-neural-network.english.md
@@ -1,8 +1,8 @@
 ---
-id: 5e8f2f13c4cdbe86b5c72d99
-title: Convolutional Neural Networks D
+id: 5e8f2f13c4cdbe86b5c72d98
+title: Creating a Convolutional Neural Network
 challengeType: 11
-videoId: eCATNvwraXg
+videoId: kfv0K8MtkIc
 ---
 
 ## Description

--- a/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/introduction-machine-learning-fundamentals.english.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/introduction-machine-learning-fundamentals.english.md
@@ -1,8 +1,8 @@
 ---
-id: 5e8f2f13c4cdbe86b5c72d98
-title: Convolutional Neural Networks C
+id: 5e8f2f13c4cdbe86b5c72d87
+title: "Introduction: Machine Learning Fundamentals"
 challengeType: 11
-videoId: kfv0K8MtkIc
+videoId: KwL1qTR5MT8
 ---
 
 ## Description

--- a/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/introduction-to-tensorflow.english.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/introduction-to-tensorflow.english.md
@@ -1,8 +1,8 @@
 ---
-id: 5e8f2f13c4cdbe86b5c72d9d
-title: Natural Language Processing With RNNs C
+id: 5e8f2f13c4cdbe86b5c72d88
+title: Introduction to TensorFlow
 challengeType: 11
-videoId: bX5681NPOcA
+videoId: r9hRyGGjOgQ
 ---
 
 ## Description

--- a/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/natural-language-processing-with-rnns-building-the-model.english.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/natural-language-processing-with-rnns-building-the-model.english.md
@@ -1,8 +1,8 @@
 ---
-id: 5e8f2f13c4cdbe86b5c72da5
-title: Reinforcement Learning With Q-Learning C
+id: 5e8f2f13c4cdbe86b5c72da1
+title: 'Natural Language Processing With RNNs: Building the Model'
 challengeType: 11
-videoId: RBBSNta234s
+videoId: 32WBFS7lfsw
 ---
 
 ## Description

--- a/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/natural-language-processing-with-rnns-create-a-play-generator.english.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/natural-language-processing-with-rnns-create-a-play-generator.english.md
@@ -1,8 +1,8 @@
 ---
-id: 5e8f2f13c4cdbe86b5c72d90
-title: Core Learning Algorithms H
+id: 5e8f2f13c4cdbe86b5c72da0
+title: 'Natural Language Processing With RNNs: Create a Play Generator'
 challengeType: 11
-videoId: IZg24y4wEPY
+videoId: j5xsxjq_Xk8
 ---
 
 ## Description

--- a/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/natural-language-processing-with-rnns-making-predictions.english.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/natural-language-processing-with-rnns-making-predictions.english.md
@@ -1,8 +1,8 @@
 ---
-id: 5e8f2f13c4cdbe86b5c72d87
-title: Intro to TensorFlow A
+id: 5e8f2f13c4cdbe86b5c72d9f
+title: 'Natural Language Processing With RNNs: Making Predictions'
 challengeType: 11
-videoId: KwL1qTR5MT8
+videoId: WO1hINnBj20
 ---
 
 ## Description

--- a/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/natural-language-processing-with-rnns-part-2.english.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/natural-language-processing-with-rnns-part-2.english.md
@@ -1,8 +1,8 @@
 ---
-id: 5e8f2f13c4cdbe86b5c72d9f
-title: Natural Language Processing With RNNs E
+id: 5e8f2f13c4cdbe86b5c72d9c
+title: 'Natural Language Processing With RNNs: Part 2'
 challengeType: 11
-videoId: WO1hINnBj20
+videoId: mUU9YXOFbZg
 ---
 
 ## Description

--- a/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/natural-language-processing-with-rnns-recurring-neural-networks.english.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/natural-language-processing-with-rnns-recurring-neural-networks.english.md
@@ -1,8 +1,8 @@
 ---
-id: 5e8f2f13c4cdbe86b5c72d8f
-title: Core Learning Algorithms G
+id: 5e8f2f13c4cdbe86b5c72d9d
+title: 'Natural Language Processing With RNNs: Recurring Neural Networks'
 challengeType: 11
-videoId: 8sqIaHc9Cz4
+videoId: bX5681NPOcA
 ---
 
 ## Description

--- a/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/natural-language-processing-with-rnns-sentimental-analysis.english.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/natural-language-processing-with-rnns-sentimental-analysis.english.md
@@ -1,8 +1,8 @@
 ---
-id: 5e8f2f13c4cdbe86b5c72d95
-title: Neural Networks with TensorFlow D
+id: 5e8f2f13c4cdbe86b5c72d9e
+title: 'Natural Language Processing With RNNs: Sentiment Analysis'
 challengeType: 11
-videoId: K8bz1bmOCTw
+videoId: lYeLtu8Nq7c
 ---
 
 ## Description

--- a/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/natural-language-processing-with-rnns-training-the-model.english.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/natural-language-processing-with-rnns-training-the-model.english.md
@@ -1,8 +1,8 @@
 ---
-id: 5e8f2f13c4cdbe86b5c72d9a
-title: Convolutional Neural Networks E
+id: 5e8f2f13c4cdbe86b5c72da2
+title: 'Natural Language Processing With RNNs: Training the Model'
 challengeType: 11
-videoId: h1XUt1AgIOI
+videoId: hEUiK7j9UI8
 ---
 
 ## Description

--- a/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/natural-language-processing-with-rnns.english.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/natural-language-processing-with-rnns.english.md
@@ -1,8 +1,8 @@
 ---
-id: 5e8f2f13c4cdbe86b5c72d89
-title: Core Learning Algorithms A
+id: 5e8f2f13c4cdbe86b5c72d9b
+title: Natural Language Processing With RNNs
 challengeType: 11
-videoId: u5lZURgcWnU
+videoId: ZyCaF5S-lKg
 ---
 
 ## Description

--- a/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/neural-networks-activation-functions.english.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/neural-networks-activation-functions.english.md
@@ -1,8 +1,8 @@
 ---
-id: 5e8f2f13c4cdbe86b5c72da2
-title: Natural Language Processing With RNNs H
+id: 5e8f2f13c4cdbe86b5c72d93
+title: 'Neural Networks: Activation Functions'
 challengeType: 11
-videoId: hEUiK7j9UI8
+videoId: S45tqW6BqRs
 ---
 
 ## Description

--- a/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/neural-networks-creating-a-model.english.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/neural-networks-creating-a-model.english.md
@@ -1,8 +1,8 @@
 ---
-id: 5e8f2f13c4cdbe86b5c72d92
-title: Neural Networks with TensorFlow A
+id: 5e8f2f13c4cdbe86b5c72d95
+title: 'Neural Networks: Creating a Model'
 challengeType: 11
-videoId: uisdfrNrZW4
+videoId: K8bz1bmOCTw
 ---
 
 ## Description

--- a/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/neural-networks-optimizers.english.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/neural-networks-optimizers.english.md
@@ -1,8 +1,8 @@
 ---
-id: 5e8f2f13c4cdbe86b5c72d8e
-title: Core Learning Algorithms F
+id: 5e8f2f13c4cdbe86b5c72d94
+title: 'Neural Networks: Optimizers'
 challengeType: 11
-videoId: 5wHw8BTd2ZQ
+videoId: hdOtRPQe1o4
 ---
 
 ## Description

--- a/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/neural-networks-with-tensorflow.english.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/neural-networks-with-tensorflow.english.md
@@ -1,8 +1,8 @@
 ---
-id: 5e8f2f13c4cdbe86b5c72da1
-title: Natural Language Processing With RNNs G
+id: 5e8f2f13c4cdbe86b5c72d92
+title: Neural Networks with TensorFlow
 challengeType: 11
-videoId: 32WBFS7lfsw
+videoId: uisdfrNrZW4
 ---
 
 ## Description

--- a/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/reinforcement-learning-with-q-learning-example.english.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/reinforcement-learning-with-q-learning-example.english.md
@@ -1,8 +1,8 @@
 ---
-id: 5e8f2f13c4cdbe86b5c72d8c
-title: Core Learning Algorithms D
+id: 5e8f2f13c4cdbe86b5c72da5
+title: 'Reinforcement Learning With Q-Learning: Example'
 challengeType: 11
-videoId: _cEwvqVoBhI
+videoId: RBBSNta234s
 ---
 
 ## Description

--- a/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/reinforcement-learning-with-q-learning-part-2.english.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/reinforcement-learning-with-q-learning-part-2.english.md
@@ -1,8 +1,8 @@
 ---
-id: 5e8f2f13c4cdbe86b5c72d88
-title: Intro to TensorFlow B
+id: 5e8f2f13c4cdbe86b5c72da4
+title: 'Reinforcement Learning With Q-Learning: Part 2'
 challengeType: 11
-videoId: r9hRyGGjOgQ
+videoId: DX7hJuaUZ7o
 ---
 
 ## Description

--- a/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/reinforcement-learning-with-q-learning.english.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/reinforcement-learning-with-q-learning.english.md
@@ -1,8 +1,8 @@
 ---
-id: 5e8f2f13c4cdbe86b5c72d9e
-title: Natural Language Processing With RNNs D
+id: 5e8f2f13c4cdbe86b5c72da3
+title: Reinforcement Learning With Q-Learning
 challengeType: 11
-videoId: lYeLtu8Nq7c
+videoId: Cf7DSU0gVb4
 ---
 
 ## Description


### PR DESCRIPTION
This PR renames the Tensorflow section and adds some content on the blank python intro pages. Note that I used the names of the video creators in the intro's. I don't think that's a problem - let me know if it is or if we should provide a link to their youtube channel or something.

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.
