### PR TITLE
fix(learn): added 1 test for headline with h2 challenge

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/headline-with-the-h2-element.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/headline-with-the-h2-element.english.md
@@ -32,6 +32,8 @@ tests:
     testString: assert.isTrue((/cat(\s)?photo(\s)?app/gi).test($("h2").text()));
   - text: Your <code>h1</code> element should have the text "Hello World".
     testString: assert.isTrue((/hello(\s)+world/gi).test($("h1").text()));
+  - text: Your <code>h1</code> element should be before your <code>h2</code> element.
+    testString: assert(code.match(/<h1>\s*?.*?\s*?<\/h1>\s*<h2>\s*?.*?\s*?<\/h2>/gi));
 
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
I have tested this on a local copy of the site running on my computer.
My fix adds 1 test to the "headline with the h2 element english" challenge.
It tests that h1 is before h2.

https://www.freecodecamp.org/learn/responsive-web-design/basic-html-and-html5/headline-with-the-h2-element
