### PR TITLE
fix: search bar width

### DIFF
--- a/client/src/components/search/searchBar/searchbar.css
+++ b/client/src/components/search/searchBar/searchbar.css
@@ -143,6 +143,7 @@ and arrow keys */
   }
   .fcc_searchBar {
     position: relative;
+    max-width: 520px;
   }
   .fcc_searchBar .ais-Hits {
     top: auto;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any addtional description of changes below this line -->
Currently the search bar is too wide, and clicks outside of the input can trigger the dropdown:

![current-learn](https://user-images.githubusercontent.com/2051070/80701579-909f7000-8b1a-11ea-9d7e-34149bb476ef.gif)

This fix limits the maximum width of the search bar to help prevent this:

![after-update](https://user-images.githubusercontent.com/2051070/80701716-ccd2d080-8b1a-11ea-8c2f-ad09ece34fa7.gif)

It's still possible to trigger the dropdown by clicking on the 10px of padding on either side of the input, but it won't be as easy as before.