### PR TITLE
fix: up and down hotkeys in search bar

### DIFF
--- a/client/src/components/search/searchBar/SearchBar.js
+++ b/client/src/components/search/searchBar/SearchBar.js
@@ -183,7 +183,7 @@ export class SearchBar extends Component {
             <label className='fcc_sr_only' htmlFor='fcc_instantsearch'>
               Search
             </label>
-            <ObserveKeys>
+            <ObserveKeys except={['Space']}>
               <SearchBox
                 focusShortcuts={[83, 191]}
                 onChange={this.handleChange}


### PR DESCRIPTION
Currently the up and down hotkeys work as expected until a white space character is entered, then it loses focus:

![current-prod](https://user-images.githubusercontent.com/2051070/92306895-852eea80-efcd-11ea-88c0-0c9a0446ed76.gif)

Seems like the fix is just to add 'Space' to the key events that should be ignored by the `ObserveKeys` component:

![update](https://user-images.githubusercontent.com/2051070/92306986-17cf8980-efce-11ea-8c9d-09d836efc2ca.gif)

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
