### PR TITLE
fix(client): ensure validation works during watch

### DIFF
--- a/client/gatsby-config.js
+++ b/client/gatsby-config.js
@@ -34,7 +34,7 @@ module.exports = {
       options: {
         name: 'challenges',
         source: buildChallenges,
-        onSourceChange: replaceChallengeNode,
+        onSourceChange: replaceChallengeNode(config.locale),
         curriculumPath: localeChallengesRootDir
       }
     },

--- a/client/utils/buildChallenges.js
+++ b/client/utils/buildChallenges.js
@@ -14,10 +14,10 @@ const arrToString = arr =>
 
 exports.localeChallengesRootDir = getChallengesDirForLang(locale);
 
-exports.replaceChallengeNode = async function replaceChallengeNode(
-  fullFilePath
-) {
-  return prepareChallenge(await createChallenge(fullFilePath));
+exports.replaceChallengeNode = locale => {
+  return async function replaceChallengeNode(fullFilePath) {
+    return prepareChallenge(await createChallenge(fullFilePath, null, locale));
+  };
 };
 
 exports.buildChallenges = async function buildChallenges() {


### PR DESCRIPTION
This fixes a bug where changing a challenge would throw an error since `validate` was missing.  