### PR TITLE
fix(learn): correct personal library replit link

### DIFF
--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/personal-library.english.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/personal-library.english.md
@@ -11,7 +11,7 @@ forumTopicId: 301571
 <section id='description'>
 Build a full stack JavaScript app that is functionally similar to this: <a href="https://personal-library--freecodecamp.repl.co/" target="_blank">https://personal-library--freecodecamp.repl.co/</a>.
 Working on this project will involve you writing your code on Repl.it on our starter project. After completing this project you can copy your public Repl.it URL (to the homepage of your app) into this screen to test it! Optionally you may choose to write your project on another platform but must be publicly visible for our testing.
-Start this project on Repl.it using <a href="https://repl.it/github/freeCodeCamp/boilerplate-project-metricimpconverter">this link</a> or clone <a href='https://github.com/freeCodeCamp/boilerplate-project-library/'>this repository</a> on GitHub! If you use Repl.it, remember to save the link to your project somewhere safe!
+Start this project on Repl.it using <a href="https://repl.it/github/freeCodeCamp/boilerplate-project-library/">this link</a> or clone <a href='https://github.com/freeCodeCamp/boilerplate-project-library/'>this repository</a> on GitHub! If you use Repl.it, remember to save the link to your project somewhere safe!
 </section>
 
 ## Instructions


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

**Page with Issue:**
https://www.freecodecamp.org/learn/quality-assurance/quality-assurance-projects/personal-library

Following from: https://forum.freecodecamp.org/t/personal-library/416423

It was pointed out that one of the links in a previous commit directed users to the metric-imperial converter boilerplate, as opposed to the personal library.