### PR TITLE
fix: tests for use a retina image challenge

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/responsive-web-design-principles/use-a-retina-image-for-higher-resolution-displays.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/responsive-web-design-principles/use-a-retina-image-for-higher-resolution-displays.english.md
@@ -34,9 +34,9 @@ Set the <code>width</code> and <code>height</code> of the <code>img</code> tag t
 ```yml
 tests:
   - text: Your <code>img</code> tag should have a <code>width</code> of 100 pixels.
-    testString: assert($('img').css('width') == '100px');
+    testString: assert(document.querySelector('img').width === 100);
   - text: Your <code>img</code> tag should have a <code>height</code> of 100 pixels.
-    testString: assert($('img').css('height') == '100px');
+    testString: assert(document.querySelector('img').height === 100);
 
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

We've gotten a couple of reports about this challenge in the support email. On my machine (Linux Mint 19.3), the current tests fail in Chrome (83.0.4103.116), but pass in Firefox (77.0.1). 

In Chrome's dev console, the height and width of the image are both 99.986px rather than 100px, even after playing with the zoom. These changes look at the actual width and height attributes of the image, and should still allow for answers like `max-width: 100px;`.
