### PR TITLE
fix(curriculum): make babel support fewer browsers

### DIFF
--- a/client/src/templates/Challenges/rechallenge/transformers.js
+++ b/client/src/templates/Challenges/rechallenge/transformers.js
@@ -60,15 +60,18 @@ async function loadBabel() {
 
 async function loadPresetEnv() {
   if (babelOptionsJSBase && babelOptionsJSBase.presets) return;
-  /* eslint-disable no-inline-comments */
-  if (!presetEnv)
-    presetEnv = await import(
-      /* webpackChunkName: "@babel/preset-env" */ '@babel/preset-env'
-    );
-  /* eslint-enable no-inline-comments */
+
+  Babel.registerPreset('env-plus', {
+    presets: [
+      [
+        Babel.availablePresets['env'],
+        { targets: { browsers: ['>1.5% and last 2 versions and not dead'] } }
+      ]
+    ]
+  });
 
   babelOptionsJSBase = {
-    presets: [presetEnv]
+    presets: ['env-plus']
   };
   babelOptionsJS = {
     ...babelOptionsJSBase,

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/write-concise-declarative-functions-with-es6.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/write-concise-declarative-functions-with-es6.english.md
@@ -46,7 +46,7 @@ tests:
   - text: <code>setGear</code> should be a declarative function.
     testString: assert(typeof bicycle.setGear === 'function' && code.match(/setGear\s*\(.+\)\s*\{/));
   - text: <code>bicycle.setGear(48)</code> should change the <code>gear</code> value to 48.
-    testString: assert((new bicycle.setGear(48)).gear === 48);
+    testString: bicycle.gear = 3; bicycle.setGear(48); assert(bicycle.gear === 48);
 
 ```
 


### PR DESCRIPTION
Babel does not handle `BigInt(1)**BigInt(1)` properly, so this restricts the browserlist to ones that do not force it to transform `x**x` to `Math.pow(x,x)`

I'm not sure if this has any weird side-effects, but it should close https://github.com/freeCodeCamp/freeCodeCamp/issues/39352

