### PR TITLE
feat (learn): Remove editable regions from seed code before displaying user's code

### DIFF
--- a/curriculum/schema/challengeSchema.js
+++ b/curriculum/schema/challengeSchema.js
@@ -3,6 +3,15 @@ Joi.objectId = require('joi-objectid')(Joi);
 
 const { challengeTypes } = require('../../client/utils/challengeTypes');
 
+const fileJoi = Joi.object().keys({
+  key: Joi.string(),
+  ext: Joi.string(),
+  name: Joi.string(),
+  head: [Joi.array().items(Joi.string().allow('')), Joi.string().allow('')],
+  tail: [Joi.array().items(Joi.string().allow('')), Joi.string().allow('')],
+  contents: [Joi.array().items(Joi.string().allow('')), Joi.string().allow('')]
+});
+
 function getSchemaForLang(lang) {
   let schema = Joi.object().keys({
     block: Joi.string(),
@@ -20,25 +29,7 @@ function getSchemaForLang(lang) {
       otherwise: Joi.string().required()
     }),
     fileName: Joi.string(),
-    files: Joi.array().items(
-      Joi.object().keys({
-        key: Joi.string(),
-        ext: Joi.string(),
-        name: Joi.string(),
-        head: [
-          Joi.array().items(Joi.string().allow('')),
-          Joi.string().allow('')
-        ],
-        tail: [
-          Joi.array().items(Joi.string().allow('')),
-          Joi.string().allow('')
-        ],
-        contents: [
-          Joi.array().items(Joi.string().allow('')),
-          Joi.string().allow('')
-        ]
-      })
-    ),
+    files: Joi.array().items(fileJoi),
     guideUrl: Joi.string().uri({ scheme: 'https' }),
     videoUrl: Joi.string().allow(''),
     forumTopicId: Joi.number(),
@@ -73,6 +64,7 @@ function getSchemaForLang(lang) {
       })
     ),
     solutions: Joi.array().items(Joi.string().optional()),
+    solutionFiles: Joi.array().items(fileJoi),
     superBlock: Joi.string(),
     superOrder: Joi.number(),
     suborder: Joi.number(),

--- a/curriculum/schema/challengeSchema.js
+++ b/curriculum/schema/challengeSchema.js
@@ -9,7 +9,8 @@ const fileJoi = Joi.object().keys({
   name: Joi.string(),
   head: [Joi.array().items(Joi.string().allow('')), Joi.string().allow('')],
   tail: [Joi.array().items(Joi.string().allow('')), Joi.string().allow('')],
-  contents: [Joi.array().items(Joi.string().allow('')), Joi.string().allow('')]
+  contents: [Joi.array().items(Joi.string().allow('')), Joi.string().allow('')],
+  editableRegionBoundaries: [Joi.array().items(Joi.string().allow(''))]
 });
 
 function getSchemaForLang(lang) {

--- a/tools/challenge-md-parser/__snapshots__/challengeSeed-to-data.test.js.snap
+++ b/tools/challenge-md-parser/__snapshots__/challengeSeed-to-data.test.js.snap
@@ -10,6 +10,7 @@ Object {
 
 testFunction('hello');
 ",
+      "editableRegionBoundaries": Array [],
       "ext": "js",
       "head": "console.log('before the test');
 ",

--- a/tools/challenge-md-parser/challengeSeed-to-data.js
+++ b/tools/challenge-md-parser/challengeSeed-to-data.js
@@ -43,20 +43,15 @@ function createCodeGetter(key, regEx, seeds) {
 // TODO: any reason to worry about CRLF?
 
 function findRegionMarkers(file) {
-  // console.log('FILE', file);
   const lines = file.contents.split('\n');
-  // console.log('LINES', lines);
   const editableLines = lines
     .map((line, id) => (line.trim() === editableRegionMarker ? id : -1))
     .filter(id => id >= 0);
-
-  // console.log('editable lines', editableLines);
 
   if (editableLines.length > 2) {
     throw Error('Editable region has too many markers' + editableLines);
   }
 
-  // TODO: clean up the logic / presentation of said logic
   if (editableLines.length === 0) {
     return null;
   } else if (editableLines.length === 1) {

--- a/tools/challenge-md-parser/challengeSeed-to-data.js
+++ b/tools/challenge-md-parser/challengeSeed-to-data.js
@@ -45,7 +45,7 @@ function createCodeGetter(key, regEx, seeds) {
 function findRegionMarkers(file) {
   // console.log('FILE', file);
   const lines = file.contents.split('\n');
-  console.log('LINES', lines);
+  // console.log('LINES', lines);
   const editableLines = lines
     .map((line, id) => (line.trim() === editableRegionMarker ? id : -1))
     .filter(id => id >= 0);

--- a/tools/challenge-md-parser/challengeSeed-to-data.test.js
+++ b/tools/challenge-md-parser/challengeSeed-to-data.test.js
@@ -1,6 +1,7 @@
 /* global describe it expect beforeEach */
 const mockAST = require('./fixtures/challenge-html-ast.json');
 const challengeSeedToData = require('./challengeSeed-to-data');
+const isArray = require('lodash/isArray');
 
 describe('challengeSeed-to-data plugin', () => {
   const plugin = challengeSeedToData();
@@ -25,31 +26,27 @@ describe('challengeSeed-to-data plugin', () => {
   });
 
   it('adds test objects to the files array following a schema', () => {
-    expect.assertions(7);
+    expect.assertions(15);
     plugin(mockAST, file);
     const {
       data: { files }
     } = file;
     const testObject = files[0];
-    expect(Object.keys(testObject).length).toEqual(6);
+    expect(Object.keys(testObject).length).toEqual(7);
     expect(testObject).toHaveProperty('key');
+    expect(typeof testObject['key']).toBe('string');
     expect(testObject).toHaveProperty('ext');
+    expect(typeof testObject['ext']).toBe('string');
     expect(testObject).toHaveProperty('name');
+    expect(typeof testObject['name']).toBe('string');
     expect(testObject).toHaveProperty('contents');
+    expect(typeof testObject['contents']).toBe('string');
     expect(testObject).toHaveProperty('head');
+    expect(typeof testObject['head']).toBe('string');
     expect(testObject).toHaveProperty('tail');
-  });
-
-  it('only adds strings to the `files` object type', () => {
-    expect.assertions(6);
-    plugin(mockAST, file);
-    const {
-      data: { files }
-    } = file;
-    const testObject = files[0];
-    Object.keys(testObject)
-      .map(key => testObject[key])
-      .forEach(value => expect(typeof value).toEqual('string'));
+    expect(typeof testObject['tail']).toBe('string');
+    expect(testObject).toHaveProperty('editableRegionBoundaries');
+    expect(isArray(testObject['editableRegionBoundaries'])).toBe(true);
   });
 
   it('should have an output to match the snapshot', () => {


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

Kris,

This PR implements functionality which is a part of @ojeytonwilliams' [current work](https://github.com/ojeytonwilliams/freeCodeCamp/tree/feat/multifile-line-decoration) on the editable region sections.  Merging this into `next-curriculum` will allow us to go ahead and start using the `--fcc-editable-region--` markers in the seed code.  When the tests run, the markers are dynamically removed as if they were never present tin the seed code.

Once this PR and # are merged into `next-curriculum` we can then merge or rebase the changes (@raisedadead which do you recommend?), so we can immediately take advantage of only using the next step's seed code for the current step's solution and be ready to define the editable regions in our next pair session. 
