### PR TITLE
fix: Jupyter notebook challenge file name

### DIFF
--- a/curriculum/challenges/_meta/data-analysis-with-python-course/meta.json
+++ b/curriculum/challenges/_meta/data-analysis-with-python-course/meta.json
@@ -26,7 +26,7 @@
     ],
     [
       "5e9a093a74c4063ca6f7c150",
-      "upyter Notebooks Cells"
+      "Jupyter Notebooks Cells"
     ],
     [
       "5e9a093a74c4063ca6f7c151",

--- a/curriculum/challenges/english/08-data-analysis-with-python/data-analysis-with-python-course/jupyter-notebooks-cells.english.md
+++ b/curriculum/challenges/english/08-data-analysis-with-python/data-analysis-with-python-course/jupyter-notebooks-cells.english.md
@@ -1,6 +1,6 @@
 ---
 id: 5e9a093a74c4063ca6f7c150
-title: upyter Notebooks Cells
+title: Jupyter Notebooks Cells
 challengeType: 11
 videoId: 5PPegAs9aLA
 ---


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `next-python-projects` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Jupyter name was missing a "J" in one of the files. I think I covered all of the places this was referenced. Feel free to comment on any other places it is mentioned. This changes the file name, the header title, and the metadata for challenges.