### PR TITLE
fix(responsive-web-design): change follow-btn class name to action-button-container

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/add-flex-superpowers-to-the-tweet-embed.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/add-flex-superpowers-to-the-tweet-embed.md
@@ -14,7 +14,7 @@ To the right is the tweet embed that will be used as the practical example. Some
 ## Instructions
 <section id='instructions'>
 Add the CSS property <code>display: flex</code> to all of the following items - note that the selectors are already set up in the CSS:
-<code>header</code>, the header's <code>.profile-name</code>, the header's <code>.follow-btn</code>, the header's <code>h3</code> and <code>h4</code>, the <code>footer</code>, and the footer's <code>.stats</code>.
+<code>header</code>, the header's <code>.profile-name</code>, the header's <code>.action-button-container</code>, the header's <code>h3</code> and <code>h4</code>, the <code>footer</code>, and the footer's <code>.stats</code>.
 </section>
 
 ## Tests
@@ -32,8 +32,8 @@ tests:
     testString: assert($('h4').css('display') == 'flex');
   - text: Your <code>.profile-name</code> should have a <code>display</code> property set to <code>flex</code>.
     testString: assert($('.profile-name').css('display') == 'flex');
-  - text: Your <code>.follow-btn</code> should have a <code>display</code> property set to <code>flex</code>.
-    testString: assert($('.follow-btn').css('display') == 'flex');
+  - text: Your <code>.action-button-container</code> should have a <code>display</code> property set to <code>flex</code>.
+    testString: assert($('.action-button-container').css('display') == 'flex');
   - text: Your <code>.stats</code> should have a <code>display</code> property set to <code>flex</code>.
     testString: assert($('.stats').css('display') == 'flex');
 
@@ -63,11 +63,11 @@ tests:
 
     margin-left: 10px;
   }
-  header .follow-btn {
+  header .action-button-container {
 
     margin: 0 0 0 auto;
   }
-  header .follow-btn button {
+  header .action-button-container button {
     border: 0;
     border-radius: 3px;
     padding: 5px;
@@ -112,7 +112,7 @@ tests:
     <h3>Quincy Larson</h3>
     <h4>@ossia</h4>
   </div>
-  <div class="follow-btn">
+  <div class="action-button-container">
     <button>Follow</button>
   </div>
 </header>
@@ -164,11 +164,11 @@ tests:
     display: flex;
     margin-left: 10px;
   }
-  header .follow-btn {
+  header .action-button-container {
     display: flex;
     margin: 0 0 0 auto;
   }
-  header .follow-btn button {
+  header .action-button-container button {
     border: 0;
     border-radius: 3px;
     padding: 5px;
@@ -213,7 +213,7 @@ tests:
     <h3>Quincy Larson</h3>
     <h4>@ossia</h4>
   </div>
-  <div class="follow-btn">
+  <div class="action-button-container">
     <button>Follow</button>
   </div>
 </header>

--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/apply-the-flex-direction-property-to-create-a-column-in-the-tweet-embed.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/apply-the-flex-direction-property-to-create-a-column-in-the-tweet-embed.md
@@ -52,11 +52,11 @@ tests:
 
     margin-left: 10px;
   }
-  header .follow-btn {
+  header .action-button-container {
     display: flex;
     margin: 0 0 0 auto;
   }
-  header .follow-btn button {
+  header .action-button-container button {
     border: 0;
     border-radius: 3px;
     padding: 5px;
@@ -98,7 +98,7 @@ tests:
     <h3>Quincy Larson</h3>
     <h4>@ossia</h4>
   </div>
-  <div class="follow-btn">
+  <div class="action-button-container">
     <button>Follow</button>
   </div>
 </header>
@@ -152,11 +152,11 @@ tests:
     flex-direction: column;
     margin-left: 10px;
   }
-  header .follow-btn {
+  header .action-button-container {
     display: flex;
     margin: 0 0 0 auto;
   }
-  header .follow-btn button {
+  header .action-button-container button {
     border: 0;
     border-radius: 3px;
     padding: 5px;
@@ -198,7 +198,7 @@ tests:
     <h3>Quincy Larson</h3>
     <h4>@ossia</h4>
   </div>
-  <div class="follow-btn">
+  <div class="action-button-container">
     <button>Follow</button>
   </div>
 </header>

--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/apply-the-flex-direction-property-to-create-rows-in-the-tweet-embed.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/apply-the-flex-direction-property-to-create-rows-in-the-tweet-embed.md
@@ -53,11 +53,11 @@ tests:
     display: flex;
     margin-left: 10px;
   }
-  header .follow-btn {
+  header .action-button-container {
     display: flex;
     margin: 0 0 0 auto;
   }
-  header .follow-btn button {
+  header .action-button-container button {
     border: 0;
     border-radius: 3px;
     padding: 5px;
@@ -103,7 +103,7 @@ tests:
     <h3>Quincy Larson</h3>
     <h4>@ossia</h4>
   </div>
-  <div class="follow-btn">
+  <div class="action-button-container">
     <button>Follow</button>
   </div>
 </header>
@@ -156,11 +156,11 @@ tests:
     display: flex;
     margin-left: 10px;
   }
-  header .follow-btn {
+  header .action-button-container {
     display: flex;
     margin: 0 0 0 auto;
   }
-  header .follow-btn button {
+  header .action-button-container button {
     border: 0;
     border-radius: 3px;
     padding: 5px;
@@ -206,7 +206,7 @@ tests:
     <h3>Quincy Larson</h3>
     <h4>@ossia</h4>
   </div>
-  <div class="follow-btn">
+  <div class="action-button-container">
     <button>Follow</button>
   </div>
 </header>

--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-align-items-property-in-the-tweet-embed.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-align-items-property-in-the-tweet-embed.md
@@ -13,7 +13,7 @@ The last challenge introduced the <code>align-items</code> property and gave an 
 
 ## Instructions
 <section id='instructions'>
-Add the CSS property <code>align-items</code> to the header's <code>.follow-btn</code> element. Set the value to <code>center</code>.
+Add the CSS property <code>align-items</code> to the header's <code>.action-button-container</code> element. Set the value to <code>center</code>.
 </section>
 
 ## Tests
@@ -21,8 +21,8 @@ Add the CSS property <code>align-items</code> to the header's <code>.follow-btn<
 
 ```yml
 tests:
-  - text: The <code>.follow-btn</code> element should have the <code>align-items</code> property set to a value of <code>center</code>.
-    testString: assert($('.follow-btn').css('align-items') == 'center');
+  - text: The <code>.action-button-container</code> element should have the <code>align-items</code> property set to a value of <code>center</code>.
+    testString: assert($('.action-button-container').css('align-items') == 'center');
 
 ```
 
@@ -53,12 +53,12 @@ tests:
     justify-content: center;
     margin-left: 10px;
   }
-  header .follow-btn {
+  header .action-button-container {
     display: flex;
 
     margin: 0 0 0 auto;
   }
-  header .follow-btn button {
+  header .action-button-container button {
     border: 0;
     border-radius: 3px;
     padding: 5px;
@@ -100,7 +100,7 @@ tests:
     <h3>Quincy Larson</h3>
     <h4>@ossia</h4>
   </div>
-  <div class="follow-btn">
+  <div class="action-button-container">
     <button>Follow</button>
   </div>
 </header>
@@ -155,12 +155,12 @@ tests:
     justify-content: center;
     margin-left: 10px;
   }
-  header .follow-btn {
+  header .action-button-container {
     display: flex;
     align-items: center;
     margin: 0 0 0 auto;
   }
-  header .follow-btn button {
+  header .action-button-container button {
     border: 0;
     border-radius: 3px;
     padding: 5px;
@@ -202,7 +202,7 @@ tests:
     <h3>Quincy Larson</h3>
     <h4>@ossia</h4>
   </div>
-  <div class="follow-btn">
+  <div class="action-button-container">
     <button>Follow</button>
   </div>
 </header>

--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-justify-content-property-in-the-tweet-embed.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-justify-content-property-in-the-tweet-embed.md
@@ -53,11 +53,11 @@ tests:
 
     margin-left: 10px;
   }
-  header .follow-btn {
+  header .action-button-container {
     display: flex;
     margin: 0 0 0 auto;
   }
-  header .follow-btn button {
+  header .action-button-container button {
     border: 0;
     border-radius: 3px;
     padding: 5px;
@@ -99,7 +99,7 @@ tests:
     <h3>Quincy Larson</h3>
     <h4>@ossia</h4>
   </div>
-  <div class="follow-btn">
+  <div class="action-button-container">
     <button>Follow</button>
   </div>
 </header>
@@ -154,11 +154,11 @@ tests:
     justify-content: center;
     margin-left: 10px;
   }
-  header .follow-btn {
+  header .action-button-container {
     display: flex;
     margin: 0 0 0 auto;
   }
-  header .follow-btn button {
+  header .action-button-container button {
     border: 0;
     border-radius: 3px;
     padding: 5px;
@@ -200,7 +200,7 @@ tests:
     <h3>Quincy Larson</h3>
     <h4>@ossia</h4>
   </div>
-  <div class="follow-btn">
+  <div class="action-button-container">
     <button>Follow</button>
   </div>
 </header>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #39608 | Improve warnings about extensions?

<!-- Feel free to add any additional description of changes below this line -->

Changes:
- All changes were tested locally
- Switches all instances of `follow-btn` to `action-button-container` as suggested in #39608