### PR TITLE
fix(learn): Remove Scrimba video links for two challenges that do not reflect current seed/solution

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/create-a-set-of-radio-buttons.english.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/create-a-set-of-radio-buttons.english.md
@@ -2,7 +2,6 @@
 id: bad87fee1348bd9aedf08834
 title: Create a Set of Radio Buttons
 challengeType: 0
-videoUrl: 'https://scrimba.com/p/pVMPUv/cNWKvuR'
 forumTopicId: 16822
 ---
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/record-collection.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/record-collection.english.md
@@ -2,7 +2,6 @@
 id: 56533eb9ac21ba0edf2244cf
 title: Record Collection
 challengeType: 1
-videoUrl: 'https://scrimba.com/c/c4mpysg'
 forumTopicId: 18261
 ---
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

This PR removes the `videoUrl` for the following two challenges due to the reasons stated:

* [Record Collection](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-javascript/record-collection) - Due to the merging of PR #39045, which changed this challenge's seed code and solution, the video is no longer accurate.
* [Create a Set of Radio Buttons](https://www.freecodecamp.org/learn/responsive-web-design/basic-html-and-html5/create-a-set-of-radio-buttons) - Even though the instructions and tests explain to nest the radio buttons inside the label elements, the video only casually mentions it and the final solution shown in the video does not nest the buttons inside the label elements.  There have been several reports on the forum about this difference where users attempt to type exactly what is shown as the solution in the video.
