### PR TITLE
fix(learn): Strengthen a test in "Data Structures: Remove Elements from a Linked List"

### DIFF
--- a/curriculum/challenges/english/10-coding-interview-prep/data-structures/remove-elements-from-a-linked-list.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/data-structures/remove-elements-from-a-linked-list.md
@@ -30,6 +30,8 @@ tests:
     testString: assert((function(){var test = new LinkedList(); test.add('cat'); test.add('dog'); test.remove('cat'); return test.head().element === 'dog'}()));
   - text: Your <code>remove</code> method should decrease the <code>length</code> of the linked list by one for every node removed.
     testString: assert((function(){var test = new LinkedList(); test.add('cat'); test.add('dog'); test.remove('cat'); return test.size() === 1})());
+  - text: Your <code>remove</code> method should <em>not</em> decrease the <code>length</code> of the linked list if it does not remove a node.
+    testString: assert((function(){var test = new LinkedList(); test.add('cat'); test.add('dog'); test.remove('fish'); return test.size() === 2})());
   - text: Your <code>remove</code> method should reassign the reference of the previous node of the removed node to the removed node&apos;s <code>next</code> reference.
     testString: assert((function(){var test = new LinkedList(); test.add('cat'); test.add('dog');test.add('kitten'); test.remove('dog'); return test.head().next.element === 'kitten'})());
   - text: Your <code>remove</code> method should not change the linked list if the element does not exist in the linked list.

--- a/curriculum/challenges/english/10-coding-interview-prep/data-structures/remove-elements-from-a-linked-list.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/data-structures/remove-elements-from-a-linked-list.md
@@ -29,9 +29,7 @@ tests:
   - text: Your <code>remove</code> method should reassign <code>head</code> to the second node when the first node is removed.
     testString: assert((function(){var test = new LinkedList(); test.add('cat'); test.add('dog'); test.remove('cat'); return test.head().element === 'dog'}()));
   - text: Your <code>remove</code> method should decrease the <code>length</code> of the linked list by one for every node removed.
-    testString: assert((function(){var test = new LinkedList(); test.add('cat'); test.add('dog'); test.remove('cat'); return test.size() === 1})());
-  - text: Your <code>remove</code> method should <em>not</em> decrease the <code>length</code> of the linked list if it does not remove a node.
-    testString: assert((function(){var test = new LinkedList(); test.add('cat'); test.add('dog'); test.remove('fish'); return test.size() === 2})());
+    testString: assert((function(){var test = new LinkedList(); test.add("cat"); test.add("dog"); test.add("hamster"); test.remove("cat"); test.remove("fish"); return test.size() === 2})());
   - text: Your <code>remove</code> method should reassign the reference of the previous node of the removed node to the removed node&apos;s <code>next</code> reference.
     testString: assert((function(){var test = new LinkedList(); test.add('cat'); test.add('dog');test.add('kitten'); test.remove('dog'); return test.head().next.element === 'kitten'})());
   - text: Your <code>remove</code> method should not change the linked list if the element does not exist in the linked list.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

Looking back at the code I wrote for this challenge a few months ago, I realized that my `remove` method was decreasing the `length` of the linked list whether or not it actually found an element to remove, and the challenge tests didn't catch that. Here's an additional test that'll catch this mistake.

### Test text:

> Your <code>remove</code> method should <em>not</em> decrease the <code>length</code> of the linked list if it does not remove a node.

The word "not" is emphasized the first time because I placed this test right after one that reads, "Your <code>remove</code> method should decrease the <code>length</code> of the linked list by one for every node removed."

### Test code:

```js
assert(
  (function () {
    var test = new LinkedList();
    test.add('cat');
    test.add('dog');
    test.remove('fish');
    return test.size() === 2;
  })()
);
```

-----

Also, all 21 tests for this challenge are passing on my end.

```shell
freeCodeCamp % cd curriculum
curriculum % npm run test -- -g "Remove Elements from a Linked List"
...
  21 passing (3s)
```