### PR TITLE
chore(tools): Change Crowdin workflow for Learn UI to no longer upload translations

### DIFF
--- a/.github/workflows/crowdin-i18n-client-ui-upload.yml
+++ b/.github/workflows/crowdin-i18n-client-ui-upload.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           # uploads
           upload_sources: true
-          upload_translations: true
+          upload_translations: false
           auto_approve_imported: false
           import_eq_suggestions: false
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

I ran the `crowdin-i18n-client-ui-upload.yml` manually earlier today which uploaded the source and translations to Crowdin.  This PR changes the config to no longer upload the translations for future uploads.