### PR TITLE
fix(tools): Validate `curriculum_locale`

### DIFF
--- a/tools/scripts/build/ensure-env.js
+++ b/tools/scripts/build/ensure-env.js
@@ -17,6 +17,14 @@ function checkClientLocale() {
   }
 }
 
+function checkCurriculumLocale() {
+  if (!availableLangs.curriculum.includes(process.env.CURRICULUM_LOCALE)) {
+    throw Error(
+      `CURRICULUM_LOCALE, ${process.env.CURRICULUM_LOCALE}, is not an available language in client/i18n/allLangs.js`
+    );
+  }
+}
+
 if (FREECODECAMP_NODE_ENV !== 'development') {
   const locationKeys = [
     'homeLocation',
@@ -64,8 +72,10 @@ if (FREECODECAMP_NODE_ENV !== 'development') {
     throw Error("SHOW_UPCOMING_CHANGES should never be 'true' in production");
 
   checkClientLocale();
+  checkCurriculumLocale();
 } else {
   checkClientLocale();
+  checkCurriculumLocale();
 }
 
 fs.writeFileSync(`${clientPath}/config/env.json`, JSON.stringify(env));


### PR DESCRIPTION
Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `master` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

I believe the issues I was facing with running this branch (and the learn map PR) locally were due to missing the `CURRICULUM_LOCALE` value from my `.env` file. We had the structure to validate the `CLIENT_LOCALE` value, so I've mirrored that for the `CURRICULUM_LOCALE` as well.