### PR TITLE
feat: allow challenges to be hidden by language

### DIFF
--- a/utils/is-audited.js
+++ b/utils/is-audited.js
@@ -1,15 +1,25 @@
 // this can go once all certs have been audited.
+
+// Currently the auditing is going through Crowdin, so once a cert has been 100%
+// proofread, we can add it in here. That means that translations can come
+// through from Crowdin whenever they are done, but we don't show them on the
+// client until we decide the entire cert is ready.
+
+// NOTE: certificates themselves (.markdown files) are not currently being
+// translated, but when they are they can be included by adding 'certificates'
+// to the arrays below
+
+const auditedCerts = {
+  espanol: [],
+  chinese: []
+};
+
 function isAuditedCert(lang, cert) {
   if (!lang || !cert)
     throw Error('Both arguments must be provided for auditing');
   // in order to see the challenges in the client, add the certification that
   // contains those challenges to this array:
-  const auditedCerts = [
-    'responsive-web-design',
-    'javascript-algorithms-and-data-structures',
-    'certificates'
-  ];
-  return lang === 'english' || auditedCerts.includes(cert);
+  return lang === 'english' || auditedCerts[lang].includes(cert);
 }
 
 exports.isAuditedCert = isAuditedCert;

--- a/utils/is-audited.js
+++ b/utils/is-audited.js
@@ -17,8 +17,6 @@ const auditedCerts = {
 function isAuditedCert(lang, cert) {
   if (!lang || !cert)
     throw Error('Both arguments must be provided for auditing');
-  // in order to see the challenges in the client, add the certification that
-  // contains those challenges to this array:
   return lang === 'english' || auditedCerts[lang].includes(cert);
 }
 


### PR DESCRIPTION
@raisedadead this fails if there are missing challenges for a language (like espanol currently), but once they're synced from Crowdin it should be fine.

Since no certs are 100% proofread this PR currently defaults to English no matter what.  Also, we don't have a Crowdin project for certifications (the .markdown files) yet, so they also default to English.