### PR TITLE
fix(curriculum): include stack with test errors

### DIFF
--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -205,8 +205,9 @@ function cleanup() {
 }
 
 function runTests({ challengesForLang, meta }) {
+  // rethrow unhandled rejections to make sure the tests exit with -1
   process.on('unhandledRejection', err => {
-    throw new Error(`unhandledRejection: ${err.name}, ${err.message}`);
+    throw err;
   });
 
   describe('Check challenges', function() {


### PR DESCRIPTION
The way I did this initially discarded useful debugging info, so this just re-throws the error to keep the stack.

For example:
![image](https://user-images.githubusercontent.com/15801806/86941662-7bf7dd80-c144-11ea-886b-97d0f25edafe.png)
