### PR TITLE
feat(i18n, client): translate breadcrumbs

### DIFF
--- a/client/src/templates/Challenges/components/Challenge-Title.js
+++ b/client/src/templates/Challenges/components/Challenge-Title.js
@@ -5,6 +5,7 @@ import { Link } from '../../../components/helpers/index';
 import { dasherize } from '../../../../../utils/slugs';
 import './challenge-title.css';
 import GreenPass from '../../../assets/icons/GreenPass';
+import i18next from 'i18next';
 
 const propTypes = {
   block: PropTypes.string,
@@ -21,7 +22,9 @@ function ChallengeTitle({ block, children, isCompleted, superBlock }) {
           className='breadcrumb-left'
           to={`/learn/${dasherize(superBlock)}`}
         >
-          <span className='ellipsis'>{superBlock}</span>
+          <span className='ellipsis'>
+            {i18next.t(`intro:${dasherize(superBlock)}.title`)}
+          </span>
         </Link>
         <div className='breadcrumb-center' />
         <Link
@@ -29,7 +32,9 @@ function ChallengeTitle({ block, children, isCompleted, superBlock }) {
           state={{ breadcrumbBlockClick: block }}
           to={`/learn/${dasherize(superBlock)}`}
         >
-          {block}
+          {i18next.t(
+            `intro:${dasherize(superBlock)}.blocks.${dasherize(block)}.title`
+          )}
         </Link>
       </div>
       <div className='challenge-title'>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `master` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Currently the breadcrumb text content is the `superBlock` and `block` props. This modifies that to pass the dasherized superBlock and block to the translation function, grabbing the translated value from the `intro.json` file.

Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>

