### PR TITLE
fix(learn): updated catphotoapp links (Arabic)

### DIFF
--- a/curriculum/challenges/arabic/01-responsive-web-design/applied-visual-design/adjust-the-hover-state-of-an-anchor-tag.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/applied-visual-design/adjust-the-hover-state-of-an-anchor-tag.arabic.md
@@ -40,7 +40,7 @@ tests:
 
 
 </style>
-<a href="http://freecatphotoapp.com/" target="_blank">CatPhotoApp</a>
+<a href="https://freecatphotoapp.com/" target="_blank">CatPhotoApp</a>
 
 ```
 
@@ -56,4 +56,5 @@ tests:
 ```js
 // solution required
 ```
+
 </section>

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-css/add-borders-around-your-elements.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-css/add-borders-around-your-elements.arabic.md
@@ -79,7 +79,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-css/add-rounded-corners-with-border-radius.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-css/add-rounded-corners-with-border-radius.arabic.md
@@ -79,7 +79,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-css/change-the-color-of-text.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-css/change-the-color-of-text.arabic.md
@@ -53,7 +53,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-css/change-the-font-size-of-an-element.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-css/change-the-font-size-of-an-element.arabic.md
@@ -57,7 +57,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-css/give-a-background-color-to-a-div-element.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-css/give-a-background-color-to-a-div-element.arabic.md
@@ -82,7 +82,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-css/import-a-google-font.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-css/import-a-google-font.arabic.md
@@ -68,7 +68,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-css/make-circular-images-with-a-border-radius.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-css/make-circular-images-with-a-border-radius.arabic.md
@@ -80,7 +80,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-css/set-the-font-family-of-an-element.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-css/set-the-font-family-of-an-element.arabic.md
@@ -61,7 +61,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-css/set-the-id-of-an-element.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-css/set-the-id-of-an-element.arabic.md
@@ -82,7 +82,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-css/size-your-images.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-css/size-your-images.arabic.md
@@ -69,7 +69,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-css/specify-how-fonts-should-degrade.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-css/specify-how-fonts-should-degrade.arabic.md
@@ -73,7 +73,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-css/style-multiple-elements-with-a-css-class.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-css/style-multiple-elements-with-a-css-class.arabic.md
@@ -65,7 +65,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-css/use-a-css-class-to-style-an-element.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-css/use-a-css-class-to-style-an-element.arabic.md
@@ -63,7 +63,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-css/use-an-id-attribute-to-style-an-element.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-css/use-an-id-attribute-to-style-an-element.arabic.md
@@ -88,7 +88,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo" id="cat-photo-form">
+  <form action="https://freecatphotoapp.com/submit-cat-photo" id="cat-photo-form">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-css/use-attribute-selectors-to-style-elements.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-css/use-attribute-selectors-to-style-elements.arabic.md
@@ -86,7 +86,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo" id="cat-photo-form">
+  <form action="https://freecatphotoapp.com/submit-cat-photo" id="cat-photo-form">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-css/use-css-selectors-to-style-elements.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-css/use-css-selectors-to-style-elements.arabic.md
@@ -59,7 +59,7 @@ tests:
     </ol>
   </div>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-html-and-html5/add-a-submit-button-to-a-form.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-html-and-html5/add-a-submit-button-to-a-form.arabic.md
@@ -54,7 +54,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <input type="text" placeholder="cat photo URL">
   </form>
 </main>

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-html-and-html5/check-radio-buttons-and-checkboxes-by-default.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-html-and-html5/check-radio-buttons-and-checkboxes-by-default.arabic.md
@@ -50,7 +50,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-html-and-html5/create-a-form-element.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-html-and-html5/create-a-form-element.arabic.md
@@ -10,7 +10,7 @@ localeTitle: إنشاء عنصر النموذج
 <section id="description"> يمكنك إنشاء نماذج ويب تقوم بالفعل بإرسال البيانات إلى خادم لا يستخدم أكثر من HTML خالص. يمكنك القيام بذلك عن طريق تحديد إجراء على عنصر <code>form</code> الخاص بك. على سبيل المثال: <code>&lt;form action=&quot;/url-where-you-want-to-submit-form-data&quot;&gt;&lt;/form&gt;</code> </section>
 
 ## Instructions
-<section id="instructions"> ضع حقل النص داخل عنصر <code>form</code> ، وأضف السمة <code>action=&quot;/submit-cat-photo&quot;</code> إلى عنصر النموذج. </section>
+<section id="instructions"> ضع حقل النص داخل عنصر <code>form</code> ، وأضف السمة <code>action=&quot;https://freecatphotoapp.com/submit-cat-photo&quot;</code> إلى عنصر النموذج. </section>
 
 ## Tests
 <section id='tests'>
@@ -19,8 +19,8 @@ localeTitle: إنشاء عنصر النموذج
 tests:
   - text: ضع عنصر إدخال النص داخل عنصر <code>form</code> .
     testString: 'assert($("form") && $("form").children("input") && $("form").children("input").length > 0, "Nest your text input element within a <code>form</code> element.");'
-  - text: تأكد من احتواء <code>form</code> على سمة <code>action</code> تم تعيينها على <code>/submit-cat-photo</code>
-    testString: 'assert($("form").attr("action") === "/submit-cat-photo", "Make sure your <code>form</code> has an <code>action</code> attribute which is set to <code>/submit-cat-photo</code>");'
+  - text: تأكد من احتواء <code>form</code> على سمة <code>action</code> تم تعيينها على <code>https://freecatphotoapp.com/submit-cat-photo</code>
+    testString: 'assert($("form").attr("action") === "https://freecatphotoapp.com/submit-cat-photo", "Make sure your <code>form</code> has an <code>action</code> attribute which is set to <code>https://freecatphotoapp.com/submit-cat-photo</code>");'
   - text: تأكد من أن عنصر <code>form</code> يحتوي على علامات فتح وغلق جيدة الإنشاء.
     testString: 'assert(code.match(/<\/form>/g) && code.match(/<form [^<]*>/g) && code.match(/<\/form>/g).length === code.match(/<form [^<]*>/g).length, "Make sure your <code>form</code> element has well-formed open and close tags.");'
 
@@ -69,4 +69,5 @@ tests:
 ```js
 // solution required
 ```
+
 </section>

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-html-and-html5/create-a-set-of-checkboxes.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-html-and-html5/create-a-set-of-checkboxes.arabic.md
@@ -54,7 +54,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label for="indoor"><input id="indoor" type="radio" name="indoor-outdoor"> Indoor</label>
     <label for="outdoor"><input id="outdoor" type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <input type="text" placeholder="cat photo URL" required>

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-html-and-html5/create-a-set-of-radio-buttons.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-html-and-html5/create-a-set-of-radio-buttons.arabic.md
@@ -60,7 +60,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <input type="text" placeholder="cat photo URL" required>
     <button type="submit">Submit</button>
   </form>

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-html-and-html5/link-to-external-pages-with-anchor-elements.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-html-and-html5/link-to-external-pages-with-anchor-elements.arabic.md
@@ -17,7 +17,7 @@ localeTitle: ربط الصفحات الخارجية بستخدام عناصر ا
 </section>
 
 ## Instructions
-<section id="instructions"> إنشاء العنصر <code>a</code> الذي يربط <code>http://freecatphotoapp.com</code> له النص &quot;cat photos&quot;، في <code> نص الرابط</code> . </section>
+<section id="instructions"> إنشاء العنصر <code>a</code> الذي يربط <code>https://freecatphotoapp.com</code> له النص &quot;cat photos&quot;، في <code> نص الرابط</code> . </section>
 
 ## Tests
 <section id='tests'>
@@ -26,7 +26,7 @@ localeTitle: ربط الصفحات الخارجية بستخدام عناصر ا
 tests:
   - text: يجب أن يحتوي العنصر <code>a</code> الخاص بك على &quot;cat photos&quot; كنص للرابط <code>anchor text </code>.  
     testString: 'assert((/cat photos/gi).test($("a").text()), "Your <code>a</code> element should have the <code>anchor text</code> of "cat photos".");'
-  - text: 'تحتاج إلى عنصر <code>a</code> يربط بالعنوان <code>http://freecatphotoapp.com</code>'
+  - text: 'تحتاج إلى عنصر <code>a</code> يربط بالعنوان <code>https://freecatphotoapp.com</code>'
     testString: 'assert(/http:\/\/(www\.)?freecatphotoapp\.com/gi.test($("a").attr("href")), "You need an <code>a</code> element that links to <code>http&#58;//freecatphotoapp<wbr>.com</code>");'
   - text: تأكد من ان العنصر <code>a</code> يحتوي على وسم إغلاق.
     testString: 'assert(code.match(/<\/a>/g) && code.match(/<\/a>/g).length === code.match(/<a/g).length, "Make sure your <code>a</code> element has a closing tag.");'
@@ -66,4 +66,5 @@ tests:
 ```js
 // solution required
 ```
+
 </section>

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-html-and-html5/link-to-internal-sections-of-a-page-with-anchor-elements.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-html-and-html5/link-to-internal-sections-of-a-page-with-anchor-elements.arabic.md
@@ -43,7 +43,7 @@ tests:
 <h2>CatPhotoApp</h2>
 <main>
 
-  <a href="http://freecatphotoapp.com" target="_blank">cat photos</a>
+  <a href="https://freecatphotoapp.com" target="_blank">cat photos</a>
 
   <img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back.">
 
@@ -70,4 +70,5 @@ tests:
 ```js
 // solution required
 ```
+
 </section>

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-html-and-html5/make-dead-links-using-the-hash-symbol.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-html-and-html5/make-dead-links-using-the-hash-symbol.arabic.md
@@ -10,7 +10,7 @@ localeTitle: جعل الروابط الميتة باستخدام رمز التج
 <section id="description"> أحيانا كنت ترغب في إضافة <code>a</code> عناصر لموقع الويب الخاص بك قبل ان تعرفه حيث سيربط. هذا مفيد أيضًا عند تغيير سلوك الارتباط باستخدام <code>JavaScript</code> ، والذي سنتعرف عليه لاحقًا. </section>
 
 ## Instructions
-<section id="instructions"> القيمة الحالية لسمة <code>href</code> عبارة عن رابط يشير إلى &quot;http://freecatphotoapp.com&quot;. استبدل قيمة السمة <code>href</code> بـ <code>#</code> ، والمعروف أيضًا باسم رمز التجزئة ، لإنشاء رابط ميت. على سبيل المثال: <code>href=&quot;#&quot;</code> </section>
+<section id="instructions"> القيمة الحالية لسمة <code>href</code> عبارة عن رابط يشير إلى &quot;https://freecatphotoapp.com&quot;. استبدل قيمة السمة <code>href</code> بـ <code>#</code> ، والمعروف أيضًا باسم رمز التجزئة ، لإنشاء رابط ميت. على سبيل المثال: <code>href=&quot;#&quot;</code> </section>
 
 ## Tests
 <section id='tests'>
@@ -32,7 +32,7 @@ tests:
 ```html
 <h2>CatPhotoApp</h2>
 <main>
-  <p>Click here to view more <a href="http://freecatphotoapp.com" target="_blank">cat photos</a>.</p>
+  <p>Click here to view more <a href="https://freecatphotoapp.com" target="_blank">cat photos</a>.</p>
 
   <img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back.">
 
@@ -54,4 +54,5 @@ tests:
 ```js
 // solution required
 ```
+
 </section>

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-html-and-html5/nest-an-anchor-element-within-a-paragraph.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-html-and-html5/nest-an-anchor-element-within-a-paragraph.arabic.md
@@ -17,16 +17,16 @@ localeTitle: عش عنصر الارتساء ضمن فقرة
 
 ```yml
 tests:
-  - text: 'تحتاج إلى <code>a</code> العنصر الذي يربط &quot;http://freecatphotoapp.com&quot;.'
-    testString: 'assert(($("a[href=\"http://freecatphotoapp.com\"]").length > 0 || $("a[href=\"http://www.freecatphotoapp.com\"]").length > 0), "You need an <code>a</code> element that links to "http://freecatphotoapp.com".");'
+  - text: 'تحتاج إلى <code>a</code> العنصر الذي يربط &quot;https://freecatphotoapp.com&quot;.'
+    testString: 'assert(($("a[href=\"https://freecatphotoapp.com\"]").length > 0 || $("a[href=\"http://www.freecatphotoapp.com\"]").length > 0), "You need an <code>a</code> element that links to "https://freecatphotoapp.com".");'
   - text: الخاص بك <code>a</code> يجب أن يكون عنصر النص مرساة &quot;صور القط&quot;
     testString: 'assert($("a").text().match(/cat\sphotos/gi), "Your <code>a</code> element should have the anchor text of "cat photos"");'
   - text: إنشاء جديد <code>p</code> العنصر حول الخاص <code>a</code> العنصر. يجب أن يكون هناك 3 علامات <code>p</code> على الأقل في كود HTML الخاص بك.
     testString: 'assert($("p") && $("p").length > 2, "Create a new <code>p</code> element around your <code>a</code> element. There should be at least 3 total <code>p</code> tags in your HTML code.");'
   - text: ''
-    testString: 'assert(($("a[href=\"http://freecatphotoapp.com\"]").parent().is("p") || $("a[href=\"http://www.freecatphotoapp.com\"]").parent().is("p")), "Your <code>a</code> element should be nested within your new <code>p</code> element.");'
+    testString: 'assert(($("a[href=\"https://freecatphotoapp.com\"]").parent().is("p") || $("a[href=\"http://www.freecatphotoapp.com\"]").parent().is("p")), "Your <code>a</code> element should be nested within your new <code>p</code> element.");'
   - text: يجب أن يحتوي عنصر <code>p</code> على النص &quot;عرض المزيد&quot; (مع وجود مسافة بعده).
-    testString: 'assert(($("a[href=\"http://freecatphotoapp.com\"]").parent().text().match(/View\smore\s/gi) || $("a[href=\"http://www.freecatphotoapp.com\"]").parent().text().match(/View\smore\s/gi)), "Your <code>p</code> element should have the text "View more " (with a space after it).");'
+    testString: 'assert(($("a[href=\"https://freecatphotoapp.com\"]").parent().text().match(/View\smore\s/gi) || $("a[href=\"http://www.freecatphotoapp.com\"]").parent().text().match(/View\smore\s/gi)), "Your <code>p</code> element should have the text "View more " (with a space after it).");'
   - text: الخاص بك <code>a</code> يجب أن <em>لا</em> يكون عنصر النص &quot;عرض أكثر&quot;.
     testString: 'assert(!$("a").text().match(/View\smore/gi), "Your <code>a</code> element should <em>not</em> have the text "View more".");'
   - text: تأكد من أن كل عنصر من عناصر <code>p</code> لديه علامة إغلاق.
@@ -47,7 +47,7 @@ tests:
 <h2>CatPhotoApp</h2>
 <main>
 
-  <a href="http://freecatphotoapp.com" target="_blank">cat photos</a>
+  <a href="https://freecatphotoapp.com" target="_blank">cat photos</a>
 
   <img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back.">
 
@@ -69,4 +69,5 @@ tests:
 ```js
 // solution required
 ```
+
 </section>

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-html-and-html5/nest-many-elements-within-a-single-div-element.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-html-and-html5/nest-many-elements-within-a-single-div-element.arabic.md
@@ -55,7 +55,7 @@ tests:
     <li>other cats</li>
   </ol>
 
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor" checked> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label><br>
     <label><input type="checkbox" name="personality" checked> Loving</label>

--- a/curriculum/challenges/arabic/01-responsive-web-design/basic-html-and-html5/use-html5-to-require-a-field.arabic.md
+++ b/curriculum/challenges/arabic/01-responsive-web-design/basic-html-and-html5/use-html5-to-require-a-field.arabic.md
@@ -48,7 +48,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <input type="text" placeholder="cat photo URL">
     <button type="submit">Submit</button>
   </form>

--- a/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/add-font-awesome-icons-to-all-of-our-buttons.arabic.md
+++ b/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/add-font-awesome-icons-to-all-of-our-buttons.arabic.md
@@ -85,7 +85,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/add-font-awesome-icons-to-our-buttons.arabic.md
+++ b/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/add-font-awesome-icons-to-our-buttons.arabic.md
@@ -86,7 +86,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/call-out-optional-actions-with-btn-info.arabic.md
+++ b/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/call-out-optional-actions-with-btn-info.arabic.md
@@ -84,7 +84,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/center-text-with-bootstrap.arabic.md
+++ b/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/center-text-with-bootstrap.arabic.md
@@ -80,7 +80,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/create-a-block-element-bootstrap-button.arabic.md
+++ b/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/create-a-block-element-bootstrap-button.arabic.md
@@ -83,7 +83,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/create-a-bootstrap-button.arabic.md
+++ b/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/create-a-bootstrap-button.arabic.md
@@ -83,7 +83,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/create-a-custom-heading.arabic.md
+++ b/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/create-a-custom-heading.arabic.md
@@ -81,7 +81,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/ditch-custom-css-for-bootstrap.arabic.md
+++ b/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/ditch-custom-css-for-bootstrap.arabic.md
@@ -96,7 +96,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/line-up-form-elements-responsively-with-bootstrap.arabic.md
+++ b/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/line-up-form-elements-responsively-with-bootstrap.arabic.md
@@ -88,7 +88,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <div class="row">
       <div class="col-xs-6">
         <label><input type="radio" name="indoor-outdoor"> Indoor</label>

--- a/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/make-images-mobile-responsive.arabic.md
+++ b/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/make-images-mobile-responsive.arabic.md
@@ -85,7 +85,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/responsively-style-checkboxes.arabic.md
+++ b/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/responsively-style-checkboxes.arabic.md
@@ -86,7 +86,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <div class="row">
       <div class="col-xs-6">
         <label><input type="radio" name="indoor-outdoor"> Indoor</label>

--- a/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/responsively-style-radio-buttons.arabic.md
+++ b/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/responsively-style-radio-buttons.arabic.md
@@ -85,7 +85,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/style-text-inputs-as-form-controls.arabic.md
+++ b/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/style-text-inputs-as-form-controls.arabic.md
@@ -88,7 +88,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <div class="row">
       <div class="col-xs-6">
         <label><input type="radio" name="indoor-outdoor"> Indoor</label>

--- a/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/taste-the-bootstrap-button-color-rainbow.arabic.md
+++ b/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/taste-the-bootstrap-button-color-rainbow.arabic.md
@@ -83,7 +83,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/use-a-span-to-target-inline-elements.arabic.md
+++ b/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/use-a-span-to-target-inline-elements.arabic.md
@@ -81,7 +81,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/use-responsive-design-with-bootstrap-fluid-containers.arabic.md
+++ b/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/use-responsive-design-with-bootstrap-fluid-containers.arabic.md
@@ -80,7 +80,7 @@ tests:
   <li>thunder</li>
   <li>other cats</li>
 </ol>
-<form action="/submit-cat-photo">
+<form action="https://freecatphotoapp.com/submit-cat-photo">
   <label><input type="radio" name="indoor-outdoor"> Indoor</label>
   <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
   <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/use-the-bootstrap-grid-to-put-elements-side-by-side.arabic.md
+++ b/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/use-the-bootstrap-grid-to-put-elements-side-by-side.arabic.md
@@ -86,7 +86,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>

--- a/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/warn-your-users-of-a-dangerous-action-with-btn-danger.arabic.md
+++ b/curriculum/challenges/arabic/03-front-end-libraries/bootstrap/warn-your-users-of-a-dangerous-action-with-btn-danger.arabic.md
@@ -85,7 +85,7 @@ tests:
     <li>thunder</li>
     <li>other cats</li>
   </ol>
-  <form action="/submit-cat-photo">
+  <form action="https://freecatphotoapp.com/submit-cat-photo">
     <label><input type="radio" name="indoor-outdoor"> Indoor</label>
     <label><input type="radio" name="indoor-outdoor"> Outdoor</label>
     <label><input type="checkbox" name="personality"> Loving</label>


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x]  My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x]  My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

This PR fixes two bugs that have been present for quite a while relating to invalid urls being used as links in the Basic HTML section.  This PR is only for the Arabic files affected.  See PR # 39215 for the English changes.

The first such bug is introduced in the [Link to External Pages with Anchor Elements](https://www.freecodecamp.org/learn/responsive-web-design/basic-html-and-html5/link-to-external-pages-with-anchor-elements) challenge.  The user is told to create an anchor element that links to `http://freecatphotoapp.com`.  I went ahead and changed it to use `https:`.

The second fix relates to a url that is introduced in the [Create a Form Element](https://www.freecodecamp.org/learn/responsive-web-design/basic-html-and-html5/create-a-form-element) challenge.  The user is told to add `action="/submit-cat-photo"` to the form element.  The issue arises when the user clicks on the Submit button in the next challenge ([Add a Submit Button to a Form](https://www.freecodecamp.org/learn/responsive-web-design/basic-html-and-html5/add-a-submit-button-to-a-form)).  Currently, nothing actually happens which is a problem in itself. I have created a new html file located at `client/static/submit-cat-photo/index.html` that contains a generic thank you message to simulate what a user might see if they were actually submitting the form.  

Related to #39215

<!-- Feel free to add any additional description of changes below this line -->
