### PR TITLE
fix: disable automatic PR creation

### DIFF
--- a/.github/workflows/crowdin-i18n-download.yml
+++ b/.github/workflows/crowdin-i18n-download.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  
+
   i18n-download-curriculum-translations:
     name: Learn
     runs-on: ubuntu-18.04
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Checkout Source Files
         uses: actions/checkout@v2
-      
+
       ##### Chinese Download #####
       - name: Crowdin Download for Chinese Translations
         uses: crowdin/github-action@master
@@ -28,12 +28,12 @@ jobs:
           download_translations: true
           skip_untranslated_files: true
           export_only_approved: true
-          
+
           commit_message: 'chore(i8n,learn): processed chinese translations'
-          
+
           # pull-request
           localization_branch_name: i18n-sync-learn-processed-chinese-translations
-          create_pull_request: true
+          create_pull_request: false
           pull_request_title: 'chore(i18n,learn): Processed chinese translations from crowdin'
           pull_request_body: ''
           pull_request_labels: 'scope: i18n, scope: learn, crowdin-sync, language: Chinese'


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `master` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Temporarily disables the automatic PR creation on Crowdin Download while
we determine the best approach for this. PRs created by the action
itself cannot trigger workflows, which prevents our CI from running. As
such, this is currently not a viable approach.

cc/ @raisedadead @RandellDawson

Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>
