### PR TITLE
fix(learn): teleport assertion output to user view

### DIFF
--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -155,7 +155,7 @@ function* executeTests(testRunner, tests, testTimeout = 5000) {
       } else {
         const { message, stack } = err;
         newTest.err = message + '\n' + stack;
-        newTest.stack = stack.replace(/ at eval.*/, '');
+        newTest.stack = stack?.replace(/ at eval.*/, '');
       }
       yield put(updateConsole(`${newTest.message}\n${newTest.stack || ''}`));
     } finally {

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -1,4 +1,3 @@
-/* eslint-disable prettier/prettier */
 import {
   delay,
   put,
@@ -156,7 +155,12 @@ function* executeTests(testRunner, tests, testTimeout = 5000) {
       } else {
         const { message, stack } = err;
         newTest.err = message + '\n' + stack;
-        newTest.stack = stack?.replace(/ (at eval|\()[\s\S]*/, '');
+
+        // Firefox handles errors differently, so if err.stack starts '@', it is Firefox,
+        // and err.message contains the assertion message
+        newTest.stack = /$@/.test(stack)
+          ? stack?.replace(/\s?(at eval|\()[\s\S]*/, '')
+          : `${err.message}\n`;
       }
       yield put(updateConsole(`${newTest.message}\n${newTest.stack || ''}`));
     } finally {

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -153,16 +153,11 @@ function* executeTests(testRunner, tests, testTimeout = 5000) {
         newTest.err = 'Test timed out';
         newTest.message = `${newTest.message} (${newTest.err})`;
       } else {
-        const { message, stack } = err;
+        const { message, stack } = err?.err ?? err;
         newTest.err = message + '\n' + stack;
-
-        // Firefox handles errors differently, so if err.stack starts '@', it is Firefox,
-        // and err.message contains the assertion message
-        newTest.stack = /$@/.test(stack)
-          ? stack?.replace(/\s?(at eval|\()[\s\S]*/, '')
-          : `${err.message}\n`;
+        newTest.stack = message;
       }
-      yield put(updateConsole(`${newTest.message}\n${newTest.stack || ''}`));
+      yield put(updateConsole(`${newTest.message}\n${newTest?.stack || ''}`));
     } finally {
       testResults.push(newTest);
     }

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -156,7 +156,6 @@ function* executeTests(testRunner, tests, testTimeout = 5000) {
       } else {
         const { message, stack } = err;
         newTest.err = message + '\n' + stack;
-        console.log(stack);
         newTest.stack = stack?.replace(/ (at eval|\()[\s\S]*/, '');
       }
       yield put(updateConsole(`${newTest.message}\n${newTest.stack || ''}`));

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -153,10 +153,7 @@ function* executeTests(testRunner, tests, testTimeout = 5000) {
         newTest.err = 'Test timed out';
         newTest.message = `${newTest.message} (${newTest.err})`;
       } else {
-        let { message, stack } = err?.err ?? err;
-        if (message.startsWith('<!DOCTYPE')) {
-          message = '';
-        }
+        const { message, stack } = err?.err ?? err;
         newTest.err = message + '\n' + stack;
         newTest.stack = message;
       }

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -94,8 +94,6 @@ export function* executeChallengeSaga() {
     const testResults = yield executeTests(testRunner, tests);
 
     yield put(updateTests(testResults));
-    console.log(testResults, testRunner);
-    // yield put(updateConsole(formatTestRunnerErrors(testResults)));
     yield put(updateConsole('// tests completed'));
     yield put(logsToConsole('// console output'));
   } catch (e) {
@@ -229,9 +227,3 @@ export function createExecuteChallengeSaga(types) {
     )
   ];
 }
-
-// Keep for PR testing (comment to annoy Mrugesh ;)
-// function formatTestRunnerErrors(testResults) {
-//   const testsWithError = testResults.filter(result => result.err);
-//   return testsWithError.map(({err}) => )
-// }

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -69,9 +69,9 @@ export function* executeChallengeSaga() {
     yield put(initLogs());
     yield put(initConsole('// running tests'));
     // reset tests to initial state
-    const tests = (yield select(
-      challengeTestsSelector
-    )).map(({ text, testString }) => ({ text, testString }));
+    const tests = (yield select(challengeTestsSelector)).map(
+      ({ text, testString }) => ({ text, testString })
+    );
     yield put(updateTests(tests));
 
     yield fork(takeEveryLog, consoleProxy);

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -153,7 +153,10 @@ function* executeTests(testRunner, tests, testTimeout = 5000) {
         newTest.err = 'Test timed out';
         newTest.message = `${newTest.message} (${newTest.err})`;
       } else {
-        const { message, stack } = err?.err ?? err;
+        let { message, stack } = err?.err ?? err;
+        if (message.startsWith('<!DOCTYPE')) {
+          message = '';
+        }
         newTest.err = message + '\n' + stack;
         newTest.stack = message;
       }

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -157,7 +157,7 @@ function* executeTests(testRunner, tests, testTimeout = 5000) {
         newTest.err = message + '\n' + stack;
         newTest.stack = stack.replace(/ at eval.*/, '');
       }
-      yield put(updateConsole(`${newTest.message}\n${newTest.stack}`));
+      yield put(updateConsole(`${newTest.message}\n${newTest.stack || ''}`));
     } finally {
       testResults.push(newTest);
     }

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import {
   delay,
   put,
@@ -69,9 +70,9 @@ export function* executeChallengeSaga() {
     yield put(initLogs());
     yield put(initConsole('// running tests'));
     // reset tests to initial state
-    const tests = (yield select(challengeTestsSelector)).map(
-      ({ text, testString }) => ({ text, testString })
-    );
+    const tests = (yield select(
+      challengeTestsSelector
+    )).map(({ text, testString }) => ({ text, testString }));
     yield put(updateTests(tests));
 
     yield fork(takeEveryLog, consoleProxy);
@@ -155,7 +156,8 @@ function* executeTests(testRunner, tests, testTimeout = 5000) {
       } else {
         const { message, stack } = err;
         newTest.err = message + '\n' + stack;
-        newTest.stack = stack?.replace(/ at eval.*/, '');
+        console.log(stack);
+        newTest.stack = stack?.replace(/ (at eval|\()[\s\S]*/, '');
       }
       yield put(updateConsole(`${newTest.message}\n${newTest.stack || ''}`));
     } finally {

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -94,6 +94,8 @@ export function* executeChallengeSaga() {
     const testResults = yield executeTests(testRunner, tests);
 
     yield put(updateTests(testResults));
+    console.log(testResults, testRunner);
+    // yield put(updateConsole(formatTestRunnerErrors(testResults)));
     yield put(updateConsole('// tests completed'));
     yield put(logsToConsole('// console output'));
   } catch (e) {
@@ -155,9 +157,9 @@ function* executeTests(testRunner, tests, testTimeout = 5000) {
       } else {
         const { message, stack } = err;
         newTest.err = message + '\n' + stack;
-        newTest.stack = stack;
+        newTest.stack = stack.replace(/ at eval.*/, '');
       }
-      yield put(updateConsole(newTest.message));
+      yield put(updateConsole(`${newTest.message}\n${newTest.stack}`));
     } finally {
       testResults.push(newTest);
     }
@@ -227,3 +229,9 @@ export function createExecuteChallengeSaga(types) {
     )
   ];
 }
+
+// Keep for PR testing (comment to annoy Mrugesh ;)
+// function formatTestRunnerErrors(testResults) {
+//   const testsWithError = testResults.filter(result => result.err);
+//   return testsWithError.map(({err}) => )
+// }

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/metric-imperial-converter.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/metric-imperial-converter.md
@@ -165,7 +165,6 @@ async (getUserInput) => {
     const data = await $.get(
       getUserInput('url') + '/api/convert?input=1//2min'
     );
-    console.log(data);
     const error = data.error ?? data;
     assert.equal(error, 'invalid number and unit');
   } catch (xhr) {

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/metric-imperial-converter.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/metric-imperial-converter.md
@@ -111,12 +111,12 @@ async (getUserInput) => {
   try {
     const data1 = await $.get(getUserInput('url') + '/api/convert?input=1gal');
     assert.equal(data1.initUnit, 'gal');
-    assert.equal(data1.returnUnit, 'L');
+    assert.equal(data1.returnUnit, 'L', 'expected some1 to be some2');
     const data2 = await $.get(getUserInput('url') + '/api/convert?input=10L');
-    assert.equal(data2.initUnit, 'L');
+    assert.equal(data2.initUnit, 'L', 'expected some2 to be some3');
     assert.equal(data2.returnUnit, 'gal');
     const data3 = await $.get(getUserInput('url') + '/api/convert?input=1l');
-    assert.equal(data3.initUnit, 'L');
+    assert.equal(data3.initUnit, 'L', 'expected some3 to be some4');
     assert.equal(data3.returnUnit, 'gal');
     const data4 = await $.get(getUserInput('url') + '/api/convert?input=10KM');
     assert.equal(data4.initUnit, 'km');

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/metric-imperial-converter.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/metric-imperial-converter.md
@@ -111,12 +111,12 @@ async (getUserInput) => {
   try {
     const data1 = await $.get(getUserInput('url') + '/api/convert?input=1gal');
     assert.equal(data1.initUnit, 'gal');
-    assert.equal(data1.returnUnit, 'L', 'expected some1 to be some2');
+    assert.equal(data1.returnUnit, 'L', 'For an input of "1gal", expected a returnUnit of "L"');
     const data2 = await $.get(getUserInput('url') + '/api/convert?input=10L');
-    assert.equal(data2.initUnit, 'L', 'expected some2 to be some3');
+    assert.equal(data2.initUnit, 'L', 'For an input of "10L", expected an initUnit of "L"');
     assert.equal(data2.returnUnit, 'gal');
     const data3 = await $.get(getUserInput('url') + '/api/convert?input=1l');
-    assert.equal(data3.initUnit, 'L', 'expected some3 to be some4');
+    assert.equal(data3.initUnit, 'L', 'For an input of "1l", expected an initUnit of "L"');
     assert.equal(data3.returnUnit, 'gal');
     const data4 = await $.get(getUserInput('url') + '/api/convert?input=10KM');
     assert.equal(data4.initUnit, 'km');

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/metric-imperial-converter.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/metric-imperial-converter.md
@@ -133,7 +133,8 @@ If my unit of measurement is invalid, returned will be `'invalid unit'`.
 async (getUserInput) => {
   try {
     const data = await $.get(getUserInput('url') + '/api/convert?input=1min');
-    assert(data.error === 'invalid unit' || data === 'invalid unit');
+    const error = data.error ?? data;
+    assert.equal(error, 'invalid unit');
   } catch (xhr) {
     throw new Error(xhr.responseText || xhr.message);
   }
@@ -148,7 +149,8 @@ async (getUserInput) => {
     const data = await $.get(
       getUserInput('url') + '/api/convert?input=1//2gal'
     );
-    assert(data.error === 'invalid number' || data === 'invalid number');
+    const error = data.error ?? data;
+    assert.equal(error, 'invalid number');
   } catch (xhr) {
     throw new Error(xhr.responseText || xhr.message);
   }
@@ -163,10 +165,9 @@ async (getUserInput) => {
     const data = await $.get(
       getUserInput('url') + '/api/convert?input=1//2min'
     );
-    assert(
-      data.error === 'invalid number and unit' ||
-        data === 'invalid number and unit'
-    );
+    console.log(data);
+    const error = data.error ?? data;
+    assert.equal(error, 'invalid number and unit');
   } catch (xhr) {
     throw new Error(xhr.responseText || xhr.message);
   }


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

I am not sure why this has not been implemented yet, as the groundwork was already there. So, this PR just adds any assertion errors to the user-visible console.

The reason the `.md` file is included in this PR, is to, _hopefully_, show a **best case** scenario of, well-written tests, combined with decent error handling - How informative it can be.

Previous output:
![image](https://user-images.githubusercontent.com/51722130/102907355-d6c08f80-446d-11eb-8233-3023b2f1c94a.png)

New output (errors are silly placeholders, please ignore):
![image](https://user-images.githubusercontent.com/51722130/102907471-fd7ec600-446d-11eb-9642-ff3351da6f52.png)

Full stack view output is still available in the browser console (however, this just points to the `frame-runner` anyway).