### PR TITLE
fix(docs): Add WSL2 setup issues warning to clone repo section

### DIFF
--- a/docs/how-to-setup-freecodecamp-locally.md
+++ b/docs/how-to-setup-freecodecamp-locally.md
@@ -90,6 +90,12 @@ This is essential, as it allows you to work on your own copy of freeCodeCamp on 
 
 [Cloning](https://help.github.com/articles/cloning-a-repository/) is where you **download** a copy of a repository from a `remote` location that is either owned by you or by someone else. In your case, this remote location is your `fork` of freeCodeCamp's repository that should be available at `https://github.com/YOUR_USER_NAME/freeCodeCamp`.
 
+> [!WARNING]
+> If you are working on a WSL2 Linux Distro, you might get performance and stability issues by running this project in a folder which is shared between Windows and WSL2 (e.g. `/mnt/c/Users/`).
+> Therefore we recommend to clone this repo into a folder which is mainly used by your WSL2 Linux Distro and not directly shared with Windows (e.g. `~/PROJECTS/`).
+>
+> See [this GitHub Issue](https://github.com/freeCodeCamp/freeCodeCamp/issues/40632) for further Information about this problem.
+
 Run these commands on your local machine:
 
 1. Open a Terminal / Command Prompt / Shell in your projects directory


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

In favor of #40632 This PR will add a warning for those which try to start the FreeCodeCamp Sourcecode inside of a WSL2 based Linux distro. The warning has been placed into the `Clone your fork from GitHub` Section, so WSL2 users will directly clone the repo into the right folder and therefore avoid performance and stability issues while still guarenteeing the docs' reading flow.