### PR TITLE
feat(client): parse test 'text' as markdown

### DIFF
--- a/client/src/templates/Challenges/components/test-suite.css
+++ b/client/src/templates/Challenges/components/test-suite.css
@@ -19,6 +19,10 @@
   padding: 5px 10px;
 }
 
+.test-output p {
+  margin: 0;
+}
+
 .test-status-icon {
   display: flex;
   align-items: center;

--- a/tools/challenge-md-parser/__snapshots__/tests-to-data.test.js.snap
+++ b/tools/challenge-md-parser/__snapshots__/tests-to-data.test.js.snap
@@ -5,7 +5,7 @@ Object {
   "tests": Array [
     Object {
       "testString": "assert.isTrue((/hello(\\\\s)+world/gi).test($('h1').text()), 'Your <code>h1</code> element should have the text \\"Hello World\\".');",
-      "text": "Your <code>h1</code> element should have the text \\"Hello World\\".",
+      "text": "<p>Your <code>h1</code> element should have the text \\"Hello World\\".</p>",
     },
   ],
 }

--- a/tools/challenge-md-parser/tests-to-data.js
+++ b/tools/challenge-md-parser/tests-to-data.js
@@ -34,6 +34,12 @@ function plugin() {
           );
           tests.question.text = mdToHTML(tests.question.text);
         }
+        if (tests.tests) {
+          tests.tests = tests.tests.map(({ text, testString }) => ({
+            text: mdToHTML(text),
+            testString
+          }));
+        }
         file.data = {
           ...file.data,
           ...tests


### PR DESCRIPTION
The parser automatically wraps the `text` in `<p>` tags, so the css needed adjusting to compensate for that.

This can generate undesirable formatting of existing test `text` if it contains elements (such as *) that can now be interpreted as markdown syntax, so this should not go into production until the existing challenges have been audited.
