### PR TITLE
test: record only if key is present

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -11,6 +11,9 @@ on:
       - master
 jobs:
   cypress-run:
+    env:
+      CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     name: Cypress run
     runs-on: ubuntu-latest
     services:
@@ -25,14 +28,11 @@ jobs:
 
       - name: Set up environment
         run: cp sample.env .env
-
+      
       - name: Cypress run
         uses: cypress-io/github-action@v1
-        env:
-          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          record: true
+          record: ${{ env.CYPRESS_RECORD_KEY != 0 }}
           build: npm run build
           # this should mirror the production build, but for now we're just using the dev
           # server and gatsby serve instead (the npm script serve:client needs updating!)


### PR DESCRIPTION
If cypress runs on a fork, then it will (typically) fail as that fork will not have `CYPRESS_RECORD_KEY` set.  This makes the recording conditional on the presence of that key.