### PR TITLE
fix(client): public profile qa and infosec certification links

### DIFF
--- a/client/src/redux/index.js
+++ b/client/src/redux/index.js
@@ -272,12 +272,12 @@ export const certificatesByNameSelector = username => state => {
       {
         show: isQaCert,
         title: ' Quality Assurance Certification',
-        showURL: 'information-security-and-quality-assurance'
+        showURL: 'quality-assurance'
       },
       {
         show: isInfosecCert,
         title: 'Information Security Certification',
-        showURL: 'information-security-and-quality-assurance'
+        showURL: 'information-security'
       },
       {
         show: isSciCompPyCert,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Currently the new Information Security and the Quality Assurance certificate buttons on the public profile page point to the old `certification/user_name/information-security-and-quality-assurance` path:

![image](https://user-images.githubusercontent.com/2051070/83246588-51c60e00-a1dd-11ea-9a02-08f9d1554b81.png)

This change points them to the new URLs, `certification/user_name/information-security` and `certification/user_name/quality-assurance`.