### PR TITLE
Fix: update code highlighting

### DIFF
--- a/client/.babelrc
+++ b/client/.babelrc
@@ -37,16 +37,35 @@
         "regenerator": true
       }
     ],
-    ["babel-plugin-transform-imports", {
+    [
+      "babel-plugin-transform-imports",
+      {
         "react-bootstrap": {
-            "transform": "react-bootstrap/lib/${member}",
-            "preventFullImport": true
+          "transform": "react-bootstrap/lib/${member}",
+          "preventFullImport": true
         },
         "lodash": {
-            "transform": "lodash/${member}",
-            "preventFullImport": true
+          "transform": "lodash/${member}",
+          "preventFullImport": true
         }
-    }
+      }
+    ],
+    [
+      "prismjs",
+      {
+        "languages": [
+          "clike",
+          "css",
+          "html",
+          "javascript",
+          "markup",
+          "mathml",
+          "python",
+          "scss",
+          "svg",
+          "xml"
+        ], "theme": "default", "css": true
+      }
     ]
   ]
 }

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3183,6 +3183,11 @@
         "resolve": "^1.12.0"
       }
     },
+    "babel-plugin-prismjs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-prismjs/-/babel-plugin-prismjs-2.0.1.tgz",
+      "integrity": "sha512-GqQGa3xX3Z2ft97oDbGvEFoxD8nKqb3ZVszrOc5H7icnEUA56BIjVYm86hfZZA82uuHLwTIfCXbEKzKG1BzKzg=="
+    },
     "babel-plugin-remove-graphql-queries": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.8.1.tgz",
@@ -4264,7 +4269,8 @@
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "optional": true
         },
         "slice-ansi": {
           "version": "3.0.0",
@@ -7804,7 +7810,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7822,11 +7829,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7839,15 +7848,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7950,7 +7962,8 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7960,6 +7973,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7972,17 +7986,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "1.2.5",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7999,6 +8016,7 @@
         "mkdirp": {
           "version": "0.5.3",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -8054,7 +8072,8 @@
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "npm-packlist": {
           "version": "1.4.8",
@@ -8079,7 +8098,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8089,6 +8109,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8157,7 +8178,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8187,6 +8209,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8204,6 +8227,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8242,11 +8266,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -10282,12 +10308,14 @@
         "ansi-regex": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "optional": true
         },
         "ansi-styles": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
           "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "optional": true,
           "requires": {
             "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
@@ -10328,6 +10356,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "optional": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -10335,7 +10364,8 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "optional": true
         },
         "emoji-regex": {
           "version": "8.0.0",
@@ -10352,7 +10382,8 @@
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "optional": true
         },
         "mimic-fn": {
           "version": "2.1.0",
@@ -10415,6 +10446,7 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "optional": true,
           "requires": {
             "ansi-regex": "^5.0.0"
           }

--- a/client/package.json
+++ b/client/package.json
@@ -20,6 +20,7 @@
     "@reach/router": "^1.2.1",
     "algoliasearch": "^3.35.1",
     "axios": "^0.19.0",
+    "babel-plugin-prismjs": "^2.0.1",
     "bezier-easing": "^2.1.0",
     "browser-cookies": "^1.2.0",
     "chai": "^4.2.0",

--- a/client/src/components/layouts/Learn.js
+++ b/client/src/components/layouts/Learn.js
@@ -13,7 +13,6 @@ import {
 import createRedirect from '../../components/createRedirect';
 import DonateModal from '../Donation/DonationModal';
 
-import 'prismjs/themes/prism.css';
 import './prism.css';
 import './prism-night.css';
 import 'react-reflex/styles.css';

--- a/client/src/components/layouts/prism.css
+++ b/client/src/components/layouts/prism.css
@@ -1,54 +1,65 @@
+code {
+  --red: red;
+  --blue: blue;
+  --black: black;
+  --dark-red: #800;
+  --dark-green: #080;
+  --light-green: #098658;
+  --darkest-blue: #00107e;
+  --dark-blue: #018;
+}
+
 code .token.operator {
   background: none;
-  color: black;
+  color: var(--black);
 }
 
 code .token.variable {
-  color: #018;
+  color: var(--dark-blue);
 }
 
 code .token.property {
-  color: red;
+  color: var(--red);
 }
 
 code .token.selector {
-  color: #800;
+  color: var(--dark-red);
 }
 
 code .token.comment {
-  color: #080;
+  color: var(--dark-green);
 }
 
 code .token.tag {
-  color: #800;
+  color: var(--dark-red);
 }
 
 code .token.attr-name {
-  color: red;
+  color: var(--red);
 }
 
 code .token.attr-value {
-  color: blue;
+  color: var(--blue);
 }
 
 code .token.keyword {
-  color: #00f;
+  color: var(--blue);
 }
 
 code .token.number {
-  color: #098658;
+  color: var(--light-green);
 }
 
 code .token.string {
-  color: #800;
+  color: var(--dark-red);
 }
 
 code .token.function {
-  color: #00107e;
+  color: var(--darkest-blue);
 }
 
 code .token.boolean {
-  color: blue;
+  color: var(--blue);
 }
 
 :not(pre) > code[class*='language-'],

--- a/client/src/components/layouts/prism.css
+++ b/client/src/components/layouts/prism.css
@@ -1,5 +1,54 @@
 code .token.operator {
   background: none;
+  color: black;
+}
+
+code .token.variable {
+  color: #018;
+}
+
+code .token.property {
+  color: red;
+}
+
+code .token.selector {
+  color: #800;
+}
+
+code .token.comment {
+  color: #080;
+}
+
+code .token.tag {
+  color: #800;
+}
+
+code .token.attr-name {
+  color: red;
+}
+
+code .token.attr-value {
+  color: blue;
+}
+
+code .token.keyword {
+  color: #00f;
+}
+
+code .token.number {
+  color: #098658;
+}
+
+code .token.string {
+  color: #800;
+}
+
+code .token.function {
+  color: #00107e;
+}
+
+code .token.boolean {
+  color: blue;
 }
 
 :not(pre) > code[class*='language-'],


### PR DESCRIPTION
Previously [sass code](https://www.freecodecamp.org/learn/front-end-libraries/sass/store-data-with-sass-variables) had not been highlighted.  This fixes that and adds Python highlighting to prepare for the new curriculum.

In addition, the code in the instructions/descriptions was highlighted differently from the editor.  It's not possible (using Prism) to make them identical, but this PR makes them closer.

- [x] Add scss and Python syntax highlighting
- [x] Sync description/instruction highlighting with editor, day mode
- [ ] Sync description/instruction highlighting with editor, night mode