### PR TITLE
fix(tools): Validate server-side keys

### DIFF
--- a/client/i18n/validate-keys.js
+++ b/client/i18n/validate-keys.js
@@ -54,9 +54,12 @@ const readComponentCode = filePath => {
 };
 
 const clientCodebase = readComponentCode(path.join(process.cwd() + '/src'));
+const serverCodebase = readComponentCode(
+  path.join(process.cwd() + '/../api-server/server')
+);
 
 for (const key of keyStrings) {
-  if (!clientCodebase.includes(key)) {
+  if (!clientCodebase.includes(key) && !serverCodebase.includes(key)) {
     console.warn(`The translation key '${key}' appears to be unused.`);
   }
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ ] My pull request targets the `master` branch of freeCodeCamp.
- [ ] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

With Tom's PR to update the flash message keys, I discovered that the script I wrote to validate key usage wasn't catching keys that were used in the `api-server` exclusively. This PR updates the script to read that codebase as well, which should result in a more accurate reporting of unused translation keys.

Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>

