### PR TITLE
feat: use crowdin for client ui translations

### DIFF
--- a/.github/workflows/crowdin-i18n-client-ui-download.yml
+++ b/.github/workflows/crowdin-i18n-client-ui-download.yml
@@ -1,0 +1,49 @@
+name: Crowdin Client UI Download
+on:
+  workflow_dispatch: 
+
+jobs:
+
+  i18n-download-client-ui-translations:
+    name: Client
+    runs-on: ubuntu-18.04
+
+    steps:
+      - name: Checkout Source Files
+        uses: actions/checkout@v2
+
+      - name: Crowdin Download
+        uses: crowdin/github-action@master
+        # options: https://github.com/crowdin/github-action/blob/master/action.yml
+        with:
+          # uploads
+          upload_sources: false
+          upload_translations: false
+          auto_approve_imported: false
+          import_eq_suggestions: false
+
+          # downloads
+          download_translations: true
+          skip_untranslated_files: true
+          export_only_approved: true
+
+          commit_message: 'chore(i8n,client): processed translations'
+
+          # pull-request
+          localization_branch_name: i18n-sync-client-processed-translations
+          create_pull_request: false
+          pull_request_title: 'chore(i18n,client): Processed translations from crowdin'
+          pull_request_body: ''
+          pull_request_labels: 'scope: i18n, platform: client, crowdin-sync'
+
+          # global options
+          config: './client/i18n/locales/crowdin.yml'
+          base_url: ${{ secrets.CROWDIN_BASE_URL_FCC }}
+
+          # Uncomment below to debug
+          # dryrun_action: true
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID_CLIENT }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_CAMPERBOT_SERVICE_TOKEN }}

--- a/.github/workflows/crowdin-i18n-client-ui-upload.yml
+++ b/.github/workflows/crowdin-i18n-client-ui-upload.yml
@@ -1,0 +1,40 @@
+name: Crowdin Client UI Upload
+on:
+  workflow_dispatch:
+
+jobs:
+  
+  i18n-upload-client-ui-files:
+    name: Client
+    runs-on: ubuntu-18.04
+
+    steps:
+      - name: Checkout Source Files
+        uses: actions/checkout@v2
+      - name: Crowdin Upload
+        uses: crowdin/github-action@master
+        # options: https://github.com/crowdin/github-action/blob/master/action.yml
+        with:
+          # uploads
+          upload_sources: true
+          upload_translations: true
+          auto_approve_imported: false
+          import_eq_suggestions: false
+
+          # downloads
+          download_translations: false
+
+          # pull-request
+          create_pull_request: false
+
+          # global options
+          config: './client/i18n/locales/crowdin.yml'
+          base_url: ${{ secrets.CROWDIN_BASE_URL_FCC }}
+
+          # Uncomment below to debug
+          # dryrun_action: true
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID_CLIENT }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_CAMPERBOT_SERVICE_TOKEN }}

--- a/client/i18n/locales/crowdin.yml
+++ b/client/i18n/locales/crowdin.yml
@@ -1,0 +1,17 @@
+"project_id_env": "CROWDIN_PROJECT_ID"
+"api_token_env": "CROWDIN_PERSONAL_TOKEN"
+"base_path_env": "CROWDIN_BASE_PATH"
+"base_url_env": "CROWDIN_BASE_URL"
+
+"preserve_hierarchy": true
+
+files: [
+ {
+  "source" : "/client/i18n/locales/english/intro.json",
+  "translation" : "/client/i18n/locales/%language%/%original_file_name%"
+ },
+ {
+  "source" : "/client/i18n/locales/english/translations.json",
+  "translation" : "/client/i18n/locales/%language%/%original_file_name%"
+ }
+]


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

Closes #40816

This PR makes it possible to manage the translations on Crowdin for the following two files:

- [client/i18n/locales/english/intro.json](https://github.com/freeCodeCamp/freeCodeCamp/blob/next-i18n-client/client/i18n/locales/english/intro.json)
- [client/i18n/locales/english/translations.json](https://github.com/freeCodeCamp/freeCodeCamp/blob/next-i18n-client/client/i18n/locales/english/translations.json)

There are two other files in the `client/i18n/locales/english/` folder, but I believe it was decided that the motivational quotes found in `motivation.json` should not be translated, as we are planning on adding quotes from each language's important and influential authors and notable figures.  I believe the `trending.json` for each language will contain different links based on each language, so it should not be managed by Crowdin.

If I need to include one or all the files, I can create a separate commit, otherwise this PR works as expected.  I created  a new Crowdin project (named `Client UI`) and tested everything.