### PR TITLE
feat(tools): add action to check for translations

### DIFF
--- a/.github/workflows/no-prs-to-translation.yml
+++ b/.github/workflows/no-prs-to-translation.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/github-script@v3
-      if: startsWith(github.head_ref, 'i18n-sync-learn-') == false
+      if: github.event.pull_request.user.login != "github-actions[bot]"
       with:
         script: |
           throw "You appear to be translating files directly on GitHub. Please use Crowdin instead."

--- a/.github/workflows/no-prs-to-translation.yml
+++ b/.github/workflows/no-prs-to-translation.yml
@@ -1,6 +1,6 @@
 name: "No changing translated files on GitHub"
 on:
-  pull_request:
+  pull_request_target:
     branches:
     - 'master'
     paths:

--- a/.github/workflows/no-prs-to-translation.yml
+++ b/.github/workflows/no-prs-to-translation.yml
@@ -1,25 +1,25 @@
-name: "No changing translated files on GitHub"
+name: 'No changing translated files on GitHub'
 on:
   pull_request_target:
     branches:
-    - 'master'
+      - 'master'
     paths:
-    - 'curriculum/challenges/**'
-    - '!curriculum/challenges/english/**'
+      - 'curriculum/challenges/**'
+      - '!curriculum/challenges/english/**'
 
 jobs:
   has-translation:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/github-script@v3
-      if: github.event.pull_request.user.login != "github-actions[bot]"
-      with:
-        github-token: ${{secrets.GITHUB_TOKEN}}
-        script: |
-          await github.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: 'You appear to be translating files directly on GitHub. Please visit https://translate.freecodecamp.org instead.'
-          })
-          throw "You appear to be translating files directly on GitHub. Please visit https://translate.freecodecamp.org instead."
+      - uses: actions/github-script@v3
+        if: github.event.pull_request.user.login != "github-actions[bot]"
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            await github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'You appear to be adding/modifying/deleting non-English curriculum files directly on GitHub. If you are trying to make translation changes to a curriculum challenge file, please visit https://translate.freecodecamp.org/curriculum instead.'
+            })
+            throw "You appear to be translating files directly on GitHub. Please visit https://translate.freecodecamp.org instead."

--- a/.github/workflows/no-prs-to-translation.yml
+++ b/.github/workflows/no-prs-to-translation.yml
@@ -15,4 +15,4 @@ jobs:
       if: github.event.pull_request.user.login != "github-actions[bot]"
       with:
         script: |
-          throw "You appear to be translating files directly on GitHub. Please use Crowdin instead."
+          throw "You appear to be translating files directly on GitHub. Please visit https://translate.freecodecamp.org instead."

--- a/.github/workflows/no-prs-to-translation.yml
+++ b/.github/workflows/no-prs-to-translation.yml
@@ -1,0 +1,18 @@
+name: "No changing translated files on GitHub"
+on:
+  pull_request:
+    branches:
+    - 'master'
+    paths:
+    - 'curriculum/challenges/**'
+    - '!curriculum/challenges/english/**'
+
+jobs:
+  has-translation:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/github-script@v3
+      if: startsWith(github.head_ref, 'i18n-sync-learn-') == false
+      with:
+        script: |
+          throw "You appear to be translating files directly on GitHub. Please use Crowdin instead."

--- a/.github/workflows/no-prs-to-translation.yml
+++ b/.github/workflows/no-prs-to-translation.yml
@@ -14,5 +14,12 @@ jobs:
     - uses: actions/github-script@v3
       if: github.event.pull_request.user.login != "github-actions[bot]"
       with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
+          await github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: 'You appear to be translating files directly on GitHub. Please visit https://translate.freecodecamp.org instead.'
+          })
           throw "You appear to be translating files directly on GitHub. Please visit https://translate.freecodecamp.org instead."


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `master` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This adds a very basic GitHub action to help catch PRs that modify translated curriculum challenges. Here's the logic:

1. A PR changes only English challenges (files within `curriculum/challenges/english`):
  - The workflow will *not* run.
2. A PR changes non-English challenges (files within `curriculum/challenges/!english`):
  - The workflow will run and will throw an error to fail.
3. The Crowdin integration opens a PR to update the translated files:
  - The workflow will run, but because the PR author is `github-actions` the action will not hit the error block and will pass.

I created a sample repository with three PRs to demonstrate these three scenarios:
https://github.com/nhcarrigan/actions-testing/pulls

@RandellDawson would you mind giving this a look?