### PR TITLE
fix: language agnostic api

### DIFF
--- a/api-server/server/utils/get-curriculum.js
+++ b/api-server/server/utils/get-curriculum.js
@@ -10,9 +10,9 @@ import { getChallengesForLang } from '../../../curriculum/getChallenges';
 
 let curriculum;
 export async function getCurriculum() {
-  curriculum = curriculum
-    ? curriculum
-    : getChallengesForLang(process.env.CURRICULUM_LOCALE);
+  // NOTE: this is always 'english' because we are only interested in the slugs
+  // and those should not change between the languages.
+  curriculum = curriculum ? curriculum : getChallengesForLang('english');
   return curriculum;
 }
 

--- a/client/utils/buildChallenges.js
+++ b/client/utils/buildChallenges.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 
 const {
   getChallengesForLang,
-  createChallengeCreator,
+  createChallenge,
   challengesDir,
   getChallengesDirForLang
 } = require('../../curriculum/getChallenges');
@@ -10,11 +10,9 @@ const { curriculumLocale } = require('../config/env.json');
 
 exports.localeChallengesRootDir = getChallengesDirForLang(curriculumLocale);
 
-const createChallenge = createChallengeCreator(challengesDir, curriculumLocale);
-
 exports.replaceChallengeNode = () => {
   return async function replaceChallengeNode(filePath) {
-    return await createChallenge(filePath);
+    return await createChallenge(challengesDir, filePath, curriculumLocale);
   };
 };
 

--- a/curriculum/getChallenges.js
+++ b/curriculum/getChallenges.js
@@ -291,10 +291,9 @@ ${getFullPath('english')}
       time
     } = meta;
     challenge.block = blockName;
-    challenge.dashedName =
-      lang === 'english'
-        ? dasherize(challenge.title)
-        : dasherize(challenge.originalTitle);
+    challenge.dashedName = useEnglish
+      ? dasherize(challenge.title)
+      : dasherize(challenge.originalTitle);
     delete challenge.originalTitle;
     challenge.order = order;
     challenge.superOrder = superOrder;

--- a/curriculum/getChallenges.js
+++ b/curriculum/getChallenges.js
@@ -192,9 +192,8 @@ async function buildSuperBlocks({ path, fullPath }, curriculum) {
   return walk(fullPath, curriculum, { depth: 1, type: 'directories' }, cb);
 }
 
-async function buildChallenges({ path, filePath }, curriculum, lang) {
+async function buildChallenges({ path }, curriculum, lang) {
   // path is relative to getChallengesDirForLang(lang)
-  const createChallenge = createChallengeCreator(challengesDir, lang);
   const block = getBlockNameFromPath(path);
   const { name: superBlock } = superBlockInfoFromPath(path);
   let challengeBlock;
@@ -214,7 +213,7 @@ async function buildChallenges({ path, filePath }, curriculum, lang) {
   }
   const { meta } = challengeBlock;
 
-  const challenge = await createChallenge(filePath, meta);
+  const challenge = await createChallenge(challengesDir, path, lang, meta);
 
   challengeBlock.challenges = [...challengeBlock.challenges, challenge];
 }
@@ -238,93 +237,90 @@ async function parseTranslation(
   return mergeChallenges(engWithTranslatedComments, translatedChal);
 }
 
-function createChallengeCreator(basePath, lang) {
-  const hasEnglishSource = hasEnglishSourceCreator(basePath);
-  return async function createChallenge(filePath, maybeMeta) {
-    function getFullPath(pathLang) {
-      return path.resolve(__dirname, basePath, pathLang, filePath);
-    }
-    let meta;
-    if (maybeMeta) {
-      meta = maybeMeta;
-    } else {
-      const metaPath = path.resolve(
-        metaDir,
-        `./${getBlockNameFromPath(filePath)}/meta.json`
-      );
-      meta = require(metaPath);
-    }
-    const { name: superBlock } = superBlockInfoFromPath(filePath);
-    if (!curriculumLangs.includes(lang))
-      throw Error(`${lang} is not a accepted language.
+async function createChallenge(basePath, filePath, lang, maybeMeta) {
+  function getFullPath(pathLang) {
+    return path.resolve(__dirname, basePath, pathLang, filePath);
+  }
+  let meta;
+  if (maybeMeta) {
+    meta = maybeMeta;
+  } else {
+    const metaPath = path.resolve(
+      metaDir,
+      `./${getBlockNameFromPath(filePath)}/meta.json`
+    );
+    meta = require(metaPath);
+  }
+  const { name: superBlock } = superBlockInfoFromPath(filePath);
+  if (!curriculumLangs.includes(lang))
+    throw Error(`${lang} is not a accepted language.
   Trying to parse ${filePath}`);
-    if (lang !== 'english' && !(await hasEnglishSource(filePath)))
-      throw Error(`Missing English challenge for
+  if (lang !== 'english' && !(await hasEnglishSource(basePath, filePath)))
+    throw Error(`Missing English challenge for
 ${filePath}
 It should be in
 ${getFullPath('english')}
 `);
-    // assumes superblock names are unique
-    // while the auditing is ongoing, we default to English for un-audited certs
-    // once that's complete, we can revert to using isEnglishChallenge(fullPath)
-    const useEnglish = lang === 'english' || !isAuditedCert(lang, superBlock);
-    const isCert = path.extname(filePath) === '.markdown';
-    let challenge;
+  // assumes superblock names are unique
+  // while the auditing is ongoing, we default to English for un-audited certs
+  // once that's complete, we can revert to using isEnglishChallenge(fullPath)
+  const useEnglish = lang === 'english' || !isAuditedCert(lang, superBlock);
+  const isCert = path.extname(filePath) === '.markdown';
+  let challenge;
 
-    if (isCert) {
-      // TODO: this uses the old parser to handle certifcates, but Markdown is a
-      // clunky way to store data, consider converting to YAML and removing the
-      // old parser.
-      challenge = await (useEnglish
-        ? parseMarkdown(getFullPath('english'))
-        : parseTranslation(
-            getFullPath('english'),
-            getFullPath(lang),
-            COMMENT_TRANSLATIONS,
-            lang,
-            parseMarkdown
-          ));
-    } else {
-      challenge = await (useEnglish
-        ? parseMD(getFullPath('english'))
-        : parseTranslation(
-            getFullPath('english'),
-            getFullPath(lang),
-            COMMENT_TRANSLATIONS,
-            lang
-          ));
-    }
-    const challengeOrder = findIndex(
-      meta.challengeOrder,
-      ([id]) => id === challenge.id
-    );
-    const {
-      name: blockName,
-      order,
-      superOrder,
-      isPrivate,
-      required = [],
-      template,
-      time
-    } = meta;
-    challenge.block = blockName;
-    challenge.dashedName = useEnglish
-      ? dasherize(challenge.title)
-      : dasherize(challenge.originalTitle);
-    delete challenge.originalTitle;
-    challenge.order = order;
-    challenge.superOrder = superOrder;
-    challenge.superBlock = superBlock;
-    challenge.challengeOrder = challengeOrder;
-    challenge.isPrivate = challenge.isPrivate || isPrivate;
-    challenge.required = required.concat(challenge.required || []);
-    challenge.template = template;
-    challenge.time = time;
-    challenge.helpCategory =
-      challenge.helpCategory || helpCategoryMap[dasherize(blockName)];
+  if (isCert) {
+    // TODO: this uses the old parser to handle certifcates, but Markdown is a
+    // clunky way to store data, consider converting to YAML and removing the
+    // old parser.
+    challenge = await (useEnglish
+      ? parseMarkdown(getFullPath('english'))
+      : parseTranslation(
+          getFullPath('english'),
+          getFullPath(lang),
+          COMMENT_TRANSLATIONS,
+          lang,
+          parseMarkdown
+        ));
+  } else {
+    challenge = await (useEnglish
+      ? parseMD(getFullPath('english'))
+      : parseTranslation(
+          getFullPath('english'),
+          getFullPath(lang),
+          COMMENT_TRANSLATIONS,
+          lang
+        ));
+  }
+  const challengeOrder = findIndex(
+    meta.challengeOrder,
+    ([id]) => id === challenge.id
+  );
+  const {
+    name: blockName,
+    order,
+    superOrder,
+    isPrivate,
+    required = [],
+    template,
+    time
+  } = meta;
+  challenge.block = blockName;
+  challenge.dashedName = useEnglish
+    ? dasherize(challenge.title)
+    : dasherize(challenge.originalTitle);
+  delete challenge.originalTitle;
+  challenge.order = order;
+  challenge.superOrder = superOrder;
+  challenge.superBlock = superBlock;
+  challenge.challengeOrder = challengeOrder;
+  challenge.isPrivate = challenge.isPrivate || isPrivate;
+  challenge.required = required.concat(challenge.required || []);
+  challenge.template = template;
+  challenge.time = time;
+  challenge.helpCategory =
+    challenge.helpCategory || helpCategoryMap[dasherize(blockName)];
 
-    return prepareChallenge(challenge);
-  };
+  return prepareChallenge(challenge);
 }
 
 // TODO: tests and more descriptive name.
@@ -372,16 +368,14 @@ function prepareChallenge(challenge) {
   return challenge;
 }
 
-function hasEnglishSourceCreator(basePath) {
+async function hasEnglishSource(basePath, translationPath) {
   const englishRoot = path.resolve(__dirname, basePath, 'english');
-  return async function(translationPath) {
-    return await access(
-      path.join(englishRoot, translationPath),
-      fs.constants.F_OK
-    )
-      .then(() => true)
-      .catch(() => false);
-  };
+  return await access(
+    path.join(englishRoot, translationPath),
+    fs.constants.F_OK
+  )
+    .then(() => true)
+    .catch(() => false);
 }
 
 function superBlockInfoFromPath(filePath) {
@@ -411,6 +405,6 @@ function arrToString(arr) {
   return Array.isArray(arr) ? arr.join('\n') : toString(arr);
 }
 
-exports.hasEnglishSourceCreator = hasEnglishSourceCreator;
+exports.hasEnglishSource = hasEnglishSource;
 exports.parseTranslation = parseTranslation;
-exports.createChallengeCreator = createChallengeCreator;
+exports.createChallenge = createChallenge;

--- a/curriculum/getChallenges.js
+++ b/curriculum/getChallenges.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const { findIndex, reduce, toString } = require('lodash');
-const readDirP = require('readdirp-walk');
+const readDirP = require('readdirp');
 const { parseMarkdown } = require('../tools/challenge-md-parser');
 const { parseMD } = require('../tools/challenge-md-parser/mdx');
 const fs = require('fs');
@@ -125,61 +125,78 @@ function getMetaForBlock(block) {
 exports.getChallengesDirForLang = getChallengesDirForLang;
 exports.getMetaForBlock = getMetaForBlock;
 
-exports.getChallengesForLang = function getChallengesForLang(lang) {
-  let curriculum = {};
+// This recursively walks the directories starting at root, and calls cb for
+// each file/directory and only resolves once all the callbacks do.
+const walk = (root, target, options, cb) => {
   return new Promise(resolve => {
     let running = 1;
     function done() {
       if (--running === 0) {
-        resolve(curriculum);
+        resolve(target);
       }
     }
-    readDirP({ root: getChallengesDirForLang(lang) })
+    readDirP(root, options)
       .on('data', file => {
         running++;
-        buildCurriculum(file, curriculum, lang).then(done);
+        cb(file, target).then(done);
       })
       .on('end', done);
   });
 };
 
-async function buildCurriculum(file, curriculum, lang) {
-  const { name, depth, path: filePath, stat } = file;
-  const createChallenge = createChallengeCreator(challengesDir, lang);
-  if (depth === 1 && stat.isDirectory()) {
-    // extract the superBlock info
-    const { order, name: superBlock } = superBlockInfo(name);
-    curriculum[superBlock] = { superBlock, order, blocks: {} };
-    return;
-  }
-  if (depth === 2 && stat.isDirectory()) {
-    const blockName = getBlockNameFromPath(filePath);
-    const metaPath = path.resolve(
-      __dirname,
-      `./challenges/_meta/${blockName}/meta.json`
+exports.getChallengesForLang = async function getChallengesForLang(lang) {
+  const root = getChallengesDirForLang(lang);
+  // scaffold the curriculum, first set up the superblocks, then recurse into
+  // the blocks
+  const curriculum = await walk(
+    root,
+    {},
+    { type: 'directories', depth: 1 },
+    buildSuperBlocks
+  );
+  const cb = (file, curriculum) => buildChallenges(file, curriculum, lang);
+  // fill the scaffold with the challenges
+  return walk(
+    root,
+    curriculum,
+    { type: 'files', fileFilter: ['*.md', '*.markdown'] },
+    cb
+  );
+};
+
+async function buildBlocks({ basename: blockName }, curriculum, superBlock) {
+  const metaPath = path.resolve(
+    __dirname,
+    `./challenges/_meta/${blockName}/meta.json`
+  );
+  const blockMeta = require(metaPath);
+  const { isUpcomingChange } = blockMeta;
+  if (typeof isUpcomingChange !== 'boolean') {
+    throw Error(
+      `meta file at ${metaPath} is missing 'isUpcomingChange', it must be 'true' or 'false'`
     );
-    const blockMeta = require(metaPath);
-    const { isUpcomingChange } = blockMeta;
-    if (typeof isUpcomingChange !== 'boolean') {
-      throw Error(
-        `meta file at ${metaPath} is missing 'isUpcomingChange', it must be 'true' or 'false'`
-      );
-    }
-
-    if (!isUpcomingChange || process.env.SHOW_UPCOMING_CHANGES === 'true') {
-      // add the block to the superBlock
-      const { name: superBlock } = superBlockInfoFromPath(filePath);
-      const blockInfo = { meta: blockMeta, challenges: [] };
-      curriculum[superBlock].blocks[name] = blockInfo;
-    }
-    return;
-  }
-  if (name === 'meta.json' || name === '.DS_Store') {
-    return;
   }
 
-  const block = getBlockNameFromPath(filePath);
-  const { name: superBlock } = superBlockInfoFromPath(filePath);
+  if (!isUpcomingChange || process.env.SHOW_UPCOMING_CHANGES === 'true') {
+    // add the block to the superBlock
+    const blockInfo = { meta: blockMeta, challenges: [] };
+    curriculum[superBlock].blocks[blockName] = blockInfo;
+  }
+}
+
+async function buildSuperBlocks({ path, fullPath }, curriculum) {
+  const { order, name: superBlock } = superBlockInfo(path);
+  curriculum[superBlock] = { superBlock, order, blocks: {} };
+
+  const cb = (file, curriculum) => buildBlocks(file, curriculum, superBlock);
+  return walk(fullPath, curriculum, { depth: 1, type: 'directories' }, cb);
+}
+
+async function buildChallenges({ path, filePath }, curriculum, lang) {
+  // path is relative to getChallengesDirForLang(lang)
+  const createChallenge = createChallengeCreator(challengesDir, lang);
+  const block = getBlockNameFromPath(path);
+  const { name: superBlock } = superBlockInfoFromPath(path);
   let challengeBlock;
 
   // TODO: this try block and process exit can all go once errors terminate the

--- a/curriculum/getChallenges.js
+++ b/curriculum/getChallenges.js
@@ -16,7 +16,6 @@ const { isAuditedCert } = require('../utils/is-audited');
 const { dasherize, nameify } = require('../utils/slugs');
 const { createPoly } = require('../utils/polyvinyl');
 const { blockNameify } = require('../utils/block-nameify');
-// const { supportedLangs } = require('./utils');
 const { helpCategoryMap } = require('../client/utils/challengeTypes');
 const {
   curriculum: curriculumLangs

--- a/curriculum/getChallenges.test.js
+++ b/curriculum/getChallenges.test.js
@@ -1,30 +1,28 @@
-/* global expect beforeAll */
+/* global expect */
 const path = require('path');
 
 const {
-  createChallengeCreator,
-  hasEnglishSourceCreator,
+  createChallenge,
+  hasEnglishSource,
   createCommentMap
 } = require('./getChallenges');
 
 const EXISTING_CHALLENGE_PATH = 'challenge.md';
 const MISSING_CHALLENGE_PATH = 'no/challenge.md';
 
-let hasEnglishSource;
-let createChallenge;
 const basePath = '__fixtures__';
 
 describe('create non-English challenge', () => {
   describe('createChallenge', () => {
     it('throws if lang is an invalid language', async () => {
-      createChallenge = createChallengeCreator(basePath, 'notlang');
       await expect(
-        createChallenge(EXISTING_CHALLENGE_PATH, {})
+        createChallenge(basePath, EXISTING_CHALLENGE_PATH, 'notlang', {})
       ).rejects.toThrow('notlang is not a accepted language');
     });
     it('throws an error if the source challenge is missing', async () => {
-      createChallenge = createChallengeCreator(basePath, 'chinese');
-      await expect(createChallenge(MISSING_CHALLENGE_PATH, {})).rejects.toThrow(
+      await expect(
+        createChallenge(basePath, MISSING_CHALLENGE_PATH, 'chinese', {})
+      ).rejects.toThrow(
         `Missing English challenge for
 ${MISSING_CHALLENGE_PATH}
 It should be in
@@ -33,19 +31,25 @@ It should be in
     });
   });
   describe('hasEnglishSource', () => {
-    beforeAll(() => {
-      hasEnglishSource = hasEnglishSourceCreator(basePath);
-    });
     it('returns a boolean', async () => {
-      const sourceExists = await hasEnglishSource(EXISTING_CHALLENGE_PATH);
+      const sourceExists = await hasEnglishSource(
+        basePath,
+        EXISTING_CHALLENGE_PATH
+      );
       expect(typeof sourceExists).toBe('boolean');
     });
     it('returns true if the English challenge exists', async () => {
-      const sourceExists = await hasEnglishSource(EXISTING_CHALLENGE_PATH);
+      const sourceExists = await hasEnglishSource(
+        basePath,
+        EXISTING_CHALLENGE_PATH
+      );
       expect(sourceExists).toBe(true);
     });
     it('returns false if the English challenge is missing', async () => {
-      const sourceExists = await hasEnglishSource(MISSING_CHALLENGE_PATH);
+      const sourceExists = await hasEnglishSource(
+        basePath,
+        MISSING_CHALLENGE_PATH
+      );
       expect(sourceExists).toBe(false);
     });
   });

--- a/curriculum/lib.js
+++ b/curriculum/lib.js
@@ -4,8 +4,6 @@ const {
   curriculum: curriculumLangs
 } = require('../client/i18n/allLangs').availableLangs;
 
-// const { supportedLangs } = require('./utils');
-
 function validateLang(lang) {
   invariant(lang, 'Please provide a language');
   invariant(

--- a/curriculum/package-lock.json
+++ b/curriculum/package-lock.json
@@ -2832,6 +2832,17 @@
           "requires": {
             "is-extglob": "^2.1.1"
           }
+        },
+        "readdirp": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+          "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "micromatch": "^3.1.10",
+            "readable-stream": "^2.0.2"
+          }
         }
       }
     },
@@ -3185,15 +3196,6 @@
         "abab": "^2.0.0",
         "whatwg-mimetype": "^2.2.0",
         "whatwg-url": "^7.0.0"
-      }
-    },
-    "dbly-linked-list": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/dbly-linked-list/-/dbly-linked-list-0.2.0.tgz",
-      "integrity": "sha512-Ool7y15f6JRDs0YKx7Dh9uiTb1jS1SZLNdT3Y2q16DlaEghXbMsmODS/XittjR2xztt1gJUpz7jVxpqAPF8VGg==",
-      "dev": true,
-      "requires": {
-        "lodash.isequal": "^4.5.0"
       }
     },
     "debug": {
@@ -3553,12 +3555,6 @@
         "through": "~2.3.1"
       }
     },
-    "eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
-      "dev": true
-    },
     "expand-brackets": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
@@ -3792,12 +3788,6 @@
       "requires": {
         "pend": "~1.2.0"
       }
-    },
-    "fifo": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/fifo/-/fifo-2.3.0.tgz",
-      "integrity": "sha1-GC3o3QYyqkfPaBbZvEMjMX1SWdw=",
-      "dev": true
     },
     "file-uri-to-path": {
       "version": "1.0.0",
@@ -4823,16 +4813,6 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-    "isflattenable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/isflattenable/-/isflattenable-1.1.0.tgz",
-      "integrity": "sha512-qr/kk8a8KmevVz0Sp899TdSAHg9ybc1HnFlFq/3ZW9G4a5IQsHz5fVnmq0poFMpCqI9wLPHSH9cCT2R1ctXoIQ==",
-      "dev": true,
-      "requires": {
-        "lodash.isarguments": "^3.1.0",
-        "lodash.isarray": "^3.0.4"
-      }
-    },
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
@@ -4861,15 +4841,6 @@
       "resolved": "https://registry.npmjs.org/joi-objectid/-/joi-objectid-2.0.0.tgz",
       "integrity": "sha1-VlSVc6Zrp5Xc9rniJt5fOy027Do=",
       "dev": true
-    },
-    "join-deep": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/join-deep/-/join-deep-1.2.1.tgz",
-      "integrity": "sha512-z1rVo21SUcDXtgWvToo8O2RfuMy6/ScnEWzyvVRRGYdWMrLqT0iGw/jkHxZ4BaBJGzTQxYhi0ZonsHlU+oJ8iw==",
-      "dev": true,
-      "requires": {
-        "reduce-deep": "^1.3.1"
-      }
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -5125,24 +5096,6 @@
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-      "dev": true
-    },
-    "lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-      "dev": true
-    },
-    "lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-      "dev": true
-    },
-    "lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
       "dev": true
     },
     "lodash.sortby": {
@@ -6480,15 +6433,6 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
-    "queue-cb": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/queue-cb/-/queue-cb-1.1.5.tgz",
-      "integrity": "sha512-PKsogFZgSyIYn9hFD401ul8RWJnTtdUw+owgvWwhcevsYwY/UvJIeIziibB61CLp7/wry5EWLHmXzjeXr441Nw==",
-      "dev": true,
-      "requires": {
-        "fifo": "^2.3.0"
-      }
-    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -6562,27 +6506,12 @@
       }
     },
     "readdirp": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "micromatch": "^3.1.10",
-        "readable-stream": "^2.0.2"
-      }
-    },
-    "readdirp-walk": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/readdirp-walk/-/readdirp-walk-1.7.0.tgz",
-      "integrity": "sha512-tGAXcAlxTM2I8SfOUniI/43eienxkywW5NuN3Ov1Qpngjnw8l1LcjSTBc6QwOpv9D0MTdPHb/wmPVKExbuYa0g==",
-      "dev": true,
-      "requires": {
-        "eventemitter3": "^3.1.0",
-        "graceful-fs": "^4.1.11",
-        "micromatch": "^3.1.10",
-        "readable-stream": "^2.0.2",
-        "walk-filtered": "^1.13.0"
+        "picomatch": "^2.2.1"
       }
     },
     "rechoir": {
@@ -6592,15 +6521,6 @@
       "dev": true,
       "requires": {
         "resolve": "^1.1.6"
-      }
-    },
-    "reduce-deep": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/reduce-deep/-/reduce-deep-1.3.1.tgz",
-      "integrity": "sha512-UJuIfS1er7MwsTQ5fkjgGo2gwM3WynmCg7VJLv/RqIU8xtCqrkFC922tWyD1dxeA+lC5pyUZi6JdIUKI6UubsA==",
-      "dev": true,
-      "requires": {
-        "isflattenable": "^1.1.0"
       }
     },
     "regenerate": {
@@ -7372,15 +7292,6 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
-      }
-    },
-    "stack-lifo": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/stack-lifo/-/stack-lifo-0.1.6.tgz",
-      "integrity": "sha512-fNXXK6AHbOIExOtJYPb1RlP8OXQr8tlpDNP5I78ZId9uK+MDCcDAkwGWTDACYLXAwOhaKLTYwkoSOihAt+/cLg==",
-      "dev": true,
-      "requires": {
-        "dbly-linked-list": "0.2.0"
       }
     },
     "stack-trace": {
@@ -8176,17 +8087,6 @@
       "dev": true,
       "requires": {
         "browser-process-hrtime": "^1.0.0"
-      }
-    },
-    "walk-filtered": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/walk-filtered/-/walk-filtered-1.24.0.tgz",
-      "integrity": "sha512-z4dwZ5IpNEfWVYEso60fsgrXpym65M+a03vumbnonJCrMll3H8JVy9xrU2RHpVGMr8rwlr5y+9qpr71h0RWdsA==",
-      "dev": true,
-      "requires": {
-        "join-deep": "^1.2.0",
-        "queue-cb": "^1.1.0",
-        "stack-lifo": "^0.1.6"
       }
     },
     "web-namespaces": {

--- a/curriculum/package.json
+++ b/curriculum/package.json
@@ -53,7 +53,7 @@
     "lodash": "^4.17.20",
     "mocha": "8.2.1",
     "puppeteer": "^5.3.1",
-    "readdirp-walk": "^1.7.0",
+    "readdirp": "^3.5.0",
     "rehype": "^11.0.0",
     "rework-visit": "^1.0.0",
     "string-similarity": "^4.0.2",

--- a/curriculum/utils.js
+++ b/curriculum/utils.js
@@ -5,8 +5,6 @@ const {
   curriculum: curriculumLangs
 } = require('../client/i18n/allLangs').availableLangs;
 
-// const supportedLangs = ['chinese', 'english'];
-
 exports.testedLang = function testedLang() {
   if (process.env.CURRICULUM_LOCALE) {
     if (curriculumLangs.includes(process.env.CURRICULUM_LOCALE)) {
@@ -19,5 +17,3 @@ exports.testedLang = function testedLang() {
     throw Error('LOCALE must be set for testing');
   }
 };
-
-// exports.supportedLangs = supportedLangs;


### PR DESCRIPTION
The api uses language to fetch the challenges. This PR sets the language to  `english`.  

This only really matters in one place. The 'Go to current challenge' button, which just uses the slug (which does not change between languages).

There are a lot of other places where the text is hard-coded to English in both the api and the client, but I'll address that in another PR.

Most of the changes are actually just refactors (and an update of `readdirp`).