### PR TITLE
feat(learn): Add/Remove Tests for Imperial-Metric Converter Project

### DIFF
--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/metric-imperial-converter.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/metric-imperial-converter.md
@@ -89,7 +89,7 @@ tests:
       }
     }
     "
-  - text: All incoming units should be accepted in both upper and lower case, but should be returned in both the <code>initUnit</code> and <code>returnUnit</code> in lower case, except for liter, which should be represented as an uppercase "L".
+  - text: All incoming units should be accepted in both upper and lower case, but should be returned in both the <code>initUnit</code> and <code>returnUnit</code> in lower case, except for liter, which should be represented as an uppercase <code>'L'</code>.
     testString: "async getUserInput => { 
       try {
         const data1 = await $.get(getUserInput('url') + '/api/convert?input=1gal');
@@ -127,7 +127,7 @@ tests:
         throw new Error(xhr.responseText || xhr.message);
       }
     }"
-  - text: If both are invalid, return will be <code>'invalid number and unit'</code>.
+  - text: If both the unit and number are invalid, returned will be <code>'invalid number and unit'</code>.
     testString: "async getUserInput => { 
       try {
         const data = await $.get(getUserInput('url') + '/api/convert?input=1//2min');

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/metric-imperial-converter.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/metric-imperial-converter.md
@@ -139,9 +139,9 @@ tests:
   - text: I can use fractions, decimals or both in my parameter(ie. 5, 1/2, 2.5/6), but if nothing is provided it will default to 1.
     testString: "async getUserInput => {
       try {
-        const data1 = await $.get(getUserInput('url') + '/api/convert?input=1/2mi');
-        assert.approximately(data1.initNum, 1/2, 0.001);
-        assert.approximately(data1.returnNum, 0.80467, 0.001);
+        const data1 = await $.get(getUserInput('url') + '/api/convert?input=mi');
+        assert.approximately(data1.initNum, 1, 0.001);
+        assert.approximately(data1.returnNum, 1.60934, 0.001);
         assert.equal(data1.returnUnit, 'km');
         const data2 = await $.get(getUserInput('url') + '/api/convert?input=1/5mi');
         assert.approximately(data2.initNum, 1/5, 0.1);
@@ -160,7 +160,7 @@ tests:
       }
     }
     "
-  - text: My return will consist of the <code>initNum</code>, <code>initUnit</code>, <code>returnNum</code>, <code>returnUnit</code>, and <code>string</code> spelling out units in format <code>'{initNum} {initial_Units} converts to {returnNum} {return_Units}'</code> with the result rounded to 5 decimals.
+  - text: My return will consist of the <code>initNum</code>, <code>initUnit</code>, <code>returnNum</code>, <code>returnUnit</code>, and <code>string</code> spelling out units in the format <code>'{initNum} {initial_Units} converts to {returnNum} {return_Units}'</code> with the result rounded to 5 decimals.
     testString: "async getUserInput => { 
       try {
         const data = await $.get(getUserInput('url') + '/api/convert?input=2mi');

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/metric-imperial-converter.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/metric-imperial-converter.md
@@ -118,7 +118,7 @@ tests:
       }
     }
     "
-  - text: If my number is invalid, returned with will 'invalid number'.
+  - text: If my number is invalid, returned will be <code>'invalid number'</code>.
     testString: "async getUserInput => { 
       try {
         const data = await $.get(getUserInput('url') + '/api/convert?input=1//2gal');
@@ -127,7 +127,7 @@ tests:
         throw new Error(xhr.responseText || xhr.message);
       }
     }"
-  - text: If both are invalid, return will be 'invalid number and unit'.
+  - text: If both are invalid, return will be <code>'invalid number and unit'</code>.
     testString: "async getUserInput => { 
       try {
         const data = await $.get(getUserInput('url') + '/api/convert?input=1//2min');
@@ -160,7 +160,7 @@ tests:
       }
     }
     "
-  - text: My return will consist of the initNum, initUnit, returnNum, returnUnit, and string spelling out units in format '{initNum} {initial_Units} converts to {returnNum} {return_Units}' with the result rounded to 5 decimals in the string.
+  - text: My return will consist of the <code>initNum</code>, <code>initUnit</code>, <code>returnNum</code>, <code>returnUnit</code>, and <code>string</code> spelling out units in format <code>'{initNum} {initial_Units} converts to {returnNum} {return_Units}'</code> with the result rounded to 5 decimals.
     testString: "async getUserInput => { 
       try {
         const data = await $.get(getUserInput('url') + '/api/convert?input=2mi');

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/metric-imperial-converter.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/metric-imperial-converter.md
@@ -34,10 +34,10 @@ tests:
       try {
         const data1 = await $.get(getUserInput('url') + '/api/convert?input=1gal');
         assert.equal(data1.returnNum, 3.78541);
-        assert.equal(data1.returnUnit, 'l');
+        assert.equal(data1.returnUnit, 'L');
         const data2 = await $.get(getUserInput('url') + '/api/convert?input=10gal');
         assert.equal(data2.returnNum, 37.8541);
-        assert.equal(data2.returnUnit, 'l');
+        assert.equal(data2.returnUnit, 'L');
         const data3 = await $.get(getUserInput('url') + '/api/convert?input=1l');
         assert.equal(data3.returnNum, 0.26417);
         assert.equal(data3.returnUnit, 'gal');
@@ -89,6 +89,25 @@ tests:
       }
     }
     "
+  - text: All incoming units should be accepted in both upper and lower case, but should be returned in both the <code>initUnit</code> and <code>returnUnit</code> in lower case, except for liter, which should be represented as an uppercase "L".
+    testString: "async getUserInput => { 
+      try {
+        const data1 = await $.get(getUserInput('url') + '/api/convert?input=1gal');
+        assert.equal(data1.initUnit, 'gal');
+        assert.equal(data1.returnUnit, 'L');
+        const data2 = await $.get(getUserInput('url') + '/api/convert?input=10L');
+        assert.equal(data2.initUnit, 'L');
+        assert.equal(data2.returnUnit, 'gal');
+        const data3 = await $.get(getUserInput('url') + '/api/convert?input=1l');
+        assert.equal(data3.initUnit, 'L');
+        assert.equal(data3.returnUnit, 'gal');
+        const data4 = await $.get(getUserInput('url') + '/api/convert?input=10KM');
+        assert.equal(data4.initUnit, 'km');
+        assert.equal(data4.returnUnit, 'mi');
+      } catch(xhr) {
+        throw new Error(xhr.responseText || xhr.message);
+      }
+    }"
   - text: If my unit of measurement is invalid, returned will be <code>'invalid unit'</code>.
     testString: "async getUserInput => { 
       try {
@@ -155,10 +174,39 @@ tests:
       }
     }"
   - text: All 16 unit tests are complete and passing.
-    testString: ''
+    testString: "async getUserInput => {
+      try {
+        const getTests = await $.get(getUserInput('url') + '/_api/get-tests' );
+        assert.isArray(getTests);
+        const unitTests = getTests.filter((test) => {
+          return !!test.context.match(/Unit Tests ->/ig);
+        });
+        assert.isAtLeast(unitTests.length, 16, 'At least 16 tests passed');
+        unitTests.forEach(test => {
+          assert.equal(test.state, 'passed', 'Tests in Passed State');
+          assert.isAtLeast(test.assertions.length, 1, 'At least one assertion per test');
+        });
+      } catch(err) {
+        throw new Error(err.responseText || err.message);
+      }
+    }"
   - text: All 5 functional tests are complete and passing.
-    testString: ''
-
+    testString: "async getUserInput => {
+      try {
+        const getTests = await $.get(getUserInput('url') + '/_api/get-tests' );
+        assert.isArray(getTests);
+        const functTests = getTests.filter((test) => {
+          return !!test.context.match(/Functional Tests ->/ig);
+        });
+        assert.isAtLeast(functTests.length, 5, 'At least 5 tests passed');
+        functTests.forEach(test => {
+          assert.equal(test.state, 'passed', 'Tests in Passed State');
+          assert.isAtLeast(test.assertions.length, 1, 'At least one assertion per test');
+        });
+      } catch(err) {
+        throw new Error(err.responseText || err.message);
+      }
+    }"
 ```
 
 </section>

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/metric-imperial-converter.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/metric-imperial-converter.md
@@ -45,7 +45,7 @@ tests:
         assert.equal(data4.returnNum, 2.64172);
         assert.equal(data4.returnUnit, 'gal');
       } catch(xhr) {
-        throw new Error(xhr.responseText);
+        throw new Error(xhr.responseText || xhr.message);
       }
     }
     "
@@ -65,7 +65,7 @@ tests:
         assert.equal(data4.returnNum, 22.04624);
         assert.equal(data4.returnUnit, 'lbs');
       } catch(xhr) {
-        throw new Error(xhr.responseText);
+        throw new Error(xhr.responseText || xhr.message);
       }
     }
     "
@@ -85,7 +85,7 @@ tests:
         assert.equal(data4.returnNum, 6.21373); 
         assert.equal(data4.returnUnit, 'mi');
       } catch(xhr) {
-        throw new Error(xhr.responseText);
+        throw new Error(xhr.responseText || xhr.message);
       }
     }
     "
@@ -93,20 +93,67 @@ tests:
     testString: "async getUserInput => { 
       try {
         const data = await $.get(getUserInput('url') + '/api/convert?input=1min');
-        assert(data.initUnit === 'invalid unit' || data === 'invalid unit');
+        assert(data.error === 'invalid unit' || data === 'invalid unit');
       } catch(xhr) {
-        throw new Error(xhr.responseText);
+        throw new Error(xhr.responseText || xhr.message);
       }
     }
     "
   - text: If my number is invalid, returned with will 'invalid number'.
-    testString: ''
+    testString: "async getUserInput => { 
+      try {
+        const data = await $.get(getUserInput('url') + '/api/convert?input=1//2gal');
+        assert(data.error === 'invalid number' || data === 'invalid number');
+      } catch(xhr) {
+        throw new Error(xhr.responseText || xhr.message);
+      }
+    }"
   - text: If both are invalid, return will be 'invalid number and unit'.
-    testString: ''
+    testString: "async getUserInput => { 
+      try {
+        const data = await $.get(getUserInput('url') + '/api/convert?input=1//2min');
+        assert(data.error === 'invalid number and unit' || data === 'invalid number and unit');
+      } catch(xhr) {
+        throw new Error(xhr.responseText || xhr.message);
+      }
+    }"
   - text: I can use fractions, decimals or both in my parameter(ie. 5, 1/2, 2.5/6), but if nothing is provided it will default to 1.
-    testString: ''
+    testString: "async getUserInput => {
+      try {
+        const data1 = await $.get(getUserInput('url') + '/api/convert?input=1/2mi');
+        assert.approximately(data1.initNum, 1/2, 0.001);
+        assert.approximately(data1.returnNum, 0.80467, 0.001);
+        assert.equal(data1.returnUnit, 'km');
+        const data2 = await $.get(getUserInput('url') + '/api/convert?input=1/5mi');
+        assert.approximately(data2.initNum, 1/5, 0.1);
+        assert.approximately(data2.returnNum, 0.32187, 0.001);
+        assert.equal(data2.returnUnit, 'km');
+        const data3 = await $.get(getUserInput('url') + '/api/convert?input=1.5/7km');
+        assert.approximately(data3.initNum, 1.5/7, 0.001);
+        assert.approximately(data3.returnNum, 0.13315, 0.001);
+        assert.equal(data3.returnUnit, 'mi');
+        const data4 = await $.get(getUserInput('url') + '/api/convert?input=3/2.7km');
+        assert.approximately(data4.initNum, 3/2.7, 0.001);
+        assert.approximately(data4.returnNum, 0.69041, 0.001);
+        assert.equal(data4.returnUnit, 'mi');
+      } catch(err) {
+        throw new Error(err.responseText || err.message);
+      }
+    }
+    "
   - text: My return will consist of the initNum, initUnit, returnNum, returnUnit, and string spelling out units in format '{initNum} {initial_Units} converts to {returnNum} {return_Units}' with the result rounded to 5 decimals in the string.
-    testString: ''
+    testString: "async getUserInput => { 
+      try {
+        const data = await $.get(getUserInput('url') + '/api/convert?input=2mi');
+        assert.equal(data.initNum, 2);
+        assert.equal(data.initUnit, 'mi');
+        assert.approximately(data.returnNum, 3.21868, 0.001);
+        assert.equal(data.returnUnit, 'km', 'returnUnit did not match');
+        assert.equal(data.string, '2 miles converts to 3.21868 kilometers')
+      } catch(xhr) {
+        throw new Error(xhr.responseText || xhr.message);
+      }
+    }"
   - text: All 16 unit tests are complete and passing.
     testString: ''
   - text: All 5 functional tests are complete and passing.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
~~* Removes the two "Information Security" tests as per #39435~~
* Add additional tests for invalid numbers/units/both number and units and final output check
* Improve error reporting for non-XHR errors.  If an assertion fails the error is in the property `message`, so I have ORed the `message` for all tests. This provides a better experience for debugging.

## Testing
I have tested from GitPod against my personal project (which passes) and against the boilerplate (which fails).

## Note on 'invalid *' tests
The current example project does not pass some of these tests.  As noted in #39470, it has some issues with some invalid units.  It also returns the error as `{ error: "invalid unit" }`.  If this is the standard, then the project/boilerplate will need to be updated to state as such.  For the moment I have adopted test strategy of checking for a value in the `.error` property and plain-text return value.
IE: 
```js
data.error === 'invalid number' || data === 'invalid number'
```