### PR TITLE
docs: Update "Responsive Web Design" Github link

### DIFF
--- a/client/src/pages/learn/responsive-web-design/index.md
+++ b/client/src/pages/learn/responsive-web-design/index.md
@@ -6,5 +6,5 @@ superBlock: Responsive Web Design
 
 This introduction is a stub
 
-Help us make it real on [GitHub](https://github.com/freeCodeCamp/learn/tree/master/src/introductions).
+Help us make it real on [GitHub](https://github.com/freeCodeCamp/freeCodeCamp/edit/master/client/src/pages/learn/responsive-web-design/index.md).
  


### PR DESCRIPTION
Current link leads to a 404 page in the old "learn" repository

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->



<!-- Feel free to add any additional description of changes below this line -->

BTW, I believe that this doc should contains an explanation about Responsive Web Design along links to the child sections e.g. `basic-html-and-html5`, `basic-css` etc. (Just like `basic-html-and-html5` has a list of children at https://www.freecodecamp.org/learn/responsive-web-design/basic-css/). I'm not a content writer so I can't help with writing content for that page, but is it ok to add, at least the list of links?

Thanks.