### PR TITLE
fix: let Cypress run in development

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -57,6 +57,8 @@ jobs:
 
       - name: Cypress run
         uses: cypress-io/github-action@v2
+        env:
+          CYPRESS_CI: true
         with:
           record: ${{ env.CYPRESS_RECORD_KEY != 0 }}
           build: npm run build
@@ -70,4 +72,3 @@ jobs:
           config: baseUrl=http://localhost:8000
           browser: ${{ matrix.browsers }}
           headless: true
-          env: CYPRESS_CI=true

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -70,3 +70,4 @@ jobs:
           config: baseUrl=http://localhost:8000
           browser: ${{ matrix.browsers }}
           headless: true
+          env: CYPRESS_CI=true

--- a/cypress/integration/top-contributor.js
+++ b/cypress/integration/top-contributor.js
@@ -15,8 +15,8 @@ describe('Top contributor in user profile', () => {
     cy.contains('Profile').click({ force: true });
 
     // If you `npm run build` the site, then this will fail (unless you set the
-    // CI environment variable to true)
-    if (Cypress.env('CI') !== 'true') {
+    // CYPRESS_CI environment variable to true)
+    if (Cypress.env('CYPRESS_CI') !== 'true') {
       cy.contains('Preview custom 404 page').click();
     }
   });

--- a/cypress/integration/top-contributor.js
+++ b/cypress/integration/top-contributor.js
@@ -14,8 +14,11 @@ describe('Top contributor in user profile', () => {
     cy.login();
     cy.contains('Profile').click({ force: true });
 
-    // The following line is only required if you want to test it in development
-    // cy.contains('Preview custom 404 page').click();
+    // If you `npm run build` the site, then this will fail (unless you set the
+    // CI environment variable to true)
+    if (process.env.CI !== 'true') {
+      cy.contains('Preview custom 404 page').click();
+    }
   });
 
   it('Should show `Top Contributor` text with badge', () => {

--- a/cypress/integration/top-contributor.js
+++ b/cypress/integration/top-contributor.js
@@ -16,7 +16,7 @@ describe('Top contributor in user profile', () => {
 
     // If you `npm run build` the site, then this will fail (unless you set the
     // CYPRESS_CI environment variable to true)
-    if (Cypress.env('CYPRESS_CI') !== 'true') {
+    if (Cypress.env('CYPRESS_CI') !== true) {
       cy.contains('Preview custom 404 page').click();
     }
   });

--- a/cypress/integration/top-contributor.js
+++ b/cypress/integration/top-contributor.js
@@ -1,4 +1,4 @@
-/* global cy */
+/* global cy Cypress */
 
 describe('Top contributor in user profile', () => {
   before(() => {
@@ -16,7 +16,7 @@ describe('Top contributor in user profile', () => {
 
     // If you `npm run build` the site, then this will fail (unless you set the
     // CI environment variable to true)
-    if (process.env.CI !== 'true') {
+    if (Cypress.env('CI') !== 'true') {
       cy.contains('Preview custom 404 page').click();
     }
   });


### PR DESCRIPTION
Following the discussion on https://github.com/freeCodeCamp/freeCodeCamp/pull/40422, this should make the default development workflow easier without breaking CI.
