### PR TITLE
fix: infosec show cert button not rendering

### DIFF
--- a/client/src/components/settings/Certification.js
+++ b/client/src/components/settings/Certification.js
@@ -129,7 +129,7 @@ const isCertMapSelector = createSelector(
     'Legacy Front End': isFrontEndCert,
     'Legacy Data Visualization': isDataVisCert,
     'Legacy Back End': isBackEndCert,
-    'Legacy Information Security And Quality Assurance': isInfosecQaCert
+    'Legacy Information Security and Quality Assurance': isInfosecQaCert
   })
 );
 


### PR DESCRIPTION
Issue:
> The only thing I couldn't work out with the split certs was getting the "Claim certification" button to change to "Show certification" after claiming the legacy infosecQA cert.

Took some digging, but found a typo.

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.