### PR TITLE
feat(curriculum): add extension tests for css-flexbox curriculum modules

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/add-flex-superpowers-to-the-tweet-embed.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/add-flex-superpowers-to-the-tweet-embed.md
@@ -19,6 +19,12 @@ Add the CSS property `display: flex` to all of the following items - note that t
 
 # --hints--
 
+Your `.follow-btn` should be rendered on the page. Be sure to turn off any extensions such as ad blockers.
+
+```js
+assert($('.follow-btn').length > 0 && $('.follow-btn').css('display') !== 'none');
+```
+
 Your `header` should have a `display` property set to `flex`.
 
 ```js
@@ -53,12 +59,6 @@ Your `.follow-btn` should have a `display` property set to `flex`.
 
 ```js
 assert($('.follow-btn').css('display') == 'flex');
-```
-
-Your `.follow-btn` should be rendered on the page. Be sure to turn off any extensions such as ad blockers.
-
-```js
-assert($('.follow-btn').length > 0 && $('.follow-btn').css('display') !== 'none');
 ```
 
 Your `.stats` should have a `display` property set to `flex`.

--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/add-flex-superpowers-to-the-tweet-embed.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/add-flex-superpowers-to-the-tweet-embed.md
@@ -55,6 +55,12 @@ Your `.follow-btn` should have a `display` property set to `flex`.
 assert($('.follow-btn').css('display') == 'flex');
 ```
 
+Your `.follow-btn` should be rendered on the page. Be sure to turn off any extensions such as ad blockers.
+
+```js
+testString: assert($('.follow-btn').length > 0 && $('.follow-btn').css('display') !== 'none');
+```
+
 Your `.stats` should have a `display` property set to `flex`.
 
 ```js

--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/add-flex-superpowers-to-the-tweet-embed.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/add-flex-superpowers-to-the-tweet-embed.md
@@ -58,7 +58,7 @@ assert($('.follow-btn').css('display') == 'flex');
 Your `.follow-btn` should be rendered on the page. Be sure to turn off any extensions such as ad blockers.
 
 ```js
-testString: assert($('.follow-btn').length > 0 && $('.follow-btn').css('display') !== 'none');
+assert($('.follow-btn').length > 0 && $('.follow-btn').css('display') !== 'none');
 ```
 
 Your `.stats` should have a `display` property set to `flex`.

--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/apply-the-flex-direction-property-to-create-a-column-in-the-tweet-embed.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/apply-the-flex-direction-property-to-create-a-column-in-the-tweet-embed.md
@@ -17,16 +17,16 @@ Add the CSS property `flex-direction` to the header's `.profile-name` element an
 
 # --hints--
 
-The `.profile-name` element should have a `flex-direction` property set to column.
-
-```js
-assert($('.profile-name').css('flex-direction') == 'column');
-```
-
 Your `.follow-btn` should be rendered on the page. Be sure to turn off any extensions such as ad blockers.
 
 ```js
 assert($('.follow-btn').length > 0 && $('.follow-btn').css('display') !== 'none');
+```
+
+The `.profile-name` element should have a `flex-direction` property set to column.
+
+```js
+assert($('.profile-name').css('flex-direction') == 'column');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/apply-the-flex-direction-property-to-create-a-column-in-the-tweet-embed.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/apply-the-flex-direction-property-to-create-a-column-in-the-tweet-embed.md
@@ -23,6 +23,12 @@ The `.profile-name` element should have a `flex-direction` property set to colum
 assert($('.profile-name').css('flex-direction') == 'column');
 ```
 
+Your `.follow-btn` should be rendered on the page. Be sure to turn off any extensions such as ad blockers.
+
+```js
+testString: assert($('.follow-btn').length > 0 && $('.follow-btn').css('display') !== 'none');
+```
+
 # --seed--
 
 ## --seed-contents--

--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/apply-the-flex-direction-property-to-create-a-column-in-the-tweet-embed.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/apply-the-flex-direction-property-to-create-a-column-in-the-tweet-embed.md
@@ -26,7 +26,7 @@ assert($('.profile-name').css('flex-direction') == 'column');
 Your `.follow-btn` should be rendered on the page. Be sure to turn off any extensions such as ad blockers.
 
 ```js
-testString: assert($('.follow-btn').length > 0 && $('.follow-btn').css('display') !== 'none');
+assert($('.follow-btn').length > 0 && $('.follow-btn').css('display') !== 'none');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/apply-the-flex-direction-property-to-create-rows-in-the-tweet-embed.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/apply-the-flex-direction-property-to-create-rows-in-the-tweet-embed.md
@@ -29,6 +29,12 @@ The `footer` should have a `flex-direction` property set to row.
 assert(code.match(/footer\s*?{[^}]*?flex-direction:\s*?row;/g));
 ```
 
+Your `.follow-btn` should be rendered on the page. Be sure to turn off any extensions such as ad blockers.
+
+```js
+testString: assert($('.follow-btn').length > 0 && $('.follow-btn').css('display') !== 'none');
+```
+
 # --seed--
 
 ## --seed-contents--

--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/apply-the-flex-direction-property-to-create-rows-in-the-tweet-embed.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/apply-the-flex-direction-property-to-create-rows-in-the-tweet-embed.md
@@ -17,6 +17,12 @@ Add the CSS property `flex-direction` to both the `header` and `footer` and set 
 
 # --hints--
 
+Your `.follow-btn` should be rendered on the page. Be sure to turn off any extensions such as ad blockers.
+
+```js
+assert($('.follow-btn').length > 0 && $('.follow-btn').css('display') !== 'none');
+```
+
 The `header` should have a `flex-direction` property set to row.
 
 ```js
@@ -27,12 +33,6 @@ The `footer` should have a `flex-direction` property set to row.
 
 ```js
 assert(code.match(/footer\s*?{[^}]*?flex-direction:\s*?row;/g));
-```
-
-Your `.follow-btn` should be rendered on the page. Be sure to turn off any extensions such as ad blockers.
-
-```js
-assert($('.follow-btn').length > 0 && $('.follow-btn').css('display') !== 'none');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/apply-the-flex-direction-property-to-create-rows-in-the-tweet-embed.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/apply-the-flex-direction-property-to-create-rows-in-the-tweet-embed.md
@@ -32,7 +32,7 @@ assert(code.match(/footer\s*?{[^}]*?flex-direction:\s*?row;/g));
 Your `.follow-btn` should be rendered on the page. Be sure to turn off any extensions such as ad blockers.
 
 ```js
-testString: assert($('.follow-btn').length > 0 && $('.follow-btn').css('display') !== 'none');
+assert($('.follow-btn').length > 0 && $('.follow-btn').css('display') !== 'none');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-align-items-property-in-the-tweet-embed.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-align-items-property-in-the-tweet-embed.md
@@ -23,6 +23,12 @@ The `.follow-btn` element should have the `align-items` property set to a value 
 assert($('.follow-btn').css('align-items') == 'center');
 ```
 
+Your `.follow-btn` should be rendered on the page. Be sure to turn off any extensions such as ad blockers.
+
+```js
+testString: assert($('.follow-btn').length > 0 && $('.follow-btn').css('display') !== 'none');
+```
+
 # --seed--
 
 ## --seed-contents--

--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-align-items-property-in-the-tweet-embed.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-align-items-property-in-the-tweet-embed.md
@@ -26,7 +26,7 @@ assert($('.follow-btn').css('align-items') == 'center');
 Your `.follow-btn` should be rendered on the page. Be sure to turn off any extensions such as ad blockers.
 
 ```js
-testString: assert($('.follow-btn').length > 0 && $('.follow-btn').css('display') !== 'none');
+assert($('.follow-btn').length > 0 && $('.follow-btn').css('display') !== 'none');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-align-items-property-in-the-tweet-embed.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-align-items-property-in-the-tweet-embed.md
@@ -17,16 +17,16 @@ Add the CSS property `align-items` to the header's `.follow-btn` element. Set th
 
 # --hints--
 
-The `.follow-btn` element should have the `align-items` property set to a value of `center`.
-
-```js
-assert($('.follow-btn').css('align-items') == 'center');
-```
-
 Your `.follow-btn` should be rendered on the page. Be sure to turn off any extensions such as ad blockers.
 
 ```js
 assert($('.follow-btn').length > 0 && $('.follow-btn').css('display') !== 'none');
+```
+
+The `.follow-btn` element should have the `align-items` property set to a value of `center`.
+
+```js
+assert($('.follow-btn').css('align-items') == 'center');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-justify-content-property-in-the-tweet-embed.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-justify-content-property-in-the-tweet-embed.md
@@ -27,6 +27,12 @@ assert(
 );
 ```
 
+Your `.follow-btn` should be rendered on the page. Be sure to turn off any extensions such as ad blockers.
+
+```js
+testString: assert($('.follow-btn').length > 0 && $('.follow-btn').css('display') !== 'none');
+```
+
 # --seed--
 
 ## --seed-contents--

--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-justify-content-property-in-the-tweet-embed.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-justify-content-property-in-the-tweet-embed.md
@@ -30,7 +30,7 @@ assert(
 Your `.follow-btn` should be rendered on the page. Be sure to turn off any extensions such as ad blockers.
 
 ```js
-testString: assert($('.follow-btn').length > 0 && $('.follow-btn').css('display') !== 'none');
+assert($('.follow-btn').length > 0 && $('.follow-btn').css('display') !== 'none');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-justify-content-property-in-the-tweet-embed.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-flexbox/use-the-justify-content-property-in-the-tweet-embed.md
@@ -17,6 +17,12 @@ Add the CSS property `justify-content` to the header's `.profile-name` element a
 
 # --hints--
 
+Your `.follow-btn` should be rendered on the page. Be sure to turn off any extensions such as ad blockers.
+
+```js
+assert($('.follow-btn').length > 0 && $('.follow-btn').css('display') !== 'none');
+```
+
 The `.profile-name` element should have the `justify-content` property set to any of these values: `center`, `flex-start`, `flex-end`, `space-between`, `space-around`, or `space-evenly`.
 
 ```js
@@ -25,12 +31,6 @@ assert(
     /header\s.profile-name\s*{\s*?.*?\s*?.*?\s*?\s*?.*?\s*?justify-content\s*:\s*(center|flex-start|flex-end|space-between|space-around|space-evenly)\s*;/g
   )
 );
-```
-
-Your `.follow-btn` should be rendered on the page. Be sure to turn off any extensions such as ad blockers.
-
-```js
-assert($('.follow-btn').length > 0 && $('.follow-btn').css('display') !== 'none');
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related #39608

<!-- Feel free to add any additional description of changes below this line -->

Replaces #40272

Changes:

Adds a test that validates the presence of `follow-btn` on the page and that its display property is not set to `none` to the following:

- css-flexbox/add-flex-superpowers-to-the-tweet-embed.md
- css-flexbox/apply-the-flex-direction-property-to-create-a-column-in-the-tweet-embed.md
- css-flexbox/apply-the-flex-direction-property-to-create-rows-in-the-tweet-embed.md
- css-flexbox/use-the-align-items-property-in-the-tweet-embed.md
- css-flexbox/use-the-justify-content-property-in-the-tweet-embed.md
