### PR TITLE
Fix: show new challenges without restart

### DIFF
--- a/client/plugins/fcc-source-challenges/gatsby-node.js
+++ b/client/plugins/fcc-source-challenges/gatsby-node.js
@@ -55,6 +55,22 @@ File changed at ${filePath}, replacing challengeNode id ${challenge.id}
       : null
   );
 
+  watcher.on('add', filePath =>
+    /\.md$/.test(filePath)
+      ? onSourceChange(filePath)
+          .then(challenge => {
+            createVisibleChallenge(challenge);
+          })
+          .catch(e =>
+            reporter.error(`fcc-add-challenge
+
+  ${e.message}
+
+  `)
+          )
+      : null
+  );
+
   function sourceAndCreateNodes() {
     return source()
       .then(challenges => Promise.all(challenges))

--- a/curriculum/getChallenges.js
+++ b/curriculum/getChallenges.js
@@ -142,6 +142,12 @@ function createChallengeCreator(basePath, lang) {
         metaDir,
         `./${getBlockNameFromPath(filePath)}/meta.json`
       );
+      // Using the current meta allows new challenges to be added and appear in
+      // the challenge order without client restart. However, since this only
+      // updates a single challenge, the order of challenges is likely to be
+      // incorrect (until the client is restarted). Adding to the end of
+      // meta.json should work perfectly.
+      delete require.cache[require.resolve(metaPath)];
       meta = require(metaPath);
     }
     const { name: superBlock } = superBlockInfoFromPath(filePath);


### PR DESCRIPTION
This allows you add new challenges without having to restart the client.  If added at the end of the meta.json, they should appear in the correct position on the map, but if they're inserted anywhere else the order is not guaranteed.  The reason for this is that the `challengeOrder` of the new challenge should be correct, but the other challenges are not forced to update.

When finish this, we should

Related to issue #39471, https://github.com/freeCodeCamp/freeCodeCamp/issues/35566
