### PR TITLE
fix(Client): Use `font-display: swap` to avoid FOIT

### DIFF
--- a/client/src/components/layouts/fonts.css
+++ b/client/src/components/layouts/fonts.css
@@ -3,6 +3,7 @@
   src: url('../../../static/fonts/lato/Lato-Light.woff') format('woff');
   font-weight: 300;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -10,6 +11,7 @@
   src: url('../../../static/fonts/lato/Lato-Regular.woff') format('woff');
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -17,6 +19,7 @@
   src: url('../../../static/fonts/lato/Lato-Italic.woff') format('woff');
   font-weight: normal;
   font-style: italic;
+  font-display: swap;
 }
 
 @font-face {
@@ -24,6 +27,7 @@
   src: url('../../../static/fonts/lato/Lato-Bold.woff') format('woff');
   font-weight: bold;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -31,6 +35,7 @@
   src: url('../../../static/fonts/lato/Lato-Black.woff') format('woff');
   font-weight: 900;
   font-style: normal;
+  font-display: swap;
 }
 
 /* roboto mono */
@@ -41,6 +46,7 @@
     format('woff');
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -49,6 +55,7 @@
     format('woff');
   font-weight: normal;
   font-style: italic;
+  font-display: swap;
 }
 
 @font-face {
@@ -57,4 +64,5 @@
     format('woff');
   font-weight: bold;
   font-style: normal;
+  font-display: swap;
 }

--- a/client/src/components/layouts/fonts.css
+++ b/client/src/components/layouts/fonts.css
@@ -3,7 +3,7 @@
   src: url('../../../static/fonts/lato/Lato-Light.woff') format('woff');
   font-weight: 300;
   font-style: normal;
-  font-display: swap;
+  font-display: fallback;
 }
 
 @font-face {
@@ -11,7 +11,7 @@
   src: url('../../../static/fonts/lato/Lato-Regular.woff') format('woff');
   font-weight: normal;
   font-style: normal;
-  font-display: swap;
+  font-display: fallback;
 }
 
 @font-face {
@@ -19,7 +19,7 @@
   src: url('../../../static/fonts/lato/Lato-Italic.woff') format('woff');
   font-weight: normal;
   font-style: italic;
-  font-display: swap;
+  font-display: fallback;
 }
 
 @font-face {
@@ -27,7 +27,7 @@
   src: url('../../../static/fonts/lato/Lato-Bold.woff') format('woff');
   font-weight: bold;
   font-style: normal;
-  font-display: swap;
+  font-display: fallback;
 }
 
 @font-face {
@@ -35,7 +35,7 @@
   src: url('../../../static/fonts/lato/Lato-Black.woff') format('woff');
   font-weight: 900;
   font-style: normal;
-  font-display: swap;
+  font-display: fallback;
 }
 
 /* roboto mono */
@@ -46,7 +46,7 @@
     format('woff');
   font-weight: normal;
   font-style: normal;
-  font-display: swap;
+  font-display: fallback;
 }
 
 @font-face {
@@ -55,7 +55,7 @@
     format('woff');
   font-weight: normal;
   font-style: italic;
-  font-display: swap;
+  font-display: fallback;
 }
 
 @font-face {
@@ -64,5 +64,5 @@
     format('woff');
   font-weight: bold;
   font-style: normal;
-  font-display: swap;
+  font-display: fallback;
 }

--- a/client/src/pages/certification.css
+++ b/client/src/pages/certification.css
@@ -1,7 +1,7 @@
 @font-face {
   font-family: 'Sax Mono';
   src: url('/fonts/saxmono.ttf') format('truetype');
-  font-display: swap;
+  font-display: fallback;
 }
 
 .certification-namespace * {

--- a/client/src/pages/certification.css
+++ b/client/src/pages/certification.css
@@ -1,6 +1,7 @@
 @font-face {
   font-family: 'Sax Mono';
   src: url('/fonts/saxmono.ttf') format('truetype');
+  font-display: swap;
 }
 
 .certification-namespace * {

--- a/tools/dashboard/probot/client/src/index.css
+++ b/tools/dashboard/probot/client/src/index.css
@@ -1,16 +1,19 @@
 @font-face {
   font-family: 'Lato';
   src: url(./fonts/Lato-Regular.ttf) format('truetype');
+  font-display: swap;
 }
 
 @font-face {
   font-family: 'Lato Light';
   src: url(./fonts/Lato-Light.ttf) format('truetype');
+  font-display: swap;
 }
 
 @font-face {
   font-family: 'Lato Bold';
   src: url(./fonts/Lato-Bold.ttf) format('truetype');
+  font-display: swap;
 }
 
 * {

--- a/tools/dashboard/probot/client/src/index.css
+++ b/tools/dashboard/probot/client/src/index.css
@@ -1,19 +1,19 @@
 @font-face {
   font-family: 'Lato';
   src: url(./fonts/Lato-Regular.ttf) format('truetype');
-  font-display: swap;
+  font-display: fallback;
 }
 
 @font-face {
   font-family: 'Lato Light';
   src: url(./fonts/Lato-Light.ttf) format('truetype');
-  font-display: swap;
+  font-display: fallback;
 }
 
 @font-face {
   font-family: 'Lato Bold';
   src: url(./fonts/Lato-Bold.ttf) format('truetype');
-  font-display: swap;
+  font-display: fallback;
 }
 
 * {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

Currently while the fonts load, the website has shows no text. This know as _FOIT_ and is bad practice as users with slower internet speed has to wait a lot of seconds before they can event see any text. This PR fixes this issue.

For more info: https://web.dev/font-display/?utm_source=lighthouse&utm_medium=ci
