### PR TITLE
fix(client): background-color in code blocks of questions

### DIFF
--- a/client/src/templates/Challenges/video/show.css
+++ b/client/src/templates/Challenges/video/show.css
@@ -21,7 +21,7 @@
 }
 
 .video-quiz-options {
-  background-color: var(--tertiary-background);
+  background-color: var(--primary-background);
 }
 
 /* remove bootstrap margin here */
@@ -35,7 +35,18 @@
   cursor: pointer;
   display: flex;
   font-weight: normal;
-  border: 2px solid var(--secondary-background);
+  border-left: 4px solid var(--tertiary-background);
+  border-right: 4px solid var(--tertiary-background);
+  border-top: 2px solid var(--tertiary-background);
+  border-bottom: 2px solid var(--tertiary-background);
+}
+
+.video-quiz-option-label:first-child {
+  border-top: 4px solid var(--tertiary-background);
+}
+
+.video-quiz-option-label:last-child {
+  border-bottom: 4px solid var(--tertiary-background);
 }
 
 .video-quiz-input-hidden {


### PR DESCRIPTION
This PR looks like this...

<img width="437" alt="Screen Shot 2020-05-30 at 7 40 22 PM" src="https://user-images.githubusercontent.com/20648924/83341875-ded89800-a2ad-11ea-9a74-c1291e3154e3.png">

I played around with no border, but the question looked too blended with the answers...
<img width="411" alt="Screen Shot 2020-05-30 at 7 28 17 PM" src="https://user-images.githubusercontent.com/20648924/83341930-805fe980-a2ae-11ea-92df-ff4099d2802c.png">

Just a draft for now in case we want something else. Note that this only fixes questions that use markdown. I think we are in the process of changing all the questions to use that.
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #38942

<!-- Feel free to add any additional description of changes below this line -->
