### PR TITLE
fix(tools): changes workflow push event

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,6 +2,7 @@ name: CodeQL
 
 on:
   push:
+    branches: ["master", "production-staging", "production-current"]
   pull_request:
   schedule:
     - cron: '0 20 * * 5'

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,5 +1,8 @@
 name: Cypress
-on: [push, pull_request]
+on:
+  push:
+    branches: ["master", "production-staging", "production-current"]
+  pull_request:
 
 jobs:
   cypress-run:

--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -1,5 +1,8 @@
 name: Node.js CI
-on: [push, pull_request]
+on:
+  push:
+    branches: ["master", "production-staging", "production-current"]
+  pull_request:
 
 jobs:
   lint:


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `master` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

In circumstances where we might be working off a branch on the freeCodeCamp repository (such as `feat/redesign-nav`) instead of our own forks, the CI runs in duplicate on PRs. This also occurs with dependabot's update PRs.

This is caused by firing the workflows on `push` events - so I've updated the workflows as follows:

Any PR will still trigger our workflows as intended.
A `push` event will only fire the `cypress`, `test`, `lint`, and `codeql` workflows if the push happens on `master`, `production-staging`, or `production-current`. As far as I know, these are the only three branches we specifically need CI running on for the `push` event as our deployment pipeline relies on these branches.

GitHub limits the number of concurrent actions we can have running at one time, so running things in duplicate on a PR is not ideal.

cc/ @raisedadead 