### PR TITLE
fix: add backslash to path test for windows paths

### DIFF
--- a/curriculum/getChallenges.js
+++ b/curriculum/getChallenges.js
@@ -175,16 +175,17 @@ Trying to parse ${fullPath}`);
 exports.createChallenge = createChallenge;
 
 function getEnglishPath(fullPath) {
-  const posix = path.posix.normalize(fullPath);
-  const match = posix.match(
-    /(.*curriculum(\/|\\)challenges\2)([^/\\]*)(.*)(\3)(.*)/
-  );
+  const posix = path
+    .normalize(fullPath)
+    .split(path.sep)
+    .join(path.posix.sep);
+  const match = posix.match(/(.*curriculum\/challenges\/)([^/]*)(.*)(\2)(.*)/);
   const lang = getChallengeLang(fullPath);
   if (!isAcceptedLanguage(lang))
     throw Error(`${getChallengeLang(fullPath)} is not a accepted language.
 Trying to parse ${fullPath}`);
   if (match) {
-    return path.join(match[1], 'english', match[4] + 'english' + match[6]);
+    return path.join(match[1], 'english', match[3] + 'english' + match[5]);
   } else {
     throw Error(`Malformed challenge path, ${fullPath} unable to parse.`);
   }

--- a/curriculum/getChallenges.js
+++ b/curriculum/getChallenges.js
@@ -176,13 +176,15 @@ exports.createChallenge = createChallenge;
 
 function getEnglishPath(fullPath) {
   const posix = path.posix.normalize(fullPath);
-  const match = posix.match(/(.*curriculum\/challenges\/)([^/]*)(.*)(\2)(.*)/);
+  const match = posix.match(
+    /(.*curriculum(\/|\\)challenges\2)([^/\\]*)(.*)(\3)(.*)/
+  );
   const lang = getChallengeLang(fullPath);
   if (!isAcceptedLanguage(lang))
     throw Error(`${getChallengeLang(fullPath)} is not a accepted language.
 Trying to parse ${fullPath}`);
   if (match) {
-    return path.join(match[1], 'english', match[3] + 'english' + match[5]);
+    return path.join(match[1], 'english', match[4] + 'english' + match[6]);
   } else {
     throw Error(`Malformed challenge path, ${fullPath} unable to parse.`);
   }


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #39451 

<!-- Feel free to add any additional description of changes below this line -->
Tested on Windows 10, and WSL: Ubuntu 20.04 -  allows both file paths to be tested.