### PR TITLE
fix(client): ensure dom ready before testing

### DIFF
--- a/client/src/client/frame-runner.js
+++ b/client/src/client/frame-runner.js
@@ -59,8 +59,22 @@ async function initTestFrame(e = {}) {
       // eval test string to actual JavaScript
       // This return can be a function
       // i.e. function() { assert(true, 'happy coding'); }
-      // eslint-disable-next-line no-eval
-      const test = eval(testString);
+      const testPromise = new Promise((resolve, reject) =>
+        // To avoid race conditions, we have to run the test in a final
+        // document ready:
+        $(() => {
+          try {
+            // eslint-disable-next-line no-eval
+            const test = eval(testString);
+            resolve({ test });
+          } catch (err) {
+            reject({ err });
+          }
+        })
+      );
+      const { test, err } = await testPromise;
+      if (err) throw err;
+
       if (typeof test === 'function') {
         await test(e.getUserInput);
       }


### PR DESCRIPTION
jQuery challenges can fail seemingly at random. These changes should prevent the race condition between a user's $( document ).ready() and test evalution.

This is difficult to test locally.  If the problem is the race condition, then in development that race is always won by the DOM as demonstrated by @lasjorg, https://github.com/freeCodeCamp/freeCodeCamp/issues/38980#issuecomment-643718025.  To be sure it's fixed, it will need testing on .dev.  

Should close #38980