### PR TITLE
Convert response testcase regex handles any variable name

### DIFF
--- a/curriculum/challenges/english/04-data-visualization/json-apis-and-ajax/get-json-with-the-javascript-fetch-method.md
+++ b/curriculum/challenges/english/04-data-visualization/json-apis-and-ajax/get-json-with-the-javascript-fetch-method.md
@@ -48,7 +48,7 @@ Your code should use `then` to convert the response to JSON.
 ```js
 assert(
   code.match(
-    /\.then\s*\(\s*\(?(?<var>\w+))?\s*=>\s*\k<var>\s*\.json\s*\(\s*\)\s*\)/g
+    /\.then\s*\(\s*\(?(?<var>\w+)\)?\s*=>\s*\k<var>\s*\.json\s*\(\s*\)\s*\)/g
   )
 );
 ```

--- a/curriculum/challenges/english/04-data-visualization/json-apis-and-ajax/get-json-with-the-javascript-fetch-method.md
+++ b/curriculum/challenges/english/04-data-visualization/json-apis-and-ajax/get-json-with-the-javascript-fetch-method.md
@@ -48,7 +48,7 @@ Your code should use `then` to convert the response to JSON.
 ```js
 assert(
   code.match(
-    /\.then\s*\(\s*(response|\(\s*response\s*\))\s*=>\s*response\s*\.json\s*\(\s*\)\s*\)/g
+    /\.then\s*\(\s*\(?(?<var>\w+))?\s*=>\s*\k<var>\s*\.json\s*\(\s*\)\s*\)/g
   )
 );
 ```


### PR DESCRIPTION
Testcase previously required that variable be named exactly "response". Changes will allow variable of any name to be used.
Example: res can now be used and tests still pass.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

Using variable name `response` is definitely typical, but I do not think we should enforce it in this case.


**Regex Speed Difference**
| Approach | Steps | 
| :---------- | :---------------| 
|Previous Approach| 68-71 Steps (based upon `(`, `)` around variable name )| 
|New Regex|64 steps