### PR TITLE
fix(curriculum): changed test to use regex

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/size-your-images.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/size-your-images.english.md
@@ -24,7 +24,6 @@ For example, if we wanted to create a CSS class called <code>larger-image</code>
 ## Instructions
 <section id='instructions'>
 Create a class called <code>smaller-image</code> and use it to resize the image so that it's only 100 pixels wide.
-<strong>Note:</strong> Due to browser implementation differences, you may need to be at 100% zoom to pass the tests on this challenge.
 </section>
 
 ## Tests
@@ -34,8 +33,8 @@ Create a class called <code>smaller-image</code> and use it to resize the image 
 tests:
   - text: Your <code>img</code> element should have the class <code>smaller-image</code>.
     testString: assert($("img[src='https://bit.ly/fcc-relaxing-cat']").attr('class') === "smaller-image");
-  - text: Your image should be 100 pixels wide. Browser zoom should be at 100%.
-    testString: assert($("img").width() === 100);
+  - text: Your image should be 100 pixels wide.
+    testString: assert(code.match(/(?<=<style>([\s\S])*)\.smaller-image[\s\n]*{[\s\S]*width\s*:\s*100px\s*;(?=[\s\S]*<\/style>)/));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/size-your-images.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/size-your-images.english.md
@@ -34,7 +34,7 @@ tests:
   - text: Your <code>img</code> element should have the class <code>smaller-image</code>.
     testString: assert($("img[src='https://bit.ly/fcc-relaxing-cat']").attr('class') === "smaller-image");
   - text: Your image should be 100 pixels wide.
-    testString: assert($("img").width() < 200 && code.match(/(?<=<style>([\s\S])*)\.smaller-image[\s\n]*{([\s\S]*;)?[\s\n]*width\s*:\s*100px\s*;(?=[\s\S]*<\/style>)/));
+    testString: assert($("img").width() < 200 && code.match(/(?<=<style>([\s\S])*)\.smaller-image[\s\n]*{([\s\S]*;)?[\s\n]*width\s*:\s*100px\s*;(?=[\s\S]*<\/style>)/i));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/size-your-images.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/size-your-images.english.md
@@ -34,7 +34,7 @@ tests:
   - text: Your <code>img</code> element should have the class <code>smaller-image</code>.
     testString: assert($("img[src='https://bit.ly/fcc-relaxing-cat']").attr('class') === "smaller-image");
   - text: Your image should be 100 pixels wide.
-    testString: assert(code.match(/(?<=<style>([\s\S])*)\.smaller-image[\s\n]*{[\s\S]*width\s*:\s*100px\s*;(?=[\s\S]*<\/style>)/));
+    testString: assert(code.match(/(?<=<style>([\s\S])*)\.smaller-image[\s\n]*{([\s\S]*;)?[\s\n]*width\s*:\s*100px\s*;(?=[\s\S]*<\/style>)/));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/size-your-images.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/size-your-images.english.md
@@ -34,7 +34,7 @@ tests:
   - text: Your <code>img</code> element should have the class <code>smaller-image</code>.
     testString: assert($("img[src='https://bit.ly/fcc-relaxing-cat']").attr('class') === "smaller-image");
   - text: Your image should be 100 pixels wide.
-    testString: assert(code.match(/(?<=<style>([\s\S])*)\.smaller-image[\s\n]*{([\s\S]*;)?[\s\n]*width\s*:\s*100px\s*;(?=[\s\S]*<\/style>)/));
+    testString: assert($("img").width() < 200 && code.match(/(?<=<style>([\s\S])*)\.smaller-image[\s\n]*{([\s\S]*;)?[\s\n]*width\s*:\s*100px\s*;(?=[\s\S]*<\/style>)/));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/size-your-images.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/size-your-images.english.md
@@ -34,7 +34,7 @@ tests:
   - text: Your <code>img</code> element should have the class <code>smaller-image</code>.
     testString: assert($("img[src='https://bit.ly/fcc-relaxing-cat']").attr('class') === "smaller-image");
   - text: Your image should be 100 pixels wide.
-    testString: assert($("img").width() < 200 && code.match(/(?<=<style>([\s\S])*)\.smaller-image[\s\n]*{([\s\S]*;)?[\s\n]*width\s*:\s*100px\s*;(?=[\s\S]*<\/style>)/i));
+    testString: assert($("img").width() < 200 && code.match(/(?<=<style>([\s\S])*)\.smaller-image[\s\n]*{([\s\S]*;)?[\s\n]*width\s*:\s*100px\s*(?=[\s\S]*<\/style>)/i));
 
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/size-your-images.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/size-your-images.english.md
@@ -34,7 +34,7 @@ tests:
   - text: Your <code>img</code> element should have the class <code>smaller-image</code>.
     testString: assert($("img[src='https://bit.ly/fcc-relaxing-cat']").attr('class') === "smaller-image");
   - text: Your image should be 100 pixels wide.
-    testString: assert($("img").width() < 200 && code.match(/(?<=<style>([\s\S])*)\.smaller-image[\s\n]*{([\s\S]*;)?[\s\n]*width\s*:\s*100px\s*(?=[\s\S]*<\/style>)/i));
+    testString: assert($("img").width() < 200 && code.match(/(?<=<style>([\s\S])*)\.smaller-image\s*{([\s\S]*;)?\s*width\s*:\s*100px\s*(;|})[\s\S]*(?=<\/style>)/i));
 
 ```
 


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

Closes #38712 

<!-- Feel free to add any additional description of changes below this line -->
This change allows users to pass the test with correct code, when browser zoom is not at 100%.

**NOTE**: Code allows poorly formatted code to pass, whilst the image is still displayed correctly.