### PR TITLE
Fix low contrast in css code blocks

### DIFF
--- a/client/static/css/prism.css
+++ b/client/static/css/prism.css
@@ -104,8 +104,8 @@
  .token.url,
  .language-css .token.string,
  .style .token.string {
-   color: #9a6e3a;
-   background: hsla(0, 0%, 100%, .5);
+   color: #ec9126;
+   background: hsla(0,0%,100%,.12);
  }
 
  .token.atrule,


### PR DESCRIPTION
Issue #39967
First noticed on "Divide the Grid Into an Area Template", text is hard to read due to low contrast in the css code block. Problem was discussed in the related issue, and this change was proposed to boost contrast above the minimum acceptable ratio of 4.5:1.
References: https://github.com/freeCodeCamp/freeCodeCamp/issues/39967

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [ x ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ x ] My pull request targets the `master` branch of freeCodeCamp.
- [ x ] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #39967

<!-- Feel free to add any additional description of changes below this line -->
Credit to @ojeytonwilliams for suggesting the change!