### PR TITLE
fix(tools): Download all languages from Crowdin

### DIFF
--- a/.github/workflows/crowdin-i18n-curriculum-download.yml
+++ b/.github/workflows/crowdin-i18n-curriculum-download.yml
@@ -24,19 +24,18 @@ jobs:
           import_eq_suggestions: false
 
           # downloads
-          download_language: zh-CN
           download_translations: true
           skip_untranslated_files: true
           export_only_approved: true
 
-          commit_message: 'chore(i8n,learn): processed chinese translations'
+          commit_message: 'chore(i8n,learn): processed translations'
 
           # pull-request
-          localization_branch_name: i18n-sync-learn-processed-chinese-translations
+          localization_branch_name: i18n-sync-learn-processed-translations
           create_pull_request: false
-          pull_request_title: 'chore(i18n,learn): Processed chinese translations from crowdin'
+          pull_request_title: 'chore(i18n,learn): Processed translations from Crowdin'
           pull_request_body: ''
-          pull_request_labels: 'scope: i18n, scope: learn, crowdin-sync, language: Chinese'
+          pull_request_labels: 'scope: i18n, scope: learn, crowdin-sync'
 
           # global options
           config: './curriculum/crowdin.yml'


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

Since we are now actively translating/approving Spanish curriculum files, I have updated the applicable download workflow to pull down all languages we currently crowdsourcing in the Curriculum project on Crowdin.
