### PR TITLE
fix: allow ctrl+enter to submit video lessons

### DIFF
--- a/client/src/templates/Challenges/components/Hotkeys.js
+++ b/client/src/templates/Challenges/components/Hotkeys.js
@@ -18,7 +18,6 @@ const mapStateToProps = createSelector(
 const mapDispatchToProps = { setEditorFocusability };
 
 const keyMap = {
-  ENTER: 'enter',
   NAVIGATION_MODE: 'escape',
   EXECUTE_CHALLENGE: ['ctrl+enter', 'command+enter'],
   FOCUS_EDITOR: 'e',
@@ -50,13 +49,11 @@ function Hotkeys({
   setEditorFocusability
 }) {
   const handlers = {
-    ENTER: e => {
-      // 'enter' disables HotKeys, this prevents that
-      e.preventDefault();
-    },
     EXECUTE_CHALLENGE: e => {
       // the 'enter' part of 'ctrl+enter' stops HotKeys from listening, so it
       // needs to be prevented.
+      // TODO: 'enter' on its own also disables HotKeys, but default behaviour
+      // should not be prevented in that case.
       e.preventDefault();
       if (executeChallenge) executeChallenge();
     },

--- a/client/src/templates/Challenges/components/Hotkeys.js
+++ b/client/src/templates/Challenges/components/Hotkeys.js
@@ -18,6 +18,7 @@ const mapStateToProps = createSelector(
 const mapDispatchToProps = { setEditorFocusability };
 
 const keyMap = {
+  ENTER: 'enter',
   NAVIGATION_MODE: 'escape',
   EXECUTE_CHALLENGE: ['ctrl+enter', 'command+enter'],
   FOCUS_EDITOR: 'e',
@@ -49,11 +50,13 @@ function Hotkeys({
   setEditorFocusability
 }) {
   const handlers = {
+    ENTER: e => {
+      // 'enter' disables HotKeys, this prevents that
+      e.preventDefault();
+    },
     EXECUTE_CHALLENGE: e => {
       // the 'enter' part of 'ctrl+enter' stops HotKeys from listening, so it
       // needs to be prevented.
-      // TODO: 'enter' on its own also disables HotKeys, but default behaviour
-      // should not be prevented in that case.
       e.preventDefault();
       if (executeChallenge) executeChallenge();
     },

--- a/client/src/templates/Challenges/video/Show.js
+++ b/client/src/templates/Challenges/video/Show.js
@@ -165,6 +165,9 @@ export class Project extends Component {
     const blockNameTitle = `${blockName} - ${title}`;
     return (
       <Hotkeys
+        executeChallenge={() => {
+          this.handleSubmit(solution, openCompletionModal);
+        }}
         innerRef={c => (this._container = c)}
         introPath={introPath}
         nextChallengePath={nextChallengePath}

--- a/client/src/templates/Challenges/video/Show.js
+++ b/client/src/templates/Challenges/video/Show.js
@@ -220,7 +220,9 @@ export class Project extends Component {
                 <ObserveKeys>
                   <div className='video-quiz-options'>
                     {answers.map((option, index) => (
-                      <label className='video-quiz-option-label'>
+                      // answers are static and have no natural id property, so
+                      // index should be fine as a key:
+                      <label className='video-quiz-option-label' key={index}>
                         <input
                           checked={this.state.selectedOption === index}
                           className='video-quiz-input-hidden'

--- a/client/src/templates/Challenges/video/Show.js
+++ b/client/src/templates/Challenges/video/Show.js
@@ -8,6 +8,7 @@ import { graphql } from 'gatsby';
 import Helmet from 'react-helmet';
 import YouTube from 'react-youtube';
 import { createSelector } from 'reselect';
+import { ObserveKeys } from 'react-hotkeys';
 
 // Local Utilities
 import PrismFormatted from '../components/PrismFormatted';
@@ -216,29 +217,31 @@ export class Project extends Component {
                 <ChallengeDescription description={description} />
                 <PrismFormatted text={text} />
                 <Spacer />
-                <div className='video-quiz-options'>
-                  {answers.map((option, index) => (
-                    <label className='video-quiz-option-label'>
-                      <input
-                        checked={this.state.selectedOption === index}
-                        className='video-quiz-input-hidden'
-                        name='quiz'
-                        onChange={this.handleOptionChange}
-                        type='radio'
-                        value={index}
-                      />{' '}
-                      <span className='video-quiz-input-visible'>
-                        {this.state.selectedOption === index ? (
-                          <span className='video-quiz-selected-input'></span>
-                        ) : null}
-                      </span>
-                      <PrismFormatted
-                        className={'video-quiz-option'}
-                        text={option}
-                      />
-                    </label>
-                  ))}
-                </div>
+                <ObserveKeys>
+                  <div className='video-quiz-options'>
+                    {answers.map((option, index) => (
+                      <label className='video-quiz-option-label'>
+                        <input
+                          checked={this.state.selectedOption === index}
+                          className='video-quiz-input-hidden'
+                          name='quiz'
+                          onChange={this.handleOptionChange}
+                          type='radio'
+                          value={index}
+                        />{' '}
+                        <span className='video-quiz-input-visible'>
+                          {this.state.selectedOption === index ? (
+                            <span className='video-quiz-selected-input'></span>
+                          ) : null}
+                        </span>
+                        <PrismFormatted
+                          className={'video-quiz-option'}
+                          text={option}
+                        />
+                      </label>
+                    ))}
+                  </div>
+                </ObserveKeys>
                 <Spacer />
                 <div
                   style={{


### PR DESCRIPTION
Fixes number 6 in [this comment](https://github.com/freeCodeCamp/freeCodeCamp/pull/38271#issuecomment-633682492)

Allows `command+enter` to submit video lessons.
Prevents `enter` from stopping the hotkey listeners. I looked at all the places the hot keys are used, I don't see this being a problem.

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
