### PR TITLE
Correct misleading instruction term

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-ending-string-patterns.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-ending-string-patterns.md
@@ -25,7 +25,7 @@ storyRegex.test(noEnding);
 
 ## Instructions
 <section id='instructions'>
-Use the anchor character (<code>$</code>) to match the string <code>"caboose"</code> at the end of the string <code>caboose</code>.
+Use the dollar sign character (<code>$</code>) to match the string <code>"caboose"</code> at the end of the string <code>caboose</code>.
 </section>
 
 ## Tests


### PR DESCRIPTION
This fix corrects misleading/incorrect terms on challenge instruction

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->

While studying this lesson [Match end string patterns](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/regular-expressions/match-ending-string-patterns), the second paragraph reads 

> You can search the end of strings using the dollar sign character $ at the end of the regex.

but the instruction statement uses a different term, which was sort of misleading and incorrect. 

> Use the ~anchor~ character ($) to match the string "caboose" at the end of the string caboose.

Personally i was thinking it's probably because it's a challenge and some context had to be hidden, but from the previous lesson [Match Beginning String Pattern](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/regular-expressions/match-beginning-string-patterns) the right term was used.
