### PR TITLE
fix(tools): Integrate certificate and comment dictionaries into the Curriculum project on Crowdin

### DIFF
--- a/curriculum/crowdin.yml
+++ b/curriculum/crowdin.yml
@@ -10,8 +10,15 @@ files: [
   "source" : "/curriculum/challenges/english/**/*.md",
   "translation" : "/curriculum/challenges/%language%/**/%original_file_name%",
   "ignore": [
-    "/**/part-[0-9][0-9][0-9].md",
-    "/curriculum/challenges/english/[0-9][0-9]-certificates/**/*.*"
+    "/**/part-[0-9][0-9][0-9].md"
   ]
- }
+ },
+ {
+  "source" : "/curriculum/challenges/english/12-certificates/**/*.yml",
+  "translation" : "/curriculum/challenges/%language%/12-certificates/**/%original_file_name%",
+ },
+ {
+  "source" : "/curriculum/dictionaries/english/comments.json",
+  "translation" : "/curriculum/dictionaries/%language%/%original_file_name%"
+ },
 ]

--- a/tools/crowdin/actions/hide-non-translated-strings/index.js
+++ b/tools/crowdin/actions/hide-non-translated-strings/index.js
@@ -44,10 +44,9 @@ const hideNonTranslatedStrings = async projectId => {
     const crowdinStrings = await getStrings({ projectId });
     if (crowdinStrings && crowdinStrings.length) {
       for (let string of crowdinStrings) {
-        const {
-          crowdinFilePath,
-          challengeTitle
-        } = challengeTitleLookup[string.data.fileId];
+        const { crowdinFilePath, challengeTitle } = challengeTitleLookup[
+          string.data.fileId
+        ];
         await updateFileString({
           projectId,
           string,

--- a/tools/crowdin/actions/hide-non-translated-strings/index.js
+++ b/tools/crowdin/actions/hide-non-translated-strings/index.js
@@ -1,5 +1,4 @@
 require('dotenv').config({ path: `${__dirname}/../../.env` });
-// const core = require('@actions/core');
 const fs = require('fs');
 const path = require('path');
 const matter = require('gray-matter');
@@ -20,7 +19,13 @@ const createChallengeTitleLookup = (
     const {
       data: { title: challengeTitle }
     } = matter(challengeContent);
-    return { ...lookup, [fileId]: challengeTitle };
+    return {
+      ...lookup,
+      [fileId]: {
+        crowdinFilePath,
+        challengeTitle
+      }
+    };
   } catch (err) {
     console.log(err.name);
     console.log(err.message);
@@ -39,8 +44,16 @@ const hideNonTranslatedStrings = async projectId => {
     const crowdinStrings = await getStrings({ projectId });
     if (crowdinStrings && crowdinStrings.length) {
       for (let string of crowdinStrings) {
-        const challengeTitle = challengeTitleLookup[string.data.fileId];
-        await updateFileString({ projectId, string, challengeTitle });
+        const {
+          crowdinFilePath,
+          challengeTitle
+        } = challengeTitleLookup[string.data.fileId];
+        await updateFileString({
+          projectId,
+          string,
+          challengeTitle,
+          crowdinFilePath
+        });
       }
     }
   }

--- a/tools/crowdin/utils/files.js
+++ b/tools/crowdin/utils/files.js
@@ -1,5 +1,4 @@
 const makeRequest = require('./make-request');
-const delay = require('./delay');
 const authHeader = require('./auth-header');
 
 const addFile = async (projectId, filename, fileContent, directoryId) => {
@@ -88,7 +87,6 @@ const getFiles = async projectId => {
   let files = [];
   while (!done) {
     const endPoint = `projects/${projectId}/files?limit=500&offset=${offset}`;
-    await delay(1000);
     const response = await makeRequest({
       method: 'get',
       endPoint,

--- a/tools/crowdin/utils/strings.js
+++ b/tools/crowdin/utils/strings.js
@@ -1,19 +1,36 @@
 const authHeader = require('./auth-header');
 const makeRequest = require('./make-request');
 
-const isHeading = str => /\h\d/.test(str);
+const isReservedHeading = (context, str) => {
+  const reservedHeadings = [
+    'after-user-code',
+    'answers',
+    'before-user-code',
+    'description',
+    'fcc-editable-region',
+    'hints',
+    'instructions',
+    'question',
+    'seed',
+    'seed-contents',
+    'solutions',
+    'text',
+    'video-solution'
+  ];
+  const captureGroupStr = `(${reservedHeadings.join('|')})`;
+  const regex = new RegExp(`--${captureGroupStr}--`);
+  return !!(context.match(/^Headline/) && str.match(regex));
+};
+
 const isCode = str => /^\/pre\/code|\/code$/.test(str);
-const isId = str => /^\d+\s*?->\s*?id/.test(str);
+
 const isTitle = str => /^(tests\s*->\s*\d+\s*)?->\s*title/.test(str);
 
 const shouldHide = (text, context, challengeTitle, crowdinFilePath) => {
-  if (crowdinFilePath.endsWith('comments.json')) {
-    return isId(context);
-  }
   if (crowdinFilePath.endsWith('.yml')) {
     return !isTitle(context);
   }
-  if (isHeading(context) || isCode(context)) {
+  if (isReservedHeading(context, text) || isCode(context)) {
     return true;
   }
   return text !== challengeTitle && context.includes('id=front-matter');


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

This PR makes the following changes:
- Changes the upload workflow for the Curriculum project on Crowdin to incorporate the comment dictionaries (JSON files) and the certificates (which are now YAML files).
- Fixed a bug in the `getStrings` function of `tools/crowdin/actions/hide-non-translated-strings/index.js` that was only checking the first 500 strings to see if they needed to be hidden or not.  Basically, when I refactored the code a month ago, I forgot to incorporate pagination.  It was not  huge deal, because the original version of the action already had hidden 99.9% of the strings that should have been hidden anyway.  Only a few new strings that were apart of some recently merged PRs were not hidden.  During the next run of the upload, these strings will be hidden.
- Improved the check for reserved heading by explicitly checking for the currently used headings (i.e. `--instructions--`, `--decription--`.

We need to get this merged as soon as possible, so I can run the upload and hide strings of these newly incorporated files.