### PR TITLE
fix(learn): Update test text in Profile Lookup

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/profile-lookup.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/profile-lookup.english.md
@@ -26,17 +26,17 @@ If <code>prop</code> does not correspond to any valid properties of a contact fo
 
 ```yml
 tests:
-  - text: <code>"Kristian", "lastName"</code> should return <code>"Vos"</code>
+  - text: <code>lookUpProfile("Kristian", "lastName")</code> should return <code>"Vos"</code>
     testString: assert(lookUpProfile('Kristian','lastName') === "Vos");
-  - text: <code>"Sherlock", "likes"</code> should return <code>["Intriguing Cases", "Violin"]</code>
+  - text: <code>lookUpProfile("Sherlock", "likes")</code> should return <code>["Intriguing Cases", "Violin"]</code>
     testString: assert.deepEqual(lookUpProfile("Sherlock", "likes"), ["Intriguing Cases", "Violin"]);
-  - text: <code>"Harry","likes"</code> should return an array
+  - text: <code>lookUpProfile("Harry", "likes")</code> should return an array
     testString: assert(typeof lookUpProfile("Harry", "likes") === "object");
-  - text: <code>"Bob", "number"</code> should return "No such contact"
+  - text: <code>lookUpProfile("Bob", "number")</code> should return "No such contact"
     testString: assert(lookUpProfile("Bob", "number") === "No such contact");
-  - text: <code>"Bob", "potato"</code> should return "No such contact"
+  - text: <code>lookUpProfile("Bob", "potato")</code> should return "No such contact"
     testString: assert(lookUpProfile("Bob", "potato") === "No such contact");
-  - text: <code>"Akira", "address"</code> should return "No such property"
+  - text: <code>lookUpProfile("Akira", "address")</code> should return "No such property"
     testString: assert(lookUpProfile("Akira", "address") === "No such property");
 
 ```


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `master` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

As far as I can tell, most of our challenge tests explicitly state the function call in the `text` fields. I noticed that this challenge only stated the arguments passed to the function. For consistency, I've updated the text to match the style of other challenges.