### PR TITLE
Remove extra / from link

### DIFF
--- a/curriculum/challenges/english/10-coding-interview-prep/take-home-projects/manage-a-book-trading-club.english.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/take-home-projects/manage-a-book-trading-club.english.md
@@ -8,7 +8,7 @@ forumTopicId: 302364
 
 ## Description
 <section id='description'>
-<strong>Objective:</strong> Build a <a href='https://glitch.com' target='_blank'>Glitch</a> app that is functionally similar to this: <a href='https://chrome-delivery.glitch.me/ /' target='_blank'>https://chrome-delivery.glitch.me</a>.
+<strong>Objective:</strong> Build a <a href='https://glitch.com' target='_blank'>Glitch</a> app that is functionally similar to this: <a href='https://chrome-delivery.glitch.me/' target='_blank'>https://chrome-delivery.glitch.me</a>.
 Fulfill the below <a href='https://en.wikipedia.org/wiki/User_story' target='_blank'>user stories</a>. Use whichever libraries or APIs you need. Give it your own personal style.
 <strong>User Story:</strong> I can view all books posted by every user.
 <strong>User Story:</strong> I can add a new book.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `master` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!-- Feel free to add any additional description of changes below this line -->

While running a quick audit on the status of Glitch hosted projects, ran into this link that appears to have an extra ` /` after the original link.
