### PR TITLE
feat(learn): migrate instructions from adnode boilerplate

### DIFF
--- a/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/how-to-put-a-profile-together.md
+++ b/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/how-to-put-a-profile-together.md
@@ -13,7 +13,7 @@ Now that we can ensure the user accessing the `/profile` is authenticated, we ca
 
 Pass the object containing the variable `username` equaling `req.user.username` into the render method of the profile view. Then, go to your `profile.pug` view, and add the following line below the existing `h1` element, and at the same level of indentation:
 
-```
+```pug
 h2.center#welcome Welcome, #{username}!
 ```
 
@@ -21,7 +21,7 @@ This creates an `h2` element with the class '`center`' and id '`welcome`' contai
 
 Also, in `profile.pug`, add a link referring to the `/logout` route, which will host the logic to unauthenticate a user.
 
-```
+```pug
 a(href='/logout') Logout
 ```
 

--- a/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/how-to-put-a-profile-together.md
+++ b/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/how-to-put-a-profile-together.md
@@ -11,7 +11,7 @@ forumTopicId: 301554
 
 Now that we can ensure the user accessing the `/profile` is authenticated, we can use the information contained in `req.user` on our page!
 
-Pass the object containing the variable `username` equaling `req.user.username` into the render method of the profile view. Then, go to your `profile.pug` view, and add the following line below the existing `h1` element, and at the same level of indentation:
+Pass an object containing the property `username` and value of `req.user.username` as the second argument for the render method of the profile view. Then, go to your `profile.pug` view, and add the following line below the existing `h1` element, and at the same level of indentation:
 
 ```pug
 h2.center#welcome Welcome, #{username}!

--- a/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/how-to-put-a-profile-together.md
+++ b/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/how-to-put-a-profile-together.md
@@ -6,41 +6,55 @@ forumTopicId: 301554
 ---
 
 ## Description
+
 <section id='description'>
 
-Now that we can ensure the user accessing the <em>/profile</em> is authenticated, we can use the information contained in 'req.user' on our page!
+Now that we can ensure the user accessing the `/profile` is authenticated, we can use the information contained in `req.user` on our page!
 
-Go ahead and pass the object containing the variable <em>username</em> equaling <code>req.user.username</code> into the render method of the profile view. Then go to your <code>profile.pug</code> view and add the line <code>h2.center#welcome Welcome, #{username}!</code> creating the h2 element with the class 'center' and id 'welcome' containing the text 'Welcome, ' and the username!
+Pass the object containing the variable `username` equaling `req.user.username` into the render method of the profile view. Then, go to your `profile.pug` view, and add the following line below the existing `h1` element, and at the same level of indentation:
 
-Also in the profile, add a link to <em>/logout</em>. That route will host the logic to unauthenticate a user. <code>a(href='/logout') Logout</code>
+```
+h2.center#welcome Welcome, #{username}!
+```
+
+This creates an `h2` element with the class '`center`' and id '`welcome`' containing the text '`Welcome, `' followed by the username.
+
+Also, in `profile.pug`, add a link referring to the `/logout` route, which will host the logic to unauthenticate a user.
+
+```
+a(href='/logout') Logout
+```
 
 Submit your page when you think you've got it right. If you're running into errors, you can check out the project completed up to this point <a href='https://gist.github.com/camperbot/136b3ad611cc80b41cab6f74bb460f6a' target='_blank'>here</a>.
 
 </section>
 
 ## Instructions
+
 <section id='instructions'>
 
 </section>
 
 ## Tests
+
 <section id='tests'>
 
 ```yml
 tests:
   - text: You should correctly add a Pug render variable to /profile.
     testString: getUserInput => $.get(getUserInput('url')+ '/_api/server.js') .then(data => { assert.match(data, /username:( |)req.user.username/gi, 'You should be passing the variable username with req.user.username into the render function of the profile page'); }, xhr => { throw new Error(xhr.statusText); })
-
 ```
 
 </section>
 
 ## Challenge Seed
+
 <section id='challengeSeed'>
 
 </section>
 
 ## Solution
+
 <section id='solution'>
 
 ```js

--- a/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/set-up-a-template-engine.md
+++ b/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/set-up-a-template-engine.md
@@ -11,17 +11,17 @@ forumTopicId: 301564
 
 As a reminder, this project is built upon the following starter project on <a href='https://repl.it/github/freeCodeCamp/boilerplate-advancednode' target='_blank'>Repl.it</a>, or clone from <a href='https://github.com/freeCodeCamp/boilerplate-advancednode/' target='_blank'>GitHub</a>.
 
-A template engine enables you to use static template files (such as those written in <em>Pug</em>) in your app. At runtime, the template engine replaces variables in a template file with actual values which can be supplied by your server. Then it transforms the template into a static HTML file that is sent to the client. This approach makes it easier to design an HTML page and allows for displaying variables on the page without needing to make an API call from the client.
+A template engine enables you to use static template files (such as those written in _Pug_) in your app. At runtime, the template engine replaces variables in a template file with actual values which can be supplied by your server. Then it transforms the template into a static HTML file that is sent to the client. This approach makes it easier to design an HTML page and allows for displaying variables on the page without needing to make an API call from the client.
 
-To set up <em>Pug</em> for use in your project, you will need to add it as a dependency in your package.json. Don't forget to add the name of the package and the version. Use the package.json for some examples of the correct syntax.
+Add `pug@~3.0.0` as a dependency in your `package.json` file.
 
-Express needs to know which template engine you are using. We will use the <code>set</code> method to assign <code>pug</code> as the <code>view engine</code> property's value: <code>app.set('view engine', 'pug')</code>
+Express needs to know which template engine you are using. We will use the `set` method to assign `pug` as the `view engine` property's value: `app.set('view engine', 'pug')`
 
-Your page will not load until you correctly render the index file in the <code>views/pug</code> directory.
+Your page will not load until you correctly render the index file in the `views/pug` directory.
 
-You should change the response for the <code>/</code> route to use <code>res.render()</code>. This method takes a string of a file path as an argument. The path can be a relative path (relative to views), or an absolute path, and does not require a file extension.
+Change the argument of the `res.render()` declaration in the `/` route to be the file path to the `views/pug` directory. The path can be a relative path (relative to views), or an absolute path, and does not require a file extension.
 
-If all went as planned, your app home page will stop showing the message "Pug template is not defined." and will now display a message indicating you've successfully rendered the Pug template!
+If all went as planned, your app home page will stop showing the message "`Pug template is not defined.`" and will now display a message indicating you've successfully rendered the Pug template!
 
 Submit your page when you think you've got it right. If you're running into errors, you can check out the project completed up to this point <a href='https://gist.github.com/camperbot/3515cd676ea4dfceab4e322f59a37791' target='_blank'>here</a>.
 


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

Related to: https://github.com/freeCodeCamp/freeCodeCamp/issues/39720

Boilerplate PR: https://github.com/freeCodeCamp/boilerplate-advancednode/pull/15

I tried as much as possible to not change unrelated content, but I also took the opportunity to change the instructions with previously discussed versioning additions, and formatting to use GitHub Flavoured MD.

Separate Issue: Husky needs to be configured to not format (search for) changes within backticks. If tests fail, this will be why. Also, might be worthwhile (especially once we migrate to mdx) to change the prettier/lint config to do the same.