### PR TITLE
Fix: replace hardGoTo with links where possible

### DIFF
--- a/client/src/client-only-routes/ShowProfileOrFourOhFour.js
+++ b/client/src/client-only-routes/ShowProfileOrFourOhFour.js
@@ -8,8 +8,7 @@ import {
   userByNameSelector,
   userProfileFetchStateSelector,
   fetchProfileForUser,
-  usernameSelector,
-  hardGoTo as navigate
+  usernameSelector
 } from '../redux';
 import FourOhFourPage from '../components/FourOhFour';
 import Profile from '../components/profile/Profile';
@@ -19,7 +18,6 @@ const propTypes = {
   fetchProfileForUser: PropTypes.func.isRequired,
   isSessionUser: PropTypes.bool,
   maybeUser: PropTypes.string,
-  navigate: PropTypes.func.isRequired,
   requestedUser: PropTypes.shape({
     username: PropTypes.string,
     profileUI: PropTypes.object
@@ -45,8 +43,7 @@ const makeMapStateToProps = () => (state, props) => {
 };
 
 const mapDispatchToProps = {
-  fetchProfileForUser,
-  navigate
+  fetchProfileForUser
 };
 
 class ShowProfileOrFourOhFour extends Component {
@@ -62,7 +59,7 @@ class ShowProfileOrFourOhFour extends Component {
       return null;
     }
 
-    const { isSessionUser, requestedUser, showLoading, navigate } = this.props;
+    const { isSessionUser, requestedUser, showLoading } = this.props;
     if (isEmpty(requestedUser)) {
       if (showLoading) {
         // We don't know if /:maybeUser is a user or not, we will show
@@ -77,13 +74,7 @@ class ShowProfileOrFourOhFour extends Component {
 
     // We have a response from the API, and we have some state in the
     // store for /:maybeUser, we now handover rendering to the Profile component
-    return (
-      <Profile
-        isSessionUser={isSessionUser}
-        navigate={navigate}
-        user={requestedUser}
-      />
-    );
+    return <Profile isSessionUser={isSessionUser} user={requestedUser} />;
   }
 }
 

--- a/client/src/client-only-routes/ShowSettings.js
+++ b/client/src/client-only-routes/ShowSettings.js
@@ -113,11 +113,6 @@ const mapDispatchToProps = {
   verifyCert
 };
 
-const createHandleSignoutClick = navigate => e => {
-  e.preventDefault();
-  return navigate(`${apiLocation}/signout`);
-};
-
 export function ShowSettings(props) {
   const {
     createFlashMessage,
@@ -194,8 +189,7 @@ export function ShowSettings(props) {
               bsSize='lg'
               bsStyle='primary'
               className='btn-invert'
-              href={'/signout'}
-              onClick={createHandleSignoutClick(navigate)}
+              href={`${apiLocation}/signout`}
             >
               Sign me out of freeCodeCamp
             </Button>

--- a/client/src/client-only-routes/ShowUser.js
+++ b/client/src/client-only-routes/ShowUser.js
@@ -16,7 +16,6 @@ import Helmet from 'react-helmet';
 import Login from '../components/Header/components/Login';
 
 import {
-  hardGoTo as navigate,
   isSignedInSelector,
   userFetchStateSelector,
   userSelector,
@@ -29,7 +28,6 @@ import './showuser.css';
 const propTypes = {
   email: PropTypes.string,
   isSignedIn: PropTypes.bool,
-  navigate: PropTypes.func.isRequired,
   reportUser: PropTypes.func.isRequired,
   userFetchState: PropTypes.shape({
     pending: PropTypes.bool,
@@ -51,7 +49,6 @@ const mapStateToProps = createSelector(
 );
 
 const mapDispatchToProps = {
-  navigate,
   reportUser
 };
 

--- a/client/src/components/Donation/DonateForm.js
+++ b/client/src/components/Donation/DonateForm.js
@@ -11,7 +11,6 @@ import {
   ToggleButton,
   ToggleButtonGroup
 } from '@freecodecamp/react-bootstrap';
-// import { StripeProvider, Elements } from 'react-stripe-elements';
 import ApplePay from './assets/ApplePay';
 import GooglePay from './assets/GooglePay';
 import acceptedCards from './assets/accepted-cards.png';
@@ -24,14 +23,9 @@ import {
 } from '../../../../config/donation-settings';
 import { deploymentEnv } from '../../../config/env.json';
 import Spacer from '../helpers/Spacer';
-// import DonateFormChildViewForHOC from './DonateFormChildViewForHOC';
 import PaypalButton from './PaypalButton';
 import DonateCompletion from './DonateCompletion';
-import {
-  isSignedInSelector,
-  signInLoadingSelector,
-  hardGoTo as navigate
-} from '../../redux';
+import { isSignedInSelector, signInLoadingSelector } from '../../redux';
 
 import './Donation.css';
 
@@ -42,7 +36,6 @@ const propTypes = {
   handleProcessing: PropTypes.func,
   isDonating: PropTypes.bool,
   isSignedIn: PropTypes.bool,
-  navigate: PropTypes.func.isRequired,
   showLoading: PropTypes.bool.isRequired,
   stripe: PropTypes.shape({
     createToken: PropTypes.func.isRequired,
@@ -58,9 +51,6 @@ const mapStateToProps = createSelector(
     showLoading
   })
 );
-const mapDispatchToProps = {
-  navigate
-};
 
 const initialState = {
   donationState: {
@@ -345,7 +335,4 @@ class DonateForm extends Component {
 DonateForm.displayName = 'DonateForm';
 DonateForm.propTypes = propTypes;
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(DonateForm);
+export default connect(mapStateToProps)(DonateForm);

--- a/client/src/components/Header/components/Login.js
+++ b/client/src/components/Header/components/Login.js
@@ -2,10 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
-import { navigate as gatsbyNavigate } from 'gatsby';
 import { Button } from '@freecodecamp/react-bootstrap';
 
-import { hardGoTo as navigate, isSignedInSelector } from '../../../redux';
+import { isSignedInSelector } from '../../../redux';
 import { apiLocation } from '../../../../config/env.json';
 
 import { gtagReportConversion } from '../../../analytics/gtag';
@@ -18,27 +17,16 @@ const mapStateToProps = createSelector(
     isSignedIn
   })
 );
-const mapDispatchToProps = {
-  navigate
-};
-
-const createOnClick = (navigate, isSignedIn) => e => {
-  e.preventDefault();
-  gtagReportConversion();
-  if (isSignedIn) {
-    return gatsbyNavigate('/learn');
-  }
-  return navigate(`${apiLocation}/signin`);
-};
 
 function Login(props) {
-  const { children, navigate, isSignedIn, ...restProps } = props;
+  const { children, isSignedIn, ...restProps } = props;
+  const href = isSignedIn ? '/learn' : `${apiLocation}/signin`;
   return (
     <Button
       bsStyle='default'
       className={(restProps.block ? 'btn-cta-big' : '') + ' signup-btn btn-cta'}
-      href='/signin'
-      onClick={createOnClick(navigate, isSignedIn)}
+      href={href}
+      onClick={() => gtagReportConversion()}
       {...restProps}
     >
       {children || 'Sign In'}
@@ -49,11 +37,7 @@ function Login(props) {
 Login.displayName = 'Login';
 Login.propTypes = {
   children: PropTypes.any,
-  isSignedIn: PropTypes.bool,
-  navigate: PropTypes.func.isRequired
+  isSignedIn: PropTypes.bool
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Login);
+export default connect(mapStateToProps)(Login);

--- a/client/src/components/Intro/Intro.test.js
+++ b/client/src/components/Intro/Intro.test.js
@@ -1,21 +1,28 @@
 /* global expect */
 import React from 'react';
 import renderer from 'react-test-renderer';
-// import ShallowRenderer from 'react-test-renderer/shallow';
+import { Provider } from 'react-redux';
+import { createStore } from '../../redux/createStore';
 
 import 'jest-dom/extend-expect';
 
 import Intro from './';
 
+function rendererCreateWithRedux(ui) {
+  return renderer.create(<Provider store={createStore()}>{ui}</Provider>);
+}
+
 describe('<Intro />', () => {
   it('has no blockquotes when loggedOut', () => {
-    const container = renderer.create(<Intro {...loggedOutProps} />).root;
+    const container = rendererCreateWithRedux(<Intro {...loggedOutProps} />)
+      .root;
     expect(container.findAllByType('blockquote').length === 0).toBeTruthy();
     expect(container.findAllByType('h1').length === 1).toBeTruthy();
   });
 
   it('has a blockquote when loggedIn', () => {
-    const container = renderer.create(<Intro {...loggedInProps} />).root;
+    const container = rendererCreateWithRedux(<Intro {...loggedInProps} />)
+      .root;
     expect(container.findAllByType('blockquote').length === 1).toBeTruthy();
     expect(container.findAllByType('h1').length === 1).toBeTruthy();
   });

--- a/client/src/components/Intro/index.js
+++ b/client/src/components/Intro/index.js
@@ -2,18 +2,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link, Spacer, Loader, FullWidthRow } from '../helpers';
 import { Row, Col } from '@freecodecamp/react-bootstrap';
-import { apiLocation, forumLocation } from '../../../config/env.json';
+import { forumLocation } from '../../../config/env.json';
 import { randomQuote } from '../../utils/get-words';
 import CurrentChallengeLink from '../helpers/CurrentChallengeLink';
 
 import './intro.css';
+import Login from '../Header/components/Login';
 
 const propTypes = {
   complete: PropTypes.bool,
   completedChallengeCount: PropTypes.number,
   isSignedIn: PropTypes.bool,
   name: PropTypes.string,
-  navigate: PropTypes.func,
   pending: PropTypes.bool,
   slug: PropTypes.string,
   username: PropTypes.string
@@ -23,7 +23,6 @@ function Intro({
   isSignedIn,
   username,
   name,
-  navigate,
   pending,
   complete,
   completedChallengeCount,
@@ -163,14 +162,9 @@ function Intro({
           </Col>
 
           <Col sm={8} smOffset={2} xs={12}>
-            <button
-              className={'btn-cta-big signup-btn btn-cta center-block'}
-              onClick={() => {
-                navigate(`${apiLocation}/signin`);
-              }}
-            >
+            <Login block={true}>
               Sign in to save your progress (it's free)
-            </button>
+            </Login>
           </Col>
         </Row>
         <Spacer />

--- a/client/src/components/Map/components/SuperBlock.test.js
+++ b/client/src/components/Map/components/SuperBlock.test.js
@@ -10,8 +10,8 @@ import { SuperBlock } from './SuperBlock';
 import mockChallengeNodes from '../../../__mocks__/challenge-nodes';
 import mockIntroNodes from '../../../__mocks__/intro-nodes';
 
-function renderWithRedux(ui) {
-  return render(<Provider store={createStore()}>{ui}</Provider>);
+function renderWithRedux(ui, store) {
+  return render(<Provider store={store || createStore()}>{ui}</Provider>);
 }
 
 test('<SuperBlock /> not expanded snapshot', () => {
@@ -52,7 +52,11 @@ test('<SuperBlock should handle toggle clicks correctly', () => {
     toggleSuperBlock: toggleSpy
   };
 
-  const { container, rerender } = renderWithRedux(<SuperBlock {...props} />);
+  const store = createStore();
+  const { container, rerender } = renderWithRedux(
+    <SuperBlock {...props} />,
+    store
+  );
 
   expect(toggleSpy).not.toHaveBeenCalled();
   expect(container.querySelector('.map-title h4')).toHaveTextContent(
@@ -66,7 +70,7 @@ test('<SuperBlock should handle toggle clicks correctly', () => {
   expect(toggleSpy).toHaveBeenCalledWith('Super Block One');
 
   rerender(
-    <Provider store={createStore()}>
+    <Provider store={store}>
       <SuperBlock {...props} isExpanded={true} />
     </Provider>
   );

--- a/client/src/components/helpers/CurrentChallengeLink.js
+++ b/client/src/components/helpers/CurrentChallengeLink.js
@@ -1,30 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { bindActionCreators } from 'redux';
-import { connect } from 'react-redux';
 
 import { apiLocation } from '../../../config/env.json';
-
-import { hardGoTo } from '../../redux';
 
 const currentChallengeApi = '/challenges/current-challenge';
 
 const propTypes = {
   children: PropTypes.any,
-  hardGoTo: PropTypes.func.isRequired,
   isLargeBtn: PropTypes.bool
 };
 
-const mapStateToProps = () => ({});
-const mapDispatchToProps = dispatch =>
-  bindActionCreators({ hardGoTo }, dispatch);
-
-const createClickHandler = hardGoTo => e => {
-  e.preventDefault();
-  return hardGoTo(`${apiLocation}${currentChallengeApi}`);
-};
-
-function CurrentChallengeLink({ children, hardGoTo, isLargeBtn }) {
+function CurrentChallengeLink({ children, isLargeBtn }) {
   let classNames;
   if (isLargeBtn) {
     classNames = 'btn btn-lg btn-primary btn-block';
@@ -32,11 +18,7 @@ function CurrentChallengeLink({ children, hardGoTo, isLargeBtn }) {
     classNames = 'btn btn-cta-big btn-primary btn-block';
   }
   return (
-    <a
-      className={classNames}
-      href={currentChallengeApi}
-      onClick={createClickHandler(hardGoTo)}
-    >
+    <a className={classNames} href={`${apiLocation}${currentChallengeApi}`}>
       {children}
     </a>
   );
@@ -45,7 +27,4 @@ function CurrentChallengeLink({ children, hardGoTo, isLargeBtn }) {
 CurrentChallengeLink.displayName = 'CurrentChallengeLink';
 CurrentChallengeLink.propTypes = propTypes;
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(CurrentChallengeLink);
+export default CurrentChallengeLink;

--- a/client/src/components/profile/Profile.js
+++ b/client/src/components/profile/Profile.js
@@ -14,7 +14,6 @@ import { apiLocation } from '../../../config/env.json';
 
 const propTypes = {
   isSessionUser: PropTypes.bool,
-  navigate: PropTypes.func.isRequired,
   user: PropTypes.shape({
     profileUI: PropTypes.shape({
       isLocked: PropTypes.bool,
@@ -157,16 +156,11 @@ function renderProfile(user) {
   );
 }
 
-function Profile({ user, isSessionUser, navigate }) {
+function Profile({ user, isSessionUser }) {
   const {
     profileUI: { isLocked = true },
     username
   } = user;
-
-  const createHandleSignoutClick = navigate => e => {
-    e.preventDefault();
-    return navigate(`${apiLocation}/signout`);
-  };
 
   return (
     <Fragment>
@@ -185,8 +179,7 @@ function Profile({ user, isSessionUser, navigate }) {
               bsSize='lg'
               bsStyle='primary'
               className='btn-invert'
-              href={'/signout'}
-              onClick={createHandleSignoutClick(navigate)}
+              href={`${apiLocation}/signout`}
             >
               Sign me out of freeCodeCamp
             </Button>

--- a/client/src/components/settings/Certification.test.js
+++ b/client/src/components/settings/Certification.test.js
@@ -3,14 +3,20 @@
 import '@testing-library/jest-dom/extend-expect';
 import React from 'react';
 import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { createStore } from '../../redux/createStore';
 
 import { CertificationSettings } from './Certification';
+
+function renderWithRedux(ui) {
+  return render(<Provider store={createStore()}>{ui}</Provider>);
+}
 
 describe('<certification />', () => {
   // shallow rendering does not render children component
   // form buttons are not included in shallow render
   it('Should render show cert button for claimed legacy cert', () => {
-    const { container } = render(
+    const { container } = renderWithRedux(
       <CertificationSettings {...defaultTestProps} />
     );
 
@@ -20,7 +26,7 @@ describe('<certification />', () => {
   });
 
   it('Should link show cert button to the claimed legacy cert', () => {
-    const { container } = render(
+    const { container } = renderWithRedux(
       <CertificationSettings {...defaultTestProps} />
     );
 
@@ -34,7 +40,7 @@ describe('<certification />', () => {
 
   // full forms with unclaimed certs should should not shallow render button
   it('Should not render show cert button for unclaimed full form', () => {
-    const { container } = render(
+    const { container } = renderWithRedux(
       <CertificationSettings {...defaultTestProps} />
     );
 
@@ -45,7 +51,7 @@ describe('<certification />', () => {
 
   // empty forms with unclaimed certs should should not shallow render button
   it('Should not render show cert button for empty form', () => {
-    const { container } = render(
+    const { container } = renderWithRedux(
       <CertificationSettings {...defaultTestProps} />
     );
 

--- a/client/src/pages/learn.js
+++ b/client/src/pages/learn.js
@@ -13,8 +13,7 @@ import Intro from '../components/Intro';
 import {
   userFetchStateSelector,
   isSignedInSelector,
-  userSelector,
-  hardGoTo as navigate
+  userSelector
 } from '../redux';
 import {
   ChallengeNode,
@@ -47,7 +46,6 @@ const propTypes = {
   hash: PropTypes.string,
   isSignedIn: PropTypes.bool,
   location: PropTypes.object,
-  navigate: PropTypes.func.isRequired,
   state: PropTypes.object,
   user: PropTypes.shape({
     name: PropTypes.string,
@@ -62,14 +60,10 @@ const hashValueSelector = (state, hash) => {
   else if (hash) return hash.substr(1);
   else return null;
 };
-const mapDispatchToProps = {
-  navigate
-};
 
 export const LearnPage = ({
   location: { hash = '', state = '' },
   isSignedIn,
-  navigate,
   fetchState: { pending, complete },
   user: { name = '', username = '', completedChallengeCount = 0 },
   data: {
@@ -90,7 +84,6 @@ export const LearnPage = ({
           completedChallengeCount={completedChallengeCount}
           isSignedIn={isSignedIn}
           name={name}
-          navigate={navigate}
           pending={pending}
           slug={slug}
           username={username}
@@ -111,10 +104,7 @@ export const LearnPage = ({
 LearnPage.displayName = 'LearnPage';
 LearnPage.propTypes = propTypes;
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(LearnPage);
+export default connect(mapStateToProps)(LearnPage);
 
 export const query = graphql`
   query FirstChallenge {


### PR DESCRIPTION
It mostly is redundant, though there's still one case were we use it programmatically. `ShowSettings` still uses it because it calls it to go to /signin.

Also, I've added a couple of commits that fix some test warning's that have been bugging me for a while!

edit: I updated this comment to consolidate the discussion