### PR TITLE
Fixed error when changing the default order of css properties

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/create-a-more-complex-shape-using-css-and-html.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/create-a-more-complex-shape-using-css-and-html.md
@@ -40,7 +40,7 @@ The `background-color` property of the `heart::after` selector should be pink.
 ```js
 const heartAfter = code.match(/\.heart::after\s*{[\s\S]+?[^\}]}/g)[0];
 assert(
-  /{\s*([\w\-]+\s*:\s*[\w]+\s*;\s*)*background-color\s*:\s*pink\s*(\}|;)/.test(heartAfter)
+  /({|;)\s*background-color\s*:\s*pink\s*(;|})/g.test(heartAfter)
 );
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/create-a-more-complex-shape-using-css-and-html.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/create-a-more-complex-shape-using-css-and-html.md
@@ -39,7 +39,7 @@ The `background-color` property of the `heart::after` selector should be pink.
 
 ```js
 assert(
-  code.match(/\.heart::after\s*?{[^\}]*?background-color\s*?:\s*?pink\s*?;/gi)
+  code.match(/\.heart::after{(\s*[\w\-]+\:\s*[\w\-]+\s*\;)*\s*background-color\s*:\s*pink\s*(}|;)/gi)
 );
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/create-a-more-complex-shape-using-css-and-html.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/create-a-more-complex-shape-using-css-and-html.md
@@ -37,7 +37,8 @@ Finally, in the `heart::before` selector, set its `content` property to an empty
 
 The `background-color` property of the `heart::after` selector should be pink.
 
-```jsconst heartAfter = code.match(/\.heart::after\s*{[\s\S]+?[^\}]}/g)[0];
+```js
+const heartAfter = code.match(/\.heart::after\s*{[\s\S]+?[^\}]}/g)[0];
 assert(
   /{\s*([\w\-]+\s*:\s*[\w]+\s*;\s*)*background-color\s*:\s*pink\s*(\}|;)/.test(heartAfter)
 );

--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/create-a-more-complex-shape-using-css-and-html.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/create-a-more-complex-shape-using-css-and-html.md
@@ -39,7 +39,7 @@ The `background-color` property of the `heart::after` selector should be pink.
 
 ```js
 assert(
-  code.match(/\.heart::after\s*?{\s*?background-color\s*?:\s*?pink\s*?;/gi)
+  code.match(/\.heart::after\s*?{[^\}]*?background-color\s*?:\s*?pink\s*?;/gi)
 );
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/create-a-more-complex-shape-using-css-and-html.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/create-a-more-complex-shape-using-css-and-html.md
@@ -37,10 +37,9 @@ Finally, in the `heart::before` selector, set its `content` property to an empty
 
 The `background-color` property of the `heart::after` selector should be pink.
 
-```js
-const heartAfter = code.match(/\.heart::after\s*{[\s\S]+?[^\}]}/g)[0];
+```jsconst heartAfter = code.match(/\.heart::after\s*{[\s\S]+?[^\}]}/g)[0];
 assert(
-  code.match(/\.heart::after{(\s*[\w\-]+\:\s*[\w\-]+\s*\;)*\s*background-color\s*:\s*pink\s*(}|;)/gi)
+  /{\s*([\w\-]+\s*:\s*[\w]+\s*;\s*)*background-color\s*:\s*pink\s*(\}|;)/.test(heartAfter)
 );
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/create-a-more-complex-shape-using-css-and-html.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/create-a-more-complex-shape-using-css-and-html.md
@@ -38,6 +38,7 @@ Finally, in the `heart::before` selector, set its `content` property to an empty
 The `background-color` property of the `heart::after` selector should be pink.
 
 ```js
+const heartAfter = code.match(/\.heart::after\s*{[\s\S]+?[^\}]}/g)[0];
 assert(
   code.match(/\.heart::after{(\s*[\w\-]+\:\s*[\w\-]+\s*\;)*\s*background-color\s*:\s*pink\s*(}|;)/gi)
 );


### PR DESCRIPTION
In the [challenge file](https://github.com/freecodecamp/freeCodeCamp/blob/master/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/create-a-more-complex-shape-using-css-and-html.md), `background-color` css property of `.heart::after` is defined first.
If the order of this property is changed, means if it's declared after another property (i.e. after `content`), test will be failed.
Error is due to Test Code, which doesn't match non-string characters in between `{` and `background-color: pink;`

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

#### Steps to Reproduce the Error:
Head to the [challenge](https://www.freecodecamp.org/learn/responsive-web-design/applied-visual-design/create-a-more-complex-shape-using-css-and-html) and change the order of `background-color` in `.heart::after`, Define it after `content` or any other property.
![Test failed while checking the code](https://user-images.githubusercontent.com/55982424/102997259-a7cc1b80-454a-11eb-8a38-8296a63aad99.png)
 