### PR TITLE
docs(docs): consolidate node.js instructions

### DIFF
--- a/docs/how-to-setup-freecodecamp-locally.md
+++ b/docs/how-to-setup-freecodecamp-locally.md
@@ -140,6 +140,16 @@ Software required for both Docker and Local builds:
 | [Node.js](http://nodejs.org)  | `12.x`  | [LTS Schedule](https://github.com/nodejs/Release#release-schedule)   |
 | npm (comes bundled with Node) | `6.x`   | Does not have LTS releases, we use the version bundled with Node LTS |
 
+If Node.js is already installed on your machine, run the following commands to validate the versions:
+
+```sh
+node -v
+npm -v
+```
+
+> [!DANGER]
+> If you have a different version, please install the recommended version. We can only support installation issues for recommended versions. See [troubleshooting](#troubleshooting) for details.
+
 **Docker Build additional prerequisite:**
 
 | Prerequisite                                                               | Version    | Notes                                                                                                        |
@@ -156,16 +166,6 @@ Software required for both Docker and Local builds:
 
 > [!TIP]
 > We highly recommend updating to the latest stable releases of the software listed above, also known as Long Term Support (LTS) releases.
-
-If Node.js is already installed on your machine, run the following commands to validate the versions:
-
-```sh
-node -v
-npm -v
-```
-
-> [!DANGER]
-> If you have a different version, please install the recommended version. We can only support installation issues for recommended versions. See [troubleshooting](#troubleshooting) for details.
 
 ### Configuring dependencies
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `master` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This is a small edit that moves the instructions that start with "If Node.js is already installed..." to under the table that states the version of Node.js that is needed.

This may be a bit trivial, but I was going through the local setup instructions and thought the ability to follow along could be improved by doing this. Before, the section I moved was under the section labeled "Local Build additional prerequisite" instead of the section with the rest of the Node.js instructions.