### PR TITLE
fix: update env validation and include newest var

### DIFF
--- a/config/env.js
+++ b/config/env.js
@@ -50,5 +50,5 @@ module.exports = Object.assign(locations, {
     !paypalClientId || paypalClientId === 'id_from_paypal_dashboard'
       ? null
       : paypalClientId,
-  showUpcomingChanges: showUpcomingChanges === 'true'
+  showUpcomingChanges: showUpcomingChanges && showUpcomingChanges === 'true'
 });

--- a/tools/scripts/build/ensure-env.js
+++ b/tools/scripts/build/ensure-env.js
@@ -15,7 +15,12 @@ if (FREECODECAMP_NODE_ENV === 'production') {
     'forumLocation',
     'newsLocation'
   ];
-  const deploymentKeys = ['locale', 'deploymentEnv', 'environment'];
+  const deploymentKeys = [
+    'locale',
+    'deploymentEnv',
+    'environment',
+    'showUpcomingChanges'
+  ];
   const searchKeys = ['algoliaAppId', 'algoliaAPIKey'];
   const donationKeys = ['stripePublicKey', 'paypalClientId'];
 
@@ -29,13 +34,14 @@ if (FREECODECAMP_NODE_ENV === 'production') {
   variables.sort();
   if (expectedVariables.length !== variables.length) {
     throw Error(`Env. variable validation failed. Expected
-    ${variables} to match
     ${expectedVariables}
+    but recieved
+    ${variables}
     `);
   }
 
   for (const key of expectedVariables) {
-    if (!env[key]) {
+    if (typeof env[key] === 'undefined' || env[key] === null) {
       throw Error(`Env. variable ${key} is missing, build cannot continue`);
     }
   }


### PR DESCRIPTION
Rather than checking if a variable is falsy, ensure-env now only cares if it exists or not.