### PR TITLE
fix(learn): revert infosec qa cert slug

### DIFF
--- a/api-server/common/utils/legacyProjectData.js
+++ b/api-server/common/utils/legacyProjectData.js
@@ -80,6 +80,8 @@ const legacyDataVisProjects = {
 };
 
 const legacyInfosecQaProjects = {
+  // Keep the settings page "Show Certification" button
+  // pointing to information-security-and-quality-assurance
   challenges: [
     // metric-imperial-converter
     '587d8249367417b2b2512c41',
@@ -93,7 +95,7 @@ const legacyInfosecQaProjects = {
     '587d824a367417b2b2512c45'
   ],
   title: 'Legacy Information Security and Quality Assurance Projects',
-  superBlock: 'legacy-information-security-and-quality-assurance'
+  superBlock: 'information-security-and-quality-assurance'
 };
 
 const legacyProjects = [

--- a/api-server/server/utils/superBlockCertTypeMap.js
+++ b/api-server/server/utils/superBlockCertTypeMap.js
@@ -5,7 +5,8 @@ const superBlockCertTypeMap = {
   'legacy-front-end': certTypes.frontEnd,
   'legacy-back-end': certTypes.backEnd,
   'legacy-data-visualization': certTypes.dataVis,
-  'legacy-information-security-and-quality-assurance': certTypes.infosecQa,
+  // Keep this slug as information-security-and-quality-assurance
+  'information-security-and-quality-assurance': certTypes.infosecQa,
 
   // modern
   'responsive-web-design': certTypes.respWebDesign,

--- a/client/src/redux/index.js
+++ b/client/src/redux/index.js
@@ -314,7 +314,9 @@ export const certificatesByNameSelector = username => state => {
       {
         show: isInfosecQaCert,
         title: 'Information Security and Quality Assurance Certification',
-        showURL: 'legacy-information-security-and-quality-assurance'
+        // Keep the public profile cert slug as
+        // information-security-and-quality-assurance
+        showURL: 'information-security-and-quality-assurance'
       }
     ]
   };

--- a/client/src/resources/certProjectMap.js
+++ b/client/src/resources/certProjectMap.js
@@ -209,35 +209,36 @@ export const legacyProjectMap = {
     }
   ],
   'Legacy Information Security and Quality Assurance': [
+    // Keep this as information-security-and-quality-assurance
     {
       id: '587d8249367417b2b2512c41',
       title: 'Metric-Imperial Converter',
       link: `${legacyInfosecQaBase}/metric-imperial-converter`,
-      superBlock: 'legacy-information-security-and-quality-assurance'
+      superBlock: 'information-security-and-quality-assurance'
     },
     {
       id: '587d8249367417b2b2512c42',
       title: 'Issue Tracker',
       link: `${legacyInfosecQaBase}/issue-tracker`,
-      superBlock: 'legacy-information-security-and-quality-assurance'
+      superBlock: 'information-security-and-quality-assurance'
     },
     {
       id: '587d824a367417b2b2512c43',
       title: 'Personal Library',
       link: `${legacyInfosecQaBase}/personal-library`,
-      superBlock: 'legacy-information-security-and-quality-assurance'
+      superBlock: 'information-security-and-quality-assurance'
     },
     {
       id: '587d824a367417b2b2512c44',
       title: 'Stock Price Checker',
       link: `${legacyInfosecQaBase}/stock-price-checker`,
-      superBlock: 'legacy-information-security-and-quality-assurance'
+      superBlock: 'information-security-and-quality-assurance'
     },
     {
       id: '587d824a367417b2b2512c45',
       title: 'Anonymous Message Board',
       link: `${legacyInfosecQaBase}/anonymous-message-board`,
-      superBlock: 'legacy-information-security-and-quality-assurance'
+      superBlock: 'information-security-and-quality-assurance'
     }
   ]
 };

--- a/client/utils/validCertNames.js
+++ b/client/utils/validCertNames.js
@@ -13,5 +13,7 @@ export default [
   'legacy-front-end',
   'legacy-back-end',
   'legacy-data-visualization',
-  'legacy-information-security-and-quality-assurance'
+  // Keep this slug as information-security-and-quality-assurance
+  // so we don't break existing links
+  'information-security-and-quality-assurance'
 ];

--- a/tools/scripts/build/__snapshots__/create-redirects.test.js.snap
+++ b/tools/scripts/build/__snapshots__/create-redirects.test.js.snap
@@ -43,7 +43,6 @@ https://freecodecamp-org.netlify.com/*        https://www.freecodecamp.org/:spla
 /:username/front-end-certification                     /certification/:username/legacy-front-end 301
 /:username/data-visualization-certification            /certification/:username/legacy-data-visualization 301
 /:username/back-end-certification                      /certification/:username/legacy-back-end 301
-/:username/information-security-and-quality-assurance  /certification/:username/legacy-information-security-and-quality-assurance 301
 /:username/full-stack-certification                    /certification/:username/full-stack 301
 
 # unsubscribe redirects

--- a/tools/scripts/build/create-redirects.js
+++ b/tools/scripts/build/create-redirects.js
@@ -64,7 +64,6 @@ https://freecodecamp-org.netlify.com/*        https://www.freecodecamp.org/:spla
 /:username/front-end-certification                     /certification/:username/legacy-front-end 301
 /:username/data-visualization-certification            /certification/:username/legacy-data-visualization 301
 /:username/back-end-certification                      /certification/:username/legacy-back-end 301
-/:username/information-security-and-quality-assurance  /certification/:username/legacy-information-security-and-quality-assurance 301
 /:username/full-stack-certification                    /certification/:username/full-stack 301
 
 # unsubscribe redirects

--- a/utils/index.js
+++ b/utils/index.js
@@ -23,8 +23,20 @@ const idToTitle = new Map(
 
 const idToPath = new Map();
 
+// Keep the timeline slugs the same
+// so we don't break existing links
+const specialPaths = {
+  'Legacy Full Stack': 'Full Stack',
+  'Legacy Information Security and Quality Assurance':
+    'Information Security and Quality Assurance'
+};
+
 for (const [id, title] of idToTitle) {
-  idToPath.set(id, dasherize(title));
+  if (specialPaths[title]) {
+    idToPath.set(id, dasherize(specialPaths[title]));
+  } else {
+    idToPath.set(id, dasherize(title));
+  }
 }
 
 export const getCertIds = () => idToPath.keys();


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Related to https://github.com/freeCodeCamp/freeCodeCamp/pull/39026, this PR reverts the `legacy-information-security-and-quality-assurance` certification slug to `information-security-and-quality-assurance` so we don't have to handle the redirects seperately.

Will refactor/rewrite comments once https://github.com/freeCodeCamp/freeCodeCamp/pull/39026 so they're not so repetitive.