### PR TITLE
fix(learn): address escaped backticks

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript-rpg-game/part-026.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript-rpg-game/part-026.md
@@ -7,7 +7,7 @@ dashedName: part-26
 
 # --description--
 
-Add double quote marks around the word "Store" in the line "You see a sign that says Store." Before each quotation mark add a `\` to signal that the following quote is not the end of the string, but should instead appear inside the string. This is called escaping.
+Add double quote marks around the word "Store" in the line "You see a sign that says Store." Before each quotation mark add a <code>\\</code> to signal that the following quote is not the end of the string, but should instead appear inside the string. This is called escaping.
 
 # --hints--
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/escape-sequences-in-strings.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/escape-sequences-in-strings.md
@@ -60,7 +60,7 @@ assert(/FirstLine\n/.test(myStr));
 assert(/\n\t/.test(myStr));
 ```
 
-`SecondLine` should be preceded by the backslash character `\`
+`SecondLine` should be preceded by the backslash character <code>\\</code>
 
 ```js
 assert(/\\SecondLine/.test(myStr));

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/escape-sequences-in-strings.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/escape-sequences-in-strings.md
@@ -30,7 +30,7 @@ You will need to use escape sequences to insert special characters correctly. Yo
 
 Here is the text with the escape sequences written out.
 
-"FirstLine```newline``tab``backslash```SecondLine`newline`ThirdLine"
+"FirstLine`newline tab backslash`SecondLine`newline`ThirdLine"
 
 # --hints--
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/escape-sequences-in-strings.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/escape-sequences-in-strings.md
@@ -30,7 +30,7 @@ You will need to use escape sequences to insert special characters correctly. Yo
 
 Here is the text with the escape sequences written out.
 
-"FirstLine`newline``tab``backslash`SecondLine`newline`ThirdLine"
+"FirstLine<code>newline</code><code>tab</code><code>backslash</code>SecondLine`newline`ThirdLine"
 
 # --hints--
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/escape-sequences-in-strings.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/escape-sequences-in-strings.md
@@ -30,7 +30,7 @@ You will need to use escape sequences to insert special characters correctly. Yo
 
 Here is the text with the escape sequences written out.
 
-"FirstLine`newline tab backslash`SecondLine`newline`ThirdLine"
+"FirstLine`newline``tab``backslash`SecondLine`newline`ThirdLine"
 
 # --hints--
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/escaping-literal-quotes-in-strings.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/escaping-literal-quotes-in-strings.md
@@ -11,7 +11,7 @@ dashedName: escaping-literal-quotes-in-strings
 
 When you are defining a string you must start and end with a single or double quote. What happens when you need a literal quote: `"` or `'` inside of your string?
 
-In JavaScript, you can <dfn>escape</dfn> a quote from considering it as an end of string quote by placing a <dfn>backslash</dfn> (`\`) in front of the quote.
+In JavaScript, you can <dfn>escape</dfn> a quote from considering it as an end of string quote by placing a <dfn>backslash</dfn> (<code>\\</code>) in front of the quote.
 
 `var sampleStr = "Alan said, \"Peter is learning JavaScript\".";`
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/quoting-strings-with-single-quotes.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/quoting-strings-with-single-quotes.md
@@ -29,8 +29,9 @@ goodStr = 'Jake asks Finn, "Hey, let\'s go on an adventure?"';
 badStr = 'Finn responds, "Let's go!"'; // Throws an error
 ```
 
-In the <dfn>goodStr</dfn> above, you can use both quotes safely by using the backslash <code>\\</code> as an escape character. **Note**  
-The backslash <code>\\</code> should not be confused with the forward slash `/`. They do not do the same thing.
+In the <dfn>goodStr</dfn> above, you can use both quotes safely by using the backslash <code>\\</code> as an escape character.
+
+**Note:** The backslash <code>\\</code> should not be confused with the forward slash `/`. They do not do the same thing.
 
 # --instructions--
 
@@ -40,7 +41,7 @@ Right now, the `<a>` tag in the string uses double quotes everywhere. You will n
 
 # --hints--
 
-You should remove all the `backslashes` (<code>\</code>).
+You should remove all the `backslashes` (<code>\\</code>).
 
 ```js
 assert(

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/quoting-strings-with-single-quotes.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/quoting-strings-with-single-quotes.md
@@ -40,7 +40,7 @@ Right now, the `<a>` tag in the string uses double quotes everywhere. You will n
 
 # --hints--
 
-You should remove all the `backslashes` (`\`).
+You should remove all the `backslashes` (<code>\</code>).
 
 ```js
 assert(

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/quoting-strings-with-single-quotes.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/quoting-strings-with-single-quotes.md
@@ -29,8 +29,8 @@ goodStr = 'Jake asks Finn, "Hey, let\'s go on an adventure?"';
 badStr = 'Finn responds, "Let's go!"'; // Throws an error
 ```
 
-In the <dfn>goodStr</dfn> above, you can use both quotes safely by using the backslash `\` as an escape character. **Note**  
-The backslash `\` should not be confused with the forward slash `/`. They do not do the same thing.
+In the <dfn>goodStr</dfn> above, you can use both quotes safely by using the backslash <code>\\</code> as an escape character. **Note**  
+The backslash <code>\\</code> should not be confused with the forward slash `/`. They do not do the same thing.
 
 # --instructions--
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/debugging/catch-mixed-usage-of-single-and-double-quotes.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/debugging/catch-mixed-usage-of-single-and-double-quotes.md
@@ -22,7 +22,7 @@ const quoteInString = "Groucho Marx once said 'Quote me as saying I was mis-quot
 const uhOhGroucho = 'I've had a perfectly wonderful evening, but this wasn't it.';
 ```
 
-Of course, it is okay to use only one style of quotes. You can escape the quotes inside the string by using the backslash (`\`) escape character:
+Of course, it is okay to use only one style of quotes. You can escape the quotes inside the string by using the backslash (<code>\\</code>) escape character:
 
 ```js
 // Correct use of same quotes:

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-letters-of-the-alphabet.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-letters-of-the-alphabet.md
@@ -28,8 +28,7 @@ matStr.match(bgRegex); // Returns null
 
 Match all the letters in the string `quoteSample`.
 
-**Note**  
-Be sure to match both upper- and lowercase **letters**.\*\*\*\*
+**Note**: Be sure to match both uppercase and lowercase **letters**.
 
 # --hints--
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-letters-of-the-alphabet.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-letters-of-the-alphabet.md
@@ -28,7 +28,7 @@ matStr.match(bgRegex); // Returns null
 
 Match all the letters in the string `quoteSample`.
 
-**Note**: Be sure to match both uppercase and lowercase **letters**.
+**Note**: Be sure to match both uppercase and lowercase letters.
 
 # --hints--
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/reuse-patterns-using-capture-groups.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/reuse-patterns-using-capture-groups.md
@@ -12,7 +12,7 @@ Some patterns you search for will occur multiple times in a string. It is wastef
 
 You can search for repeat substrings using <dfn>capture groups</dfn>. Parentheses, `(` and `)`, are used to find repeat substrings. You put the regex of the pattern that will repeat in between the parentheses.
 
-To specify where that repeat string will appear, you use a backslash (`\`) and then a number. This number starts at 1 and increases with each additional capture group you use. An example would be `\1` to match the first group.
+To specify where that repeat string will appear, you use a backslash (<code>\\</code>) and then a number. This number starts at 1 and increases with each additional capture group you use. An example would be `\1` to match the first group.
 
 The example below matches any word that occurs twice separated by a space:
 

--- a/curriculum/challenges/english/05-apis-and-microservices/basic-node-and-express/start-a-working-express-server.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/basic-node-and-express/start-a-working-express-server.md
@@ -8,7 +8,7 @@ dashedName: start-a-working-express-server
 
 # --description--
 
-In the first two lines of the file `myApp.js`, you can see how easy it is to create an Express app object. This object has several methods, and you will learn many of them in these challenges. One fundamental method is `app.listen(port)`. It tells your server to listen on a given port, putting it in running state. For testing reasons, we need the app to be running in the background so we added this method in the \`server.js\` file for you.
+In the first two lines of the file `myApp.js`, you can see how easy it is to create an Express app object. This object has several methods, and you will learn many of them in these challenges. One fundamental method is `app.listen(port)`. It tells your server to listen on a given port, putting it in running state. For testing reasons, we need the app to be running in the background so we added this method in the `server.js` file for you.
 
 Let’s serve our first string! In Express, routes takes the following structure: `app.METHOD(PATH, HANDLER)`. METHOD is an http method in lowercase. PATH is a relative path on the server (it can be a string, or even a regular expression). HANDLER is a function that Express calls when the route is matched. Handlers take the form `function(req, res) {...}`, where req is the request object, and res is the response object. For example, the handler
 

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/personal-library.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/personal-library.md
@@ -109,7 +109,7 @@ async (getUserInput) => {
 };
 ```
 
-You can send a <b>POST</b> request containing `comment` as the form body data to `/api/books/{_id}` to add a comment to a book. The returned response will be the books object similar to <b>GET</b> `/api/books/{_id}` request in an earlier test. If `comment` is not included in the request, return the string \`missing required field comment\`\`. If no book is found, return the string `no book exists`.
+You can send a <b>POST</b> request containing `comment` as the form body data to `/api/books/{_id}` to add a comment to a book. The returned response will be the books object similar to <b>GET</b> `/api/books/{_id}` request in an earlier test. If `comment` is not included in the request, return the string `missing required field comment`. If no book is found, return the string `no book exists`.
 
 ```js
 async (getUserInput) => {

--- a/curriculum/challenges/english/09-information-security/information-security-with-helmetjs/ask-browsers-to-access-your-site-via-https-only-with-helmet.hsts.md
+++ b/curriculum/challenges/english/09-information-security/information-security-with-helmetjs/ask-browsers-to-access-your-site-via-https-only-with-helmet.hsts.md
@@ -14,7 +14,7 @@ HTTP Strict Transport Security (HSTS) is a web security policy which helps to pr
 
 # --instructions--
 
-Configure `helmet.hsts()` to use HTTPS for the next 90 days. Pass the config object `{maxAge: timeInSeconds, force: true}`. You can create a variable \`ninetyDaysInSeconds = 90\*24\*60\*60;\` to use for the \`timeInSeconds\`. Repl.it already has hsts enabled. To override its settings you need to set the field "force" to true in the config object. We will intercept and restore the Repl.it header, after inspecting it for testing.
+Configure `helmet.hsts()` to use HTTPS for the next 90 days. Pass the config object `{maxAge: timeInSeconds, force: true}`. You can create a variable `ninetyDaysInSeconds = 90\*24\*60\*60;` to use for the `timeInSeconds`. Repl.it already has hsts enabled. To override its settings you need to set the field "force" to true in the config object. We will intercept and restore the Repl.it header, after inspecting it for testing.
 
 Note: Configuring HTTPS on a custom website requires the acquisition of a domain, and a SSL/TSL Certificate.
 

--- a/curriculum/challenges/english/09-information-security/information-security-with-helmetjs/ask-browsers-to-access-your-site-via-https-only-with-helmet.hsts.md
+++ b/curriculum/challenges/english/09-information-security/information-security-with-helmetjs/ask-browsers-to-access-your-site-via-https-only-with-helmet.hsts.md
@@ -14,7 +14,7 @@ HTTP Strict Transport Security (HSTS) is a web security policy which helps to pr
 
 # --instructions--
 
-Configure `helmet.hsts()` to use HTTPS for the next 90 days. Pass the config object `{maxAge: timeInSeconds, force: true}`. You can create a variable `ninetyDaysInSeconds = 90\*24\*60\*60;` to use for the `timeInSeconds`. Repl.it already has hsts enabled. To override its settings you need to set the field "force" to true in the config object. We will intercept and restore the Repl.it header, after inspecting it for testing.
+Configure `helmet.hsts()` to use HTTPS for the next 90 days. Pass the config object `{maxAge: timeInSeconds, force: true}`. You can create a variable `ninetyDaysInSeconds = 90*24*60*60;` to use for the `timeInSeconds`. Repl.it already has hsts enabled. To override its settings you need to set the field "force" to true in the config object. We will intercept and restore the Repl.it header, after inspecting it for testing.
 
 Note: Configuring HTTPS on a custom website requires the acquisition of a domain, and a SSL/TSL Certificate.
 

--- a/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/lzw-compression.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/lzw-compression.md
@@ -14,7 +14,7 @@ You can read a complete description of it in the [Wikipedia article](https://en.
 
 # --instructions--
 
-Write a function that takes two parameters. The first parameter is a boolean where \`true\` indicates compress and \`false\` indicates decompress. The second parameter is either a string or an array to be processed. If it is a string to be compressed, return an array of numbers. If it's an array of numbers to be decompressed, return a string.
+Write a function that takes two parameters. The first parameter is a boolean where `true` indicates compress and `false` indicates decompress. The second parameter is either a string or an array to be processed. If it is a string to be compressed, return an array of numbers. If it's an array of numbers to be decompressed, return a string.
 
 # --hints--
 

--- a/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/s-expressions.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/s-expressions.md
@@ -22,9 +22,9 @@ Newlines and other whitespace may be ignored unless contained within a quoted st
 
 Handling escaped quotes inside a string is optional; thus "`(foo"bar)`" may be treated as a string "`foo"bar`", or as an error.
 
-For this, the reader need not recognize "`\`" for escaping, but should, in addition, recognize numbers if the language has appropriate data types.
+For this, the reader need not recognize "<ocde>\\</code>" for escaping, but should, in addition, recognize numbers if the language has appropriate data types.
 
-Note that with the exception of "`()"`" ("`\`" if escaping is supported) and whitespace there are no special characters. Anything else is allowed without quotes.
+Note that with the exception of "`()"`" ("<code>\\</code>`" if escaping is supported) and whitespace there are no special characters. Anything else is allowed without quotes.
 
 The reader should be able to read the following input
 

--- a/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/s-expressions.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/s-expressions.md
@@ -24,7 +24,7 @@ Handling escaped quotes inside a string is optional; thus "`(foo"bar)`" may be t
 
 For this, the reader need not recognize "<ocde>\\</code>" for escaping, but should, in addition, recognize numbers if the language has appropriate data types.
 
-Note that with the exception of "`()"`" ("<code>\\</code>`" if escaping is supported) and whitespace there are no special characters. Anything else is allowed without quotes.
+Note that with the exception of "`()`" ("<code>\\</code>" if escaping is supported) and whitespace there are no special characters. Anything else is allowed without quotes.
 
 The reader should be able to read the following input
 

--- a/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/s-expressions.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/s-expressions.md
@@ -24,7 +24,7 @@ Handling escaped quotes inside a string is optional; thus "`(foo"bar)`" may be t
 
 For this, the reader need not recognize "<ocde>\\</code>" for escaping, but should, in addition, recognize numbers if the language has appropriate data types.
 
-Note that with the exception of "`()`" ("<code>\\</code>" if escaping is supported) and whitespace there are no special characters. Anything else is allowed without quotes.
+Note that with the exception of "`()"`" ("<code>\\</code>" if escaping is supported) and whitespace there are no special characters. Anything else is allowed without quotes.
 
 The reader should be able to read the following input
 

--- a/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/s-expressions.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/s-expressions.md
@@ -22,7 +22,7 @@ Newlines and other whitespace may be ignored unless contained within a quoted st
 
 Handling escaped quotes inside a string is optional; thus "`(foo"bar)`" may be treated as a string "`foo"bar`", or as an error.
 
-For this, the reader need not recognize "<ocde>\\</code>" for escaping, but should, in addition, recognize numbers if the language has appropriate data types.
+For this, the reader need not recognize "<code>\\</code>" for escaping, but should, in addition, recognize numbers if the language has appropriate data types.
 
 Note that with the exception of "`()"`" ("<code>\\</code>" if escaping is supported) and whitespace there are no special characters. Anything else is allowed without quotes.
 

--- a/curriculum/challenges/english/10-coding-interview-prep/take-home-projects/build-a-nightlife-coordination-app.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/take-home-projects/build-a-nightlife-coordination-app.md
@@ -22,7 +22,7 @@ Here are the specific user stories you should implement for this project:
 
 **Hint:** Try using the [Yelp API](https://www.yelp.com/developers/documentation/v3) to find venues in the cities your users search for. If you use Yelp's API, be sure to mention so in your app.
 
-When you are done, make sure a working demo of your project is hosted somewhere public. Then submit the URL to it in the \`Solution Link\` field. Optionally, also submit a link to your project's source code in the \`GitHub Link\` field.
+When you are done, make sure a working demo of your project is hosted somewhere public. Then submit the URL to it in the `Solution Link` field. Optionally, also submit a link to your project's source code in the `GitHub Link` field.
 
 # --solutions--
 

--- a/curriculum/challenges/english/10-coding-interview-prep/take-home-projects/build-a-voting-app.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/take-home-projects/build-a-voting-app.md
@@ -28,7 +28,7 @@ Here are the specific user stories you should implement for this project:
 
 **User Story:** As an authenticated user, if you don't like the options on a poll, you can create a new option.
 
-When you are done, make sure a working demo of your project is hosted somewhere public. Then submit the URL to it in the \`Solution Link\` field. Optionally, also submit a link to your project's source code in the \`GitHub Link\` field.
+When you are done, make sure a working demo of your project is hosted somewhere public. Then submit the URL to it in the `Solution Link` field. Optionally, also submit a link to your project's source code in the `GitHub Link` field.
 
 # --solutions--
 

--- a/curriculum/challenges/english/10-coding-interview-prep/take-home-projects/build-an-image-search-abstraction-layer.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/take-home-projects/build-an-image-search-abstraction-layer.md
@@ -18,7 +18,7 @@ Here are the specific user stories you should implement for this project:
 
 **User Story:** You can get a list of the most recently submitted search strings.
 
-When you are done, make sure a working demo of your project is hosted somewhere public. Then submit the URL to it in the \`Solution Link\` field. Optionally, also submit a link to your project's source code in the \`GitHub Link\` field.
+When you are done, make sure a working demo of your project is hosted somewhere public. Then submit the URL to it in the `Solution Link` field. Optionally, also submit a link to your project's source code in the `GitHub Link` field.
 
 # --solutions--
 

--- a/curriculum/challenges/english/10-coding-interview-prep/take-home-projects/chart-the-stock-market.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/take-home-projects/chart-the-stock-market.md
@@ -20,7 +20,7 @@ Here are the specific user stories you should implement for this project:
 
 **User Story:** You can see changes in real-time when any other user adds or removes a stock. For this you will need to use Web Sockets.
 
-When you are done, make sure a working demo of your project is hosted somewhere public. Then submit the URL to it in the \`Solution Link\` field. Optionally, also submit a link to your project's source code in the \`GitHub Link\` field.
+When you are done, make sure a working demo of your project is hosted somewhere public. Then submit the URL to it in the `Solution Link` field. Optionally, also submit a link to your project's source code in the `GitHub Link` field.
 
 # --solutions--
 


### PR DESCRIPTION
Addresses the instances of escaped backticks - where a backtick is
preceded by a backslash.  In most cases, this was left over from the
old parser. In some cases, a backtick was intended to be wrapped in
code tags and has been adjusted accordingly.

This issue came to light due to a bug in the translation flow on
Crowdin.

Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `master` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
