### PR TITLE
fix(curriculum): Add line breaks to description of 'Nest an Anchor Element within a Paragraph'

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/nest-an-anchor-element-within-a-paragraph.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/nest-an-anchor-element-within-a-paragraph.md
@@ -18,11 +18,19 @@ You can nest links within other text elements.
 ```
 
 Let's break down the example:
-Normal text is wrapped in the <code>p</code> element:<br> <code>&#60;p&#62; Here's a ... for you to follow. &#60;/p&#62;</code>
-Next is the <i>anchor</i> element <code>&#60;a&#62;</code> (which requires a closing tag <code>&#60;/a&#62;</code>):<br>  <code>&#60;a&#62; ... &#60;/a&#62;</code>
-<code>target</code> is an anchor tag attribute that specifies where to open the link and the value <code>"_blank"</code> specifies to open the link in a new tab
+
+Normal text is wrapped in the <code>p</code> element:  
+<code>&#60;p&#62; Here's a ... for you to follow. &#60;/p&#62;</code>
+
+Next is the <i>anchor</i> element <code>&#60;a&#62;</code> (which requires a closing tag <code>&#60;/a&#62;</code>):  
+<code>&#60;a&#62; ... &#60;/a&#62;</code>  
+
+<code>target</code> is an anchor tag attribute that specifies where to open the link. The value <code>"_blank"</code> specifies to open the link in a new tab.
+
 <code>href</code> is an anchor tag attribute that contains the URL address of the link:<br>  `<a href="http://freecodecamp.org"> ... </a>`
-The text, <strong>"link to freecodecamp.org"</strong>, within the <code>a</code> element called <code>anchor text</code>, will display a link to click:<br>  <code>&#60;a href=" ... "&#62;link to freecodecamp.org&#60;/a&#62;</code>
+
+The text, <strong>"link to freecodecamp.org"</strong>, within the <code>a</code> element called <code>anchor text</code>, will display a link to click:<br>  <code>&#60;a href=" ... "&#62;link to freecodecamp.org&#60;/a&#62;</code>  
+
 The final output of the example will look like this:<br><p>Here's a <a target="_blank" href="http://freecodecamp.org"> link to freecodecamp.org</a> for you to follow.</p>
 </section>
 


### PR DESCRIPTION
Add some line breaks to make the description paragraph easier to read.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `master` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

As I was working through the lesson content I came to **Nest an Anchor Element within a Paragraph** in **basic-html-and-html5** and had a hard time reading through a very compact paragraph. This PR does not add or remove any text it just adds some line breaks to make the content easier parse. 

Before
![Screen Shot 2020-11-24 at 12 57 45 PM](https://user-images.githubusercontent.com/15613806/100144890-b690b700-2e54-11eb-84fb-26acc49fe7b2.png)

After
![Screen Shot 2020-11-24 at 12 57 55 PM](https://user-images.githubusercontent.com/15613806/100144896-bbee0180-2e54-11eb-96f9-ddb75a9f1c31.png)

