### PR TITLE
refactor(client): simply landing query

### DIFF
--- a/client/src/components/landing/index.js
+++ b/client/src/components/landing/index.js
@@ -14,7 +14,7 @@ import './landing.css';
 import '../Map/map.css';
 
 const propTypes = {
-  edges: PropTypes.array
+  nodes: PropTypes.array
 };
 
 const BigCallToAction = () => (
@@ -38,8 +38,8 @@ const AsFeaturedSection = () => (
   </Row>
 );
 
-export const Landing = ({ edges }) => {
-  const superBlocks = uniq(edges.map(element => element.node.superBlock));
+export const Landing = ({ nodes }) => {
+  const superBlocks = uniq(nodes.map(node => node.superBlock));
   const interviewPrep = superBlocks.splice(-1);
   return (
     <Fragment>

--- a/client/src/pages/index.js
+++ b/client/src/pages/index.js
@@ -7,10 +7,10 @@ import { AllChallengeNode } from '../redux/propTypes';
 
 export const IndexPage = ({
   data: {
-    allChallengeNode: { edges }
+    allChallengeNode: { nodes }
   }
 }) => {
-  return <Landing edges={edges} />;
+  return <Landing nodes={nodes} />;
 };
 
 const propTypes = {
@@ -30,18 +30,8 @@ export const query = graphql`
       filter: { isHidden: { eq: false } }
       sort: { fields: [superOrder, order, challengeOrder] }
     ) {
-      edges {
-        node {
-          fields {
-            slug
-            blockName
-          }
-          id
-          block
-          title
-          superBlock
-          dashedName
-        }
+      nodes {
+        superBlock
       }
     }
   }


### PR DESCRIPTION
Following on from https://github.com/freeCodeCamp/freeCodeCamp/pull/38913#issuecomment-635236974  'distinct' or 'group' queries do not respect the field sort order, so cannot be used.  This simplifies the query within those constraints.
