### PR TITLE
fix(tools, crowdin): do not skip downloading untranslated files

### DIFF
--- a/.github/workflows/crowdin-i18n-curriculum-download.yml
+++ b/.github/workflows/crowdin-i18n-curriculum-download.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
 
       ##### Chinese Download #####
-      - name: Crowdin Download for Chinese Translations
+      - name: Crowdin Download for Translations
         uses: crowdin/github-action@master
         # options: https://github.com/crowdin/github-action/blob/master/action.yml
         with:
@@ -25,7 +25,7 @@ jobs:
 
           # downloads
           download_translations: true
-          skip_untranslated_files: true
+          skip_untranslated_files: false
           export_only_approved: true
 
           commit_message: 'chore(i8n,learn): processed translations'

--- a/.github/workflows/crowdin-i18n-curriculum-download.yml
+++ b/.github/workflows/crowdin-i18n-curriculum-download.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout Source Files
         uses: actions/checkout@v2
 
-      ##### Chinese Download #####
+      ##### Download #####
       - name: Crowdin Download for Translations
         uses: crowdin/github-action@master
         # options: https://github.com/crowdin/github-action/blob/master/action.yml


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

Using the following settings for the Crowdin Curriculum Project download:
```
download_translations: true
skip_untranslated_files: false
export_only_approved: true
```
I have validated the following:

- If a file has not been translated at all, it pulled down the English version.
- I the file is 100% translated but not approved, it pulls down the English version.
- If the file is 100% translated and 100% approved, it pulls down the translated file.
- If a file has been partially translated and those translations have been approved, it still will only pull down the English version.