### PR TITLE
feat(learn): Move metric imperial converter tests

### DIFF
--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/metric-imperial-converter.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/metric-imperial-converter.md
@@ -237,7 +237,7 @@ async getUserInput => {
 };
 ```
 
-Your return will consist of the `initNum`, `initUnit`, `returnNum`, `returnUnit`, and `string` spelling out units in the format `'{initNum} {iniUnitString} converts to {returnNum} {returnUnitString}'` with the result rounded to 5 decimals.
+Your return will consist of the `initNum`, `initUnit`, `returnNum`, `returnUnit`, and `string` spelling out units in the format `'{initNum} {initUnitString} converts to {returnNum} {returnUnitString}'` with the result rounded to 5 decimals.
 
 ```js
 async getUserInput => {

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/metric-imperial-converter.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/metric-imperial-converter.md
@@ -19,7 +19,6 @@ When you are done, make sure a working demo of your project is hosted somewhere 
 
 - Complete the necessary conversion logic in `/controllers/convertHandler.js`
 - Complete the necessary routes in `/routes/api.js`
-- Create all of the functional tests in `tests/2_functional-tests.js`
 - Copy the `sample.env` file to `.env` and set the variables appropriately
 - To run the tests uncomment `NODE_ENV=test` in your `.env` file
 - To run the tests in the console, use the command `npm run test`. To open the Repl.it console, press Ctrl+Shift+P (Cmd if on a Mac) and type "open shell"
@@ -32,7 +31,9 @@ Write the following tests in `tests/1_unit-tests.js`:
 - `convertHandler` should correctly read a fractional input with a decimal.
 - `convertHandler` should correctly return an error on a double-fraction (i.e. `3/2/3`).
 - `convertHandler` should correctly return an error on no numerical input.
-- `convertHandler` should correctly return the converted unit for each valid input unit.
+- `convertHandler` should correctly read each valid input unit.
+- `convertHandler` should correctly return an error for an invalid input unit.
+- `convertHandler` should return the correct return unit for each valid input unit.
 - `convertHandler` should correctly return the spelled-out string unit for each valid input unit.
 - `convertHandler` should correctly convert `gal` to `L`.
 - `convertHandler` should correctly convert `L` to `gal`.

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/metric-imperial-converter.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/metric-imperial-converter.md
@@ -51,7 +51,7 @@ Write the following tests in `tests/2_functional-tests.js`:
 
 # --hints--
 
-I can provide my own project, not the example URL.
+You can provide your own project, not the example URL.
 
 ```js
 getUserInput => {
@@ -63,12 +63,12 @@ getUserInput => {
 };
 ```
 
-I can GET /api/convert with a single parameter containing an accepted number and unit and have it converted. (Hint: Split the input by looking for the index of the first character which will mark the start of the unit)
+You can `GET` /api/convert with a single parameter containing an accepted number and unit and have it converted. (Hint: Split the input by looking for the index of the first character which will mark the start of the unit)
 
 ```js
 ```
 
-I can convert `'gal'` to `'L'` and vice versa. (1 gal to 3.78541 L)
+You can convert `'gal'` to `'L'` and vice versa. (1 gal to 3.78541 L)
 
 ```js
 async getUserInput => {
@@ -91,7 +91,7 @@ async getUserInput => {
 };
 ```
 
-I can convert `'lbs'` to `'kg'` and vice versa. (1 lbs to 0.453592 kg)
+You can convert `'lbs'` to `'kg'` and vice versa. (1 lbs to 0.453592 kg)
 
 ```js
 async getUserInput => {
@@ -114,7 +114,7 @@ async getUserInput => {
 };
 ```
 
-I can convert `'mi'` to `'km'` and vice versa. (1 mi to 1.60934 km)
+You can convert `'mi'` to `'km'` and vice versa. (1 mi to 1.60934 km)
 
 ```js
 async getUserInput => {
@@ -160,7 +160,7 @@ async getUserInput => {
 };
 ```
 
-If my unit of measurement is invalid, returned will be `'invalid unit'`.
+If your unit of measurement is invalid, returned will be `'invalid unit'`.
 
 ```js
 async getUserInput => {
@@ -173,7 +173,7 @@ async getUserInput => {
 };
 ```
 
-If my number is invalid, returned will be `'invalid number'`.
+If your number is invalid, returned will be `'invalid number'`.
 
 ```js
 async getUserInput => {
@@ -206,7 +206,7 @@ async getUserInput => {
 };
 ```
 
-I can use fractions, decimals or both in my parameter(ie. 5, 1/2, 2.5/6), but if nothing is provided it will default to 1.
+You can use fractions, decimals or both in your parameter (ie. 5, 1/2, 2.5/6), but if nothing is provided it will default to 1.
 
 ```js
 async getUserInput => {
@@ -237,7 +237,7 @@ async getUserInput => {
 };
 ```
 
-My return will consist of the `initNum`, `initUnit`, `returnNum`, `returnUnit`, and `string` spelling out units in the format `'{initNum} {initial_Units} converts to {returnNum} {return_Units}'` with the result rounded to 5 decimals.
+Your return will consist of the `initNum`, `initUnit`, `returnNum`, `returnUnit`, and `string` spelling out units in the format `'{initNum} {iniUnitString} converts to {returnNum} {returnUnitString}'` with the result rounded to 5 decimals.
 
 ```js
 async getUserInput => {

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/metric-imperial-converter.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/metric-imperial-converter.md
@@ -9,18 +9,52 @@ forumTopicId: 301570
 
 Build a full stack JavaScript app that is functionally similar to this: <https://metric-imperial-converter.freecodecamp.rocks/>. Working on this project will involve you writing your code using one of the following methods:
 
--   Clone [this GitHub repo](https://github.com/freeCodeCamp/boilerplate-project-metricimpconverter/) and complete your project locally.
--   Use [our repl.it starter project](https://repl.it/github/freeCodeCamp/boilerplate-project-metricimpconverter) to complete your project.
--   Use a site builder of your choice to complete the project. Be sure to incorporate all the files from our GitHub repo.
+- Clone [this GitHub repo](https://github.com/freeCodeCamp/boilerplate-project-metricimpconverter/) and complete your project locally.
+- Use [our repl.it starter project](https://repl.it/github/freeCodeCamp/boilerplate-project-metricimpconverter) to complete your project.
+- Use a site builder of your choice to complete the project. Be sure to incorporate all the files from our GitHub repo.
 
 When you are done, make sure a working demo of your project is hosted somewhere public. Then submit the URL to it in the `Solution Link` field. Optionally, also submit a link to your project's source code in the `GitHub Link` field.
+
+# --instructions--
+
+- Complete the necessary conversion logic in `/controllers/convertHandler.js`
+- Complete the necessary routes in `/routes/api.js`
+- Create all of the functional tests in `tests/2_functional-tests.js`
+- Copy the `sample.env` file to `.env` and set the variables appropriately
+- To run the tests uncomment `NODE_ENV=test` in your `.env` file
+- To run the tests in the console, use the command `npm run test`. To open the Repl.it console, press Ctrl+Shift+P (Cmd if on a Mac) and type "open shell"
+
+Write the following tests in `tests/1_unit-tests.js`:
+
+- `convertHandler` should correctly read a whole number input.
+- `convertHandler` should correctly read a decimal number input.
+- `convertHandler` should correctly read a fractional input.
+- `convertHandler` should correctly read a fractional input with a decimal.
+- `convertHandler` should correctly return an error on a double-fraction (i.e. `3/2/3`).
+- `convertHandler` should correctly return an error on no numerical input.
+- `convertHandler` should correctly return the converted unit for each valid input unit.
+- `convertHandler` should correctly return the spelled-out string unit for each valid input unit.
+- `convertHandler` should correctly convert `gal` to `L`.
+- `convertHandler` should correctly convert `L` to `gal`.
+- `convertHandler` should correctly convert `mi` to `km`.
+- `convertHandler` should correctly convert `km` to `mi`.
+- `convertHandler` should correctly convert `lbs` to `kg`.
+- `convertHandler` should correctly convert `kg` to `lbs`.
+
+Write the following tests in `tests/2_functional-tests.js`:
+
+- Convert a valid input such as `10L`: `GET` request to `/api/convert`.
+- Convert an invalid input such as `32g`: `GET` request to `/api/convert`.
+- Convert an invalid number such as `3/7.2/4kg`: `GET` request to `/api/convert`.
+- Convert an invalid number AND unit such as `3/7.2/4kilomegagram`: `GET` request to `/api/convert`.
+- Convert with no number such as `kg`: `GET` request to `/api/convert`.
 
 # --hints--
 
 I can provide my own project, not the example URL.
 
 ```js
-(getUserInput) => {
+getUserInput => {
   assert(
     !/.*\/metric-imperial-converter\.freecodecamp\.rocks/.test(
       getUserInput('url')
@@ -32,13 +66,12 @@ I can provide my own project, not the example URL.
 I can GET /api/convert with a single parameter containing an accepted number and unit and have it converted. (Hint: Split the input by looking for the index of the first character which will mark the start of the unit)
 
 ```js
-
 ```
 
 I can convert `'gal'` to `'L'` and vice versa. (1 gal to 3.78541 L)
 
 ```js
-async (getUserInput) => {
+async getUserInput => {
   try {
     const data1 = await $.get(getUserInput('url') + '/api/convert?input=1gal');
     assert.equal(data1.returnNum, 3.78541);
@@ -61,7 +94,7 @@ async (getUserInput) => {
 I can convert `'lbs'` to `'kg'` and vice versa. (1 lbs to 0.453592 kg)
 
 ```js
-async (getUserInput) => {
+async getUserInput => {
   try {
     const data1 = await $.get(getUserInput('url') + '/api/convert?input=1lbs');
     assert.equal(data1.returnNum, 0.45359);
@@ -84,7 +117,7 @@ async (getUserInput) => {
 I can convert `'mi'` to `'km'` and vice versa. (1 mi to 1.60934 km)
 
 ```js
-async (getUserInput) => {
+async getUserInput => {
   try {
     const data1 = await $.get(getUserInput('url') + '/api/convert?input=1mi');
     assert.equal(data1.returnNum, 1.60934);
@@ -107,7 +140,7 @@ async (getUserInput) => {
 All incoming units should be accepted in both upper and lower case, but should be returned in both the `initUnit` and `returnUnit` in lower case, except for liter, which should be represented as an uppercase `'L'`.
 
 ```js
-async (getUserInput) => {
+async getUserInput => {
   try {
     const data1 = await $.get(getUserInput('url') + '/api/convert?input=1gal');
     assert.equal(data1.initUnit, 'gal');
@@ -130,7 +163,7 @@ async (getUserInput) => {
 If my unit of measurement is invalid, returned will be `'invalid unit'`.
 
 ```js
-async (getUserInput) => {
+async getUserInput => {
   try {
     const data = await $.get(getUserInput('url') + '/api/convert?input=1min');
     assert(data.error === 'invalid unit' || data === 'invalid unit');
@@ -143,7 +176,7 @@ async (getUserInput) => {
 If my number is invalid, returned will be `'invalid number'`.
 
 ```js
-async (getUserInput) => {
+async getUserInput => {
   try {
     const data = await $.get(
       getUserInput('url') + '/api/convert?input=1//2gal'
@@ -158,7 +191,7 @@ async (getUserInput) => {
 If both the unit and number are invalid, returned will be `'invalid number and unit'`.
 
 ```js
-async (getUserInput) => {
+async getUserInput => {
   try {
     const data = await $.get(
       getUserInput('url') + '/api/convert?input=1//2min'
@@ -176,7 +209,7 @@ async (getUserInput) => {
 I can use fractions, decimals or both in my parameter(ie. 5, 1/2, 2.5/6), but if nothing is provided it will default to 1.
 
 ```js
-async (getUserInput) => {
+async getUserInput => {
   try {
     const data1 = await $.get(getUserInput('url') + '/api/convert?input=mi');
     assert.approximately(data1.initNum, 1, 0.001);
@@ -207,7 +240,7 @@ async (getUserInput) => {
 My return will consist of the `initNum`, `initUnit`, `returnNum`, `returnUnit`, and `string` spelling out units in the format `'{initNum} {initial_Units} converts to {returnNum} {return_Units}'` with the result rounded to 5 decimals.
 
 ```js
-async (getUserInput) => {
+async getUserInput => {
   try {
     const data = await $.get(getUserInput('url') + '/api/convert?input=2mi');
     assert.equal(data.initNum, 2);
@@ -224,15 +257,15 @@ async (getUserInput) => {
 All 16 unit tests are complete and passing.
 
 ```js
-async (getUserInput) => {
+async getUserInput => {
   try {
     const getTests = await $.get(getUserInput('url') + '/_api/get-tests');
     assert.isArray(getTests);
-    const unitTests = getTests.filter((test) => {
+    const unitTests = getTests.filter(test => {
       return !!test.context.match(/Unit Tests ->/gi);
     });
     assert.isAtLeast(unitTests.length, 16, 'At least 16 tests passed');
-    unitTests.forEach((test) => {
+    unitTests.forEach(test => {
       assert.equal(test.state, 'passed', 'Tests in Passed State');
       assert.isAtLeast(
         test.assertions.length,
@@ -249,15 +282,15 @@ async (getUserInput) => {
 All 5 functional tests are complete and passing.
 
 ```js
-async (getUserInput) => {
+async getUserInput => {
   try {
     const getTests = await $.get(getUserInput('url') + '/_api/get-tests');
     assert.isArray(getTests);
-    const functTests = getTests.filter((test) => {
+    const functTests = getTests.filter(test => {
       return !!test.context.match(/Functional Tests ->/gi);
     });
     assert.isAtLeast(functTests.length, 5, 'At least 5 tests passed');
-    functTests.forEach((test) => {
+    functTests.forEach(test => {
       assert.equal(test.state, 'passed', 'Tests in Passed State');
       assert.isAtLeast(
         test.assertions.length,

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/metric-imperial-converter.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/metric-imperial-converter.md
@@ -63,7 +63,7 @@ getUserInput => {
 };
 ```
 
-You can `GET` /api/convert with a single parameter containing an accepted number and unit and have it converted. (Hint: Split the input by looking for the index of the first character which will mark the start of the unit)
+You can `GET` `/api/convert` with a single parameter containing an accepted number and unit and have it converted. (Hint: Split the input by looking for the index of the first character which will mark the start of the unit)
 
 ```js
 ```

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/metric-imperial-converter.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/metric-imperial-converter.md
@@ -160,7 +160,7 @@ async getUserInput => {
 };
 ```
 
-If your unit of measurement is invalid, returned will be `'invalid unit'`.
+If the unit of measurement is invalid, returned will be `'invalid unit'`.
 
 ```js
 async getUserInput => {
@@ -173,7 +173,7 @@ async getUserInput => {
 };
 ```
 
-If your number is invalid, returned will be `'invalid number'`.
+If the number is invalid, returned will be `'invalid number'`.
 
 ```js
 async getUserInput => {
@@ -206,7 +206,7 @@ async getUserInput => {
 };
 ```
 
-You can use fractions, decimals or both in your parameter (ie. 5, 1/2, 2.5/6), but if nothing is provided it will default to 1.
+You can use fractions, decimals or both in the parameter (ie. 5, 1/2, 2.5/6), but if nothing is provided it will default to 1.
 
 ```js
 async getUserInput => {

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/metric-imperial-converter.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/metric-imperial-converter.md
@@ -30,7 +30,7 @@ Write the following tests in `tests/1_unit-tests.js`:
 - `convertHandler` should correctly read a fractional input.
 - `convertHandler` should correctly read a fractional input with a decimal.
 - `convertHandler` should correctly return an error on a double-fraction (i.e. `3/2/3`).
-- `convertHandler` should correctly return an error on no numerical input.
+- `convertHandler` should correctly default to a numerical input of `1` when no numerical input is provided.
 - `convertHandler` should correctly read each valid input unit.
 - `convertHandler` should correctly return an error for an invalid input unit.
 - `convertHandler` should return the correct return unit for each valid input unit.

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/metric-imperial-converter.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/metric-imperial-converter.md
@@ -263,7 +263,7 @@ async getUserInput => {
     const getTests = await $.get(getUserInput('url') + '/_api/get-tests');
     assert.isArray(getTests);
     const unitTests = getTests.filter(test => {
-      return !!test.context.match(/Unit Tests ->/gi);
+      return !!test.context.match(/Unit Tests/gi);
     });
     assert.isAtLeast(unitTests.length, 16, 'At least 16 tests passed');
     unitTests.forEach(test => {
@@ -288,7 +288,7 @@ async getUserInput => {
     const getTests = await $.get(getUserInput('url') + '/_api/get-tests');
     assert.isArray(getTests);
     const functTests = getTests.filter(test => {
-      return !!test.context.match(/Functional Tests ->/gi);
+      return !!test.context.match(/Functional Tests/gi);
     });
     assert.isAtLeast(functTests.length, 5, 'At least 5 tests passed');
     functTests.forEach(test => {


### PR DESCRIPTION
Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `master` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #40307 

<!-- Feel free to add any additional description of changes below this line -->

This PR moves the tests to the `/learn` page (PR coming to remove them from the boilerplate).

Related Boilerplate PR: https://github.com/freeCodeCamp/boilerplate-project-metricimpconverter/pull/14