### PR TITLE
fix(client): format cert date in user's timezone

### DIFF
--- a/api-server/server/boot/certificate.js
+++ b/api-server/server/boot/certificate.js
@@ -5,7 +5,6 @@ import dedent from 'dedent';
 import { Observable } from 'rx';
 import debug from 'debug';
 import { isEmail } from 'validator';
-import format from 'date-fns/format';
 import { reportError } from '../middlewares/sentry-error-handler.js';
 
 import { ifNoUser401 } from '../utils/middleware';
@@ -542,7 +541,7 @@ function createShowCert(app) {
           certTitle,
           username,
           name,
-          date: format(new Date(completedDate), 'MMMM D, YYYY'),
+          date: completedDate,
           completionTime
         });
       }

--- a/client/src/client-only-routes/ShowCertification.js
+++ b/client/src/client-only-routes/ShowCertification.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
+import format from 'date-fns/format';
 import { Grid, Row, Col, Image, Button } from '@freecodecamp/react-bootstrap';
 import FreeCodeCampLogo from '../assets/icons/freeCodeCampLogo';
 // eslint-disable-next-line max-len
@@ -45,7 +46,6 @@ const propTypes = {
     errored: PropTypes.bool
   }),
   isDonating: PropTypes.bool,
-  issueDate: PropTypes.string,
   showCert: PropTypes.func.isRequired,
   signedInUserName: PropTypes.string,
   userFetchState: PropTypes.shape({
@@ -250,7 +250,7 @@ class ShowCertification extends Component {
               <Col md={7} sm={12}>
                 <div className='issue-date'>
                   Issued&nbsp;
-                  <strong>{issueDate}</strong>
+                  <strong>{format(new Date(issueDate), 'MMMM D, YYYY')}</strong>
                 </div>
               </Col>
             </header>


### PR DESCRIPTION
Instead of calculating the date on the server (and using its timezone), this sends the date to the client for formatting in the user's local timezone.

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/39186