### PR TITLE
feat: allow users to return to multiple domains

### DIFF
--- a/api-server/server/component-passport.js
+++ b/api-server/server/component-passport.js
@@ -11,6 +11,8 @@ import { getUserById } from './utils/user-stats';
 import { homeLocation } from '../../config/env';
 import passportProviders from './passport-providers';
 import { setAccessTokenToResponse } from './utils/getSetAccessToken';
+import { jwtSecret } from '../../config/secrets';
+import getReturnTo from './utils/get-return-to';
 
 const passportOptions = {
   emailOptional: true,
@@ -101,10 +103,14 @@ export const createPassportCallbackAuthenticator = (strategy, config) => (
   res,
   next
 ) => {
-  const returnTo =
-    req && req.query && req.query.state
-      ? Buffer.from(req.query.state, 'base64').toString('utf-8')
-      : `${homeLocation}/learn`;
+  const state = req && req.query && req.query.state;
+  const { returnTo } = getReturnTo(state, jwtSecret);
+
+  // TODO: getReturnTo returns a {returnTo, success} object, so we can use
+  // 'success' to show a flash message, but currently it immediately gets
+  // overwritten by a second message. We should either change the message if
+  // !success or allow multiple messages to appear at once.
+
   return passport.authenticate(
     strategy,
     { session: false },
@@ -116,7 +122,6 @@ export const createPassportCallbackAuthenticator = (strategy, config) => (
       if (!user || !userInfo) {
         return res.redirect('/signin');
       }
-      const redirect = `${returnTo}`;
 
       const { accessToken } = userInfo;
       const { provider } = config;
@@ -140,9 +145,10 @@ we recommend using your email address: ${user.email} to sign in instead.
         setAccessTokenToResponse({ accessToken }, req, res);
         req.login(user);
       }
-      // TODO: enable 'returnTo' for sign-up
+      // TODO: handle returning to /email-sign-up without relying on
+      // homeLocation
       if (user.acceptedPrivacyTerms) {
-        return res.redirectWithFlash(redirect);
+        return res.redirectWithFlash(returnTo);
       } else {
         return res.redirectWithFlash(`${homeLocation}/email-sign-up`);
       }

--- a/api-server/server/utils/get-return-to.js
+++ b/api-server/server/utils/get-return-to.js
@@ -1,0 +1,23 @@
+const jwt = require('jsonwebtoken');
+const { allowedOrigins } = require('../../../config/cors-settings');
+const { homeLocation } = require('../../../config/env.json');
+
+function getReturnTo(encryptedReturnTo, secret) {
+  let returnTo;
+  let success = false;
+  try {
+    returnTo = jwt.verify(encryptedReturnTo, secret).returnTo;
+    // we add the '/' to prevent returns to
+    // www.freecodecamp.org.somewhere.else.com
+    if (!allowedOrigins.some(origin => returnTo.startsWith(origin + '/'))) {
+      throw Error();
+    }
+    success = true;
+  } catch {
+    returnTo = `${homeLocation}/learn`;
+  }
+
+  return { returnTo, success };
+}
+
+module.exports = getReturnTo;

--- a/api-server/server/utils/get-return-to.test.js
+++ b/api-server/server/utils/get-return-to.test.js
@@ -1,0 +1,54 @@
+/* global describe expect it */
+
+const { homeLocation } = require('../../../config/env.json');
+const jwt = require('jsonwebtoken');
+
+const getReturnTo = require('./get-return-to');
+
+const validJWTSecret = 'this is a super secret string';
+const invalidJWTSecret = 'This is not correct secret';
+const validReturnTo = 'https://www.freecodecamp.org/settings';
+const invalidReturnTo = 'https://www.freecodecamp.org.fake/settings';
+const defaultReturnTo = `${homeLocation}/learn`;
+
+describe('get-return-to', () => {
+  describe('getReturnTo', () => {
+    it('should extract returnTo from a jwt', () => {
+      expect.assertions(1);
+
+      const encryptedReturnTo = jwt.sign(
+        { returnTo: validReturnTo },
+        validJWTSecret
+      );
+      expect(getReturnTo(encryptedReturnTo, validJWTSecret)).toStrictEqual({
+        returnTo: validReturnTo,
+        success: true
+      });
+    });
+
+    it('should return a default url if the secrets do not match', () => {
+      expect.assertions(1);
+
+      const encryptedReturnTo = jwt.sign(
+        { returnTo: validReturnTo },
+        invalidJWTSecret
+      );
+      expect(getReturnTo(encryptedReturnTo, validJWTSecret)).toStrictEqual({
+        returnTo: defaultReturnTo,
+        success: false
+      });
+    });
+
+    it('should return a default url for unknown origins', () => {
+      expect.assertions(1);
+      const encryptedReturnTo = jwt.sign(
+        { returnTo: invalidReturnTo },
+        validJWTSecret
+      );
+      expect(getReturnTo(encryptedReturnTo, validJWTSecret)).toStrictEqual({
+        returnTo: defaultReturnTo,
+        success: false
+      });
+    });
+  });
+});

--- a/client/src/client-only-routes/ShowSettings.js
+++ b/client/src/client-only-routes/ShowSettings.js
@@ -5,7 +5,7 @@ import { createSelector } from 'reselect';
 import { Grid, Button } from '@freecodecamp/react-bootstrap';
 import Helmet from 'react-helmet';
 
-import { apiLocation } from '../../config/env.json';
+import { apiLocation, homeLocation } from '../../config/env.json';
 import {
   signInLoadingSelector,
   userSelector,
@@ -167,7 +167,7 @@ export function ShowSettings(props) {
   }
 
   if (!isSignedIn) {
-    navigate(`${apiLocation}/signin?returnTo=settings`);
+    navigate(`${apiLocation}/signin?returnTo=${homeLocation}/settings`);
     return <Loader fullScreen={true} />;
   }
 

--- a/client/src/client-only-routes/ShowSettings.test.js
+++ b/client/src/client-only-routes/ShowSettings.test.js
@@ -1,7 +1,7 @@
 /* global jest, expect */
 import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
-import { apiLocation } from '../../config/env.json';
+import { apiLocation, homeLocation } from '../../config/env.json';
 
 import { ShowSettings } from './ShowSettings';
 
@@ -23,7 +23,7 @@ describe('<ShowSettings />', () => {
     shallow.render(<ShowSettings {...loggedOutProps} />);
     expect(navigate).toHaveBeenCalledTimes(1);
     expect(navigate).toHaveBeenCalledWith(
-      `${apiLocation}/signin?returnTo=settings`
+      `${apiLocation}/signin?returnTo=${homeLocation}/settings`
     );
     const result = shallow.getRenderOutput();
     // Renders Loader rather than ShowSettings


### PR DESCRIPTION
Instead of tying the api to a `homeLocation` this allows it to redirect to multiple domains (the ones allowed by CORS).

/settings is updated accordingly.