### PR TITLE
feat: add loader on video challenges

### DIFF
--- a/client/src/templates/Challenges/video/Show.js
+++ b/client/src/templates/Challenges/video/Show.js
@@ -18,6 +18,7 @@ import ChallengeDescription from '../components/Challenge-Description';
 import Spacer from '../../../components/helpers/Spacer';
 import CompletionModal from '../components/CompletionModal';
 import Hotkeys from '../components/Hotkeys';
+import Loader from '../../../components/helpers/Loader';
 import {
   isChallengeCompletedSelector,
   challengeMounted,
@@ -72,7 +73,8 @@ export class Project extends Component {
       downloadURL: null,
       selectedOption: 0,
       answer: 1,
-      showWrong: false
+      showWrong: false,
+      videoIsLoaded: false
     };
 
     this.handleSubmit = this.handleSubmit.bind(this);
@@ -135,6 +137,12 @@ export class Project extends Component {
     });
   };
 
+  videoIsReady = () => {
+    this.setState({
+      videoIsLoaded: true
+    });
+  };
+
   render() {
     const {
       data: {
@@ -170,9 +178,19 @@ export class Project extends Component {
                 <ChallengeTitle isCompleted={isChallengeCompleted}>
                   {blockNameTitle}
                 </ChallengeTitle>
-                <div style={{ textAlign: 'center' }}>
+                <div className='video-wrapper'>
+                  {!this.state.videoIsLoaded ? (
+                    <div className='video-placeholder-loader'>
+                      <Loader />
+                    </div>
+                  ) : null}
                   <YouTube
-                    onEnd={openCompletionModal}
+                    className={
+                      this.state.videoIsLoaded
+                        ? 'display-youtube-video'
+                        : 'hide-youtube-video'
+                    }
+                    onReady={this.videoIsReady}
                     opts={{ rel: 0 }}
                     videoId={videoId}
                   />

--- a/client/src/templates/Challenges/video/show.css
+++ b/client/src/templates/Challenges/video/show.css
@@ -1,3 +1,24 @@
+.video-wrapper {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+  align-items: center;
+}
+
+.video-placeholder-loader {
+  min-height: 360px;
+  display: flex;
+  align-items: center;
+}
+
+.display-youtube-video {
+  display: block;
+}
+
+.hide-youtube-video {
+  display: none;
+}
+
 .video-quiz-options {
   padding: 1px 16px;
   background-color: var(--tertiary-background);


### PR DESCRIPTION
gif:
![Apr-24-2020 13-32-41](https://user-images.githubusercontent.com/20648924/80245359-2e350400-8630-11ea-885f-848faa6a088a.gif)

hmm, it's good - but it doesn't always show up if you have a fast connection. Seems like there's enough time that it should show up. Kinda seems like a problem with the loader itself and not this implementation of it.

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #38631

<!-- Feel free to add any addtional description of changes below this line -->
