### PR TITLE
fix(api): csrf over http in development

### DIFF
--- a/api-server/server/middlewares/csurf.js
+++ b/api-server/server/middlewares/csurf.js
@@ -5,7 +5,7 @@ export default function() {
     cookie: {
       domain: process.env.COOKIE_DOMAIN || 'localhost',
       sameSite: 'strict',
-      secure: true
+      secure: process.env.FREECODECAMP_NODE_ENV === 'production'
     }
   });
   return function csrf(req, res, next) {


### PR DESCRIPTION
With the `secure` requirement, the local site was failing the csrf checks because it could not get a cookie.