### PR TITLE
refactor: rationalise environment variables

### DIFF
--- a/api-server/server/boot/donate.js
+++ b/api-server/server/boot/donate.js
@@ -277,7 +277,7 @@ export default function donateBoot(app, done) {
   const stripeInvalid = stripeSecretInvalid || stripPublicInvalid;
 
   if (stripeInvalid || paypalInvalid) {
-    if (process.env.FREECODECAMP_NODE_ENV === 'production') {
+    if (process.env.NODE_BUILD_ENV !== 'development') {
       throw new Error('Donation API keys are required to boot the server!');
     }
     log('Donation disabled in development unless ALL test keys are provided');

--- a/api-server/server/boot/explorer.js
+++ b/api-server/server/boot/explorer.js
@@ -3,7 +3,7 @@ const createDebugger = require('debug');
 const log = createDebugger('fcc:boot:explorer');
 
 module.exports = function mountLoopBackExplorer(app) {
-  if (process.env.FREECODECAMP_NODE_ENV === 'production') {
+  if (process.env.NODE_BUILD_ENV !== 'development') {
     return;
   }
   let explorer;

--- a/api-server/server/index.js
+++ b/api-server/server/index.js
@@ -28,7 +28,7 @@ if (sentry.dns === 'dsn_from_sentry_dashboard') {
   log('Sentry initialized');
 }
 
-Rx.config.longStackSupport = process.env.NODE_DEBUG !== 'production';
+Rx.config.longStackSupport = process.env.NODE_BUILD_ENV === 'development';
 const app = loopback();
 
 app.set('state namespace', '__fcc__');

--- a/api-server/server/middlewares/csp.js
+++ b/api-server/server/middlewares/csp.js
@@ -12,7 +12,7 @@ let trusted = [
 const host = process.env.HOST || 'localhost';
 const port = process.env.SYNC_PORT || '3000';
 
-if (process.env.FREECODECAMP_NODE_ENV !== 'production') {
+if (process.env.NODE_BUILD_ENV === 'development') {
   trusted = trusted.concat([`ws://${host}:${port}`, 'http://localhost:8000']);
 }
 

--- a/api-server/server/middlewares/csurf.js
+++ b/api-server/server/middlewares/csurf.js
@@ -5,7 +5,7 @@ export default function() {
     cookie: {
       domain: process.env.COOKIE_DOMAIN || 'localhost',
       sameSite: 'strict',
-      secure: process.env.FREECODECAMP_NODE_ENV === 'production'
+      secure: process.env.NODE_BUILD_ENV !== 'development'
     }
   });
   return function csrf(req, res, next) {

--- a/api-server/server/middlewares/error-handlers.js
+++ b/api-server/server/middlewares/error-handlers.js
@@ -21,7 +21,7 @@ ${JSON.stringify(error, null, 2)}
 `;
 };
 
-const isDev = process.env.FREECODECAMP_NODE_ENV !== 'production';
+const isDev = process.env.NODE_BUILD_ENV === 'development';
 
 export default function prodErrorHandler() {
   // error handling in production.

--- a/client/gatsby-node.js
+++ b/client/gatsby-node.js
@@ -42,7 +42,7 @@ exports.onCreateNode = function onCreateNode({ node, actions, getNode }) {
 
 exports.createPages = function createPages({ graphql, actions, reporter }) {
   if (!env.algoliaAPIKey || !env.algoliaAppId) {
-    if (process.env.FREECODECAMP_NODE_ENV === 'production') {
+    if (process.env.NODE_BUILD_ENV !== 'development') {
       throw new Error(
         'Algolia App id and API key are required to start the client!'
       );
@@ -54,7 +54,7 @@ exports.createPages = function createPages({ graphql, actions, reporter }) {
   }
 
   if (!env.stripePublicKey) {
-    if (process.env.FREECODECAMP_NODE_ENV === 'production') {
+    if (process.env.NODE_BUILD_ENV !== 'development') {
       throw new Error('Stripe public key is required to start the client!');
     } else {
       reporter.info(

--- a/client/src/redux/createStore.js
+++ b/client/src/redux/createStore.js
@@ -32,15 +32,15 @@ const composeEnhancers = composeWithDevTools({
 
 export const createStore = () => {
   let store;
-  if (environment === 'production') {
+  if (environment === 'development') {
     store = reduxCreateStore(
       rootReducer,
-      applyMiddleware(sagaMiddleware, epicMiddleware)
+      composeEnhancers(applyMiddleware(sagaMiddleware, epicMiddleware))
     );
   } else {
     store = reduxCreateStore(
       rootReducer,
-      composeEnhancers(applyMiddleware(sagaMiddleware, epicMiddleware))
+      applyMiddleware(sagaMiddleware, epicMiddleware)
     );
   }
   sagaMiddleware.run(rootSaga);

--- a/config/env.js
+++ b/config/env.js
@@ -1,8 +1,8 @@
 const path = require('path');
 const fs = require('fs');
 
-// CI is 'true' in the build pipeline
-if (process.env.CI !== 'true') {
+// IN_AZURE_BUILD is 'true' in the build pipeline
+if (process.env.IN_AZURE_BUILD !== 'true') {
   const envPath = path.resolve(__dirname, '../.env');
   if (!fs.existsSync(envPath)) {
     throw Error('.env not found, please copy sample.env to .env.');

--- a/config/env.js
+++ b/config/env.js
@@ -1,11 +1,14 @@
 const path = require('path');
 const fs = require('fs');
 
-const envPath = path.resolve(__dirname, '../.env');
-if (!fs.existsSync(envPath)) {
-  throw Error('.env not found, please copy sample.env to .env.');
+// CI is 'true' in the build pipeline
+if (process.env.CI !== 'true') {
+  const envPath = path.resolve(__dirname, '../.env');
+  if (!fs.existsSync(envPath)) {
+    throw Error('.env not found, please copy sample.env to .env.');
+  }
+  require('dotenv').config({ path: envPath });
 }
-require('dotenv').config({ path: envPath });
 
 const {
   HOME_LOCATION: home,

--- a/config/env.js
+++ b/config/env.js
@@ -21,7 +21,8 @@ const {
   ALGOLIA_API_KEY: algoliaAPIKey,
   PAYPAL_CLIENT_ID: paypalClientId,
   DEPLOYMENT_ENV: deploymentEnv,
-  SHOW_UPCOMING_CHANGES: showUpcomingChanges
+  SHOW_UPCOMING_CHANGES: showUpcomingChanges,
+  NODE_BUILD_ENV: environment
 } = process.env;
 
 const locations = {
@@ -34,7 +35,7 @@ const locations = {
 module.exports = Object.assign(locations, {
   locale,
   deploymentEnv,
-  environment: process.env.FREECODECAMP_NODE_ENV || 'development',
+  environment,
   stripePublicKey:
     !stripePublicKey || stripePublicKey === 'pk_from_stripe_dashboard'
       ? null

--- a/sample.env
+++ b/sample.env
@@ -45,6 +45,8 @@ PAYPAL_WEBHOOK_ID=webhook_id_from_paypal_dashboard
 # ---------------------
 DEPLOYMENT_ENV='staging'
 FREECODECAMP_NODE_ENV='development'
+# If CI is 'true' .env is ignored (this is a Gatsby convention, we use it CD)
+CI='false'
 # Language to build
 LOCALE=english
 # Show or hide WIP in progress challenges

--- a/sample.env
+++ b/sample.env
@@ -47,8 +47,8 @@ PAYPAL_WEBHOOK_ID=webhook_id_from_paypal_dashboard
 DEPLOYMENT_ENV='staging'
 # Differs between production (.org and .dev) and local development
 NODE_BUILD_ENV='development'
-# If CI is 'true' .env is ignored (this is a Gatsby convention, we use it CD)
-CI='false'
+# Used to ignore .env in the pipeline
+IN_AZURE_BUILD='false'
 # Language to build
 LOCALE=english
 # Show or hide WIP in progress challenges

--- a/sample.env
+++ b/sample.env
@@ -43,8 +43,10 @@ PAYPAL_WEBHOOK_ID=webhook_id_from_paypal_dashboard
 # ---------------------
 # Build variants
 # ---------------------
+# Differs between .org and .dev
 DEPLOYMENT_ENV='staging'
-FREECODECAMP_NODE_ENV='development'
+# Differs between production (.org and .dev) and local development
+NODE_BUILD_ENV='development'
 # If CI is 'true' .env is ignored (this is a Gatsby convention, we use it CD)
 CI='false'
 # Language to build

--- a/tools/scripts/build/ensure-env.js
+++ b/tools/scripts/build/ensure-env.js
@@ -9,9 +9,7 @@ const log = debug('fcc:ensure-env');
 const clientPath = path.resolve(__dirname, '../../../client');
 const globalConfigPath = path.resolve(__dirname, '../../../config');
 
-const { FREECODECAMP_NODE_ENV } = process.env;
-
-if (FREECODECAMP_NODE_ENV !== 'development') {
+if (process.env.NODE_BUILD_ENV !== 'development') {
   const locationKeys = [
     'homeLocation',
     'apiLocation',


### PR DESCRIPTION
Also, `!== 'development'` instead of `=== 'production'` protects against typos. 