### PR TITLE
fix(learn): updated catphotoapp links (Spanish)

### DIFF
--- a/curriculum/challenges/spanish/01-responsive-web-design/applied-visual-design/adjust-the-hover-state-of-an-anchor-tag.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/applied-visual-design/adjust-the-hover-state-of-an-anchor-tag.spanish.md
@@ -40,7 +40,7 @@ tests:
 
 
 </style>
-<a href="http://freecatphotoapp.com/" target="_blank">CatPhotoApp</a>
+<a href="https://freecatphotoapp.com/" target="_blank">CatPhotoApp</a>
 
 ```
 

--- a/curriculum/challenges/spanish/01-responsive-web-design/basic-css/add-borders-around-your-elements.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/basic-css/add-borders-around-your-elements.spanish.md
@@ -93,7 +93,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Interior</label>
     <label><input type="radio" name="indoor-outdoor"> Exterior</label><br>
     <label><input type="checkbox" name="personality" checked> Amoroso</label>

--- a/curriculum/challenges/spanish/01-responsive-web-design/basic-css/add-rounded-corners-with-border-radius.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/basic-css/add-rounded-corners-with-border-radius.spanish.md
@@ -81,7 +81,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Interior</label>
     <label><input type="radio" name="indoor-outdoor"> Exterior</label><br>
     <label><input type="checkbox" name="personality" checked> Amoroso</label>

--- a/curriculum/challenges/spanish/01-responsive-web-design/basic-css/change-the-color-of-text.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/basic-css/change-the-color-of-text.spanish.md
@@ -54,7 +54,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Interior</label>
     <label><input type="radio" name="indoor-outdoor"> Exterior</label><br>
     <label><input type="checkbox" name="personality" checked> Amoroso</label>

--- a/curriculum/challenges/spanish/01-responsive-web-design/basic-css/change-the-font-size-of-an-element.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/basic-css/change-the-font-size-of-an-element.spanish.md
@@ -57,7 +57,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Interior</label>
     <label><input type="radio" name="indoor-outdoor"> Exterior</label><br>
     <label><input type="checkbox" name="personality" checked> Amoroso</label>

--- a/curriculum/challenges/spanish/01-responsive-web-design/basic-css/give-a-background-color-to-a-div-element.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/basic-css/give-a-background-color-to-a-div-element.spanish.md
@@ -82,7 +82,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Interior</label>
     <label><input type="radio" name="indoor-outdoor"> Exterior</label><br>
     <label><input type="checkbox" name="personality" checked> Amoroso</label>

--- a/curriculum/challenges/spanish/01-responsive-web-design/basic-css/import-a-google-font.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/basic-css/import-a-google-font.spanish.md
@@ -68,7 +68,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Interior</label>
     <label><input type="radio" name="indoor-outdoor"> Exterior</label><br>
     <label><input type="checkbox" name="personality" checked> Amoroso</label>

--- a/curriculum/challenges/spanish/01-responsive-web-design/basic-css/make-circular-images-with-a-border-radius.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/basic-css/make-circular-images-with-a-border-radius.spanish.md
@@ -80,7 +80,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
       <label><input type="radio" name="indoor-outdoor" checked> Interior</label>
     <label><input type="radio" name="indoor-outdoor"> Exterior</label><br>
     <label><input type="checkbox" name="personality" checked> Amoroso</label>

--- a/curriculum/challenges/spanish/01-responsive-web-design/basic-css/set-the-font-family-of-an-element.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/basic-css/set-the-font-family-of-an-element.spanish.md
@@ -61,7 +61,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Interior</label>
     <label><input type="radio" name="indoor-outdoor"> Exterior</label><br>
     <label><input type="checkbox" name="personality" checked> Amoroso</label>

--- a/curriculum/challenges/spanish/01-responsive-web-design/basic-css/set-the-id-of-an-element.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/basic-css/set-the-id-of-an-element.spanish.md
@@ -82,7 +82,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Interior</label>
     <label><input type="radio" name="indoor-outdoor"> Exterior</label><br>
     <label><input type="checkbox" name="personality" checked> Amoroso</label>

--- a/curriculum/challenges/spanish/01-responsive-web-design/basic-css/size-your-images.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/basic-css/size-your-images.spanish.md
@@ -69,7 +69,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Interior</label>
     <label><input type="radio" name="indoor-outdoor"> Exterior</label><br>
     <label><input type="checkbox" name="personality" checked> Amoroso</label>

--- a/curriculum/challenges/spanish/01-responsive-web-design/basic-css/specify-how-fonts-should-degrade.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/basic-css/specify-how-fonts-should-degrade.spanish.md
@@ -73,7 +73,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Interior</label>
     <label><input type="radio" name="indoor-outdoor"> Exterior</label><br>
     <label><input type="checkbox" name="personality" checked> Amoroso</label>

--- a/curriculum/challenges/spanish/01-responsive-web-design/basic-css/style-multiple-elements-with-a-css-class.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/basic-css/style-multiple-elements-with-a-css-class.spanish.md
@@ -66,7 +66,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Interior</label>
     <label><input type="radio" name="indoor-outdoor"> Exterior</label><br>
     <label><input type="checkbox" name="personality" checked> Amoroso</label>

--- a/curriculum/challenges/spanish/01-responsive-web-design/basic-css/use-a-css-class-to-style-an-element.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/basic-css/use-a-css-class-to-style-an-element.spanish.md
@@ -63,7 +63,7 @@ tests:
     </ol>
   </div>
   
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Interior</label>
     <label><input type="radio" name="indoor-outdoor"> Exterior</label><br>
     <label><input type="checkbox" name="personality" checked> Amoroso</label>

--- a/curriculum/challenges/spanish/01-responsive-web-design/basic-css/use-an-id-attribute-to-style-an-element.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/basic-css/use-an-id-attribute-to-style-an-element.spanish.md
@@ -88,7 +88,7 @@ tests:
     </ol>
   </div>
  
-  <form action="/submit-cat-photo" id="cat-photo-form">
+  <form action="https://freecatphotoapp.com/submit-cat-photo" id="cat-photo-form">
     <label><input type="radio" name="indoor-outdoor" checked> Interior</label>
     <label><input type="radio" name="indoor-outdoor"> Exterior</label><br>
     <label><input type="checkbox" name="personality" checked> Amoroso</label>

--- a/curriculum/challenges/spanish/01-responsive-web-design/basic-css/use-attribute-selectors-to-style-elements.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/basic-css/use-attribute-selectors-to-style-elements.spanish.md
@@ -86,7 +86,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo" id="cat-photo-form">
+  <form action="https://freecatphotoapp.com/submit-cat-photo" id="cat-photo-form">
     <label><input type="radio" name="indoor-outdoor" checked> Interior</label>
     <label><input type="radio" name="indoor-outdoor"> Exterior</label><br>
     <label><input type="checkbox" name="personality" checked> Amoroso</label>

--- a/curriculum/challenges/spanish/01-responsive-web-design/basic-css/use-css-selectors-to-style-elements.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/basic-css/use-css-selectors-to-style-elements.spanish.md
@@ -59,7 +59,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/spanish/01-responsive-web-design/basic-html-and-html5/add-a-submit-button-to-a-form.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/basic-html-and-html5/add-a-submit-button-to-a-form.spanish.md
@@ -54,7 +54,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <input type="text" placeholder="cat photo URL">
   </form>
 </main>

--- a/curriculum/challenges/spanish/01-responsive-web-design/basic-html-and-html5/check-radio-buttons-and-checkboxes-by-default.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/basic-html-and-html5/check-radio-buttons-and-checkboxes-by-default.spanish.md
@@ -50,7 +50,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/spanish/01-responsive-web-design/basic-html-and-html5/create-a-form-element.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/basic-html-and-html5/create-a-form-element.spanish.md
@@ -10,7 +10,7 @@ localeTitle: Crear un elemento de formulario
 <section id="description"> Puede crear formularios web que envíen datos reales a un servidor usando nada más que HTML. Puedes hacerlo especificando un action en tu elemento <code>form</code> . Por ejemplo: <code>&lt;form action=&quot;/url-where-you-want-to-submit-form-data&quot;&gt;&lt;/form&gt;</code> </section>
 
 ## Instructions
-<section id="instructions"> Anida el campo de texto dentro de un elemento <code>form</code> y agrega el atributo <code>action=&quot;/submit-cat-photo&quot;</code> al elemento formulario. </section>
+<section id="instructions"> Anida el campo de texto dentro de un elemento <code>form</code> y agrega el atributo <code>action=&quot;https://freecatphotoapp.com/submit-cat-photo&quot;</code> al elemento formulario. </section>
 
 ## Tests
 <section id='tests'>
@@ -19,8 +19,8 @@ localeTitle: Crear un elemento de formulario
 tests:
   - text: Anida el elemento de entrada de texto dentro de un elemento de <code>form</code> .
     testString: 'assert($("form") && $("form").children("input") && $("form").children("input").length > 0, "Nest your text input element within a <code>form</code> element.");'
-  - text: Asegúrese de que su <code>form</code> tenga un atributo <code>action</code> y cuyo valor sea <code>/submit-cat-photo</code>
-    testString: 'assert($("form").attr("action") === "/submit-cat-photo", "Make sure your <code>form</code> has an <code>action</code> attribute which is set to <code>/submit-cat-photo</code>");'
+  - text: Asegúrese de que su <code>form</code> tenga un atributo <code>action</code> y cuyo valor sea <code>https://freecatphotoapp.com/submit-cat-photo</code>
+    testString: 'assert($("form").attr("action") === "https://freecatphotoapp.com/submit-cat-photo", "Make sure your <code>form</code> has an <code>action</code> attribute which is set to <code>https://freecatphotoapp.com/submit-cat-photo</code>");'
   - text: Asegúrese de que su elemento <code>form</code> tenga las etiquetas de apertura y cierre bien formadas.
     testString: 'assert(code.match(/<\/form>/g) && code.match(/<form [^<]*>/g) && code.match(/<\/form>/g).length === code.match(/<form [^<]*>/g).length, "Make sure your <code>form</code> element has well-formed open and close tags.");'
 

--- a/curriculum/challenges/spanish/01-responsive-web-design/basic-html-and-html5/create-a-set-of-checkboxes.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/basic-html-and-html5/create-a-set-of-checkboxes.spanish.md
@@ -54,7 +54,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label for="indoor"><input id="indoor" type="radio" name="indoor-outdoor"> Indoor</label>
     <label for="outdoor"><input id="outdoor" type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <input type="text" placeholder="cat photo URL" required>

--- a/curriculum/challenges/spanish/01-responsive-web-design/basic-html-and-html5/create-a-set-of-radio-buttons.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/basic-html-and-html5/create-a-set-of-radio-buttons.spanish.md
@@ -60,7 +60,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <input type="text" placeholder="cat photo URL" required>
     <button type="submit">Submit</button>
   </form>

--- a/curriculum/challenges/spanish/01-responsive-web-design/basic-html-and-html5/link-to-external-pages-with-anchor-elements.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/basic-html-and-html5/link-to-external-pages-with-anchor-elements.spanish.md
@@ -10,7 +10,7 @@ localeTitle: Enlace a páginas externas con elementos de anclaje
 <section id="description"> Puede usar elementos de anclaje <code>anchor</code> para vincular contenido fuera de su página web.  los elementos de anclaje <code>anchor</code> necesitan una dirección web de destino denominada atributo <code>href</code> . También necesitara agregar texto al elemento de anclaje. Aquí hay un ejemplo: <code>&lt;a href=&quot;https://freecodecamp.org&quot;&gt;this links to freecodecamp.org&lt;/a&gt;</code> Luego, su navegador mostrará el texto <strong>&quot;este enlace a freecodecamp.org&quot;</strong> como un enlace en el que puede hacer clic. Y ese enlace lo llevará a la dirección web <strong>https://www.freecodecamp.org</strong> . </section>
 
 ## Instructions
-<section id="instructions"> Crear un elemento de anclaje <code>a</code>  que une a <code>http://freecatphotoapp.com</code> y tiene &quot;fotos de gatos&quot; como su texto de anclaje <code>anchor text</code> . </section>
+<section id="instructions"> Crear un elemento de anclaje <code>a</code>  que une a <code>https://freecatphotoapp.com</code> y tiene &quot;fotos de gatos&quot; como su texto de anclaje <code>anchor text</code> . </section>
 
 ## Tests
 <section id='tests'>

--- a/curriculum/challenges/spanish/01-responsive-web-design/basic-html-and-html5/link-to-internal-sections-of-a-page-with-anchor-elements.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/basic-html-and-html5/link-to-internal-sections-of-a-page-with-anchor-elements.spanish.md
@@ -43,7 +43,7 @@ tests:
 <h2>CatPhotoApp</h2>
 <main>
 
-  <a href="http://freecatphotoapp.com" target="_blank">cat photos</a>
+  <a href="https://freecatphotoapp.com" target="_blank">cat photos</a>
 
   <img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back.">
 

--- a/curriculum/challenges/spanish/01-responsive-web-design/basic-html-and-html5/make-dead-links-using-the-hash-symbol.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/basic-html-and-html5/make-dead-links-using-the-hash-symbol.spanish.md
@@ -10,7 +10,7 @@ localeTitle: Realizar enlaces muertos usando el símbolo de hash
 <section id="description"> A veces desea agregar elementos<code>a</code> a su sitio web antes de saber a donde lo va a llevar. Esto también es útil cuando está cambiando el comportamiento de un enlace usando <code>JavaScript</code> , que aprenderemos más adelante. </section>
 
 ## Instructions
-<section id="instructions"> El valor actual del atributo <code>href</code> es un enlace que apunta a &quot;http://freecatphotoapp.com&quot;. Reemplace el valor del atributo <code>href</code> con un <code>#</code> , también conocido como símbolo de hash, para crear un enlace muerto. Por ejemplo: <code>href=&quot;#&quot;</code> </section>
+<section id="instructions"> El valor actual del atributo <code>href</code> es un enlace que apunta a &quot;https://freecatphotoapp.com&quot;. Reemplace el valor del atributo <code>href</code> con un <code>#</code> , también conocido como símbolo de hash, para crear un enlace muerto. Por ejemplo: <code>href=&quot;#&quot;</code> </section>
 
 ## Tests
 <section id='tests'>
@@ -32,7 +32,7 @@ tests:
 ```html
 <h2>CatPhotoApp</h2>
 <main>
-  <p>Click here to view more <a href="http://freecatphotoapp.com" target="_blank">cat photos</a>.</p>
+  <p>Click here to view more <a href="https://freecatphotoapp.com" target="_blank">cat photos</a>.</p>
 
   <img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back.">
 

--- a/curriculum/challenges/spanish/01-responsive-web-design/basic-html-and-html5/nest-an-anchor-element-within-a-paragraph.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/basic-html-and-html5/nest-an-anchor-element-within-a-paragraph.spanish.md
@@ -17,16 +17,16 @@ localeTitle: Anidar un elemento de anclaje dentro de un párrafo
 
 ```yml
 tests:
-  - text: 'Es necesario un <code>a</code> elemento que une a &quot;http://freecatphotoapp.com&quot;.'
-    testString: 'assert(($("a[href=\"http://freecatphotoapp.com\"]").length > 0 || $("a[href=\"http://www.freecatphotoapp.com\"]").length > 0), "You need an <code>a</code> element that links to "http://freecatphotoapp.com".");'
+  - text: 'Es necesario un <code>a</code> elemento que une a &quot;https://freecatphotoapp.com&quot;.'
+    testString: 'assert(($("a[href=\"https://freecatphotoapp.com\"]").length > 0 || $("a[href=\"http://www.freecatphotoapp.com\"]").length > 0), "You need an <code>a</code> element that links to "https://freecatphotoapp.com".");'
   - text: Su <code>a</code> elemento debe tener el texto de anclaje de fotos &quot;gato&quot;
     testString: 'assert($("a").text().match(/cat\sphotos/gi), "Your <code>a</code> element should have the anchor text of "cat photos"");'
   - text: Crear un nuevo <code>p</code> elemento alrededor de su <code>a</code> elemento. Debe haber al menos 3 etiquetas <code>p</code> en total en su código HTML.
     testString: 'assert($("p") && $("p").length > 2, "Create a new <code>p</code> element around your <code>a</code> element. There should be at least 3 total <code>p</code> tags in your HTML code.");'
   - text: Su <code>a</code> elemento debe estar anidada dentro de su nueva <code>p</code> elemento.
-    testString: 'assert(($("a[href=\"http://freecatphotoapp.com\"]").parent().is("p") || $("a[href=\"http://www.freecatphotoapp.com\"]").parent().is("p")), "Your <code>a</code> element should be nested within your new <code>p</code> element.");'
+    testString: 'assert(($("a[href=\"https://freecatphotoapp.com\"]").parent().is("p") || $("a[href=\"http://www.freecatphotoapp.com\"]").parent().is("p")), "Your <code>a</code> element should be nested within your new <code>p</code> element.");'
   - text: Su elemento <code>p</code> debe tener el texto &quot;Ver más&quot; (con un espacio detrás de él).
-    testString: 'assert(($("a[href=\"http://freecatphotoapp.com\"]").parent().text().match(/View\smore\s/gi) || $("a[href=\"http://www.freecatphotoapp.com\"]").parent().text().match(/View\smore\s/gi)), "Your <code>p</code> element should have the text "View more " (with a space after it).");'
+    testString: 'assert(($("a[href=\"https://freecatphotoapp.com\"]").parent().text().match(/View\smore\s/gi) || $("a[href=\"http://www.freecatphotoapp.com\"]").parent().text().match(/View\smore\s/gi)), "Your <code>p</code> element should have the text "View more " (with a space after it).");'
   - text: Su <code>a</code> elemento <em>no</em> debería tener el texto &quot;Ver más&quot;.
     testString: 'assert(!$("a").text().match(/View\smore/gi), "Your <code>a</code> element should <em>not</em> have the text "View more".");'
   - text: Asegúrese de que cada uno de sus elementos <code>p</code> tenga una etiqueta de cierre.
@@ -47,7 +47,7 @@ tests:
 <h2>CatPhotoApp</h2>
 <main>
 
-  <a href="http://freecatphotoapp.com" target="_blank">cat photos</a>
+  <a href="https://freecatphotoapp.com" target="_blank">cat photos</a>
 
   <img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back.">
 

--- a/curriculum/challenges/spanish/01-responsive-web-design/basic-html-and-html5/nest-many-elements-within-a-single-div-element.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/basic-html-and-html5/nest-many-elements-within-a-single-div-element.spanish.md
@@ -55,7 +55,7 @@ tests:
     <li>other cats</li>
   </ol>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/spanish/01-responsive-web-design/basic-html-and-html5/use-html5-to-require-a-field.spanish.md
+++ b/curriculum/challenges/spanish/01-responsive-web-design/basic-html-and-html5/use-html5-to-require-a-field.spanish.md
@@ -48,7 +48,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <input type="text" placeholder="cat photo URL">
     <button type="submit">Submit</button>
   </form>

--- a/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/add-font-awesome-icons-to-all-of-our-buttons.spanish.md
+++ b/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/add-font-awesome-icons-to-all-of-our-buttons.spanish.md
@@ -85,7 +85,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/add-font-awesome-icons-to-our-buttons.spanish.md
+++ b/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/add-font-awesome-icons-to-our-buttons.spanish.md
@@ -87,7 +87,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/call-out-optional-actions-with-btn-info.spanish.md
+++ b/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/call-out-optional-actions-with-btn-info.spanish.md
@@ -85,7 +85,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/center-text-with-bootstrap.spanish.md
+++ b/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/center-text-with-bootstrap.spanish.md
@@ -80,7 +80,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/create-a-block-element-bootstrap-button.spanish.md
+++ b/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/create-a-block-element-bootstrap-button.spanish.md
@@ -83,7 +83,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/create-a-bootstrap-button.spanish.md
+++ b/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/create-a-bootstrap-button.spanish.md
@@ -83,7 +83,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/create-a-custom-heading.spanish.md
+++ b/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/create-a-custom-heading.spanish.md
@@ -81,7 +81,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/ditch-custom-css-for-bootstrap.spanish.md
+++ b/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/ditch-custom-css-for-bootstrap.spanish.md
@@ -97,7 +97,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/line-up-form-elements-responsively-with-bootstrap.spanish.md
+++ b/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/line-up-form-elements-responsively-with-bootstrap.spanish.md
@@ -88,7 +88,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <div class="row">
       <div class="col-xs-6">
         <label><input type="radio" name="indoor-outdoor"> Indoor</label>

--- a/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/make-images-mobile-responsive.spanish.md
+++ b/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/make-images-mobile-responsive.spanish.md
@@ -85,7 +85,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/responsively-style-checkboxes.spanish.md
+++ b/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/responsively-style-checkboxes.spanish.md
@@ -86,7 +86,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <div class="row">
       <div class="col-xs-6">
         <label><input type="radio" name="indoor-outdoor"> Indoor</label>

--- a/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/responsively-style-radio-buttons.spanish.md
+++ b/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/responsively-style-radio-buttons.spanish.md
@@ -85,7 +85,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/style-text-inputs-as-form-controls.spanish.md
+++ b/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/style-text-inputs-as-form-controls.spanish.md
@@ -88,7 +88,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <div class="row">
       <div class="col-xs-6">
         <label><input type="radio" name="indoor-outdoor"> Indoor</label>

--- a/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/taste-the-bootstrap-button-color-rainbow.spanish.md
+++ b/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/taste-the-bootstrap-button-color-rainbow.spanish.md
@@ -83,7 +83,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/use-a-span-to-target-inline-elements.spanish.md
+++ b/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/use-a-span-to-target-inline-elements.spanish.md
@@ -89,7 +89,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/use-responsive-design-with-bootstrap-fluid-containers.spanish.md
+++ b/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/use-responsive-design-with-bootstrap-fluid-containers.spanish.md
@@ -80,7 +80,7 @@ tests:
   <li>thunder</li>
   <li>other cats</li>
 </ol>
-<form action="/submit-cat-photo">
+<form action="https://freecatphotoapp.com/submit-cat-photo">
   <label><input type="radio" name="indoor-outdoor"> Indoor</label>
   <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
   <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/use-the-bootstrap-grid-to-put-elements-side-by-side.spanish.md
+++ b/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/use-the-bootstrap-grid-to-put-elements-side-by-side.spanish.md
@@ -87,7 +87,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/warn-your-users-of-a-dangerous-action-with-btn-danger.spanish.md
+++ b/curriculum/challenges/spanish/03-front-end-libraries/bootstrap/warn-your-users-of-a-dangerous-action-with-btn-danger.spanish.md
@@ -86,7 +86,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x]  My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x]  My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

This PR fixes two bugs that have been present for quite a while relating to invalid urls being used as links in the Basic HTML section.  This PR is only for the Spanish files affected.  See PR # 39215 for the English changes.

The first such bug is introduced in the [Link to External Pages with Anchor Elements](https://www.freecodecamp.org/learn/responsive-web-design/basic-html-and-html5/link-to-external-pages-with-anchor-elements) challenge.  The user is told to create an anchor element that links to `http://freecatphotoapp.com`.  I went ahead and changed it to use `https:`.

The second fix relates to a url that is introduced in the [Create a Form Element](https://www.freecodecamp.org/learn/responsive-web-design/basic-html-and-html5/create-a-form-element) challenge.  The user is told to add `action="/submit-cat-photo"` to the form element.  The issue arises when the user clicks on the Submit button in the next challenge ([Add a Submit Button to a Form](https://www.freecodecamp.org/learn/responsive-web-design/basic-html-and-html5/add-a-submit-button-to-a-form)).  Currently, nothing actually happens which is a problem in itself. I have created a new html file located at `client/static/submit-cat-photo/index.html` that contains a generic thank you message to simulate what a user might see if they were actually submitting the form.  

Related to #39215

<!-- Feel free to add any additional description of changes below this line -->
