### PR TITLE
fix(tools) Improve efficiency of the Hide Non-translated Strings GitHub action

### DIFF
--- a/tools/crowdin/actions/hide-non-translated-strings/index.js
+++ b/tools/crowdin/actions/hide-non-translated-strings/index.js
@@ -6,7 +6,10 @@ const matter = require('gray-matter');
 const { getFiles } = require('../../utils/files');
 const { getStrings, updateFileString } = require('../../utils/strings');
 
-const createChallengeTitleLookup = (lookup, { fileId, path: crowdinFilePath }) => {
+const createChallengeTitleLookup = (
+  lookup,
+  { fileId, path: crowdinFilePath }
+) => {
   const challengeFilePath = path.join(
     __dirname,
     '/../../../../',
@@ -17,7 +20,7 @@ const createChallengeTitleLookup = (lookup, { fileId, path: crowdinFilePath }) =
     const {
       data: { title: challengeTitle }
     } = matter(challengeContent);
-    return { ...lookup, [fileId]: challengeTitle }
+    return { ...lookup, [fileId]: challengeTitle };
   } catch (err) {
     console.log(err.name);
     console.log(err.message);
@@ -26,21 +29,23 @@ const createChallengeTitleLookup = (lookup, { fileId, path: crowdinFilePath }) =
 };
 
 const hideNonTranslatedStrings = async projectId => {
-  console.log('start hiding non-translated strings...');
+  console.log('hide non-translated strings...');
   const crowdinFiles = await getFiles(projectId);
   if (crowdinFiles && crowdinFiles.length) {
-    const challengeTitleLookup = crowdinFiles
-      .reduce(createChallengeTitleLookup, {});
+    const challengeTitleLookup = crowdinFiles.reduce(
+      createChallengeTitleLookup,
+      {}
+    );
     const crowdinStrings = await getStrings({ projectId });
     if (crowdinStrings && crowdinStrings.length) {
       for (let string of crowdinStrings) {
-        const challengeTitle = challengeTitleLookup[string.fileId]
+        const challengeTitle = challengeTitleLookup[string.data.fileId];
         await updateFileString({ projectId, string, challengeTitle });
       }
     }
   }
-  console.log('hiding non-translated strings complete');
+  console.log('complete');
 };
 
 const projectId = process.env.CROWDIN_PROJECT_ID;
-hideNonTranslatedStrings(2);
+hideNonTranslatedStrings(projectId);

--- a/tools/crowdin/actions/hide-non-translated-strings/index.js
+++ b/tools/crowdin/actions/hide-non-translated-strings/index.js
@@ -4,27 +4,38 @@ const fs = require('fs');
 const path = require('path');
 const matter = require('gray-matter');
 const { getFiles } = require('../../utils/files');
-const { updateFileStrings } = require('../../utils/strings');
+const { getStrings, updateFileString } = require('../../utils/strings');
+
+const createChallengeTitleLookup = (lookup, { fileId, path: crowdinFilePath }) => {
+  const challengeFilePath = path.join(
+    __dirname,
+    '/../../../../',
+    crowdinFilePath
+  );
+  try {
+    const challengeContent = fs.readFileSync(challengeFilePath);
+    const {
+      data: { title: challengeTitle }
+    } = matter(challengeContent);
+    return { ...lookup, [fileId]: challengeTitle }
+  } catch (err) {
+    console.log(err.name);
+    console.log(err.message);
+  }
+  return lookup;
+};
 
 const hideNonTranslatedStrings = async projectId => {
   console.log('start hiding non-translated strings...');
   const crowdinFiles = await getFiles(projectId);
   if (crowdinFiles && crowdinFiles.length) {
-    for (let { fileId, path: crowdinFilePath } of crowdinFiles) {
-      const challengeFilePath = path.join(
-        __dirname,
-        '/../../../../',
-        crowdinFilePath
-      );
-      try {
-        const challengeContent = fs.readFileSync(challengeFilePath);
-        const {
-          data: { title: challengeTitle }
-        } = matter(challengeContent);
-        await updateFileStrings({ projectId, fileId, challengeTitle });
-      } catch (err) {
-        console.log(err.name);
-        console.log(err.message);
+    const challengeTitleLookup = crowdinFiles
+      .reduce(createChallengeTitleLookup, {});
+    const crowdinStrings = await getStrings({ projectId });
+    if (crowdinStrings && crowdinStrings.length) {
+      for (let string of crowdinStrings) {
+        const challengeTitle = challengeTitleLookup[string.fileId]
+        await updateFileString({ projectId, string, challengeTitle });
       }
     }
   }
@@ -32,4 +43,4 @@ const hideNonTranslatedStrings = async projectId => {
 };
 
 const projectId = process.env.CROWDIN_PROJECT_ID;
-hideNonTranslatedStrings(projectId);
+hideNonTranslatedStrings(2);

--- a/tools/crowdin/utils/strings.js
+++ b/tools/crowdin/utils/strings.js
@@ -70,14 +70,20 @@ const updateFileStrings = async ({ projectId, fileId, challengeTitle }) => {
 };
 
 const updateFileString = async ({ projectId, string, challengeTitle }) => {
-  const { data: { id: stringId, text, isHidden, context } } = string;
+  const {
+    data: { id: stringId, text, isHidden, context }
+  } = string;
   const hideString = shouldHide(text, context, challengeTitle);
   if (!isHidden && hideString) {
-    // await changeHiddenStatus(projectId, stringId, true);
-    console.log('changed isHidden status for ' + challengeTitle + ' - ' + text);
+    await changeHiddenStatus(projectId, stringId, true);
+    console.log(
+      `${challengeTitle} - stringId: ${stringId} - changed isHidden status to true`
+    );
   } else if (isHidden && !hideString) {
-    // await changeHiddenStatus(projectId, stringId, false);
-    console.log('changed isHidden status for ' + challengeTitle + ' - ' + text);
+    await changeHiddenStatus(projectId, stringId, false);
+    console.log(
+      `${challengeTitle} - stringId: ${stringId} - changed isHidden status to false`
+    );
   }
 };
 

--- a/tools/crowdin/utils/strings.js
+++ b/tools/crowdin/utils/strings.js
@@ -13,7 +13,10 @@ const shouldHide = (text, context, challengeTitle) => {
 
 const getStrings = async ({ projectId, fileId }) => {
   let headers = { ...authHeader };
-  const endPoint = `projects/${projectId}/strings?fileId=${fileId}&limit=500`;
+  let endPoint = `projects/${projectId}/strings?limit=500`;
+  if (fileId) {
+    endPoint += `&fileId=${fileId}`;
+  }
   const strings = await makeRequest({ method: 'get', endPoint, headers });
   if (strings.data) {
     return strings.data;
@@ -66,9 +69,21 @@ const updateFileStrings = async ({ projectId, fileId, challengeTitle }) => {
   }
 };
 
+const updateFileString = async ({ projectId, string, challengeTitle }) => {
+  const { data: { id: stringId, text, isHidden, context } } = string;
+  const hideString = shouldHide(text, context, challengeTitle);
+  if (!isHidden && hideString) {
+    // await changeHiddenStatus(projectId, stringId, true);
+    console.log('changed isHidden status for ' + challengeTitle + ' - ' + text);
+  } else if (isHidden && !hideString) {
+    // await changeHiddenStatus(projectId, stringId, false);
+    console.log('changed isHidden status for ' + challengeTitle + ' - ' + text);
+  }
+};
+
 module.exports = {
   getStrings,
-  changeHiddenStatus,
   updateString,
-  updateFileStrings
+  updateFileStrings,
+  updateFileString
 };

--- a/tools/crowdin/utils/strings.js
+++ b/tools/crowdin/utils/strings.js
@@ -77,12 +77,12 @@ const updateFileString = async ({ projectId, string, challengeTitle }) => {
   if (!isHidden && hideString) {
     await changeHiddenStatus(projectId, stringId, true);
     console.log(
-      `${challengeTitle} - stringId: ${stringId} - changed isHidden status to true`
+      `${challengeTitle} - stringId: ${stringId} - changed isHidden to true`
     );
   } else if (isHidden && !hideString) {
     await changeHiddenStatus(projectId, stringId, false);
     console.log(
-      `${challengeTitle} - stringId: ${stringId} - changed isHidden status to false`
+      `${challengeTitle} - stringId: ${stringId} - changed isHidden to false`
     );
   }
 };


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

This PR makes a significant improvement to how quickly `tools/crowdin/actions/hide-non-translated-strings/index.js` runs.  I originally wrote the action to iterate through each file on Crowdin and pull its strings and then hide/unhide based on specific criteria.  That meant 1650 requests to Crowdins api.  Now it only makes about 60 calls to Crowdins api because it pulls all the strings down 500 at a time (using pagination of the strings).  Before this change, it was taking about 9-10 minutes each time the action ran after uploading files to Crowdin.  With these changes, it only takes about 30-40 seconds to complete.

I left the other functions that I used before, just in case we ever need them for other purposes.  I also added logging, so that it shows every time a string's `isHidden` is changed to `true` or `false`.