### PR TITLE
fix(client): ensure presetEnv is loaded

### DIFF
--- a/client/src/templates/Challenges/rechallenge/transformers.js
+++ b/client/src/templates/Challenges/rechallenge/transformers.js
@@ -59,11 +59,12 @@ async function loadBabel() {
 }
 
 async function loadPresetEnv() {
-  if (presetEnv) return;
+  if (babelOptionsJSBase && babelOptionsJSBase.presets) return;
   /* eslint-disable no-inline-comments */
-  presetEnv = await import(
-    /* webpackChunkName: "@babel/preset-env" */ '@babel/preset-env'
-  );
+  if (!presetEnv)
+    presetEnv = await import(
+      /* webpackChunkName: "@babel/preset-env" */ '@babel/preset-env'
+    );
   /* eslint-enable no-inline-comments */
 
   babelOptionsJSBase = {


### PR DESCRIPTION
Prior to this, if a user first loaded a React challenge and then navigated to a JS challenge, they would see
TypeError: Cannot read property 'presets' of undefined
in the console and be unable to run tests or evaluate code until they reloaded the page.