### PR TITLE
fix: redirect to email sign up on first login

### DIFF
--- a/api-server/common/models/user.json
+++ b/api-server/common/models/user.json
@@ -101,11 +101,11 @@
     },
     "acceptedPrivacyTerms": {
       "type": "boolean",
-      "default": true
+      "default": false
     },
     "sendQuincyEmail": {
       "type": "boolean",
-      "default": true
+      "default": false
     },
     "currentChallengeId": {
       "type": "string",

--- a/api-server/server/component-passport.js
+++ b/api-server/server/component-passport.js
@@ -140,7 +140,12 @@ we recommend using your email address: ${user.email} to sign in instead.
         setAccessTokenToResponse({ accessToken }, req, res);
         req.login(user);
       }
-      return res.redirectWithFlash(redirect);
+      // TODO: enable 'returnTo' for sign-up
+      if (user.acceptedPrivacyTerms) {
+        return res.redirectWithFlash(redirect);
+      } else {
+        return res.redirectWithFlash(`${homeLocation}/email-sign-up`);
+      }
     }
   )(req, res, next);
 };

--- a/client/src/components/layouts/Learn.js
+++ b/client/src/components/layouts/Learn.js
@@ -33,7 +33,7 @@ const mapDispatchToProps = {
   tryToShowDonationModal
 };
 
-const RedirectAcceptPrivacyTerm = createRedirect('/accept-privacy-terms');
+const RedirectEmailSignUp = createRedirect('/email-sign-up');
 
 class LearnLayout extends Component {
   componentDidMount() {
@@ -60,7 +60,7 @@ class LearnLayout extends Component {
     }
 
     if (isSignedIn && !acceptedPrivacyTerms) {
-      return <RedirectAcceptPrivacyTerm />;
+      return <RedirectEmailSignUp />;
     }
 
     return (

--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -493,3 +493,27 @@ blockquote .small {
 #search::placeholder {
   color: var(--secondary-color);
 }
+
+/* checkbox */
+
+.checkbox-inline input[type='checkbox'] {
+  margin-left: -30px;
+}
+
+.checkbox-inline {
+  padding-left: 30px;
+}
+
+input[type='checkbox'] {
+  height: 21px;
+  width: 21px;
+}
+
+/* general page styling */
+.default-page-wrapper {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 20px;
+}

--- a/client/src/pages/email-sign-up.js
+++ b/client/src/pages/email-sign-up.js
@@ -2,18 +2,21 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
+import SectionHeader from '../components/settings/SectionHeader';
+
 import {
   Row,
   Col,
   Button,
   FormGroup,
   ControlLabel,
+  Grid,
   Checkbox
 } from '@freecodecamp/react-bootstrap';
 import Helmet from 'react-helmet';
 import { createSelector } from 'reselect';
 
-import { ButtonSpacer, Spacer } from '../components/helpers';
+import { ButtonSpacer } from '../components/helpers';
 import { acceptTerms, userSelector } from '../redux';
 import createRedirect from '../components/createRedirect';
 
@@ -80,43 +83,40 @@ class AcceptPrivacyTerms extends Component {
         <Helmet>
           <title>Email Sign Up | freeCodeCamp.org</title>
         </Helmet>
-        <Spacer size={2} />
-        <Row className='text-center'>
-          <Col sm={8} smOffset={2} xs={12}>
-            <h1>Email Sign Up </h1>
-          </Col>
-        </Row>
-        <Spacer size={2} />
-        <Row>
-          <Col sm={8} smOffset={2} xs={12}>
-            <form onSubmit={this.handleSubmit}>
-              <FormGroup>
-                <ControlLabel htmlFor='quincy-email'>
-                  Quincy's Emails
-                </ControlLabel>
-                <Spacer />
-                <Checkbox
-                  checked={quincyEmail}
-                  id='quincy-email'
-                  inline={true}
-                  onChange={this.createHandleChange('quincyEmail')}
+        <Grid className='default-page-wrapper'>
+          <SectionHeader>Email Sign Up</SectionHeader>
+          <Row>
+            <Col sm={8} smOffset={2} xs={12}>
+              <form onSubmit={this.handleSubmit}>
+                <FormGroup>
+                  <ControlLabel htmlFor='quincy-email'>
+                    Quincy's Emails
+                  </ControlLabel>
+                  <ButtonSpacer />
+                  <Checkbox
+                    checked={quincyEmail}
+                    id='quincy-email'
+                    inline={true}
+                    onChange={this.createHandleChange('quincyEmail')}
+                  >
+                    I want weekly emails from Quincy, freeCodeCamp.org's
+                    founder.
+                  </Checkbox>
+                </FormGroup>
+                <ButtonSpacer />
+                <Button
+                  block={true}
+                  bsSize='lg'
+                  bsStyle='primary'
+                  className='big-cta-btn'
+                  type='submit'
                 >
-                  I want weekly emails from Quincy, freeCodeCamp.org's founder.
-                </Checkbox>
-              </FormGroup>
-              <ButtonSpacer />
-              <Button
-                block={true}
-                bsStyle='primary'
-                className='big-cta-btn'
-                type='submit'
-              >
-                Continue to freeCodeCamp.org
-              </Button>
-              <Spacer size={2} />
-            </form>
-          </Col>
-        </Row>
+                  Continue to freeCodeCamp.org
+                </Button>
+              </form>
+            </Col>
+          </Row>
+        </Grid>
       </Fragment>
     );
   }

--- a/client/src/pages/email-sign-up.js
+++ b/client/src/pages/email-sign-up.js
@@ -13,7 +13,7 @@ import {
 import Helmet from 'react-helmet';
 import { createSelector } from 'reselect';
 
-import { ButtonSpacer, Spacer, Link } from '../components/helpers';
+import { ButtonSpacer, Spacer } from '../components/helpers';
 import { acceptTerms, userSelector } from '../redux';
 import createRedirect from '../components/createRedirect';
 
@@ -31,16 +31,14 @@ const mapStateToProps = createSelector(
 );
 const mapDispatchToProps = dispatch =>
   bindActionCreators({ acceptTerms }, dispatch);
-const RedirectHome = createRedirect('/');
+const RedirectToLearn = createRedirect('/learn');
 
 class AcceptPrivacyTerms extends Component {
   constructor(props) {
     super(props);
 
     this.state = {
-      privacyPolicy: false,
-      termsOfService: false,
-      quincyEmail: true
+      quincyEmail: false
     };
     this.createHandleChange = this.createHandleChange.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
@@ -55,74 +53,43 @@ class AcceptPrivacyTerms extends Component {
 
   handleSubmit(e) {
     e.preventDefault();
-    const { privacyPolicy, termsOfService, quincyEmail } = this.state;
-    if (!privacyPolicy || !termsOfService) {
-      return null;
-    }
+    const { quincyEmail } = this.state;
+
     return this.props.acceptTerms(quincyEmail);
+  }
+
+  componentWillUnmount() {
+    // if a user navigates away from here we should set acceptedPrivacyTerms
+    // to true (so they do not get pulled back) without changing their email
+    // preferences (hence the null payload)
+    // This ensures the user has to click the checkbox and then click the
+    // 'Continue...' button to sign up.
+    if (!this.props.acceptedPrivacyTerms) {
+      this.props.acceptTerms(null);
+    }
   }
 
   render() {
     const { acceptedPrivacyTerms } = this.props;
     if (acceptedPrivacyTerms) {
-      return <RedirectHome />;
+      return <RedirectToLearn />;
     }
-    const { privacyPolicy, termsOfService, quincyEmail } = this.state;
+    const { quincyEmail } = this.state;
     return (
       <Fragment>
         <Helmet>
-          <title>Privacy Policy and Terms of Service | freeCodeCamp.org</title>
+          <title>Email Sign Up | freeCodeCamp.org</title>
         </Helmet>
         <Spacer size={2} />
         <Row className='text-center'>
           <Col sm={8} smOffset={2} xs={12}>
-            <h1>
-              Please review our updated privacy policy and the terms of service.
-            </h1>
+            <h1>Email Sign Up </h1>
           </Col>
         </Row>
         <Spacer size={2} />
         <Row>
           <Col sm={8} smOffset={2} xs={12}>
             <form onSubmit={this.handleSubmit}>
-              <FormGroup>
-                <ControlLabel htmlFor='terms-of-service'>
-                  Terms of Service
-                </ControlLabel>
-                <Spacer />
-                <Checkbox
-                  checked={termsOfService}
-                  id='terms-of-service'
-                  inline={true}
-                  onChange={this.createHandleChange('termsOfService')}
-                >
-                  I accept the{' '}
-                  <Link external={true} to='/news/terms-of-service'>
-                    terms of service
-                  </Link>{' '}
-                  (required)
-                </Checkbox>
-              </FormGroup>
-              <Spacer />
-              <FormGroup>
-                <ControlLabel htmlFor='privacy-policy'>
-                  Privacy Policy
-                </ControlLabel>
-                <Spacer />
-                <Checkbox
-                  checked={privacyPolicy}
-                  id='privacy-policy'
-                  inline={true}
-                  onChange={this.createHandleChange('privacyPolicy')}
-                >
-                  I accept the{' '}
-                  <Link external={true} to='/news/privacy-policy'>
-                    privacy policy
-                  </Link>{' '}
-                  (required)
-                </Checkbox>
-              </FormGroup>
-              <Spacer />
               <FormGroup>
                 <ControlLabel htmlFor='quincy-email'>
                   Quincy's Emails
@@ -142,7 +109,6 @@ class AcceptPrivacyTerms extends Component {
                 block={true}
                 bsStyle='primary'
                 className='big-cta-btn'
-                disabled={!privacyPolicy || !termsOfService}
                 type='submit'
               >
                 Continue to freeCodeCamp.org

--- a/client/src/redux/accept-terms-saga.js
+++ b/client/src/redux/accept-terms-saga.js
@@ -10,7 +10,7 @@ function* acceptTermsSaga({ payload: quincyEmails }) {
   try {
     const { data: response } = yield call(putUserAcceptsTerms, quincyEmails);
 
-    yield put(acceptTermsComplete());
+    yield put(acceptTermsComplete(quincyEmails));
     yield put(createFlashMessage(response));
   } catch (e) {
     yield put(acceptTermsError(e));
@@ -18,7 +18,7 @@ function* acceptTermsSaga({ payload: quincyEmails }) {
 }
 
 function* acceptCompleteSaga() {
-  yield call(navigate, '/');
+  yield call(navigate, '/learn');
 }
 
 export function createAcceptTermsSaga(types) {

--- a/client/src/redux/index.js
+++ b/client/src/redux/index.js
@@ -364,6 +364,27 @@ function spreadThePayloadOnUser(state, payload) {
 
 export const reducer = handleActions(
   {
+    [types.acceptTermsComplete]: (state, { payload }) => {
+      const { appUsername } = state;
+      return {
+        ...state,
+        user: {
+          ...state.user,
+          [appUsername]: {
+            ...state.user[appUsername],
+            // TODO: the user accepts the privacy terms in practice during auth
+            // however, it's currently being used to track if they've accepted
+            // or rejected the newsletter. Ideally this should be migrated,
+            // since they can't sign up without accepting the terms.
+            acceptedPrivacyTerms: true,
+            sendQuincyEmail:
+              payload === null
+                ? state.user[appUsername].sendQuincyEmail
+                : payload
+          }
+        }
+      };
+    },
     [types.allowBlockDonationRequests]: state => ({
       ...state,
       canRequestBlockDonation: true


### PR DESCRIPTION
I'm using `acceptedPrivacyTerms` as a proxy for 'has logged in before'.  In reality new users have to have accepted the terms before logging in, but it's a useful flag that can be used to ask them (once) if they would like the newsletter.  I think we should migrate to a better name, though.

Also, this breaks the redirect via query parameters. Sorry about that - I'll try to restore it later.
