### PR TITLE
fix(learn): Possible semantic error in explanation comment

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/copy-an-array-with-the-spread-operator.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/copy-an-array-with-the-spread-operator.md
@@ -14,7 +14,7 @@ In practice, we can use the spread operator to copy an array like so:
 let thisArray = [true, true, undefined, false, null];
 let thatArray = [...thisArray];
 // thatArray equals [true, true, undefined, false, null]
-// thisArray remains unchanged, and is identical to thatArray
+// thisArray remains unchanged, and is similar to thatArray
 ```
 
 </section>

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/copy-an-array-with-the-spread-operator.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-data-structures/copy-an-array-with-the-spread-operator.md
@@ -14,7 +14,7 @@ In practice, we can use the spread operator to copy an array like so:
 let thisArray = [true, true, undefined, false, null];
 let thatArray = [...thisArray];
 // thatArray equals [true, true, undefined, false, null]
-// thisArray remains unchanged, and is similar to thatArray
+// thisArray remains unchanged and thatArray contains the same elements as thisArray
 ```
 
 </section>


### PR DESCRIPTION
"identical" generally means that both variables are linked to exact same array which is not the case:
``` thisArray !== thatArray ```

Maybe "similar" or other word could be used instead

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->
<!-- Feel free to add any additional description of changes below this line -->
