### PR TITLE
feat(tools): add action to check for translations

### DIFF
--- a/.github/workflows/no-prs-to-translation.yml
+++ b/.github/workflows/no-prs-to-translation.yml
@@ -1,0 +1,25 @@
+name: 'No changing translated files on GitHub'
+on:
+  pull_request_target:
+    branches:
+      - 'master'
+    paths:
+      - 'curriculum/challenges/**'
+      - '!curriculum/challenges/english/**'
+
+jobs:
+  has-translation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v3
+        if: github.event.pull_request.user.login != "github-actions[bot]"
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            await github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'You appear to be adding/modifying/deleting non-English curriculum files directly on GitHub. If you are trying to make translation changes to a curriculum challenge file, please visit https://translate.freecodecamp.org/curriculum instead.'
+            })
+            throw "You appear to be translating files directly on GitHub. Please visit https://translate.freecodecamp.org instead."


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ ] My pull request targets the `master` branch of freeCodeCamp.
- [ ] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Per a discussion with @RandellDawson, we believe the translation PRs have all been resolved. I've cherrypicked the commit that adds the action to prevent PRs from changing non-English challenge files out of the `next-i18n-client` branch and am bringing it in to `master` to allow us to avoid accidental merges to translated challenge files.
