### PR TITLE
fix(learn): abstract comments from code

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/declare-the-doctype-of-an-html-document.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/declare-the-doctype-of-an-html-document.md
@@ -19,12 +19,12 @@ The `!` and uppercase `DOCTYPE` is important, especially for older browsers. The
 
 Next, the rest of your HTML code needs to be wrapped in `html` tags. The opening `<html>` goes directly below the `<!DOCTYPE html>` line, and the closing `</html>` goes at the end of the page.
 
-Here's an example of the page structure:
+Here's an example of the page structure. Your HTML code would go in the space between the two `html` tags.
 
 ```html
 <!DOCTYPE html>
 <html>
-  <!-- Your HTML code goes here -->
+
 </html>
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/define-the-head-and-body-of-an-html-document.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/define-the-head-and-body-of-an-html-document.md
@@ -19,10 +19,11 @@ Here's an example of a page's layout:
 <!DOCTYPE html>
 <html>
   <head>
-    <!-- metadata elements -->
+    <meta />
   </head>
   <body>
-    <!-- page contents -->
+    <div>
+    </div>
   </body>
 </html>
 ```


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

In a discussion with @RandellDawson a while back, we considered the best approach for removing the comments from codeblocks within our challenges' description and instruction sections. These comments are currently not configured to parse through the comment dictionaries, and because they are in code blocks they are not translatable on Crowdin.

Randy ran a script that generated a [list of challenges with code blocks containing comments](https://gist.github.com/RandellDawson/f827b8ab502332ac34b071d990700605), which revealed only 2 instances within the Responsive Web Design section. In the interest of facilitating our translation sprint for this first certification, I've abstracted the comment information out of the code and into the challenge text.

We should discuss the best approach for how to handle the rest of these comments (there are a lot) after this initial push is complete. 

/cc @ojeytonwilliams 