### PR TITLE
fix(learn): add test to return early pattern

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/return-early-pattern-for-functions.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/return-early-pattern-for-functions.english.md
@@ -46,8 +46,8 @@ tests:
     testString: assert(abTest(2,8) === 18 );
   - text: <code>abTest(3,3)</code> should return <code>12</code>
     testString: assert(abTest(3,3) === 12 );
-  - text: <code>abTest(0,2)</code> should return <code>2</code>
-    testString: assert(abTest(0,2) === 2);
+  - text: <code>abTest(0,0)</code> should return <code>0</code>
+    testString: assert(abTest(0,0) === 0);
     
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/return-early-pattern-for-functions.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/return-early-pattern-for-functions.english.md
@@ -46,7 +46,7 @@ tests:
     testString: assert(abTest(2,8) === 18 );
   - text: <code>abTest(3,3)</code> should return <code>12</code>
     testString: assert(abTest(3,3) === 12 );
-  - text: <code>abTest(0,2)</code> should return <code>1</code>
+  - text: <code>abTest(0,2)</code> should return <code>2</code>
     testString: assert(abTest(0,2) === 2);
     
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/return-early-pattern-for-functions.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/return-early-pattern-for-functions.english.md
@@ -46,7 +46,9 @@ tests:
     testString: assert(abTest(2,8) === 18 );
   - text: <code>abTest(3,3)</code> should return <code>12</code>
     testString: assert(abTest(3,3) === 12 );
-
+  - text: <code>abTest(0,2)</code> should return <code>1</code>
+    testString: assert(abTest(0,2) === 2);
+    
 ```
 
 </section>


### PR DESCRIPTION
Currently no test for a = 0 or b = 0. This results in if(a<=0 || b<= 0) also being a valid solution

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #38750

<!-- Feel free to add any additional description of changes below this line -->
