### PR TITLE
fix(client): add visual hierarchy to card blocks

### DIFF
--- a/client/src/templates/Introduction/SuperBlockIntro.js
+++ b/client/src/templates/Introduction/SuperBlockIntro.js
@@ -190,6 +190,9 @@ export class SuperBlockIntroductionPage extends Component {
                       )}
                       superBlockDashedName={superBlockDashedName}
                     />
+                    {blockDashedName !== 'project-euler' ? (
+                      <Spacer size={2} />
+                    ) : null}
                   </div>
                 ))}
                 {superBlock !== 'Coding Interview Prep' && (

--- a/client/src/templates/Introduction/components/Block.js
+++ b/client/src/templates/Introduction/components/Block.js
@@ -11,7 +11,6 @@ import Challenges from './Challenges';
 import Caret from '../../../assets/icons/Caret';
 import GreenPass from '../../../assets/icons/GreenPass';
 import GreenNotCompleted from '../../../assets/icons/GreenNotCompleted';
-import { Spacer } from '../../../components/helpers';
 
 const mapStateToProps = (state, ownProps) => {
   const expandedSelector = makeExpandedBlockSelector(ownProps.blockDashedName);
@@ -166,7 +165,6 @@ export class Block extends Component {
             isProjectBlock={isProjectBlock}
           />
         )}
-        {blockDashedName !== 'project-euler' ? <Spacer size={2} /> : null}
       </div>
     );
   }

--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -51,7 +51,7 @@
 
 button.map-title {
   cursor: pointer;
-  padding: 18px 8px;
+  padding: 18px 15px;
 }
 
 .map-title:hover {
@@ -77,7 +77,7 @@ button.map-title {
   display: flex;
   align-items: center;
   padding: 18px 8px;
-  background: transparent;
+  background: var(--secondary-background);
   border: none;
   text-align: left;
   width: 100%;
@@ -94,6 +94,18 @@ button.map-title {
 .block .map-is-cert:hover {
   color: var(--tertiary-color);
   background-color: var(--tertiary-background);
+}
+
+.block-ui .block {
+  background: var(--primary-background);
+}
+
+.block-ui .block .big-block-title {
+  padding: 25px 15px 10px;
+}
+.block-ui .block .block-description {
+  padding: 0 15px 15px;
+  border-bottom: 3px solid var(--secondary-background);
 }
 
 .map-cert-title > h3 {
@@ -134,8 +146,12 @@ button.map-title {
   stroke: var(--color-quaternary);
 }
 
-.open > .map-title svg:first-child {
+.map-title svg:first-child {
   transform: rotate(90deg);
+}
+
+.open > .map-title svg:first-child {
+  transform: rotate(-90deg);
 }
 
 .map-challenges-ul {
@@ -151,7 +167,7 @@ button.map-title {
 
 .map-challenge-title a {
   width: 100%;
-  padding: 10px 20px 10px 30px;
+  padding: 10px 15px;
 }
 
 .block-description {


### PR DESCRIPTION
This pr aims to make the cards stand out against the background.

Additionally, since the current blocks have one level of hierarchy, it would point the icon towards the direction in which the accordion will be expanded. 

In the future iterations the carrot could be replaced with a simplified arrow.


![image](https://user-images.githubusercontent.com/4591597/106151642-9e5b5200-618d-11eb-83f7-d945d453e7d3.png)
