### PR TITLE
Add new reference link and fix spacing issues in Comma Quibbling

### DIFF
--- a/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/comma-quibbling.english.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/comma-quibbling.english.md
@@ -7,7 +7,7 @@ forumTopicId: 302234
 
 ## Description
 <section id='description'>
-Comma quibbling is a task originally set by Eric Lippert in his <a href="https://blogs.msdn.com/b/ericlippert/archive/2009/04/15/comma-quibbling.aspx" target="_blank">blog</a>.
+Comma quibbling is a task originally set by Eric Lippert in his <a href="https://blogs.msdn.com/b/ericlippert/archive/2009/04/15/comma-quibbling.aspx" target="_blank">blog</a> (<a href="https://ericlippert.com/2009/04/15/restating-the-problem/" target="_blank">updated</a>).
 </section>
 
 ## Instructions

--- a/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/comma-quibbling.english.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/comma-quibbling.english.md
@@ -44,7 +44,7 @@ tests:
     testString: assert.equal(quibble(testCases[1]), results[1]);
   - text: <code>quibble(["ABC", "DEF"])</code> should return "{ABC and DEF}".
     testString: assert.equal(quibble(testCases[2]), results[2]);
-  - text: <code>quibble(["ABC", "DEF", "G", "H"])</code> should return "{ABC,DEF,G and H}".
+  - text: <code>quibble(["ABC", "DEF", "G", "H"])</code> should return "{ABC, DEF, G and H}".
     testString: assert.equal(quibble(testCases[3]), results[3]);
 
 ```
@@ -71,7 +71,7 @@ function quibble(words) {
 
 ```js
 const testCases = [[], ["ABC"], ["ABC", "DEF"], ["ABC", "DEF", "G", "H"]];
-const results = ["{}", "{ABC}", "{ABC and DEF}", "{ABC,DEF,G and H}"];
+const results = ["{}", "{ABC}", "{ABC and DEF}", "{ABC, DEF, G and H}"];
 ```
 
 </div>
@@ -85,7 +85,7 @@ const results = ["{}", "{ABC}", "{ABC and DEF}", "{ABC,DEF,G and H}"];
 ```js
 function quibble(words) {
   return "{" +
-    words.slice(0, words.length - 1).join(",") +
+    words.slice(0, words.length - 1).join(", ") +
    (words.length > 1 ? " and " : "") +
    (words[words.length - 1] || '') +
   "}";


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This add a new reference link to Eric Lippert's blog at its current location, specifically to a post discussing the original posts concerning the Comma Quibbling problem.  This also aligns the comma-space description provided in test 4 of the challenge with the tests and solution function.
