### PR TITLE
chore(tools): Add GitHub Action to label merge conflicts

### DIFF
--- a/.github/workflows/label_merge_conflicts.yml
+++ b/.github/workflows/label_merge_conflicts.yml
@@ -1,0 +1,14 @@
+name: 'Check for merge conflicts'
+on:
+  push:
+    branches:
+      - master
+      - 'next-curriculum'
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mschilde/auto-label-merge-conflicts@master
+        with:
+          CONFLICT_LABEL_NAME: 'status: merge conflict'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/label_merge_conflicts.yml
+++ b/.github/workflows/label_merge_conflicts.yml
@@ -3,7 +3,7 @@ on:
   push
 jobs:
   triage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: mschilde/auto-label-merge-conflicts@master
         with:

--- a/.github/workflows/label_merge_conflicts.yml
+++ b/.github/workflows/label_merge_conflicts.yml
@@ -1,9 +1,6 @@
 name: 'Check for merge conflicts'
 on:
-  push:
-    branches:
-      - master
-      - 'next-curriculum'
+  push
 jobs:
   triage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Checklist:
- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

I found [this GitHub Action](https://github.com/mschilde/auto-label-merge-conflicts) that adds `status: merge conflict` to any PRs that have merge conflicts anytime a push is made to specific branches (I targeted `master` and `next-curriculum` for now).

This action has the added bonus of removing any `status: merge conflict` label if a PR no longer has a merge conflict.

I tested the action out on a personal repo and seems to work as advertised.  If we like this one, I think I could tweak this action, so it also adds a comment to the PR that tags OP.  This would make it so that the GitHub notification feature marks it as a `mention` instead of just `subscribed`, in order to draw more attention these PRs. 
