### PR TITLE
Fix tests to allow spaces in "Sass: Create Reusable CSS with Mixins"

### DIFF
--- a/curriculum/challenges/english/03-front-end-libraries/sass/create-reusable-css-with-mixins.md
+++ b/curriculum/challenges/english/03-front-end-libraries/sass/create-reusable-css-with-mixins.md
@@ -55,15 +55,15 @@ tests:
   - text: Your code should declare a mixin named <code>border-radius</code> which has a parameter named <code>$radius</code>.
     testString: assert(code.match(/@mixin\s+?border-radius\s*?\(\s*?\$radius\s*?\)\s*?{/gi));
   - text: Your code should include the <code>-webkit-border-radius</code> vendor prefix that uses the <code>$radius</code> parameter.
-    testString: assert(code.match(/-webkit-border-radius:\s*?\$radius;/gi));
+    testString: assert(__helpers.removeWhiteSpace(code).match(/-webkit-border-radius:\s*?\$radius;/gi));
   - text: Your code should include the <code>-moz-border-radius</code> vendor prefix that uses the <code>$radius</code> parameter.
-    testString: assert(code.match(/-moz-border-radius:\s*?\$radius;/gi));
+    testString: assert(__helpers.removeWhiteSpace(code).match(/-moz-border-radius:\s*?\$radius;/gi));
   - text: Your code should include the <code>-ms-border-radius</code> vendor prefix that uses the <code>$radius</code> parameter.
-    testString: assert(code.match(/-ms-border-radius:\s*?\$radius;/gi));
+    testString: assert(__helpers.removeWhiteSpace(code).match(/-ms-border-radius:\s*?\$radius;/gi));
   - text: Your code should include the general <code>border-radius</code> rule that uses the <code>$radius</code> parameter.
-    testString: assert(code.match(/border-radius:\s*?\$radius;/gi).length == 4);
+    testString: assert(__helpers.removeWhiteSpace(code).match(/border-radius:\s*?\$radius;/gi).length == 4);
   - text: Your code should call the <code>border-radius mixin</code> using the <code>@include</code> keyword, setting it to 15px.
-    testString: assert(code.match(/@include\s+?border-radius\(\s*?15px\s*?\);/gi));
+    testString: assert(code.match(/@include\s+?border-radius\(\s*?15px\s*?\)\s*;/gi));
 
 ```
 

--- a/curriculum/challenges/english/03-front-end-libraries/sass/create-reusable-css-with-mixins.md
+++ b/curriculum/challenges/english/03-front-end-libraries/sass/create-reusable-css-with-mixins.md
@@ -55,13 +55,13 @@ tests:
   - text: Your code should declare a mixin named <code>border-radius</code> which has a parameter named <code>$radius</code>.
     testString: assert(code.match(/@mixin\s+?border-radius\s*?\(\s*?\$radius\s*?\)\s*?{/gi));
   - text: Your code should include the <code>-webkit-border-radius</code> vendor prefix that uses the <code>$radius</code> parameter.
-    testString: assert(__helpers.removeWhiteSpace(code).match(/-webkit-border-radius:\s*?\$radius;/gi));
+    testString: assert(__helpers.removeWhiteSpace(code).match(/-webkit-border-radius:\$radius;/gi));
   - text: Your code should include the <code>-moz-border-radius</code> vendor prefix that uses the <code>$radius</code> parameter.
-    testString: assert(__helpers.removeWhiteSpace(code).match(/-moz-border-radius:\s*?\$radius;/gi));
+    testString: assert(__helpers.removeWhiteSpace(code).match(/-moz-border-radius:\$radius;/gi));
   - text: Your code should include the <code>-ms-border-radius</code> vendor prefix that uses the <code>$radius</code> parameter.
-    testString: assert(__helpers.removeWhiteSpace(code).match(/-ms-border-radius:\s*?\$radius;/gi));
+    testString: assert(__helpers.removeWhiteSpace(code).match(/-ms-border-radius:\$radius;/gi));
   - text: Your code should include the general <code>border-radius</code> rule that uses the <code>$radius</code> parameter.
-    testString: assert(__helpers.removeWhiteSpace(code).match(/border-radius:\s*?\$radius;/gi).length == 4);
+    testString: assert(__helpers.removeWhiteSpace(code).match(/border-radius:\$radius;/gi).length == 4);
   - text: Your code should call the <code>border-radius mixin</code> using the <code>@include</code> keyword, setting it to 15px.
     testString: assert(code.match(/@include\s+?border-radius\(\s*?15px\s*?\)\s*;/gi));
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #40212

<!-- Feel free to add any additional description of changes below this line -->

Allows tests to pass when there are spaces around `:` or `;`.