### PR TITLE
fix(learn) / title request from "Hello" to "Home page" 

### DIFF
--- a/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/use-a-template-engines-powers.english.md
+++ b/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/use-a-template-engines-powers.english.md
@@ -13,8 +13,8 @@ One of the greatest features of using a template engine is being able to pass va
 In your Pug file, you're able to use a variable by referencing the variable name as <code>#{variable_name}</code> inline with other text on an element or by using an equal sign on the element without a space such as <code>p=variable_name</code> which assigns the variable's value to the p element's text.
 We strongly recommend looking at the syntax and structure of Pug <a href='https://github.com/pugjs/pug'>here</a> on GitHub's README. Pug is all about using whitespace and tabs to show nested elements and cutting down on the amount of code needed to make a beautiful site.
 Looking at our pug file 'index.pug' included in your project, we used the variables <em>title</em> and <em>message</em>.
-To pass those along from our server, you will need to add an object as a second argument to your <em>res.render</em> with the variables and their values. For example, pass this object along setting the variables for your index view: <code>{title: 'Hello', message: 'Please login'}</code>
-It should look like: <code>res.render(process.cwd() + '/views/pug/index', {title: 'Hello', message: 'Please login'});</code>
+To pass those along from our server, you will need to add an object as a second argument to your <em>res.render</em> with the variables and their values. For example, pass this object along setting the variables for your index view: <code>{title: 'Home page', message: 'Please login'}</code>
+It should look like: <code>res.render(process.cwd() + '/views/pug/index', {title: 'Home page', message: 'Please login'});</code>
 Now refresh your page and you should see those values rendered in your view in the correct spot as laid out in your index.pug file! Submit your page when you think you've got it right.
 </section>
 


### PR DESCRIPTION
Change the text that ask for the title to be "Hello" to "Home page".
This change is necessary in order to pass the "create a new middleware" challenge test, changing this wont affect current challenge tests. Its just a simple syntax change.

https://github.com/freeCodeCamp/freeCodeCamp/issues/16967 checkout this issue to see whats its all about.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

It will probably need fixed on other languages too