### PR TITLE
fix(client): remove `outline: none` on Menu button

### DIFF
--- a/client/src/components/Header/components/universalNav.css
+++ b/client/src/components/Header/components/universalNav.css
@@ -182,6 +182,11 @@
   border: 1px solid var(--gray-00);
 }
 
+.toggle-button-nav:focus {
+  outline: 5px auto -webkit-focus-ring-color !important;
+  outline-offset: -3px;
+}
+
 .navatar {
   display: contents;
 }

--- a/client/src/components/Header/components/universalNav.css
+++ b/client/src/components/Header/components/universalNav.css
@@ -170,7 +170,6 @@
   font-family: 'lato', sans-serif;
   font-size: 18px;
   color: var(--gray-00);
-  outline: none;
   background-color: var(--theme-color);
   cursor: pointer;
   max-height: calc(var(--header-height) - 6px);


### PR DESCRIPTION
Removed outline: none on  MenuButton so the outline becomes visible when pressing Tab.  Ref issue #40873.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
