### PR TITLE
Add backticks to dfn-tag to circumvent parser bug

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/inherit-css-variables.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/inherit-css-variables.md
@@ -11,7 +11,7 @@ dashedName: inherit-css-variables
 
 When you create a variable, it is available for you to use inside the selector in which you create it. It also is available in any of that selector's descendants. This happens because CSS variables are inherited, just like ordinary properties.
 
-To make use of inheritance, CSS variables are often defined in the <dfn>:root</dfn> element.
+To make use of inheritance, CSS variables are often defined in the <dfn>`:root`</dfn> element.
 
 `:root` is a <dfn>pseudo-class</dfn> selector that matches the root element of the document, usually the `html` element. By creating your variables in `:root`, they will be available globally and can be accessed from any other selector in the style sheet.
 


### PR DESCRIPTION
Before this, the parser mistakenly sanitized the definition for :root away.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #40695

<!-- Feel free to add any additional description of changes below this line -->
