### PR TITLE
fix: catch edge case of lang in path

### DIFF
--- a/client/src/components/createLanguageRedirect.js
+++ b/client/src/components/createLanguageRedirect.js
@@ -9,12 +9,12 @@ const createLanguageRedirect = ({ clientLocale, lang }) => {
     )
     .join('/');
 
-  const domain = window?.location?.hostname
+  const hostTail = window?.location?.host
     .split('.')
     .slice(1)
     .join('.');
   const nextClient = lang !== 'chinese' ? 'www' : 'chinese';
-  const nextLocation = `${window?.location?.protocol}//${nextClient}.${domain}`;
+  const nextLocation = `${window?.location?.protocol}//${nextClient}.${hostTail}`;
 
   if (lang === 'english' || lang === 'chinese')
     return `${nextLocation}/${path}`;

--- a/client/src/components/createLanguageRedirect.js
+++ b/client/src/components/createLanguageRedirect.js
@@ -4,9 +4,7 @@ const createLanguageRedirect = ({ clientLocale, lang }) => {
 
   let path = window?.location?.pathname?.split('/');
   path = path
-    .filter(
-      (item, i) => i !== 0 || (item !== clientLocale && item !== lang && item)
-    )
+    .filter(item => (item !== clientLocale && item !== lang ? item : ''))
     .join('/');
 
   const hostTail = window?.location?.host

--- a/client/src/components/createLanguageRedirect.js
+++ b/client/src/components/createLanguageRedirect.js
@@ -4,10 +4,12 @@ const createLanguageRedirect = ({ clientLocale, lang }) => {
 
   let path = window?.location?.pathname?.split('/');
   path = path
-    .filter(item => (item !== clientLocale && item !== lang ? item : ''))
+    .filter(
+      (item, i) => i !== 0 || (item !== clientLocale && item !== lang && item)
+    )
     .join('/');
 
-  const domain = window?.location?.host
+  const domain = window?.location?.hostname
     .split('.')
     .slice(1)
     .join('.');

--- a/client/src/components/createLanguageRedirect.test.js
+++ b/client/src/components/createLanguageRedirect.test.js
@@ -60,15 +60,6 @@ describe('createLanguageRedirect for clientLocale === english', () => {
       expect(receivedPageURL).toBe(francaisPageURL);
     });
 
-    it('should not replace the second espanol', () => {
-      delete window.location;
-      window.location = new URL(singleEspanolURL);
-      const receivedPageURL = createLanguageRedirect({
-        ...envVars,
-        lang: 'espanol'
-      });
-      expect(receivedPageURL).toBe(doubleEspanolURL);
-    });
   });
 
   describe('settings page', () => {

--- a/client/src/components/createLanguageRedirect.test.js
+++ b/client/src/components/createLanguageRedirect.test.js
@@ -59,7 +59,6 @@ describe('createLanguageRedirect for clientLocale === english', () => {
       });
       expect(receivedPageURL).toBe(francaisPageURL);
     });
-
   });
 
   describe('settings page', () => {

--- a/client/src/components/createLanguageRedirect.test.js
+++ b/client/src/components/createLanguageRedirect.test.js
@@ -16,11 +16,6 @@ describe('createLanguageRedirect for clientLocale === english', () => {
       'https://www.freecodecamp.org/espanol/learn/responsive-web-design/basic-html-and-html5/inform-with-the-paragraph-element';
     const francaisPageURL =
       'https://www.freecodecamp.org/francais/learn/responsive-web-design/basic-html-and-html5/inform-with-the-paragraph-element';
-    const singleEspanolURL =
-      'https://www.freecodecamp.org/learn/responsive-web-design/basic-html-and-html5/espanol';
-
-    const doubleEspanolURL =
-      'https://www.freecodecamp.org/espanol/learn/responsive-web-design/basic-html-and-html5/espanol';
 
     const originalLocation = window.location;
 

--- a/client/src/components/createLanguageRedirect.test.js
+++ b/client/src/components/createLanguageRedirect.test.js
@@ -16,6 +16,11 @@ describe('createLanguageRedirect for clientLocale === english', () => {
       'https://www.freecodecamp.org/espanol/learn/responsive-web-design/basic-html-and-html5/inform-with-the-paragraph-element';
     const francaisPageURL =
       'https://www.freecodecamp.org/francais/learn/responsive-web-design/basic-html-and-html5/inform-with-the-paragraph-element';
+    const singleEspanolURL =
+      'https://www.freecodecamp.org/learn/responsive-web-design/basic-html-and-html5/espanol';
+
+    const doubleEspanolURL =
+      'https://www.freecodecamp.org/espanol/learn/responsive-web-design/basic-html-and-html5/espanol';
 
     const originalLocation = window.location;
 
@@ -58,6 +63,16 @@ describe('createLanguageRedirect for clientLocale === english', () => {
         lang: 'francais'
       });
       expect(receivedPageURL).toBe(francaisPageURL);
+    });
+
+    it('should not replace the second espanol', () => {
+      delete window.location;
+      window.location = new URL(singleEspanolURL);
+      const receivedPageURL = createLanguageRedirect({
+        ...envVars,
+        lang: 'espanol'
+      });
+      expect(receivedPageURL).toBe(doubleEspanolURL);
     });
   });
 


### PR DESCRIPTION
Handles the edgiest of edge cases where paths include the current or target client lang as a path segment: e.g. espanol/learn/responsive-web-design/basic-html-and-html5/espanol