### PR TITLE
fix: account for tab height when sizing editor

### DIFF
--- a/client/src/templates/Challenges/classic/Editor.js
+++ b/client/src/templates/Challenges/classic/Editor.js
@@ -966,6 +966,8 @@ class Editor extends Component {
           <MonacoEditor
             editorDidMount={this.editorDidMount}
             editorWillMount={this.editorWillMount}
+            // TODO: avoid hard-coding this (it's the tab height)
+            height='calc(100% - 39px)'
             key={`${editorTheme}`}
             onChange={this.onChange}
             options={this.options}


### PR DESCRIPTION
@ahmadabdolsaheb this fixes the problems caused by putting the tabs next to the editor, but it's not pretty.  Any idea how to do it better?
