### PR TITLE
fix(docs, tools): switch to main in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ Checklist:
 
 - [ ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
 - [ ] My pull request has a descriptive title (not a vague title like `Update index.md`)
-- [ ] My pull request targets the `master` branch of freeCodeCamp.
+- [ ] My pull request targets the `main` branch of freeCodeCamp.
 - [ ] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.
 
 <!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `master` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Changes `master` to `main` in the template to reflect our branch rename.

Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>

