### PR TITLE
fix: set merge conflict Action to run every 12 hours instead of every 15 minutes

### DIFF
--- a/.github/workflows/label_merge_conflicts.yml
+++ b/.github/workflows/label_merge_conflicts.yml
@@ -1,7 +1,7 @@
 name: 'Check for merge conflicts'
 on:
   schedule:
-    # run this Action every 15 minutes
+    # run this Action every 12 hours
     - cron:  '* */12 * * *'
 jobs:
   triage:

--- a/.github/workflows/label_merge_conflicts.yml
+++ b/.github/workflows/label_merge_conflicts.yml
@@ -2,7 +2,7 @@ name: 'Check for merge conflicts'
 on:
   schedule:
     # run this Action every 15 minutes
-    - cron:  '*/15 * * * *'
+    - cron:  '* */12 * * *'
 jobs:
   triage:
     runs-on: ubuntu-18.04

--- a/.github/workflows/label_merge_conflicts.yml
+++ b/.github/workflows/label_merge_conflicts.yml
@@ -2,7 +2,7 @@ name: 'Check for merge conflicts'
 on:
   schedule:
     # run this Action every 12 hours
-    - cron:  '* */12 * * *'
+    - cron:  '0 */12 * * *'
 jobs:
   triage:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x]  My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

Related to PR #39327

After a discussion with @ojeytonwilliams, we decided that running this Action every 12 hours is sufficient for labeling/unlabeling  merge conflicts.