### PR TITLE
feat: add button to add cert to LinkedIn profile

### DIFF
--- a/client/src/client-only-routes/ShowCertification.js
+++ b/client/src/client-only-routes/ShowCertification.js
@@ -25,7 +25,7 @@ import standardErrorMessage from '../utils/standardErrorMessage';
 import reallyWeirdErrorMessage from '../utils/reallyWeirdErrorMessage';
 
 import RedirectHome from '../components/RedirectHome';
-import { Loader } from '../components/helpers';
+import { Loader, Spacer } from '../components/helpers';
 
 const propTypes = {
   cert: PropTypes.shape({
@@ -158,7 +158,8 @@ class ShowCertification extends Component {
       fetchState,
       validCertName,
       createFlashMessage,
-      certName
+      certName,
+      signedInUserName
     } = this.props;
 
     const {
@@ -236,6 +237,26 @@ class ShowCertification extends Component {
       </Grid>
     );
 
+    const linkedInBtn = (
+      <Row>
+        <Spacer size={2} />
+        <Button
+          bsStyle='primary'
+          className='btn-invert'
+          target='_blank'
+          href={`https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME&name=${certTitle}&organizationId=4831032&issueYear=${new Date(
+            issueDate
+          ).getFullYear()}&
+issueMonth=${new Date(
+            issueDate
+          ).getMonth()}&certUrl=https://freecodecamp.org/certification/
+                  {username}/{certName}`}
+        >
+          Add this certification to my LinkedIn profile
+        </Button>
+      </Row>
+    );
+
     return (
       <div className='certificate-outer-wrapper'>
         {isDonationDisplayed && !isDonationClosed ? donationSection : ''}
@@ -295,6 +316,7 @@ class ShowCertification extends Component {
             </footer>
           </Row>
         </Grid>
+        {signedInUserName === username ? linkedInBtn : ''}
       </div>
     );
   }

--- a/client/src/client-only-routes/ShowCertification.js
+++ b/client/src/client-only-routes/ShowCertification.js
@@ -249,8 +249,9 @@ class ShowCertification extends Component {
       <Row className='text-center'>
         <Spacer size={2} />
         <Button
+          block={true}
+          bsSize='lg'
           bsStyle='primary'
-          className='btn-invert'
           target='_blank'
           href={`https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME&name=${certTitle}&organizationId=4831032&issueYear=${certYear}&issueMonth=${certMonth}&certUrl=${certURL}`}
         >
@@ -258,12 +259,13 @@ class ShowCertification extends Component {
         </Button>
         <Spacer />
         <Button
+          block={true}
+          bsSize='lg'
           bsStyle='primary'
-          className='btn-invert'
           target='_blank'
           href={`https://twitter.com/intent/tweet?text=I just earned the ${certTitle} certification @freeCodeCamp! Check it out here: ${certURL}`}
         >
-          Share this certification with my friends on Twitter
+          Share this certification on Twitter
         </Button>
       </Row>
     );
@@ -318,10 +320,7 @@ class ShowCertification extends Component {
                 <p>Executive Director, freeCodeCamp.org</p>
               </div>
               <Row>
-                <p className='verify'>
-                  Verify this certification at:
-                  {certURL}
-                </p>
+                <p className='verify'>Verify this certification at {certURL}</p>
               </Row>
             </footer>
           </Row>

--- a/client/src/client-only-routes/ShowCertification.js
+++ b/client/src/client-only-routes/ShowCertification.js
@@ -46,6 +46,9 @@ const propTypes = {
     errored: PropTypes.bool
   }),
   isDonating: PropTypes.bool,
+  location: PropTypes.shape({
+    pathname: PropTypes.string
+  }),
   showCert: PropTypes.func.isRequired,
   signedInUserName: PropTypes.string,
   userFetchState: PropTypes.shape({
@@ -158,8 +161,8 @@ class ShowCertification extends Component {
       fetchState,
       validCertName,
       createFlashMessage,
-      certName,
-      signedInUserName
+      signedInUserName,
+      location: { pathname }
     } = this.props;
 
     const {
@@ -196,6 +199,11 @@ class ShowCertification extends Component {
       certTitle,
       completionTime
     } = cert;
+
+    const certDate = new Date(issueDate);
+    const certYear = certDate.getFullYear();
+    const certMonth = certDate.getMonth();
+    const certURL = `https://freecodecamp.org${pathname}`;
 
     const donationCloseBtn = (
       <div>
@@ -237,22 +245,25 @@ class ShowCertification extends Component {
       </Grid>
     );
 
-    const linkedInBtn = (
-      <Row>
+    const shareCertBtns = (
+      <Row className='text-center'>
         <Spacer size={2} />
         <Button
           bsStyle='primary'
           className='btn-invert'
           target='_blank'
-          href={`https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME&name=${certTitle}&organizationId=4831032&issueYear=${new Date(
-            issueDate
-          ).getFullYear()}&
-issueMonth=${new Date(
-            issueDate
-          ).getMonth()}&certUrl=https://freecodecamp.org/certification/
-                  {username}/{certName}`}
+          href={`https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME&name=${certTitle}&organizationId=4831032&issueYear=${certYear}&issueMonth=${certMonth}&certUrl=${certURL}`}
         >
           Add this certification to my LinkedIn profile
+        </Button>
+        <Spacer />
+        <Button
+          bsStyle='primary'
+          className='btn-invert'
+          target='_blank'
+          href={`https://twitter.com/intent/tweet?text=I just earned the ${certTitle} certification @freeCodeCamp! Check it out here: ${certURL}`}
+        >
+          Share this certification with my friends on Twitter
         </Button>
       </Row>
     );
@@ -271,7 +282,7 @@ issueMonth=${new Date(
               <Col md={7} sm={12}>
                 <div className='issue-date'>
                   Issued&nbsp;
-                  <strong>{format(new Date(issueDate), 'MMMM D, YYYY')}</strong>
+                  <strong>{format(certDate, 'MMMM D, YYYY')}</strong>
                 </div>
               </Col>
             </header>
@@ -309,14 +320,13 @@ issueMonth=${new Date(
               <Row>
                 <p className='verify'>
                   Verify this certification at:
-                  https://www.freecodecamp.org/certification/
-                  {username}/{certName}
+                  {certURL}
                 </p>
               </Row>
             </footer>
           </Row>
         </Grid>
-        {signedInUserName === username ? linkedInBtn : ''}
+        {signedInUserName === username ? shareCertBtns : ''}
       </div>
     );
   }

--- a/client/src/components/layouts/Certification.js
+++ b/client/src/components/layouts/Certification.js
@@ -25,17 +25,11 @@ class CertificationLayout extends Component {
   }
 
   render() {
-    const { children, theme = 'default', useTheme = true } = this.props;
+    const { children } = this.props;
 
     return (
       <Fragment>
-        <Helmet
-          bodyAttributes={{
-            class: useTheme
-              ? `${theme === 'default' ? 'light-palette' : 'dark-palette'}`
-              : 'light-palette'
-          }}
-        ></Helmet>
+        <Helmet bodyAttributes={{ class: 'light-palette' }}></Helmet>
         {children}
       </Fragment>
     );
@@ -48,9 +42,7 @@ CertificationLayout.propTypes = {
   executeGA: PropTypes.func,
   fetchUser: PropTypes.func.isRequired,
   isSignedIn: PropTypes.bool,
-  pathname: PropTypes.string.isRequired,
-  theme: PropTypes.string,
-  useTheme: PropTypes.bool
+  pathname: PropTypes.string.isRequired
 };
 
 export default connect(

--- a/client/src/components/layouts/Certification.js
+++ b/client/src/components/layouts/Certification.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 
 import { fetchUser, isSignedInSelector, executeGA } from '../../redux';
 import { createSelector } from 'reselect';
+import Helmet from 'react-helmet';
 
 const mapStateToProps = createSelector(
   isSignedInSelector,
@@ -22,8 +23,22 @@ class CertificationLayout extends Component {
     }
     this.props.executeGA({ type: 'page', data: pathname });
   }
+
   render() {
-    return <Fragment>{this.props.children}</Fragment>;
+    const { children, theme = 'default', useTheme = true } = this.props;
+
+    return (
+      <Fragment>
+        <Helmet
+          bodyAttributes={{
+            class: useTheme
+              ? `${theme === 'default' ? 'light-palette' : 'dark-palette'}`
+              : 'light-palette'
+          }}
+        ></Helmet>
+        {children}
+      </Fragment>
+    );
   }
 }
 
@@ -33,7 +48,9 @@ CertificationLayout.propTypes = {
   executeGA: PropTypes.func,
   fetchUser: PropTypes.func.isRequired,
   isSignedIn: PropTypes.bool,
-  pathname: PropTypes.string.isRequired
+  pathname: PropTypes.string.isRequired,
+  theme: PropTypes.string,
+  useTheme: PropTypes.bool
 };
 
 export default connect(

--- a/client/utils/gatsby/layoutSelector.js
+++ b/client/utils/gatsby/layoutSelector.js
@@ -16,9 +16,7 @@ export default function layoutSelector({ element, props }) {
   }
   if (/^\/certification(\/.*)*/.test(pathname)) {
     return (
-      <CertificationLayout pathname={pathname} useTheme={true}>
-        {element}
-      </CertificationLayout>
+      <CertificationLayout pathname={pathname}>{element}</CertificationLayout>
     );
   }
   if (/^\/guide(\/.*)*/.test(pathname)) {

--- a/client/utils/gatsby/layoutSelector.js
+++ b/client/utils/gatsby/layoutSelector.js
@@ -16,7 +16,9 @@ export default function layoutSelector({ element, props }) {
   }
   if (/^\/certification(\/.*)*/.test(pathname)) {
     return (
-      <CertificationLayout pathname={pathname}>{element}</CertificationLayout>
+      <CertificationLayout pathname={pathname} useTheme={true}>
+        {element}
+      </CertificationLayout>
     );
   }
   if (/^\/guide(\/.*)*/.test(pathname)) {

--- a/cypress/integration/ShowCertification.js
+++ b/cypress/integration/ShowCertification.js
@@ -1,0 +1,88 @@
+/* global cy */
+
+describe('A certification,', function() {
+  describe('while viewing your own,', function() {
+    before(() => {
+      cy.visit('/');
+      cy.contains("Get started (it's free)").click({ force: true });
+      cy.contains('Update my account settings').click({ force: true });
+
+      // set user settings to public to claim a cert
+      cy.get('label:contains(Public)>input').each(el => {
+        if (!/toggle-active/.test(el[0].parentElement.className)) {
+          cy.wrap(el).click({ force: true });
+          cy.wait(1000);
+        }
+      });
+
+      // if honest policy not accepted
+      cy.get('.honesty-policy button').then(btn => {
+        if (btn[0].innerText === 'Agree') {
+          btn[0].click({ force: true });
+          cy.wait(1000);
+        }
+      });
+
+      // fill in legacy front end form
+      cy.get('#dynamic-legacy-front-end input').each(el => {
+        cy.wrap(el)
+          .clear({ force: true })
+          .type('https://nhl.com', { force: true, delay: 0 });
+      });
+
+      // if "Save Progress" button exists
+      cy.get('#dynamic-legacy-front-end').then(form => {
+        if (form[0][10] && form[0][10].innerHTML === 'Save Progress') {
+          form[0][10].click({ force: true });
+          cy.wait(1000);
+        }
+      });
+
+      // if "Claim Certification" button exists
+      cy.get('#dynamic-legacy-front-end').then(form => {
+        if (form[0][10] && form[0][10].innerHTML === 'Claim Certification') {
+          form[0][10].click({ force: true });
+          cy.wait(1000);
+        }
+      });
+
+      cy.get('#button-legacy-front-end')
+        .contains('Show Certification')
+        .click({ force: true });
+    });
+
+    it('should render a LinkedIn button', function() {
+      cy.contains('Add this certification to my LinkedIn profile').should(
+        'have.attr',
+        'href',
+        'https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME&name=Legacy Front End&organizationId=4831032&issueYear=2020&issueMonth=8&certUrl=https://freecodecamp.org/certification/developmentuser/legacy-front-end'
+      );
+    });
+
+    it('should render a Twitter button', function() {
+      cy.contains('Share this certification on Twitter').should(
+        'have.attr',
+        'href',
+        'https://twitter.com/intent/tweet?text=I just earned the Legacy Front End certification @freeCodeCamp! Check it out here: https://freecodecamp.org/certification/developmentuser/legacy-front-end'
+      );
+    });
+  });
+
+  describe("while viewing someone else's,", function() {
+    before(() => {
+      cy.go('back');
+      cy.contains('Sign me out of freeCodeCamp').click({ force: true });
+      cy.visit('/certification/developmentuser/legacy-front-end');
+    });
+
+    it('should not render a LinkedIn button', function() {
+      cy.contains('Add this certification to my LinkedIn profile').should(
+        'not.exist'
+      );
+    });
+
+    it('should not render a Twitter button', function() {
+      cy.contains('Share this certification on Twitter').should('not.exist');
+    });
+  });
+});


### PR DESCRIPTION
This add a button to all certifications for users to add the cert to their linkedin profiles. (and now a button to share on twitter, as well)

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #38194

<!-- Feel free to add any additional description of changes below this line -->

Viewing your own cert:
<img width="686" alt="Screen Shot 2020-08-26 at 5 24 36 PM" src="https://user-images.githubusercontent.com/20648924/91362896-095cc300-e7c1-11ea-9ae2-20ed40f91324.png">

The linkedin button brings up this:
![Screen Shot 2020-08-26 at 5 18 44 PM](https://user-images.githubusercontent.com/20648924/91362938-1ed1ed00-e7c1-11ea-923e-18f72a3cbc4f.png)

The twitter button brings up this:
![Screen Shot 2020-08-26 at 5 19 28 PM](https://user-images.githubusercontent.com/20648924/91362976-301af980-e7c1-11ea-9ade-273353f79e84.png)



Todo:
Fix twitter images
