### PR TITLE
feat: add markdown explanation to video challenge docs

### DIFF
--- a/docs/how-to-help-with-video-challenges.md
+++ b/docs/how-to-help-with-video-challenges.md
@@ -100,7 +100,7 @@ Questions and answers can contain certain HTML tags like `<br>` for a new line. 
 
 #### Use markdown to format your question
 
-You can also use markdown in your question instead of HTML if you choose, but you need to add one thing. A space and a "pipe" after the word `text:`, like this:
+You can also use markdown in your question as well as HTML. The simplest way to ensure that it is formatted correctly is to start the question with `text: |`, like this:
 
 ```yml
 question:

--- a/docs/how-to-help-with-video-challenges.md
+++ b/docs/how-to-help-with-video-challenges.md
@@ -162,7 +162,7 @@ question:
     console.log(‘hello world’);
     ```
   answers:
-    - ‘hello’
+    - stars *in* a string are fine
     - '**but need quotes** when starting a line'
     - ‘hello world’
   solution: 3

--- a/docs/how-to-help-with-video-challenges.md
+++ b/docs/how-to-help-with-video-challenges.md
@@ -160,10 +160,9 @@ question:
     What does this JavaScript code log to the console?
     ```js
     console.log('hello world');
-
-New paragraph after an empty line.
-
     ```
+
+    New paragraph after an empty line.
   answers:
     - hello *world*
     - '**hello** world' # the string cannot start with a *, hence the quotes.

--- a/docs/how-to-help-with-video-challenges.md
+++ b/docs/how-to-help-with-video-challenges.md
@@ -159,7 +159,7 @@ question:
   text: |
     What does this JavaScript code log to the console?
     ```js
-    console.log(‘hello world’);
+    console.log('hello world');
 
 New paragraph after an empty line.
 

--- a/docs/how-to-help-with-video-challenges.md
+++ b/docs/how-to-help-with-video-challenges.md
@@ -32,7 +32,7 @@ An optional description with helpful information related to the video.
 <section id='tests'>
 
 ```yml
-tests:
+question:
   text: 'Question'
   answers:
     - 'Answer One'
@@ -85,7 +85,7 @@ You can add the question locally or directly throught the GitHub interface. To a
 If a question has not yet been added to a particular video challenge, it will have the following default question:
 
 ```yml
-tests:
+question:
   text: Question
   answers:
     - one

--- a/docs/how-to-help-with-video-challenges.md
+++ b/docs/how-to-help-with-video-challenges.md
@@ -163,7 +163,7 @@ question:
     ```
   answers:
     - ‘hello’
-    - ‘world’
+    - '**but need quotes** when starting a line'
     - ‘hello world’
   solution: 3
 ````

--- a/docs/how-to-help-with-video-challenges.md
+++ b/docs/how-to-help-with-video-challenges.md
@@ -103,7 +103,7 @@ Questions and answers can contain certain HTML tags like `<br>` for a new line. 
 You can also use markdown in your question instead of HTML if you choose, but you need to add one thing. A space and a "pipe" after the word `text:`, like this:
 
 ```yml
-tests:
+question:
   text: |
     Question
   answers:

--- a/docs/how-to-help-with-video-challenges.md
+++ b/docs/how-to-help-with-video-challenges.md
@@ -98,11 +98,28 @@ Update the word “Question” with your question. Update the “one”, “two�
 
 Questions and answers can contain certain HTML tags like `<br>` for a new line. Surround code with `<pre></pre>` You will need to add a `<br>` at the end of each line of code.
 
+#### Use markdown to format your question
+
+You can also use markdown in your question instead of HTML if you choose, but you need to add one thing. A space and a "pipe" after the word `text:`, like this:
+
+```yml
+tests:
+  text: |
+    Question
+  answers:
+    - one
+    - two
+    - three
+  solution: 3
+```
+
+Then you need to make sure that your question is on a new line and indented one level more than `text: |`.
+
 Make sure each answer is plausible but there is only one correct answer.
 
 ## Question examples
 
-Here are a few examples:
+#### Here are a few examples with HTML:
 ```yml
 question:
   text: 'What will print out after running this code:<pre>width = 15<br>height = 12.0<br>print(height/3)</pre>'
@@ -135,6 +152,21 @@ question:
     - '7'
   solution: 3
 ```
+
+#### Example with markdown:
+````yml
+question:
+  text: |
+    What does this JavaScript code log to the console?
+    ```js
+    console.log(‘hello world’);
+    ```
+  answers:
+    - ‘hello’
+    - ‘world’
+    - ‘hello world’
+  solution: 3
+````
 
 For more examples, you can look at the markdown files for the following video course. All the challenges already have questions: [Python for Everybody Course](https://github.com/freeCodeCamp/freeCodeCamp/tree/next-python-projects/curriculum/challenges/english/07-scientific-computing-with-python/python-for-everybody)
 

--- a/docs/how-to-help-with-video-challenges.md
+++ b/docs/how-to-help-with-video-challenges.md
@@ -167,7 +167,7 @@ New paragraph after an empty line.
   answers:
     - stars *in* a string are fine
     - '**but need quotes** when starting a line'
-    - ‘hello world’
+    - hello world
   solution: 3
 ````
 

--- a/docs/how-to-help-with-video-challenges.md
+++ b/docs/how-to-help-with-video-challenges.md
@@ -166,7 +166,7 @@ New paragraph after an empty line.
     ```
   answers:
     - hello *world*
-    - '**but need quotes** when starting a line'
+    - '**hello** world' # the string cannot start with a *, hence the quotes.
     - hello world
   solution: 3
 ````

--- a/docs/how-to-help-with-video-challenges.md
+++ b/docs/how-to-help-with-video-challenges.md
@@ -160,6 +160,9 @@ question:
     What does this JavaScript code log to the console?
     ```js
     console.log(‘hello world’);
+
+New paragraph after an empty line.
+
     ```
   answers:
     - stars *in* a string are fine

--- a/docs/how-to-help-with-video-challenges.md
+++ b/docs/how-to-help-with-video-challenges.md
@@ -165,7 +165,7 @@ New paragraph after an empty line.
 
     ```
   answers:
-    - stars *in* a string are fine
+    - hello *world*
     - '**but need quotes** when starting a line'
     - hello world
   solution: 3


### PR DESCRIPTION
This adds an explanation to the docs about using markdown in video questions.

I kind of put markdown on there as another option. I would prefer that they all use markdown, but either way works I guess - and the doc was all nice, so I left most it how it was.

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
