### PR TITLE
fix(learn): avoid conflict with spring forward EST to EDT

### DIFF
--- a/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/date-manipulation.english.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/date-manipulation.english.md
@@ -8,8 +8,8 @@ forumTopicId: 302244
 ## Description
 <section id='description'>
 Given a date string in EST, output the given date as a string with 12 hours added to the time. Time zone should be preserved.
-Example input: <code>"March 7 2009 7:30pm EST"</code>
-Example output: <code>"March 8 2009 7:30am EST"</code>
+Example input: <code>"March 6 2009 7:30pm EST"</code>
+Example output: <code>"March 7 2009 7:30am EST"</code>
 </section>
 
 ## Instructions
@@ -28,8 +28,8 @@ tests:
     testString: assert(typeof add12Hours('January 17 2017 11:43am EST') === 'string');
   - text: <code>add12Hours("January 17 2017 11:43am EST")</code> should return <code>"January 17 2017 11:43pm EST"</code>
     testString: assert(add12Hours('January 17 2017 11:43am EST') === 'January 17 2017 11:43pm EST');
-  - text: Should handle day change. <code>add12Hours("March 7 2009 7:30pm EST")</code> should return <code>"March 8 2009 7:30am EST"</code>
-    testString: assert(add12Hours('March 7 2009 7:30pm EST') === 'March 8 2009 7:30am EST');
+  - text: Should handle day change. <code>add12Hours("March 6 2009 7:30pm EST")</code> should return <code>"March 7 2009 7:30am EST"</code>
+    testString: assert(add12Hours('March 6 2009 7:30pm EST') === 'March 7 2009 7:30am EST');
   - text: Should handle month change in a leap years. <code>add12Hours("February 29 2004 9:15pm EST")</code> should return <code>"March 1 2004 9:15am EST"</code>
     testString: assert(add12Hours('February 29 2004 9:15pm EST') === 'March 1 2004 9:15am EST');
   - text: Should handle month change in a common years. <code>add12Hours("February 28 1999 3:15pm EST")</code> should return <code>"March 1 1999 3:15am EST"</code>


### PR DESCRIPTION
March 8, 2009 is the weekend of spring forward to EDT in the US.  This change moves the example date and test back one day to add twelve hours to a time on March 6, 2009, resulting in a time on March 7, 2009.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

The example and test four in Rosetta Code:  Date Manipulation ignore the fact that the time changes from EST to EDT on March 8, 2009, which is the target date of the example and test.  This moves the date back one day to avoid the problem.
