### PR TITLE
fix: prevent dev tools from accessing state in prod

### DIFF
--- a/client/gatsby-node.js
+++ b/client/gatsby-node.js
@@ -169,9 +169,6 @@ exports.onCreateWebpackConfig = ({ stage, plugins, actions }) => {
         process.env.HOME_PATH || 'http://localhost:3000'
       ),
       STRIPE_PUBLIC_KEY: JSON.stringify(process.env.STRIPE_PUBLIC_KEY || ''),
-      ENVIRONMENT: JSON.stringify(
-        process.env.FREECODECAMP_NODE_ENV || 'development'
-      ),
       PAYPAL_SUPPORTERS: JSON.stringify(process.env.PAYPAL_SUPPORTERS || 404)
     })
   ];

--- a/client/src/redux/createStore.js
+++ b/client/src/redux/createStore.js
@@ -30,7 +30,7 @@ const composeEnhancers = composeWithDevTools({
 
 export const createStore = () => {
   let store;
-  if (process.env.FREECODECAMP_NODE_ENV === 'production') {
+  if (ENVIRONMENT === 'production') {
     store = reduxCreateStore(
       rootReducer,
       applyMiddleware(sagaMiddleware, epicMiddleware)

--- a/client/src/redux/createStore.js
+++ b/client/src/redux/createStore.js
@@ -31,7 +31,7 @@ const composeEnhancers = composeWithDevTools({
 
 export const createStore = () => {
   let store;
-  if (process.env.ENVIRONMENT === 'production') {
+  if (ENVIRONMENT === 'production') {
     store = reduxCreateStore(
       rootReducer,
       applyMiddleware(sagaMiddleware, epicMiddleware)

--- a/client/src/redux/createStore.js
+++ b/client/src/redux/createStore.js
@@ -1,4 +1,4 @@
-/* global process.env.ENVIRONMENT */
+/* global ENVIRONMENT */
 /* eslint-disable-next-line  max-len */
 import { composeWithDevTools } from 'redux-devtools-extension/logOnlyInProduction';
 import { createStore as reduxCreateStore, applyMiddleware } from 'redux';

--- a/client/src/redux/createStore.js
+++ b/client/src/redux/createStore.js
@@ -38,7 +38,7 @@ export const createStore = () => {
   } else {
     store = reduxCreateStore(
       rootReducer,
-      applyMiddleware(sagaMiddleware, epicMiddleware)
+      composeEnhancers(applyMiddleware(sagaMiddleware, epicMiddleware))
     );
   }
   sagaMiddleware.run(rootSaga);

--- a/client/src/redux/createStore.js
+++ b/client/src/redux/createStore.js
@@ -30,7 +30,7 @@ const composeEnhancers = composeWithDevTools({
 
 export const createStore = () => {
   let store;
-  if (process.env.FREECODECAMP_NODE_ENV === 'development') {
+  if (process.env.FREECODECAMP_NODE_ENV === 'production') {
     store = reduxCreateStore(
       rootReducer,
       composeEnhancers(applyMiddleware(sagaMiddleware, epicMiddleware))

--- a/client/src/redux/createStore.js
+++ b/client/src/redux/createStore.js
@@ -1,4 +1,4 @@
-/* global ENVIRONMENT */
+/* global process.env.ENVIRONMENT */
 /* eslint-disable-next-line  max-len */
 import { composeWithDevTools } from 'redux-devtools-extension/logOnlyInProduction';
 import { createStore as reduxCreateStore, applyMiddleware } from 'redux';
@@ -31,7 +31,7 @@ const composeEnhancers = composeWithDevTools({
 
 export const createStore = () => {
   let store;
-  if (ENVIRONMENT === 'production') {
+  if (process.env.ENVIRONMENT === 'production') {
     store = reduxCreateStore(
       rootReducer,
       applyMiddleware(sagaMiddleware, epicMiddleware)

--- a/client/src/redux/createStore.js
+++ b/client/src/redux/createStore.js
@@ -1,3 +1,4 @@
+/* global ENVIRONMENT */
 /* eslint-disable-next-line  max-len */
 import { composeWithDevTools } from 'redux-devtools-extension/logOnlyInProduction';
 import { createStore as reduxCreateStore, applyMiddleware } from 'redux';
@@ -30,7 +31,7 @@ const composeEnhancers = composeWithDevTools({
 
 export const createStore = () => {
   let store;
-  if (ENVIRONMENT === 'production') {
+  if (process.env.ENVIRONMENT === 'production') {
     store = reduxCreateStore(
       rootReducer,
       applyMiddleware(sagaMiddleware, epicMiddleware)

--- a/client/src/redux/createStore.js
+++ b/client/src/redux/createStore.js
@@ -1,4 +1,3 @@
-/* global ENVIRONMENT */
 /* eslint-disable-next-line  max-len */
 import { composeWithDevTools } from 'redux-devtools-extension/logOnlyInProduction';
 import { createStore as reduxCreateStore, applyMiddleware } from 'redux';
@@ -9,6 +8,8 @@ import rootEpic from './rootEpic';
 import rootReducer from './rootReducer';
 import rootSaga from './rootSaga';
 import { isBrowser } from '../../utils';
+
+import { environment } from '../../../config/env.json';
 
 const clientSide = isBrowser();
 
@@ -31,7 +32,7 @@ const composeEnhancers = composeWithDevTools({
 
 export const createStore = () => {
   let store;
-  if (ENVIRONMENT === 'production') {
+  if (environment === 'production') {
     store = reduxCreateStore(
       rootReducer,
       applyMiddleware(sagaMiddleware, epicMiddleware)

--- a/client/src/redux/createStore.js
+++ b/client/src/redux/createStore.js
@@ -29,10 +29,18 @@ const composeEnhancers = composeWithDevTools({
 });
 
 export const createStore = () => {
-  const store = reduxCreateStore(
-    rootReducer,
-    composeEnhancers(applyMiddleware(sagaMiddleware, epicMiddleware))
-  );
+  let store;
+  if (process.env.FREECODECAMP_NODE_ENV === 'development') {
+    store = reduxCreateStore(
+      rootReducer,
+      composeEnhancers(applyMiddleware(sagaMiddleware, epicMiddleware))
+    );
+  } else {
+    store = reduxCreateStore(
+      rootReducer,
+      applyMiddleware(sagaMiddleware, epicMiddleware)
+    );
+  }
   sagaMiddleware.run(rootSaga);
   epicMiddleware.run(rootEpic);
   if (module.hot) {

--- a/client/src/redux/createStore.js
+++ b/client/src/redux/createStore.js
@@ -33,7 +33,7 @@ export const createStore = () => {
   if (process.env.FREECODECAMP_NODE_ENV === 'production') {
     store = reduxCreateStore(
       rootReducer,
-      composeEnhancers(applyMiddleware(sagaMiddleware, epicMiddleware))
+      applyMiddleware(sagaMiddleware, epicMiddleware)
     );
   } else {
     store = reduxCreateStore(

--- a/config/env.js
+++ b/config/env.js
@@ -37,6 +37,7 @@ const locations = {
 module.exports = Object.assign(locations, {
   locale,
   deploymentEnv,
+  environment: process.env.FREECODECAMP_NODE_ENV || 'development',
   stripePublicKey:
     !stripePublicKey || stripePublicKey === 'pk_from_stripe_dashboard'
       ? null


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #38638

<!-- Feel free to add any addtional description of changes below this line -->

In the freecodecamp.org website, Redux dev tools extension can be used to access the current and previous state. This problem was fixed in this PR.