### PR TITLE
Clarify ambiguous instructions in "Stack Class"

### DIFF
--- a/curriculum/challenges/english/10-coding-interview-prep/data-structures/create-a-stack-class.english.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/data-structures/create-a-stack-class.english.md
@@ -17,7 +17,7 @@ Apart from the <code>push</code> and <code>pop</code> method, stacks have other 
 ## Instructions
 <section id='instructions'>
 
-Write a <code>push</code> method that pushes an element to the top of the stack, a <code>pop</code> method that removes the element on the top of the stack, a <code>peek</code> method that looks at the first element in the stack, an <code>isEmpty</code> method that checks if the stack is empty, and a <code>clear</code> method that removes all elements from the stack.
+Write a <code>push</code> method that pushes an element to the top of the stack, a <code>pop</code> method that removes and returns the element on the top of the stack, a <code>peek</code> method that looks at the top element in the stack, an <code>isEmpty</code> method that checks if the stack is empty, and a <code>clear</code> method that removes all elements from the stack.
 Normally stacks don't have this, but we've added a <code>print</code> helper method that console logs the collection.
 </section>
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!-- Feel free to add any additional description of changes below this line -->

Original instructions don't specify that the `pop` method ought to return the removed element, and for the `peek` method it uses the ambiguous descriptor "first" instead of "top".

These ambiguities are already clarified in the test names farther down on the page, but may as well clarify the instructions as well.