### PR TITLE
fix(learn): clarify gradient description

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/create-a-gradual-css-linear-gradient.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/create-a-gradual-css-linear-gradient.md
@@ -10,7 +10,7 @@ forumTopicId: 301047
 <section id='description'>
 Applying a color on HTML elements is not limited to one flat hue. CSS provides the ability to use color transitions, otherwise known as gradients, on elements. This is accessed through the <code>background</code> property's <code>linear-gradient()</code> function. Here is the general syntax:
 <code>background: linear-gradient(gradient_direction, color 1, color 2, color 3, ...);</code>
-The first argument specifies the direction from which color transition starts - it can be stated as a degree, where <code>90deg</code> makes a horizontal gradient (from left to right) and <code>45deg</code> is angled like a forward slash (from bottom left to top right). The following arguments specify the order of colors used in the gradient.
+The first argument specifies the direction from which color transition starts - it can be stated as a degree, where <code>90deg</code> makes a horizontal gradient (from left to right) and <code>45deg</code> makes a diagonal gradient (from bottom left to top right). The following arguments specify the order of colors used in the gradient.
 Example:
 <code>background: linear-gradient(90deg, red, yellow, rgb(204, 204, 255));</code>
 </section>

--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/create-a-gradual-css-linear-gradient.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/create-a-gradual-css-linear-gradient.md
@@ -10,7 +10,7 @@ forumTopicId: 301047
 <section id='description'>
 Applying a color on HTML elements is not limited to one flat hue. CSS provides the ability to use color transitions, otherwise known as gradients, on elements. This is accessed through the <code>background</code> property's <code>linear-gradient()</code> function. Here is the general syntax:
 <code>background: linear-gradient(gradient_direction, color 1, color 2, color 3, ...);</code>
-The first argument specifies the direction from which color transition starts - it can be stated as a degree, where <code>90deg</code> makes a horizontal gradient (from left to right) and <code>45deg</code> is angled like a backslash. The following arguments specify the order of colors used in the gradient.
+The first argument specifies the direction from which color transition starts - it can be stated as a degree, where <code>90deg</code> makes a horizontal gradient (from left to right) and <code>45deg</code> is angled like a forward slash (from bottom left to top right). The following arguments specify the order of colors used in the gradient.
 Example:
 <code>background: linear-gradient(90deg, red, yellow, rgb(204, 204, 255));</code>
 </section>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
The description of the 45 degree CSS linear-gradient states that it is angled like a backslash, which is confusing because it's actually angled like a forward slash. I'm suggesting a modification of the description that I think is clearer.