### PR TITLE
Clarify how object names are associated with destructured fields

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-pass-an-object-as-a-functions-parameters.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-pass-an-object-as-a-functions-parameters.english.md
@@ -27,7 +27,8 @@ const profileUpdate = ({ name, age, nationality, location }) => {
 ```
 
 This removes some extra lines and makes our code look neat.
-This has the added benefit of not having to manipulate an entire object in a function — only the fields that are needed are copied inside the function.
+This has the added benefit of not bringing an entire object in a function. 
+When you call the function on an object (by passing the object's name as an argument), only a subset of the object's fields are copied inside the function—the fields that have been specified in the function definition.
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-pass-an-object-as-a-functions-parameters.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-pass-an-object-as-a-functions-parameters.english.md
@@ -26,7 +26,7 @@ const profileUpdate = ({ name, age, nationality, location }) => {
 }
 ```
 
-When <code>profileData</code> is passed to the above function, the values are destructed from the function parameter for use within the function.
+When <code>profileData</code> is passed to the above function, the values are destructured from the function parameter for use within the function.
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-pass-an-object-as-a-functions-parameters.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-to-pass-an-object-as-a-functions-parameters.english.md
@@ -26,9 +26,7 @@ const profileUpdate = ({ name, age, nationality, location }) => {
 }
 ```
 
-This removes some extra lines and makes our code look neat.
-This has the added benefit of not bringing an entire object in a function. 
-When you call the function on an object (by passing the object's name as an argument), only a subset of the object's fields are copied inside the function—the fields that have been specified in the function definition.
+When <code>profileData</code> is passed to the above function, the values are destructed from the function parameter for use within the function.
 </section>
 
 ## Instructions


### PR DESCRIPTION
I have added some language to clarify how an object's name is associated with its fields when the object is destructured in place in a function definition.

As written, I found the examples confusing. The first example, where the object is destructured *not* in place, makes perfect sense, and it is clear that the specified fields come from the object `profileData` because the object is named in the example.

But in the second example, involving destructuring in place, the object `profileData` is not named anywhere. Instead, the example just includes field names. As I read this, I was scratching my head, asking, "How does the program know that these field names are associated with the `profileData` object? I don't see the object's name anywhere."

Of course, the answer is that the object's name gets passed as an argument when the function is called. I'm sure this is obvious to experienced programmers. But it wasn't obvious to me, and I'm an educated beginner. In fact, to figure it out, I played around with the code in repl.it for a while before I figured it out. I don't think that this is something the reader needs to figure out on his own at this point. It's not part of the pedagogical goals here. So I propose a minor revision that explains how an object's name is associated with the fields when the object is destructured in place in a function definition.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
