### PR TITLE
fix(learn): updated catphotoapp links (Portuguese)

### DIFF
--- a/curriculum/challenges/portuguese/01-responsive-web-design/applied-visual-design/adjust-the-hover-state-of-an-anchor-tag.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/applied-visual-design/adjust-the-hover-state-of-an-anchor-tag.portuguese.md
@@ -40,7 +40,7 @@ tests:
 
 
 </style>
-<a href="http://freecatphotoapp.com/" target="_blank">CatPhotoApp</a>
+<a href="https://freecatphotoapp.com/" target="_blank">CatPhotoApp</a>
 
 ```
 

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/add-borders-around-your-elements.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/add-borders-around-your-elements.portuguese.md
@@ -79,7 +79,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/add-rounded-corners-with-border-radius.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/add-rounded-corners-with-border-radius.portuguese.md
@@ -79,7 +79,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/change-the-color-of-text.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/change-the-color-of-text.portuguese.md
@@ -53,7 +53,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/change-the-font-size-of-an-element.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/change-the-font-size-of-an-element.portuguese.md
@@ -57,7 +57,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/give-a-background-color-to-a-div-element.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/give-a-background-color-to-a-div-element.portuguese.md
@@ -82,7 +82,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/import-a-google-font.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/import-a-google-font.portuguese.md
@@ -68,7 +68,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/make-circular-images-with-a-border-radius.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/make-circular-images-with-a-border-radius.portuguese.md
@@ -80,7 +80,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/set-the-font-family-of-an-element.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/set-the-font-family-of-an-element.portuguese.md
@@ -61,7 +61,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/set-the-id-of-an-element.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/set-the-id-of-an-element.portuguese.md
@@ -82,7 +82,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/size-your-images.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/size-your-images.portuguese.md
@@ -69,7 +69,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/specify-how-fonts-should-degrade.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/specify-how-fonts-should-degrade.portuguese.md
@@ -73,7 +73,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/style-multiple-elements-with-a-css-class.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/style-multiple-elements-with-a-css-class.portuguese.md
@@ -66,7 +66,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/use-a-css-class-to-style-an-element.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/use-a-css-class-to-style-an-element.portuguese.md
@@ -63,7 +63,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/use-an-id-attribute-to-style-an-element.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/use-an-id-attribute-to-style-an-element.portuguese.md
@@ -88,7 +88,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo" id="cat-photo-form">
+  <form action="https://freecatphotoapp.com/submit-cat-photo" id="cat-photo-form">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>
@@ -167,7 +167,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo" id="cat-photo-form">
+  <form action="https://freecatphotoapp.com/submit-cat-photo" id="cat-photo-form">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/use-attribute-selectors-to-style-elements.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/use-attribute-selectors-to-style-elements.portuguese.md
@@ -86,7 +86,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo" id="cat-photo-form">
+  <form action="https://freecatphotoapp.com/submit-cat-photo" id="cat-photo-form">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/use-css-selectors-to-style-elements.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-css/use-css-selectors-to-style-elements.portuguese.md
@@ -59,7 +59,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>
@@ -109,7 +109,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-html-and-html5/add-a-submit-button-to-a-form.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-html-and-html5/add-a-submit-button-to-a-form.portuguese.md
@@ -54,7 +54,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <input type="text" placeholder="cat photo URL">
   </form>
 </main>

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-html-and-html5/check-radio-buttons-and-checkboxes-by-default.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-html-and-html5/check-radio-buttons-and-checkboxes-by-default.portuguese.md
@@ -50,7 +50,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-html-and-html5/create-a-form-element.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-html-and-html5/create-a-form-element.portuguese.md
@@ -10,7 +10,7 @@ localeTitle: Crie um elemento de formulário
 <section id="description"> Você pode criar formulários da Web que realmente enviam dados para um servidor usando nada além de HTML puro. Você pode fazer isso especificando uma ação <code>action</code> no seu elemento de <code>form</code>. O valor definido como ação é o endereço que aponta para algum recurso do seu servidor, onde pode conter códigos de linguagens back-end como PHP, Java, Python e etc. Um exemplo de uso: <code>&lt;form action=&quot;/url-where-you-want-to-submit-form-data&quot;&gt;&lt;/form&gt;</code> </section>
 
 ## Instruções
-<section id="instructions"> Aninhe seu campo de texto dentro de um elemento de <code>form</code> e adicione o atributo <code>action=&quot;/submit-cat-photo&quot;</code> ao elemento form. </section>
+<section id="instructions"> Aninhe seu campo de texto dentro de um elemento de <code>form</code> e adicione o atributo <code>action=&quot;https://freecatphotoapp.com/submit-cat-photo&quot;</code> ao elemento form. </section>
 
 ## Tests
 <section id='tests'>
@@ -19,8 +19,8 @@ localeTitle: Crie um elemento de formulário
 tests:
   - text: Aninhe seu elemento de entrada de texto em um elemento de <code>form</code> .
     testString: 'assert($("form") && $("form").children("input") && $("form").children("input").length > 0, "Nest your text input element within a <code>form</code> element.");'
-  - text: Certifique-se de que seu <code>form</code> tenha um atributo de <code>action</code> definido como <code>/submit-cat-photo</code>
-    testString: 'assert($("form").attr("action") === "/submit-cat-photo", "Make sure your <code>form</code> has an <code>action</code> attribute which is set to <code>/submit-cat-photo</code>");'
+  - text: Certifique-se de que seu <code>form</code> tenha um atributo de <code>action</code> definido como <code>https://freecatphotoapp.com/submit-cat-photo</code>
+    testString: 'assert($("form").attr("action") === "https://freecatphotoapp.com/submit-cat-photo", "Make sure your <code>form</code> has an <code>action</code> attribute which is set to <code>https://freecatphotoapp.com/submit-cat-photo</code>");'
   - text: Certifique-se de que seu elemento de <code>form</code> tenha tags de abertura e fechamento bem formadas.
     testString: 'assert(code.match(/<\/form>/g) && code.match(/<form [^<]*>/g) && code.match(/<\/form>/g).length === code.match(/<form [^<]*>/g).length, "Make sure your <code>form</code> element has well-formed open and close tags.");'
 

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-html-and-html5/create-a-set-of-checkboxes.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-html-and-html5/create-a-set-of-checkboxes.portuguese.md
@@ -54,7 +54,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label for="indoor"><input id="indoor" type="radio" name="indoor-outdoor"> Indoor</label>
     <label for="outdoor"><input id="outdoor" type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <input type="text" placeholder="cat photo URL" required>

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-html-and-html5/create-a-set-of-radio-buttons.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-html-and-html5/create-a-set-of-radio-buttons.portuguese.md
@@ -60,7 +60,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <input type="text" placeholder="cat photo URL" required>
     <button type="submit">Submit</button>
   </form>

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-html-and-html5/link-to-external-pages-with-anchor-elements.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-html-and-html5/link-to-external-pages-with-anchor-elements.portuguese.md
@@ -10,7 +10,7 @@ localeTitle: Link para páginas externas com elementos âncora
 <section id="description"> Você pode usar elementos <code>a</code> (<i>âncora</i>) para vincular à conteúdo fora da sua página da web. Elementos <code>a</code> precisam de um endereço da Web de destino chamado atributo <code>href</code> . Eles também precisam de texto âncora. Aqui está um exemplo: <code>&lt;a href=&quot;https://freecodecamp.org&quot;&gt;this links to freecodecamp.org&lt;/a&gt;</code> Então o seu navegador irá exibir o texto <strong>&quot;this links to freecodecamp.org&quot;</strong> como um link que você pode clicar. E esse link levará você ao endereço da Web <strong>https://www.freecodecamp.org</strong> . </section>
 
 ## Instructions
-<section id="instructions"> Crie um elemento <code>a</code> que vincule a <code>http://freecatphotoapp.com</code> e tenha &quot;cat photos&quot; como <code>anchor text</code> . </section>
+<section id="instructions"> Crie um elemento <code>a</code> que vincule a <code>https://freecatphotoapp.com</code> e tenha &quot;cat photos&quot; como <code>anchor text</code> . </section>
 
 ## Tests
 <section id='tests'>

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-html-and-html5/link-to-internal-sections-of-a-page-with-anchor-elements.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-html-and-html5/link-to-internal-sections-of-a-page-with-anchor-elements.portuguese.md
@@ -43,7 +43,7 @@ tests:
 <h2>CatPhotoApp</h2>
 <main>
 
-  <a href="http://freecatphotoapp.com" target="_blank">cat photos</a>
+  <a href="https://freecatphotoapp.com" target="_blank">cat photos</a>
 
   <img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back.">
 

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-html-and-html5/make-dead-links-using-the-hash-symbol.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-html-and-html5/make-dead-links-using-the-hash-symbol.portuguese.md
@@ -10,7 +10,7 @@ localeTitle: Faça links mortos usando o símbolo Hash
 <section id="description"> Alguma vezes você irá adicionar elementos <code>a</code> em seu site antes mesmo de saber para onde eles irão ligar. Isso também é útil quando você está alterando o comportamento de um link usando <code>JavaScript</code> , o qual aprenderemos mais tarde. </section>
 
 ## Instructions
-<section id="instructions"> O valor atual do atributo <code>href</code> é um link que aponta para &quot;http://freecatphotoapp.com&quot;. Substitua o valor do atributo <code>href</code> por um <code>#</code> , também conhecido como um símbolo de hash, para criar um link morto. Por exemplo: <code>href=&quot;#&quot;</code> </section>
+<section id="instructions"> O valor atual do atributo <code>href</code> é um link que aponta para &quot;https://freecatphotoapp.com&quot;. Substitua o valor do atributo <code>href</code> por um <code>#</code> , também conhecido como um símbolo de hash, para criar um link morto. Por exemplo: <code>href=&quot;#&quot;</code> </section>
 
 ## Tests
 <section id='tests'>
@@ -32,7 +32,7 @@ tests:
 ```html
 <h2>CatPhotoApp</h2>
 <main>
-  <p>Click here to view more <a href="http://freecatphotoapp.com" target="_blank">cat photos</a>.</p>
+  <p>Click here to view more <a href="https://freecatphotoapp.com" target="_blank">cat photos</a>.</p>
 
   <img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back.">
 

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-html-and-html5/nest-an-anchor-element-within-a-paragraph.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-html-and-html5/nest-an-anchor-element-within-a-paragraph.portuguese.md
@@ -17,16 +17,16 @@ localeTitle: Aninhar um elemento âncora dentro de um parágrafo
 
 ```yml
 tests:
-  - text: 'Você precisa de <code>a</code> elemento que vincule a &quot;http://freecatphotoapp.com&quot;.'
-    testString: 'assert(($("a[href=\"http://freecatphotoapp.com\"]").length > 0 || $("a[href=\"http://www.freecatphotoapp.com\"]").length > 0), "You need an <code>a</code> element that links to "http://freecatphotoapp.com".");'
+  - text: 'Você precisa de <code>a</code> elemento que vincule a &quot;https://freecatphotoapp.com&quot;.'
+    testString: 'assert(($("a[href=\"https://freecatphotoapp.com\"]").length > 0 || $("a[href=\"http://www.freecatphotoapp.com\"]").length > 0), "You need an <code>a</code> element that links to "https://freecatphotoapp.com".");'
   - text: Sua <code>a</code> elemento deve ter o texto âncora de &quot;fotos do gato&quot;
     testString: 'assert($("a").text().match(/cat\sphotos/gi), "Your <code>a</code> element should have the anchor text of "cat photos"");'
   - text: Criar um novo <code>p</code> elemento em torno de seu <code>a</code> elemento. Deve haver pelo menos três tags <code>p</code> no seu código HTML.
     testString: 'assert($("p") && $("p").length > 2, "Create a new <code>p</code> element around your <code>a</code> element. There should be at least 3 total <code>p</code> tags in your HTML code.");'
   - text: Seu <code>a</code> elemento deve ser aninhado em seu novo elemento <code>p</code> .
-    testString: 'assert(($("a[href=\"http://freecatphotoapp.com\"]").parent().is("p") || $("a[href=\"http://www.freecatphotoapp.com\"]").parent().is("p")), "Your <code>a</code> element should be nested within your new <code>p</code> element.");'
+    testString: 'assert(($("a[href=\"https://freecatphotoapp.com\"]").parent().is("p") || $("a[href=\"http://www.freecatphotoapp.com\"]").parent().is("p")), "Your <code>a</code> element should be nested within your new <code>p</code> element.");'
   - text: Seu elemento <code>p</code> deve ter o texto &quot;Ver mais&quot; (com um espaço após ele).
-    testString: 'assert(($("a[href=\"http://freecatphotoapp.com\"]").parent().text().match(/View\smore\s/gi) || $("a[href=\"http://www.freecatphotoapp.com\"]").parent().text().match(/View\smore\s/gi)), "Your <code>p</code> element should have the text "View more " (with a space after it).");'
+    testString: 'assert(($("a[href=\"https://freecatphotoapp.com\"]").parent().text().match(/View\smore\s/gi) || $("a[href=\"http://www.freecatphotoapp.com\"]").parent().text().match(/View\smore\s/gi)), "Your <code>p</code> element should have the text "View more " (with a space after it).");'
   - text: Sua <code>a</code> elemento <em>não</em> deve ter o texto &quot;Ver mais&quot;.
     testString: 'assert(!$("a").text().match(/View\smore/gi), "Your <code>a</code> element should <em>not</em> have the text "View more".");'
   - text: Certifique-se de que cada um dos seus elementos <code>p</code> tenha uma tag de fechamento.
@@ -47,7 +47,7 @@ tests:
 <h2>CatPhotoApp</h2>
 <main>
 
-  <a href="http://freecatphotoapp.com" target="_blank">cat photos</a>
+  <a href="https://freecatphotoapp.com" target="_blank">cat photos</a>
 
   <img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back.">
 

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-html-and-html5/nest-many-elements-within-a-single-div-element.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-html-and-html5/nest-many-elements-within-a-single-div-element.portuguese.md
@@ -55,7 +55,7 @@ tests:
     <li>other cats</li>
   </ol>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/portuguese/01-responsive-web-design/basic-html-and-html5/use-html5-to-require-a-field.portuguese.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/basic-html-and-html5/use-html5-to-require-a-field.portuguese.md
@@ -48,7 +48,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <input type="text" placeholder="cat photo URL">
     <button type="submit">Submit</button>
   </form>

--- a/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/add-font-awesome-icons-to-all-of-our-buttons.portuguese.md
+++ b/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/add-font-awesome-icons-to-all-of-our-buttons.portuguese.md
@@ -85,7 +85,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/add-font-awesome-icons-to-our-buttons.portuguese.md
+++ b/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/add-font-awesome-icons-to-our-buttons.portuguese.md
@@ -87,7 +87,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/call-out-optional-actions-with-btn-info.portuguese.md
+++ b/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/call-out-optional-actions-with-btn-info.portuguese.md
@@ -85,7 +85,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/center-text-with-bootstrap.portuguese.md
+++ b/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/center-text-with-bootstrap.portuguese.md
@@ -80,7 +80,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/create-a-block-element-bootstrap-button.portuguese.md
+++ b/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/create-a-block-element-bootstrap-button.portuguese.md
@@ -83,7 +83,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/create-a-bootstrap-button.portuguese.md
+++ b/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/create-a-bootstrap-button.portuguese.md
@@ -83,7 +83,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/create-a-custom-heading.portuguese.md
+++ b/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/create-a-custom-heading.portuguese.md
@@ -81,7 +81,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/ditch-custom-css-for-bootstrap.portuguese.md
+++ b/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/ditch-custom-css-for-bootstrap.portuguese.md
@@ -97,7 +97,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/line-up-form-elements-responsively-with-bootstrap.portuguese.md
+++ b/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/line-up-form-elements-responsively-with-bootstrap.portuguese.md
@@ -88,7 +88,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <div class="row">
       <div class="col-xs-6">
         <label><input type="radio" name="indoor-outdoor"> Indoor</label>

--- a/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/make-images-mobile-responsive.portuguese.md
+++ b/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/make-images-mobile-responsive.portuguese.md
@@ -85,7 +85,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/responsively-style-checkboxes.portuguese.md
+++ b/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/responsively-style-checkboxes.portuguese.md
@@ -86,7 +86,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <div class="row">
       <div class="col-xs-6">
         <label><input type="radio" name="indoor-outdoor"> Indoor</label>

--- a/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/responsively-style-radio-buttons.portuguese.md
+++ b/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/responsively-style-radio-buttons.portuguese.md
@@ -85,7 +85,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/style-text-inputs-as-form-controls.portuguese.md
+++ b/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/style-text-inputs-as-form-controls.portuguese.md
@@ -88,7 +88,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <div class="row">
       <div class="col-xs-6">
         <label><input type="radio" name="indoor-outdoor"> Indoor</label>

--- a/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/taste-the-bootstrap-button-color-rainbow.portuguese.md
+++ b/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/taste-the-bootstrap-button-color-rainbow.portuguese.md
@@ -83,7 +83,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/use-a-span-to-target-inline-elements.portuguese.md
+++ b/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/use-a-span-to-target-inline-elements.portuguese.md
@@ -82,7 +82,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/use-responsive-design-with-bootstrap-fluid-containers.portuguese.md
+++ b/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/use-responsive-design-with-bootstrap-fluid-containers.portuguese.md
@@ -80,7 +80,7 @@ tests:
   <li>thunder</li>
   <li>other cats</li>
 </ol>
-<form action="/submit-cat-photo">
+<form action="https://freecatphotoapp.com/submit-cat-photo">
   <label><input type="radio" name="indoor-outdoor"> Indoor</label>
   <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
   <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/use-the-bootstrap-grid-to-put-elements-side-by-side.portuguese.md
+++ b/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/use-the-bootstrap-grid-to-put-elements-side-by-side.portuguese.md
@@ -87,7 +87,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/warn-your-users-of-a-dangerous-action-with-btn-danger.portuguese.md
+++ b/curriculum/challenges/portuguese/03-front-end-libraries/bootstrap/warn-your-users-of-a-dangerous-action-with-btn-danger.portuguese.md
@@ -86,7 +86,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x]  My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x]  My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

This PR fixes two bugs that have been present for quite a while relating to invalid urls being used as links in the Basic HTML section.  This PR is only for the Portuguese files affected.  See PR # 39215 for the English changes.

The first such bug is introduced in the [Link to External Pages with Anchor Elements](https://www.freecodecamp.org/learn/responsive-web-design/basic-html-and-html5/link-to-external-pages-with-anchor-elements) challenge.  The user is told to create an anchor element that links to `http://freecatphotoapp.com`.  I went ahead and changed it to use `https:`.

The second fix relates to a url that is introduced in the [Create a Form Element](https://www.freecodecamp.org/learn/responsive-web-design/basic-html-and-html5/create-a-form-element) challenge.  The user is told to add `action="/submit-cat-photo"` to the form element.  The issue arises when the user clicks on the Submit button in the next challenge ([Add a Submit Button to a Form](https://www.freecodecamp.org/learn/responsive-web-design/basic-html-and-html5/add-a-submit-button-to-a-form)).  Currently, nothing actually happens which is a problem in itself. I have created a new html file located at `client/static/submit-cat-photo/index.html` that contains a generic thank you message to simulate what a user might see if they were actually submitting the form.  

Related to #39215

<!-- Feel free to add any additional description of changes below this line -->
