### PR TITLE
fix(learn): ES6 Getters + Setters tests

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-getters-and-setters-to-control-access-to-an-object.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-getters-and-setters-to-control-access-to-an-object.md
@@ -65,7 +65,7 @@ tests:
   - text: A <code>setter</code> should  be defined.
     testString: assert((() => {const desc = Object.getOwnPropertyDescriptor(Thermostat.prototype, 'temperature');return !!desc && typeof desc.set === 'function';})());
   - text: Calling the <code>setter</code> with a Celsius value should set the temperature.
-    testString: assert((() => {const t = new Thermostat(32); t.temperature = 26;return t.temperature === 26;})());
+    testString: assert((() => {const t = new Thermostat(32); t.temperature = 26; const u = new Thermostat(32); u.temperature = 50; return t.temperature === 26 && u.temperature === 50;})());
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-getters-and-setters-to-control-access-to-an-object.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-getters-and-setters-to-control-access-to-an-object.md
@@ -57,13 +57,13 @@ tests:
   - text: <code>class</code> keyword should be used.
     testString: assert(code.match(/class/g));
   - text: <code>Thermostat</code> should be able to be instantiated.
-    testString: assert((() => {const t = new Thermostat(32);return typeof t === 'object' && t.temperature === 0;})());
+    testString: assert((() => {const t = new Thermostat(122);return typeof t === 'object' && t.temperature === 50;})());
   - text: A <code>getter</code> should be defined.
     testString: assert((() => {const desc = Object.getOwnPropertyDescriptor(Thermostat.prototype, 'temperature');return !!desc && typeof desc.get === 'function';})());
   - text: A <code>setter</code> should  be defined.
     testString: assert((() => {const desc = Object.getOwnPropertyDescriptor(Thermostat.prototype, 'temperature');return !!desc && typeof desc.set === 'function';})());
   - text: Calling the <code>setter</code> should set the temperature.
-    testString: assert((() => {const t = new Thermostat(32); t.temperature = 26;return t.temperature !== 0;})());
+    testString: assert((() => {const t = new Thermostat(32); t.temperature = 26;return t.temperature === 26;})());
 
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-getters-and-setters-to-control-access-to-an-object.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-getters-and-setters-to-control-access-to-an-object.md
@@ -40,7 +40,7 @@ Getters and setters are important because they hide internal implementation deta
 ## Instructions
 <section id='instructions'>
 Use the <code>class</code> keyword to create a Thermostat class. The constructor accepts a Fahrenheit temperature.
-Now create a <code>getter</code> and a <code>setter</code> in the class, to obtain the temperature in Celsius.
+In the class, create a <code>getter</code> to obtain the temperature in Celsius and a <code>setter</code> to set the temperature in Celsius.
 Remember that <code>C = 5/9 * (F - 32)</code> and <code>F = C * 9.0 / 5 + 32</code>, where <code>F</code> is the value of temperature in Fahrenheit, and <code>C</code> is the value of the same temperature in Celsius.
 <strong>Note:</strong> When you implement this, you will track the temperature inside the class in one scale, either Fahrenheit or Celsius.
 This is the power of a getter and a setter. You are creating an API for another user, who can get the correct result regardless of which one you track.
@@ -57,12 +57,14 @@ tests:
   - text: <code>class</code> keyword should be used.
     testString: assert(code.match(/class/g));
   - text: <code>Thermostat</code> should be able to be instantiated.
-    testString: assert((() => {const t = new Thermostat(122);return typeof t === 'object' && t.temperature === 50;})());
+    testString: assert((() => {const t = new Thermostat(122);return typeof t === 'object'})());
+  - text: When instantiated with a Fahrenheit value, <code>Thermostat</code> should set the correct temperature.
+    testString: assert((() => {const t = new Thermostat(122);return t.temperature === 50})());
   - text: A <code>getter</code> should be defined.
     testString: assert((() => {const desc = Object.getOwnPropertyDescriptor(Thermostat.prototype, 'temperature');return !!desc && typeof desc.get === 'function';})());
   - text: A <code>setter</code> should  be defined.
     testString: assert((() => {const desc = Object.getOwnPropertyDescriptor(Thermostat.prototype, 'temperature');return !!desc && typeof desc.set === 'function';})());
-  - text: Calling the <code>setter</code> should set the temperature.
+  - text: Calling the <code>setter</code> with a Celsius value should set the temperature.
     testString: assert((() => {const t = new Thermostat(32); t.temperature = 26;return t.temperature === 26;})());
 
 ```


### PR DESCRIPTION
Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `master` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #38558 

<!-- Feel free to add any additional description of changes below this line -->

This PR strengthens the tests on the ES6: Getter/Setter challenge to prevent hard-coded values and confirm that the following rules are met:
* Instantiating a new `Thermostat` accepts a Fahrenheit parameter and stores it as a Celsius value.
* Getting the `temperature` of the `Thermostat` returns a Celsius value.
* Setting the `temperature` accepts a Celsius value (so no conversion is made).

These rules follow the example provided in the challenge seed, and remove the hard-coding/math errors in the linked issue.
