### PR TITLE
fix(curriculum) typo in Create Reusable CSS

### DIFF
--- a/curriculum/challenges/english/03-front-end-libraries/sass/create-reusable-css-with-mixins.english.md
+++ b/curriculum/challenges/english/03-front-end-libraries/sass/create-reusable-css-with-mixins.english.md
@@ -55,11 +55,11 @@ Write a mixin for <code>border-radius</code> and give it a <code>$radius</code> 
 tests:
   - text: Your code should declare a mixin named <code>border-radius</code> which has a parameter named <code>$radius</code>.
     testString: assert(code.match(/@mixin\s+?border-radius\s*?\(\s*?\$radius\s*?\)\s*?{/gi));
-  - text: Your code should include the <code>-webkit-border-radius</code> vender prefix that uses the <code>$radius</code> parameter.
+  - text: Your code should include the <code>-webkit-border-radius</code> vendor prefix that uses the <code>$radius</code> parameter.
     testString: assert(code.match(/-webkit-border-radius:\s*?\$radius;/gi));
-  - text: Your code should include the <code>-moz-border-radius</code> vender prefix that uses the <code>$radius</code> parameter.
+  - text: Your code should include the <code>-moz-border-radius</code> vendor prefix that uses the <code>$radius</code> parameter.
     testString: assert(code.match(/-moz-border-radius:\s*?\$radius;/gi));
-  - text: Your code should include the <code>-ms-border-radius</code> vender prefix that uses the <code>$radius</code> parameter.
+  - text: Your code should include the <code>-ms-border-radius</code> vendor prefix that uses the <code>$radius</code> parameter.
     testString: assert(code.match(/-ms-border-radius:\s*?\$radius;/gi));
   - text: Your code should include the general <code>border-radius</code> rule that uses the <code>$radius</code> parameter.
     testString: assert(code.match(/border-radius:\s*?\$radius;/gi).length == 4);


### PR DESCRIPTION
Fixed a typo on the Sass Challenge "Create Reusable CSS with Mixins" where the word "vendor" was spelled incorrectly as "vender" in the test cases. Screenshot below.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [ x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ x] My pull request targets the `master` branch of freeCodeCamp.
- [ x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
![Screen Shot 2020-08-16 at 11 39 51 AM](https://user-images.githubusercontent.com/25686852/90339657-bbbdaa80-dfb7-11ea-891e-e8bf31f430bf.png)