### PR TITLE
fix(tool-panel): unify help option casing

### DIFF
--- a/client/src/templates/Challenges/components/Tool-Panel.js
+++ b/client/src/templates/Challenges/components/Tool-Panel.js
@@ -75,7 +75,7 @@ function ToolPanel({
               href={guideUrl}
               target='_blank'
             >
-              {'Get a hint'}
+              {'Get a Hint'}
             </MenuItem>
           ) : null}
           {videoUrl ? (
@@ -84,7 +84,7 @@ function ToolPanel({
               className='btn-invert'
               onClick={openVideoModal}
             >
-              {'Watch a video'}
+              {'Watch a Video'}
             </MenuItem>
           ) : null}
           <MenuItem
@@ -92,7 +92,7 @@ function ToolPanel({
             className='btn-invert'
             onClick={openHelpModal}
           >
-            {'Ask for help'}
+            {'Ask for Help'}
           </MenuItem>
         </DropdownButton>
       </div>

--- a/client/src/templates/Challenges/components/Tool-Panel.js
+++ b/client/src/templates/Challenges/components/Tool-Panel.js
@@ -75,7 +75,7 @@ function ToolPanel({
               href={guideUrl}
               target='_blank'
             >
-              {'Get a Hint'}
+              {'Get a hint'}
             </MenuItem>
           ) : null}
           {videoUrl ? (


### PR DESCRIPTION
The "Get a hint" option is cased differently than the other two options.
This commit makes the casing of this option consistent with the others.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Current appearance ([example lesson](https://www.freecodecamp.org/learn/responsive-web-design/basic-css/adjust-the-margin-of-an-element)):

![image](https://user-images.githubusercontent.com/2754821/103471696-263d7000-4d38-11eb-9374-ae67eba7fa6a.png)


<!-- Feel free to add any additional description of changes below this line -->
