### PR TITLE
fix(learn): Low-contrast CSS strings in code blocks

### DIFF
--- a/client/src/components/layouts/prism-night.css
+++ b/client/src/components/layouts/prism-night.css
@@ -110,6 +110,13 @@ padding in night mode */
   color: #7ec699;
 }
 
+/* CSS code block strings have low contrast in night mode. This attempts to increase contrast above 4.5:1 */
+.night .language-css .token.string,
+.night .style .token.string {
+  color: #ec9126;
+  background: hsl(0 0% 100% / 0.12);
+}
+
 .night .token.operator,
 .night .token.entity,
 .night .token.url {


### PR DESCRIPTION
First noticed on the challenge "Divide the Grid Into an Area Template", text is hard to read in night mode due to low contrast in the CSS code block. Problem was discussed in issue #39967, and this change was proposed to boost contrast above the minimum acceptable ratio of 4.5:1.

This change only targets CSS code blocks in night mode, and only strings. I could not find code blocks in other languages with this issue, but they may exist.
This also does not target `.token.operator`, `.token.entity`, or `.token.url`. There is no issue here with contrast, but these classes do not include a background. A proposed future change could be to remove the background from `.token.string` as well, but this change is not made here, as current style guides recommend the background.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #39967

<!-- Feel free to add any additional description of changes below this line -->
Shoutout to @erictleung for the proposed changes!