### PR TITLE
fix(curriculum) - Fixed regex parser for detecting h2 element

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/import-a-google-font.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/import-a-google-font.english.md
@@ -34,7 +34,7 @@ tests:
   - text: Your <code>h2</code> element should use the font <code>Lobster</code>.
     testString: assert($("h2").css("font-family").match(/lobster/i));
   - text: You should use an <code>h2</code> CSS selector to change the font.
-    testString: assert(/\s*h2\s*\{\s*font-family\:\s*(\"|"|\')?Lobster(\"|"|\')?(.{0,})\s*;\s*\}/gi.test(code));
+    testString: assert(/\s*h2\s*\{\s*font-family\:\s*(['"])?Lobster\1\s*;\s*\}/gi.test(code));
   - text: Your <code>p</code> element should still use the font <code>monospace</code>.
     testString: assert($("p").css("font-family").match(/monospace/i));
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/import-a-google-font.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/import-a-google-font.english.md
@@ -34,7 +34,7 @@ tests:
   - text: Your <code>h2</code> element should use the font <code>Lobster</code>.
     testString: assert($("h2").css("font-family").match(/lobster/i));
   - text: You should use an <code>h2</code> CSS selector to change the font.
-    testString: 'assert(/\s*h2\s*\{\s*font-family\:\s*(\"|")?Lobster(\"|")?(.{0,})\s*;\s*\}/gi.test(code));'
+    testString: assert(/\s*h2\s*\{\s*font-family\:\s*(\"|"|\')?Lobster(\"|"|\')?(.{0,})\s*;\s*\}/gi.test(code));
   - text: Your <code>p</code> element should still use the font <code>monospace</code>.
     testString: assert($("p").css("font-family").match(/monospace/i));
 


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

Closes #38932

<!-- Feel free to add any additional description of changes below this line -->
Before:
Couldn't parse the h2 CSS selector because of an incorrect regex parser

After:
Can parse h2 selector correctly and also allows single and double quotes or without quotes for Lobster font