### PR TITLE
fix(api): use mongodb+srv url protocol

### DIFF
--- a/api-server/server/datasources.production.js
+++ b/api-server/server/datasources.production.js
@@ -3,6 +3,7 @@ var secrets = require('../../config/secrets');
 module.exports = {
   db: {
     connector: 'mongodb',
+    protocol: 'mongodb+srv',
     connectionTimeout: 10000,
     url: secrets.db,
     useNewUrlParser: true,


### PR DESCRIPTION
This upgrades the protocol. The code change will be a hot patch on the API instances, during the migration. This PR can be merged after the fact for code consistency. 