### PR TITLE
feat(learn): allow word breaks in tool panel

### DIFF
--- a/client/src/templates/Challenges/components/test-suite.css
+++ b/client/src/templates/Challenges/components/test-suite.css
@@ -7,6 +7,7 @@
 
 .challenge-test-suite code {
   white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 .test-result {


### PR DESCRIPTION
This is motivated by a desire to remove <wbr>s from the test texts