### PR TITLE
docs(docs): Fix bad link on contribute page

### DIFF
--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -4,7 +4,7 @@
 
 ## Here are some quick and fun ways you can help the community.
 
-- <span class='cover-icon'><i class="fas fa-question-circle"></i></span> [Help by answering coding questions](https://forum.freecodecamp.org/c/help?max_posts=1) on our community forum.
+- <span class='cover-icon'><i class="fas fa-question-circle"></i></span> [Help by answering coding questions](https://forum.freecodecamp.org) on our community forum.
 - <span class='cover-icon'><i class="fas fa-comments"></i></span> [Give feedback on coding projects](https://forum.freecodecamp.org/c/project-feedback?max_posts=1) built by campers.
 - <span class='cover-icon'><i class="fas fa-language"></i></span> [Help us translate](https://translate.freecodecamp.org) these Contributing Guidelines.
 - <span class='cover-icon'><i class="fab fa-github"></i></span> [Contribute to our open source codebase](/index?id=our-open-source-codebase) on GitHub.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
Fix the bad link on the contribute page.
The link on "Help by answering coding questions" was directing to an erroneous page. I tested the change locally
Closes #40274