### PR TITLE
fix(learn): Added test for edge case

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-algorithm-scripting/confirm-the-ending.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-algorithm-scripting/confirm-the-ending.english.md
@@ -35,6 +35,8 @@ tests:
     testString: assert(confirmEnding("He has to give me a new name", "name") === true);
   - text: <code>confirmEnding("Open sesame", "same")</code> should return true.
     testString: assert(confirmEnding("Open sesame", "same") === true);
+  - text: <code>confirmEnding("Open sesame", "sage")</code> should return false.
+    testString: assert(confirmEnding("Open sesame", "sage") === false);
   - text: <code>confirmEnding("Open sesame", "pen")</code> should return false.
     testString: assert(confirmEnding("Open sesame", "pen") === false);
   - text: <code>confirmEnding("Open sesame", "game")</code> should return false.

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-algorithm-scripting/confirm-the-ending.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-algorithm-scripting/confirm-the-ending.english.md
@@ -37,8 +37,6 @@ tests:
     testString: assert(confirmEnding("Open sesame", "same") === true);
   - text: <code>confirmEnding("Open sesame", "sage")</code> should return false.
     testString: assert(confirmEnding("Open sesame", "sage") === false);
-  - text: <code>confirmEnding("Open sesame", "pen")</code> should return false.
-    testString: assert(confirmEnding("Open sesame", "pen") === false);
   - text: <code>confirmEnding("Open sesame", "game")</code> should return false.
     testString: assert(confirmEnding("Open sesame", "game") === false);
   - text: <code>confirmEnding("If you want to save our world, you must hurry. We dont know how much longer we can withstand the nothing", "mountain")</code> should return false.


### PR DESCRIPTION
Checklist:

- [*] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [*] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [*] My pull request targets the `master` branch of freeCodeCamp.
- [*] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

Closes #39320 

<!-- Feel free to add any additional description of changes below this line -->

Test fixes the edge case scenario that this code is run:

```
function confirmEnding(str, target) {

  for (let i = target.length, j = 0; i > 0; i--, j++) {
    if (str[str.length-i] == target[j]) {
      return true;
    } else {
      return false;
    }
  }
}

confirmEnding("Open sesame", "sage");
```

In this case, the test would pass but would not follow the criteria of the challenge which is to confirm that the ending is correct, letter for letter.
