### PR TITLE
Use native GitHub Sponsors functionality

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-custom: https://www.freecodecamp.org/donate
+github: freecodecamp


### PR DESCRIPTION
This seems to be all we need to do [based on GitHub's documentation](https://help.github.com/en/github/administering-a-repository/displaying-a-sponsor-button-in-your-repository#about-funding-files).

