### PR TITLE
fix: improve challenge logs

### DIFF
--- a/client/src/client/workers/test-evaluator.js
+++ b/client/src/client/workers/test-evaluator.js
@@ -80,8 +80,15 @@ ${e.data.testString}`);
         // rethrow error, since test failed.
         throw err;
       }
-      // log build errors
-      __utils.log(err);
+      // log build errors unless they're related to import/export/require (there
+      // are challenges that use them and they should not trigger warnings)
+      if (
+        err.name !== 'ReferenceError' ||
+        (err.message !== 'require is not defined' &&
+          err.message !== 'exports is not defined')
+      ) {
+        __utils.log(err);
+      }
       // the tests may not require working code, so they are evaluated even if
       // the user code does not get executed.
       testResult = eval(e.data.testString);

--- a/client/src/client/workers/test-evaluator.js
+++ b/client/src/client/workers/test-evaluator.js
@@ -32,11 +32,11 @@ const __utils = (() => {
     self.postMessage(data);
   }
 
-  function log(msg) {
-    if (!(msg instanceof chai.AssertionError)) {
+  function log(...msgs) {
+    if (msgs && msgs[0] && !(msgs[0] instanceof chai.AssertionError)) {
       // discards the stack trace via toString as it only useful to debug the
       // site, not a specific challenge.
-      console.log(msg.toString());
+      console.log(...msgs.map(msg => msg.toString()));
     }
   }
 


### PR DESCRIPTION
Addresses the point raised by @Sky020 here: https://github.com/freeCodeCamp/freeCodeCamp/issues/38474#issuecomment-653821059

In the process I realised that statements like `console.log('a','b')` would just log `a`, so I fixed that. 