### PR TITLE
feat: add python syntax highlighting

### DIFF
--- a/client/.babelrc
+++ b/client/.babelrc
@@ -37,16 +37,34 @@
         "regenerator": true
       }
     ],
-    ["babel-plugin-transform-imports", {
+    [
+      "babel-plugin-transform-imports",
+      {
         "react-bootstrap": {
-            "transform": "react-bootstrap/lib/${member}",
-            "preventFullImport": true
+          "transform": "react-bootstrap/lib/${member}",
+          "preventFullImport": true
         },
         "lodash": {
-            "transform": "lodash/${member}",
-            "preventFullImport": true
+          "transform": "lodash/${member}",
+          "preventFullImport": true
         }
-    }
+      }
+    ],
+    [
+      "prismjs",
+      {
+        "languages": [
+          "clike",
+          "css",
+          "html",
+          "javascript",
+          "markup",
+          "mathml",
+          "python",
+          "svg",
+          "xml"
+        ], "theme": "default", "css": true
+      }
     ]
   ]
 }

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3521,6 +3521,11 @@
         "resolve": "^1.12.0"
       }
     },
+    "babel-plugin-prismjs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-prismjs/-/babel-plugin-prismjs-2.0.1.tgz",
+      "integrity": "sha512-GqQGa3xX3Z2ft97oDbGvEFoxD8nKqb3ZVszrOc5H7icnEUA56BIjVYm86hfZZA82uuHLwTIfCXbEKzKG1BzKzg=="
+    },
     "babel-plugin-remove-graphql-queries": {
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.9.1.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -20,6 +20,7 @@
     "@reach/router": "^1.2.1",
     "algoliasearch": "^3.35.1",
     "axios": "^0.19.0",
+    "babel-plugin-prismjs": "^2.0.1",
     "bezier-easing": "^2.1.0",
     "browser-cookies": "^1.2.0",
     "chai": "^4.2.0",

--- a/client/src/components/layouts/Learn.js
+++ b/client/src/components/layouts/Learn.js
@@ -13,7 +13,6 @@ import {
 import createRedirect from '../../components/createRedirect';
 import DonateModal from '../Donation/DonationModal';
 
-import 'prismjs/themes/prism.css';
 import './prism.css';
 import './prism-night.css';
 import 'react-reflex/styles.css';


### PR DESCRIPTION
To err on the side of caution, this explicitly includes all languages that were implicitly included before using the Babel plugin.

This is just the Python part of https://github.com/freeCodeCamp/freeCodeCamp/pull/38730/.  The rest could take some time to complete, but the Python highlighting can be enabled independently.

Answer with highlighting:

![PythonAnswerHigh](https://user-images.githubusercontent.com/15801806/84780676-22d5d780-afe6-11ea-8400-26725b159624.png)
without:
![PythonAnswersBefore](https://user-images.githubusercontent.com/15801806/84780682-236e6e00-afe6-11ea-9308-5a644a84bc5d.png)
Description with highlighting:
![PythonDescBefore](https://user-images.githubusercontent.com/15801806/84780685-24070480-afe6-11ea-919e-08c0597d2fb8.png)
without
![PythonDescriptionHigh](https://user-images.githubusercontent.com/15801806/84780686-24070480-afe6-11ea-8932-cbdc7cdeba2d.png)

and nightmode:

![PyAnsNight](https://user-images.githubusercontent.com/15801806/84781113-b60f0d00-afe6-11ea-9df0-9f52e333f407.png)
![PyDescNight](https://user-images.githubusercontent.com/15801806/84781116-b6a7a380-afe6-11ea-94c9-8865a3ad0501.png)
