### PR TITLE
remove MDN links from English challenges

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/increment-a-number-with-javascript.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/increment-a-number-with-javascript.english.md
@@ -19,7 +19,6 @@ is the equivalent of
 ## Instructions
 <section id='instructions'>
 Change the code to use the <code>++</code> operator on <code>myVar</code>.
-<strong>Hint</strong><br>Learn more about <a href="https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Increment_()" target="_blank">Arithmetic operators - Increment (++)</a>.
 </section>
 
 ## Tests

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/record-collection.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/record-collection.english.md
@@ -18,6 +18,7 @@ If <code>prop</code> is <code>"tracks"</code> but the album doesn't have a <code
 If <code>prop</code> is <code>"tracks"</code> and <code>value</code> isn't empty (<code>""</code>), push the <code>value</code> onto the end of the album's existing <code>tracks</code> array.
 If <code>value</code> is empty (<code>""</code>), delete the given <code>prop</code> property from the album.
 <strong>Hints</strong><br>Use <code>bracket notation</code> when <a href="/learn/javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-variables" target="_blank">accessing object properties with variables</a>.
+The `push` array method will be helpful here. Check out our <a href="https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-javascript/manipulate-arrays-with-push" target="_blank">Manipulate Arrays With push()</a> challenge to review how it works.
 You may refer back to <a href="/learn/javascript-algorithms-and-data-structures/basic-javascript/manipulating-complex-objects" target="_blank">Manipulating Complex Objects</a> Introducing JavaScript Object Notation (JSON) for a refresher.
 </section>
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/record-collection.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/record-collection.english.md
@@ -18,7 +18,6 @@ If <code>prop</code> is <code>"tracks"</code> but the album doesn't have a <code
 If <code>prop</code> is <code>"tracks"</code> and <code>value</code> isn't empty (<code>""</code>), push the <code>value</code> onto the end of the album's existing <code>tracks</code> array.
 If <code>value</code> is empty (<code>""</code>), delete the given <code>prop</code> property from the album.
 <strong>Hints</strong><br>Use <code>bracket notation</code> when <a href="/learn/javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-variables" target="_blank">accessing object properties with variables</a>.
-Push is an array method you can read about on <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/push" target="_blank">Mozilla Developer Network</a>.
 You may refer back to <a href="/learn/javascript-algorithms-and-data-structures/basic-javascript/manipulating-complex-objects" target="_blank">Manipulating Complex Objects</a> Introducing JavaScript Object Notation (JSON) for a refresher.
 </section>
 

--- a/curriculum/challenges/english/03-front-end-libraries/jquery/change-text-inside-an-element-using-jquery.english.md
+++ b/curriculum/challenges/english/03-front-end-libraries/jquery/change-text-inside-an-element-using-jquery.english.md
@@ -14,7 +14,7 @@ Here's how you would rewrite and emphasize the text of our heading:
 <code>$("h3").html("&#60;em&#62;jQuery Playground&#60;/em&#62;");</code>
 jQuery also has a similar function called <code>.text()</code> that only alters text without adding tags. In other words, this function will not evaluate any HTML tags passed to it, but will instead treat it as the text you want to replace the existing content with.
 Change the button with id <code>target4</code> by emphasizing its text.
-<a href="https://developer.mozilla.org/en/docs/Web/HTML/Element/em" target="_blank">View the MDN web docs for &#60;em&#62;</a> to learn the difference between <code>&#60;i&#62;</code> and <code>&#60;em&#62</code> and their uses.
+<a href="https://www.freecodecamp.org/news/html-elements-explained-what-are-html-tags/#em-element" target="_blank">View our news article for &#60;em&#62;</a> to learn the difference between <code>&#60;i&#62;</code> and <code>&#60;em&#62</code> and their uses.
 Note that while the <code>&#60;i&#62;</code> tag has traditionally been used to emphasize text, it has since been adopted for use as a tag for icons. The <code>&#60;em&#62;</code> tag is now widely accepted as the tag for emphasis. Either will work for this challenge.
 </section>
 

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/use-assert.isok-and-assert.isnotok.english.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/use-assert.isok-and-assert.isnotok.english.md
@@ -12,7 +12,8 @@ forumTopicId: 301607
 As a reminder, this project is being built upon the following starter project on <a href='https://glitch.com/edit/#!/remix/clone-from-repo?REPO_URL=https://github.com/freeCodeCamp/boilerplate-mochachai/'>Glitch</a>, or cloned from <a href='https://github.com/freeCodeCamp/boilerplate-mochachai/'>GitHub</a>.
 
 <code>isOk()</code> will test for a truthy value and <code>isNotOk()</code> will test for a falsy value.
-To learn more about truthy and falsy, try our <a href="https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-algorithm-scripting/falsy-bouncer" target="_blank">Falsy Bouncer</a> challenge.
+
+To learn more about truthy and falsy values, try our <a href="https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-algorithm-scripting/falsy-bouncer" target="_blank">Falsy Bouncer</a> challenge.
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/use-assert.isok-and-assert.isnotok.english.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/use-assert.isok-and-assert.isnotok.english.md
@@ -12,7 +12,6 @@ forumTopicId: 301607
 As a reminder, this project is being built upon the following starter project on <a href='https://glitch.com/edit/#!/remix/clone-from-repo?REPO_URL=https://github.com/freeCodeCamp/boilerplate-mochachai/'>Glitch</a>, or cloned from <a href='https://github.com/freeCodeCamp/boilerplate-mochachai/'>GitHub</a>.
 
 <code>isOk()</code> will test for a truthy value and <code>isNotOk()</code> will test for a falsy value.
-
 To learn more about truthy and falsy values, try our <a href="https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-algorithm-scripting/falsy-bouncer" target="_blank">Falsy Bouncer</a> challenge.
 </section>
 

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/use-assert.isok-and-assert.isnotok.english.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/use-assert.isok-and-assert.isnotok.english.md
@@ -12,8 +12,7 @@ forumTopicId: 301607
 As a reminder, this project is being built upon the following starter project on <a href='https://glitch.com/edit/#!/remix/clone-from-repo?REPO_URL=https://github.com/freeCodeCamp/boilerplate-mochachai/'>Glitch</a>, or cloned from <a href='https://github.com/freeCodeCamp/boilerplate-mochachai/'>GitHub</a>.
 
 <code>isOk()</code> will test for a truthy value and <code>isNotOk()</code> will test for a falsy value.
-[Truthy reference](https://developer.mozilla.org/en-US/docs/Glossary/Truthy)
-[Falsy reference](https://developer.mozilla.org/en-US/docs/Glossary/Falsy)
+To learn more about truthy and falsy, try our <a href="https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-algorithm-scripting/falsy-bouncer" target="_blank">Falsy Bouncer</a> challenge.
 </section>
 
 ## Instructions


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #37827

<!-- Feel free to add any additional description of changes below this line -->

> @Sky020 You might try to search https://freecodecamp.org/news to see if you can find a good article there.  Many of the most popular Guide Topics were transported to a corresponding news article.
>
>Currently, there are only 4 challenges with MDN links:
>
>* [Increment a Number with JavaScript](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-javascript/increment-a-number-with-javascript) - The MDN information does not give any further incite to using the `++` operator, so I think we just remove this link all together.  Also, it would not make sense to create an entire news article for this, though we could create a Guide topic on the forum I suppose and make it a wiki.
>
>* [Record Collection](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-javascript/record-collection) - The MDN link relates to the `push` method which is already introduced way before this challenge, so I think we can just delete this link.
>
>* [Change Text Inside an Element Using jQuery]() - The MDN link here (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em) actually has some merit.  I think we could either create a news article or a forum Guide topic with similar information and examples and link to it instead.
>
>* [Use Assert.isOK and Assert.isNotOK](https://www.freecodecamp.org/learn/quality-assurance/quality-assurance-and-testing-with-chai/use-assert-isok-and-assert-isnotok) - The Truthy and Falsy MDN links could be replaced by a link to the [Falsy Bouncer](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-algorithm-scripting/falsy-bouncer) challenge or a news or forum article covering the information in more detail.
>
>The above is just my thoughts on the links.  If at all possible, I think the links to MDN should be removed.
>
_Originally posted by @RandellDawson in https://github.com/freeCodeCamp/freeCodeCamp/issues/37827#issuecomment-665854174_

# Todo
- [x] Increment a Number with JavaScript
- [x] Change Text Inside an Element Using jQuery
- [x] Use Assert.isOK and Assert.isNotOK
#### What verbiage do we want here?

- [x] Record Collection

> @RandellDawson , That is excellent! In this case, I suggest because other members were in agreement in the linked PR, we open this to _help wanted_ (or _first-timers_), and do as you have suggested above.
> 
> One point on my side:
> 
> > Record Collection - The MDN link relates to the push method which is already introduced way before this challenge, so I think we can just delete this link.
> 
> Instead of removing the link, I suggest it be changed to direct to the challenge that introduces the `push` method.
> 
> So, if you agree, Randell, I leave it to you to open this to _first-timers_ or otherwise.
_Originally posted by @Sky020 in https://github.com/freeCodeCamp/freeCodeCamp/issues/37827#issuecomment-665927113_

#### Which ```push``` challenge is being referenced here? Want to ensure I replace this MDN link with the correct challenge link.

