### PR TITLE
fix(learn): Disable prettier formatting on challenge files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,4 +3,4 @@
 client/static
 fixtures
 curriculum/challenges/_meta/*/*
-curriculum/challenges/*
+curriculum/challenges/**/*

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@
 client/static
 fixtures
 curriculum/challenges/_meta/*/*
+curriculum/challenges/*


### PR DESCRIPTION
Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `master` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

@ojeytonwilliams and I have been talking about this pretty in-depth the past couple of days. With the new challenge template format, Prettier is doing some strange things when formatting the `.md` files. As a specific example, it enforces EOL semi-colons for this code block: https://github.com/freeCodeCamp/freeCodeCamp/pull/40344#discussion_r532235152

Because many editors offer a "format on save" option, we're getting PRs with unintentional formatting changes that break the context of the content - as a temporary hot fix, this PR sets prettier to ignore our challenge files while we explore the configuration needed to make this work properly.
