### PR TITLE
feat(client): Add link to Code Radio in navigation bar

### DIFF
--- a/client/i18n/locales/chinese/translations.json
+++ b/client/i18n/locales/chinese/translations.json
@@ -55,6 +55,7 @@
     "sign-out": "退出",
     "curriculum": "课程",
     "forum": "论坛",
+    "radio": "Radio",
     "profile": "个人资料",
     "update-settings": "更新我的账号设置",
     "sign-me-out": "退出登录 freeCodeCamp",

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -57,6 +57,7 @@
     "sign-out": "Sign out",
     "curriculum": "Curriculum",
     "forum": "Forum",
+    "radio": "Radio",
     "profile": "Profile",
     "update-settings": "Update my account settings",
     "sign-me-out": "Sign me out of freeCodeCamp",

--- a/client/i18n/locales/espanol/translations.json
+++ b/client/i18n/locales/espanol/translations.json
@@ -57,6 +57,7 @@
     "sign-out": "Cerrar sesión",
     "curriculum": "Plan de estudio",
     "forum": "Foro",
+    "radio": "Radio",
     "profile": "Perfil",
     "update-settings": "Actualizar la configuración de mi cuenta",
     "sign-me-out": "Cerrar sesión en freeCodeCamp",

--- a/client/i18n/translations-schema.js
+++ b/client/i18n/translations-schema.js
@@ -62,6 +62,7 @@ const translationsSchema = {
     'sign-out': 'Sign out',
     curriculum: 'Curriculum',
     forum: 'Forum',
+    radio: 'Radio',
     profile: 'Profile',
     'update-settings': 'Update my account settings',
     'sign-me-out': 'Sign me out of freeCodeCamp',

--- a/client/src/components/Header/Header.test.js
+++ b/client/src/components/Header/Header.test.js
@@ -34,7 +34,8 @@ describe('<NavLinks />', () => {
     shallow.render(<AuthOrProfile {...landingPageProps} />);
     const result = shallow.getRenderOutput();
     expect(
-      hasForumNavItem(result) &&
+      hasRadioNavItem(result) &&
+        hasForumNavItem(result) &&
         hasCurriculumNavItem(result) &&
         hasSignInButton(result)
     ).toBeTruthy();
@@ -110,17 +111,24 @@ const navigationLinks = (component, navItem) => {
     .props;
 };
 
-const profileNavItem = component => component[2].children[0];
+const profileNavItem = component => component[3].children[0];
+
+const hasRadioNavItem = component => {
+  const { children, to } = navigationLinks(component, 0);
+  return (
+    children === 'buttons.radio' && to === 'https://coderadio.freecodecamp.org'
+  );
+};
 
 const hasForumNavItem = component => {
-  const { children, to } = navigationLinks(component, 0);
+  const { children, to } = navigationLinks(component, 1);
   return (
     children === 'buttons.forum' && to === 'https://forum.freecodecamp.org'
   );
 };
 
 const hasCurriculumNavItem = component => {
-  const { children, to } = navigationLinks(component, 1);
+  const { children, to } = navigationLinks(component, 2);
   return children === 'buttons.curriculum' && to === '/learn';
 };
 

--- a/client/src/components/Header/components/NavLinks.js
+++ b/client/src/components/Header/components/NavLinks.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link, SkeletonSprite, AvatarRenderer } from '../../helpers';
 import PropTypes from 'prop-types';
 import Login from '../components/Login';
-import { forumLocation } from '../../../../../config/env.json';
+import { forumLocation, radioLocation } from '../../../../../config/env.json';
 import { useTranslation } from 'react-i18next';
 
 const propTypes = {
@@ -18,8 +18,18 @@ export function AuthOrProfile({ user, pending }) {
   const isTopContributor =
     user && user.yearsTopContributor && user.yearsTopContributor.length > 0;
 
-  const CurriculumAndForumLinks = (
+  const NavigationLinks = (
     <>
+      <li>
+        <Link
+          className='nav-link'
+          external={true}
+          sameTab={false}
+          to={radioLocation}
+        >
+          {t('buttons.radio')}
+        </Link>
+      </li>
       <li>
         <Link
           className='nav-link'
@@ -47,7 +57,7 @@ export function AuthOrProfile({ user, pending }) {
   } else if (!isUserSignedIn) {
     return (
       <>
-        {CurriculumAndForumLinks}
+        {NavigationLinks}
         <Login data-test-label='landing-small-cta'>
           {t('buttons.sign-in')}
         </Login>
@@ -56,7 +66,7 @@ export function AuthOrProfile({ user, pending }) {
   } else {
     return (
       <>
-        {CurriculumAndForumLinks}
+        {NavigationLinks}
         <li>
           <Link className='nav-link' to={`/${user.username}`}>
             {t('buttons.profile')}

--- a/config/env.js
+++ b/config/env.js
@@ -15,6 +15,7 @@ const {
   API_LOCATION: apiLocation,
   FORUM_LOCATION: forumLocation,
   NEWS_LOCATION: newsLocation,
+  RADIO_LOCATION: radioLocation,
   CLIENT_LOCALE: clientLocale,
   CURRICULUM_LOCALE: curriculumLocale,
   SHOW_LOCALE_DROPDOWN_MENU: showLocaleDropdownMenu,
@@ -30,7 +31,8 @@ const locations = {
   homeLocation,
   apiLocation,
   forumLocation,
-  newsLocation
+  newsLocation,
+  radioLocation
 };
 
 module.exports = Object.assign(locations, {

--- a/cypress/integration/learn/common-components/navbar.js
+++ b/cypress/integration/learn/common-components/navbar.js
@@ -11,7 +11,7 @@ const selectors = {
 describe('Navbar', () => {
   beforeEach(() => {
     cy.visit('/');
-    cy.viewport(1200, 660);
+    cy.viewport(1300, 660);
   });
 
   it('Should render properly', () => {
@@ -51,7 +51,7 @@ describe('Navbar', () => {
 
   // have the curriculum and CTA on landing and /learn pages.
   it(
-    'Should have `Forum` and `Curriculum` links on landing and learn pages' +
+    'Should have `Radio`, `Forum`, and `Curriculum` links on landing and learn pages' +
       'page when not signed in',
     () => {
       cy.get(selectors.navigationLinks).contains('Forum');
@@ -61,6 +61,7 @@ describe('Navbar', () => {
       cy.url().should('include', '/learn');
       cy.get(selectors.navigationLinks).contains('Curriculum');
       cy.get(selectors.navigationLinks).contains('Forum');
+      cy.get(selectors.navigationLinks).contains('Radio');
     }
   );
 

--- a/sample.env
+++ b/sample.env
@@ -64,6 +64,7 @@ HOME_LOCATION='http://localhost:8000'
 API_LOCATION='http://localhost:3000'
 FORUM_LOCATION='https://forum.freecodecamp.org'
 NEWS_LOCATION='https://www.freecodecamp.org/news'
+RADIO_LOCATION='https://coderadio.freecodecamp.org'
 
 # ---------------------
 # Debugging Mode Keys


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `master` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Per https://github.com/freeCodeCamp/coderadio-client/issues/80#issuecomment-747625527, this PR adds a `Radio` link to the /learn navigation bar. The link opens a *new tab* for the CodeRadio client (I went with a new tab because campers are likely to run the radio in the background while continuing to work on the curriculum).

Following the existing pattern for the `forum` and `news` data, I added an environment variable for the `RADIO_LOCATION`, mapped it in the config, and verified that it worked in my local instance. 

I've updated the tests for the header component to reflect the change in links.