### PR TITLE
fix: update instructions to be consistent

### DIFF
--- a/curriculum/challenges/english/05-apis-and-microservices/apis-and-microservices-projects/file-metadata-microservice.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/apis-and-microservices-projects/file-metadata-microservice.english.md
@@ -25,9 +25,9 @@ Start this project on Repl.it using <a href='https://repl.it/github/freeCodeCamp
 tests:
   - text: I can submit a form that includes a file upload.
     testString: ''
-  - text: The form file input field has the `name` attribute set to `upfile`.
+  - text: The form file input field has the <code>name</code> attribute set to <code>upfile</code>.
     testString: ''
-  - text: When I submit something, I will receive the file `name`, `type`, and `size` in bytes within the JSON response.
+  - text: When I submit something, I will receive the file <code>name</code>, <code>type</code>, and <code>size</code> in bytes within the JSON response.
     testString: ''
 
 ```

--- a/curriculum/challenges/english/05-apis-and-microservices/apis-and-microservices-projects/file-metadata-microservice.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/apis-and-microservices-projects/file-metadata-microservice.english.md
@@ -23,9 +23,11 @@ Start this project on Repl.it using <a href='https://repl.it/github/freeCodeCamp
 
 ```yml
 tests:
-  - text: I can submit a FormData object that includes a file upload.
+  - text: I can submit a form that includes a file upload.
     testString: ''
-  - text: 'When I submit something, I will receive the file size in bytes within the JSON response.'
+  - text: The form file input field has the `name` attribute set to `upfile`.
+    testString: ''
+  - text: When I submit something, I will receive the file `name`, `type`, and `size` in bytes within the JSON response.
     testString: ''
 
 ```


### PR DESCRIPTION
The example project returns this:
![Screen Shot 2020-09-10 at 9 22 32 AM](https://user-images.githubusercontent.com/20648924/92746321-ce25cc80-f348-11ea-88d7-950b36f51525.png)

So I updated the instructions to match that, and the user stories on the boilerplate. I have [made a PR over there to match these.](https://github.com/freeCodeCamp/boilerplate-project-filemetadata/pull/8) 

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #37553

<!-- Feel free to add any additional description of changes below this line -->
