### PR TITLE
chore: use sample.env as Travis enviroment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,10 @@ env:
   global:
     - NO_UPDATE_NOTIFIER=1
     - NODE_NO_WARNINGS=1
-    - FREECODECAMP_NODE_ENV=production
-    - API_LOCATION="http://localhost:3000"
-    - FORUM_PROXY="https://forum.localhost"
-    - NEWS_PROXY="https://news.localhost"
-    
 
 before_install:
   - npm config set loglevel warn
+  - cp sample.env .env
 
 install: npm ci
 


### PR DESCRIPTION
This makes the ci environment mirror the local one, so that if a contributor's tests pass so should the ci tests.

I ran this on my fork, which does not specify any enviroment variables, and [passed](https://travis-ci.com/github/ojeytonwilliams/freeCodeCamp/jobs/328140212)