### PR TITLE
fix(api): csurf to SameSite 'strict', https only

### DIFF
--- a/api-server/server/middlewares/csurf.js
+++ b/api-server/server/middlewares/csurf.js
@@ -3,7 +3,9 @@ import csurf from 'csurf';
 export default function() {
   const protection = csurf({
     cookie: {
-      domain: process.env.COOKIE_DOMAIN || 'localhost'
+      domain: process.env.COOKIE_DOMAIN || 'localhost',
+      sameSite: 'strict',
+      secure: true
     }
   });
   return function csrf(req, res, next) {


### PR DESCRIPTION
Lax and http are probably sufficient, but if the stricter versions work there's no harm using them.

I was not sure how properly test this locally, so this might be another we need to push to staging to check.