### PR TITLE
feat(gitpod): Add env variables to .bashrc so they can be accessed globally

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -12,11 +12,11 @@ ports:
   onOpen: ignore
 
 tasks:
-- before: >
-    echo -e '
-    export COOKIE_DOMAIN=gitpod.io\n
-    export HOME_LOCATION=$(gp url 8000)\n
-    export API_LOCATION=$(gp url 3000)\n
+- before: |
+    echo '
+    export COOKIE_DOMAIN=gitpod.io
+    export HOME_LOCATION=$(gp url 8000)
+    export API_LOCATION=$(gp url 3000)
     ' >> ~/.bashrc;
     exit;
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -12,6 +12,14 @@ ports:
   onOpen: ignore
 
 tasks:
+- before: >
+    echo -e '
+    export COOKIE_DOMAIN=gitpod.io\n
+    export HOME_LOCATION=$(gp url 8000)\n
+    export API_LOCATION=$(gp url 3000)\n
+    ' >> ~/.bashrc;
+    exit;
+
 - name: db
   # starting mongo in background, so it doesn't block prebuilds
   before: >


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

As discussed on Gitter, running `npm run seed` or `npm run develop` does not work on GitPod since the required environment variables (`COOKIE_DOMAIN`, `HOME_LOCATION` and `API_LOCATION`) are not set.
Adding an extra task to `.gitpod.yml` that writes these variables to `~/.bashrc` makes them available in new terminals as well.