### PR TITLE
fix(curriculum): Changed "statement" to "expression"

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/use-the-conditional-ternary-operator.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/use-the-conditional-ternary-operator.english.md
@@ -9,7 +9,7 @@ forumTopicId: 301181
 <section id='description'>
 The <dfn>conditional operator</dfn>, also called the <dfn>ternary operator</dfn>, can be used as a one line if-else expression.
 The syntax is:
-<code>condition ? statement-if-true : statement-if-false;</code>
+<code>condition ? expression-if-true : expression-if-false;</code>
 The following function uses an if-else statement to check a condition:
 
 ```js


### PR DESCRIPTION
The ternary operator doesn't allow statements, just expressions. I don't know if this is an actual issue per see because this challenge is a beginner level. Maybe it's not necessary to be 100% precise. This is my first time contributing to open source. I apologize if I didn't do something right.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
