### PR TITLE
docs(cypress): create how-to-add-cypress-tests doc

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -11,6 +11,7 @@
 - **Optional Guides**
   - [Catch outgoing emails locally](how-to-catch-outgoing-emails-locally.md)
   - [Set up freeCodeCamp on WSL](how-to-setup-wsl.md)
+  - [Add Cypress tests](how-to-add-cypress-tests.md)
 
 ---
 

--- a/docs/how-to-add-cypress-tests.md
+++ b/docs/how-to-add-cypress-tests.md
@@ -1,0 +1,64 @@
+# How to add Cypress tests
+
+When making changes to JavaScript, CSS, or HTML which could change the functionality or layout of a page, it's important to add corresponding [Cypress](https://docs.cypress.io) integration tests.
+
+To learn how to write Cypress tests, or 'specs', please see Cypress' official [documentation](https://docs.cypress.io/guides/getting-started/writing-your-first-test.html).
+
+> Note: When writing tests for freeCodeCamp, remember to add `/* global cy */` to the top of the file to avoid ESLint issues.
+
+### Where to add a test
+
+- Cypress tests are in the `./cypress` directory.
+
+- Cypress tests for a curriculum module are in the corresponding curriculum directory, i.e. `cypress/integration/learn/responsive-web-design/basic-css/index.js`.
+
+### How to run tests
+
+**1. Change directory to the freeCodeCamp directory:**
+
+    ```console
+    cd yourProjectDirectory
+    ```
+
+**2. Start the MongoDB server in a separate terminal**
+
+  - On macOS & Ubuntu:
+
+    ```console
+    mongod
+    ```
+
+  - On Windows, you must specify the full path to the `mongod` binary
+
+    ```console
+    "C:\Program Files\MongoDB\Server\3.6\bin\mongod"
+    ```
+
+**3. Start up the API server and the client applications.**
+
+    ```console
+    npm run develop
+    ```
+
+**4. Run the cypress tests**
+
+  To run tests against production builds, replace `dev` with `prd` bellow.
+
+  - To run all tests in the `./cypress` directory:
+
+    ```console
+    npm run cypress:dev:run
+    ```
+
+  - To run a single test:
+
+    ```console 
+    npm run cypress:dev:run -- --spec=cypress/pathToYourSpec/youSpecFileName.js
+    ```
+
+  - To create a development build, start the development server, and run all existing cypress end-to-end tests:
+
+    ```console 
+    npm run e2e:dev:run
+    ```
+

--- a/docs/how-to-add-cypress-tests.md
+++ b/docs/how-to-add-cypress-tests.md
@@ -14,33 +14,13 @@ To learn how to write Cypress tests, or 'specs', please see Cypress' official [d
 
 ### How to run tests
 
-**1. Change directory to the freeCodeCamp directory:**
+**1. Ensure that MongoDB and client applications are running**
 
-    ```console
-    cd yourProjectDirectory
-    ```
+  - [Start MongoDB and seed the database](/how-to-setup-freecodecamp-locally?id=step-3-start-mongodb-and-seed-the-database)
 
-**2. Start the MongoDB server in a separate terminal**
-
-  - On macOS & Ubuntu:
-
-    ```console
-    mongod
-    ```
-
-  - On Windows, you must specify the full path to the `mongod` binary
-
-    ```console
-    "C:\Program Files\MongoDB\Server\3.6\bin\mongod"
-    ```
-
-**3. Start up the API server and the client applications.**
-
-    ```console
-    npm run develop
-    ```
-
-**4. Run the cypress tests**
+  - [Start the freeCodeCamp client application and API server](/how-to-setup-freecodecamp-locally?id=step-4-start-the-freecodecamp-client-application-and-api-server)
+ 
+**2. Run the cypress tests**
 
   To run tests against production builds, replace `dev` with `prd` bellow.
 

--- a/docs/how-to-add-cypress-tests.md
+++ b/docs/how-to-add-cypress-tests.md
@@ -16,9 +16,9 @@ To learn how to write Cypress tests, or 'specs', please see Cypress' official [d
 
 **1. Ensure that MongoDB and client applications are running**
 
-  - [Start MongoDB and seed the database](/how-to-setup-freecodecamp-locally?id=step-3-start-mongodb-and-seed-the-database)
+  - [Start MongoDB and seed the database](/how-to-setup-freecodecamp-locally#step-3-start-mongodb-and-seed-the-database)
 
-  - [Start the freeCodeCamp client application and API server](/how-to-setup-freecodecamp-locally?id=step-4-start-the-freecodecamp-client-application-and-api-server)
+  - [Start the freeCodeCamp client application and API server](/how-to-setup-freecodecamp-locally#step-4-start-the-freecodecamp-client-application-and-api-server)
  
 **2. Run the cypress tests**
 
@@ -41,4 +41,3 @@ To learn how to write Cypress tests, or 'specs', please see Cypress' official [d
     ```console 
     npm run e2e:dev:run
     ```
-

--- a/docs/how-to-open-a-pull-request.md
+++ b/docs/how-to-open-a-pull-request.md
@@ -67,7 +67,7 @@ Some examples of good PRs titles would be:
 
    - This is very important when making changes that are not just edits to text content like documentation or a challenge description. Examples of changes that need local testing include JavaScript, CSS, or HTML which could change the functionality or layout of a page.
 
-   - These changes should be accompanied by corresponding [Cypress integration tests](/how-to-add-cypress-tests).
+   - If your PR affects the behaviour of a page it should be accompanied by corresponding [Cypress integration tests](/how-to-add-cypress-tests).
 
 ## Feedback on pull requests
 

--- a/docs/how-to-open-a-pull-request.md
+++ b/docs/how-to-open-a-pull-request.md
@@ -65,7 +65,9 @@ Some examples of good PRs titles would be:
 
 5. Indicate if you have tested on a local copy of the site or not.
 
-   This is very important when making changes that are not just edits to text content like documentation or a challenge description. Examples of changes that need local testing include JavaScript, CSS, or HTML which could change the functionality or layout of a page.
+   - This is very important when making changes that are not just edits to text content like documentation or a challenge description. Examples of changes that need local testing include JavaScript, CSS, or HTML which could change the functionality or layout of a page.
+
+   - These changes should be accompanied by corresponding [Cypress integration tests](/how-to-add-cypress-tests).
 
 ## Feedback on pull requests
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #38853

<!-- Feel free to add any additional description of changes below this line -->

This pull request commits the following changes:

- creates `how-to-add-cypress-tests.md`
- references cypress doc in `how-to-open-a-pull-request.md`
- adds cypress doc to the sidebar

I was not able to get the docs up and running locally (Windows on WSL-2 Ubuntu) using the [working-on-docs-theme](https://contribute.freecodecamp.org/#/how-to-work-on-the-docs-theme) guide.

I did my best to keep things short and to the point. There are several issues that contributors can run into that I don't delve into, like needing to run `mongod` with the `sudo` command in WSL-2. I'm open to feedback as to whether or not to include more details.
