### PR TITLE
fix: set hours to claim certs to 300

### DIFF
--- a/api-server/server/boot/certificate.js
+++ b/api-server/server/boot/certificate.js
@@ -162,9 +162,9 @@ const completionHours = {
   [certTypes.apisMicroservices]: 300,
   [certTypes.qaV7]: 300,
   [certTypes.infosecV7]: 300,
-  [certTypes.sciCompPyV7]: 400,
-  [certTypes.dataAnalysisPyV7]: 400,
-  [certTypes.machineLearningPyV7]: 400
+  [certTypes.sciCompPyV7]: 300,
+  [certTypes.dataAnalysisPyV7]: 300,
+  [certTypes.machineLearningPyV7]: 300
 };
 
 function getCertById(anId, allChallenges) {


### PR DESCRIPTION
It's a quick fix. I'm not sure if we want to adjust the hours on the legacy certs to 300 as well - I feel like those should be left alone. 

I know there was some talk on the issue about another method, but maybe we can just fix it like this for now and maybe make another issue to try and extract these to a common config file.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #39284

<!-- Feel free to add any additional description of changes below this line -->
