### PR TITLE
fix(learn): update Write Arrow Functions with Parameters tests

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/write-arrow-functions-with-parameters.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/write-arrow-functions-with-parameters.english.md
@@ -48,7 +48,7 @@ tests:
   - text: <code>myConcat</code> should be a function.
     testString: assert(typeof myConcat === 'function');
   - text: <code>myConcat()</code> should return <code>[1, 2, 3, 4, 5]</code>.
-    testString: assert(() => { const a = myConcat([1], [2]); return a[0] == 1 && a[1] == 2; });
+    testString: assert.deepEqual(myConcat([1, 2], [3, 4, 5]), [1, 2, 3, 4, 5]);
   - text: <code>function</code> keyword should not be used.
     testString: getUserInput => assert(!getUserInput('index').match(/function/g));
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/write-arrow-functions-with-parameters.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/write-arrow-functions-with-parameters.english.md
@@ -45,8 +45,8 @@ tests:
     testString: getUserInput => assert(!getUserInput('index').match(/var/g));
   - text: <code>myConcat</code> should be a constant variable (by using <code>const</code>).
     testString: getUserInput => assert(getUserInput('index').match(/const\s+myConcat/g));
-  - text: <code>myConcat</code> should be a function.
-    testString: assert(typeof myConcat === 'function');
+  - text: <code>myConcat</code> should be an arrow function with two parameters
+    testString: assert(/myConcat=\(\w+,\w+\)=>/.test(code.replace(/\s/g, '')) && typeof myConcat === 'function');
   - text: <code>myConcat()</code> should return <code>[1, 2, 3, 4, 5]</code>.
     testString: assert.deepEqual(myConcat([1, 2], [3, 4, 5]), [1, 2, 3, 4, 5]);
   - text: <code>function</code> keyword should not be used.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #39049

<!-- Feel free to add any additional description of changes below this line -->

**Before:**

The lesson on page will allow the user to pass the test using the following answer;
```
const myConcat = (arr1, arr2) => arr1.push(arr2);
console.log(myConcat([1, 2], [3, 4, 5]));
```

And the console below displays "3"
Further testing reveals it will also pass with the following code;
```
const myConcat = () => {};
console.log(3);
```

**After:**

It won't pass something like this now:

```
const myConcat = () => {};
console.log(3);
```

or this:

` #const myConcat = eval("(func"+"tion(){})");`
