### PR TITLE
fix(learn): Remove arrows from test name assertion

### DIFF
--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/american-british-translator.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/american-british-translator.md
@@ -102,7 +102,9 @@ async (getUserInput) => {
 };
 ```
 
-The `/api/translate` route should handle the way time is written in American and British English. For example, ten thirty is written as "10.30" in British English and "10:30" in American English. NOTE: The `span` element should wrap the full time string, i.e. `<span class="highlight">10:30</span>`.
+The `/api/translate` route should handle the way time is written in American and British English. For example, ten thirty is written as "10.30" in British English and "10:30" in American English.
+
+**Note:** The `span` element should wrap the entire time string, i.e. `<span class="highlight">10:30</span>`.
 
 ```js
 async (getUserInput) => {

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/american-british-translator.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/american-british-translator.md
@@ -102,9 +102,7 @@ async (getUserInput) => {
 };
 ```
 
-The `/api/translate` route should handle the way time is written in American and British English. For example, ten thirty is written as "10.30" in British English and "10:30" in American English.
-
-**Note:** The `span` element should wrap the entire time string, i.e. `<span class="highlight">10:30</span>`.
+The `/api/translate` route should handle the way time is written in American and British English. For example, ten thirty is written as "10.30" in British English and "10:30" in American English. The `span` element should wrap the entire time string, i.e. `<span class="highlight">10:30</span>`.
 
 ```js
 async (getUserInput) => {

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/american-british-translator.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/american-british-translator.md
@@ -102,7 +102,7 @@ async (getUserInput) => {
 };
 ```
 
-The `/api/translate` route should handle the way time is written in American and British English. For example, ten thirty is written as "10.30" in British English and "10:30" in American English.
+The `/api/translate` route should handle the way time is written in American and British English. For example, ten thirty is written as "10.30" in British English and "10:30" in American English. NOTE: The `span` element should wrap the full time string, i.e. `<span class="highlight">10:30</span>`.
 
 ```js
 async (getUserInput) => {

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/american-british-translator.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/american-british-translator.md
@@ -283,7 +283,7 @@ async (getUserInput) => {
     const getTests = await $.get(getUserInput('url') + '/_api/get-tests');
     assert.isArray(getTests);
     const unitTests = getTests.filter((test) => {
-      return !!test.context.match(/Unit Tests ->/gi);
+      return !!test.context.match(/Unit Tests/gi);
     });
     assert.isAtLeast(unitTests.length, 24, 'At least 24 tests passed');
     unitTests.forEach((test) => {
@@ -308,7 +308,7 @@ async (getUserInput) => {
     const getTests = await $.get(getUserInput('url') + '/_api/get-tests');
     assert.isArray(getTests);
     const functTests = getTests.filter((test) => {
-      return !!test.context.match(/Functional Tests ->/gi);
+      return !!test.context.match(/Functional Tests/gi);
     });
     assert.isAtLeast(functTests.length, 6, 'At least 6 tests passed');
     functTests.forEach((test) => {


### PR DESCRIPTION
Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `master` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

As noted in https://github.com/freeCodeCamp/freeCodeCamp/pull/40358, @moT01 caught an issue with the way we are differentiating between unit/functional tests in a camper's project. Because we've removed the test structure from the boilerplate, the format for the "test context" can differ if the user nests the test declarations on a different level. This changes the placement of the arrow symbol in the context name. 

For better future-proofing, I removed the arrow from the assertion entirely. I fixed the Metric-Imperial Converter in the existing (linked) PR, so this PR is to catch the other projects. From what I could see, only the American British Translator had the arrow present.