### PR TITLE
fix: use free versions of the icons temporarily

### DIFF
--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -4,8 +4,8 @@
 
 ## Here are some quick and fun ways you can help the community.
 
-- <span class='cover-icon' style="color: #002ead;"><i class="fad fa-question-circle"></i></span> [Help by answering coding questions](https://forum.freecodecamp.org/c/help?max_posts=1) on our community forum.
-- <span class='cover-icon' style="color: #00471b;"><i class="fad fa-comments-alt"></i></span> [Give feedback on coding projects](https://forum.freecodecamp.org/c/project-feedback?max_posts=1) built by campers.
+- <span class='cover-icon' style="color: #002ead;"><i class="far fa-question-circle"></i></span> [Help by answering coding questions](https://forum.freecodecamp.org/c/help?max_posts=1) on our community forum.
+- <span class='cover-icon' style="color: #00471b;"><i class="far fa-comments"></i></span> [Give feedback on coding projects](https://forum.freecodecamp.org/c/project-feedback?max_posts=1) built by campers.
 - <span class='cover-icon' style="color: #c4302b;"><i class="fab fa-youtube"></i></span> [Help us add subtitles (closed captions)](https://www.youtube.com/timedtext_cs_panel?c=UC8butISFwT-Wl7EV0hUK0BQ&tab=2) to our YouTube channel videos.
 - <span class='cover-icon' style="color: #000000;"><i class="fab fa-github"></i></span> [Contribute to our open source codebase](/index?id=our-open-source-codebase) on GitHub.
 

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,6 +1,6 @@
-- **<i class="fad fa-hourglass-start"></i> Getting Started**
+- **<i class="fas fa-hourglass-start"></i> Getting Started**
   - [Introduction](/index.md 'Contribute to the freeCodeCamp.org Community')
-- **<i class="fad fa-code"></i> Code Contribution**
+- **<i class="fas fa-code"></i> Code Contribution**
   - [Work on coding challenges](/how-to-work-on-coding-challenges.md)
   - [Help with video challenges](/how-to-help-with-video-challenges.md)
   - [Set up freeCodeCamp locally](/how-to-setup-freecodecamp-locally.md)
@@ -12,7 +12,7 @@
 
 ---
 
-- **<i class="fad fa-plane-alt"></i> Flight Manuals** (for Staff & Mods)
+- **<i class="fas fa-plane"></i> Flight Manuals** (for Staff & Mods)
   - [Moderator Handbook](/flight-manuals/moderator-handbook.md)
   - [Reply Templates](/flight-manuals/using-reply-templates.md)
   - [DevOps Overview](/devops.md)
@@ -20,14 +20,14 @@
 
 ---
 
-- **<i class="fad fa-language"></i> 中文社区贡献指南**
+- **<i class="fas fa-language"></i> 中文社区贡献指南**
   - [成为专栏作者](/chinese-guides/news-author-application.md)
   - [文章翻译计划](/chinese-guides/news-translations.md)
   - [视频翻译计划](/chinese-guides/video-translations.md)
 
 ---
 
-- **<i class="fad fa-user-friends"></i> Our Community**
+- **<i class="fas fa-user-friends"></i> Our Community**
   - [**<i class="fab fa-github"></i> GitHub Repository**](https://github.com/freecodecamp/freecodecamp)
   - [**<i class="fab fa-discourse"></i> Contributors category on Forum**](https://freecodecamp.org/forum/c/contributors)
   - [**<i class="fab fa-gitter"></i> Contributors chat room on Gitter**](https://gitter.im/FreeCodeCamp/Contributors)

--- a/docs/index.html
+++ b/docs/index.html
@@ -24,13 +24,13 @@
     + 'Since 2015, 40,000 graduates have gotten jobs at tech '
     + 'companies including Google, Apple, Amazon, and Microsoft.' name='twitter:description' />
 
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.14.0/css/all.min.css" integrity="sha512-1PKOgIY59xJ8Co8+NE6FZ+LOAZKjy+KY8iq0G4B3CyeY6wYHN3yt9PW0XpSriVlkMXe40PTKnXrLnZ9+fkDaog==" crossorigin="anonymous" />
+
   <!-- Theme -->
   <!-- <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-simple.css"> -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsify/themes/vue.css">
   <!-- Custom theme stylesheet -->
   <link rel="stylesheet" href="_theme.css">
-
-  <script src="https://kit.fontawesome.com/4b366379be.js" crossorigin="anonymous"></script>
 
 </head>
 
@@ -119,5 +119,7 @@
   <script src="https://cdn.jsdelivr.net/npm/docsify-plugin-flexible-alerts@1"></script>
   <script src="https://unpkg.com/docsify-pagination/dist/docsify-pagination.min.js"></script>
   <script src="https://unpkg.com/docsify-remote-markdown/dist/docsify-remote-markdown.min.js"></script>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.14.0/js/all.min.js" integrity="sha512-YSdqvJoZr83hj76AIVdOcvLWYMWzy6sJyIMic2aQz5kh2bPTd9dzY3NtdeEAzPp/PhgZqr4aJObB3ym/vsItMg==" crossorigin="anonymous"></script>
 
 </html>


### PR DESCRIPTION
We do have a perpetual license to the duotone pro icons we were using, but it would requires us to host it on the CDN with the correct CORS settings.

Will circle around to it when I get more time. For now, this should fix the broken hosted versions from FontAwesome CDN which was a paid subscription.

We have no intention of renewing it. 