### PR TITLE
fix(learn): change requirements for positive and negative lookaheads

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/positive-and-negative-lookahead.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/positive-and-negative-lookahead.md
@@ -36,7 +36,7 @@ checkPass.test(password); // Returns true
 
 # --instructions--
 
-Use lookaheads in the `pwRegex` to match passwords that are greater than 5 characters long, do not begin with numbers, and have two consecutive digits.
+Use lookaheads in the `pwRegex` to match passwords that are greater than 5 characters long, and have two consecutive digits.
 
 # --hints--
 
@@ -70,22 +70,22 @@ Your regex should match `"abc123"`
 assert(pwRegex.test('abc123'));
 ```
 
-Your regex should not match `"1234"`
+Your regex should not match `"12345"`
 
 ```js
-assert(!pwRegex.test('1234'));
+assert(!pwRegex.test('12345'));
 ```
 
-Your regex should not match `"8pass99"`
+Your regex should match `"8pass99"`
 
 ```js
-assert(!pwRegex.test('8pass99'));
+assert(pwRegex.test('8pass99'));
 ```
 
-Your regex should not match `"12abcde"`
+Your regex should not match `"1a2bcde"`
 
 ```js
-assert(!pwRegex.test('12abcde'));
+assert(!pwRegex.test('1a2bcde'));
 ```
 
 Your regex should match `"astr1on11aut"`
@@ -107,5 +107,5 @@ let result = pwRegex.test(sampleWord);
 # --solutions--
 
 ```js
-var pwRegex =  /^\D(?=\w{5})(?=\w*\d{2})/;
+let pwRegex =  /(?=\w{6})(?=\w*\d{2})/;
 ```


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #35700

<!-- Feel free to add any additional description of changes below this line -->
@ieahleen I would appreciate your feedback on this - specifically based on your comment on the issue. I would say the example code describes what you were looking for about clarification on _asserting, but not matching_.