### PR TITLE
fix: qa project links on settings page

### DIFF
--- a/client/src/resources/certAndProjectMap.js
+++ b/client/src/resources/certAndProjectMap.js
@@ -7,7 +7,7 @@ const feLibsBase = '/learn/front-end-libraries/front-end-libraries-projects';
 const dataVisBase = '/learn/data-visualization/data-visualization-projects';
 const apiMicroBase =
   '/learn/apis-and-microservices/apis-and-microservices-projects';
-const qaBase = 'learn/quality-assurance/quality-assurance-projects';
+const qaBase = '/learn/quality-assurance/quality-assurance-projects';
 const infoSecBase = '/learn/information-security/information-security-projects';
 const sciCompPyBase =
   '/learn/scientific-computing-with-python/' +


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Currently the links for the QA projects on the settings page point to `https://www.freecodecamp.org/settings/learn/quality-assurance/quality-assurance-projects/project-name`. Clicking on one of these links takes you back to the landing page.

This fix just adds a missing forward slash, allowing the links to be built correctly.