### PR TITLE
removed use strict from various challenges

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/local-scope-and-functions.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/local-scope-and-functions.md
@@ -57,7 +57,6 @@ tests:
 
 ```js
 function myLocalScope() {
-  'use strict';
 
   // Only change code below this line
 
@@ -81,7 +80,6 @@ console.log('outside myLocalScope', myVar);
 
 ```js
 function myLocalScope() {
-  'use strict';
 
   // Only change code below this line
   var myVar;

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/compare-scopes-of-the-var-and-let-keywords.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/compare-scopes-of-the-var-and-let-keywords.md
@@ -54,7 +54,6 @@ console.log(printNumTwo());
 As you can see, <code>printNumTwo()</code> prints 3 and not 2. This is because the value assigned to <code>i</code> was updated and the <code>printNumTwo()</code> returns the global <code>i</code> and not the value <code>i</code> had when the function was created in the for loop. The <code>let</code> keyword does not follow this behavior:
 
 ```js
-'use strict';
 let printNumTwo;
 for (let i = 0; i < 3; i++) {
   if (i === 2) {
@@ -101,7 +100,6 @@ tests:
 
 ```js
 function checkScope() {
-  'use strict';
   var i = 'function scope';
   if (true) {
     i = 'block scope';
@@ -123,7 +121,6 @@ function checkScope() {
 
 ```js
 function checkScope() {
-  'use strict';
   let i = 'function scope';
   if (true) {
     let i = 'block scope';

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/declare-a-read-only-variable-with-the-const-keyword.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/declare-a-read-only-variable-with-the-const-keyword.md
@@ -11,7 +11,6 @@ The keyword <code>let</code> is not the only new way to declare variables. In ES
 <code>const</code> has all the awesome features that <code>let</code> has, with the added bonus that variables declared using <code>const</code> are read-only. They are a constant value, which means that once a variable is assigned with <code>const</code>, it cannot be reassigned.
 
 ```js
-"use strict";
 const FAV_PET = "Cats";
 FAV_PET = "Dogs"; // returns error
 ```
@@ -51,7 +50,6 @@ tests:
 
 ```js
 function printManyTimes(str) {
-  "use strict";
 
   // Only change code below this line
 
@@ -77,7 +75,6 @@ printManyTimes("freeCodeCamp");
 
 ```js
 function printManyTimes(str) {
-  "use strict";
 
   const SENTENCE = str + " is cool!";
   for (let i = 0; i < str.length; i+=2) {

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/mutate-an-array-declared-with-const.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/mutate-an-array-declared-with-const.md
@@ -12,7 +12,6 @@ Some developers prefer to assign all their variables using <code>const</code> by
 However, it is important to understand that objects (including arrays and functions) assigned to a variable using <code>const</code> are still mutable. Using the <code>const</code> declaration only prevents reassignment of the variable identifier.
 
 ```js
-"use strict";
 const s = [5, 6, 7];
 s = [1, 2, 3]; // throws error, trying to assign a const
 s[2] = 45; // works just as it would with an array declared with var or let
@@ -53,7 +52,6 @@ tests:
 ```js
 const s = [5, 7, 2];
 function editInPlace() {
-  'use strict';
   // Only change code below this line
 
   // Using s = [2, 5, 7] would be invalid
@@ -75,7 +73,6 @@ editInPlace();
 ```js
 const s = [5, 7, 2];
 function editInPlace() {
-  'use strict';
   s[0] = 2;
   s[1] = 5;
   s[2] = 7;

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/prevent-object-mutation.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/prevent-object-mutation.md
@@ -54,7 +54,6 @@ tests:
 
 ```js
 function freezeObj() {
-  'use strict';
   const MATH_CONSTANTS = {
     PI: 3.14
   };
@@ -83,7 +82,6 @@ const PI = freezeObj();
 
 ```js
 function freezeObj() {
-  'use strict';
   const MATH_CONSTANTS = {
     PI: 3.14
   };

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-arrow-functions-to-write-concise-anonymous-functions.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-arrow-functions-to-write-concise-anonymous-functions.md
@@ -67,7 +67,6 @@ tests:
 
 ```js
 var magic = function() {
-  "use strict";
   return new Date();
 };
 ```
@@ -83,7 +82,6 @@ var magic = function() {
 
 ```js
 const magic = () => {
-  "use strict";
   return new Date();
 };
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-with-the-rest-parameter-to-reassign-array-elements.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-with-the-rest-parameter-to-reassign-array-elements.md
@@ -51,7 +51,6 @@ tests:
 ```js
 const source = [1,2,3,4,5,6,7,8,9,10];
 function removeFirstTwo(list) {
-  "use strict";
   // Only change code below this line
   const arr = list; // Change this line
   // Only change code above this line
@@ -73,7 +72,6 @@ const arr = removeFirstTwo(source);
 ```js
 const source = [1,2,3,4,5,6,7,8,9,10];
 function removeFirstTwo(list) {
-  "use strict";
   const [, , ...arr] = list;
   return arr;
 }

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/write-arrow-functions-with-parameters.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/write-arrow-functions-with-parameters.md
@@ -64,7 +64,6 @@ tests:
 
 ```js
 var myConcat = function(arr1, arr2) {
-  "use strict";
   return arr1.concat(arr2);
 };
 
@@ -82,7 +81,6 @@ console.log(myConcat([1, 2], [3, 4, 5]));
 
 ```js
 const myConcat = (arr1, arr2) =>  {
-  "use strict";
   return arr1.concat(arr2);
 };
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/write-concise-object-literal-declarations-using-object-property-shorthand.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/write-concise-object-literal-declarations-using-object-property-shorthand.md
@@ -53,7 +53,6 @@ tests:
 
 ```js
 const createPerson = (name, age, gender) => {
-  "use strict";
   // Only change code below this line
   return {
     name: name,
@@ -75,7 +74,6 @@ const createPerson = (name, age, gender) => {
 
 ```js
 const createPerson = (name, age, gender) => {
-  "use strict";
   return {
     name,
     age,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Continuining #40320 

@RandellDawson last thing - how do I deal with 02-javascript-algorithms-and-data-structures/es6/explore-differences-between-the-var-and-let-keywords.md ?
specifically this part (lines 31-37):

> So unlike <code>var</code>, when using <code>let</code>, a variable with the same name can only be declared once.
> Note the <code>"use strict"</code>. This enables Strict Mode, which catches common coding mistakes and "unsafe" actions. For instance:
> 
> ```js
> "use strict";
> x = 3.14; // throws an error because x is not declared
> ```
> 

should I remove all references to strict mode from description or leave a reference to it?