### PR TITLE
fix(client, i18n): translate mobile tabs

### DIFF
--- a/client/i18n/locales/chinese/translations.json
+++ b/client/i18n/locales/chinese/translations.json
@@ -285,6 +285,12 @@
     "cert-map-estimates": {
       "certs": "认证（300 小时）",
       "coding-prep": "（数千小时的挑战）"
+    },
+    "editor-tabs": {
+      "info": "信息",
+      "code": "码",
+      "tests": "测验",
+      "preview": "预习"
     }
   },
   "donate": {

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -285,6 +285,12 @@
     "cert-map-estimates": {
       "certs": "Certification (300\u00A0hours)",
       "coding-prep": "(Thousands of hours of challenges)"
+    },
+    "editor-tabs": {
+      "info": "Info",
+      "code": "Code",
+      "tests": "Tests",
+      "preview": "Preview"
     }
   },
   "donate": {

--- a/client/i18n/locales/espanol/translations.json
+++ b/client/i18n/locales/espanol/translations.json
@@ -285,6 +285,12 @@
     "cert-map-estimates": {
       "certs": "Certificación (300 horas)",
       "coding-prep": "(Miles de horas de desafíos)"
+    },
+    "editor-tabs": {
+      "info": "Información",
+      "code": "Código",
+      "tests": "Pruebas",
+      "preview": "Avance"
     }
   },
   "donate": {

--- a/client/i18n/translations-schema.js
+++ b/client/i18n/translations-schema.js
@@ -334,6 +334,12 @@ const translationsSchema = {
     'cert-map-estimates': {
       certs: 'Certification (300\u00A0hours)',
       'coding-prep': '(Thousands of hours of challenges)'
+    },
+    'editor-tabs': {
+      info: 'Info',
+      code: 'Code',
+      tests: 'Tests',
+      preview: 'Preview'
     }
   },
   donate: {

--- a/client/src/templates/Challenges/classic/MobileLayout.js
+++ b/client/src/templates/Challenges/classic/MobileLayout.js
@@ -9,6 +9,7 @@ import { currentTabSelector, moveToTab } from '../redux';
 import { bindActionCreators } from 'redux';
 import EditorTabs from './EditorTabs';
 import { showUpcomingChanges } from '../../../../../config/env.json';
+import i18next from 'i18next';
 
 const mapStateToProps = createStructuredSelector({
   currentTab: currentTabSelector
@@ -64,18 +65,29 @@ class MobileLayout extends Component {
           id='challenge-page-tabs'
           onSelect={moveToTab}
         >
-          <TabPane eventKey={1} title='Info'>
+          <TabPane eventKey={1} title={i18next.t('learn.editor-tabs.info')}>
             {instructions}
           </TabPane>
-          <TabPane eventKey={2} title='Code' {...editorTabPaneProps}>
+          <TabPane
+            eventKey={2}
+            title={i18next.t('learn.editor-tabs.code')}
+            {...editorTabPaneProps}
+          >
             {showUpcomingChanges && <EditorTabs />}
             {editor}
           </TabPane>
-          <TabPane eventKey={3} title='Tests' {...editorTabPaneProps}>
+          <TabPane
+            eventKey={3}
+            title={i18next.t('learn.editor-tabs.tests')}
+            {...editorTabPaneProps}
+          >
             {testOutput}
           </TabPane>
           {hasPreview && (
-            <TabPane eventKey={4} title='Preview'>
+            <TabPane
+              eventKey={4}
+              title={i18next.t('learn.editor-tabs.preview')}
+            >
               {preview}
             </TabPane>
           )}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #41027 

<!-- Feel free to add any additional description of changes below this line -->

Adds tranlsation to the tabs that appear for mobile screens in a
challenge view.
