### PR TITLE
fix: set merge conflict Action to run every 15 minutes instead of on push

### DIFF
--- a/.github/workflows/label_merge_conflicts.yml
+++ b/.github/workflows/label_merge_conflicts.yml
@@ -1,6 +1,8 @@
 name: 'Check for merge conflicts'
 on:
-  push
+  schedule:
+    # run this Action every 15 minutes
+    - cron:  '*/15 * * * *'
 jobs:
   triage:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x]  My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

It seems running the Action `on push` was causing an error to be thrown when commits were being merged into the repo.  This was due to the Action attempting to check for the mergeability status a PR 5 times and throwing the following error:
```bash
##[error]Cannot determine mergeable status!
```
While it is expected behavior of the Action, it is not desirable to see the red X on the commit just because GitHub could not figure out the merge status quickly enough.  This PR is an attempt to significantly reduce this situation from occurring by only running the Action every 15 minutes instead of `on push` as it currently works.  

If this does not yield in a significant reduction of the error, then we will either remove the Action or modify it to not throw the error.  I personally think if it can not determine the status, that the Action should do nothing (not label or unlabel anything) and could certainly be modified to do this (as well as add a comment tagging the OP) to alert the OP via GitHub notification (a GitHub mention).