### PR TITLE
fix: replace . with - in slugs

### DIFF
--- a/utils/slugs.js
+++ b/utils/slugs.js
@@ -2,7 +2,7 @@ exports.dasherize = function dasherize(name) {
   return ('' + name)
     .toLowerCase()
     .trim()
-    .replace(/\s/g, '-')
+    .replace(/\s|\./g, '-')
     .replace(/[^a-z\d\-.]/g, '');
 };
 

--- a/utils/slugs.test.js
+++ b/utils/slugs.test.js
@@ -14,12 +14,16 @@ describe('dasherize', () => {
     expect(dasherize('the space  between')).toBe('the-space--between');
   });
 
+  it('converts dots to dashes', () => {
+    expect(dasherize('the..dots.. between')).toBe('the--dots---between');
+  });
+
   it('trims off surrounding whitespace', () => {
     expect(dasherize('  the space  between    ')).toBe('the-space--between');
   });
 
-  it('removes everything except letters, numbers, - and .', () => {
-    expect(dasherize('1a!"£$%^*()_+=-.b2')).toBe('1a-.b2');
+  it('removes everything except letters, numbers and -', () => {
+    expect(dasherize('1a!"£$%^*()_+=-.b2')).toBe('1a--b2');
   });
 });
 


### PR DESCRIPTION
In principle there could be a clash if someone named a challenges `one.thing`, `one thing` and `one-thing`, but we've already had the potential for the last two to clash with no issues.