### PR TITLE
fix: keep unsubscribed donors as isDonating

### DIFF
--- a/api-server/server/utils/donation.js
+++ b/api-server/server/utils/donation.js
@@ -149,21 +149,12 @@ export async function cancelDonation(body, app) {
   const {
     resource: { id, status_update_time = new Date(Date.now()).toISOString() }
   } = body;
-  const { User, Donation } = app.models;
+  const { Donation } = app.models;
   Donation.findOne({ where: { subscriptionId: id } }, (err, donation) => {
     if (err || !donation) throw Error(err);
-    const userId = donation.userId;
     log(`Updating donation record: ${donation.subscriptionId}`);
     donation.updateAttributes({
       endDate: new Date(status_update_time).toISOString()
-    });
-
-    User.findOne({ where: { id: userId } }, (err, user) => {
-      if (err || !user || !user.donationEmails) throw Error(err);
-      log('Updating user record for donation cancellation');
-      user.updateAttributes({
-        isDonating: false
-      });
     });
   });
 }

--- a/api-server/server/utils/donation.test.js
+++ b/api-server/server/utils/donation.test.js
@@ -157,10 +157,7 @@ describe('donation', () => {
       expect(updateDonationAttr).toHaveBeenCalledWith({
         endDate: new Date(status_update_time).toISOString()
       });
-
-      expect(updateUserAttr).toHaveBeenCalledWith({
-        isDonating: false
-      });
+      expect(updateUserAttr).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->
@raisedadead, this pr updates the logic for Paypal unsubscription hooks, so only the donation record is updated and the user records stays as `isDonating`;

<!-- Feel free to add any additional description of changes below this line -->
