### PR TITLE
fix(client): remove auto redirect on report user page

### DIFF
--- a/client/src/client-only-routes/ShowUser.js
+++ b/client/src/client-only-routes/ShowUser.js
@@ -92,7 +92,7 @@ class ShowUser extends Component {
         <main>
           <FullWidthRow>
             <Spacer size={2} />
-            <Panel bsStyle='info'>
+            <Panel bsStyle='info' className='text-center'>
               <Panel.Heading>
                 <Panel.Title componentClass='h3'>
                   You need to be signed in to report a user

--- a/client/src/client-only-routes/ShowUser.js
+++ b/client/src/client-only-routes/ShowUser.js
@@ -13,7 +13,7 @@ import {
 } from '@freecodecamp/react-bootstrap';
 import Helmet from 'react-helmet';
 
-import { apiLocation } from '../../config/env.json';
+import Login from '../components/Header/components/Login';
 
 import {
   hardGoTo as navigate,
@@ -61,8 +61,7 @@ class ShowUser extends Component {
 
     this.timer = null;
     this.state = {
-      textarea: '',
-      time: 5
+      textarea: ''
     };
     this.handleChange = this.handleChange.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
@@ -88,17 +87,6 @@ class ShowUser extends Component {
     return reportUser({ username, reportDescription });
   }
 
-  setNavigationTimer(navigate) {
-    if (!this.timer) {
-      this.timer = setInterval(() => {
-        if (this.state.time <= 0) {
-          navigate(`${apiLocation}/signin`);
-        }
-        this.setState({ time: this.state.time - 1 });
-      }, 1000);
-    }
-  }
-
   render() {
     const { username, isSignedIn, userFetchState, email } = this.props;
     const { pending, complete, errored } = userFetchState;
@@ -107,8 +95,6 @@ class ShowUser extends Component {
     }
 
     if ((complete || errored) && !isSignedIn) {
-      const { navigate } = this.props;
-      this.setNavigationTimer(navigate);
       return (
         <main>
           <FullWidthRow>
@@ -120,24 +106,11 @@ class ShowUser extends Component {
                 </Panel.Title>
               </Panel.Heading>
               <Panel.Body className='text-center'>
-                <Spacer />
-                <p>
-                  You will be redirected to sign in to freeCodeCamp.org
-                  automatically in {this.state.time} seconds
-                </p>
-                <p>
-                  <Button
-                    bsStyle='default'
-                    href='/signin'
-                    onClick={e => {
-                      e.preventDefault();
-                      return navigate(`${apiLocation}/signin`);
-                    }}
-                  >
-                    Or click here if you do not want to wait
-                  </Button>
-                </p>
-                <Spacer />
+                <Spacer size={2} />
+                <Col md={6} mdOffset={3} sm={8} smOffset={2} xs={12}>
+                  <Login block={true}>Click here to sign in</Login>
+                </Col>
+                <Spacer size={3} />
               </Panel.Body>
             </Panel>
           </FullWidthRow>

--- a/client/src/client-only-routes/ShowUser.js
+++ b/client/src/client-only-routes/ShowUser.js
@@ -24,6 +24,8 @@ import {
 } from '../redux';
 import { Spacer, Loader, FullWidthRow } from '../components/helpers';
 
+import './showuser.css';
+
 const propTypes = {
   email: PropTypes.string,
   isSignedIn: PropTypes.bool,

--- a/client/src/client-only-routes/ShowUser.js
+++ b/client/src/client-only-routes/ShowUser.js
@@ -59,18 +59,11 @@ class ShowUser extends Component {
   constructor(props) {
     super(props);
 
-    this.timer = null;
     this.state = {
       textarea: ''
     };
     this.handleChange = this.handleChange.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
-  }
-
-  componentWillUnmount() {
-    if (this.timer) {
-      clearInterval(this.timer);
-    }
   }
 
   handleChange(e) {

--- a/client/src/client-only-routes/showuser.css
+++ b/client/src/client-only-routes/showuser.css
@@ -1,0 +1,4 @@
+/* remove bootstrap margin*/
+.row {
+  margin: 0;
+}


### PR DESCRIPTION
This removes the auto redirect on the report user page for people that aren't signed in.

#### Before:
<img width="1128" alt="Screen Shot 2020-05-31 at 11 29 41 AM" src="https://user-images.githubusercontent.com/20648924/83357457-0bce8e80-a332-11ea-9067-3b3a023cda76.png">

#### After:
<img width="1311" alt="Screen Shot 2020-05-31 at 11 03 38 AM" src="https://user-images.githubusercontent.com/20648924/83357440-e93c7580-a331-11ea-9cfd-468c90d5ca0c.png">

There was also a tiny bit of margin on this page causing the horizontal scroll bar to show up that I removed...
![Screen Shot 2020-05-31 at 11 31 10 AM](https://user-images.githubusercontent.com/20648924/83357516-6e278f00-a332-11ea-8951-23252967a31a.png)

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
