### PR TITLE
fix(cypress): Re-introduce Firefox in Cypress CI

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        browsers: [chrome]
+        browsers: [chrome, firefox]
     services:
       mongodb:
         image: mongo:3.6.19

--- a/cypress/integration/learn/challenges/output.js
+++ b/cypress/integration/learn/challenges/output.js
@@ -40,7 +40,7 @@ describe('Classic challenge', function() {
   it('shows test output when the tests are run', () => {
     cy.visit(locations.index);
     // first wait for the editor to load
-    cy.get(selectors.editor, { timeout: 10000 });
+    cy.get(selectors.editor, { timeout: 15000 });
     cy.get(selectors.runTestsButton)
       .click()
       .then(() => {
@@ -53,7 +53,7 @@ describe('Classic challenge', function() {
   it('shows test output when the tests are triggered by the keyboard', () => {
     cy.visit(locations.index);
     // first wait for the editor to load
-    cy.get(selectors.editor, { timeout: 10000 });
+    cy.get(selectors.editor, { timeout: 15000 });
     cy.get(selectors.hotkeys)
       .focus()
       .type('{ctrl}{enter}')


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #39679 

<!-- Feel free to add any additional description of changes below this line -->

Let's re-introduce Firefox before parallelizing Cypress CI. I've increased the timeout by 5 more seconds and I think that should do it. If everything goes ok, we can start parallelizing Cypress CI.
