### PR TITLE
fix: style for video answers

### DIFF
--- a/client/src/components/layouts/prism-night.css
+++ b/client/src/components/layouts/prism-night.css
@@ -39,6 +39,13 @@
   overflow: auto;
 }
 
+/* Without this, the above selector takes precedence and messes up the answer
+padding in night mode */
+.night .video-quiz-option > pre {
+  padding: 0;
+  margin: 0;
+}
+
 .night :not(pre) > code[class*='language-'],
 .night pre[class*='language-'] {
   background: var(--primary-background);

--- a/client/src/templates/Challenges/video/show.css
+++ b/client/src/templates/Challenges/video/show.css
@@ -24,9 +24,10 @@
   background-color: var(--primary-background);
 }
 
-/* remove bootstrap margin here */
+/* remove bootstrap margin and center the radio buttons */
 .video-quiz-options > label {
   margin: 0;
+  align-items: center;
 }
 
 .video-quiz-option-label {
@@ -89,4 +90,6 @@
 .video-quiz-option > pre {
   padding: 0;
   margin: 0;
+  /* remove default prism background */
+  background: none;
 }


### PR DESCRIPTION
Vertically centers the radio buttons.
Fixes answer backgrounds.
Corrects answer padding on night mode. (see the comment in prism-night.css)