### PR TITLE
Remove `add` method test from "Reverse a Doubly Linked List"

### DIFF
--- a/curriculum/challenges/english/10-coding-interview-prep/data-structures/reverse-a-doubly-linked-list.english.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/data-structures/reverse-a-doubly-linked-list.english.md
@@ -23,8 +23,6 @@ Let's create one more method for our doubly linked list called reverse which rev
 tests:
   - text: The DoublyLinkedList data structure should exist.
     testString: assert((function() { var test = false; if (typeof DoublyLinkedList !== 'undefined') { test = new DoublyLinkedList() }; return (typeof test == 'object')})());
-  - text: The DoublyLinkedList should have a method called add.
-    testString: assert((function() { var test = false; if (typeof DoublyLinkedList !== 'undefined') { test = new DoublyLinkedList() }; if (test.add == undefined) { return false; }; return (typeof test.add == 'function')})());
   - text: The DoublyLinkedList should have a method called reverse.
     testString: assert((function() { var test = false; if (typeof DoublyLinkedList !== 'undefined') { test = new DoublyLinkedList() }; if (test.reverse == undefined) { return false; }; return (typeof test.reverse == 'function')})());
   - text: Reversing an empty list should return null.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!-- Feel free to add any additional description of changes below this line -->

The second test for [Reverse a Doubly Linked List](https://www.freecodecamp.org/learn/coding-interview-prep/data-structures/reverse-a-doubly-linked-list) reads "The DoublyLinkedList should have a method called add." At this point, the student had just written an `add` method in the previous lesson, [Create a Doubly Linked List](https://www.freecodecamp.org/learn/coding-interview-prep/data-structures/create-a-doubly-linked-list), and this test name suggests that they will have to write another from scratch, since an `add` method is not provided in the challenge seed. This is not necessary, though, since the `js-teardown` script creates an `add` method and assigns it to `DoublyLinkedList.prototype` before the tests are run.