### PR TITLE
fix(tools): disable i18n linting

### DIFF
--- a/client/i18n/schema-validation.js
+++ b/client/i18n/schema-validation.js
@@ -1,7 +1,6 @@
 const path = require('path');
 const fs = require('fs');
 const { translationsSchema } = require('./translations-schema');
-const { availableLangs } = require('./allLangs');
 const { trendingSchema } = require('./trending-schema');
 const { motivationSchema } = require('./motivation-schema');
 const { introSchema } = require('./intro-schema');
@@ -265,8 +264,8 @@ const metaTagsSchemaValidation = languages => {
   });
 };
 
-translationSchemaValidation(availableLangs.client);
-trendingSchemaValidation(availableLangs.client);
-motivationSchemaValidation(availableLangs.client);
-introSchemaValidation(availableLangs.client);
-metaTagsSchemaValidation(availableLangs.client);
+translationSchemaValidation(['english']);
+trendingSchemaValidation(['english']);
+motivationSchemaValidation(['english']);
+introSchemaValidation(['english']);
+metaTagsSchemaValidation(['english']);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Disables the schema validation for non-English translation files. This will allow us to merge PRs without having to modify the i18n objects through GitHub, ensuring that we are doing those changes through Crowdin explicitly.

This comes from a discussion with @RandellDawson about how to best avoid duplicate work, and how to approach the addition of new UI elements that require translation. With this flow, a PR that adds a new UI element would only add the key to the appropriate English file. Then we would upload the change to Crowdin, pull down the translation, and merge that to land the key on the other locale files.

As it stands, there are some concerns about this approach. We'll want to establish the infrastructure to allow running CI on specific language builds, so we can adjust this to test the language file for each locale and prevent deployments with missing translation keys.

/cc @raisedadead 