### PR TITLE
fix(tools): Use endsWith instead of regex

### DIFF
--- a/tools/crowdin/utils/strings.js
+++ b/tools/crowdin/utils/strings.js
@@ -24,7 +24,7 @@ const isReservedHeading = (context, str) => {
 
 const isCode = str => /^\/pre\/code|\/code$/.test(str);
 
-const isTitle = str => /^(tests\s*->\s*\d+\s*)?->\s*title/.test(str);
+const isTitle = str => str.endsWith('title');
 
 const shouldHide = (text, context, challengeTitle, crowdinFilePath) => {
   if (crowdinFilePath.endsWith('.yml')) {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

This PR fixes a bug where the context for a YAML `title` key was not working with the regex.  @nhcarrigan suggested to just use `endsWith('title')` to avoid the complex regex I was using.
