### PR TITLE
fix(docs): add formatting instructions for coding challenge text

### DIFF
--- a/docs/how-to-work-on-coding-challenges.md
+++ b/docs/how-to-work-on-coding-challenges.md
@@ -215,6 +215,7 @@ Here are specific formatting guidelines for challenge text and examples:
 Use <code>parseInt</code> to convert the variable <code>realNumber</code> into an integer.
 ```
 - References to file names and path directories (i.e. `package.json`, `src/components`) should be wrapped in `<code>` tags.
+- Mention of tools, packages, and trademarks (i.e. _Pug, MongoDB_) should be wrapped in `<em>` tags.
 - Multi-line code blocks **must be preceded by an empty line**. The next line must start with three backticks followed immediately by one of the [supported languages](https://prismjs.com/#supported-languages). To complete the code block, you must start a newline which only has three backticks and **another empty line**. See example below:
   
 **Note:** If you are going to use an example code in YAML, use `yaml` instead of `yml` for the language to the right of the backticks.
@@ -232,6 +233,8 @@ The following is an example of code:
 - Additional information in the form of a note should be formatted `<strong>Note:</strong> Rest of note text...`
 - If multiple notes are needed, then list all of the notes in separate sentences using the format `<strong>Notes:</strong> First note text. Second note text.`.
 - Use double quotes where applicable
+
+**Note:** The equivalent _MarkDown_ should be used, where applicable, in place of _HTML_ tags.
 
 ## Writing tests
 

--- a/docs/how-to-work-on-coding-challenges.md
+++ b/docs/how-to-work-on-coding-challenges.md
@@ -215,7 +215,6 @@ Here are specific formatting guidelines for challenge text and examples:
 Use <code>parseInt</code> to convert the variable <code>realNumber</code> into an integer.
 ```
 - References to file names and path directories (e.g. `package.json`, `src/components`) should be wrapped in `<code>` tags.
-- Mention of tools, packages, and trademarks (e.g. _Pug, MongoDB_) should be wrapped in `<em>` tags.
 - Multi-line code blocks **must be preceded by an empty line**. The next line must start with three backticks followed immediately by one of the [supported languages](https://prismjs.com/#supported-languages). To complete the code block, you must start a newline which only has three backticks and **another empty line**. See example below:
   
 **Note:** If you are going to use an example code in YAML, use `yaml` instead of `yml` for the language to the right of the backticks.

--- a/docs/how-to-work-on-coding-challenges.md
+++ b/docs/how-to-work-on-coding-challenges.md
@@ -215,7 +215,7 @@ Here are specific formatting guidelines for challenge text and examples:
 Use <code>parseInt</code> to convert the variable <code>realNumber</code> into an integer.
 ```
 - References to file names and path directories (e.g. `package.json`, `src/components`) should be wrapped in `<code>` tags.
-- Mention of tools, packages, and trademarks (i.e. _Pug, MongoDB_) should be wrapped in `<em>` tags.
+- Mention of tools, packages, and trademarks (e.g. _Pug, MongoDB_) should be wrapped in `<em>` tags.
 - Multi-line code blocks **must be preceded by an empty line**. The next line must start with three backticks followed immediately by one of the [supported languages](https://prismjs.com/#supported-languages). To complete the code block, you must start a newline which only has three backticks and **another empty line**. See example below:
   
 **Note:** If you are going to use an example code in YAML, use `yaml` instead of `yml` for the language to the right of the backticks.

--- a/docs/how-to-work-on-coding-challenges.md
+++ b/docs/how-to-work-on-coding-challenges.md
@@ -211,11 +211,13 @@ Here are specific formatting guidelines for challenge text and examples:
 - Language keywords go in `<code>` tags. For example, HTML tag names or CSS property names
 - The first instance of a keyword when it's being defined, or general keywords (i.e. "object" or "immutable") go in `<dfn>` tags
 - References to code parts (i.e. function, method or variable names) should be wrapped in `<code>` tags. See example below:
-- Use <code>parseInt</code> to convert the variable <code>realNumber</code> into an integer.
-- Multi-line code blocks **must be preceded by an empty line**. The next line must start with three backticks followed immediately by one of the [supported languages](https://prismjs.com/#supported-languages). To complete the code block, you must start a newline which only has three backticks and **another empty line**.
-  **Note:** If you are going to use an example code in YAML, use `yaml` instead of `yml` for the language to the right of the backticks.
-
-See example below:
+```md
+Use <code>parseInt</code> to convert the variable <code>realNumber</code> into an integer.
+```
+- References to file names and path directories (i.e. `package.json`, `src/components`) should be wrapped in `<code>` tags.
+- Multi-line code blocks **must be preceded by an empty line**. The next line must start with three backticks followed immediately by one of the [supported languages](https://prismjs.com/#supported-languages). To complete the code block, you must start a newline which only has three backticks and **another empty line**. See example below:
+  
+**Note:** If you are going to use an example code in YAML, use `yaml` instead of `yml` for the language to the right of the backticks.
 
 ````md
 The following is an example of code:

--- a/docs/how-to-work-on-coding-challenges.md
+++ b/docs/how-to-work-on-coding-challenges.md
@@ -209,12 +209,12 @@ Our goal is to have thousands of 2-minute challenges. These can flow together an
 Here are specific formatting guidelines for challenge text and examples:
 
 - Language keywords go in `<code>` tags. For example, HTML tag names or CSS property names
-- The first instance of a keyword when it's being defined, or general keywords (i.e. "object" or "immutable") go in `<dfn>` tags
+- The first instance of a keyword when it's being defined, or general keywords (e.g. "object" or "immutable") go in `<dfn>` tags
 - References to code parts (i.e. function, method or variable names) should be wrapped in `<code>` tags. See example below:
 ```md
 Use <code>parseInt</code> to convert the variable <code>realNumber</code> into an integer.
 ```
-- References to file names and path directories (i.e. `package.json`, `src/components`) should be wrapped in `<code>` tags.
+- References to file names and path directories (e.g. `package.json`, `src/components`) should be wrapped in `<code>` tags.
 - Mention of tools, packages, and trademarks (i.e. _Pug, MongoDB_) should be wrapped in `<em>` tags.
 - Multi-line code blocks **must be preceded by an empty line**. The next line must start with three backticks followed immediately by one of the [supported languages](https://prismjs.com/#supported-languages). To complete the code block, you must start a newline which only has three backticks and **another empty line**. See example below:
   
@@ -234,7 +234,7 @@ The following is an example of code:
 - If multiple notes are needed, then list all of the notes in separate sentences using the format `<strong>Notes:</strong> First note text. Second note text.`.
 - Use single-quotes where applicable
 
-**Note:** The equivalent _MarkDown_ should be used, where applicable, in place of _HTML_ tags.
+**Note:** The equivalent _Markdown_ should be used, where applicable, in place of _HTML_ tags.
 
 ## Writing tests
 

--- a/docs/how-to-work-on-coding-challenges.md
+++ b/docs/how-to-work-on-coding-challenges.md
@@ -232,7 +232,7 @@ The following is an example of code:
 
 - Additional information in the form of a note should be formatted `<strong>Note:</strong> Rest of note text...`
 - If multiple notes are needed, then list all of the notes in separate sentences using the format `<strong>Notes:</strong> First note text. Second note text.`.
-- Use double quotes where applicable
+- Use single-quotes where applicable
 
 **Note:** The equivalent _MarkDown_ should be used, where applicable, in place of _HTML_ tags.
 


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

Closes #39614

This PR updates the docs with clarification on how to format coding challenge text

![image](https://user-images.githubusercontent.com/51722130/94151388-3e1c7280-fe72-11ea-8507-8b44ff87f7c1.png)
