### PR TITLE
Wrapped all the test results with quotation

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/convert-html-entities.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/convert-html-entities.english.md
@@ -21,19 +21,19 @@ Convert the characters <code>&</code>, <code><</code>, <code>></code>, <code>"</
 
 ```yml
 tests:
-  - text: <code>convertHTML("Dolce & Gabbana")</code> should return <code>Dolce &amp;amp; Gabbana</code>.
+  - text: <code>convertHTML("Dolce & Gabbana")</code> should return <code>"Dolce &amp;amp; Gabbana"</code>.
     testString: assert.match(convertHTML("Dolce & Gabbana"), /Dolce &amp; Gabbana/);
-  - text: <code>convertHTML("Hamburgers < Pizza < Tacos")</code> should return <code>Hamburgers &amp;lt; Pizza &amp;lt; Tacos</code>.
+  - text: <code>convertHTML("Hamburgers < Pizza < Tacos")</code> should return <code>"Hamburgers &amp;lt; Pizza &amp;lt; Tacos"</code>.
     testString: assert.match(convertHTML("Hamburgers < Pizza < Tacos"), /Hamburgers &lt; Pizza &lt; Tacos/);
-  - text: <code>convertHTML("Sixty > twelve")</code> should return <code>Sixty &amp;gt; twelve</code>.
+  - text: <code>convertHTML("Sixty > twelve")</code> should return <code>"Sixty &amp;gt; twelve"</code>.
     testString: assert.match(convertHTML("Sixty > twelve"), /Sixty &gt; twelve/);
-  - text: <code>convertHTML(&apos;Stuff in "quotation marks"&apos;)</code> should return <code>Stuff in &amp;quot;quotation marks&amp;quot;</code>.
+  - text: <code>convertHTML(&apos;Stuff in "quotation marks"&apos;)</code> should return <code>"Stuff in &amp;quot;quotation marks&amp;quot;"</code>.
     testString: assert.match(convertHTML('Stuff in "quotation marks"'), /Stuff in &quot;quotation marks&quot;/);
-  - text: <code>convertHTML("Schindler&apos;s List")</code> should return <code>Schindler&amp;apos;s List</code>.
+  - text: <code>convertHTML("Schindler&apos;s List")</code> should return <code>"Schindler&amp;apos;s List"</code>.
     testString: assert.match(convertHTML("Schindler's List"), /Schindler&apos;s List/);
-  - text: <code>convertHTML("<>")</code> should return <code>&amp;lt;&amp;gt;</code>.
+  - text: <code>convertHTML("<>")</code> should return <code>"&amp;lt;&amp;gt;"</code>.
     testString: assert.match(convertHTML('<>'), /&lt;&gt;/);
-  - text: <code>convertHTML("abc")</code> should return <code>abc</code>.
+  - text: <code>convertHTML("abc")</code> should return <code>"abc"</code>.
     testString: assert.strictEqual(convertHTML('abc'), 'abc');
 
 ```


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #38705

<!-- Feel free to add any addtional description of changes below this line -->

In the `Intermediate Algorithm Scripting: Convert HTML Entities` challenge, all the test have results which aren't wrapped with quotation even though they are string. I've checked all the other FCC challenges and confirmed that the other challenges results (if the result is a string), is wrapped with quotation mark (For example: `Intermediate Algorithm Scripting: Spinal Tap Case`). This is an formatting inconsistency that'll somewhat confuse the beginners as all the other challenges follow this formatting technique.

This formatting inconsistency is fixed in this PR!