### PR TITLE
feat(learn): Add test for file metadata project

### DIFF
--- a/curriculum/challenges/english/05-apis-and-microservices/apis-and-microservices-projects/file-metadata-microservice.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/apis-and-microservices-projects/file-metadata-microservice.english.md
@@ -25,7 +25,6 @@ Start this project on Repl.it using <a href='https://repl.it/github/freeCodeCamp
 tests:
   - text: I can provide my own project, not the example URL.
     testString: "getUserInput => {
-      const url = getUserInput('url');
       assert(!(new RegExp('.*/file-metadata.freecodecamp.repl.co')).test(getUserInput('url')));
     }"
   - text: I can submit a form that includes a file upload.

--- a/curriculum/challenges/english/05-apis-and-microservices/apis-and-microservices-projects/file-metadata-microservice.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/apis-and-microservices-projects/file-metadata-microservice.english.md
@@ -23,12 +23,38 @@ Start this project on Repl.it using <a href='https://repl.it/github/freeCodeCamp
 
 ```yml
 tests:
+  - text: I can provide my own project, not the example URL.
+    testString: "getUserInput => {
+      const url = getUserInput('url');
+      assert(!(new RegExp('.*/file-metadata.freecodecamp.repl.co')).test(getUserInput('url')));
+    }"
   - text: I can submit a form that includes a file upload.
-    testString: ''
+    testString: "async getUserInput => {
+      const site = await fetch(getUserInput('url'));
+      const data = await site.text();
+      assert(/<form.*>/.test(data));
+      assert(/type=['|\"]file['|\"]/.test(data));
+    }"
   - text: The form file input field has the <code>name</code> attribute set to <code>upfile</code>.
-    testString: ''
+    testString: "async getUserInput => {
+      const site = await fetch(getUserInput('url'));
+      const data = await site.text();
+      assert(/name=['|\"]upfile['|\"]/.test(data));
+    }"
   - text: When I submit something, I will receive the file <code>name</code>, <code>type</code>, and <code>size</code> in bytes within the JSON response.
-    testString: ''
+    testString: "async getUserInput => {
+      const formData = new FormData();
+      const fileData = await fetch('../../../../../icons/icon-48x48.png');
+      const file = await fileData.blob();
+      formData.append('upfile', file, 'icon');
+      const data = await fetch(getUserInput('url') + '/api/fileanalyse', {
+        method: 'POST', body: formData
+      });
+      const parsed = await data.json();
+      assert.property(parsed, 'size');
+      assert.equal(parsed.name, 'icon');
+      assert.equal(parsed.type, 'image/png');
+    }"
 
 ```
 

--- a/curriculum/challenges/english/05-apis-and-microservices/apis-and-microservices-projects/file-metadata-microservice.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/apis-and-microservices-projects/file-metadata-microservice.english.md
@@ -7,6 +7,7 @@ forumTopicId: 301506
 ---
 
 ## Description
+
 <section id='description'>
 Build a full stack JavaScript app that is functionally similar to this: <a href='https://file-metadata.freecodecamp.repl.co/' target='_blank'>https://file-metadata.freecodecamp.repl.co/</a>.
 Working on this project will involve you writing your code on Repl.it on our starter project. After completing this project you can copy your public Repl.it URL (to the homepage of your app) into this screen to test it! Optionally you may choose to write your project on another platform but it must be publicly visible for our testing.
@@ -14,11 +15,13 @@ Start this project on Repl.it using <a href='https://repl.it/github/freeCodeCamp
 </section>
 
 ## Instructions
+
 <section id='instructions'>
 
 </section>
 
 ## Tests
+
 <section id='tests'>
 
 ```yml
@@ -31,14 +34,15 @@ tests:
     testString: "async getUserInput => {
       const site = await fetch(getUserInput('url'));
       const data = await site.text();
-      assert(/<form.*>/.test(data));
-      assert(/type=['|\"]file['|\"]/.test(data));
+      const doc = new DOMParser().parseFromString(data, 'text/html');
+      assert(doc.querySelector('input[type=\"file\"]'));
     }"
   - text: The form file input field has the <code>name</code> attribute set to <code>upfile</code>.
     testString: "async getUserInput => {
       const site = await fetch(getUserInput('url'));
       const data = await site.text();
-      assert(/name=['|\"]upfile['|\"]/.test(data));
+      const doc = new DOMParser().parseFromString(data, 'text/html');
+      assert(doc.querySelector('input[name=\"upfile\"]'));
     }"
   - text: When I submit something, I will receive the file <code>name</code>, <code>type</code>, and <code>size</code> in bytes within the JSON response.
     testString: "async getUserInput => {
@@ -60,11 +64,13 @@ tests:
 </section>
 
 ## Challenge Seed
+
 <section id='challengeSeed'>
 
 </section>
 
 ## Solution
+
 <section id='solution'>
 
 ```js

--- a/curriculum/challenges/english/05-apis-and-microservices/apis-and-microservices-projects/file-metadata-microservice.english.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/apis-and-microservices-projects/file-metadata-microservice.english.md
@@ -44,7 +44,7 @@ tests:
   - text: When I submit something, I will receive the file <code>name</code>, <code>type</code>, and <code>size</code> in bytes within the JSON response.
     testString: "async getUserInput => {
       const formData = new FormData();
-      const fileData = await fetch('../../../../../icons/icon-48x48.png');
+      const fileData = await fetch('https://cdn.freecodecamp.org/weather-icons/01d.png');
       const file = await fileData.blob();
       formData.append('upfile', file, 'icon');
       const data = await fetch(getUserInput('url') + '/api/fileanalyse', {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `master` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to #37185 

<!-- Feel free to add any additional description of changes below this line -->

I've added some tests to the File Metadata project. 
Test 1: Asserts that the user's submission is not the example URL.
Test 2: Fetches the user's submission, reads it as text, and looks for a `<form>` element and a `type` attribute of `file`.
Test 3: Fetches the user's submission, reads it as text, and looks for a `name` attribute of `upfile`.
Test 4: Posts a file to the user's submission, checks for valid properties in the response. This one was tricky - the best work around I could find was to encode a local image from the repository (in this case, one of the icons) into a FormData object and send that to the endpoint.

**NOTE** The example project was down while I was working on these, so I had to fork it and test against a cloned instance. 