### PR TITLE
Fixed Redux dev tool plugin in production problem

### DIFF
--- a/client/src/redux/createStore.js
+++ b/client/src/redux/createStore.js
@@ -24,9 +24,11 @@ const epicMiddleware = createEpicMiddleware({
   }
 });
 
-const composeEnhancers = composeWithDevTools({
-  // options like actionSanitizer, stateSanitizer
-});
+if (process.env.FREECODECAMP_NODE_ENV === 'development') {
+  const composeEnhancers = composeWithDevTools({
+    // options like actionSanitizer, stateSanitizer
+  });
+}
 
 export const createStore = () => {
   const store = reduxCreateStore(


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #38638

<!-- Feel free to add any addtional description of changes below this line -->

In the freecodecamp.org website, Redux dev tools extension can be used to access the current and previous state. This problem was fixed in this PR.