### PR TITLE
feat(learn): Move sudoku solver tests

### DIFF
--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/sudoku-solver.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/sudoku-solver.md
@@ -24,6 +24,38 @@ When you are done, make sure a working demo of your project is hosted somewhere 
 - To run the challenge tests on this page, set `NODE_ENV` to `test` without quotes in the `.env` file
 - To run the tests in the console, use the command `npm run test`. To open the Repl.it console, press Ctrl+Shift+P (Cmd if on a Mac) and type "open shell"
 
+Write the following tests in `tests/1_unit-tests.js`:
+
+- Logic handles a valid puzzle string of 81 characters
+- Logic handles a puzzle string with invalid characters (not 1-9 or `.`)
+- Logic handles a puzzle string that is not 81 characters in length
+- Logic handles a valid row placement
+- Logic handles an invalid row placement
+- Logic handles a valid column placement
+- Logic handles an invalid column placement
+- Logic handles a valid region (3x3 grid) placement
+- Logic handles an invalid region (3x3 grid) placement
+- Valid puzzle strings pass the solver
+- Invalid puzzle strings fail the solver
+- Solver returns the the expected solution for an incomplete puzzzle
+
+Write the following tests in `tests/2_functional-tests.js`
+
+- Solve a puzzle with valid puzzle string: POST request to `/api/solve`
+- Solve a puzzle with missing puzzle string: POST request to `/api/solve`
+- Solve a puzzle with invalid characters: POST request to `/api/solve`
+- Solve a puzzle with incorrect length: POST request to `/api/solve`
+- Solve a puzzle that cannot be solved: POST request to `/api/solve`
+- Check a puzzle placement with all fields: POST request to `/api/check`
+- Check a puzzle placement with single placement conflict: POST request to `/api/check`
+- Check a puzzle placement with multiple placement conflicts: POST request to `/api/check`
+- Check a puzzle placement with all placement conflicts: POST request to `/api/check`
+- Check a puzzle placement with missing required fields: POST request to `/api/check`
+- Check a puzzle placement with invalid characters: POST request to `/api/check`
+- Check a puzzle placement with incorrect length: POST request to `/api/check`
+- Check a puzzle placement with invalid placement coordinate: POST request to `/api/check`
+- Check a puzzle placement with invalid placement value: POST request to `/api/check`
+
 </section>
 
 ## Tests


### PR DESCRIPTION
Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Moves the functional test descriptions out of the boilerplate and into the `/learn` page for translation purposes.
