### PR TITLE
fix: Updated the regex in Applied Visual Design: Adjust the background-color Property of Text CSS test

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/adjust-the-background-color-property-of-text.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/adjust-the-background-color-property-of-text.md
@@ -26,7 +26,7 @@ Also for the <code>h4</code>, remove the <code>height</code> property and add <c
 ```yml
 tests:
   - text: Your code should add a <code>background-color</code> property to the <code>h4</code> element set to <code>rgba(45, 45, 45, 0.1)</code>.
-    testString: assert(code.match(/(background-color|background):\s*?rgba\(\s*?45\s*?,\s*?45\s*?,\s*?45\s*?,\s*?0?\.1\s*?\)(;?\s*?}|;\s*?)/gi));
+    testString: assert(/(background-color|background):rgba\(45,45,45,0?\.1\)(;?}|;)/gi.test(code.replace(/\s/g, '')));
   - text: Your code should add a <code>padding</code> property to the <code>h4</code> element and set it to 10 pixels.
     testString: assert($('h4').css('padding-top') == '10px' && $('h4').css('padding-right') == '10px' && $('h4').css('padding-bottom') == '10px' && $('h4').css('padding-left') == '10px');
   - text: The <code>height</code> property on the <code>h4</code> element should be removed.

--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/adjust-the-background-color-property-of-text.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/adjust-the-background-color-property-of-text.md
@@ -26,7 +26,7 @@ Also for the <code>h4</code>, remove the <code>height</code> property and add <c
 ```yml
 tests:
   - text: Your code should add a <code>background-color</code> property to the <code>h4</code> element set to <code>rgba(45, 45, 45, 0.1)</code>.
-    testString: assert(code.match(/(background-color|background):\s*?rgba\(\s*?45\s*?,\s*?45\s*?,\s*?45\s*?,\s*?0?\.1\s*?\);/gi));
+    testString: assert(code.match(/(background-color|background):\s*?rgba\(\s*?45\s*?,\s*?45\s*?,\s*?45\s*?,\s*?0?\.1\s*?\)(;?\s*?}|;\s*?)/gi));
   - text: Your code should add a <code>padding</code> property to the <code>h4</code> element and set it to 10 pixels.
     testString: assert($('h4').css('padding-top') == '10px' && $('h4').css('padding-right') == '10px' && $('h4').css('padding-bottom') == '10px' && $('h4').css('padding-left') == '10px');
   - text: The <code>height</code> property on the <code>h4</code> element should be removed.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #39823

<!-- Feel free to add any additional description of changes below this line -->

As mentioned by @Skye020 in issue #39823, I have made the semi-colon after the background-colour declaration optional, but only if it is the last declaration in the scope.