### PR TITLE
fix(learn): update regex specify exact number of matches - allows global flag on regex

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/specify-exact-number-of-matches.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/specify-exact-number-of-matches.english.md
@@ -36,15 +36,15 @@ tests:
   - text: Your regex should use curly brackets.
     testString: assert(timRegex.source.match(/{.*?}/).length > 0);
   - text: Your regex should not match <code>"Timber"</code>
-    testString: assert(!timRegex.test("Timber"));
+    testString: timRegex.lastIndex = 0; assert(!timRegex.test("Timber"));
   - text: Your regex should not match <code>"Timmber"</code>
-    testString: assert(!timRegex.test("Timmber"));
+    testString: timRegex.lastIndex = 0; assert(!timRegex.test("Timmber"));
   - text: Your regex should not match <code>"Timmmber"</code>
-    testString: assert(!timRegex.test("Timmmber"));
+    testString: timRegex.lastIndex = 0; assert(!timRegex.test("Timmmber"));
   - text: Your regex should match <code>"Timmmmber"</code>
-    testString: assert(timRegex.test("Timmmmber"));
+    testString: timRegex.lastIndex = 0; assert(timRegex.test("Timmmmber"));
   - text: Your regex should not match <code>"Timber"</code> with 30 <code>m</code>'s in it.
-    testString: assert(!timRegex.test("Ti" + "m".repeat(30) + "ber"));
+    testString: timRegex.lastIndex = 0; assert(!timRegex.test("Ti" + "m".repeat(30) + "ber"));
 
 ```
 


### PR DESCRIPTION


Checklist:



- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.



Closes #38640

Just resets the timRegex last index to 0, before all tests after the first one, to ensure that the global flag doesn't make the tests fail.


