### PR TITLE
fix: third test now parses response body

### DIFF
--- a/curriculum/challenges/english/05-apis-and-microservices/apis-and-microservices-projects/url-shortener-microservice.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/apis-and-microservices-projects/url-shortener-microservice.md
@@ -82,7 +82,7 @@ async (getUserInput) => {
     url + '/api/shorturl/' + shortenedUrlVariable
   );
   if (getResponse) {
-    const { redirected, url } = getResponse;
+    const { redirected, url } = await getResponse.json();
     assert.isTrue(redirected);
     assert.strictEqual(
       url,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Replaced `getResponse` with `await getResponse.json()` because the test always failed due to response body not getting parsed which in turn set wrong values for `redirected` and `url`. I have tested it locally and after the update, it works just fine.

![Screenshot from 2021-01-21 23-10-25](https://user-images.githubusercontent.com/61061679/105393499-38774380-5c3e-11eb-97b6-99a9718a6a3c.png)

