### PR TITLE
Fix broken rendering of root element introduction in basic CSS track

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/inherit-css-variables.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/inherit-css-variables.md
@@ -10,7 +10,7 @@ forumTopicId: 301088
 
 When you create a variable, it is available for you to use inside the selector in which you create it. It also is available in any of that selector's descendants. This happens because CSS variables are inherited, just like ordinary properties.
 
-To make use of inheritance, CSS variables are often defined in the <dfn>:root</dfn> element.
+To make use of inheritance, CSS variables are often defined in the `:root` element.
 
 `:root` is a <dfn>pseudo-class</dfn> selector that matches the root element of the document, usually the `html` element. By creating your variables in `:root`, they will be available globally and can be accessed from any other selector in the style sheet.
 


### PR DESCRIPTION
`<dfn>` doesn't seem to work properly on `:root` (likely due to the colon) - this breaks the rendering of the whole paragraph (current rendering can be observed [here](https://www.freecodecamp.org/learn/responsive-web-design/basic-css/inherit-css-variables) and in the screenshot below). Instead we're now using simple inline code.

Broken rendering:
![image](https://user-images.githubusercontent.com/519867/102691789-5dc3fc80-420f-11eb-9ae4-5a2a3b85aeb4.png)

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!-- Feel free to add any additional description of changes below this line -->
