### PR TITLE
docs: remove beta statement

### DIFF
--- a/docs/how-to-help-with-video-challenges.md
+++ b/docs/how-to-help-with-video-challenges.md
@@ -1,6 +1,6 @@
 # How to help with video challenges
 
-Video challenges are a new type of challenge in the freeCodeCamp curriculum. They are currently only in beta and not available yet on freeCodeCamp.org.
+Video challenges are a new type of challenge in the freeCodeCamp curriculum.
 
 A video challenge is a small section of a full-length video course on a particular topic. A video challenge page embeds a YouTube video. Each challenge page has a single multiple-choice question related to the video. A user must answer the question correctly before moving on the the next video challenge in the course.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `master` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

While reviewing the contributing documentation to find an answer for a camper, I ran across a line that stated the video challenges were in beta and not available on the `.org` website. As this is no longer the case, the line should be removed. 