### PR TITLE
feat(client): assetPrefix and hosting client app

### DIFF
--- a/client/gatsby-config.js
+++ b/client/gatsby-config.js
@@ -3,7 +3,8 @@ const path = require('path');
 const {
   clientLocale,
   curriculumLocale,
-  homeLocation
+  homeLocation,
+  assetsLocation
 } = require('../config/env');
 const {
   buildChallenges,
@@ -22,6 +23,7 @@ module.exports = {
     title: 'freeCodeCamp',
     siteUrl: homeLocation
   },
+  assetPrefix: assetsLocation,
   pathPrefix: pathPrefix,
   plugins: [
     'gatsby-plugin-react-helmet',

--- a/config/env.js
+++ b/config/env.js
@@ -15,6 +15,7 @@ const {
   API_LOCATION: apiLocation,
   FORUM_LOCATION: forumLocation,
   NEWS_LOCATION: newsLocation,
+  ASSETS_LOCATION: assetsLocation,
   CLIENT_LOCALE: clientLocale,
   CURRICULUM_LOCALE: curriculumLocale,
   SHOW_LOCALE_DROPDOWN_MENU: showLocaleDropdownMenu,
@@ -30,7 +31,8 @@ const locations = {
   homeLocation,
   apiLocation,
   forumLocation,
-  newsLocation
+  newsLocation,
+  assetsLocation
 };
 
 module.exports = Object.assign(locations, {

--- a/sample.env
+++ b/sample.env
@@ -64,6 +64,7 @@ HOME_LOCATION='http://localhost:8000'
 API_LOCATION='http://localhost:3000'
 FORUM_LOCATION='https://forum.freecodecamp.org'
 NEWS_LOCATION='https://www.freecodecamp.org/news'
+ASSETS_LOCATION='http://localhost:8000'
 
 # ---------------------
 # Debugging Mode Keys

--- a/tools/scripts/build/ensure-env.js
+++ b/tools/scripts/build/ensure-env.js
@@ -30,7 +30,8 @@ if (FREECODECAMP_NODE_ENV !== 'development') {
     'homeLocation',
     'apiLocation',
     'forumLocation',
-    'newsLocation'
+    'newsLocation',
+    'assetsLocation'
   ];
   const deploymentKeys = [
     'clientLocale',


### PR DESCRIPTION
Add a `assetPrefix` to Gatsby config to host all static files and manage hosting on production better.