### PR TITLE
fix(learn): add e2e tests for navigation buttons in /learn

### DIFF
--- a/cypress/integration/learn/navigation-buttons/update-my-account-settings-button.js
+++ b/cypress/integration/learn/navigation-buttons/update-my-account-settings-button.js
@@ -1,0 +1,21 @@
+/* global cy */
+
+describe('The `Update my account settings` button works properly', function() {
+  beforeEach(() => {
+    cy.visit('/');
+
+    cy.contains("Get started (it's free)").click({ force: true });
+  });
+
+  it('Should get rendered', function() {
+    cy.contains('View my Portfolio').should(
+      'have.class',
+      'btn btn-lg btn-primary btn-block'
+    );
+  });
+
+  it('Should take user to their account settings when clicked', function() {
+    cy.contains('Update my account settings').click({ force: true });
+    cy.url().should('include', '/settings');
+  });
+});

--- a/cypress/integration/learn/navigation-buttons/update-my-account-settings-button.js
+++ b/cypress/integration/learn/navigation-buttons/update-my-account-settings-button.js
@@ -12,6 +12,8 @@ describe('The `Update my account settings` button works properly', function() {
       'have.class',
       'btn btn-lg btn-primary btn-block'
     );
+
+    cy.contains('View my Portfolio').should('be.visible');
   });
 
   it('Should take user to their account settings when clicked', function() {

--- a/cypress/integration/learn/navigation-buttons/view-portfolio-button.js
+++ b/cypress/integration/learn/navigation-buttons/view-portfolio-button.js
@@ -1,0 +1,21 @@
+/* global cy */
+
+describe('The `View my Portfolio` button works properly', function() {
+  beforeEach(() => {
+    cy.visit('/');
+
+    cy.contains("Get started (it's free)").click({ force: true });
+  });
+
+  it('Button gets rendered', function() {
+    cy.contains('View my Portfolio').should(
+      'have.class',
+      'btn btn-lg btn-primary btn-block'
+    );
+  });
+
+  it('Button takes user to their portfolio when clicked', function() {
+    cy.contains('View my Portfolio').click({ force: true });
+    cy.url().should('include', '/developmentuser');
+  });
+});

--- a/cypress/integration/learn/navigation-buttons/view-portfolio-button.js
+++ b/cypress/integration/learn/navigation-buttons/view-portfolio-button.js
@@ -12,6 +12,8 @@ describe('The `View my Portfolio` button works properly', function() {
       'have.class',
       'btn btn-lg btn-primary btn-block'
     );
+
+    cy.contains('View my Portfolio').should('be.visible');
   });
 
   it('Button takes user to their portfolio when clicked', function() {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `master` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to #38611

<!-- Feel free to add any additional description of changes below this line -->

This PR adds e2e tests for the `View my Portfolio` and `Update my account settings` button in the `/learn` directory.

I'll be adding more e2e tests overtime. If there's anything that needs to be changed, feel free to @ me. 😃 
