### PR TITLE
fix(learn): updated catphotoapp links (Chinese)

### DIFF
--- a/curriculum/challenges/chinese/01-responsive-web-design/applied-visual-design/adjust-the-hover-state-of-an-anchor-tag.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/applied-visual-design/adjust-the-hover-state-of-an-anchor-tag.chinese.md
@@ -53,7 +53,7 @@ tests:
   
   
 </style>
-<a href="http://freecatphotoapp.com/" target="_blank">猫咪相册 App</a>
+<a href="https://freecatphotoapp.com/" target="_blank">猫咪相册 App</a>
 ```
 
 </div>

--- a/curriculum/challenges/chinese/01-responsive-web-design/basic-css/add-borders-around-your-elements.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/basic-css/add-borders-around-your-elements.chinese.md
@@ -98,7 +98,7 @@ tests:
     </ol>
   </div>
   
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor">室内</label>
     <label><input type="radio" name="indoor-outdoor">室外</label><br>
     <label><input type="checkbox" name="personality">忠诚</label>

--- a/curriculum/challenges/chinese/01-responsive-web-design/basic-css/add-rounded-corners-with-border-radius.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/basic-css/add-rounded-corners-with-border-radius.chinese.md
@@ -85,7 +85,7 @@ tests:
     </ol>
   </div>
   
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor">室内</label>
     <label><input type="radio" name="indoor-outdoor">室外</label><br>
     <label><input type="checkbox" name="personality">忠诚</label>

--- a/curriculum/challenges/chinese/01-responsive-web-design/basic-css/change-the-color-of-text.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/basic-css/change-the-color-of-text.chinese.md
@@ -64,7 +64,7 @@ tests:
     </ol>
   </div>
   
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor">室内</label>
     <label><input type="radio" name="indoor-outdoor">室外</label><br>
     <label><input type="checkbox" name="personality">忠诚</label>

--- a/curriculum/challenges/chinese/01-responsive-web-design/basic-css/change-the-font-size-of-an-element.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/basic-css/change-the-font-size-of-an-element.chinese.md
@@ -69,7 +69,7 @@ tests:
     </ol>
   </div>
   
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor">室内</label>
     <label><input type="radio" name="indoor-outdoor">室外</label><br>
     <label><input type="checkbox" name="personality">忠诚</label>

--- a/curriculum/challenges/chinese/01-responsive-web-design/basic-css/give-a-background-color-to-a-div-element.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/basic-css/give-a-background-color-to-a-div-element.chinese.md
@@ -95,7 +95,7 @@ tests:
     </ol>
   </div>
   
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor">室内</label>
     <label><input type="radio" name="indoor-outdoor">室外</label><br>
     <label><input type="checkbox" name="personality">忠诚</label>

--- a/curriculum/challenges/chinese/01-responsive-web-design/basic-css/import-a-google-font.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/basic-css/import-a-google-font.chinese.md
@@ -80,7 +80,7 @@ tests:
     </ol>
   </div>
   
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor">室内</label>
     <label><input type="radio" name="indoor-outdoor">室外</label><br>
     <label><input type="checkbox" name="personality">忠诚</label>

--- a/curriculum/challenges/chinese/01-responsive-web-design/basic-css/make-circular-images-with-a-border-radius.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/basic-css/make-circular-images-with-a-border-radius.chinese.md
@@ -85,7 +85,7 @@ tests:
     </ol>
   </div>
   
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor">室内</label>
     <label><input type="radio" name="indoor-outdoor">室外</label><br>
     <label><input type="checkbox" name="personality">忠诚</label>

--- a/curriculum/challenges/chinese/01-responsive-web-design/basic-css/set-the-font-family-of-an-element.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/basic-css/set-the-font-family-of-an-element.chinese.md
@@ -74,7 +74,7 @@ tests:
     </ol>
   </div>
   
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor">室内</label>
     <label><input type="radio" name="indoor-outdoor">室外</label><br>
     <label><input type="checkbox" name="personality">忠诚</label>

--- a/curriculum/challenges/chinese/01-responsive-web-design/basic-css/set-the-id-of-an-element.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/basic-css/set-the-id-of-an-element.chinese.md
@@ -91,7 +91,7 @@ tests:
     </ol>
   </div>
   
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor">室内</label>
     <label><input type="radio" name="indoor-outdoor">室外</label><br>
     <label><input type="checkbox" name="personality">忠诚</label>

--- a/curriculum/challenges/chinese/01-responsive-web-design/basic-css/size-your-images.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/basic-css/size-your-images.chinese.md
@@ -85,7 +85,7 @@ tests:
     </ol>
   </div>
   
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor">室内</label>
     <label><input type="radio" name="indoor-outdoor">室外</label><br>
     <label><input type="checkbox" name="personality">忠诚</label>

--- a/curriculum/challenges/chinese/01-responsive-web-design/basic-css/specify-how-fonts-should-degrade.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/basic-css/specify-how-fonts-should-degrade.chinese.md
@@ -90,7 +90,7 @@ tests:
     </ol>
   </div>
   
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor">室内</label>
     <label><input type="radio" name="indoor-outdoor">室外</label><br>
     <label><input type="checkbox" name="personality">忠诚</label>

--- a/curriculum/challenges/chinese/01-responsive-web-design/basic-css/style-multiple-elements-with-a-css-class.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/basic-css/style-multiple-elements-with-a-css-class.chinese.md
@@ -70,7 +70,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor">室内</label>
     <label><input type="radio" name="indoor-outdoor">室外</label><br>
     <label><input type="checkbox" name="personality">忠诚</label>

--- a/curriculum/challenges/chinese/01-responsive-web-design/basic-css/use-a-css-class-to-style-an-element.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/basic-css/use-a-css-class-to-style-an-element.chinese.md
@@ -83,7 +83,7 @@ tests:
     </ol>
   </div>
   
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor">室内</label>
     <label><input type="radio" name="indoor-outdoor">室外</label><br>
     <label><input type="checkbox" name="personality">忠诚</label>

--- a/curriculum/challenges/chinese/01-responsive-web-design/basic-css/use-an-id-attribute-to-style-an-element.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/basic-css/use-an-id-attribute-to-style-an-element.chinese.md
@@ -102,7 +102,7 @@ tests:
     </ol>
   </div>
   
-  <form action="/submit-cat-photo" id="cat-photo-form">
+  <form action="https://freecatphotoapp.com/submit-cat-photo" id="cat-photo-form">
     <label><input type="radio" name="indoor-outdoor">室内</label>
     <label><input type="radio" name="indoor-outdoor">室外</label><br>
     <label><input type="checkbox" name="personality">忠诚</label>

--- a/curriculum/challenges/chinese/01-responsive-web-design/basic-css/use-attribute-selectors-to-style-elements.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/basic-css/use-attribute-selectors-to-style-elements.chinese.md
@@ -100,7 +100,7 @@ tests:
     </ol>
   </div>
   
-  <form action="/submit-cat-photo" id="cat-photo-form">
+  <form action="https://freecatphotoapp.com/submit-cat-photo" id="cat-photo-form">
     <label><input type="radio" name="indoor-outdoor">室内</label>
     <label><input type="radio" name="indoor-outdoor">室外</label><br>
     <label><input type="checkbox" name="personality">忠诚</label>

--- a/curriculum/challenges/chinese/01-responsive-web-design/basic-css/use-css-selectors-to-style-elements.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/basic-css/use-css-selectors-to-style-elements.chinese.md
@@ -84,7 +84,7 @@ tests:
     </ol>
   </div>
   
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor">室内</label>
     <label><input type="radio" name="indoor-outdoor">室外</label><br>
     <label><input type="checkbox" name="personality">忠诚</label>

--- a/curriculum/challenges/chinese/01-responsive-web-design/basic-html-and-html5/add-a-submit-button-to-a-form.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/basic-html-and-html5/add-a-submit-button-to-a-form.chinese.md
@@ -61,7 +61,7 @@ tests:
     <li>打雷</li>
     <li>同类</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <input type="text" placeholder="猫咪图片地址">
   </form>
 </main>

--- a/curriculum/challenges/chinese/01-responsive-web-design/basic-html-and-html5/check-radio-buttons-and-checkboxes-by-default.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/basic-html-and-html5/check-radio-buttons-and-checkboxes-by-default.chinese.md
@@ -56,7 +56,7 @@ tests:
     <li>打雷</li>
     <li>同类</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor">室内</label>
     <label><input type="radio" name="indoor-outdoor">室外</label><br>
     <label><input type="checkbox" name="personality">忠诚</label>

--- a/curriculum/challenges/chinese/01-responsive-web-design/basic-html-and-html5/create-a-form-element.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/basic-html-and-html5/create-a-form-element.chinese.md
@@ -16,7 +16,7 @@ localeTitle: 创建一个表单
 
 ## Instructions
 <section id='instructions'>
-在<code>input</code>输入框外层创建一个<code>form</code>表单，然后设置表单的<code>action</code>属性为<code>"/submit-cat-photo"</code>。
+在<code>input</code>输入框外层创建一个<code>form</code>表单，然后设置表单的<code>action</code>属性为<code>"https://freecatphotoapp.com/submit-cat-photo"</code>。
 </section>
 
 ## Tests
@@ -26,8 +26,8 @@ localeTitle: 创建一个表单
 tests:
   - text: '在<code>input</code>输入框外层创建一个<code>form</code>表单。'
     testString: assert($("form") && $("form").children("input") && $("form").children("input").length > 0);
-  - text: '确保表单的<code>action</code>属性为<code>"/submit-cat-photo"</code>。'
-    testString: assert($("form").attr("action") === "/submit-cat-photo");
+  - text: '确保表单的<code>action</code>属性为<code>"https://freecatphotoapp.com/submit-cat-photo"</code>。'
+    testString: assert($("form").attr("action") === "https://freecatphotoapp.com/submit-cat-photo");
   - text: '确保表单有开始标记和结束标记。'
     testString: assert(code.match(/<\/form>/g) && code.match(/<form [^<]*>/g) && code.match(/<\/form>/g).length === code.match(/<form [^<]*>/g).length);
 

--- a/curriculum/challenges/chinese/01-responsive-web-design/basic-html-and-html5/create-a-set-of-checkboxes.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/basic-html-and-html5/create-a-set-of-checkboxes.chinese.md
@@ -67,7 +67,7 @@ tests:
     <li>打雷</li>
     <li>同类</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label for="indoor"><input id="indoor" type="radio" name="indoor-outdoor">室内</label>
     <label for="outdoor"><input id="outdoor" type="radio" name="indoor-outdoor">室外</label><br>
     <input type="text" placeholder="猫咪图片地址" required>

--- a/curriculum/challenges/chinese/01-responsive-web-design/basic-html-and-html5/create-a-set-of-radio-buttons.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/basic-html-and-html5/create-a-set-of-radio-buttons.chinese.md
@@ -84,7 +84,7 @@ tests:
     <li>打雷</li>
     <li>同类</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <input type="text" placeholder="猫咪图片地址" required>
     <button type="submit">提交</button>
   </form>

--- a/curriculum/challenges/chinese/01-responsive-web-design/basic-html-and-html5/link-to-external-pages-with-anchor-elements.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/basic-html-and-html5/link-to-external-pages-with-anchor-elements.chinese.md
@@ -17,7 +17,7 @@ localeTitle: 用 a 实现网页间的跳转
 
 ## Instructions
 <section id='instructions'>
-创建一个 <code>a</code>，它的<code>href</code>属性为<code>http://freecatphotoapp.com</code> ，它的文本为<code>cat photos</code>。
+创建一个 <code>a</code>，它的<code>href</code>属性为<code>https://freecatphotoapp.com</code> ，它的文本为<code>cat photos</code>。
 </section>
 
 ## Tests

--- a/curriculum/challenges/chinese/01-responsive-web-design/basic-html-and-html5/link-to-internal-sections-of-a-page-with-anchor-elements.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/basic-html-and-html5/link-to-internal-sections-of-a-page-with-anchor-elements.chinese.md
@@ -59,7 +59,7 @@ tests:
 <h2>CatPhotoApp</h2>
 <main>
   
-  <a href="http://freecatphotoapp.com" target="_blank">cat photos</a>
+  <a href="https://freecatphotoapp.com" target="_blank">cat photos</a>
   
   <img src="https://bit.ly/fcc-relaxing-cat" alt="一只仰卧着的萌猫">
   

--- a/curriculum/challenges/chinese/01-responsive-web-design/basic-html-and-html5/make-dead-links-using-the-hash-symbol.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/basic-html-and-html5/make-dead-links-using-the-hash-symbol.chinese.md
@@ -15,7 +15,7 @@ localeTitle: '用 # 号来创建链接占位符'
 
 ## Instructions
 <section id='instructions'>
-<code>href</code>属性的当前值是指向 "http://freecatphotoapp.com"，将<code>href</code>属性的值替换为<code>#</code>，就可以创建固定链接。
+<code>href</code>属性的当前值是指向 "https://freecatphotoapp.com"，将<code>href</code>属性的值替换为<code>#</code>，就可以创建固定链接。
 例如: <code>href="#"</code>
 </section>
 
@@ -39,7 +39,7 @@ tests:
 ```html
 <h2>CatPhotoApp</h2>
 <main>
-  <p>点击这里可以获取更多<a href="http://freecatphotoapp.com" target="_blank">猫咪图片</a>。</p>
+  <p>点击这里可以获取更多<a href="https://freecatphotoapp.com" target="_blank">猫咪图片</a>。</p>
   
   <img src="https://bit.ly/fcc-relaxing-cat" alt="一只仰卧着的萌猫">
   

--- a/curriculum/challenges/chinese/01-responsive-web-design/basic-html-and-html5/nest-an-anchor-element-within-a-paragraph.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/basic-html-and-html5/nest-an-anchor-element-within-a-paragraph.chinese.md
@@ -38,16 +38,16 @@ localeTitle: 将 a 嵌套在段落中
 
 ```yml
 tests:
-  - text: '你需要一个指向 "http://freecatphotoapp.com" 的 <code>a</code> 。'
-    testString: assert(($("a[href=\"http://freecatphotoapp.com\"]").length > 0 || $("a[href=\"http://www.freecatphotoapp.com\"]").length > 0));
+  - text: '你需要一个指向 "https://freecatphotoapp.com" 的 <code>a</code> 。'
+    testString: assert(($("a[href=\"https://freecatphotoapp.com\"]").length > 0 || $("a[href=\"http://www.freecatphotoapp.com\"]").length > 0));
   - text: '<code>a</code> 的文本应为：cat photos。'
     testString: assert($("a").text().match(/cat\sphotos/gi));
   - text: '在 <code>a</code> 的外部创建一个新段落，这样页面就有 3 个段落了。'
     testString: assert($("p") && $("p").length > 2);
   - text: '<code>a</code> 应嵌套在新段落内。'
-    testString: assert(($("a[href=\"http://freecatphotoapp.com\"]").parent().is("p") || $("a[href=\"http://www.freecatphotoapp.com\"]").parent().is("p")));
+    testString: assert(($("a[href=\"https://freecatphotoapp.com\"]").parent().is("p") || $("a[href=\"http://www.freecatphotoapp.com\"]").parent().is("p")));
   - text: '段落应该包含文本 View more（记得 more 后面有一个空格）。'
-    testString: assert(($("a[href=\"http://freecatphotoapp.com\"]").parent().text().match(/View\smore\s/gi) || $("a[href=\"http://www.freecatphotoapp.com\"]").parent().text().match(/View\smore\s/gi)));
+    testString: assert(($("a[href=\"https://freecatphotoapp.com\"]").parent().text().match(/View\smore\s/gi) || $("a[href=\"http://www.freecatphotoapp.com\"]").parent().text().match(/View\smore\s/gi)));
   - text: '<code>a</code> 不应该包含文本 View more。'
     testString: assert(!$("a").text().match(/View\smore/gi));
   - text: '确保每个段落有结束标记。'
@@ -68,7 +68,7 @@ tests:
 <h2>CatPhotoApp</h2>
 <main>
   
-  <a href="http://freecatphotoapp.com" target="_blank">cat photos</a>
+  <a href="https://freecatphotoapp.com" target="_blank">cat photos</a>
   
   <img src="https://bit.ly/fcc-relaxing-cat" alt="一只仰卧着的萌猫">
   
@@ -85,5 +85,6 @@ tests:
 
 ## Solution
 <section id='solution'>
+
 </section>
-              
+

--- a/curriculum/challenges/chinese/01-responsive-web-design/basic-html-and-html5/nest-many-elements-within-a-single-div-element.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/basic-html-and-html5/nest-many-elements-within-a-single-div-element.chinese.md
@@ -63,7 +63,7 @@ tests:
     <li>同类</li>
   </ol>
   
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor">室内</label>
     <label><input type="radio" name="indoor-outdoor">室外</label><br>
     <label><input type="checkbox" name="personality">忠诚</label>

--- a/curriculum/challenges/chinese/01-responsive-web-design/basic-html-and-html5/use-html5-to-require-a-field.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/basic-html-and-html5/use-html5-to-require-a-field.chinese.md
@@ -54,7 +54,7 @@ tests:
     <li>打雷</li>
     <li>同类</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <input type="text" placeholder="猫咪图片地址">
     <button type="submit">提交</button>
   </form>

--- a/curriculum/challenges/chinese/01-responsive-web-design/basic-html-and-html5/use-the-value-attribute-with-radio-buttons-and-checkboxes.chinese.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/basic-html-and-html5/use-the-value-attribute-with-radio-buttons-and-checkboxes.chinese.md
@@ -74,7 +74,7 @@ tests:
     <li>打雷</li>
     <li>同类</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/add-font-awesome-icons-to-all-of-our-buttons.chinese.md
+++ b/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/add-font-awesome-icons-to-all-of-our-buttons.chinese.md
@@ -85,7 +85,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/add-font-awesome-icons-to-our-buttons.chinese.md
+++ b/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/add-font-awesome-icons-to-our-buttons.chinese.md
@@ -87,7 +87,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/call-out-optional-actions-with-btn-info.chinese.md
+++ b/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/call-out-optional-actions-with-btn-info.chinese.md
@@ -85,7 +85,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/center-text-with-bootstrap.chinese.md
+++ b/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/center-text-with-bootstrap.chinese.md
@@ -80,7 +80,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/create-a-block-element-bootstrap-button.chinese.md
+++ b/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/create-a-block-element-bootstrap-button.chinese.md
@@ -83,7 +83,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/create-a-bootstrap-button.chinese.md
+++ b/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/create-a-bootstrap-button.chinese.md
@@ -83,7 +83,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/create-a-custom-heading.chinese.md
+++ b/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/create-a-custom-heading.chinese.md
@@ -81,7 +81,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/ditch-custom-css-for-bootstrap.chinese.md
+++ b/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/ditch-custom-css-for-bootstrap.chinese.md
@@ -97,7 +97,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/line-up-form-elements-responsively-with-bootstrap.chinese.md
+++ b/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/line-up-form-elements-responsively-with-bootstrap.chinese.md
@@ -88,7 +88,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <div class="row">
       <div class="col-xs-6">
         <label><input type="radio" name="indoor-outdoor"> Indoor</label>

--- a/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/make-images-mobile-responsive.chinese.md
+++ b/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/make-images-mobile-responsive.chinese.md
@@ -85,7 +85,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/responsively-style-checkboxes.chinese.md
+++ b/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/responsively-style-checkboxes.chinese.md
@@ -86,7 +86,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <div class="row">
       <div class="col-xs-6">
         <label><input type="radio" name="indoor-outdoor"> Indoor</label>

--- a/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/responsively-style-radio-buttons.chinese.md
+++ b/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/responsively-style-radio-buttons.chinese.md
@@ -85,7 +85,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/style-text-inputs-as-form-controls.chinese.md
+++ b/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/style-text-inputs-as-form-controls.chinese.md
@@ -88,7 +88,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <div class="row">
       <div class="col-xs-6">
         <label><input type="radio" name="indoor-outdoor"> Indoor</label>

--- a/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/taste-the-bootstrap-button-color-rainbow.chinese.md
+++ b/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/taste-the-bootstrap-button-color-rainbow.chinese.md
@@ -83,7 +83,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/use-a-span-to-target-inline-elements.chinese.md
+++ b/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/use-a-span-to-target-inline-elements.chinese.md
@@ -82,7 +82,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/use-responsive-design-with-bootstrap-fluid-containers.chinese.md
+++ b/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/use-responsive-design-with-bootstrap-fluid-containers.chinese.md
@@ -80,7 +80,7 @@ tests:
   <li>thunder</li>
   <li>other cats</li>
 </ol>
-<form action="/submit-cat-photo">
+<form action="https://freecatphotoapp.com/submit-cat-photo">
   <label><input type="radio" name="indoor-outdoor"> Indoor</label>
   <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
   <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/use-the-bootstrap-grid-to-put-elements-side-by-side.chinese.md
+++ b/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/use-the-bootstrap-grid-to-put-elements-side-by-side.chinese.md
@@ -87,7 +87,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/warn-your-users-of-a-dangerous-action-with-btn-danger.chinese.md
+++ b/curriculum/challenges/chinese/03-front-end-libraries/bootstrap/warn-your-users-of-a-dangerous-action-with-btn-danger.chinese.md
@@ -86,7 +86,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x]  My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x]  My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

This PR fixes two bugs that have been present for quite a while relating to invalid urls being used as links in the Basic HTML section.  This PR is only for the Chinese files affected.  See PR # 39215 for the English changes.

The first such bug is introduced in the [Link to External Pages with Anchor Elements](https://www.freecodecamp.org/learn/responsive-web-design/basic-html-and-html5/link-to-external-pages-with-anchor-elements) challenge.  The user is told to create an anchor element that links to `http://freecatphotoapp.com`.  I went ahead and changed it to use `https:`.

The second fix relates to a url that is introduced in the [Create a Form Element](https://www.freecodecamp.org/learn/responsive-web-design/basic-html-and-html5/create-a-form-element) challenge.  The user is told to add `action="/submit-cat-photo"` to the form element.  The issue arises when the user clicks on the Submit button in the next challenge ([Add a Submit Button to a Form](https://www.freecodecamp.org/learn/responsive-web-design/basic-html-and-html5/add-a-submit-button-to-a-form)).  Currently, nothing actually happens which is a problem in itself. I have created a new html file located at `client/static/submit-cat-photo/index.html` that contains a generic thank you message to simulate what a user might see if they were actually submitting the form.  

Related to #39215

<!-- Feel free to add any additional description of changes below this line -->
