### PR TITLE
fix : contributor's chat room link

### DIFF
--- a/tools/contributor/README.md
+++ b/tools/contributor/README.md
@@ -2,4 +2,4 @@
 
 # Contribute
 
-Tools to help maintain [freeCodeCamp.org](https://www.freecodecamp.org)'s Open Source Codebase on GitHub. We are currently working on creating a tools dashboard for helping you review PRs and translations. Hangout with us in the [contributor's chat room](https://chat.freecodecamp.org/contributors) to learn more. 
+Tools to help maintain [freeCodeCamp.org](https://www.freecodecamp.org)'s Open Source Codebase on GitHub. We are currently working on creating a tools dashboard for helping you review PRs and translations. Hangout with us in the [contributor's chat room](https://chat.freecodecamp.org/channel/contributors) to learn more. 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #40930 

<!-- Feel free to add any additional description of changes below this line -->

In details: the problem is when click on this [link](https://chat.freecodecamp.org/contributors) in `/tools/contributor/` directory to open [contributor's chat room](https://chat.freecodecamp.org/contributors) link is not valid and go to `404` page. As follows:

I recommend to replace this link by [this](https://chat.freecodecamp.org/channel/contributors) because the basic going to contributors channel.

![i404](https://user-images.githubusercontent.com/54971231/107082110-617e0380-67fc-11eb-9219-b1d74fe50ee4.png)

Thanks