### PR TITLE
fix (learn): Changed freecodecamp.org/cat-photos link to freecatphotoapp.com link (v7)

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-10.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-10.md
@@ -10,7 +10,7 @@ isHidden: true
 
 You can link to another page with the anchor (`a`) element. For example, <a href="https://www.freecodecamp.org"></a> would link to `freecodecamp.org`. 
 
-Add an anchor element after the paragraph that links to `https://www.freecodecamp.org/cat-photos`. At this point, the link won’t show up in the preview.
+Add an anchor element after the paragraph that links to `https://freecatphotoapp.com`. At this point, the link won’t show up in the preview.
 
 </section>
 
@@ -27,8 +27,8 @@ tests:
     testString: const collection = [...document.querySelectorAll('a, p')].map(node => node.nodeName); assert( collection.indexOf('P') < collection.indexOf('A') );
   - text: Your anchor (`a`) element does not have an `href` attribute. Check that there is a space after the opening tag's name and/or there are spaces before all attribute names.
     testString: assert( document.querySelector('a').hasAttribute('href') );
-  - text: "Your anchor (`a`) element should link to `https://www.freecodecamp.org/cat-photos`. You have either omitted the URL or have a typo."
-    testString: assert( document.querySelector('a').getAttribute('href') === 'https://www.freecodecamp.org/cat-photos' );
+  - text: "Your anchor (`a`) element should link to `https://freecatphotoapp.com`. You have either omitted the URL or have a typo."
+    testString: assert( document.querySelector('a').getAttribute('href') === 'https://freecatphotoapp.com' );
   - text: Although you have set the anchor ('a') element's `href` attribute to the correct link, it is recommended to always surround the value of an attribute with quotation marks.
     testString: assert( !/\<a\s+href\s*=\s*https:\/\/www.freecodecamp.org\/cat-photos/.test(code) );
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-11.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-11.md
@@ -44,7 +44,7 @@ tests:
       <!-- TODO: Add link to cat photos -->
       <p>Click here to view more cat photos.</p>
       --fcc-editable-region--
-      <a href="https://www.freecodecamp.org/cat-photos"></a>
+      <a href="https://freecatphotoapp.com"></a>
       --fcc-editable-region--
       <img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back.">
     </main>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-12.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-12.md
@@ -24,7 +24,7 @@ tests:
   - text: The link's text should be `cat photos`. You have either omitted the text or have a typo.
     testString: const nestedAnchor = $('p > a')[0];
       assert( 
-        nestedAnchor.getAttribute('href') === 'https://www.freecodecamp.org/cat-photos' &&
+        nestedAnchor.getAttribute('href') === 'https://freecatphotoapp.com' &&
         nestedAnchor.innerText.toLowerCase().replace(/\s+/g, ' ') === 'cat photos'
       );
   - text: After nesting the anchor (`a`) element, the only `p` element content visible in the browser should be `Click here to view more cat photos.` Double check the text, spacing, or punctuation of both the `p` and nested anchor element.
@@ -50,7 +50,7 @@ tests:
       <!-- TODO: Add link to cat photos -->
       --fcc-editable-region--
       <p>Click here to view more cat photos.</p>
-      <a href="https://www.freecodecamp.org/cat-photos">cat photos</a>
+      <a href="https://freecatphotoapp.com">cat photos</a>
       --fcc-editable-region--
       <img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back.">
     </main>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-13.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-13.md
@@ -43,7 +43,7 @@ tests:
       <h2>Cat Photos</h2>
       <!-- TODO: Add link to cat photos -->
       --fcc-editable-region--
-      <p>Click here to view more <a href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
+      <p>Click here to view more <a href="https://freecatphotoapp.com">cat photos</a>.</p>
       --fcc-editable-region--
       <img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back.">
     </main>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-14.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-14.md
@@ -8,7 +8,7 @@ isHidden: true
 ## Description
 <section id='description'>
 
-Turn the image into a link by surrounding it with necessary element tags. Use `https://www.freecodecamp.org/cat-photos` as the anchor's `href` attribute value.
+Turn the image into a link by surrounding it with necessary element tags. Use `https://freecatphotoapp.com` as the anchor's `href` attribute value.
 
 </section>
 
@@ -29,8 +29,8 @@ tests:
     testString: assert( code.match(/<\/a>/g).length === 2 );
   - text: Your anchor (`a`) element does not have an `href` attribute. Check that there is a space after the opening tag's name and/or there are spaces before all attribute names.
     testString: assert( document.querySelector('a').hasAttribute('href') );
-  - text: Your anchor (`a`) element should link to `https://www.freecodecamp.org/cat-photos`. You have either omitted the URL or have a typo.
-    testString: assert( document.querySelectorAll('a')[1].getAttribute('href') === 'https://www.freecodecamp.org/cat-photos' );
+  - text: Your anchor (`a`) element should link to `https://freecatphotoapp.com`. You have either omitted the URL or have a typo.
+    testString: assert( document.querySelectorAll('a')[1].getAttribute('href') === 'https://freecatphotoapp.com' );
   - text: Your `img` element should be nested within the anchor (`a`) element. The entire `img` element should be inside the opening and closing tags of the anchor (`a`) element. 
     testString: assert( document.querySelector('img').parentNode.nodeName === "A" );
 
@@ -50,7 +50,7 @@ tests:
     <main>
       <h2>Cat Photos</h2>
       <!-- TODO: Add link to cat photos -->
-      <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
+      <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
       --fcc-editable-region--
       <img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back.">
       --fcc-editable-region--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-15.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-15.md
@@ -50,8 +50,8 @@ tests:
     <main>
       <h2>Cat Photos</h2>
       <!-- TODO: Add link to cat photos -->
-      <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-      <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+      <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+      <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
     </main>
     --fcc-editable-region--
   </body>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-16.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-16.md
@@ -58,8 +58,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       --fcc-editable-region--
     </main>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-17.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-17.md
@@ -51,8 +51,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       --fcc-editable-region--
       <section>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-18.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-18.md
@@ -49,8 +49,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       --fcc-editable-region--
       <section>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-19.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-19.md
@@ -43,8 +43,8 @@ tests:
       <section>
       <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         --fcc-editable-region--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-20.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-20.md
@@ -50,8 +50,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-21.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-21.md
@@ -47,8 +47,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-22.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-22.md
@@ -43,8 +43,8 @@ tests:
       <section>
       <h2>Cat Photos</h2>
       <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-23.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-23.md
@@ -50,8 +50,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-24.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-24.md
@@ -44,8 +44,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-25.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-25.md
@@ -44,8 +44,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-26.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-26.md
@@ -46,8 +46,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-27.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-27.md
@@ -40,8 +40,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-28.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-28.md
@@ -48,8 +48,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-29.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-29.md
@@ -44,8 +44,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-30.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-30.md
@@ -52,8 +52,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-31.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-31.md
@@ -44,8 +44,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-32.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-32.md
@@ -51,8 +51,8 @@ tests:
       <section>
       <h2>Cat Photos</h2>
       <!-- TODO: Add link to cat photos -->
-      <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-      <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+      <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+      <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       --fcc-editable-region--
       <section>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-33.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-33.md
@@ -56,8 +56,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-34.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-34.md
@@ -50,8 +50,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-35.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-35.md
@@ -54,8 +54,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-36.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-36.md
@@ -54,8 +54,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-37.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-37.md
@@ -46,8 +46,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-38.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-38.md
@@ -46,8 +46,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-39.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-39.md
@@ -46,8 +46,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-40.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-40.md
@@ -42,8 +42,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-41.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-41.md
@@ -44,8 +44,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-42.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-42.md
@@ -46,8 +46,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-43.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-43.md
@@ -64,8 +64,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-44.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-44.md
@@ -50,8 +50,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-45.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-45.md
@@ -44,8 +44,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-46.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-46.md
@@ -48,8 +48,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-47.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-47.md
@@ -48,8 +48,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       <section>
         <h2>Cat Lists</h2>
         <h3>Things cats love:</h3>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-48.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-48.md
@@ -52,8 +52,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       <section>
         <h2>Cat Lists</h2>
         <h3>Things cats love:</h3>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-49.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-49.md
@@ -48,8 +48,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-50.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-50.md
@@ -54,8 +54,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-51.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-51.md
@@ -63,8 +63,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-52.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-52.md
@@ -54,8 +54,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-53.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-53.md
@@ -56,8 +56,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-54.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-54.md
@@ -37,8 +37,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-55.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-55.md
@@ -62,8 +62,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-56.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-56.md
@@ -42,8 +42,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-57.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-57.md
@@ -52,8 +52,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-58.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-58.md
@@ -52,8 +52,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-59.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-59.md
@@ -52,8 +52,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-60.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-60.md
@@ -48,8 +48,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-61.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-61.md
@@ -44,8 +44,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-62.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-62.md
@@ -45,8 +45,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-63.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-63.md
@@ -52,8 +52,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-64.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-64.md
@@ -47,8 +47,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-65.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-65.md
@@ -51,8 +51,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-66.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-66.md
@@ -49,8 +49,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-67.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-67.md
@@ -47,8 +47,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>
@@ -119,8 +119,8 @@ tests:
       <section>
         <h2>Cat Photos</h2>
         <!-- TODO: Add link to cat photos -->
-        <p>Click here to view more <a target="_blank" href="https://www.freecodecamp.org/cat-photos">cat photos</a>.</p>
-        <a href="https://www.freecodecamp.org/cat-photos"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
+        <p>Click here to view more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a>.</p>
+        <a href="https://freecatphotoapp.com"><img src="https://bit.ly/fcc-relaxing-cat" alt="A cute orange cat lying on its back."></a>
       </section>
       <section>
         <h2>Cat Lists</h2>


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ ] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

This PR updates the link used in the Cat Photo App project to use `https://freecatphotoapp.com` instead of `https://www.freecodecamp.org/cat-photos`.  We originally thought the cat photos url was going to be a static page on freecodecamp.org, but then we ended up using the freecatphotoapp.com domain instead.
