### PR TITLE
fix(learn): Added test for Capitalized -> uncapitalized variants

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/search-and-replace.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/search-and-replace.english.md
@@ -30,6 +30,8 @@ tests:
     testString: assert.deepEqual(myReplace("Let us go to the store", "store", "mall"), "Let us go to the mall");
   - text: <code>myReplace("He is Sleeping on the couch", "Sleeping", "sitting")</code> should return "He is Sitting on the couch".
     testString: assert.deepEqual(myReplace("He is Sleeping on the couch", "Sleeping", "sitting"), "He is Sitting on the couch");
+  - text: <code>myReplace("I think we should look up there", "up", "Down")</code> should return "I think we should look down there".
+    testString: assert.deepEqual(myReplace("I think we should look up there", "up", "Down"), "I think we should look down there");
   - text: <code>myReplace("This has a spellngi error", "spellngi", "spelling")</code> should return "This has a spelling error".
     testString: assert.deepEqual(myReplace("This has a spellngi error", "spellngi", "spelling"), "This has a spelling error");
   - text: <code>myReplace("His name is Tom", "Tom", "john")</code> should return "His name is John".


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [*] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [*] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [*] My pull request targets the `master` branch of freeCodeCamp.
- [*] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!-- Feel free to add any additional description of changes below this line -->

I noticed that there is an edge case that violates the description of the "Search & Replace" challenge.

"Preserve the case of the first character in the original word when you are replacing it." - Challenge Description

Currently, the tests check uncapitalized input and unchanged input, but not for capitalized input.

Example of working code -->

```
myReplace("He is Sleeping on the couch", "Sleeping", "sitting")
```

Code that passes the test but doesn't adhere to rules -->

```
String.prototype.capitalize = function() {
  return this.charAt(0).toUpperCase() + this.slice(1);
}

function myReplace(str, before, after) {

  before.match(/^[^a-z]/) 
  ? after = after.capitalize()
  : false

  return str.replace(before, after);
}

myReplace("I think we should look up there", "up", "Down");
```

