### PR TITLE
Feat: multifile multiple editors

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1740,6 +1740,16 @@
         "@types/yargs": "^13.0.0"
       }
     },
+    "@loadable/component": {
+      "version": "5.13.1",
+      "resolved": "https://registry.npmjs.org/@loadable/component/-/component-5.13.1.tgz",
+      "integrity": "sha512-qTNfTv5bVfb9eTKNUOMzPweRnxzNaxCmLZEsFEMn+kxpd86iXae+IpibXFJlnb052Q4fVkcWM2tvmWLc/+HzLg==",
+      "requires": {
+        "@babel/runtime": "^7.7.7",
+        "hoist-non-react-statics": "^3.3.1",
+        "react-is": "^16.12.0"
+      }
+    },
     "@mdx-js/mdx": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-1.6.1.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -17,6 +17,7 @@
     "@freecodecamp/loop-protect": "^2.2.1",
     "@freecodecamp/react-bootstrap": "^0.32.3",
     "@freecodecamp/react-calendar-heatmap": "^1.0.0",
+    "@loadable/component": "^5.13.1",
     "@reach/router": "^1.2.1",
     "algoliasearch": "^3.35.1",
     "axios": "^0.19.0",

--- a/client/src/templates/Challenges/classic/DesktopLayout.js
+++ b/client/src/templates/Challenges/classic/DesktopLayout.js
@@ -17,6 +17,12 @@ const propTypes = {
   testOutput: PropTypes.element
 };
 
+const reflexProps = {
+  propagateDimensions: true,
+  renderOnResize: true,
+  renderOnResizeRate: 20
+};
+
 class DesktopLayout extends Component {
   render() {
     const {
@@ -37,23 +43,11 @@ class DesktopLayout extends Component {
         <ReflexElement flex={1} {...resizeProps}>
           {challengeFile && (
             <ReflexContainer key={challengeFile.key} orientation='horizontal'>
-              <ReflexElement
-                flex={1}
-                propagateDimensions={true}
-                renderOnResize={true}
-                renderOnResizeRate={20}
-                {...resizeProps}
-              >
+              <ReflexElement flex={1} {...reflexProps} {...resizeProps}>
                 {editor}
               </ReflexElement>
               <ReflexSplitter propagate={true} {...resizeProps} />
-              <ReflexElement
-                flex={0.25}
-                propagateDimensions={true}
-                renderOnResize={true}
-                renderOnResizeRate={20}
-                {...resizeProps}
-              >
+              <ReflexElement flex={0.25} {...reflexProps} {...resizeProps}>
                 {testOutput}
               </ReflexElement>
             </ReflexContainer>

--- a/client/src/templates/Challenges/classic/Editor.js
+++ b/client/src/templates/Challenges/classic/Editor.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 import isEqual from 'lodash/isEqual';
+import Loadable from '@loadable/component';
 
 import {
   canFocusEditorSelector,
@@ -20,7 +21,7 @@ import { toSortedArray } from '../../../../../utils/sort-files';
 
 import './editor.css';
 
-const MonacoEditor = React.lazy(() => import('react-monaco-editor'));
+const MonacoEditor = Loadable(() => import('react-monaco-editor'));
 
 const propTypes = {
   canFocus: PropTypes.bool,

--- a/client/src/templates/Challenges/classic/Editor.js
+++ b/client/src/templates/Challenges/classic/Editor.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
-import isEqual from 'lodash/isEqual';
 import Loadable from '@loadable/component';
 
 import {
@@ -291,8 +290,6 @@ class Editor extends Component {
     ];
 
     if (editableBoundaries.length === 2) {
-      this.showEditableRegion(editableBoundaries);
-
       // TODO: is there a nicer approach/way of organising everything that
       // avoids the binds? babel-plugin-transform-class-properties ?
       const getViewZoneTop = this.getViewZoneTop.bind(this);
@@ -349,6 +346,7 @@ class Editor extends Component {
         editor.layoutOverlayWidget(this._overlayWidget);
         editor.layoutOverlayWidget(this._outputWidget);
       });
+      this.showEditableRegion(editableBoundaries);
     }
   };
 
@@ -501,18 +499,21 @@ class Editor extends Component {
 
   showEditableRegion(editableBoundaries) {
     if (editableBoundaries.length !== 2) return;
+    // TODO: The heuristic has been commented out for now because the cursor
+    // position is not saved at the moment, so it's redundant. I'm leaving it
+    // here for now, in case we decide to save it in future.
     // this is a heuristic: if the cursor is at the start of the page, chances
     // are the user has not edited yet. If so, move to the start of the editable
     // region.
-    if (
-      isEqual({ ...this._editor.getPosition() }, { lineNumber: 1, column: 1 })
-    ) {
-      this._editor.setPosition({
-        lineNumber: editableBoundaries[0] + 1,
-        column: 1
-      });
-      this._editor.revealLines(...editableBoundaries);
-    }
+    // if (
+    //  isEqual({ ...this._editor.getPosition() }, { lineNumber: 1, column: 1 })
+    // ) {
+    this._editor.setPosition({
+      lineNumber: editableBoundaries[0] + 1,
+      column: 1
+    });
+    this._editor.revealLinesInCenter(...editableBoundaries);
+    // }
   }
 
   highlightLines(stickiness, target, range, oldIds = []) {

--- a/client/src/templates/Challenges/classic/EditorTabs.js
+++ b/client/src/templates/Challenges/classic/EditorTabs.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const propTypes = {
+  challengeFiles: PropTypes.object.isRequired,
+  toggleTab: PropTypes.func.isRequired,
+  visibleEditors: PropTypes.shape({
+    indexjs: PropTypes.bool,
+    indexjsx: PropTypes.bool,
+    indexcss: PropTypes.bool,
+    indexhtml: PropTypes.bool
+  })
+};
+
+const EditorTabs = ({ challengeFiles, toggleTab, visibleEditors }) => (
+  <div className='monaco-editor-tabs'>
+    {challengeFiles['indexjsx'] && (
+      <button
+        aria-selected={visibleEditors.indexjsx}
+        className='monaco-editor-tab'
+        onClick={() => toggleTab('indexjsx')}
+        role='tab'
+      >
+        script.jsx
+      </button>
+    )}
+    {challengeFiles['indexhtml'] && (
+      <button
+        aria-selected={visibleEditors.indexhtml}
+        className='monaco-editor-tab'
+        onClick={() => toggleTab('indexhtml')}
+        role='tab'
+      >
+        index.html
+      </button>
+    )}
+    {challengeFiles['indexcss'] && (
+      <button
+        aria-selected={visibleEditors.indexcss}
+        className='monaco-editor-tab'
+        onClick={() => toggleTab('indexcss')}
+        role='tab'
+      >
+        styles.css
+      </button>
+    )}
+    {challengeFiles['indexjs'] && (
+      <button
+        aria-selected={visibleEditors.indexjs}
+        className='monaco-editor-tab'
+        onClick={() => toggleTab('indexjs')}
+        role='tab'
+      >
+        script.js
+      </button>
+    )}
+  </div>
+);
+
+EditorTabs.displayName = 'EditorTabs';
+EditorTabs.propTypes = propTypes;
+
+export default EditorTabs;

--- a/client/src/templates/Challenges/classic/MultifileEditor.js
+++ b/client/src/templates/Challenges/classic/MultifileEditor.js
@@ -3,6 +3,7 @@ import React, { Component, Suspense } from 'react';
 import { connect } from 'react-redux';
 import { ReflexContainer, ReflexElement, ReflexSplitter } from 'react-reflex';
 import { createSelector } from 'reselect';
+import { isEmpty } from 'lodash';
 import { isDonationModalOpenSelector, userSelector } from '../../../redux';
 import {
   canFocusEditorSelector,
@@ -69,6 +70,15 @@ const mapDispatchToProps = {
   updateFile
 };
 
+function getTargetEditor(challengeFiles) {
+  let targetEditor = Object.values(challengeFiles).find(
+    ({ editableRegionBoundaries }) => !isEmpty(editableRegionBoundaries)
+  )?.key;
+
+  // fallback for when there is no editable region.
+  return targetEditor || toSortedArray(challengeFiles)[0].key;
+}
+
 class MultifileEditor extends Component {
   constructor(...props) {
     super(...props);
@@ -129,7 +139,7 @@ class MultifileEditor extends Component {
 
     const { challengeFiles } = this.props;
 
-    const targetEditor = toSortedArray(challengeFiles)[0].key;
+    const targetEditor = getTargetEditor(challengeFiles);
 
     this.state = {
       visibleEditors: { [targetEditor]: true }

--- a/client/src/templates/Challenges/classic/MultifileEditor.js
+++ b/client/src/templates/Challenges/classic/MultifileEditor.js
@@ -138,7 +138,6 @@ class MultifileEditor extends Component {
     };
 
     const { challengeFiles } = this.props;
-
     const targetEditor = getTargetEditor(challengeFiles);
 
     this.state = {
@@ -207,6 +206,7 @@ class MultifileEditor extends Component {
     // TODO: tabs should be dynamically created from the challengeFiles
     // TODO: the tabs mess up the rendering (scroll doesn't work properly and
     // the in-editor description)
+    const targetEditor = getTargetEditor(challengeFiles);
 
     return (
       <ReflexContainer
@@ -230,9 +230,9 @@ class MultifileEditor extends Component {
                     <Editor
                       challengeFiles={challengeFiles}
                       containerRef={containerRef}
-                      // TODO: only pass description to the editor with the
-                      // editable region
-                      description={description}
+                      description={
+                        targetEditor === 'indexhtml' ? description : null
+                      }
                       fileKey='indexhtml'
                       key='indexhtml'
                       ref={editorRef}
@@ -251,9 +251,9 @@ class MultifileEditor extends Component {
                     <Editor
                       challengeFiles={challengeFiles}
                       containerRef={containerRef}
-                      // TODO: only pass description to the editor with the
-                      // editable region
-                      description={'this sentence is not here'}
+                      description={
+                        targetEditor === 'indexcss' ? description : null
+                      }
                       fileKey='indexcss'
                       key='indexcss'
                       resizeProps={resizeProps}
@@ -272,9 +272,9 @@ class MultifileEditor extends Component {
                     <Editor
                       challengeFiles={challengeFiles}
                       containerRef={containerRef}
-                      // TODO: only pass description to the editor with the
-                      // editable region
-                      description={'neither is this one'}
+                      description={
+                        targetEditor === 'indexjs' ? description : null
+                      }
                       fileKey='indexjs'
                       key='indexjs'
                       resizeProps={resizeProps}

--- a/client/src/templates/Challenges/classic/MultifileEditor.js
+++ b/client/src/templates/Challenges/classic/MultifileEditor.js
@@ -1,0 +1,294 @@
+import PropTypes from 'prop-types';
+import React, { Component, Suspense } from 'react';
+import { connect } from 'react-redux';
+import { ReflexContainer, ReflexElement, ReflexSplitter } from 'react-reflex';
+import { createSelector } from 'reselect';
+import { isDonationModalOpenSelector, userSelector } from '../../../redux';
+import {
+  canFocusEditorSelector,
+  consoleOutputSelector,
+  executeChallenge,
+  inAccessibilityModeSelector,
+  saveEditorContent,
+  setAccessibilityMode,
+  setEditorFocusability,
+  updateFile
+} from '../redux';
+import './editor.css';
+import { Loader } from '../../../components/helpers';
+import EditorTabs from './EditorTabs';
+import Editor from './Editor';
+import { toSortedArray } from '../../../../../utils/sort-files';
+
+const propTypes = {
+  canFocus: PropTypes.bool,
+  // TODO: use shape
+  challengeFiles: PropTypes.object,
+  containerRef: PropTypes.any.isRequired,
+  contents: PropTypes.string,
+  description: PropTypes.string,
+  dimensions: PropTypes.object,
+  editorRef: PropTypes.any.isRequired,
+  executeChallenge: PropTypes.func.isRequired,
+  ext: PropTypes.string,
+  fileKey: PropTypes.string,
+  inAccessibilityMode: PropTypes.bool.isRequired,
+  initialEditorContent: PropTypes.string,
+  initialExt: PropTypes.string,
+  output: PropTypes.arrayOf(PropTypes.string),
+  resizeProps: PropTypes.shape({
+    onStopResize: PropTypes.func,
+    onResize: PropTypes.func
+  }),
+  saveEditorContent: PropTypes.func.isRequired,
+  setAccessibilityMode: PropTypes.func.isRequired,
+  setEditorFocusability: PropTypes.func,
+  theme: PropTypes.string,
+  updateFile: PropTypes.func.isRequired
+};
+
+const mapStateToProps = createSelector(
+  canFocusEditorSelector,
+  consoleOutputSelector,
+  inAccessibilityModeSelector,
+  isDonationModalOpenSelector,
+  userSelector,
+  (canFocus, output, accessibilityMode, open, { theme = 'default' }) => ({
+    canFocus: open ? false : canFocus,
+    output,
+    inAccessibilityMode: accessibilityMode,
+    theme
+  })
+);
+
+const mapDispatchToProps = {
+  executeChallenge,
+  saveEditorContent,
+  setAccessibilityMode,
+  setEditorFocusability,
+  updateFile
+};
+
+class MultifileEditor extends Component {
+  constructor(...props) {
+    super(...props);
+
+    // TENATIVE PLAN: create a typical order [html/jsx, css, js], put the
+    // available files into that order.  i.e. if it's just one file it will
+    // automatically be first, but  if there's jsx and js (for some reason) it
+    //  will be [jsx, js].
+    // this.state = {
+    //   fileKey: 'indexhtml'
+    // };
+
+    // NOTE: This looks like it should be react state. However we need
+    // to access monaco.editor to create the models and store the state and that
+    // is only available in the react-monaco-editor component's lifecycle hooks
+    // and not react's lifecyle hooks.
+    // As a result it was unclear how to link up the editor's lifecycle with
+    // react's lifecycle. Simply storing the models and state here and letting
+    // the editor control them seems to be the best solution.
+
+    // TODO: is there any point in initializing this? It should be fine with
+    // this.data = {indexjs:{}, indexcss:{}, indexhtml:{}, indexjsx: {}}
+
+    this.data = {
+      indexjs: {
+        model: null,
+        state: null,
+        viewZoneId: null,
+        startEditDecId: null,
+        endEditDecId: null,
+        viewZoneHeight: null
+      },
+      indexcss: {
+        model: null,
+        state: null,
+        viewZoneId: null,
+        startEditDecId: null,
+        endEditDecId: null,
+        viewZoneHeight: null
+      },
+      indexhtml: {
+        model: null,
+        state: null,
+        viewZoneId: null,
+        startEditDecId: null,
+        endEditDecId: null,
+        viewZoneHeight: null
+      },
+      indexjsx: {
+        model: null,
+        state: null,
+        viewZoneId: null,
+        startEditDecId: null,
+        endEditDecId: null,
+        viewZoneHeight: null
+      }
+    };
+
+    const { challengeFiles } = this.props;
+
+    const targetEditor = toSortedArray(challengeFiles)[0].key;
+
+    this.state = {
+      visibleEditors: { [targetEditor]: true }
+    };
+
+    // TODO: we might want to store the current editor here
+    this.focusOnEditor = this.focusOnEditor.bind(this);
+  }
+
+  focusOnHotkeys() {
+    if (this.props.containerRef.current) {
+      this.props.containerRef.current.focus();
+    }
+  }
+
+  focusOnEditor() {
+    // TODO: it should focus one of the editors
+    // this._editor.focus();
+  }
+
+  toggleTab = newFileKey => {
+    this.setState(state => ({
+      visibleEditors: {
+        ...state.visibleEditors,
+        [newFileKey]: !state.visibleEditors[newFileKey]
+      }
+    }));
+  };
+
+  componentWillUnmount() {
+    // this.setState({ fileKey: null });
+    this.data = null;
+  }
+
+  render() {
+    const {
+      challengeFiles,
+      containerRef,
+      description,
+      editorRef,
+      theme,
+      resizeProps
+    } = this.props;
+    const { visibleEditors } = this.state;
+    const editorTheme = theme === 'night' ? 'vs-dark-custom' : 'vs-custom';
+    // TODO: the tabs mess up the rendering (scroll doesn't work properly and
+    // the in-editor description)
+
+    // TODO: the splitters should appear between editors, so logically this
+    // would be best as
+    // editors.map(props => <EditorWrapper ...props>).join(<ReflexSplitter>)
+    // ...probably! As long as we can put keys in the right places.
+    const reflexProps = {
+      propagateDimensions: true,
+      renderOnResize: true,
+      renderOnResizeRate: 20
+    };
+
+    // TODO: this approach (||ing the visibleEditors) isn't great.
+    const splitCSS = visibleEditors.indexhtml && visibleEditors.indexcss;
+    const splitJS =
+      visibleEditors.indexcss ||
+      (visibleEditors.indexhtml && visibleEditors.indexjs);
+
+    // TODO: tabs should be dynamically created from the challengeFiles
+    // TODO: the tabs mess up the rendering (scroll doesn't work properly and
+    // the in-editor description)
+
+    return (
+      <ReflexContainer
+        orientation='horizontal'
+        {...reflexProps}
+        {...resizeProps}
+      >
+        <ReflexElement flex={0.1}>
+          <EditorTabs
+            challengeFiles={challengeFiles}
+            toggleTab={this.toggleTab.bind(this)}
+            visibleEditors={visibleEditors}
+          />
+        </ReflexElement>
+        <ReflexElement flex={0.9} {...reflexProps} {...resizeProps}>
+          <ReflexContainer orientation='vertical'>
+            {visibleEditors.indexhtml && (
+              <ReflexElement {...reflexProps} {...resizeProps}>
+                <Suspense fallback={<Loader timeout={600} />}>
+                  <span className='notranslate'>
+                    <Editor
+                      challengeFiles={challengeFiles}
+                      containerRef={containerRef}
+                      // TODO: only pass description to the editor with the
+                      // editable region
+                      description={description}
+                      fileKey='indexhtml'
+                      key='indexhtml'
+                      ref={editorRef}
+                      resizeProps={resizeProps}
+                      theme={editorTheme}
+                    />
+                  </span>
+                </Suspense>
+              </ReflexElement>
+            )}
+            {splitCSS && <ReflexSplitter propagate={true} {...resizeProps} />}
+            {visibleEditors.indexcss && (
+              <ReflexElement {...reflexProps} {...resizeProps}>
+                <Suspense fallback={<Loader timeout={600} />}>
+                  <span className='notranslate'>
+                    <Editor
+                      challengeFiles={challengeFiles}
+                      containerRef={containerRef}
+                      // TODO: only pass description to the editor with the
+                      // editable region
+                      description={'this sentence is not here'}
+                      fileKey='indexcss'
+                      key='indexcss'
+                      resizeProps={resizeProps}
+                      theme={editorTheme}
+                    />
+                  </span>
+                </Suspense>
+              </ReflexElement>
+            )}
+            {splitJS && <ReflexSplitter propagate={true} {...resizeProps} />}
+
+            {visibleEditors.indexjs && (
+              <ReflexElement {...reflexProps} {...resizeProps}>
+                <Suspense fallback={<Loader timeout={600} />}>
+                  <span className='notranslate'>
+                    <Editor
+                      challengeFiles={challengeFiles}
+                      containerRef={containerRef}
+                      // TODO: only pass description to the editor with the
+                      // editable region
+                      description={'neither is this one'}
+                      fileKey='indexjs'
+                      key='indexjs'
+                      resizeProps={resizeProps}
+                      theme={editorTheme}
+                    />
+                  </span>
+                </Suspense>
+              </ReflexElement>
+            )}
+          </ReflexContainer>
+        </ReflexElement>
+      </ReflexContainer>
+    );
+  }
+}
+
+MultifileEditor.displayName = 'MultifileEditor';
+MultifileEditor.propTypes = propTypes;
+
+// NOTE: withRef gets replaced by forwardRef in react-redux 6,
+// https://github.com/reduxjs/react-redux/releases/tag/v6.0.0
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+  null,
+  { withRef: true }
+)(MultifileEditor);

--- a/client/src/templates/Challenges/classic/Show.js
+++ b/client/src/templates/Challenges/classic/Show.js
@@ -9,7 +9,7 @@ import { first } from 'lodash';
 import Media from 'react-responsive';
 
 import LearnLayout from '../../../components/layouts/Learn';
-import Editor from './Editor';
+import MultifileEditor from './MultifileEditor';
 import Preview from '../components/Preview';
 import SidePanel from '../components/Side-Panel';
 import Output from '../components/Output';
@@ -224,11 +224,12 @@ class ShowClassic extends Component {
     const { description } = this.getChallenge();
     return (
       files && (
-        <Editor
+        <MultifileEditor
           challengeFiles={files}
           containerRef={this.containerRef}
           description={description}
-          ref={this.editorRef}
+          editorRef={this.editorRef}
+          resizeProps={this.resizeProps}
         />
       )
     );

--- a/client/src/templates/Challenges/components/Output.js
+++ b/client/src/templates/Challenges/components/Output.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import sanitizeHtml from 'sanitize-html';
 
 import './output.css';
+import { isEmpty } from 'lodash';
 
 const propTypes = {
   defaultOutput: PropTypes.string,
@@ -12,9 +13,12 @@ const propTypes = {
 class Output extends Component {
   render() {
     const { output, defaultOutput } = this.props;
-    const message = sanitizeHtml(output ? output.join('\n') : defaultOutput, {
-      allowedTags: ['b', 'i', 'em', 'strong', 'code', 'wbr']
-    });
+    const message = sanitizeHtml(
+      !isEmpty(output) ? output.join('\n') : defaultOutput,
+      {
+        allowedTags: ['b', 'i', 'em', 'strong', 'code', 'wbr']
+      }
+    );
     return (
       <pre
         className='output-text'

--- a/client/src/templates/Challenges/projects/backend/Show.js
+++ b/client/src/templates/Challenges/projects/backend/Show.js
@@ -128,7 +128,7 @@ export class BackEnd extends Component {
       },
       pageContext: { challengeMeta }
     } = this.props;
-    initConsole('');
+    initConsole();
     initTests(tests);
     updateChallengeMeta({ ...challengeMeta, title, challengeType });
     challengeMounted(challengeMeta.id);

--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -130,6 +130,9 @@ export const createFiles = createAction(types.createFiles, challengeFiles =>
 
 // TODO: secure with tests
 function getLines(contents, range) {
+  if (isEmpty(range)) {
+    return '';
+  }
   const lines = contents.split('\n');
   const editableLines = isEmpty(lines)
     ? []

--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -297,7 +297,7 @@ export const reducer = handleActions(
 
     [types.initConsole]: (state, { payload }) => ({
       ...state,
-      consoleOut: [payload]
+      consoleOut: payload ? [payload] : []
     }),
     [types.updateConsole]: (state, { payload }) => ({
       ...state,

--- a/cypress/integration/learn/challenges/output.js
+++ b/cypress/integration/learn/challenges/output.js
@@ -1,0 +1,61 @@
+/* global cy */
+
+const selectors = {
+  defaultOutput: '.output-text',
+  hotkeys: '.default-layout > div',
+  runTestsButton: 'button:contains("Run the Tests")'
+};
+
+const locations = {
+  index:
+    '/learn/responsive-web-design/basic-html-and-html5/' +
+    'say-hello-to-html-elements'
+};
+
+const defaultOutput = `
+/**
+* Your test output will go here.
+*/`;
+
+const runningOutput = '// running tests';
+const finishedOutput = '// tests completed';
+
+describe('Classic challenge', function() {
+  it('renders', () => {
+    cy.visit(locations.index);
+
+    cy.title().should(
+      'eq',
+      'Learn Basic HTML and HTML5: Say Hello to HTML Elements |' +
+        ' freeCodeCamp.org'
+    );
+  });
+
+  it('renders the default output text', () => {
+    cy.visit(locations.index);
+    cy.get(selectors.defaultOutput).contains(defaultOutput);
+  });
+
+  it('shows test output when the tests are run', () => {
+    cy.visit(locations.index);
+    cy.get(selectors.runTestsButton)
+      .click()
+      .then(() => {
+        cy.get(selectors.defaultOutput)
+          .contains(runningOutput)
+          .contains(finishedOutput);
+      });
+  });
+
+  it('shows test output when the tests are triggered by the keyboard', () => {
+    cy.visit(locations.index);
+    cy.get(selectors.hotkeys)
+      .focus()
+      .type('{ctrl}{enter}')
+      .then(() => {
+        cy.get(selectors.defaultOutput)
+          .contains(runningOutput)
+          .contains(finishedOutput);
+      });
+  });
+});


### PR DESCRIPTION
The last commit was cherry-picked from master, because I realised the output was not working correctly.  If it's too far out of scope, I can pop that in another PR.

Again, there's a debug commit to facilitate testing (I've blocked it to remind myself to remove that after QA).  This time there are three challenges, starting with Create an Ordered List, so you can see how moving between challenges and the 'target editor' work.
