### PR TITLE
fix(client): improve accuracy of offline warning

### DIFF
--- a/client/src/components/OfflineWarning/OfflineWarning.js
+++ b/client/src/components/OfflineWarning/OfflineWarning.js
@@ -11,7 +11,7 @@ const propTypes = {
 function OfflineWarning({ isOnline, isSignedIn }) {
   return !isSignedIn || isOnline ? null : (
     <div className='offline-warning'>
-      We cannot reach the server to update your progress.
+      You appear to be offline, your progress may not be being saved.
     </div>
   );
 }


### PR DESCRIPTION
The old message made it sound like there was a problem with the server, even though no attempt was being made to contact it.

Ideally we want users to check their internet connection if they see this (because that's probably the trigger).