### PR TITLE
fix: Change crowdin.yml config to upload all challenge sections

### DIFF
--- a/curriculum/crowdin.yml
+++ b/curriculum/crowdin.yml
@@ -7,8 +7,8 @@
 
 files: [
  {
-  "source" : "/curriculum/challenges/english/01-responsive-web-design/**/*.md",
-  "translation" : "/curriculum/challenges/%language%/01-responsive-web-design/**/%original_file_name%",
+  "source" : "/curriculum/challenges/english/**/*.md",
+  "translation" : "/curriculum/challenges/%language%/**/%original_file_name%",
   "ignore": [
     "/**/part-[0-9][0-9][0-9].md",
     "/curriculum/challenges/english/[0-9][0-9]-certificates/**/*.*"


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

This PR adjusts the `curriculum/crowdin.yml` file config so that all the challenge file sections are uploaded instead of just the `Responsive Web Design` section we were using for test purposes.

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
