### PR TITLE
fix(learn): replace single bactick with <code> tag for Crowdin

### DIFF
--- a/curriculum/challenges/english/05-apis-and-microservices/mongodb-and-mongoose/use-model.find-to-search-your-database.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/mongodb-and-mongoose/use-model.find-to-search-your-database.md
@@ -12,7 +12,7 @@ In its simplest usage, `Model.find()` accepts a query document (a JSON object) a
 
 # --instructions--
 
-Modify the `findPeopleByName` function to find all the people having a given name, using `Model.find() -> [Person]`
+Modify the `findPeopleByName` function to find all the people having a given name, using <code>Model.find() -\> [Person]</code>
 
 Use the function argument `personName` as the search key.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

In the [Use model.findById() to Search Your Database By _id](https://raw.githubusercontent.com/freeCodeCamp/freeCodeCamp/master/curriculum/challenges/english/05-apis-and-microservices/mongodb-and-mongoose/use-model.findbyid-to-search-your-database-by-id.md) challenge, Crowdin's parser converted the `>` in the inline code block `Model.findById() -> Person` to an HTML entity `&gt;` which was causing a custom QA check to trigger.

This PR changes the backticks to `<code></code>` and then we escape the `>` with a backslash.  This properly renders on `/learn` still.