### PR TITLE
feat(learn): add full stack certificate markdown

### DIFF
--- a/client/src/components/settings/Certification.js
+++ b/client/src/components/settings/Certification.js
@@ -472,8 +472,7 @@ export class CertificationSettings extends Component {
       is2018DataVisCert,
       isApisMicroservicesCert,
       isFrontEndLibsCert,
-      is2020QaCert,
-      is2020InfosecCert,
+      isInfosecQaCert,
       isJsAlgoDataStructCert,
       isRespWebDesignCert
     } = this.props;
@@ -482,8 +481,7 @@ export class CertificationSettings extends Component {
       is2018DataVisCert &&
       isApisMicroservicesCert &&
       isFrontEndLibsCert &&
-      is2020QaCert &&
-      is2020InfosecCert &&
+      isInfosecQaCert &&
       isJsAlgoDataStructCert &&
       isRespWebDesignCert;
 
@@ -509,11 +507,11 @@ export class CertificationSettings extends Component {
     return (
       <FullWidthRow key={superBlock}>
         <Spacer />
-        <h3>Full Stack Certification</h3>
+        <h3>Legacy Full Stack Certification</h3>
         <div>
           <p>
             Once you've earned the following freeCodeCamp certifications, you'll
-            be able to claim The Full Stack Developer Certification:
+            be able to claim the Legacy Full Stack Developer Certification:
           </p>
           <ul>
             <li>Responsive Web Design</li>
@@ -521,7 +519,7 @@ export class CertificationSettings extends Component {
             <li>Front End Libraries</li>
             <li>Data Visualization</li>
             <li>APIs and Microservices</li>
-            <li>Quality Assurance</li>
+            <li>Legacy Information Security and Quality Assurance</li>
           </ul>
         </div>
 

--- a/curriculum/challenges/_meta/full-stack-certificate/meta.json
+++ b/curriculum/challenges/_meta/full-stack-certificate/meta.json
@@ -1,0 +1,18 @@
+{
+  "name": "Full Stack Certificate",
+  "dashedName": "full-stack-certificate",
+  "order": 5,
+  "time": "",
+  "template": "",
+  "required": [],
+  "superBlock": "certificates",
+  "superOrder": 12,
+  "challengeOrder": [
+    [
+      "561add10cb82ac38a17213bd",
+      "Full Stack Certificate"
+    ]
+  ],
+  "isPrivate": true,
+  "fileName": "12-certificates/full-stack-certificate.json"
+}

--- a/curriculum/challenges/english/12-certificates/full-stack-certificate/full-stack-certificate.english.md
+++ b/curriculum/challenges/english/12-certificates/full-stack-certificate/full-stack-certificate.english.md
@@ -1,0 +1,53 @@
+---
+id: 561add10cb82ac38a17213bd
+title: Full Stack Certificate
+challengeType: 7
+isHidden: false
+isPrivate: true
+---
+
+## Description
+<section id='description'>
+
+</section>
+
+## Instructions
+<section id='instructions'>
+
+</section>
+
+## Tests
+<section id='tests'>
+
+```yml
+tests:
+  - id: 561add10cb82ac38a17513bc
+    title: Responsive Web Design Certificate
+  - id: 561abd10cb81ac38a17513bc
+    title: JavaScript Algorithms and Data Structures Certificate
+  - id: 561acd10cb82ac38a17513bc
+    title: Front End Libraries Certificate
+  - id: 5a553ca864b52e1d8bceea14
+    title: Data Visualization Certificate
+  - id: 561add10cb82ac38a17523bc
+    title: API's and Microservices Certificate
+  - id: 561add10cb82ac38a17213bc
+    title: Legacy Information Security and Quality Assurance Certificate
+
+```
+
+</section>
+
+## Challenge Seed
+<section id='challengeSeed'>
+
+</section>
+
+## Solution
+<section id='solution'>
+
+```js
+// solution required
+```
+
+</section>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #18128 
Closes #39002
Closes #38920

Also partially addresses https://github.com/freeCodeCamp/freeCodeCamp/issues/38934.

<!-- Feel free to add any additional description of changes below this line -->

Currently this just adds a full stack certification markdown file and makes it so the front 3, data viz, API and microservices, and new QA certification all you need to claim it. This doesn't rename the certification to "Legacy Full Stack Certification" yet.

@ahmadabdolsaheb and I were discussing whether this legacy full stack cert should require the new QA certification mentioned in https://github.com/freeCodeCamp/freeCodeCamp/issues/38934#issuecomment-636374471, or the Legacy Information Security and Quality Assurance certification (isInfosecQaCert in the db).
