### PR TITLE
Rectified misspelled Variable renderOnline at Line 149

### DIFF
--- a/curriculum/challenges/english/03-front-end-libraries/react/use-array.filter-to-dynamically-filter-an-array.english.md
+++ b/curriculum/challenges/english/03-front-end-libraries/react/use-array.filter-to-dynamically-filter-an-array.english.md
@@ -146,7 +146,7 @@ class MyComponent extends React.Component {
     const usersOnline = this.state.users.filter(user => {
       return user.online;
     });
-    const renderOnlineUsers = usersOnline.map(user => {
+    const renderOnline = usersOnline.map(user => {
       return (
         <li key={user.username}>{user.username}</li>
       );


### PR DESCRIPTION
At line 149 renderOnline variable was misspelled as renderOnlineUsers resulting in code unable to execute.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->