### PR TITLE
fix(learn): Fix the public assets folder confusion by giving it its own folder

### DIFF
--- a/curriculum/challenges/english/05-apis-and-microservices/basic-node-and-express/serve-static-assets.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/basic-node-and-express/serve-static-assets.md
@@ -8,21 +8,23 @@ dashedName: serve-static-assets
 
 # --description--
 
-An HTML server usually has one or more directories that are accessible by the user. You can place there the static assets needed by your application (stylesheets, scripts, images). In Express, you can put in place this functionality using the middleware `express.static(path)`, where the `path` parameter is the absolute path of the folder containing the assets. If you don’t know what middleware is... don’t worry, we will discuss in detail later. Basically, middleware are functions that intercept route handlers, adding some kind of information. A middleware needs to be mounted using the method `app.use(path, middlewareFunction)`. The first `path` argument is optional. If you don’t pass it, the middleware will be executed for all requests.
+An HTML server usually has one or more directories that are accessible by the user. You can place there the static assets needed by your application (stylesheets, scripts, images). 
+In Express, you can put in place this functionality using the middleware `express.static(path)`, where the `path` parameter is the absolute path of the folder containing the assets. 
+If you don’t know what middleware is... don’t worry, we will discuss in detail later. Basically, middleware are functions that intercept route handlers, adding some kind of information. A middleware needs to be mounted using the method `app.use(path, middlewareFunction)`. The first `path` argument is optional. If you don’t pass it, the middleware will be executed for all requests.
 
 # --instructions--
 
-Mount the `express.static()` middleware for all requests with `app.use()`. The absolute path to the assets folder is `__dirname + /public`.
+Mount the `express.static()` middleware to the path `/public` with `app.use()`. The absolute path to the assets folder is `__dirname + /public`.
 
-Now your app should be able to serve a CSS stylesheet. From outside, the public folder will appear mounted to the root directory. Your front-page should look a little better now!
+Now your app should be able to serve a CSS stylesheet. Note that the `/public/style.css` file is referenced in the `/views/index.html` in the project boilerplate. Also note that you should still keep the code in a previous challenge serving the `/views/index.html` to the root. Your front-page should look a little better now!
 
 # --hints--
 
-Your app should serve asset files from the `/public` directory
+Your app should serve asset files from the `/public` directory to `/public` path
 
 ```js
 (getUserInput) =>
-  $.get(getUserInput('url') + '/style.css').then(
+  $.get(getUserInput('url') + '/public/style.css').then(
     (data) => {
       assert.match(
         data,

--- a/curriculum/challenges/english/05-apis-and-microservices/basic-node-and-express/serve-static-assets.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/basic-node-and-express/serve-static-assets.md
@@ -16,7 +16,7 @@ If you don’t know what middleware is... don’t worry, we will discuss in deta
 
 Mount the `express.static()` middleware to the path `/public` with `app.use()`. The absolute path to the assets folder is `__dirname + /public`.
 
-Now your app should be able to serve a CSS stylesheet. Note that the `/public/style.css` file is referenced in the `/views/index.html` in the project boilerplate. Also note that you should still keep the code in a previous challenge serving the `/views/index.html` to the root. Your front-page should look a little better now!
+Now your app should be able to serve a CSS stylesheet. Note that the `/public/style.css` file is referenced in the `/views/index.html` in the project boilerplate. Your front-page should look a little better now!
 
 # --hints--
 

--- a/curriculum/challenges/english/05-apis-and-microservices/basic-node-and-express/serve-static-assets.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/basic-node-and-express/serve-static-assets.md
@@ -8,8 +8,10 @@ dashedName: serve-static-assets
 
 # --description--
 
-An HTML server usually has one or more directories that are accessible by the user. You can place there the static assets needed by your application (stylesheets, scripts, images). 
-In Express, you can put in place this functionality using the middleware `express.static(path)`, where the `path` parameter is the absolute path of the folder containing the assets. 
+An HTML server usually has one or more directories that are accessible by the user. You can place there the static assets needed by your application (stylesheets, scripts, images).
+
+In Express, you can put in place this functionality using the middleware `express.static(path)`, where the `path` parameter is the absolute path of the folder containing the assets.
+
 If you don’t know what middleware is... don’t worry, we will discuss in detail later. Basically, middleware are functions that intercept route handlers, adding some kind of information. A middleware needs to be mounted using the method `app.use(path, middlewareFunction)`. The first `path` argument is optional. If you don’t pass it, the middleware will be executed for all requests.
 
 # --instructions--

--- a/curriculum/challenges/english/05-apis-and-microservices/basic-node-and-express/serve-static-assets.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/basic-node-and-express/serve-static-assets.md
@@ -20,7 +20,7 @@ Now your app should be able to serve a CSS stylesheet. Note that the `/public/st
 
 # --hints--
 
-Your app should serve asset files from the `/public` directory to `/public` path
+Your app should serve asset files from the `/public` directory to the `/public` path
 
 ```js
 (getUserInput) =>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->
<!-- Feel free to add any additional description of changes below this line -->
Although it is mentioned in the description that an HTML server usually has one or more public assets directories, the assets had been mounted to the root folder. I suppose this is non-standard and confusing. 

I understand perhaps the author(s) wanted this to work with the simple idea of having a `/style.css` file in the `index.html` file in the boilerplate, but the `index.html` view should align with a node server best practices not the other way around.

- Changed the instruction so that the code mounts `public` folder to `public` path instead of root.
- Added a note about how this relates to the `index.html` file.
- NOTE that this works paired with this PR in freeCodeCamp/boilerplate-express : freeCodeCamp/boilerplate-express#51