### PR TITLE
fix(curriculum): Improve punctuation/formatting in "Add Axes to a Visualization"

### DIFF
--- a/curriculum/challenges/english/04-data-visualization/data-visualization-with-d3/add-axes-to-a-visualization.english.md
+++ b/curriculum/challenges/english/04-data-visualization/data-visualization-with-d3/add-axes-to-a-visualization.english.md
@@ -9,7 +9,7 @@ forumTopicId: 301472
 ## Description
 <section id='description'>
 Another way to improve the scatter plot is to add an x-axis and a y-axis.
-D3 has two methods <code>axisLeft()</code> and <code>axisBottom()</code> to render the y and x axes, respectively. (Axes is the plural form of axis). Here's an example to create the x-axis based on the <code>xScale</code> in the previous challenges:
+D3 has two methods, <code>axisLeft()</code> and <code>axisBottom()</code>, to render the y- and x-axes, respectively ("axes" is the plural form of "axis"). Here's an example to create the x-axis based on the <code>xScale</code> in the previous challenges:
 <code>const xAxis = d3.axisBottom(xScale);</code>
 The next step is to render the axis on the SVG canvas. To do so, you can use a general SVG component, the <code>g</code> element. The <code>g</code> stands for group.
 Unlike <code>rect</code>, <code>circle</code>, and <code>text</code>, an axis is just a straight line when it's rendered. Because it is a simple shape, using <code>g</code> works.

--- a/curriculum/challenges/english/04-data-visualization/data-visualization-with-d3/add-axes-to-a-visualization.english.md
+++ b/curriculum/challenges/english/04-data-visualization/data-visualization-with-d3/add-axes-to-a-visualization.english.md
@@ -9,7 +9,7 @@ forumTopicId: 301472
 ## Description
 <section id='description'>
 Another way to improve the scatter plot is to add an x-axis and a y-axis.
-D3 has two methods, <code>axisLeft()</code> and <code>axisBottom()</code>, to render the y- and x-axes, respectively ("axes" is the plural form of "axis"). Here's an example to create the x-axis based on the <code>xScale</code> in the previous challenges:
+D3 has two methods, <code>axisLeft()</code> and <code>axisBottom()</code>, to render the y-axis and x-axis, respectively. Here's an example to create the x-axis based on the <code>xScale</code> in the previous challenges:
 <code>const xAxis = d3.axisBottom(xScale);</code>
 The next step is to render the axis on the SVG canvas. To do so, you can use a general SVG component, the <code>g</code> element. The <code>g</code> stands for group.
 Unlike <code>rect</code>, <code>circle</code>, and <code>text</code>, an axis is just a straight line when it's rendered. Because it is a simple shape, using <code>g</code> works.

--- a/curriculum/challenges/english/04-data-visualization/data-visualization-with-d3/add-axes-to-a-visualization.english.md
+++ b/curriculum/challenges/english/04-data-visualization/data-visualization-with-d3/add-axes-to-a-visualization.english.md
@@ -10,7 +10,11 @@ forumTopicId: 301472
 <section id='description'>
 Another way to improve the scatter plot is to add an x-axis and a y-axis.
 D3 has two methods, <code>axisLeft()</code> and <code>axisBottom()</code>, to render the y-axis and x-axis, respectively. Here's an example to create the x-axis based on the <code>xScale</code> in the previous challenges:
-<code>const xAxis = d3.axisBottom(xScale);</code>
+
+```js
+const xAxis = d3.axisBottom(xScale);
+```
+
 The next step is to render the axis on the SVG canvas. To do so, you can use a general SVG component, the <code>g</code> element. The <code>g</code> stands for group.
 Unlike <code>rect</code>, <code>circle</code>, and <code>text</code>, an axis is just a straight line when it's rendered. Because it is a simple shape, using <code>g</code> works.
 The last step is to apply a <code>transform</code> attribute to position the axis on the SVG canvas in the right place. Otherwise, the line would render along the border of SVG canvas and wouldn't be visible.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!-- Feel free to add any additional description of changes below this line -->
1. Adds commas to [set off an appositive phrase](https://en.wikipedia.org/wiki/Comma#Parenthetical_phrases) ("<code>axisLeft()</code> and <code>axisBottom()</code>").
2. Adds appropriate [suspended hyphens](https://en.wikipedia.org/wiki/Hyphen#Suspended_hyphens) to "y- and x-axes".
3. Moves the parenthetical "&hairsp;'axes' is the plural form of 'axis'&hairsp;" to be part of the previous sentence. I think it fits better there, rather than as its own sentence.