### PR TITLE
fix(editor): Add quickSuggestions false to editor options

### DIFF
--- a/client/src/templates/Challenges/classic/Editor.js
+++ b/client/src/templates/Challenges/classic/Editor.js
@@ -120,7 +120,8 @@ class Editor extends Component {
       dragAndDrop: true,
       lightbulb: {
         enabled: false
-      }
+      },
+      quickSuggestions: false
     };
 
     this._editor = null;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

This is a fix for the cursor getting stuck inside an invisible quick suggest menu. The cause is the changes in https://github.com/freeCodeCamp/freeCodeCamp/pull/38551.

Closes #38880
