### PR TITLE
fix catastrophic backtracking when removing HTML comments

### DIFF
--- a/client/src/utils/curriculum-helpers.js
+++ b/client/src/utils/curriculum-helpers.js
@@ -1,7 +1,7 @@
 import { parse } from '@babel/parser';
 import generate from '@babel/generator';
 
-const removeHtmlComments = str => str.replace(/<!--(.|\r|\n)*?-->/g, '');
+const removeHtmlComments = str => str.replace(/<!--.*?-->/gs, '');
 
 const removeCssComments = str => str.replace(/\/\*[\s\S]+?\*\//g, '');
 

--- a/client/src/utils/curriculum-helpers.js
+++ b/client/src/utils/curriculum-helpers.js
@@ -1,7 +1,7 @@
 import { parse } from '@babel/parser';
 import generate from '@babel/generator';
 
-const removeHtmlComments = str => str.replace(/<!--(.|\s)*?-->/g, '');
+const removeHtmlComments = str => str.replace(/<!--(.|\r|\n)*?-->/g, '');
 
 const removeCssComments = str => str.replace(/\/\*[\s\S]+?\*\//g, '');
 


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!-- Feel free to add any additional description of changes below this line -->

---- 

The regexp `/<!--(.|\s)*?-->/g` can experience catastrophic backtracking while matching a string like:   
 `<!-- ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​ ​--​X >`    
(notice how it does not end with `-->`).    

This means it might take literally years to test the regexp on a string of 100 chars.

[Here is a regexp debugger showcasing the catastrophic backtracking](https://regex101.com/r/2jvwFi/1/debugger). 

This is because both `.` and `\s` matches the space character, and there is therefore a large number of possible ways for `(.|\s)*` to match a long sequence of spaces.  
The regexp evaluator is greedy, and the problem therefore only exists when the string does not match the regexp, as the regexp evaluator will try every possibility before giving up. 

The fix is simply to remove the ambiguity such that there is only one possible way for the regexp to match a sequence of white-space.