### PR TITLE
Feat: multifile editable contents

### DIFF
--- a/client/src/client/frame-runner.js
+++ b/client/src/client/frame-runner.js
@@ -5,8 +5,10 @@ window.$ = jQuery;
 
 document.__initTestFrame = initTestFrame;
 
-async function initTestFrame(e = {}) {
-  const code = (e.code || '').slice(0);
+async function initTestFrame(e = { code: {} }) {
+  const code = (e.code.contents || '').slice();
+  // eslint-disable-next-line no-unused-vars
+  const editableContents = (e.code.editableContents || '').slice();
   if (!e.getUserInput) {
     e.getUserInput = () => code;
   }

--- a/client/src/client/workers/test-evaluator.js
+++ b/client/src/client/workers/test-evaluator.js
@@ -55,7 +55,9 @@ const __utils = (() => {
 /* Run the test if there is one.  If not just evaluate the user code */
 self.onmessage = async e => {
   /* eslint-disable no-unused-vars */
-  const { code = '' } = e.data;
+  const code = (e.data?.code?.contents || '').slice();
+  const editableContents = (e.data?.code?.editableContents || '').slice();
+
   const assert = chai.assert;
   // Fake Deep Equal dependency
   const DeepEqual = (a, b) => JSON.stringify(a) === JSON.stringify(b);

--- a/client/src/templates/Challenges/classic/Show.js
+++ b/client/src/templates/Challenges/classic/Show.js
@@ -323,7 +323,9 @@ export default connect(
   mapDispatchToProps
 )(ShowClassic);
 
-// TODO: handle jsx (not sure why it doesn't get an editableRegion)
+// TODO: handle jsx (not sure why it doesn't get an editableRegion) EDIT:
+// probably because the dummy challenge didn't include it, so Gatsby couldn't
+// infer it.
 export const query = graphql`
   query ClassicChallenge($slug: String!) {
     challengeNode(fields: { slug: { eq: $slug } }) {

--- a/client/src/templates/Challenges/redux/code-storage-epic.js
+++ b/client/src/templates/Challenges/redux/code-storage-epic.js
@@ -138,7 +138,13 @@ function loadCodeEpic(action$, state$) {
                   ...file,
                   contents: codeFound[file.key]
                     ? codeFound[file.key].contents
-                    : file.contents
+                    : file.contents,
+                  editableContents: codeFound[file.key]
+                    ? codeFound[file.key].editableContents
+                    : file.editableContents,
+                  editableRegionBoundaries: codeFound[file.key]
+                    ? codeFound[file.key].editableRegionBoundaries
+                    : file.editableRegionBoundaries
                 }
               }),
               {}

--- a/client/src/templates/Challenges/utils/build.js
+++ b/client/src/templates/Challenges/utils/build.js
@@ -53,13 +53,15 @@ function buildSourceMap(files) {
   // the same name 'index'. This made the last file the only file to  appear in
   // sources.
   // A better solution is to store and handle them separately. Perhaps never
-  // setting the name to 'index'.
+  // setting the name to 'index'. Use 'contents' instead?
+  // TODO: is file.source ever defined?
   return files.reduce(
     (sources, file) => {
       sources[file.name] += file.source || file.contents;
+      sources.editableContents += file.editableContents;
       return sources;
     },
-    { index: '' }
+    { index: '', editableContents: '' }
   );
 }
 
@@ -111,7 +113,10 @@ export function getTestRunner(buildData, { proxyLogger }, document) {
 }
 
 function getJSTestRunner({ build, sources }, proxyLogger) {
-  const code = sources && 'index' in sources ? sources['index'] : '';
+  const code = {
+    contents: sources.index,
+    editableContents: sources.editableContents
+  };
 
   const testWorker = createWorker(testEvaluator, { terminateWorker: true });
 

--- a/client/src/templates/Challenges/utils/frame.js
+++ b/client/src/templates/Challenges/utils/frame.js
@@ -98,7 +98,10 @@ const initTestFrame = frameReady => ctx => {
     const { sources, loadEnzyme } = ctx;
     // default for classic challenges
     // should not be used for modern
-    const code = sources && 'index' in sources ? sources['index'] : '';
+    const code = {
+      contents: sources.index,
+      editableContents: sources.editableContents
+    };
     // provide the file name and get the original source
     const getUserInput = fileName => toString(sources[fileName]);
     await ctx.document.__initTestFrame({ code, getUserInput, loadEnzyme });

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -439,7 +439,10 @@ async function createTestRunner(challenge, solution, buildChallenge) {
     required,
     template
   });
-  const code = sources && 'index' in sources ? sources['index'] : '';
+  const code = {
+    contents: sources.index,
+    editableContents: sources.editableContents
+  };
 
   const evaluator = await (buildChallenge === buildDOMChallenge
     ? getContextEvaluator(build, sources, code, loadEnzyme)


### PR DESCRIPTION
Challenge tests can now reference `editableContents`, which contains only the text inside the editor's 'editable region'.