### PR TITLE
fix(curriculum): parse directives correctly

### DIFF
--- a/tools/challenge-md-parser/mdx/__fixtures__/ast-directives.json
+++ b/tools/challenge-md-parser/mdx/__fixtures__/ast-directives.json
@@ -1,0 +1,185 @@
+{
+  "type": "root",
+  "children": [
+    {
+      "type": "heading",
+      "depth": 1,
+      "children": [
+        {
+          "type": "text",
+          "value": "--description--",
+          "position": {
+            "start": { "line": 1, "column": 3, "offset": 2 },
+            "end": { "line": 1, "column": 18, "offset": 17 }
+          }
+        }
+      ],
+      "position": {
+        "start": { "line": 1, "column": 1, "offset": 0 },
+        "end": { "line": 1, "column": 18, "offset": 17 }
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "textDirective",
+          "name": "root",
+          "attributes": {},
+          "children": [],
+          "position": {
+            "start": { "line": 3, "column": 1, "offset": 19 },
+            "end": { "line": 3, "column": 6, "offset": 24 }
+          }
+        },
+        {
+          "type": "text",
+          "value": " appears, ",
+          "position": {
+            "start": { "line": 3, "column": 6, "offset": 24 },
+            "end": { "line": 3, "column": 16, "offset": 34 }
+          }
+        },
+        {
+          "type": "textDirective",
+          "name": "import",
+          "attributes": {},
+          "children": [],
+          "position": {
+            "start": { "line": 3, "column": 16, "offset": 34 },
+            "end": { "line": 3, "column": 23, "offset": 41 }
+          }
+        },
+        {
+          "type": "text",
+          "value": " appears",
+          "position": {
+            "start": { "line": 3, "column": 23, "offset": 41 },
+            "end": { "line": 3, "column": 31, "offset": 49 }
+          }
+        }
+      ],
+      "position": {
+        "start": { "line": 3, "column": 1, "offset": 19 },
+        "end": { "line": 3, "column": 31, "offset": 49 }
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "the next paragraph should appear",
+          "position": {
+            "start": { "line": 5, "column": 1, "offset": 51 },
+            "end": { "line": 5, "column": 33, "offset": 83 }
+          }
+        }
+      ],
+      "position": {
+        "start": { "line": 5, "column": 1, "offset": 51 },
+        "end": { "line": 5, "column": 33, "offset": 83 }
+      }
+    },
+    {
+      "type": "leafDirective",
+      "name": "import",
+      "attributes": {},
+      "children": [],
+      "position": {
+        "start": { "line": 7, "column": 1, "offset": 85 },
+        "end": { "line": 7, "column": 9, "offset": 93 }
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "even though it's an import directive, but if we use the full syntax ",
+          "position": {
+            "start": { "line": 9, "column": 1, "offset": 95 },
+            "end": { "line": 9, "column": 58, "offset": 152 }
+          }
+        },
+        {
+          "type": "inlineCode",
+          "value": "::directive-name{attr=\"name\" attr2=\"a/path\"}",
+          "position": {
+            "start": { "line": 9, "column": 58, "offset": 152 },
+            "end": { "line": 9, "column": 100, "offset": 194 }
+          }
+        }
+      ],
+      "position": {
+        "start": { "line": 9, "column": 1, "offset": 95 },
+        "end": { "line": 9, "column": 100, "offset": 194 }
+      }
+    },
+    {
+      "type": "leafDirective",
+      "name": "import",
+      "attributes": { "component": "name", "from": "script.md" },
+      "children": [],
+      "position": {
+        "start": { "line": 11, "column": 1, "offset": 196 },
+        "end": { "line": 11, "column": 44, "offset": 239 }
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "it goes.",
+          "position": {
+            "start": { "line": 13, "column": 1, "offset": 241 },
+            "end": { "line": 13, "column": 9, "offset": 249 }
+          }
+        }
+      ],
+      "position": {
+        "start": { "line": 13, "column": 1, "offset": 241 },
+        "end": { "line": 13, "column": 9, "offset": 249 }
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "::: name [inline-content] {key=val}\na container directive\n:::",
+          "position": {
+            "start": { "line": 15, "column": 1, "offset": 251 },
+            "end": { "line": 17, "column": 4, "offset": 312 }
+          }
+        }
+      ],
+      "position": {
+        "start": { "line": 15, "column": 1, "offset": 251 },
+        "end": { "line": 17, "column": 4, "offset": 312 }
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": ":::",
+          "position": {
+            "start": { "line": 19, "column": 1, "offset": 314 },
+            "end": { "line": 19, "column": 4, "offset": 317 }
+          }
+        }
+      ],
+      "position": {
+        "start": { "line": 19, "column": 1, "offset": 314 },
+        "end": { "line": 19, "column": 4, "offset": 317 }
+      }
+    }
+  ],
+  "position": {
+    "start": { "line": 1, "column": 1, "offset": 0 },
+    "end": { "line": 20, "column": 1, "offset": 318 }
+  }
+}

--- a/tools/challenge-md-parser/mdx/__fixtures__/with-directives.md
+++ b/tools/challenge-md-parser/mdx/__fixtures__/with-directives.md
@@ -1,0 +1,17 @@
+# --description--
+
+:root appears, :import appears
+
+the next paragraph should appear
+
+::import
+
+even though it's an import directive, but if we use the full syntax `::directive-name{attr="name" attr2="a/path"}`
+
+::import{component="name" from="script.md"}
+
+it goes.
+
+::: name [inline-content] {key=val}
+a container directive
+:::

--- a/tools/challenge-md-parser/mdx/__snapshots__/index.acceptance.test.js.snap
+++ b/tools/challenge-md-parser/mdx/__snapshots__/index.acceptance.test.js.snap
@@ -1,5 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`challenge parser it should not parse directives we do not use 1`] = `
+Object {
+  "description": "<section id=\\"description\\">
+<p>:root appears, :import appears</p>
+<p>the next paragraph should appear</p>
+<p>even though it's an import directive, but if we use the full syntax <code>::directive-name{attr=\\"name\\" attr2=\\"a/path\\"}</code></p>
+<p>it goes.</p>
+<p>::: name [inline-content] {key=val}
+a container directive
+:::</p>
+</section>",
+  "solutions": Array [
+    Object {},
+  ],
+  "tests": Array [],
+}
+`;
+
 exports[`challenge parser it should parse video questions 1`] = `
 Object {
   "description": "<section id=\\"description\\">

--- a/tools/challenge-md-parser/mdx/index.acceptance.test.js
+++ b/tools/challenge-md-parser/mdx/index.acceptance.test.js
@@ -53,4 +53,11 @@ describe('challenge parser', () => {
     );
     expect(parsed).toMatchSnapshot();
   });
+
+  it('it should not parse directives we do not use', async () => {
+    const parsed = await parseMD(
+      path.resolve(__dirname, '__fixtures__/with-directives.md')
+    );
+    expect(parsed).toMatchSnapshot();
+  });
 });

--- a/tools/challenge-md-parser/mdx/index.js
+++ b/tools/challenge-md-parser/mdx/index.js
@@ -37,14 +37,14 @@ const processor = unified()
   // the final five 'add' plugins insert content into file.data
   // TODO: rename test->hint everywhere? It should make things easier to reason
   // about.
-  .use(addTests)
-  .use(addVideoQuestion)
   .use(addSeed)
   .use(addSolution)
   // the directives will have been parsed and used by this point, any remaining
   // 'directives' will be from text like the css selector :root. These should be
   // converted back to text before they're added to the challenge object.
   .use(restoreDirectives)
+  .use(addVideoQuestion)
+  .use(addTests)
   .use(addText, ['description', 'instructions']);
 
 exports.parseMD = function parseMD(filename) {

--- a/tools/challenge-md-parser/mdx/index.js
+++ b/tools/challenge-md-parser/mdx/index.js
@@ -3,6 +3,7 @@ const remark = require('remark-parse');
 const directive = require('remark-directive');
 const frontmatter = require('remark-frontmatter');
 const addTests = require('./plugins/add-tests');
+const restoreDirectives = require('./plugins/restore-directives');
 const replaceImports = require('./plugins/replace-imports');
 const addFrontmatter = require('./plugins/add-frontmatter');
 const addText = require('./plugins/add-text');
@@ -33,14 +34,18 @@ const processor = unified()
   // ::use{component="Script"}
   // appears.
   .use(replaceImports)
-  // the final five plugins insert content into file.data
-  .use(addText, ['description', 'instructions'])
+  // the final five 'add' plugins insert content into file.data
   // TODO: rename test->hint everywhere? It should make things easier to reason
   // about.
   .use(addTests)
   .use(addVideoQuestion)
   .use(addSeed)
-  .use(addSolution);
+  .use(addSolution)
+  // the directives will have been parsed and used by this point, any remaining
+  // 'directives' will be from text like the css selector :root. These should be
+  // converted back to text before they're added to the challenge object.
+  .use(restoreDirectives)
+  .use(addText, ['description', 'instructions']);
 
 exports.parseMD = function parseMD(filename) {
   return new Promise((resolve, reject) => {

--- a/tools/challenge-md-parser/mdx/package-lock.json
+++ b/tools/challenge-md-parser/mdx/package-lock.json
@@ -287,17 +287,35 @@
       }
     },
     "mdast-util-directive": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-directive/-/mdast-util-directive-1.0.0.tgz",
-      "integrity": "sha512-04nOvmHrQfcgPQDAn9x0gW05vhqXmkGPP9G7o8BE+7Oy16oyTAgJpJyVFTscPyEzfsP7p7LSKJAXWqTCBvPjuw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-directive/-/mdast-util-directive-1.0.1.tgz",
+      "integrity": "sha512-VuO1za7BMtWMg8KA8eZrTBorEnCOOW5CXfIuNzUXe7YPie/wLgmNk/jxLMY8m+mzuqnO5eN0JuvlgFtO9EJpbQ==",
       "requires": {
-        "mdast-util-to-markdown": "^0.5.0",
+        "mdast-util-to-markdown": "^0.6.0",
         "parse-entities": "^2.0.0",
         "repeat-string": "^1.0.0",
         "stringify-entities": "^3.1.0",
         "unist-util-visit-parents": "^3.0.0"
       },
       "dependencies": {
+        "mdast-util-to-markdown": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.1.tgz",
+          "integrity": "sha512-4qJtZ0qdyYeexAXoOZiU0uHIFVncJAmCkHkSluAsvDaVWODtPyNEo9I1ns0T4ulxu2EHRH5u/bt1cV0pdHCX+A==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "longest-streak": "^2.0.0",
+            "mdast-util-to-string": "^2.0.0",
+            "parse-entities": "^2.0.0",
+            "repeat-string": "^1.0.0",
+            "zwitch": "^1.0.0"
+          }
+        },
+        "mdast-util-to-string": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
+          "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w=="
+        },
         "unist-util-visit-parents": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
@@ -417,12 +435,23 @@
       }
     },
     "micromark-extension-directive": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-1.0.0.tgz",
-      "integrity": "sha512-6FjvznI5GpUysZqGtTEMeDaC/D3FdWFVc3CC5gDZB3fBtqiaIRBhCNg4fbqvrFSC0T2eqRbO2dJ7ZFU86gAtEQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-1.1.1.tgz",
+      "integrity": "sha512-xkv00i9brg3LkOMleJc/mlDZlb2TF2TomSS0D4AVhWVDZx4OmuYxFlqtKHuiDXXiVp4mhcZfHsuWdvELdT7I9g==",
       "requires": {
-        "micromark": "~2.10.0",
+        "micromark": "~2.11.0",
         "parse-entities": "^2.0.0"
+      },
+      "dependencies": {
+        "micromark": {
+          "version": "2.11.2",
+          "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.2.tgz",
+          "integrity": "sha512-IXuP76p2uj8uMg4FQc1cRE7lPCLsfAXuEfdjtdO55VRiFO1asrCSQ5g43NmPqFtRwzEnEhafRVzn2jg0UiKArQ==",
+          "requires": {
+            "debug": "^4.0.0",
+            "parse-entities": "^2.0.0"
+          }
+        }
       }
     },
     "micromark-extension-frontmatter": {
@@ -566,6 +595,34 @@
       "integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
       "requires": {
         "mdast-util-from-markdown": "^0.8.0"
+      }
+    },
+    "remark-stringify": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-9.0.1.tgz",
+      "integrity": "sha512-mWmNg3ZtESvZS8fv5PTvaPckdL4iNlCHTt8/e/8oN08nArHRHjNZMKzA/YW3+p7/lYqIw4nx1XsjCBo/AxNChg==",
+      "requires": {
+        "mdast-util-to-markdown": "^0.6.0"
+      },
+      "dependencies": {
+        "mdast-util-to-markdown": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.1.tgz",
+          "integrity": "sha512-4qJtZ0qdyYeexAXoOZiU0uHIFVncJAmCkHkSluAsvDaVWODtPyNEo9I1ns0T4ulxu2EHRH5u/bt1cV0pdHCX+A==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "longest-streak": "^2.0.0",
+            "mdast-util-to-string": "^2.0.0",
+            "parse-entities": "^2.0.0",
+            "repeat-string": "^1.0.0",
+            "zwitch": "^1.0.0"
+          }
+        },
+        "mdast-util-to-string": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
+          "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w=="
+        }
       }
     },
     "repeat-string": {

--- a/tools/challenge-md-parser/mdx/package.json
+++ b/tools/challenge-md-parser/mdx/package.json
@@ -23,6 +23,7 @@
     "remark-frontmatter": "^3.0.0",
     "remark-html": "^12.0.0",
     "remark-parse": "^9.0.0",
+    "remark-stringify": "^9.0.1",
     "to-vfile": "^5.0.1",
     "unified": "^7.0.0",
     "unist-util-find": "^1.0.1",

--- a/tools/challenge-md-parser/mdx/plugins/replace-imports.js
+++ b/tools/challenge-md-parser/mdx/plugins/replace-imports.js
@@ -31,6 +31,10 @@ function plugin() {
     }
     const importPromises = importedFiles.map(async ({ attributes }) => {
       const { from, component } = attributes;
+      // if these are missing, bail, since it's not an import.
+      if (!from || !component) {
+        return null;
+      }
       const location = path.resolve(file.dirname, from);
       return await read(location)
         .then(parse)
@@ -68,7 +72,11 @@ function plugin() {
         remove(tree, { type: 'leafDirective', name: 'import' });
         next();
       })
-      .catch(next);
+      .catch(err => {
+        console.log('error processing ::import');
+        console.log(err);
+        next(err);
+      });
   }
 }
 

--- a/tools/challenge-md-parser/mdx/plugins/restore-directives.js
+++ b/tools/challenge-md-parser/mdx/plugins/restore-directives.js
@@ -3,8 +3,6 @@ const { matches } = require('unist-util-select');
 const directive = require('mdast-util-directive');
 var toMarkdown = require('mdast-util-to-markdown');
 
-// TODO: needs tests (and confirmation it doesn't break imports), but I think
-// this approach is sound.
 function plugin() {
   return transformer;
 

--- a/tools/challenge-md-parser/mdx/plugins/restore-directives.js
+++ b/tools/challenge-md-parser/mdx/plugins/restore-directives.js
@@ -1,0 +1,34 @@
+const visit = require('unist-util-visit');
+const { matches } = require('unist-util-select');
+const directive = require('mdast-util-directive');
+var toMarkdown = require('mdast-util-to-markdown');
+
+// TODO: needs tests (and confirmation it doesn't break imports), but I think
+// this approach is sound.
+function plugin() {
+  return transformer;
+
+  function transformer(tree) {
+    visit(tree, visitor);
+
+    function visitor(node, id, parent) {
+      // currently `remark-directive` seems to be ignoring containerDirectives
+      // but, assuming that will get fixed, we test for it anyway.
+      const isDirective =
+        matches('leafDirective', node) ||
+        matches('textDirective', node) ||
+        matches('containerDirective', node);
+
+      if (isDirective) {
+        parent.children[id] = {
+          type: 'text',
+          value: toMarkdown(node, {
+            extensions: [directive.toMarkdown]
+          }).trim()
+        };
+      }
+    }
+  }
+}
+
+module.exports = plugin;

--- a/tools/challenge-md-parser/mdx/plugins/restore-directives.test.js
+++ b/tools/challenge-md-parser/mdx/plugins/restore-directives.test.js
@@ -1,0 +1,66 @@
+/* global describe it expect */
+const cloneDeep = require('lodash/cloneDeep');
+const { selectAll } = require('unist-util-select');
+const find = require('unist-util-find');
+
+const restoreDirectives = require('./restore-directives');
+const directivesOriginalAST = require('../__fixtures__/ast-directives.json');
+
+describe('restore-directives', () => {
+  let directivesAST;
+  beforeEach(() => {
+    directivesAST = cloneDeep(directivesOriginalAST);
+  });
+
+  it('should return a function', () => {
+    expect.assertions(1);
+    const plugin = restoreDirectives();
+
+    expect(typeof plugin).toEqual('function');
+  });
+  // TODO: if remark-directive starts processing containers, add them to the
+  // tests
+  it('should remove any directives in the AST', () => {
+    expect.assertions(4);
+    const plugin = restoreDirectives();
+    let leaves = selectAll('leafDirective', directivesAST);
+    let text = selectAll('textDirective', directivesAST);
+    expect(leaves.length).toBe(2);
+    expect(text.length).toBe(2);
+    plugin(directivesAST);
+    leaves = selectAll('leafDirective', directivesAST);
+    text = selectAll('textDirective', directivesAST);
+    expect(leaves.length).toBe(0);
+    expect(text.length).toBe(0);
+  });
+
+  it('should put the original text into the AST', () => {
+    expect.assertions(4);
+    const plugin = restoreDirectives();
+
+    let nodeWithImport = find(
+      directivesAST,
+      node => node.value && node.value.includes('::import')
+    );
+    let nodeWithRoot = find(
+      directivesAST,
+      node => node.value && node.value.includes(':root')
+    );
+
+    expect(nodeWithImport).not.toBeTruthy();
+    expect(nodeWithRoot).not.toBeTruthy();
+    plugin(directivesAST);
+
+    nodeWithImport = find(
+      directivesAST,
+      node => node.value && node.value.includes('::import')
+    );
+    nodeWithRoot = find(
+      directivesAST,
+      node => node.value && node.value.includes(':root')
+    );
+
+    expect(nodeWithImport).toBeTruthy();
+    expect(nodeWithRoot).toBeTruthy();
+  });
+});

--- a/tools/challenge-md-parser/mdx/tools/full-parse.js
+++ b/tools/challenge-md-parser/mdx/tools/full-parse.js
@@ -1,10 +1,10 @@
 const { inspect } = require('util');
 const path = require('path');
 
-const { parsemd } = require('../index');
+const { parseMD } = require('../index');
 
 (async () => {
-  const fullPath = path.resolve(__dirname, '../__fixtures__/realistic.md');
-  const output = await parsemd(fullPath);
+  const fullPath = path.resolve(__dirname, './example.md');
+  const output = await parseMD(fullPath);
   console.log(inspect(output, null, null, true));
 })();

--- a/tools/challenge-md-parser/mdx/tools/parse-md.js
+++ b/tools/challenge-md-parser/mdx/tools/parse-md.js
@@ -2,7 +2,6 @@ const { read } = require('to-vfile');
 const remark = require('remark');
 const directives = require('remark-directive');
 const stringify = require('remark-stringify');
-// const html = require('remark-html');
 
 (async () => {
   const path = './example.md';

--- a/tools/challenge-md-parser/mdx/tools/parse-md.js
+++ b/tools/challenge-md-parser/mdx/tools/parse-md.js
@@ -1,12 +1,16 @@
 const { read } = require('to-vfile');
 const remark = require('remark');
-const html = require('remark-html');
+const directives = require('remark-directive');
+const stringify = require('remark-stringify');
+// const html = require('remark-html');
 
 (async () => {
   const path = './example.md';
   const file = await read(path);
   const contents = await remark()
-    .use(html)
+    .use(directives)
+    .use(() => tree => console.dir(tree, { depth: null, colors: true }))
+    .use(stringify)
     .process(file);
   console.log(contents);
 })();


### PR DESCRIPTION
This prevents description, instruction, video question or hint text like `:root` from breaking challenge rendering.  We use some directives (::import and ::id), but, in general, they should be converted back to text before the challenge is rendered.

Closes #40491