### PR TITLE
fix(learn): correct LCG equation in description

### DIFF
--- a/curriculum/challenges/chinese/10-coding-interview-prep/rosetta-code/linear-congruential-generator.md
+++ b/curriculum/challenges/chinese/10-coding-interview-prep/rosetta-code/linear-congruential-generator.md
@@ -9,7 +9,7 @@ forumTopicId: 385266
 
 The [linear congruential generator](<https://en.wikipedia.org/wiki/linear congruential generator>) is a very simple example of a [random number generator](<http://rosettacode.org/wiki/random number generator>). All linear congruential generators use this formula:
 
-$$r\_{n + 1} = a \\times r_n + c \\pmod m$$
+$$r_{n + 1} = (a \times r_n + c)\mod m$$
 
 Where:
 

--- a/curriculum/challenges/chinese/10-coding-interview-prep/rosetta-code/linear-congruential-generator.md
+++ b/curriculum/challenges/chinese/10-coding-interview-prep/rosetta-code/linear-congruential-generator.md
@@ -9,7 +9,7 @@ forumTopicId: 385266
 
 The [linear congruential generator](<https://en.wikipedia.org/wiki/linear congruential generator>) is a very simple example of a [random number generator](<http://rosettacode.org/wiki/random number generator>). All linear congruential generators use this formula:
 
-$$r_{n + 1} = (a \times r_n + c) \bmod m$$
+$$r\_{n + 1} = a \\times r_n + c \\pmod m$$
 
 Where:
 

--- a/curriculum/challenges/chinese/10-coding-interview-prep/rosetta-code/linear-congruential-generator.md
+++ b/curriculum/challenges/chinese/10-coding-interview-prep/rosetta-code/linear-congruential-generator.md
@@ -9,7 +9,7 @@ forumTopicId: 385266
 
 The [linear congruential generator](<https://en.wikipedia.org/wiki/linear congruential generator>) is a very simple example of a [random number generator](<http://rosettacode.org/wiki/random number generator>). All linear congruential generators use this formula:
 
-$$r_{n + 1} = (a \times r_n + c)\mod m$$
+$$r_{n + 1} = (a \times r_n + c) \bmod m$$
 
 Where:
 

--- a/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/linear-congruential-generator.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/linear-congruential-generator.md
@@ -9,7 +9,7 @@ forumTopicId: 385266
 
 The [linear congruential generator](<https://en.wikipedia.org/wiki/linear congruential generator>) is a very simple example of a [random number generator](<http://rosettacode.org/wiki/random number generator>). All linear congruential generators use this formula:
 
-$$r\_{n + 1} = a \\times r_n + c \\pmod m$$
+$$r_{n + 1} = (a \times r_n + c)\mod m$$
 
 Where:
 

--- a/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/linear-congruential-generator.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/linear-congruential-generator.md
@@ -9,7 +9,7 @@ forumTopicId: 385266
 
 The [linear congruential generator](<https://en.wikipedia.org/wiki/linear congruential generator>) is a very simple example of a [random number generator](<http://rosettacode.org/wiki/random number generator>). All linear congruential generators use this formula:
 
-$$r_{n + 1} = (a \times r_n + c)\mod m$$
+$$r_{n + 1} = (a \times r_n + c) \bmod m$$
 
 Where:
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!-- Feel free to add any additional description of changes below this line -->
In the Rosetta Code: Linear congruential generator (LCG), the equation for the LCG in the description is difficult to interpret for order of operations.  While working through the challenge, I interpreted the equation from the description as r(n+1) = (a * r(n)) + (c * mod m).

Correcting parentheses in markdown to reflect operator precedence and be consistent with references.

- [Wikipedia article referenced from challenge](https://en.wikipedia.org/wiki/Linear_congruential_generator)
- [Assignment in COS126 course from Princeton](https://www.cs.princeton.edu/courses/archive/spring03/cs126/assignments/cycle.html)