### PR TITLE
Feat(curriculum): scss not sass

### DIFF
--- a/client/src/templates/Challenges/rechallenge/transformers.js
+++ b/client/src/templates/Challenges/rechallenge/transformers.js
@@ -177,7 +177,9 @@ function getBabelOptions({ preview = false, protect = true }) {
 
 const sassWorker = createWorker(sassCompile);
 async function transformSASS(element) {
-  const styleTags = element.querySelectorAll('style[type="text/sass"]');
+  // we only teach scss syntax, not sass. Also the compiler does not seem to be
+  // able to deal with sass.
+  const styleTags = element.querySelectorAll('style[type~="text/scss"]');
   await Promise.all(
     [].map.call(styleTags, async style => {
       style.type = 'text/css';

--- a/curriculum/challenges/english/03-front-end-libraries/sass/apply-a-style-until-a-condition-is-met-with-while.english.md
+++ b/curriculum/challenges/english/03-front-end-libraries/sass/apply-a-style-until-a-condition-is-met-with-while.english.md
@@ -60,7 +60,7 @@ tests:
 <div id='html-seed'>
 
 ```html
-<style type='text/sass'>
+<style type='text/scss'>
 
 
 
@@ -81,7 +81,7 @@ tests:
 <section id='solution'>
 
 ```html
-<style type='text/sass'>
+<style type='text/scss'>
   $x: 1;
   @while $x < 6 {
     .text-#{$x}{

--- a/curriculum/challenges/english/03-front-end-libraries/sass/create-reusable-css-with-mixins.english.md
+++ b/curriculum/challenges/english/03-front-end-libraries/sass/create-reusable-css-with-mixins.english.md
@@ -75,7 +75,7 @@ tests:
 <div id='html-seed'>
 
 ```html
-<style type='text/sass'>
+<style type='text/scss'>
 
 
 
@@ -101,7 +101,7 @@ tests:
 <section id='solution'>
 
 ```html
-<style type='text/sass'>
+<style type='text/scss'>
   @mixin border-radius($radius) {
     -webkit-border-radius: $radius;
     -moz-border-radius: $radius;

--- a/curriculum/challenges/english/03-front-end-libraries/sass/extend-one-set-of-css-styles-to-another-element.english.md
+++ b/curriculum/challenges/english/03-front-end-libraries/sass/extend-one-set-of-css-styles-to-another-element.english.md
@@ -58,7 +58,7 @@ tests:
 <div id='html-seed'>
 
 ```html
-<style type='text/sass'>
+<style type='text/scss'>
   h3{
     text-align: center;
   }
@@ -92,7 +92,7 @@ tests:
 <section id='solution'>
 
 ```html
-<style type='text/sass'>
+<style type='text/scss'>
   h3{
     text-align: center;
   }

--- a/curriculum/challenges/english/03-front-end-libraries/sass/nest-css-with-sass.english.md
+++ b/curriculum/challenges/english/03-front-end-libraries/sass/nest-css-with-sass.english.md
@@ -66,7 +66,7 @@ tests:
 <div id='html-seed'>
 
 ```html
-<style type='text/sass'>
+<style type='text/scss'>
   .blog-post {
 
   }
@@ -95,7 +95,7 @@ tests:
 <section id='solution'>
 
 ```html
-<style type='text/sass'>
+<style type='text/scss'>
   .blog-post {
     h1 {
       text-align: center;

--- a/curriculum/challenges/english/03-front-end-libraries/sass/store-data-with-sass-variables.english.md
+++ b/curriculum/challenges/english/03-front-end-libraries/sass/store-data-with-sass-variables.english.md
@@ -54,7 +54,7 @@ tests:
 <div id='html-seed'>
 
 ```html
-<style type='text/sass'>
+<style type='text/scss'>
 
 
   .header{
@@ -90,7 +90,7 @@ tests:
 <section id='solution'>
 
 ```html
-<style type='text/sass'>
+<style type='text/scss'>
   $text-color: red;
 
   .header{

--- a/curriculum/challenges/english/03-front-end-libraries/sass/use-each-to-map-over-items-in-a-list.english.md
+++ b/curriculum/challenges/english/03-front-end-libraries/sass/use-each-to-map-over-items-in-a-list.english.md
@@ -77,7 +77,7 @@ tests:
 <div id='html-seed'>
 
 ```html
-<style type='text/sass'>
+<style type='text/scss'>
 
 
 
@@ -104,7 +104,7 @@ The solution requires using the $color variable twice: once for the class name a
 ### List Data type
 
 ```html
-<style type='text/sass'>
+<style type='text/scss'>
 
   @each $color in blue, black, red {
     .#{$color}-bg {background-color: $color;}
@@ -124,7 +124,7 @@ The solution requires using the $color variable twice: once for the class name a
 ### Map Data type
 
 ```html
-<style type='text/sass'>
+<style type='text/scss'>
 
   $colors: (color1: blue, color2: black, color3: red);
 

--- a/curriculum/challenges/english/03-front-end-libraries/sass/use-for-to-create-a-sass-loop.english.md
+++ b/curriculum/challenges/english/03-front-end-libraries/sass/use-for-to-create-a-sass-loop.english.md
@@ -72,7 +72,7 @@ tests:
 <div id='html-seed'>
 
 ```html
-<style type='text/sass'>
+<style type='text/scss'>
 
 
 
@@ -95,7 +95,7 @@ tests:
 <section id='solution'>
 
 ```html
-<style type='text/sass'>
+<style type='text/scss'>
 
 @for $i from 1 through 5 {
   .text-#{$i} { font-size: 15px * $i; }
@@ -111,7 +111,7 @@ tests:
 ```
 
 ```html
-<style type='text/sass'>
+<style type='text/scss'>
 
 @for $i from 1 to 6 {
   .text-#{$i} { font-size: 15px * $i; }

--- a/curriculum/challenges/english/03-front-end-libraries/sass/use-if-and-else-to-add-logic-to-your-styles.english.md
+++ b/curriculum/challenges/english/03-front-end-libraries/sass/use-if-and-else-to-add-logic-to-your-styles.english.md
@@ -77,7 +77,7 @@ tests:
 <div id='html-seed'>
 
 ```html
-<style type='text/sass'>
+<style type='text/scss'>
 
 
 
@@ -102,7 +102,7 @@ tests:
 <section id='solution'>
 
 ```html
-<style type='text/sass'>
+<style type='text/scss'>
   @mixin border-stroke($val) {
     @if $val == light {
       border: 1px solid black;


### PR DESCRIPTION
Since we only teach the scss syntax, it makes sense to use `text/scss` in the editor.  That way the editor will recognise and highlight the code.

Related to https://github.com/freeCodeCamp/freeCodeCamp/pull/38730