### PR TITLE
fix(learn): Remove strong syntax around code inline code

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/link-to-external-pages-with-anchor-elements.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/link-to-external-pages-with-anchor-elements.md
@@ -15,7 +15,7 @@ You can use `a` (*anchor*) elements to link to content outside of your web page.
 
 `<a href="https://freecodecamp.org">this links to freecodecamp.org</a>`
 
-Then your browser will display the text **"this links to freecodecamp.org"** as a link you can click. And that link will take you to the web address **`https://www.freecodecamp.org`**.
+Then your browser will display the text `this links to freecodecamp.org` as a link you can click. And that link will take you to the web address `https://www.freecodecamp.org`.
 
 # --instructions--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

This PR changes the description to wrap the the originally quoted `this links to freecodecamp.org` in single backticks.  As it stands now, the Chinese file translated the "this links to" but it should not have been (if properly wrapped in an inline code block).  This PR also removes the strong syntax around the link which is not semantically correct and code cause problems on Crowdin.

**See screenshot below of how the text appears in English**
![image](https://user-images.githubusercontent.com/5313213/105294125-83c61f00-5b76-11eb-9868-106ebc831676.png)

**See screenshot below of how the text appears in Chinese (notice the text that should not really have been translated).  Once this PR is merged and the file is upload to Crowdin, it will get fixed there and should come back down without the string translated.**
![image](https://user-images.githubusercontent.com/5313213/105298941-b1f82e80-5b77-11eb-8163-90f2fe439df8.png)
