### PR TITLE
fix: Update Proper Certificate Month when adding it to linkedin

### DIFF
--- a/client/src/client-only-routes/ShowCertification.js
+++ b/client/src/client-only-routes/ShowCertification.js
@@ -245,7 +245,7 @@ const ShowCertification = props => {
 
   const certDate = new Date(date);
   const certYear = certDate.getFullYear();
-  const certMonth = certDate.getMonth();
+  const certMonth = certDate.getMonth() + 1; // Linkedin Certificate API is 1 base-index
   const certURL = `https://freecodecamp.org${pathname}`;
 
   const donationCloseBtn = (


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [ x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ x] My pull request targets the `main` branch of freeCodeCamp.
- [ x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #40971

<!-- Feel free to add any additional description of changes below this line -->
The LinkedIn API expects the issueMonth field as 1-based index instead of 0-based index. But in the existing code, we were using date.getMonth() which returns month as 0-based index.