### PR TITLE
feat(client): show line numbers on video questions

### DIFF
--- a/client/.babelrc
+++ b/client/.babelrc
@@ -63,7 +63,10 @@
           "python",
           "svg",
           "xml"
-        ], "theme": "default", "css": true
+        ],
+        "theme": "default",
+        "css": true,
+        "plugins": ["line-numbers"]
       }
     ]
   ]

--- a/client/src/templates/Challenges/video/Show.js
+++ b/client/src/templates/Challenges/video/Show.js
@@ -221,7 +221,7 @@ export class Project extends Component {
                   </i>
                 </div>
                 <ChallengeDescription description={description} />
-                <PrismFormatted text={text} />
+                <PrismFormatted className={'line-numbers'} text={text} />
                 <Spacer />
                 <ObserveKeys>
                   <div className='video-quiz-options'>


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/15801806/86920405-0bdc5e00-c12a-11ea-9758-5fb2a8fee1f8.png)


After: 

![image](https://user-images.githubusercontent.com/15801806/86920287-d899cf00-c129-11ea-8148-e18ef21ade19.png)

Related to https://github.com/freeCodeCamp/freeCodeCamp/pull/39189, as it removes the necessity to add in line numbers by hand.