### PR TITLE
fix(learn): tests for the selection sort challenge

### DIFF
--- a/curriculum/challenges/english/10-coding-interview-prep/algorithms/implement-selection-sort.english.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/algorithms/implement-selection-sort.english.md
@@ -30,7 +30,7 @@ tests:
   - text: <code>selectionSort</code> should return an array that is unchanged except for order.
     testString: assert.sameMembers(selectionSort([1,4,2,8,345,123,43,32,5643,63,123,43,2,55,1,234,92]), [1,4,2,8,345,123,43,32,5643,63,123,43,2,55,1,234,92]);
   - text: <code>selectionSort</code> should not use the built-in <code>.sort()</code> method.
-    testString: assert(!code.match(/\.?[\s\S]*?sort/));
+    testString: assert(!code.match(/(\A|\n)(?!.*(\\\\|((?![\s\S]*)))).*\.\s*sort\s*?\([\s\S]*\)/));
 
 ```
 


### PR DESCRIPTION
Edited the test for the selection sort challenge. It was triggering flags when using the term "sort" out of the appropriate contexts such as in comments or in names of other methods. Also edited it to account for when parameters are passed.