### PR TITLE
fix: make videos bigger + add styles

### DIFF
--- a/client/src/templates/Challenges/video/Show.js
+++ b/client/src/templates/Challenges/video/Show.js
@@ -196,7 +196,11 @@ export class Project extends Component {
                         : 'hide-youtube-video'
                     }
                     onReady={this.videoIsReady}
-                    opts={{ rel: 0 }}
+                    opts={{
+                      rel: 0,
+                      width: '960px',
+                      height: '540px'
+                    }}
                     videoId={videoId}
                   />
                   <i>

--- a/client/src/templates/Challenges/video/show.css
+++ b/client/src/templates/Challenges/video/show.css
@@ -3,10 +3,11 @@
   flex-direction: column;
   justify-content: space-evenly;
   align-items: center;
+  padding: 20px 0;
 }
 
 .video-placeholder-loader {
-  min-height: 360px;
+  min-height: 540px;
   display: flex;
   align-items: center;
 }
@@ -20,16 +21,21 @@
 }
 
 .video-quiz-options {
-  padding: 1px 16px;
   background-color: var(--tertiary-background);
+}
+
+/* remove bootstrap margin here */
+.video-quiz-options > label {
+  margin: 0;
 }
 
 .video-quiz-option-label {
   display: block;
-  margin: 20px;
+  padding: 20px;
   cursor: pointer;
   display: flex;
   font-weight: normal;
+  border: 2px solid var(--secondary-background);
 }
 
 .video-quiz-input-hidden {
@@ -63,6 +69,13 @@
   transform: translate(-50%, -50%);
 }
 
+/* remove bootstrap properties */
 .video-quiz-option > p {
+  margin: 0;
+}
+
+/* remove bootstrap properties */
+.video-quiz-option > pre {
+  padding: 0;
   margin: 0;
 }


### PR DESCRIPTION
This does three things:
- makes the youtube videos bigger
- removes the margin on `pre` tags so they line up with the radio buttons
- adds a border between the options so it looks a little better

#### Before is on the left - This PR is on the right:
<img width="1431" alt="Screen Shot 2020-05-27 at 2 13 51 PM" src="https://user-images.githubusercontent.com/20648924/83062890-f7824d00-a024-11ea-9c1c-3683a67d9e63.png">

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
