### PR TITLE
chore: use short branch names

### DIFF
--- a/.github/workflows/crowdin-i18n-client-ui-download.yml
+++ b/.github/workflows/crowdin-i18n-client-ui-download.yml
@@ -30,7 +30,7 @@ jobs:
           commit_message: 'chore(i8n,client): processed translations'
 
           # pull-request
-          localization_branch_name: i18n-sync-client-processed-translations
+          localization_branch_name: i18n-sync-client
           create_pull_request: false
           pull_request_title: 'chore(i18n,client): Processed translations from crowdin'
           pull_request_body: ''

--- a/.github/workflows/crowdin-i18n-curriculum-download.yml
+++ b/.github/workflows/crowdin-i18n-curriculum-download.yml
@@ -31,7 +31,7 @@ jobs:
           commit_message: 'chore(i8n,learn): processed translations'
 
           # pull-request
-          localization_branch_name: i18n-sync-learn-processed-translations
+          localization_branch_name: i18n-sync-learn
           create_pull_request: false
           pull_request_title: 'chore(i18n,learn): Processed translations from Crowdin'
           pull_request_body: ''

--- a/.github/workflows/crowdin-i18n-docs-download..yml
+++ b/.github/workflows/crowdin-i18n-docs-download..yml
@@ -31,7 +31,7 @@ jobs:
           commit_message: 'chore(i8n,docs): processed translations'
 
           # pull-request
-          localization_branch_name: i18n-sync-docs-processed-translations
+          localization_branch_name: i18n-sync-docs
           create_pull_request: false
           pull_request_title: 'chore(i18n,docs): Processed translations from crowdin'
           pull_request_body: ''


### PR DESCRIPTION
We should use short branch names, tiny names. Even acronyms or drp vwls like ths. It helps because branch names are just identifers (they are meant to be typed out, sometimes without the help from tab-completion). If we need to convey information that can be very much done in a commit description, PR description.

