### PR TITLE
feat(learn): move readme information for python projects

### DIFF
--- a/client/src/templates/Challenges/projects/frontend/Show.js
+++ b/client/src/templates/Challenges/projects/frontend/Show.js
@@ -103,7 +103,8 @@ export class Project extends Component {
           fields: { blockName },
           forumTopicId,
           title,
-          description
+          description,
+          instructions
         }
       },
       openCompletionModal,
@@ -129,7 +130,10 @@ export class Project extends Component {
               <Col md={8} mdOffset={2} sm={10} smOffset={1} xs={12}>
                 <Spacer />
                 <ChallengeTitle>{blockNameTitle}</ChallengeTitle>
-                <ChallengeDescription description={description} />
+                <ChallengeDescription
+                  description={description}
+                  instructions={instructions}
+                />
                 <SolutionForm
                   challengeType={challengeType}
                   description={description}
@@ -166,6 +170,7 @@ export const query = graphql`
       forumTopicId
       title
       description
+      instructions
       challengeType
       helpCategory
       fields {

--- a/curriculum/challenges/english/07-scientific-computing-with-python/scientific-computing-with-python-projects/arithmetic-formatter.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/scientific-computing-with-python-projects/arithmetic-formatter.md
@@ -11,7 +11,7 @@ Create a function that receives a list of strings that are arithmetic problems a
 
 You can access [the full project description and starter code on Repl.it](https://repl.it/github/freeCodeCamp/boilerplate-arithmetic-formatter).
 
-After going to that link, fork the project. Once you complete the project based on the instructions in 'README.md', submit your project link below.
+After going to that link, fork the project. Once you complete the project based on the instructions, submit your project link below.
 
 We are still developing the interactive instructional part of the Python curriculum. For now, here are some videos on the freeCodeCamp.org YouTube channel that will teach you everything you need to know to complete this project:
 
@@ -23,6 +23,79 @@ We are still developing the interactive instructional part of the Python curricu
     <a href='https://www.freecodecamp.org/news/learn-python-basics-in-depth-video-course/'>Learn Python Video Course</a> (2 hours)
   </li>
 <ul>
+
+# --instructions--
+
+## Assignment
+
+Students in primary school often arrange arithmetic problems vertically to make them easier to solve. For example, "235 + 52" becomes:
+
+```
+  235
++  52
+-----
+```
+
+Create a function that receives a list of strings that are arithmetic problems and returns the problems arranged vertically and side-by-side. The function should optionally take a second argument. When the second argument is set to `True`, the answers should be displayed.
+
+## For example
+
+Function Call:
+
+```py
+arithmetic_arranger(["32 + 698", "3801 - 2", "45 + 43", "123 + 49"])
+```
+
+Output:
+
+```
+   32      3801      45      123
++ 698    -    2    + 43    +  49
+-----    ------    ----    -----
+```
+
+Function Call:
+
+```py
+arithmetic_arranger(["32 + 8", "1 - 3801", "9999 + 9999", "523 - 49"], True)
+```
+
+Output:
+
+```
+  32         1      9999      523
++  8    - 3801    + 9999    -  49
+----    ------    ------    -----
+  40     -3800     19998      474
+```
+
+## Rules
+
+The function will return the correct conversion if the supplied problems are properly formatted, otherwise, it will **return** a **string** that describes an error that is meaningful to the user.  
+
+
+* Situations that will return an error:
+  * If there are **too many problems** supplied to the function. The limit is **five**, anything more will return: `Error: Too many problems.`
+  * The appropriate operators the function will accept are **addition** and **subtraction**. Multiplication and division will return an error. Other operators not mentioned in this bullet point will not need to be tested. The error returned will be: `Error: Operator must be '+' or '-'.`
+  * Each number (operand) should only contain digits. Otherwise, the function will return: `Error: Numbers must only contain digits.`
+  * Each operand (aka number on each side of the operator) has a max of four digits in width. Otherwise, the error string returned will be: `Error: Numbers cannot be more than four digits.`
+* If the user supplied the correct format of problems, the conversion you return will follow these rules:
+  * There should be a single space between the operator and the longest of the two operands, the operator will be on the same line as the second operand, both operands will be in the same order as provided (the first will be the top one and the second will be the bottom.
+  * Numbers should be right-aligned.
+  * There should be four spaces between each problem.
+  * There should be dashes at the bottom of each problem. The dashes should run along the entire length of each problem individually. (The example above shows what this should look like.)
+
+## Development
+
+Write your code in `arithmetic_arranger.py`. For development, you can use `main.py` to test your `arithmetic_arranger()` function. Click the "run" button and `main.py` will run.
+
+## Testing 
+
+The unit tests for this project are in `test_module.py`. We imported the tests from `test_module.py` to `main.py` for your convenience. The tests will run automatically whenever you hit the "run" button.
+
+## Submitting
+
+Copy your project's URL and submit it to freeCodeCamp.
 
 # --hints--
 

--- a/curriculum/challenges/english/07-scientific-computing-with-python/scientific-computing-with-python-projects/budget-app.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/scientific-computing-with-python-projects/budget-app.md
@@ -24,6 +24,80 @@ We are still developing the interactive instructional part of the Python curricu
   </li>
 </ul>
 
+# --instructions--
+
+## Assignment
+
+Complete the `Category` class in `budget.py`. It should be able to instantiate objects based on different budget categories like *food*, *clothing*, and *entertainment*. When objects are created, they are passed in the name of the category. The class should have an instance variable called `ledger` that is a list. The class should also contain the following methods:
+
+* A `deposit` method that accepts an amount and description. If no description is given, it should default to an empty string. The method should append an object to the ledger list in the form of `{"amount": amount, "description": description}`.
+* A `withdraw` method that is similar to the `deposit` method, but the amount passed in should be stored in the ledger as a negative number. If there are not enough funds, nothing should be added to the ledger. This method should return `True` if the withdrawal took place, and `False` otherwise.
+* A `get_balance` method that returns the current balance of the budget category based on the deposits and withdrawals that have occurred.
+* A `transfer` method that accepts an amount and another budget category as arguments. The method should add a withdrawal with the amount and the description "Transfer to [Destination Budget Category]". The method should then add a deposit to the other budget category with the amount and the description "Transfer from [Source Budget Category]". If there are not enough funds, nothing should be added to either ledgers. This method should return `True` if the transfer took place, and `False` otherwise.
+* A `check_funds` method that accepts an amount as an argument. It returns `False` if the amount is greater than the balance of the budget category and returns `True` otherwise. This method should be used by both the `withdraw` method and `transfer` method.
+
+When the budget object is printed it should display:
+
+* A title line of 30 characters where the name of the category is centered in a line of `*` characters.
+* A list of the items in the ledger. Each line should show the description and amount. The first 23 characters of the description should be displayed, then the amount. The amount should be right aligned, contain two decimal places, and display a maximum of 7 characters.
+* A line displaying the category total.
+
+Here is an example of the output:
+
+```
+*************Food*************
+initial deposit        1000.00
+groceries               -10.15
+restaurant and more foo -15.89
+Transfer to Clothing    -50.00
+Total: 923.96
+```
+
+Besides the `Category` class, create a function (ouside of the class) called `create_spend_chart` that takes a list of categories as an argument. It should return a string that is a bar chart.
+
+The chart should show the percentage spent in each category passed in to the function. The percentage spent should be calculated only with withdrawals and not with deposits. Down the left side of the chart should be labels 0 - 100. The "bars" in the bar chart should be made out of the "o" character. The height of each bar should be rounded down to the nearest 10. The horizontal line below the bars should go two spaces past the final bar. Each category name should be vertacally below the bar. There should be a title at the top that says "Percentage spent by category".
+
+This function will be tested with up to four categories.
+
+Look at the example output below very closely and make sure the spacing of the output matches the example exactly.
+
+```
+Percentage spent by category
+100|          
+ 90|          
+ 80|          
+ 70|          
+ 60| o        
+ 50| o        
+ 40| o        
+ 30| o        
+ 20| o  o     
+ 10| o  o  o  
+  0| o  o  o  
+    ----------
+     F  C  A  
+     o  l  u  
+     o  o  t  
+     d  t  o  
+        h     
+        i     
+        n     
+        g     
+```
+
+The unit tests for this project are in `test_module.py`.
+
+## Development
+
+Write your code in `budget.py`. For development, you can use `main.py` to test your `Category` class. Click the "run" button and `main.py` will run.
+
+## Testing 
+
+We imported the tests from `test_module.py` to `main.py` for your convenience. The tests will run automatically whenever you hit the "run" button.
+
+## Submitting
+
+Copy your project's URL and submit it to freeCodeCamp.
 # --hints--
 
 It should create a Category class and pass all tests.

--- a/curriculum/challenges/english/07-scientific-computing-with-python/scientific-computing-with-python-projects/polygon-area-calculator.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/scientific-computing-with-python-projects/polygon-area-calculator.md
@@ -24,6 +24,88 @@ We are still developing the interactive instructional part of the Python curricu
   </li>
 </ul>
 
+# --instructions--
+## Assignment
+
+In this project you will use object oriented programming to create a Rectangle class and a Square class. The Square class should be a subclass of Rectangle and inherit methods and attributes.
+
+## Rectangle class
+When a Rectangle object is created, it should be initialized with `width` and `height` attributes. The class should also contain the following methods:
+
+* `set_width`
+* `set_height`
+* `get_area`: Returns area (`width * height`)
+* `get_perimeter`: Returns perimeter (`2 * width + 2 * height`)
+* `get_diagonal`: Returns diagonal (`(width ** 2 + height ** 2) ** .5`)
+* `get_picture`: Returns a string that represents the shape using lines of "\*". The number of lines should be equal to the height and the number of "\*" in each line should be equal to the width. There should be a new line (`\n`) at the end of each line. If the width or height is larger than 50, this should return the string: "Too big for picture.".
+* `get_amount_inside`: Takes another shape (square or rectangle) as an argument. Returns the number of times the passed in shape could fit inside the shape (with no rotations). For instance, a rectangle with a width of 4 and a height of 8 could fit in two squares with sides of 4.
+
+Additionally, if an instance of a Rectangle is represented as a string, it should look like: `Rectangle(width=5, height=10)`
+
+## Square class
+The Square class should be a subclass of Rectangle. When a Square object is created, a single side length is passed in. The `__init__` method should store the side length in both the `width` and `height` attributes from the Rectangle class.
+
+The Square class should be able to access the Rectangle class methods but should also contain a `set_side` method. If an instance of a Square is represented as a string, it should look like: `Square(side=9)`
+
+Additionally, the `set_width` and `set_height` methods on the Square class should set both the width and height.
+
+## Usage example
+
+```py
+rect = shape_calculator.Rectangle(10, 5)
+print(rect.get_area())
+rect.set_height(3)
+print(rect.get_perimeter())
+print(rect)
+print(rect.get_picture())
+
+sq = shape_calculator.Square(9)
+print(sq.get_area())
+sq.set_side(4)
+print(sq.get_diagonal())
+print(sq)
+print(sq.get_picture())
+
+rect.set_height(8)
+rect.set_width(16)
+print(rect.get_amount_inside(sq))
+```
+
+That code should return:
+
+```
+50
+26
+Rectangle(width=10, height=3)
+**********
+**********
+**********
+
+81
+5.656854249492381
+Square(side=4)
+****
+****
+****
+****
+
+8
+```
+
+The unit tests for this project are in `test_module.py`.
+
+## Development
+
+Write your code in `shape_calculator.py`. For development, you can use `main.py` to test your `shape_calculator()` function. Click the "run" button and `main.py` will run.
+
+## Testing 
+
+We imported the tests from `test_module.py` to `main.py` for your convenience. The tests will run automatically whenever you hit the "run" button.
+
+## Submitting
+
+Copy your project's URL and submit it to freeCodeCamp.
+
 # --hints--
 
 It should create a Rectangle class and Square class and pass all tests.

--- a/curriculum/challenges/english/07-scientific-computing-with-python/scientific-computing-with-python-projects/probability-calculator.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/scientific-computing-with-python-projects/probability-calculator.md
@@ -22,6 +22,63 @@ We are still developing the interactive instructional part of the Python curricu
   </li>
 </ul>
 
+# --instructions--
+
+## Assignment
+
+Suppose there is a hat containing 5 blue balls, 4 red balls, and 2 green balls. What is the probability that a random draw of 4 balls will contain at least 1 red ball and 2 green balls? While it would be possible to calculate the probability using advanced mathematics, an easier way is to write a program to perform a large number of experiments to estimate an approximate probability.
+
+For this project, you will write a program to determine the approximate probability of drawing certain balls randomly from a hat. 
+
+First, create a `Hat` class in `prob_calculator.py`. The class should take a variable number of arguments that specify the number of balls of each color that are in the hat. For example, a class object could be created in any of these ways:
+
+```
+hat1 = Hat(yellow=3, blue=2, green=6)
+hat2 = Hat(red=5, orange=4)
+hat3 = Hat(red=5, orange=4, black=1, blue=0, pink=2, striped=9)
+```
+
+A hat will always be created with at least one ball. The arguments passed into the hat object upon creation should be converted to a `contents` instance variable. `contents` should be a list of strings containing one item for each ball in the hat. Each item in the list should be a color name representing a single ball of that color. For example, if your hat is `{"red": 2, "blue": 1}`, `contents` should be `["red", "red", "blue"]`.
+
+The `Hat` class should have a `draw` method that accepts an argument indicating the number of balls to draw from the hat. This method should remove balls at random from `contents` and return those balls as a list of strings. The balls should not go back into the hat during the draw, similar to an urn experiment without replacement. If the number of balls to draw exceeds the available quantity, return all the balls.
+
+Next, create an `experiment` function in `prob_calculator.py` (not inside the `Hat` class). This function should accept the following arguments:
+
+* `hat`: A hat object containing balls that should be copied inside the function.
+* `expected_balls`: An object indicating the exact group of balls to attempt to draw from the hat for the experiment. For example, to determine the probability of drawing 2 blue balls and 1 red ball from the hat, set `expected_balls` to `{"blue":2, "red":1}`.
+* `num_balls_drawn`: The number of balls to draw out of the hat in each experiment.
+* `num_experiments`: The number of experiments to perform. (The more experiments performed, the more accurate the approximate probability will be.)
+
+The `experiment` function should return a probability. 
+
+For example, let's say that you want to determine the probability of getting at least 2 red balls and 1 green ball when you draw 5 balls from a hat containing 6 black, 4 red, and 3 green. To do this, we perform `N` experiments, count how many times `M` we get at least 2 red balls and 1 green ball, and estimate the probability as `M/N`. Each experiment consists of starting with a hat containing the specified balls, drawing a number of balls, and checking if we got the balls we were attempting to draw.
+
+Here is how you would call the `experiment` function based on the example above with 2000 experiments:
+
+```
+hat = Hat(black=6, red=4, green=3)
+probability = experiment(hat=hat, 
+                  expected_balls={"red":2,"green":1},
+                  num_balls_drawn=5,
+                  num_experiments=2000)
+```
+
+Since this is based on random draws, the probability will be slightly different each time the code is run.
+
+*Hint: Consider using the modules that are already imported at the top of `prob_calculator.py`.*
+
+## Development
+
+Write your code in `prob_calculator.py`. For development, you can use `main.py` to test your code. Click the "run" button and `main.py` will run.
+
+## Testing 
+
+The unit tests for this project are in `test_module.py`. We imported the tests from `test_module.py` to `main.py` for your convenience. The tests will run automatically whenever you hit the "run" button.
+
+## Submitting
+
+Copy your project's URL and submit it to freeCodeCamp.
+
 # --hints--
 
 It should correctly calculate probabilities and pass all tests.

--- a/curriculum/challenges/english/07-scientific-computing-with-python/scientific-computing-with-python-projects/time-calculator.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/scientific-computing-with-python-projects/time-calculator.md
@@ -22,6 +22,58 @@ We are still developing the interactive instructional part of the Python curricu
   </li>
 </ul>
 
+# --instructions--
+
+## Assignment
+
+Write a function named `add_time` that takes in two required parameters and one optional parameter:
+
+* a start time in the 12-hour clock format (ending in AM or PM) 
+* a duration time that indicates the number of hours and minutes
+* (optional) a starting day of the week, case insensitive
+
+The function should add the duration time to the start time and return the result.
+
+If the result will be the next day, it should show `(next day)` after the time. If the result will be more than one day later, it should show `(n days later)` after the time, where "n" is the number of days later.
+
+If the function is given the optional starting day of the week parameter, then the output should display the day of the week of the result. The day of the week in the output should appear after the time and before the number of days later.
+
+Below are some examples of different cases the function should handle. Pay close attention to the spacing and punctuation of the results.
+
+```py
+add_time("3:00 PM", "3:10")
+# Returns: 6:10 PM
+
+add_time("11:30 AM", "2:32", "Monday")
+# Returns: 2:02 PM, Monday
+
+add_time("11:43 AM", "00:20")
+# Returns: 12:03 PM
+
+add_time("10:10 PM", "3:30")
+# Returns: 1:40 AM (next day)
+
+add_time("11:43 PM", "24:20", "tueSday")
+# Returns: 12:03 AM, Thursday (2 days later)
+
+add_time("6:30 PM", "205:12")
+# Returns: 7:42 AM (9 days later)
+```
+
+Do not import any Python libraries. Assume that the start times are valid times. The minutes in the duration time will be a whole number less than 60, but the hour can be any whole number.
+
+## Development
+
+Write your code in `time_calculator.py`. For development, you can use `main.py` to test your `time_calculator()` function. Click the "run" button and `main.py` will run.
+
+## Testing 
+
+The unit tests for this project are in `test_module.py`. We imported the tests from `test_module.py` to `main.py` for your convenience. The tests will run automatically whenever you hit the "run" button.
+
+## Submitting
+
+Copy your project's URL and submit it to freeCodeCamp.
+
 # --hints--
 
 It should correctly add times and pass all tests.

--- a/curriculum/challenges/english/08-data-analysis-with-python/data-analysis-with-python-projects/demographic-data-analyzer.md
+++ b/curriculum/challenges/english/08-data-analysis-with-python/data-analysis-with-python-projects/demographic-data-analyzer.md
@@ -15,6 +15,55 @@ After going to that link, fork the project. Once you complete the project based 
 
 We are still developing the interactive instructional part of the data analysis with Python curriculum. For now, you will have to use other resources to learn how to pass this challenge.
 
+# --instructions--
+
+## Assignment
+
+# Demographic Data Analyzer
+
+In this challenge you must analyze demographic data using Pandas. You are given a dataset of demographic data that was extracted from the 1994 Census database. Here is a sample of what the data looks like:
+
+|    |   age | workclass        |   fnlwgt | education   |   education-num | marital-status     | occupation        | relationship   | race   | sex    |   capital-gain |   capital-loss |   hours-per-week | native-country   | salary   |
+|---:|------:|:-----------------|---------:|:------------|----------------:|:-------------------|:------------------|:---------------|:-------|:-------|---------------:|---------------:|-----------------:|:-----------------|:---------|
+|  0 |    39 | State-gov        |    77516 | Bachelors   |              13 | Never-married      | Adm-clerical      | Not-in-family  | White  | Male   |           2174 |              0 |               40 | United-States    | <=50K    |
+|  1 |    50 | Self-emp-not-inc |    83311 | Bachelors   |              13 | Married-civ-spouse | Exec-managerial   | Husband        | White  | Male   |              0 |              0 |               13 | United-States    | <=50K    |
+|  2 |    38 | Private          |   215646 | HS-grad     |               9 | Divorced           | Handlers-cleaners | Not-in-family  | White  | Male   |              0 |              0 |               40 | United-States    | <=50K    |
+|  3 |    53 | Private          |   234721 | 11th        |               7 | Married-civ-spouse | Handlers-cleaners | Husband        | Black  | Male   |              0 |              0 |               40 | United-States    | <=50K    |
+|  4 |    28 | Private          |   338409 | Bachelors   |              13 | Married-civ-spouse | Prof-specialty    | Wife           | Black  | Female |              0 |              0 |               40 | Cuba             | <=50K    |
+
+
+You must use Pandas to answer the following questions:
+
+* How many people of each race are represented in this dataset? This should be a Pandas series with race names as the index labels. (`race` column)
+* What is the average age of men?
+* What is the percentage of people who have a Bachelor's degree?
+* What percentage of people with advanced education (`Bachelors`, `Masters`, or `Doctorate`) make more than 50K?
+* What percentage of people without advanced education make more than 50K?
+* What is the minimum number of hours a person works per week?
+* What percentage of the people who work the minimum number of hours per week have a salary of more than 50K?
+* What country has the highest percentage of people that earn >50K and what is that percentage?
+* Identify the most popular occupation for those who earn >50K in India. 
+
+Use the starter code in the file `demographic_data_anaylizer`. Update the code so all variables set to "None" are set to the appropriate calculation or code. Round all decimals to the nearest tenth.
+
+Unit tests are written for you under `test_module.py`.
+
+## Development
+
+For development, you can use `main.py` to test your functions. Click the "run" button and `main.py` will run.
+
+## Testing 
+
+We imported the tests from `test_module.py` to `main.py` for your convenience. The tests will run automatically whenever you hit the "run" button.
+
+## Submitting
+
+Copy your project's URL and submit it to freeCodeCamp.
+
+## Dataset Source
+
+Dua, D. and Graff, C. (2019). UCI Machine Learning Repository [http://archive.ics.uci.edu/ml]. Irvine, CA: University of California, School of Information and Computer Science.
+
 # --hints--
 
 It should pass all Python tests.

--- a/curriculum/challenges/english/08-data-analysis-with-python/data-analysis-with-python-projects/mean-variance-standard-deviation-calculator.md
+++ b/curriculum/challenges/english/08-data-analysis-with-python/data-analysis-with-python-projects/mean-variance-standard-deviation-calculator.md
@@ -15,6 +15,56 @@ After going to that link, fork the project. Once you complete the project based 
 
 We are still developing the interactive instructional part of the data analysis with Python curriculum. For now, you will have to use other resources to learn how to pass this challenge.
 
+# --instructions--
+
+## Assignment
+
+Create a function named `calculate()` in `mean_var_std.py` that uses Numpy to output the mean, variance, standard deviation, max, min, and sum of the rows, columns, and elements in a 3 x 3 matrix. 
+
+The input of the function should be a list containing 9 digits. The function should convert the list into a 3 x 3 Numpy array, and then return a dictionary containing the mean, variance, standard deviation, max, min, and sum along both axes and for the flattened matrix. 
+
+The returned dictionary should follow this format:
+
+```py
+{
+  'mean': [axis1, axis2, flattened],
+  'variance': [axis1, axis2, flattened],
+  'standard deviation': [axis1, axis2, flattened],
+  'max': [axis1, axis2, flattened],
+  'min': [axis1, axis2, flattened],
+  'sum': [axis1, axis2, flattened]
+}
+```
+
+If a list containing less than 9 elements is passed into the function, it should raise a `ValueError` exception with the message: "List must contain nine numbers." The values in the returned dictionary should be lists and not Numpy arrays.
+
+For example, `calculate([0,1,2,3,4,5,6,7,8])` should return:
+
+```py
+{
+  'mean': [[3.0, 4.0, 5.0], [1.0, 4.0, 7.0], 4.0], 
+  'variance': [[6.0, 6.0, 6.0], [0.6666666666666666, 0.6666666666666666, 0.6666666666666666], 6.666666666666667], 
+  'standard deviation': [[2.449489742783178, 2.449489742783178, 2.449489742783178], [0.816496580927726, 0.816496580927726, 0.816496580927726], 2.581988897471611],
+  'max': [[6, 7, 8], [2, 5, 8], 8],
+  'min': [[0, 1, 2], [0, 3, 6], 0],
+  'sum': [[9, 12, 15], [3, 12, 21], 36]}
+}
+```
+
+The unit tests for this project are in `test_module.py`.
+
+## Development
+
+For development, you can use `main.py` to test your `calculate()` function. Click the "run" button and `main.py` will run.
+
+## Testing 
+
+We imported the tests from `test_module.py` to `main.py` for your convenience. The tests will run automatically whenever you hit the "run" button.
+
+## Submitting
+
+Copy your project's URL and submit it to freeCodeCamp.
+
 # --hints--
 
 It should pass all Python tests.

--- a/curriculum/challenges/english/08-data-analysis-with-python/data-analysis-with-python-projects/medical-data-visualizer.md
+++ b/curriculum/challenges/english/08-data-analysis-with-python/data-analysis-with-python-projects/medical-data-visualizer.md
@@ -15,6 +15,65 @@ After going to that link, fork the project. Once you complete the project based 
 
 We are still developing the interactive instructional part of the data analysis with Python curriculum. For now, you will have to use other resources to learn how to pass this challenge.
 
+# --instructions--
+## Assignment
+
+In this project, you will visualize and make calculations from medical examination data using matplotlib, seaborn, and pandas. The dataset values were collected during medical examinations.
+
+## Data description
+
+The rows in the dataset represent patients and the columns represent information like body measurements, results from various blood tests, and lifestyle choices. You will use the dataset to explore the relationship between cardiac disease, body measurements, blood markers, and lifestyle choices.
+
+File name: medical_examination.csv
+
+| Feature | Variable Type | Variable      | Value Type |
+|:-------:|:------------:|:-------------:|:----------:|
+| Age | Objective Feature | age | int (days) |
+| Height | Objective Feature | height | int (cm) |
+| Weight | Objective Feature | weight | float (kg) |
+| Gender | Objective Feature | gender | categorical code |
+| Systolic blood pressure | Examination Feature | ap_hi | int |
+| Diastolic blood pressure | Examination Feature | ap_lo | int |
+| Cholesterol | Examination Feature | cholesterol | 1: normal, 2: above normal, 3: well above normal |
+| Glucose | Examination Feature | gluc | 1: normal, 2: above normal, 3: well above normal |
+| Smoking | Subjective Feature | smoke | binary |
+| Alcohol intake | Subjective Feature | alco | binary |
+| Physical activity | Subjective Feature | active | binary |
+| Presence or absence of cardiovascular disease | Target Variable | cardio | binary |
+
+## Tasks
+
+Create a chart similar to `examples/Figure_1.png`, where we show the counts of good and bad outcomes for the `cholesterol`, `gluc`, `alco`, `active`, and `smoke` variables for patients with cardio=1 and cardio=0 in different panels.
+
+Use the data to complete the following tasks in `medical_data_visualizer.py`:
+
+* Add an `overweight` column to the data. To determine if a person is overweight, first calculate their BMI by dividing their weight in kilograms by the square of their height in meters. If that value is > 25 then the person is overweight. Use the value 0 for NOT overweight and the value 1 for overweight.
+* Normalize the data by making 0 always good and 1 always bad. If the value of `cholesterol` or `gluc` is 1, make the value 0. If the value is more than 1, make the value 1.
+* Convert the data into long format and create a chart that shows the value counts of the categorical features using seaborn's `catplot()`. The dataset should be split by 'Cardio' so there is one chart for each `cardio` value. The chart should look like `examples/Figure_1.png`.
+* Clean the data. Filter out the following patient segments that represent incorrect data:
+  * diastolic pressure is higher than systolic (Keep the correct data with `df['ap_lo'] <= df['ap_hi'])`)
+  * height is less than the 2.5th percentile (Keep the correct data with `(df['height'] >= df['height'].quantile(0.025))`)
+  * height is more than the 97.5th percentile
+  * weight is less than the 2.5th percentile
+  * weight is more than the 97.5th percentile
+* Create a correlation matrix using the dataset. Plot the correlation matrix using seaborn's `heatmap()`. Mask the upper triangle. The chart should look like `examples/Figure_2.png`.
+
+Any time a variable is set to `None`, make sure to set it to the correct code.
+
+Unit tests are written for you under `test_module.py`.
+
+## Development
+
+For development, you can use `main.py` to test your functions. Click the "run" button and `main.py` will run.
+
+## Testing 
+
+We imported the tests from `test_module.py` to `main.py` for your convenience. The tests will run automatically whenever you hit the "run" button.
+
+## Submitting
+
+Copy your project's URL and submit it to freeCodeCamp.
+
 # --hints--
 
 It should pass all Python tests.

--- a/curriculum/challenges/english/08-data-analysis-with-python/data-analysis-with-python-projects/page-view-time-series-visualizer.md
+++ b/curriculum/challenges/english/08-data-analysis-with-python/data-analysis-with-python-projects/page-view-time-series-visualizer.md
@@ -15,6 +15,34 @@ After going to that link, fork the project. Once you complete the project based 
 
 We are still developing the interactive instructional part of the data analysis with Python curriculum. For now, you will have to use other resources to learn how to pass this challenge.
 
+# --instructions--
+
+## Assignment
+
+For this project you will visualize time series data using a line chart, bar chart, and box plots. You will use Pandas, Matplotlib, and Seaborn to visualize a dataset containing the number of page views each day on the freeCodeCamp.org forum from 2016-05-09 to 2019-12-03. The data visualizations will help you understand the patterns in visits and identify yearly and monthly growth.
+
+Use the data to complete the following tasks:
+
+* Use Pandas to import the data from "fcc-forum-pageviews.csv". Set the index to the "date" column.
+* Clean the data by filtering out days when the page views were in the top 2.5% of the dataset or bottom 2.5% of the dataset.
+* Create a `draw_line_plot` function that uses Matplotlib to draw a line chart similar to "examples/Figure_1.png". The title should be "Daily freeCodeCamp Forum Page Views 5/2016-12/2019". The label on the x axis should be "Date" and the label on the y axis should be "Page Views".
+* Create a `draw_bar_plot` function that draws a bar chart similar to "examples/Figure_2.png". It should show average daily page views for each month grouped by year. The legend should show month labels and have a title of "Months". On the chart, the label on the x axis should be "Years" and the label on the y axis should be "Average Page Views".
+* Create a `draw_box_plot` function that uses Searborn to draw two adjacent box plots similar to "examples/Figure_3.png". These box plots should show how the values are distributed within a given year or month and how it compares over time. The title of the first chart should be "Year-wise Box Plot (Trend)" and the title of the second chart should be "Month-wise Box Plot (Seasonality)". Make sure the month labels on bottom start at "Jan" and the x and x axis are labeled correctly.
+
+For each chart, make sure to use a copy of the data frame. Unit tests are written for you under `test_module.py`.
+
+## Development
+
+For development, you can use `main.py` to test your functions. Click the "run" button and `main.py` will run.
+
+## Testing 
+
+We imported the tests from `test_module.py` to `main.py` for your convenience. The tests will run automatically whenever you hit the "run" button.
+
+## Submitting
+
+Copy your project's URL and submit it to freeCodeCamp.
+
 # --hints--
 
 It should pass all Python tests.

--- a/curriculum/challenges/english/08-data-analysis-with-python/data-analysis-with-python-projects/sea-level-predictor.md
+++ b/curriculum/challenges/english/08-data-analysis-with-python/data-analysis-with-python-projects/sea-level-predictor.md
@@ -15,6 +15,37 @@ After going to that link, fork the project. Once you complete the project based 
 
 We are still developing the interactive instructional part of the data analysis with Python curriculum. For now, you will have to use other resources to learn how to pass this challenge.
 
+# --instructions--
+
+## Assignment
+
+You will analyze a dataset of the global average sea level change since 1880. You will use the data to predict the sea level change through year 2050.
+
+Use the data to complete the following tasks:
+
+* Use Pandas to import the data from `epa-sea-level.csv`.
+* Use matplotlib to create a scatter plot using the "Year" column as the x-axis and the "CSIRO Adjusted Sea Level" column as the y-axix.
+* Use the `linregress` function from `scipi.stats` to get the slope and y-intercept of the line of best fit. Plot the line of best fit over the top of the scatter plot. Make the line go through the year 2050 to predict the sea level rise in 2050.
+* Plot a new line of best fit just using the data from year 2000 through the most recent year in the dataset. Make the line also go through the year 2050 to predict the sea level rise in 2050 if the rate of rise continues as it has since the year 2000.
+* The x label should be "Year", the y label should be "Sea Level (inches)", and the title should be "Rise in Sea Level".
+
+Unit tests are written for you under `test_module.py`.
+
+## Development
+
+For development, you can use `main.py` to test your functions. Click the "run" button and `main.py` will run.
+
+## Testing 
+
+We imported the tests from `test_module.py` to `main.py` for your convenience. The tests will run automatically whenever you hit the "run" button.
+
+## Submitting
+
+Copy your project's URL and submit it to freeCodeCamp.
+
+## Data Source
+[Global Average Absolute Sea Level Change, 1880-2014 from the US Environmental Protection Agency using data from CSIRO, 2015; NOAA, 2015.](https://datahub.io/core/sea-level-rise)
+
 # --hints--
 
 It should pass all Python tests.

--- a/curriculum/challenges/english/09-information-security/information-security-projects/port-scanner.md
+++ b/curriculum/challenges/english/09-information-security/information-security-projects/port-scanner.md
@@ -25,6 +25,69 @@ We are still developing the interactive instructional part of the Python curricu
   </li>
 </ul>
 
+# --instructions--
+
+## Assignment
+
+Create a port scanner using Python.
+
+In the `port_scanner.py` file, create a function called `get_open_ports` that takes a `target` argument and a `port_range` argument. `target` can be a URL or IP address. `port_range` is a list of two numbers indicating the first and last numbers of the range of ports to check.
+
+Here are examples of how the function may be called:
+
+```
+get_open_ports("209.216.230.240", [440, 445])
+get_open_ports("www.stackoverflow.com", [79, 82])
+```
+
+The function should return a list of open ports in the given range.
+
+The `get_open_ports` function should also take an optional third argument of `True` to indicate "Verbose" mode. If this is set to true, the function shourd return a descriptive string instead of a list of ports.
+
+Here is the format of the string that should be returned in verbose mode (text inside `{}` indicates the information that should appear):
+
+```
+Open ports for {URL} ({IP address})
+PORT     SERVICE
+{port}   {service name}
+{port}   {service name}
+```
+
+You can use the dictionary in `common_ports.py` to get the correct service name for each port.
+
+For example, if the function is called like this:
+
+```
+port_scanner.get_open_ports("scanme.nmap.org", [20, 80], True)
+```
+
+It should return the following:
+
+```
+Open ports for scanme.nmap.org (45.33.32.156)
+PORT     SERVICE
+22       ssh
+80       http
+```
+
+Make sure to include proper spacing and new line characters.
+
+If the URL passed into the `get_open_ports` function is invalid, the function should return the string: "Error: Invalid hostname".
+
+If the IP address passed into the `get_open_ports` function is invalid, the function should return the string: "Error:  Invalid IP address".
+
+## Development
+
+Write your code in `port_scanner.py`. For development, you can use `main.py` to test your code. Click the "run" button and `main.py` will run.
+
+## Testing 
+
+The unit tests for this project are in `test_module.py`. We imported the tests from `test_module.py` to `main.py` for your convenience. The tests will run automatically whenever you hit the "run" button.
+
+## Submitting
+
+Copy your project's URL and submit it to freeCodeCamp.
+
 # --hints--
 
 It should pass all Python tests.

--- a/curriculum/challenges/english/09-information-security/information-security-projects/sha-1-password-cracker.md
+++ b/curriculum/challenges/english/09-information-security/information-security-projects/sha-1-password-cracker.md
@@ -25,6 +25,45 @@ We are still developing the interactive instructional part of the Python curricu
   </li>
 </ul>
 
+# --instructions--
+
+## Assignment
+
+Passwords should never be stored in plain text. They should be stored as hashes, just in case the password list is discovered. However, not all hashes are created equal. 
+
+For this project you will learn about the importance of good security by creating a password cracker to figure out passwords that were hashed using SHA-1.
+
+Create a function that takes in a SHA-1 hash of a password and returns the password if it is one of the top 10,000 passwords used. If the SHA-1 hash is NOT of a password in the database, return "PASSWORD NOT IN DATABASE".
+
+The function should hash each password from `top-10000-passwords.txt` and compare it to the hash passed into the function.
+
+The function should take an optional second argument named `use_salts`. If set to true, each salt string from the file `known-salts.txt` should be appended AND prepended to each password from `top-10000-passwords.txt` before hashing and before comparing it to the hash passed into the function.
+
+Here are some hashed passwords to test the function with:
+
+* `b305921a3723cd5d70a375cd21a61e60aabb84ec` should return "sammy123"
+* `c7ab388a5ebefbf4d550652f1eb4d833e5316e3e` should return "abacab"
+* `5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8` should return "password"
+
+Here are some hashed passwords to test the function with when `use_salts` is set to `True`:
+
+* `53d8b3dc9d39f0184144674e310185e41a87ffd5` should return "superman"
+* `da5a4e8cf89539e66097acd2f8af128acae2f8ae` should return "q1w2e3r4t5"
+* `ea3f62d498e3b98557f9f9cd0d905028b3b019e1` should return "bubbles1"
+
+The `hashlib` library has been imported for you. You should condider using it in your code. [Learn more about "hashlib" here.](https://docs.python.org/3/library/hashlib.html)
+
+## Development
+
+Write your code in `password_cracker.py`. For development, you can use `main.py` to test your code. Click the "run" button and `main.py` will run.
+
+## Testing 
+
+The unit tests for this project are in `test_module.py`. We imported the tests from `test_module.py` to `main.py` for your convenience. The tests will run automatically whenever you hit the "run" button.
+
+## Submitting
+
+Copy your project's URL and submit it to freeCodeCamp.
 # --hints--
 
 It should pass all Python tests.

--- a/curriculum/challenges/english/11-machine-learning-with-python/machine-learning-with-python-projects/rock-paper-scissors.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/machine-learning-with-python-projects/rock-paper-scissors.md
@@ -15,6 +15,52 @@ After going to that link, fork the project. Once you complete the project based 
 
 We are still developing the interactive instructional part of the machine learning curriculum. For now, you will have to use other resources to learn how to pass this challenge.
 
+# --instructions--
+
+## Assignment
+
+For this challenge, you will create a program to play Rock, Paper, Scissors. A program that picks at random will usually win 50% of the time. To pass this challenge your program must play matches against four different bots, winning at least 60% of the games in each match.
+
+In the file `RPS.py` you are provided with a function called `player`. The function takes an argument that is a string describing the last move of the opponent ("R", "P", or "S"). The function should return a string representing the next move for it to play ("R", "P", or "S").
+
+A player function will receive an empty string as an argument for the first game in a match since there is no previous play.
+
+The file `RPS.py` shows an example function that you will need to update. The example function is defined with two arguments (`player(prev_play, opponent_history = [])`). The function is never called with a second argument so that one is completely optional. The reason why the example function contains a second argument (`opponent_history = []`) is because that is the only way to save state between consecutive calls of the `player` function. You only need the `opponent_history` argument if you want to keep track of the opponent_history.
+
+*Hint: To defeat all four opponents, your program may need to have multiple strategies that change depending on the plays of the opponent.*
+
+## Development
+
+Do not modify `RPS_game.py`. Write all your code in `RPS.py`. For development, you can use `main.py` to test your code. 
+
+`main.py` imports the game function and bots from `RPS_game.py`.
+
+To test your code, play a game with the `play` function. The `play` function takes four arguments:
+
+* two players to play against each other (the players are actually functions)
+* the number of games to play in the match
+* an optional argument to see a log of each game. Set it to `True` to see these messages.
+
+```py
+play(player1, player2, num_games[, verbose])
+```
+
+For example, here is how you would call the function if you want `player` and `quincy` to play 1000 games against each other and you want to see the results of each game:
+
+```py
+play(player, quincy, 1000, verbose=True)
+```
+
+Click the "run" button and `main.py` will run.
+
+## Testing 
+
+The unit tests for this project are in `test_module.py`. We imported the tests from `test_module.py` to `main.py` for your convenience. If you uncomment the last line in `main.py`, the tests will run automatically whenever you hit the "run" button.
+
+## Submitting
+
+Copy your project's URL and submit it to freeCodeCamp.
+
 # --hints--
 
 It should pass all Python tests.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `master` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Not sure if we want to go this route, so leaving this in draft for now, but:

I've copied the project instructions from the Python boilerplate `README.md` files into their respective `/learn` pages, so they can be included in the translation flow.

- @RandellDawson: when you have time, we should verify this would render appropriately on Crowdin
- @ojeytonwilliams: I modified the parser for the front-end challenges (because python projects appear to be categorised as that) to display the `instructions` text - is that the best approach or should I instead re-categorise the python projects as backend?

Also, do we want to move the instructions from the Jupyter Notebook based projects as well? 