### PR TITLE
fix(client): display challenge completion status inline

### DIFF
--- a/client/src/templates/Challenges/components/Challenge-Title.js
+++ b/client/src/templates/Challenges/components/Challenge-Title.js
@@ -37,14 +37,14 @@ function ChallengeTitle({ block, children, isCompleted, superBlock }) {
           )}
         </Link>
       </div>
-      <div className='challenge-title'>
+   <div className='challenge-title'>
         <b>{children}</b>
+        {isCompleted ? (
+          <GreenPass
+            style={{ height: '15px', width: '15px', marginLeft: '7px' }}
+          />
+        ) : null}
       </div>
-      {isCompleted ? (
-        <GreenPass
-          style={{ height: '15px', width: '15px', marginLeft: '7px' }}
-        />
-      ) : null}
     </div>
   );
 }

--- a/client/src/templates/Challenges/components/Challenge-Title.js
+++ b/client/src/templates/Challenges/components/Challenge-Title.js
@@ -37,7 +37,7 @@ function ChallengeTitle({ block, children, isCompleted, superBlock }) {
           )}
         </Link>
       </div>
-   <div className='challenge-title'>
+      <div className='challenge-title'>
         <b>{children}</b>
         {isCompleted ? (
           <GreenPass

--- a/client/src/templates/Challenges/components/__snapshots__/ChallengeTitle.test.js.snap
+++ b/client/src/templates/Challenges/components/__snapshots__/ChallengeTitle.test.js.snap
@@ -34,64 +34,64 @@ exports[`<ChallengeTitle/> renders correctly 1`] = `
     <b>
       title text
     </b>
-  </div>
-  <span
-    className="sr-only"
-  >
-    icons.passed
-  </span>
-  <svg
-    height="50"
-    style={
-      Object {
-        "height": "15px",
-        "marginLeft": "7px",
-        "width": "15px",
+    <span
+      className="sr-only"
+    >
+      icons.passed
+    </span>
+    <svg
+      height="50"
+      style={
+        Object {
+          "height": "15px",
+          "marginLeft": "7px",
+          "width": "15px",
+        }
       }
-    }
-    viewBox="0 0 200 200"
-    width="50"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <g>
-      <title>
-        icons.passed
-      </title>
-      <circle
-        cx="100"
-        cy="99"
-        fill="var(--primary-color)"
-        r="95"
-        stroke="var(--primary-color)"
-        strokeDasharray="null"
-        strokeLinecap="null"
-        strokeLinejoin="null"
-      />
-      <rect
-        fill="var(--primary-background)"
-        height="30"
-        stroke="var(--primary-background)"
-        strokeDasharray="null"
-        strokeLinecap="null"
-        strokeLinejoin="null"
-        transform="rotate(-45, 120, 106.321)"
-        width="128.85878"
-        x="55.57059"
-        y="91.32089"
-      />
-      <rect
-        fill="var(--primary-background)"
-        height="30"
-        stroke="var(--primary-background)"
-        strokeDasharray="null"
-        strokeLinecap="null"
-        strokeLinejoin="null"
-        transform="rotate(45, 66.75, 123.75)"
-        width="80.66548"
-        x="26.41726"
-        y="108.75"
-      />
-    </g>
-  </svg>
+      viewBox="0 0 200 200"
+      width="50"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g>
+        <title>
+          icons.passed
+        </title>
+        <circle
+          cx="100"
+          cy="99"
+          fill="var(--primary-color)"
+          r="95"
+          stroke="var(--primary-color)"
+          strokeDasharray="null"
+          strokeLinecap="null"
+          strokeLinejoin="null"
+        />
+        <rect
+          fill="var(--primary-background)"
+          height="30"
+          stroke="var(--primary-background)"
+          strokeDasharray="null"
+          strokeLinecap="null"
+          strokeLinejoin="null"
+          transform="rotate(-45, 120, 106.321)"
+          width="128.85878"
+          x="55.57059"
+          y="91.32089"
+        />
+        <rect
+          fill="var(--primary-background)"
+          height="30"
+          stroke="var(--primary-background)"
+          strokeDasharray="null"
+          strokeLinecap="null"
+          strokeLinejoin="null"
+          transform="rotate(45, 66.75, 123.75)"
+          width="80.66548"
+          x="26.41726"
+          y="108.75"
+        />
+      </g>
+    </svg>
+  </div>
 </div>
 `;

--- a/client/src/templates/Challenges/components/challenge-title.css
+++ b/client/src/templates/Challenges/components/challenge-title.css
@@ -4,6 +4,7 @@
 }
 
 .challenge-title {
+  display: inline-block;
   margin: 20px 0px 15px;
 }
 

--- a/client/src/templates/Challenges/components/challenge-title.css
+++ b/client/src/templates/Challenges/components/challenge-title.css
@@ -4,7 +4,6 @@
 }
 
 .challenge-title {
-  display: inline-block;
   margin: 20px 0px 15px;
 }
 


### PR DESCRIPTION
This fixes issue #41003. It solves the problem of the challenge completion status rendering on a new-line

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
