### PR TITLE
feat: action to create issue on english changes

### DIFF
--- a/.github/ENGLISH_CHANGES_ISSUE.md
+++ b/.github/ENGLISH_CHANGES_ISSUE.md
@@ -1,0 +1,12 @@
+---
+title: "i18n: Modifications have been made to English file(s) on the client"
+assignees:
+labels: "platform: client, scope: i18n"
+---
+
+It looks like a recent commit ({{ sha }}) made changes to one or more of the English translation files. The same changes should be made to the other languages. Or, if the changes aren't needed, feel free to close this issue.
+
+|         | Changes not needed | or PR to fix |                       |
+| ------- | ------------------ | ------------ | --------------------- |
+| Espanol |                    |              | @freeCodeCamp/espanol |
+| Chinese |                    |              | @freeCodeCamp/chinese |

--- a/.github/workflows/english-changes.yml
+++ b/.github/workflows/english-changes.yml
@@ -1,0 +1,24 @@
+# This will create an issue when a push to master 
+# contains changes to any of the files listed below
+
+name: Client English Changes
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - 'client/i18n/locales/english/translations.json'
+      - 'client/i18n/locales/english/intro.json'
+
+jobs:
+  has-english-changes:
+    name: Check for changes to client English i18n files
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: JasonEtco/create-an-issue@v2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        filename: .github/ENGLISH_CHANGES_ISSUE.md

--- a/.github/workflows/english-changes.yml
+++ b/.github/workflows/english-changes.yml
@@ -5,7 +5,8 @@ name: Client English Changes
 
 on:
   push:
-    branches: [ master ]
+    # Change to master when next is merged into it
+    branches: [ next-i18n-client ]
     paths:
       - 'client/i18n/locales/english/translations.json'
       - 'client/i18n/locales/english/intro.json'


### PR DESCRIPTION
This adds an action to create an issue when english text changes. It can serve as a temp way to make sure the translations are kept in sync with english until we move the files to crowdin.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
