### PR TITLE
fix(client): sync Redux store and DB

### DIFF
--- a/api-server/server/boot/certificate.js
+++ b/api-server/server/boot/certificate.js
@@ -370,7 +370,11 @@ function createVerifyCert(certTypeIds, app) {
             type: message.includes('Congratulations') ? 'success' : 'info',
             message
           },
-          isCertMap: getUserIsCertMap(user)
+          isCertMap: getUserIsCertMap(user),
+          // send back the completed challenges
+          // NOTE: we could just send back the latest challenge, but this
+          // ensures the challenges are synced.
+          completedChallenges: user.completedChallenges
         });
       }, next);
   };

--- a/client/src/redux/index.js
+++ b/client/src/redux/index.js
@@ -482,12 +482,10 @@ export const reducer = handleActions(
         error: payload
       }
     }),
-    [types.submitComplete]: (state, { payload: { id, challArray } }) => {
-      // TODO: possibly more of the payload (files?) should be added
-      // to the completedChallenges array.
-      let submittedchallenges = [{ id, completedDate: Date.now() }];
-      if (challArray) {
-        submittedchallenges = challArray;
+    [types.submitComplete]: (state, { payload }) => {
+      let submittedchallenges = [{ ...payload, completedDate: Date.now() }];
+      if (payload.challArray) {
+        submittedchallenges = payload.challArray;
       }
       const { appUsername } = state;
       return {

--- a/client/src/redux/settings/settings-sagas.js
+++ b/client/src/redux/settings/settings-sagas.js
@@ -79,9 +79,14 @@ function* validateUsernameSaga({ payload }) {
 function* verifyCertificationSaga({ payload }) {
   try {
     const {
-      data: { response, isCertMap }
+      data: { response, isCertMap, completedChallenges }
     } = yield call(putVerifyCert, payload);
-    yield put(verifyCertComplete({ ...response, payload: isCertMap }));
+    yield put(
+      verifyCertComplete({
+        ...response,
+        payload: { ...isCertMap, completedChallenges }
+      })
+    );
     yield put(createFlashMessage(response));
   } catch (e) {
     yield put(verifyCertError(e));


### PR DESCRIPTION
The user's completed challenges were not getting updated after claiming a cert (which is stored as a type of challenge) and so did not appear on the timeline.

Various properties (including, crucially, `solution`) returned after successful submission were not being added to `completedChallenges` and so the settings page was rendering incorrectly.

Closes #38984