### PR TITLE
Made the Escaping literal quotes challenge accept the dot inside the double quotes too

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/escaping-literal-quotes-in-strings.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/escaping-literal-quotes-in-strings.md
@@ -35,7 +35,7 @@ assert(code.match(/\\"/g).length === 4 && code.match(/[^\\]"/g).length === 2);
 Variable myStr should contain the string: `I am a "double quoted" string inside "double quotes".`
 
 ```js
-assert(myStr === 'I am a "double quoted" string inside "double quotes".');
+assert(/I am a "double quoted" string inside "double quotes.?".?/.test(myStr));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/escaping-literal-quotes-in-strings.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/escaping-literal-quotes-in-strings.md
@@ -35,7 +35,7 @@ assert(code.match(/\\"/g).length === 4 && code.match(/[^\\]"/g).length === 2);
 Variable myStr should contain the string: `I am a "double quoted" string inside "double quotes".`
 
 ```js
-assert(/I am a "double quoted" string inside "double quotes.?".?/.test(myStr));
+assert(/I am a "double quoted" string inside "double quotes(\."|"\.)$/.test(myStr));
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #40398 

<!-- Feel free to add any additional description of changes below this line -->

As discussed in the issue, now both versions of the string pass:
```
I am a "double quoted" string inside "double quotes".
I am a "double quoted" string inside "double quotes."
```

regex changed to as per requests below `."|".`