### PR TITLE
Fix false negatives in bubble sort test

### DIFF
--- a/curriculum/challenges/english/10-coding-interview-prep/algorithms/implement-bubble-sort.english.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/algorithms/implement-bubble-sort.english.md
@@ -32,7 +32,7 @@ tests:
   - text: <code>bubbleSort</code> should return an array that is unchanged except for order.
     testString: assert.sameMembers(bubbleSort([1,4,2,8,345,123,43,32,5643,63,123,43,2,55,1,234,92]), [1,4,2,8,345,123,43,32,5643,63,123,43,2,55,1,234,92]);
   - text: <code>bubbleSort</code> should not use the built-in <code>.sort()</code> method.
-    testString: assert(!code.match(/\.?[\s\S]*?sort/));
+    testString: assert(!code.match(/\.\s*sort\s*\(/));
 
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!-- Feel free to add any additional description of changes below this line -->

I completed [Algorithms: Implement Bubble Sort](https://www.freecodecamp.org/learn/coding-interview-prep/algorithms/implement-bubble-sort) without using `Array.prototype.sort()` but using a boolean variable I named `sorted` to keep track of whether or not I should keep looping. The challenge tests gave me a false negative on the "`bubbleSort` should not use the built-in `.sort()` method" test until I renamed my `sorted` variable as `srtd`.

![screenshot](https://user-images.githubusercontent.com/5317080/81734694-e43a8380-9461-11ea-8b70-867f8134c8cd.png)

The regex for this test currently reads `/\.?[\s\S]*?sort/`, but `[\s\S]` means "any character that either *is* white space or *isn't* white space", right? And doesn't `\.?` include the possibility that *no* period precedes `sort`?

I think my updated regex, `/\.\s*sort\s*\(/`, should mean "one `.` followed by any amount of white space followed by `sort` followed by any amount of white space followed by `(`". That look right?