### PR TITLE
fix: "undefined is a keyword" broken link

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/return-early-pattern-for-functions.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/return-early-pattern-for-functions.english.md
@@ -8,29 +8,33 @@ forumTopicId: 18272
 ---
 
 ## Description
+
 <section id='description'>
 When a <code>return</code> statement is reached, the execution of the current function stops and control returns to the calling location.
 <strong>Example</strong>
 
 ```js
 function myFun() {
-  console.log("Hello");
-  return "World";
-  console.log("byebye")
+  console.log('Hello');
+  return 'World';
+  console.log('byebye');
 }
 myFun();
 ```
 
 The above outputs "Hello" to the console, returns "World", but <code>"byebye"</code> is never output, because the function exits at the <code>return</code> statement.
+
 </section>
 
 ## Instructions
+
 <section id='instructions'>
 Modify the function <code>abTest</code> so that if <code>a</code> or <code>b</code> are less than <code>0</code> the function will immediately exit with a value of <code>undefined</code>.
-<strong>Hint</strong><br>Remember that <a href='http://www.freecodecamp.org/challenges/understanding-uninitialized-variables' target='_blank'><code>undefined</code> is a keyword</a>, not a string.
+<strong>Hint</strong><br>Remember that <a href='understanding-undefined-value-returned-from-a-function' target='_blank'><code>undefined</code> is a keyword</a>, not a string.
 </section>
 
 ## Tests
+
 <section id='tests'>
 
 ```yml
@@ -49,12 +53,12 @@ tests:
     testString: assert(abTest(3,3) === 12 );
   - text: <code>abTest(0,0)</code> should return <code>0</code>
     testString: assert(abTest(0,0) === 0);
-    
 ```
 
 </section>
 
 ## Challenge Seed
+
 <section id='challengeSeed'>
 
 <div id='js-seed'>
@@ -64,29 +68,25 @@ tests:
 function abTest(a, b) {
   // Only change code below this line
 
-
-
   // Only change code above this line
 
   return Math.round(Math.pow(Math.sqrt(a) + Math.sqrt(b), 2));
 }
 
-abTest(2,2);
+abTest(2, 2);
 ```
 
 </div>
 
-
-
 </section>
 
 ## Solution
-<section id='solution'>
 
+<section id='solution'>
 
 ```js
 function abTest(a, b) {
-  if(a < 0 || b < 0) {
+  if (a < 0 || b < 0) {
     return undefined;
   }
   return Math.round(Math.pow(Math.sqrt(a) + Math.sqrt(b), 2));


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #38895

<!-- Feel free to add any additional description of changes below this line -->
I have changed the "undefined is a keyword" link from "http://www.freecodecamp.org/challenges/understanding-uninitialized-variables" to "understanding-undefined-value-returned-from-a-function" because with the previous link it was showing "404 Page not found" error on the opened page
