### PR TITLE
fix: exercise tracker solution URL

### DIFF
--- a/curriculum/challenges/arabic/05-apis-and-microservices/apis-and-microservices-projects/exercise-tracker.arabic.md
+++ b/curriculum/challenges/arabic/05-apis-and-microservices/apis-and-microservices-projects/exercise-tracker.arabic.md
@@ -8,7 +8,7 @@ isRequired: true
 
 ## Description
 <section id='description'> 
-قم بإنشاء تطبيق جافا سكريبت كاملا يشبه وظيفيًا ما يلي: <a href='https://fuschia-custard.glitch.me/' target='_blank'>https://fuschia-custard.glitch.me/</a>.
+قم بإنشاء تطبيق جافا سكريبت كاملا يشبه وظيفيًا ما يلي: <a href='https://nonstop-pond.glitch.me/' target='_blank'>https://nonstop-pond.glitch.me/</a>.
  
 سيتطلب عملك كتابة برنامجك على مشروعنا المبدأي في Glitch. بعد الانتهاء من هذا المشروع ، يمكنك نسخ عنوان URL الافتراضي الخاص بك (إلى الصفحة الرئيسية لتطبيقك) في هذه الشاشة لاختباره!
 يمكنك أيضا اختياريا كتابة مشروعك على نظام أساسي آخر ، ولكن يجب أن يكون مرئيًا بشكل عام لاختبارنا. 

--- a/curriculum/challenges/chinese/05-apis-and-microservices/apis-and-microservices-projects/exercise-tracker.chinese.md
+++ b/curriculum/challenges/chinese/05-apis-and-microservices/apis-and-microservices-projects/exercise-tracker.chinese.md
@@ -7,7 +7,7 @@ isRequired: true
 ---
 
 ## Description
-<section id='description'> 构建一个功能类似于此的完整堆栈JavaScript应用程序： <a href='https://fuschia-custard.glitch.me/' target='_blank'>https://fuschia-custard.glitch.me/</a>。在这个项目上工作将涉及您在我们的入门项目上的Glitch上编写代码。完成此项目后，您可以将公共故障网址（到应用程序的主页）复制到此屏幕进行测试！您可以选择在另一个平台上编写项目，但必须公开显示我们的测试。使用<a href='https://glitch.com/#!/import/github/freeCodeCamp/boilerplate-project-exercisetracker/' target='_blank'>此链接</a>在Glitch上启动此项目或在GitHub上克隆<a href='https://github.com/freeCodeCamp/boilerplate-project-exercisetracker/'>此存储库</a>！如果您使用Glitch，请记住将项目链接保存到安全的地方！
+<section id='description'> 构建一个功能类似于此的完整堆栈JavaScript应用程序： <a href='https://nonstop-pond.glitch.me/' target='_blank'>https://nonstop-pond.glitch.me/</a>。在这个项目上工作将涉及您在我们的入门项目上的Glitch上编写代码。完成此项目后，您可以将公共故障网址（到应用程序的主页）复制到此屏幕进行测试！您可以选择在另一个平台上编写项目，但必须公开显示我们的测试。使用<a href='https://glitch.com/#!/import/github/freeCodeCamp/boilerplate-project-exercisetracker/' target='_blank'>此链接</a>在Glitch上启动此项目或在GitHub上克隆<a href='https://github.com/freeCodeCamp/boilerplate-project-exercisetracker/'>此存储库</a>！如果您使用Glitch，请记住将项目链接保存到安全的地方！
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/05-apis-and-microservices/apis-and-microservices-projects/exercise-tracker.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/apis-and-microservices-projects/exercise-tracker.english.md
@@ -8,7 +8,7 @@ forumTopicId: 301505
 
 ## Description
 <section id='description'>
-Build a full stack JavaScript app that is functionally similar to this: <a href='https://fuschia-custard.glitch.me/' target='_blank'>https://fuschia-custard.glitch.me/</a>.
+Build a full stack JavaScript app that is functionally similar to this: <a href='https://nonstop-pond.glitch.me/' target='_blank'>https://nonstop-pond.glitch.me/</a>.
 Working on this project will involve you writing your code on Glitch on our starter project. After completing this project you can copy your public glitch url (to the homepage of your app) into this screen to test it! Optionally you may choose to write your project on another platform but it must be publicly visible for our testing.
 Start this project on Glitch using <a href='https://glitch.com/edit/#!/remix/clone-from-repo?REPO_URL=https://github.com/freeCodeCamp/boilerplate-project-exercisetracker/' target='_blank'>this link</a> or clone <a href='https://github.com/freeCodeCamp/boilerplate-project-exercisetracker/'>this repository</a> on GitHub! If you use Glitch, remember to save the link to your project somewhere safe!
 </section>
@@ -26,7 +26,7 @@ tests:
   - text: I can provide my own project, not the example url.
     testString: "getUserInput => {
       const url = getUserInput('url');
-      assert(!(new RegExp('.*/fuschia-custard\\.glitch\\.me\\.*')).test(getUserInput('url')));
+      assert(!(new RegExp('.*/nonstop-pond\\.glitch\\.me\\.*')).test(getUserInput('url')));
     }
     "
 

--- a/curriculum/challenges/portuguese/05-apis-and-microservices/apis-and-microservices-projects/exercise-tracker.portuguese.md
+++ b/curriculum/challenges/portuguese/05-apis-and-microservices/apis-and-microservices-projects/exercise-tracker.portuguese.md
@@ -8,7 +8,7 @@ isRequired: true
 
 ## Description
 <section id='description'> 
-Crie um aplicativo JavaScript de pilha completa que seja funcionalmente semelhante a este: <a href='https://fuschia-custard.glitch.me/' target='_blank'>https://fuschia-custard.glitch.me/</a> . 
+Crie um aplicativo JavaScript de pilha completa que seja funcionalmente semelhante a este: <a href='https://nonstop-pond.glitch.me/' target='_blank'>https://nonstop-pond.glitch.me/</a> . 
 Trabalhar neste projeto envolverá você escrevendo seu código no Glitch em nosso projeto inicial. Depois de concluir este projeto, você pode copiar sua URL de falha pública (para a página inicial do seu aplicativo) nesta tela para testá-lo! Opcionalmente, você pode optar por escrever seu projeto em outra plataforma, mas deve estar publicamente visível para nossos testes. 
 iniciar este projeto em Glitch usando <a href='https://glitch.com/#!/import/github/freeCodeCamp/boilerplate-project-exercisetracker/' target='_blank'>este link</a> ou clonar <a href='https://github.com/freeCodeCamp/boilerplate-project-exercisetracker/'>este repositório</a> no GitHub! Se você usa o Glitch, lembre-se de salvar o link do seu projeto em algum lugar seguro! 
 </section>

--- a/curriculum/challenges/russian/05-apis-and-microservices/apis-and-microservices-projects/exercise-tracker.russian.md
+++ b/curriculum/challenges/russian/05-apis-and-microservices/apis-and-microservices-projects/exercise-tracker.russian.md
@@ -9,7 +9,7 @@ localeTitle: Трекер упражнений
 
 ## Description
 <section id='description'>
-Создайте полноценное приложение JavaScript, функционально похожее на это: <a href='https://fuschia-custard.glitch.me/' target='_blank'>https://fuschia-custard.glitch.me/</a> . 
+Создайте полноценное приложение JavaScript, функционально похожее на это: <a href='https://nonstop-pond.glitch.me/' target='_blank'>https://nonstop-pond.glitch.me/</a> . 
 Работа над этим проектом потребует от вас написания кода на Glitch для нашего стартового проекта. После завершения этого проекта вы можете скопировать общедоступный URL-адрес сбоя (на главную страницу вашего приложения) на этот экран, чтобы протестировать его! При желании вы можете написать свой проект на другой платформе, но он должен быть открыт для нашего тестирования. 
 Запустите этот проект на Glitch по <a href='https://glitch.com/#!/import/github/freeCodeCamp/boilerplate-project-exercisetracker/' target='_blank'>этой ссылке</a> или клонируйте <a href='https://github.com/freeCodeCamp/boilerplate-project-exercisetracker/'>этот репозиторий</a> на GitHub! Если вы используете Glitch, не забудьте сохранить ссылку на ваш проект в безопасном месте!
 </section>

--- a/curriculum/challenges/spanish/05-apis-and-microservices/apis-and-microservices-projects/exercise-tracker.spanish.md
+++ b/curriculum/challenges/spanish/05-apis-and-microservices/apis-and-microservices-projects/exercise-tracker.spanish.md
@@ -9,7 +9,7 @@ forumTopicId: 301505
 
 ## Description
 <section id='description'> 
-Cree una aplicación de JavaScript full stack que sea funcionalmente similar a esta: <a href='https://fuschia-custard.glitch.me/' target='_blank'>https://fuschia-custard.glitch.me/</a> . 
+Cree una aplicación de JavaScript full stack que sea funcionalmente similar a esta: <a href='https://nonstop-pond.glitch.me/' target='_blank'>https://nonstop-pond.glitch.me/</a> . 
 Trabajar en este proyecto implicará que escriba su código en Glitch en nuestro proyecto de inicio. Después de completar el proyecto, puede copiar su URL pública de Glitch (en la página de inicio de su aplicación) en esta pantalla para probarlo. Opcionalmente, puede optar por escribir su proyecto en otra plataforma, pero debe ser visible públicamente para nuestras pruebas. 
 Inicie este proyecto en Glitch usando <a href='https://glitch.com/#!/import/github/freeCodeCamp/boilerplate-project-exercisetracker/' target='_blank'>este enlace</a> o clone <a href='https://github.com/freeCodeCamp/boilerplate-project-exercisetracker/'>este repositorio</a> en GitHub! Si utiliza Glitch, recuerde guardar el enlace a su proyecto en un lugar seguro. 
 </section>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

The current example project, https://fuschia-custard.glitch.me/, is not owned by freeCodeCamp. We're currently in the process of migrating to Atlas, which includes some of the backend projects.

This PR switches the URLs to fCC's version of the project at https://nonstop-pond.glitch.me/. It also adjusts one of the tests to check if https://nonstop-pond.glitch.me/ is submitted rather than https://fuschia-custard.glitch.me/.
