### PR TITLE
Fixed missing closing bracket and deleted variable declared twice in rosetta code greatest-sub-sequential-sum challenge.

### DIFF
--- a/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/greatest-subsequential-sum.english.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/greatest-subsequential-sum.english.md
@@ -32,7 +32,7 @@ tests:
     testString: assert.deepEqual(maximumSubsequence([0, 8, 10, -2, -4, -1, -5, -3]), [ 0, 8, 10 ]);
   - text: <code>maximumSubsequence([ 9, 9, -10, 1 ])</code> should return <code>[ 9, 9 ]</code>.
     testString: assert.deepEqual(maximumSubsequence([ 9, 9, -10, 1 ]), [ 9, 9 ]);
-  - text: <code>maximumSubsequence([ 7, 1, -5, -3, -8, 1 ]</code> should return <code>[ 7, 1 ]</code>.
+  - text: <code>maximumSubsequence([ 7, 1, -5, -3, -8, 1 ])</code> should return <code>[ 7, 1 ]</code>.
     testString: assert.deepEqual(maximumSubsequence([ 7, 1, -5, -3, -8, 1 ]), [ 7, 1 ]);
   - text: <code>maximumSubsequence([ -3, 6, -1, 4, -4, -6 ])</code> should return <code>[ 6, -1, 4 ]</code>.
     testString: assert.deepEqual(maximumSubsequence([ -3, 6, -1, 4, -4, -6 ]), [ 6, -1, 4 ]);
@@ -73,7 +73,6 @@ function maximumSubsequence(population) {
   }
   var greatest;
   var maxValue = 0;
-  var subsequence = [];
 
   for (var i = 0, len = population.length; i < len; i++) {
       for (var j = i; j <= len; j++) {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

 - In test description 6, a closing bracket was omitted. Changed `maximumSubsequence([ 7, 1, -5, -3, -8, 1 ]` to `maximumSubsequence([ 7, 1, -5, -3, -8, 1 ])`.
- In the solution to the challenge, variable `subsequence` was declared twice. Outside the loop `var subsequence = [];` and inside the loop `var subsequence = population.slice(i, j);`.
