### PR TITLE
fix(CI): update runner, display .env for upcoming

### DIFF
--- a/.github/workflows/crowdin-i18n.yml
+++ b/.github/workflows/crowdin-i18n.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   i18n-sync-docs:
     name: Docs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
       - name: Checkout Source Files
@@ -25,17 +25,17 @@ jobs:
 
           # downloads
           download_translations: true
-          commit_message: 'chore(docs,i8n): processed translations from crowdin'
+          commit_message: "chore(docs,i8n): processed translations from crowdin"
 
           # pull-request
           localization_branch_name: i18n-sync-docs
           create_pull_request: true
-          pull_request_title: 'chore(docs,i8n): processed translations from crowdin'
-          pull_request_body: ''
-          pull_request_labels: 'scope: i18n, scope: docs, crowdin-sync'
+          pull_request_title: "chore(docs,i8n): processed translations from crowdin"
+          pull_request_body: ""
+          pull_request_labels: "scope: i18n, scope: docs, crowdin-sync"
 
           # global options
-          config: './docs/crowdin.yml'
+          config: "./docs/crowdin.yml"
           base_url: ${{ secrets.CROWDIN_BASE_URL_FCC }}
 
           # Uncomment below to debug

--- a/.github/workflows/node.js-tests-upcoming.yml
+++ b/.github/workflows/node.js-tests-upcoming.yml
@@ -1,4 +1,4 @@
-name: Node.js CI (Next)
+name: Node.js CI - Test Upcomming Changes
 on:
   push:
     branches:
@@ -7,9 +7,8 @@ on:
       - upcoming-**
   schedule:
     # run this Action every 14 days
-    - cron: '0 * */14 * *'
+    - cron: "0 * */14 * *"
   workflow_dispatch:
-
 
 jobs:
   lint:
@@ -43,7 +42,10 @@ jobs:
             ${{ runner.os }}-
 
       - name: Set Environment variables
-        run: cp sample.env .env
+        run: |
+          cp sample.env .env
+          echo 'SHOW_UPCOMING_CHANGES=true' >> .env
+          cat .env
 
       - name: Lint Source Files
         run: |
@@ -54,7 +56,7 @@ jobs:
   test:
     name: Test
     needs: lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       matrix:
@@ -83,9 +85,10 @@ jobs:
             ${{ runner.os }}-
 
       - name: Set Environment variables
-        run: | 
+        run: |
           cp sample.env .env
           echo 'SHOW_UPCOMING_CHANGES=true' >> .env
+          cat .env
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/node.js-tests-upcoming.yml
+++ b/.github/workflows/node.js-tests-upcoming.yml
@@ -1,4 +1,4 @@
-name: Node.js CI - Test Upcomming Changes
+name: Node.js CI - Test Upcoming
 on:
   push:
     branches:

--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -44,7 +44,7 @@ jobs:
   test:
     name: Test
     needs: lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       matrix:


### PR DESCRIPTION
I forgot before that sample env gets copied and the show upcoming variable is used as is, we would be needing to override it, this PR should do that by adding it as the last entry. 

Dotenv picks up the latest value.