### PR TITLE
fix(curriculum): remove unnecessary `*/` from description of Basic JavaScript: Delete Properties from a JavaScript Object

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/delete-properties-from-a-javascript-object.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/delete-properties-from-a-javascript-object.english.md
@@ -35,7 +35,6 @@ After the last line shown above, <code>ourDog</code> looks like:
   "tails": 1,
   "friends": ["everything!"]
 }
-*/
 ```
 
 </section>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes NA

<!-- Feel free to add any additional description of changes below this line -->
In the lesson at https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-javascript/delete-properties-from-a-javascript-object , there is unnecessay `*/` code line at the last.

![image](https://user-images.githubusercontent.com/58929492/83344946-24877600-a32b-11ea-8e40-f9d71751d806.png)

This PR removes this line.