### PR TITLE
render code as-is from user panel

### DIFF
--- a/client/src/templates/Challenges/rechallenge/builders.js
+++ b/client/src/templates/Challenges/rechallenge/builders.js
@@ -18,11 +18,10 @@ const htmlCatch = '\n<!--fcc-->\n';
 const jsCatch = '\n;/*fcc*/\n';
 
 const defaultTemplate = ({ source }) => `
-  <body id='display-body'style='margin:8px;'>
-    <!-- fcc-start-source -->
-      ${source}
-    <!-- fcc-end-source -->
-  </body>`;
+<!DOCTYPE html>
+<html>
+  ${source}
+</html>`;
 
 const wrapInScript = partial(
   transformContents,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Right now, the code is stripped of the `<head>` and `<body>` tags and something like this happens:
![image](https://user-images.githubusercontent.com/34807532/85945934-92d94b80-b95e-11ea-8be1-6144d9467d64.png)

The change being made would send the tags within the `<head>` to the `<head>` of the `iframe` and likewise for the body.

<!-- Feel free to add any additional description of changes below this line -->
Edit: I didn't run the tests on the curriculum, because as far as I understand, some challenges will need tests to be rewritten