### PR TITLE
fix(docs): display text direction correctly

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -134,10 +134,17 @@
 
             // Used from https://github.com/ckoliber/docsify-rtl/blob/master/build/docsify-rtl.js,
             // Currently this is a hack because can't use the plugin as is.
-            if (vm.route.path.search('Arabic') !== -1) {
+            if (vm.route.path.search('Arabic') !== -1 || vm.route.path.search('Hebrew') !== -1) {
               for (var counter = 0, elements = document.getElementsByClassName("markdown-section"); counter < elements.length; counter++) {
                 var item = elements[counter];
                 item.dir = "rtl";
+              }
+            };
+
+            if (vm.route.path.search('Arabic') === -1 && vm.route.path.search('Hebrew') === -1) {
+              for (var counter = 0, elements = document.getElementsByClassName("markdown-section"); counter < elements.length; counter++) {
+                var item = elements[counter];
+                item.dir = "ltr";
               }
             };
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #40062

<!-- Feel free to add any additional description of changes below this line -->

Adds a condition to the index.html file of /docs to display the text direction accordingly

![language-switch](https://user-images.githubusercontent.com/25715018/100548238-de8d7980-329d-11eb-8886-49bef9f992d5.gif)
