### PR TITLE
fix(learn): Strengthen test for "Check if Tree is Binary Search Tree"

### DIFF
--- a/curriculum/challenges/english/10-coding-interview-prep/data-structures/check-if-binary-search-tree.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/data-structures/check-if-binary-search-tree.md
@@ -25,7 +25,7 @@ In this challenge, you will create a utility for your tree. Write a JavaScript m
 ```yml
 tests:
   - text: Your Binary Search Tree should return true when checked with <code>isBinarySearchTree()</code>.
-    testString: assert((function() { var test = false; if (typeof BinarySearchTree !== 'undefined') { test = new BinarySearchTree() } else { return false; }; test.push(3); test.push(4); test.push(5); return isBinarySearchTree(test) == true})());
+    testString: assert((function() { var test = false; if (typeof BinarySearchTree !== 'undefined') { test = new BinarySearchTree() } else { return false; }; test.push(1); test.push(5); test.push(3); test.push(2); test.push(4); return isBinarySearchTree(test) == true})());
 ```
 
 </section>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

Just discovered that in the `isBinarySearchTree` I wrote for this challenge a few months ago, my function would throw an error if it encountered a node with a left child but no right child. I've updated the test for this challenge to check a few more node situations and catch mistakes like mine.

Here's the tree the original test created:

```
3
 \
  4
   \
    5
```

Here's the tree my updated test creates:

```
  1
   \
    5
   /
  3
 / \
2   4
```

This ensures the function will encounter all four kinds of nodes in the test:
- Nodes with both left and right children
- Nodes with only a left child
- Nodes with only a right child
- Nodes with no children

-----

And all tests are passing on my end.

```shell
freeCodeCamp % cd curriculum
curriculum % npm run test -- -g "Check if Tree is Binary Search Tree"
...
  5 passing (2s)
```