### PR TITLE
fix: Removed reply template from flight manuals children

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -27,7 +27,6 @@
 
 - **Flight Manuals** (for Staff & Mods)
   - [Moderator Handbook](moderator-handbook.md)
-  - [Reply Templates](moderator-handbook?id=using-reply-templates)
   - [DevOps Handbook](devops.md)
 
 ---

--- a/docs/i18n/Afrikaans/_sidebar.md
+++ b/docs/i18n/Afrikaans/_sidebar.md
@@ -27,7 +27,6 @@
 
 - **Flight Manuals** (for Staff & Mods)
   - [Moderator Handbook](moderator-handbook.md)
-  - [Reply Templates](moderator-handbook?id=using-reply-templates)
   - [DevOps Handbook](devops.md)
 
 ---

--- a/docs/i18n/Arabic/_sidebar.md
+++ b/docs/i18n/Arabic/_sidebar.md
@@ -27,7 +27,6 @@
 
 - **Flight Manuals** (for Staff & Mods)
   - [Moderator Handbook](moderator-handbook.md)
-  - [Reply Templates](moderator-handbook?id=using-reply-templates)
   - [DevOps Handbook](devops.md)
 
 ---

--- a/docs/i18n/Catalan/_sidebar.md
+++ b/docs/i18n/Catalan/_sidebar.md
@@ -27,7 +27,6 @@
 
 - **Flight Manuals** (for Staff & Mods)
   - [Moderator Handbook](moderator-handbook.md)
-  - [Reply Templates](moderator-handbook?id=using-reply-templates)
   - [DevOps Handbook](devops.md)
 
 ---

--- a/docs/i18n/Chinese/_sidebar.md
+++ b/docs/i18n/Chinese/_sidebar.md
@@ -27,7 +27,6 @@
 
 - **Flight Manuals** (for Staff & Mods)
   - [Moderator Handbook](moderator-handbook.md)
-  - [Reply Templates](moderator-handbook?id=using-reply-templates)
   - [DevOps Handbook](devops.md)
 
 ---

--- a/docs/i18n/Czech/_sidebar.md
+++ b/docs/i18n/Czech/_sidebar.md
@@ -27,7 +27,6 @@
 
 - **Flight Manuals** (for Staff & Mods)
   - [Moderator Handbook](moderator-handbook.md)
-  - [Reply Templates](moderator-handbook?id=using-reply-templates)
   - [DevOps Handbook](devops.md)
 
 ---

--- a/docs/i18n/Danish/_sidebar.md
+++ b/docs/i18n/Danish/_sidebar.md
@@ -27,7 +27,6 @@
 
 - **Flight Manuals** (for Staff & Mods)
   - [Moderator Handbook](moderator-handbook.md)
-  - [Reply Templates](moderator-handbook?id=using-reply-templates)
   - [DevOps Handbook](devops.md)
 
 ---

--- a/docs/i18n/Dutch/_sidebar.md
+++ b/docs/i18n/Dutch/_sidebar.md
@@ -27,7 +27,6 @@
 
 - **Flight Manuals** (for Staff & Mods)
   - [Moderator Handbook](moderator-handbook.md)
-  - [Reply Templates](moderator-handbook?id=using-reply-templates)
   - [DevOps Handbook](devops.md)
 
 ---

--- a/docs/i18n/Finnish/_sidebar.md
+++ b/docs/i18n/Finnish/_sidebar.md
@@ -27,7 +27,6 @@
 
 - **Flight Manuals** (for Staff & Mods)
   - [Moderator Handbook](moderator-handbook.md)
-  - [Reply Templates](moderator-handbook?id=using-reply-templates)
   - [DevOps Handbook](devops.md)
 
 ---

--- a/docs/i18n/French/_sidebar.md
+++ b/docs/i18n/French/_sidebar.md
@@ -27,7 +27,6 @@
 
 - **Flight Manuals** (for Staff & Mods)
   - [Moderator Handbook](moderator-handbook.md)
-  - [Reply Templates](moderator-handbook?id=using-reply-templates)
   - [DevOps Handbook](devops.md)
 
 ---

--- a/docs/i18n/German/_sidebar.md
+++ b/docs/i18n/German/_sidebar.md
@@ -27,7 +27,6 @@
 
 - **Flight Manuals** (for Staff & Mods)
   - [Moderator Handbook](moderator-handbook.md)
-  - [Reply Templates](moderator-handbook?id=using-reply-templates)
   - [DevOps Handbook](devops.md)
 
 ---

--- a/docs/i18n/Greek/_sidebar.md
+++ b/docs/i18n/Greek/_sidebar.md
@@ -27,7 +27,6 @@
 
 - **Flight Manuals** (for Staff & Mods)
   - [Moderator Handbook](moderator-handbook.md)
-  - [Reply Templates](moderator-handbook?id=using-reply-templates)
   - [DevOps Handbook](devops.md)
 
 ---

--- a/docs/i18n/Hebrew/_sidebar.md
+++ b/docs/i18n/Hebrew/_sidebar.md
@@ -27,7 +27,6 @@
 
 - **Flight Manuals** (for Staff & Mods)
   - [Moderator Handbook](moderator-handbook.md)
-  - [Reply Templates](moderator-handbook?id=using-reply-templates)
   - [DevOps Handbook](devops.md)
 
 ---

--- a/docs/i18n/Hindi/_sidebar.md
+++ b/docs/i18n/Hindi/_sidebar.md
@@ -27,7 +27,6 @@
 
 - **Flight Manuals** (for Staff & Mods)
   - [Moderator Handbook](moderator-handbook.md)
-  - [Reply Templates](moderator-handbook?id=using-reply-templates)
   - [DevOps Handbook](devops.md)
 
 ---

--- a/docs/i18n/Hungarian/_sidebar.md
+++ b/docs/i18n/Hungarian/_sidebar.md
@@ -27,7 +27,6 @@
 
 - **Flight Manuals** (for Staff & Mods)
   - [Moderator Handbook](moderator-handbook.md)
-  - [Reply Templates](moderator-handbook?id=using-reply-templates)
   - [DevOps Handbook](devops.md)
 
 ---

--- a/docs/i18n/Italian/_sidebar.md
+++ b/docs/i18n/Italian/_sidebar.md
@@ -27,7 +27,6 @@
 
 - **Flight Manuals** (for Staff & Mods)
   - [Moderator Handbook](moderator-handbook.md)
-  - [Reply Templates](moderator-handbook?id=using-reply-templates)
   - [DevOps Handbook](devops.md)
 
 ---

--- a/docs/i18n/Japanese/_sidebar.md
+++ b/docs/i18n/Japanese/_sidebar.md
@@ -27,7 +27,6 @@
 
 - **Flight Manuals** (for Staff & Mods)
   - [Moderator Handbook](moderator-handbook.md)
-  - [Reply Templates](moderator-handbook?id=using-reply-templates)
   - [DevOps Handbook](devops.md)
 
 ---

--- a/docs/i18n/Korean/_sidebar.md
+++ b/docs/i18n/Korean/_sidebar.md
@@ -27,7 +27,6 @@
 
 - **Flight Manuals** (for Staff & Mods)
   - [Moderator Handbook](moderator-handbook.md)
-  - [Reply Templates](moderator-handbook?id=using-reply-templates)
   - [DevOps Handbook](devops.md)
 
 ---

--- a/docs/i18n/Norwegian/_sidebar.md
+++ b/docs/i18n/Norwegian/_sidebar.md
@@ -27,7 +27,6 @@
 
 - **Flight Manuals** (for Staff & Mods)
   - [Moderator Handbook](moderator-handbook.md)
-  - [Reply Templates](moderator-handbook?id=using-reply-templates)
   - [DevOps Handbook](devops.md)
 
 ---

--- a/docs/i18n/Polish/_sidebar.md
+++ b/docs/i18n/Polish/_sidebar.md
@@ -27,7 +27,6 @@
 
 - **Flight Manuals** (for Staff & Mods)
   - [Moderator Handbook](moderator-handbook.md)
-  - [Reply Templates](moderator-handbook?id=using-reply-templates)
   - [DevOps Handbook](devops.md)
 
 ---

--- a/docs/i18n/Portuguese/_sidebar.md
+++ b/docs/i18n/Portuguese/_sidebar.md
@@ -27,7 +27,6 @@
 
 - **Flight Manuals** (for Staff & Mods)
   - [Moderator Handbook](moderator-handbook.md)
-  - [Reply Templates](moderator-handbook?id=using-reply-templates)
   - [DevOps Handbook](devops.md)
 
 ---

--- a/docs/i18n/Romanian/_sidebar.md
+++ b/docs/i18n/Romanian/_sidebar.md
@@ -27,7 +27,6 @@
 
 - **Flight Manuals** (for Staff & Mods)
   - [Moderator Handbook](moderator-handbook.md)
-  - [Reply Templates](moderator-handbook?id=using-reply-templates)
   - [DevOps Handbook](devops.md)
 
 ---

--- a/docs/i18n/Russian/_sidebar.md
+++ b/docs/i18n/Russian/_sidebar.md
@@ -27,7 +27,6 @@
 
 - **Flight Manuals** (for Staff & Mods)
   - [Moderator Handbook](moderator-handbook.md)
-  - [Reply Templates](moderator-handbook?id=using-reply-templates)
   - [DevOps Handbook](devops.md)
 
 ---

--- a/docs/i18n/Serbian/_sidebar.md
+++ b/docs/i18n/Serbian/_sidebar.md
@@ -27,7 +27,6 @@
 
 - **Flight Manuals** (for Staff & Mods)
   - [Moderator Handbook](moderator-handbook.md)
-  - [Reply Templates](moderator-handbook?id=using-reply-templates)
   - [DevOps Handbook](devops.md)
 
 ---

--- a/docs/i18n/Spanish/_sidebar.md
+++ b/docs/i18n/Spanish/_sidebar.md
@@ -27,7 +27,6 @@
 
 - **Flight Manuals** (for Staff & Mods)
   - [Moderator Handbook](moderator-handbook.md)
-  - [Reply Templates](moderator-handbook?id=using-reply-templates)
   - [DevOps Handbook](devops.md)
 
 ---

--- a/docs/i18n/Swahili/_sidebar.md
+++ b/docs/i18n/Swahili/_sidebar.md
@@ -27,7 +27,6 @@
 
 - **Flight Manuals** (for Staff & Mods)
   - [Moderator Handbook](moderator-handbook.md)
-  - [Reply Templates](moderator-handbook?id=using-reply-templates)
   - [DevOps Handbook](devops.md)
 
 ---

--- a/docs/i18n/Swedish/_sidebar.md
+++ b/docs/i18n/Swedish/_sidebar.md
@@ -27,7 +27,6 @@
 
 - **Flight Manuals** (for Staff & Mods)
   - [Moderator Handbook](moderator-handbook.md)
-  - [Reply Templates](moderator-handbook?id=using-reply-templates)
   - [DevOps Handbook](devops.md)
 
 ---

--- a/docs/i18n/Turkish/_sidebar.md
+++ b/docs/i18n/Turkish/_sidebar.md
@@ -27,7 +27,6 @@
 
 - **Flight Manuals** (for Staff & Mods)
   - [Moderator Handbook](moderator-handbook.md)
-  - [Reply Templates](moderator-handbook?id=using-reply-templates)
   - [DevOps Handbook](devops.md)
 
 ---

--- a/docs/i18n/Ukrainian/_sidebar.md
+++ b/docs/i18n/Ukrainian/_sidebar.md
@@ -27,7 +27,6 @@
 
 - **Flight Manuals** (for Staff & Mods)
   - [Moderator Handbook](moderator-handbook.md)
-  - [Reply Templates](moderator-handbook?id=using-reply-templates)
   - [DevOps Handbook](devops.md)
 
 ---

--- a/docs/i18n/Vietnamese/_sidebar.md
+++ b/docs/i18n/Vietnamese/_sidebar.md
@@ -27,7 +27,6 @@
 
 - **Flight Manuals** (for Staff & Mods)
   - [Moderator Handbook](moderator-handbook.md)
-  - [Reply Templates](moderator-handbook?id=using-reply-templates)
   - [DevOps Handbook](devops.md)
 
 ---


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

Closes #40063 

Reply templates should not be a subfolder of flight manuals because it's a subfolder of Moderator Handbook.
