### PR TITLE
fix(learn): Added more values to doubly linked list to improve last two tests for the Reverse a Doubly Linked List challenge

### DIFF
--- a/curriculum/challenges/english/10-coding-interview-prep/data-structures/reverse-a-doubly-linked-list.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/data-structures/reverse-a-doubly-linked-list.md
@@ -27,9 +27,9 @@ tests:
   - text: Reversing an empty list should return null.
     testString: assert((function() { var test = false; if (typeof DoublyLinkedList !== 'undefined') { test = new DoublyLinkedList() }; return (test.reverse() == null); })());
   - text: The reverse method should reverse the list.
-    testString: assert((function() { var test = false; if (typeof DoublyLinkedList !== 'undefined') { test = new DoublyLinkedList() }; test.add(58); test.add(61); test.add(32); test.reverse(); return (test.print().join('') == '326158'); })());
+    testString: assert((function() { var test = false; if (typeof DoublyLinkedList !== 'undefined') { test = new DoublyLinkedList() }; test.add(58); test.add(61); test.add(32); test.add(95); test.add(41); test.reverse(); return (test.print().join('') == '4195326158'); })());
   - text: The next and previous references should be correctly maintained when a list is reversed.
-    testString: assert((function() { var test = false; if (typeof DoublyLinkedList !== 'undefined') { test = new DoublyLinkedList() }; test.add(11); test.add(22); test.add(33); test.reverse(); return (test.printReverse().join('') == '112233'); })());
+    testString: assert((function() { var test = false; if (typeof DoublyLinkedList !== 'undefined') { test = new DoublyLinkedList() }; test.add(11); test.add(22); test.add(33); test.add(44); test.add(55); test.reverse(); return (test.printReverse().join('') == '1122334455'); })());
 
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

While on the forum, I noticed [this thread](https://forum.freecodecamp.org/t/reverse-doubly-linked-list-is-my-code-correct/430517/) where the user's solution for the [Reverse a Doubly Linked List challenge](https://www.freecodecamp.org/learn/coding-interview-prep/data-structures/reverse-a-doubly-linked-list) did not correctly reverse a doubly linked list, but passed all the tests.  I adjusted the last two tests to add two more values to the lists, so in case a user just swaps the head and the tail nodes, the tests will not pass (as the case of the existing tests which only add three values).
