### PR TITLE
fix(i18n): remove Chinese: + Spanish: from translations

### DIFF
--- a/client/i18n/locales/chinese/translations.json
+++ b/client/i18n/locales/chinese/translations.json
@@ -470,11 +470,11 @@
     "use-valid-url": "请使用有效的 URL"
   },
   "certification": {
-    "certifies": "Chinese: This certifies that",
-    "completed": "Chinese: has successfully completed the freeCodeCamp.org",
-    "developer": "Chinese: Developer Certification, representing approximately",
-    "executive": "Chinese: Executive Director, freeCodeCamp.org",
-    "verify": "Chinese: Verify this certification at {{certURL}}",
-    "issued": "Chinese: Issued"
+    "certifies": "This certifies that",
+    "completed": "has successfully completed the freeCodeCamp.org",
+    "developer": "Developer Certification, representing approximately",
+    "executive": "Executive Director, freeCodeCamp.org",
+    "verify": "Verify this certification at {{certURL}}",
+    "issued": "Issued"
   }
 }

--- a/client/i18n/locales/espanol/translations.json
+++ b/client/i18n/locales/espanol/translations.json
@@ -470,11 +470,11 @@
     "use-valid-url": "Utiliza un URL válido"
   },
   "certification": {
-    "certifies": "Spanish: This certifies that",
-    "completed": "Spanish: has successfully completed the freeCodeCamp.org",
-    "developer": "Spanish: Developer Certification, representing approximately",
-    "executive": "Spanish: Executive Director, freeCodeCamp.org",
-    "verify": "Spanish: Verify this certification at {{certURL}}",
-    "issued": "Spanish: Issued"
+    "certifies": "This certifies that",
+    "completed": "has successfully completed the freeCodeCamp.org",
+    "developer": "Developer Certification, representing approximately",
+    "executive": "Executive Director, freeCodeCamp.org",
+    "verify": "Verify this certification at {{certURL}}",
+    "issued": "Issued"
   }
 }


### PR DESCRIPTION
Following the discussion https://github.com/freeCodeCamp/freeCodeCamp/pull/40919#discussion_r570788258 I've removed the debugging text to make sure it never lands in production.
