### PR TITLE
feat: expand cypress tests to include some cert claiming

### DIFF
--- a/cypress/integration/settings/certifications.js
+++ b/cypress/integration/settings/certifications.js
@@ -1,0 +1,103 @@
+/* global cy expect */
+
+import '@testing-library/cypress/add-commands';
+
+describe('Settings certifications area', () => {
+  before(() => {
+    cy.exec('npm run seed');
+    cy.visit('/');
+    cy.contains("Get started (it's free)").click({ force: true });
+    cy.contains('Update my account settings').click({ force: true });
+  });
+
+  describe('initially', () => {
+    it('Should render 11 "Claim Certification" buttons', () => {
+      cy.findAllByText('Claim Certification').should($btns => {
+        expect($btns).to.have.length(11);
+      });
+    });
+
+    it('Should render zero "Show Certification" buttons', () => {
+      cy.contains('Show Certification').should('not.exist');
+    });
+
+    it('Should render one "Agree" button', () => {
+      cy.contains('Agree').should('exist');
+    });
+
+    describe('before isHonest', () => {
+      it('Should show "must agree" message when trying to claim a cert', () => {
+        cy.contains('Claim Certification').click();
+        cy.contains(
+          'To claim a certification, you must first accept our academic honesty policy'
+        ).should('exist');
+      });
+    });
+
+    describe('after isHonest', () => {
+      beforeEach(() => {
+        cy.visit('/');
+        cy.contains("Get started (it's free)").click({ force: true });
+        cy.contains('Update my account settings').click({ force: true });
+      });
+
+      it('Should render "You have accepted our Academic Honesty Policy." button after clicking "Agree"', () => {
+        cy.contains('Agree').click({ force: true });
+        cy.contains('You have accepted our Academic Honesty Policy.').should(
+          'exist'
+        );
+      });
+
+      it('Should show "incompleted projects" message when clicking "Claim Certification"', () => {
+        cy.contains('Claim Certification').click({ force: true });
+
+        cy.contains(
+          'It looks like you have not completed the necessary steps. Please complete the required projects to claim the Responsive Web Design Certification'
+        ).should('exist');
+      });
+
+      it('Should show "Your projects have been updated." message after submitting projects', () => {
+        cy.get(
+          '#dynamic-information-security-and-quality-assurance input'
+        ).each(el => {
+          cy.wrap(el)
+            .clear({ force: true })
+            .type('https://nhl.com', { force: true, delay: 0 });
+        });
+
+        cy.get('#dynamic-information-security-and-quality-assurance').then(
+          form => {
+            if (form[0][5] && form[0][5].innerHTML === 'Save Progress') {
+              form[0][5].click({ force: true });
+              cy.wait(1000);
+            }
+          }
+        );
+
+        cy.contains('Your projects have been updated.').should('exist');
+      });
+
+      it('Should render 12 "Claim Certification" buttons after submitting legacy projects', () => {
+        cy.findAllByText('Claim Certification').should($btns => {
+          expect($btns).to.have.length(12);
+        });
+      });
+
+      it('Should show "congrats" message after claiming a cert', () => {
+        cy.get(
+          '#dynamic-information-security-and-quality-assurance button'
+        ).click();
+
+        cy.contains(
+          '@developmentuser, you have successfully claimed the Legacy Information Security and Quality Assurance Certification! Congratulations on behalf of the freeCodeCamp.org team!'
+        ).should('exist');
+      });
+
+      it('Should render a "Show Certification" button after submitting enough projects', () => {
+        cy.findAllByText('Show Certification').should($btns => {
+          expect($btns).to.have.length(1);
+        });
+      });
+    });
+  });
+});

--- a/cypress/integration/top-contributor.js
+++ b/cypress/integration/top-contributor.js
@@ -1,5 +1,4 @@
 /* global cy */
-import { environment } from '../../client/config/env';
 
 describe('Top contributor in user profile', () => {
   before(() => {
@@ -15,9 +14,8 @@ describe('Top contributor in user profile', () => {
     cy.login();
     cy.contains('Profile').click({ force: true });
 
-    if (environment === 'development') {
-      cy.contains('Preview custom 404 page').click();
-    }
+    // The following line is only required if you want to test it in development
+    // cy.contains('Preview custom 404 page').click();
   });
 
   it('Should show `Top Contributor` text with badge', () => {

--- a/cypress/integration/top-contributor.js
+++ b/cypress/integration/top-contributor.js
@@ -1,4 +1,5 @@
 /* global cy */
+import { environment } from '../../client/config/env';
 
 describe('Top contributor in user profile', () => {
   before(() => {
@@ -14,8 +15,9 @@ describe('Top contributor in user profile', () => {
     cy.login();
     cy.contains('Profile').click({ force: true });
 
-    // The following line is only required if you want to test it in development
-    // cy.contains('Preview custom 404 page').click();
+    if (environment === 'development') {
+      cy.contains('Preview custom 404 page').click();
+    }
   });
 
   it('Should show `Top Contributor` text with badge', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2330,6 +2330,234 @@
         "defer-to-connect": "^1.0.1"
       }
     },
+    "@testing-library/cypress": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/cypress/-/cypress-7.0.2.tgz",
+      "integrity": "sha512-avBCbcCMPFHvWg4BBCA/pIh3MCwcKoJ+rc3XyZdKC5mFYPV7edjW3s4KZx/x3klXuttyuM/UesRhbSj4l5aQbw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^7.26.6"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+          "dev": true
+        }
+      }
+    },
+    "@testing-library/dom": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.29.0.tgz",
+      "integrity": "sha512-0hhuJSmw/zLc6ewR9cVm84TehuTd7tbqBX9pRNSp8znJ9gTmSgesdbiGZtt8R6dL+2rgaPFp9Yjr7IU1HWm49w==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^4.2.2",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.4",
+        "lz-string": "^1.4.4",
+        "pretty-format": "^26.6.2"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+          "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.10.4"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+          "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+          "dev": true
+        },
+        "@babel/highlight": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+          "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            }
+          }
+        },
+        "@babel/runtime": {
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "@jest/types": {
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/istanbul-reports": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
+          "integrity": "sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^2.0.1"
+              }
+            },
+            "supports-color": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            }
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+          "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.6.2",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^17.0.1"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^2.0.1"
+              }
+            }
+          }
+        },
+        "react-is": {
+          "version": "17.0.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+          "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+          "dev": true
+        }
+      }
+    },
+    "@types/aria-query": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.0.tgz",
+      "integrity": "sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A==",
+      "dev": true
+    },
     "@types/babel__core": {
       "version": "7.1.9",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.9.tgz",
@@ -5616,6 +5844,12 @@
         "esutils": "^2.0.2",
         "isarray": "^1.0.0"
       }
+    },
+    "dom-accessibility-api": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.4.tgz",
+      "integrity": "sha512-TvrjBckDy2c6v6RLxPv5QXOnU+SmF9nBII5621Ve5fu6Z/BDrENurBEvlC1f44lKEUVqOpK4w9E5Idc5/EgkLQ==",
+      "dev": true
     },
     "domexception": {
       "version": "1.0.1",
@@ -10435,6 +10669,12 @@
       "requires": {
         "yallist": "^3.0.2"
       }
+    },
+    "lz-string": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+      "dev": true
     },
     "macos-release": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "test:utils": "jest --rootDir ./utils"
   },
   "devDependencies": {
+    "@testing-library/cypress": "^7.0.2",
     "babel-eslint": "^10.1.0",
     "cross-env": "^7.0.2",
     "cypress": "^6.0.0",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/40400

<!-- Feel free to add any additional description of changes below this line -->
This adds some tests for working with the certifications in the settings area. Claiming certs, submitting projects, etc.

~~It also fixes one thing that was bothering me in the top contributor tests. You had to manually uncomment a line to pass the tests. I made the test conditionally run. Hopefully it passes the tests on here - if it doesn't, I will probably just revert that.~~

It also adds [a cypress testing library](https://testing-library.com/docs/cypress-testing-library/intro/) to expand cypress. Not sure if we want it, but it adds a few handy methods that weren't available without it. I suppose I could find a way around it if needed.