### PR TITLE
fix(i18n): localize cert dates in correct format

### DIFF
--- a/client/src/client-only-routes/ShowCertification.js
+++ b/client/src/client-only-routes/ShowCertification.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
-import format from 'date-fns/format';
 import { Grid, Row, Col, Image, Button } from '@freecodecamp/react-bootstrap';
 
 import ShowProjectLinks from './ShowProjectLinks';
@@ -28,10 +27,14 @@ import { certMap } from '../../src/resources/certAndProjectMap';
 import { createFlashMessage } from '../components/Flash/redux';
 import standardErrorMessage from '../utils/standardErrorMessage';
 import reallyWeirdErrorMessage from '../utils/reallyWeirdErrorMessage';
+import { langCodes } from '../../i18n/allLangs';
+import { clientLocale } from '../../../config/env.json';
 
 import RedirectHome from '../components/RedirectHome';
 import { Loader, Spacer } from '../components/helpers';
 import { isEmpty } from 'lodash';
+
+const localeCode = langCodes[clientLocale];
 
 const propTypes = {
   cert: PropTypes.shape({
@@ -326,7 +329,13 @@ const ShowCertification = props => {
             <Col md={7} sm={12}>
               <div data-cy='issue-date' className='issue-date'>
                 {t('certification.issued')}&nbsp;
-                <strong>{format(certDate, 'MMMM d, y')}</strong>
+                <strong>
+                  {certDate.toLocaleString([localeCode, 'en-US'], {
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric'
+                  })}
+                </strong>
               </div>
             </Col>
           </header>


### PR DESCRIPTION
I tried a few things:

JavaScripts .toLocaleString gave me this:
![Screen Shot 2021-02-10 at 7 12 53 AM](https://user-images.githubusercontent.com/20648924/107514785-beb4e480-6b6f-11eb-9ad2-c0469d8fa3c1.png)
![Screen Shot 2021-02-10 at 7 12 37 AM](https://user-images.githubusercontent.com/20648924/107514792-c1173e80-6b6f-11eb-8a88-01603539b843.png)
![Screen Shot 2021-02-10 at 7 12 08 AM](https://user-images.githubusercontent.com/20648924/107514798-c2e10200-6b6f-11eb-9c47-8aa2528b0336.png)

date-fns gave me this:
![Screen Shot 2021-02-10 at 7 09 02 AM](https://user-images.githubusercontent.com/20648924/107514850-d42a0e80-6b6f-11eb-9478-6ba5030b1e40.png)
![Screen Shot 2021-02-10 at 7 09 42 AM](https://user-images.githubusercontent.com/20648924/107514856-d5f3d200-6b6f-11eb-961a-380e9ad0e9a3.png)
![Screen Shot 2021-02-10 at 7 10 00 AM](https://user-images.githubusercontent.com/20648924/107514862-d7bd9580-6b6f-11eb-95d0-ca9c150c42ae.png)

Draft for now to discuss what we like, and possibly see if there's some other config to make it what we want.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #41026

<!-- Feel free to add any additional description of changes below this line -->
