### PR TITLE
chore: Modify crowdin upload workflow to not upload translations anymore

### DIFF
--- a/.github/workflows/crowdin-i18n-download.yml
+++ b/.github/workflows/crowdin-i18n-download.yml
@@ -1,9 +1,6 @@
 name: Crowdin i18n Download Translations
 on:
   workflow_dispatch:
-  push:
-    branches:
-    - test-crowdin-download
 
 jobs:
   
@@ -36,7 +33,7 @@ jobs:
           
           # pull-request
           localization_branch_name: i18n-sync-learn-processed-chinese-translations
-          create_pull_request: false
+          create_pull_request: true
           pull_request_title: 'chore(i18n,learn): Processed chinese translations from crowdin'
           pull_request_body: ''
           pull_request_labels: 'scope: i18n, scope: learn, crowdin-sync, language: Chinese'

--- a/.github/workflows/crowdin-i18n-upload.yml
+++ b/.github/workflows/crowdin-i18n-upload.yml
@@ -1,9 +1,6 @@
 name: Crowdin i18n Upload Action
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - test-crowdin-upload
 
 jobs:
   
@@ -27,7 +24,7 @@ jobs:
         with:
           # uploads
           upload_sources: true
-          upload_translations: true
+          upload_translations: false
           auto_approve_imported: false
           import_eq_suggestions: false
 


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

This PR simply changes the `.github/workflows/crowdin-i18n-upload.yml` to no longer upload translations.  We only needed to do this one time to get the current Chinese translations we had on `master` up to Crowdin, for translation memory purposes.  All future runs of the workflow only needs to upload English file's additions/changes.

I also went ahead and removed the `on push` by branch, since we now can just manually run the workflow on master when we want.  At a later date, we will set the workflow on a schedule.

Lastly, I changed the download workflow to actually create a PR in addition to creating a branch for the downloaded translations.