### PR TITLE
fix(client): select only required props (Login)

### DIFF
--- a/client/src/components/Header/components/Login.js
+++ b/client/src/components/Header/components/Login.js
@@ -19,15 +19,14 @@ const mapStateToProps = createSelector(
 );
 
 function Login(props) {
-  const { children, isSignedIn, ...restProps } = props;
+  const { block, children, isSignedIn } = props;
   const href = isSignedIn ? '/learn' : `${apiLocation}/signin`;
   return (
     <Button
       bsStyle='default'
-      className={(restProps.block ? 'btn-cta-big' : '') + ' signup-btn btn-cta'}
+      className={(block ? 'btn-cta-big' : '') + ' signup-btn btn-cta'}
       href={href}
       onClick={() => gtagReportConversion()}
-      {...restProps}
     >
       {children || 'Sign In'}
     </Button>
@@ -36,6 +35,7 @@ function Login(props) {
 
 Login.displayName = 'Login';
 Login.propTypes = {
+  block: PropTypes.bool,
   children: PropTypes.any,
   isSignedIn: PropTypes.bool
 };

--- a/client/src/components/Header/components/Login.js
+++ b/client/src/components/Header/components/Login.js
@@ -19,12 +19,18 @@ const mapStateToProps = createSelector(
 );
 
 function Login(props) {
-  const { block, children, isSignedIn } = props;
+  const {
+    block,
+    'data-test-label': dataTestLabel,
+    children,
+    isSignedIn
+  } = props;
   const href = isSignedIn ? '/learn' : `${apiLocation}/signin`;
   return (
     <Button
       bsStyle='default'
       className={(block ? 'btn-cta-big' : '') + ' signup-btn btn-cta'}
+      data-test-label={dataTestLabel}
       href={href}
       onClick={() => gtagReportConversion()}
     >
@@ -37,6 +43,7 @@ Login.displayName = 'Login';
 Login.propTypes = {
   block: PropTypes.bool,
   children: PropTypes.any,
+  'data-test-label': PropTypes.string,
   isSignedIn: PropTypes.bool
 };
 


### PR DESCRIPTION
Rather than passing all of the remaining props, this selects `block' which is the only one we actually use (I think).
