### PR TITLE
fix(learn): updated catphotoapp links (Russian)

### DIFF
--- a/curriculum/challenges/russian/01-responsive-web-design/applied-visual-design/adjust-the-hover-state-of-an-anchor-tag.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/applied-visual-design/adjust-the-hover-state-of-an-anchor-tag.russian.md
@@ -45,7 +45,7 @@ tests:
 
 
 </style>
-<a href="http://freecatphotoapp.com/" target="_blank">CatPhotoApp</a>
+<a href="https://freecatphotoapp.com/" target="_blank">CatPhotoApp</a>
 
 ```
 
@@ -65,7 +65,7 @@ tests:
     color: rgba(0,0,255,1);
   }
 </style>
-<a href="http://freecatphotoapp.com/" target="_blank">CatPhotoApp</a>
+<a href="https://freecatphotoapp.com/" target="_blank">CatPhotoApp</a>
 ```
 
 </section>

--- a/curriculum/challenges/russian/01-responsive-web-design/basic-css/add-borders-around-your-elements.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/basic-css/add-borders-around-your-elements.russian.md
@@ -84,7 +84,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>
@@ -152,7 +152,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/russian/01-responsive-web-design/basic-css/add-rounded-corners-with-border-radius.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/basic-css/add-rounded-corners-with-border-radius.russian.md
@@ -84,7 +84,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>
@@ -153,7 +153,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/russian/01-responsive-web-design/basic-css/change-the-color-of-text.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/basic-css/change-the-color-of-text.russian.md
@@ -60,7 +60,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>
@@ -102,7 +102,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/russian/01-responsive-web-design/basic-css/change-the-font-size-of-an-element.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/basic-css/change-the-font-size-of-an-element.russian.md
@@ -62,7 +62,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>
@@ -113,7 +113,7 @@ tests:
     </ol>
   </div>
   
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/russian/01-responsive-web-design/basic-css/give-a-background-color-to-a-div-element.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/basic-css/give-a-background-color-to-a-div-element.russian.md
@@ -87,7 +87,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>
@@ -160,7 +160,7 @@ tests:
     </ol>
   </div>
   
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/russian/01-responsive-web-design/basic-css/import-a-google-font.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/basic-css/import-a-google-font.russian.md
@@ -73,7 +73,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>
@@ -131,7 +131,7 @@ tests:
     </ol>
   </div>
   
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/russian/01-responsive-web-design/basic-css/make-circular-images-with-a-border-radius.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/basic-css/make-circular-images-with-a-border-radius.russian.md
@@ -85,7 +85,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>
@@ -155,7 +155,7 @@ tests:
     </ol>
   </div>
   
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/russian/01-responsive-web-design/basic-css/set-the-font-family-of-an-element.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/basic-css/set-the-font-family-of-an-element.russian.md
@@ -66,7 +66,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>
@@ -119,7 +119,7 @@ tests:
     </ol>
   </div>
   
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/russian/01-responsive-web-design/basic-css/set-the-id-of-an-element.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/basic-css/set-the-id-of-an-element.russian.md
@@ -87,7 +87,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>
@@ -160,7 +160,7 @@ tests:
     </ol>
   </div>
   
-  <form action="/submit-cat-photo" id="cat-photo-form">
+  <form action="https://freecatphotoapp.com/submit-cat-photo" id="cat-photo-form">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/russian/01-responsive-web-design/basic-css/size-your-images.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/basic-css/size-your-images.russian.md
@@ -74,7 +74,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>
@@ -136,7 +136,7 @@ tests:
     </ol>
   </div>
   
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/russian/01-responsive-web-design/basic-css/specify-how-fonts-should-degrade.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/basic-css/specify-how-fonts-should-degrade.russian.md
@@ -78,7 +78,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>
@@ -136,7 +136,7 @@ tests:
     </ol>
   </div>
   
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/russian/01-responsive-web-design/basic-css/style-multiple-elements-with-a-css-class.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/basic-css/style-multiple-elements-with-a-css-class.russian.md
@@ -70,7 +70,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>
@@ -118,7 +118,7 @@ tests:
     </ol>
   </div>
   
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/russian/01-responsive-web-design/basic-css/use-a-css-class-to-style-an-element.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/basic-css/use-a-css-class-to-style-an-element.russian.md
@@ -68,7 +68,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>
@@ -116,7 +116,7 @@ tests:
     </ol>
   </div>
   
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/russian/01-responsive-web-design/basic-css/use-an-id-attribute-to-style-an-element.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/basic-css/use-an-id-attribute-to-style-an-element.russian.md
@@ -93,7 +93,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo" id="cat-photo-form">
+  <form action="https://freecatphotoapp.com/submit-cat-photo" id="cat-photo-form">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>
@@ -170,7 +170,7 @@ tests:
     </ol>
   </div>
   
-  <form action="/submit-cat-photo" id="cat-photo-form">
+  <form action="https://freecatphotoapp.com/submit-cat-photo" id="cat-photo-form">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/russian/01-responsive-web-design/basic-css/use-attribute-selectors-to-style-elements.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/basic-css/use-attribute-selectors-to-style-elements.russian.md
@@ -91,7 +91,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo" id="cat-photo-form">
+  <form action="https://freecatphotoapp.com/submit-cat-photo" id="cat-photo-form">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>
@@ -168,7 +168,7 @@ tests:
     </ol>
   </div>
   
-  <form action="/submit-cat-photo" id="cat-photo-form">
+  <form action="https://freecatphotoapp.com/submit-cat-photo" id="cat-photo-form">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/russian/01-responsive-web-design/basic-css/use-css-selectors-to-style-elements.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/basic-css/use-css-selectors-to-style-elements.russian.md
@@ -64,7 +64,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>
@@ -111,7 +111,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/russian/01-responsive-web-design/basic-html-and-html5/add-a-submit-button-to-a-form.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/basic-html-and-html5/add-a-submit-button-to-a-form.russian.md
@@ -59,7 +59,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <input type="text" placeholder="cat photo URL">
   </form>
 </main>
@@ -92,7 +92,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <input type="text" placeholder="cat photo URL">
     <button type="submit">Submit</button>
   </form>

--- a/curriculum/challenges/russian/01-responsive-web-design/basic-html-and-html5/check-radio-buttons-and-checkboxes-by-default.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/basic-html-and-html5/check-radio-buttons-and-checkboxes-by-default.russian.md
@@ -55,7 +55,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label for="indoor"><input id="indoor" type="radio" name="indoor-outdoor" value="indoor"> Indoor</label>
     <label for="outdoor"><input id="outdoor" type="radio" name="indoor-outdoor" value="outdoor"> Outdoor</label><br>
     <label for="loving"><input id="loving" type="checkbox" name="personality" value="loving"> Loving</label>
@@ -94,7 +94,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label for="indoor"><input id="indoor" type="radio" name="indoor-outdoor" value="indoor" checked> Indoor</label>
     <label for="outdoor"><input id="outdoor" type="radio" name="indoor-outdoor" value="outdoor"> Outdoor</label><br>
     <label for="loving"><input id="loving" type="checkbox" name="personality" value="loving" checked> Loving</label>

--- a/curriculum/challenges/russian/01-responsive-web-design/basic-html-and-html5/create-a-form-element.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/basic-html-and-html5/create-a-form-element.russian.md
@@ -14,7 +14,7 @@ localeTitle: Создание элемента формы
 
 ## Instructions
 <section id='instructions'>
-Заглушите свое текстовое поле внутри элемента <code>form</code> и добавьте атрибут <code>action=&quot;/submit-cat-photo&quot;</code> в элемент формы.
+Заглушите свое текстовое поле внутри элемента <code>form</code> и добавьте атрибут <code>action=&quot;https://freecatphotoapp.com/submit-cat-photo&quot;</code> в элемент формы.
 </section>
 
 ## Tests
@@ -24,8 +24,8 @@ localeTitle: Создание элемента формы
 tests:
   - text: Nest your text input element within a <code>form</code> element.
     testString: assert($("form") && $("form").children("input") && $("form").children("input").length > 0);
-  - text: Make sure your <code>form</code> has an <code>action</code> attribute which is set to <code>/submit-cat-photo</code>
-    testString: assert($("form").attr("action") === "/submit-cat-photo");
+  - text: Make sure your <code>form</code> has an <code>action</code> attribute which is set to <code>https://freecatphotoapp.com/submit-cat-photo</code>
+    testString: assert($("form").attr("action") === "https://freecatphotoapp.com/submit-cat-photo");
   - text: Make sure your <code>form</code> element has well-formed open and close tags.
     testString: assert(code.match(/<\/form>/g) && code.match(/<form [^<]*>/g) && code.match(/<\/form>/g).length === code.match(/<form [^<]*>/g).length);
 
@@ -88,7 +88,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <input type="text" placeholder="cat photo URL">
   </form>
 </main>

--- a/curriculum/challenges/russian/01-responsive-web-design/basic-html-and-html5/create-a-set-of-checkboxes.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/basic-html-and-html5/create-a-set-of-checkboxes.russian.md
@@ -61,7 +61,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label for="indoor"><input id="indoor" type="radio" name="indoor-outdoor"> Indoor</label>
     <label for="outdoor"><input id="outdoor" type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <input type="text" placeholder="cat photo URL" required>
@@ -97,7 +97,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label for="indoor"><input id="indoor" type="radio" name="indoor-outdoor"> Indoor</label>
     <label for="outdoor"><input id="outdoor" type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label for="playful"><input id="playful" type="checkbox" name="personality">Playful</label>

--- a/curriculum/challenges/russian/01-responsive-web-design/basic-html-and-html5/create-a-set-of-radio-buttons.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/basic-html-and-html5/create-a-set-of-radio-buttons.russian.md
@@ -65,7 +65,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <input type="text" placeholder="cat photo URL" required>
     <button type="submit">Submit</button>
   </form>
@@ -99,7 +99,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
    <label for="indoor"><input id="indoor" type="radio" name="indoor-outdoor"> Indoor</label>
     <label for="outdoor"><input id="outdoor" type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <input type="text" placeholder="cat photo URL" required>

--- a/curriculum/challenges/russian/01-responsive-web-design/basic-html-and-html5/link-to-external-pages-with-anchor-elements.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/basic-html-and-html5/link-to-external-pages-with-anchor-elements.russian.md
@@ -14,7 +14,7 @@ localeTitle: Ссылка на внешние страницы с элемент
 
 ## Instructions
 <section id='instructions'>
-Создайте элемент, который ссылается на <code><http://freecatphotoapp.com></code> и имеет «фотографии котят» в качестве его якорного текста.
+Создайте элемент, который ссылается на <code><https://freecatphotoapp.com></code> и имеет «фотографии котят» в качестве его якорного текста.
 </section>
 
 ## Tests
@@ -65,7 +65,7 @@ tests:
   
   <img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back.">
   
-  <a href="http://freecatphotoapp.com">cat photos</a>
+  <a href="https://freecatphotoapp.com">cat photos</a>
   <p>Kitty ipsum dolor sit amet, shed everywhere shed everywhere stretching attack your ankles chase the red dot, hairball run catnip eat the grass sniff.</p>
   <p>Purr jump eat the grass rip the couch scratched sunbathe, shed everywhere rip the couch sleep in the sink fluffy fur catnip scratched.</p>
 </main>

--- a/curriculum/challenges/russian/01-responsive-web-design/basic-html-and-html5/link-to-internal-sections-of-a-page-with-anchor-elements.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/basic-html-and-html5/link-to-internal-sections-of-a-page-with-anchor-elements.russian.md
@@ -48,7 +48,7 @@ tests:
 <h2>CatPhotoApp</h2>
 <main>
 
-  <a href="http://freecatphotoapp.com" target="_blank">cat photos</a>
+  <a href="https://freecatphotoapp.com" target="_blank">cat photos</a>
 
   <img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back.">
 

--- a/curriculum/challenges/russian/01-responsive-web-design/basic-html-and-html5/make-dead-links-using-the-hash-symbol.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/basic-html-and-html5/make-dead-links-using-the-hash-symbol.russian.md
@@ -14,7 +14,7 @@ localeTitle: Создание мертвых ссылок с использов�
 
 ## Instructions
 <section id='instructions'>
-Текущее значение атрибута <code>href</code> - это ссылка, которая указывает на «http://freecatphotoapp.com». Замените значение атрибута <code>href</code> символом <code>#</code> , также известным как хэш-символ, чтобы создать мертвую ссылку. Например: <code>href=&quot;#&quot;</code>
+Текущее значение атрибута <code>href</code> - это ссылка, которая указывает на «https://freecatphotoapp.com». Замените значение атрибута <code>href</code> символом <code>#</code> , также известным как хэш-символ, чтобы создать мертвую ссылку. Например: <code>href=&quot;#&quot;</code>
 </section>
 
 ## Tests
@@ -37,7 +37,7 @@ tests:
 ```html
 <h2>CatPhotoApp</h2>
 <main>
-  <p>Click here to view more <a href="http://freecatphotoapp.com" target="_blank">cat photos</a>.</p>
+  <p>Click here to view more <a href="https://freecatphotoapp.com" target="_blank">cat photos</a>.</p>
 
   <img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back.">
 

--- a/curriculum/challenges/russian/01-responsive-web-design/basic-html-and-html5/nest-an-anchor-element-within-a-paragraph.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/basic-html-and-html5/nest-an-anchor-element-within-a-paragraph.russian.md
@@ -22,16 +22,16 @@ localeTitle: Гнездо анкерного элемента в абзаце
 
 ```yml
 tests:
-  - text: You need an <code>a</code> element that links to "http://freecatphotoapp.com".
-    testString: assert(($("a[href=\"http://freecatphotoapp.com\"]").length > 0 || $("a[href=\"http://www.freecatphotoapp.com\"]").length > 0));
+  - text: You need an <code>a</code> element that links to "https://freecatphotoapp.com".
+    testString: assert(($("a[href=\"https://freecatphotoapp.com\"]").length > 0 || $("a[href=\"http://www.freecatphotoapp.com\"]").length > 0));
   - text: Your <code>a</code> element should have the anchor text of "cat photos"
     testString: assert($("a").text().match(/cat\sphotos/gi));
   - text: Create a new <code>p</code> element around your <code>a</code> element. There should be at least 3 total <code>p</code> tags in your HTML code.
     testString: assert($("p") && $("p").length > 2);
   - text: Your <code>a</code> element should be nested within your new <code>p</code> element.
-    testString: assert(($("a[href=\"http://freecatphotoapp.com\"]").parent().is("p") || $("a[href=\"http://www.freecatphotoapp.com\"]").parent().is("p")));
+    testString: assert(($("a[href=\"https://freecatphotoapp.com\"]").parent().is("p") || $("a[href=\"http://www.freecatphotoapp.com\"]").parent().is("p")));
   - text: Your <code>p</code> element should have the text "View more " (with a space after it).
-    testString: assert(($("a[href=\"http://freecatphotoapp.com\"]").parent().text().match(/View\smore\s/gi) || $("a[href=\"http://www.freecatphotoapp.com\"]").parent().text().match(/View\smore\s/gi)));
+    testString: assert(($("a[href=\"https://freecatphotoapp.com\"]").parent().text().match(/View\smore\s/gi) || $("a[href=\"http://www.freecatphotoapp.com\"]").parent().text().match(/View\smore\s/gi)));
   - text: Your <code>a</code> element should <em>not</em> have the text "View more".
     testString: assert(!$("a").text().match(/View\smore/gi));
   - text: Make sure each of your <code>p</code> elements has a closing tag.
@@ -52,7 +52,7 @@ tests:
 <h2>CatPhotoApp</h2>
 <main>
 
-  <a href="http://freecatphotoapp.com" target="_blank">cat photos</a>
+  <a href="https://freecatphotoapp.com" target="_blank">cat photos</a>
 
   <img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back.">
 
@@ -72,7 +72,7 @@ tests:
 ```html
 <h2>CatPhotoApp</h2>
 <main>
-  <p>View more <a target="_blank" href="http://freecatphotoapp.com">cat photos</a></p>
+  <p>View more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a></p>
 
   <img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back.">
 

--- a/curriculum/challenges/russian/01-responsive-web-design/basic-html-and-html5/nest-many-elements-within-a-single-div-element.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/basic-html-and-html5/nest-many-elements-within-a-single-div-element.russian.md
@@ -60,7 +60,7 @@ tests:
     <li>other cats</li>
   </ol>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label for="indoor"><input id="indoor" type="radio" name="indoor-outdoor" value="indoor" checked> Indoor</label>
     <label for="outdoor"><input id="outdoor" type="radio" name="indoor-outdoor" value="outdoor"> Outdoor</label><br>
     <label for="loving"><input id="loving" type="checkbox" name="personality" value="loving" checked> Loving</label>
@@ -100,7 +100,7 @@ tests:
       <li>other cats</li>
     </ol>
   </div>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label for="indoor"><input id="indoor" type="radio" name="indoor-outdoor" value="indoor" checked> Indoor</label>
     <label for="outdoor"><input id="outdoor" type="radio" name="indoor-outdoor" value="outdoor"> Outdoor</label><br>
     <label for="loving"><input id="loving" type="checkbox" name="personality" value="loving" checked> Loving</label>

--- a/curriculum/challenges/russian/01-responsive-web-design/basic-html-and-html5/use-html5-to-require-a-field.russian.md
+++ b/curriculum/challenges/russian/01-responsive-web-design/basic-html-and-html5/use-html5-to-require-a-field.russian.md
@@ -53,7 +53,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <input type="text" placeholder="cat photo URL">
     <button type="submit">Submit</button>
   </form>
@@ -87,7 +87,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <input type="text" required placeholder="cat photo URL">
     <button type="submit">Submit</button>
   </form>

--- a/curriculum/challenges/russian/03-front-end-libraries/bootstrap/add-font-awesome-icons-to-all-of-our-buttons.russian.md
+++ b/curriculum/challenges/russian/03-front-end-libraries/bootstrap/add-font-awesome-icons-to-all-of-our-buttons.russian.md
@@ -90,7 +90,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>
@@ -158,7 +158,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/russian/03-front-end-libraries/bootstrap/add-font-awesome-icons-to-our-buttons.russian.md
+++ b/curriculum/challenges/russian/03-front-end-libraries/bootstrap/add-font-awesome-icons-to-our-buttons.russian.md
@@ -92,7 +92,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>
@@ -160,7 +160,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/russian/03-front-end-libraries/bootstrap/call-out-optional-actions-with-btn-info.russian.md
+++ b/curriculum/challenges/russian/03-front-end-libraries/bootstrap/call-out-optional-actions-with-btn-info.russian.md
@@ -88,7 +88,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>
@@ -159,7 +159,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/russian/03-front-end-libraries/bootstrap/center-text-with-bootstrap.russian.md
+++ b/curriculum/challenges/russian/03-front-end-libraries/bootstrap/center-text-with-bootstrap.russian.md
@@ -83,7 +83,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>
@@ -151,7 +151,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/russian/03-front-end-libraries/bootstrap/create-a-block-element-bootstrap-button.russian.md
+++ b/curriculum/challenges/russian/03-front-end-libraries/bootstrap/create-a-block-element-bootstrap-button.russian.md
@@ -86,7 +86,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>
@@ -155,7 +155,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/russian/03-front-end-libraries/bootstrap/create-a-bootstrap-button.russian.md
+++ b/curriculum/challenges/russian/03-front-end-libraries/bootstrap/create-a-bootstrap-button.russian.md
@@ -86,7 +86,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>
@@ -162,7 +162,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/russian/03-front-end-libraries/bootstrap/create-a-custom-heading.russian.md
+++ b/curriculum/challenges/russian/03-front-end-libraries/bootstrap/create-a-custom-heading.russian.md
@@ -84,7 +84,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>
@@ -153,7 +153,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/russian/03-front-end-libraries/bootstrap/ditch-custom-css-for-bootstrap.russian.md
+++ b/curriculum/challenges/russian/03-front-end-libraries/bootstrap/ditch-custom-css-for-bootstrap.russian.md
@@ -100,7 +100,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>
@@ -164,7 +164,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/russian/03-front-end-libraries/bootstrap/line-up-form-elements-responsively-with-bootstrap.russian.md
+++ b/curriculum/challenges/russian/03-front-end-libraries/bootstrap/line-up-form-elements-responsively-with-bootstrap.russian.md
@@ -91,7 +91,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <div class="row">
       <div class="col-xs-6">
         <label><input type="radio" name="indoor-outdoor"> Indoor</label>
@@ -174,7 +174,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <div class="row">
       <div class="col-xs-6">
         <label><input type="radio" name="indoor-outdoor"> Indoor</label>

--- a/curriculum/challenges/russian/03-front-end-libraries/bootstrap/make-images-mobile-responsive.russian.md
+++ b/curriculum/challenges/russian/03-front-end-libraries/bootstrap/make-images-mobile-responsive.russian.md
@@ -88,7 +88,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>
@@ -156,7 +156,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/russian/03-front-end-libraries/bootstrap/responsively-style-checkboxes.russian.md
+++ b/curriculum/challenges/russian/03-front-end-libraries/bootstrap/responsively-style-checkboxes.russian.md
@@ -89,7 +89,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <div class="row">
       <div class="col-xs-6">
         <label><input type="radio" name="indoor-outdoor"> Indoor</label>
@@ -164,7 +164,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <div class="row">
       <div class="col-xs-6">
         <label><input type="radio" name="indoor-outdoor"> Indoor</label>

--- a/curriculum/challenges/russian/03-front-end-libraries/bootstrap/responsively-style-radio-buttons.russian.md
+++ b/curriculum/challenges/russian/03-front-end-libraries/bootstrap/responsively-style-radio-buttons.russian.md
@@ -88,7 +88,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>
@@ -156,7 +156,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
   <div class="row">
       <div class="col-xs-6">
         <label><input type="radio" name="indoor-outdoor"> Indoor</label>

--- a/curriculum/challenges/russian/03-front-end-libraries/bootstrap/style-text-inputs-as-form-controls.russian.md
+++ b/curriculum/challenges/russian/03-front-end-libraries/bootstrap/style-text-inputs-as-form-controls.russian.md
@@ -91,7 +91,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <div class="row">
       <div class="col-xs-6">
         <label><input type="radio" name="indoor-outdoor"> Indoor</label>
@@ -174,7 +174,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <div class="row">
       <div class="col-xs-6">
         <label><input type="radio" name="indoor-outdoor"> Indoor</label>

--- a/curriculum/challenges/russian/03-front-end-libraries/bootstrap/taste-the-bootstrap-button-color-rainbow.russian.md
+++ b/curriculum/challenges/russian/03-front-end-libraries/bootstrap/taste-the-bootstrap-button-color-rainbow.russian.md
@@ -86,7 +86,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>
@@ -155,7 +155,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/russian/03-front-end-libraries/bootstrap/use-a-span-to-target-inline-elements.russian.md
+++ b/curriculum/challenges/russian/03-front-end-libraries/bootstrap/use-a-span-to-target-inline-elements.russian.md
@@ -92,7 +92,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>
@@ -158,7 +158,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/russian/03-front-end-libraries/bootstrap/use-responsive-design-with-bootstrap-fluid-containers.russian.md
+++ b/curriculum/challenges/russian/03-front-end-libraries/bootstrap/use-responsive-design-with-bootstrap-fluid-containers.russian.md
@@ -85,7 +85,7 @@ tests:
   <li>thunder</li>
   <li>other cats</li>
 </ol>
-<form action="/submit-cat-photo">
+<form action="https://freecatphotoapp.com/submit-cat-photo">
   <label><input type="radio" name="indoor-outdoor"> Indoor</label>
   <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
   <label><input type="checkbox" name="personality"> Loving</label>
@@ -150,7 +150,7 @@ tests:
   <li>thunder</li>
   <li>other cats</li>
 </ol>
-<form action="/submit-cat-photo">
+<form action="https://freecatphotoapp.com/submit-cat-photo">
   <label><input type="radio" name="indoor-outdoor"> Indoor</label>
   <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
   <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/russian/03-front-end-libraries/bootstrap/use-the-bootstrap-grid-to-put-elements-side-by-side.russian.md
+++ b/curriculum/challenges/russian/03-front-end-libraries/bootstrap/use-the-bootstrap-grid-to-put-elements-side-by-side.russian.md
@@ -90,7 +90,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>
@@ -170,7 +170,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/russian/03-front-end-libraries/bootstrap/warn-your-users-of-a-dangerous-action-with-btn-danger.russian.md
+++ b/curriculum/challenges/russian/03-front-end-libraries/bootstrap/warn-your-users-of-a-dangerous-action-with-btn-danger.russian.md
@@ -89,7 +89,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>
@@ -160,7 +160,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x]  My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x]  My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

This PR fixes two bugs that have been present for quite a while relating to invalid urls being used as links in the Basic HTML section.  This PR is only for the Rusian files affected.  See PR # 39215 for the English changes.

The first such bug is introduced in the [Link to External Pages with Anchor Elements](https://www.freecodecamp.org/learn/responsive-web-design/basic-html-and-html5/link-to-external-pages-with-anchor-elements) challenge.  The user is told to create an anchor element that links to `http://freecatphotoapp.com`.  I went ahead and changed it to use `https:`.

The second fix relates to a url that is introduced in the [Create a Form Element](https://www.freecodecamp.org/learn/responsive-web-design/basic-html-and-html5/create-a-form-element) challenge.  The user is told to add `action="/submit-cat-photo"` to the form element.  The issue arises when the user clicks on the Submit button in the next challenge ([Add a Submit Button to a Form](https://www.freecodecamp.org/learn/responsive-web-design/basic-html-and-html5/add-a-submit-button-to-a-form)).  Currently, nothing actually happens which is a problem in itself. I have created a new html file located at `client/static/submit-cat-photo/index.html` that contains a generic thank you message to simulate what a user might see if they were actually submitting the form.  

Related to #39215
