### PR TITLE
feat(learn): add backend solution url to help post

### DIFF
--- a/client/src/templates/Challenges/redux/create-question-epic.js
+++ b/client/src/templates/Challenges/redux/create-question-epic.js
@@ -36,7 +36,9 @@ function createQuestionEpic(action$, state$, { window }) {
         navigator: { userAgent },
         location: { href }
       } = window;
-      const projectFormValues = projectFormValuesSelector(state);
+      const projectFormValues = Object.entries(
+        projectFormValuesSelector(state)
+      );
       const endingText = dedent(
         `**Your browser information:**
 
@@ -52,11 +54,11 @@ function createQuestionEpic(action$, state$, { window }) {
         `**Tell us what's happening:**
         \n\n
         ${
-          projectFormValues
+          projectFormValues.length > 0
             ? `**Your project link(s)**\n`
             : `**Your code so far**`
         }
-        ${Object.entries(projectFormValues)
+        ${projectFormValues
           ?.map(([key, val]) => `${key}: ${val}\n`)
           ?.join('') || filesToMarkdown(files)}
         \n

--- a/client/src/templates/Challenges/redux/create-question-epic.js
+++ b/client/src/templates/Challenges/redux/create-question-epic.js
@@ -4,7 +4,8 @@ import {
   types,
   closeModal,
   challengeFilesSelector,
-  challengeMetaSelector
+  challengeMetaSelector,
+  projectFormValuesSelector
 } from '../redux';
 import { tap, mapTo } from 'rxjs/operators';
 import { forumLocation } from '../../../../../config/env.json';
@@ -35,7 +36,7 @@ function createQuestionEpic(action$, state$, { window }) {
         navigator: { userAgent },
         location: { href }
       } = window;
-      const backendSolutionLink = state?.challenge?.projectFormValues?.solution;
+      const projectFormValues = projectFormValuesSelector(state);
       const endingText = dedent(
         `**Your browser information:**
 
@@ -48,12 +49,18 @@ function createQuestionEpic(action$, state$, { window }) {
       );
 
       let textMessage = dedent(
-        `**Tell us what's happening:**\n\n\n\n**Your code so far**
+        `**Tell us what's happening:**
+        \n\n
         ${
-          Object.entries(files).length > 0
-            ? filesToMarkdown(files)
-            : backendSolutionLink ?? ''
-        }\n${endingText}`
+          projectFormValues
+            ? `**Your project link(s)**\n`
+            : `**Your code so far**`
+        }
+        ${Object.entries(projectFormValues)
+          ?.map(([key, val]) => `${key}: ${val}\n`)
+          ?.join('') || filesToMarkdown(files)}
+        \n
+        ${endingText}`
       );
 
       const altTextMessage = dedent(

--- a/client/src/templates/Challenges/redux/create-question-epic.js
+++ b/client/src/templates/Challenges/redux/create-question-epic.js
@@ -54,7 +54,7 @@ function createQuestionEpic(action$, state$, { window }) {
         `**Tell us what's happening:**
         \n\n
         ${
-          projectFormValues.length > 0
+          projectFormValues.length
             ? `**Your project link(s)**\n`
             : `**Your code so far**`
         }

--- a/client/src/templates/Challenges/redux/create-question-epic.js
+++ b/client/src/templates/Challenges/redux/create-question-epic.js
@@ -35,7 +35,7 @@ function createQuestionEpic(action$, state$, { window }) {
         navigator: { userAgent },
         location: { href }
       } = window;
-
+      const backendSolutionLink = state?.challenge?.projectFormValues?.solution;
       const endingText = dedent(
         `**Your browser information:**
 
@@ -49,7 +49,11 @@ function createQuestionEpic(action$, state$, { window }) {
 
       let textMessage = dedent(
         `**Tell us what's happening:**\n\n\n\n**Your code so far**
-        ${filesToMarkdown(files)}\n${endingText}`
+        ${
+          Object.entries(files).length > 0
+            ? filesToMarkdown(files)
+            : backendSolutionLink ?? ''
+        }\n${endingText}`
       );
 
       const altTextMessage = dedent(


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

With this, when a Camper uses the Ask for Help button on a challenge, the pre-populated post now includes a link to their solution url on backend challenges.

This just helps us on the forum, when Campers forget to include a link to the code they are trying to submit.

In order for this to work, the tests have to be run at least once with the given URL. (They do not need to pass)