### PR TITLE
fix(client): undent dents caused by dedent

### DIFF
--- a/client/src/templates/Challenges/redux/create-question-epic.js
+++ b/client/src/templates/Challenges/redux/create-question-epic.js
@@ -41,8 +41,11 @@ function createQuestionEpic(action$, state$, { window }) {
       );
       const endingText = dedent(
         `**Your browser information:**
+
         User Agent is: <code>${userAgent}</code>.
+
         **Challenge:** ${challengeTitle}
+
         **Link to the challenge:**
         ${href}`
       );
@@ -64,15 +67,25 @@ function createQuestionEpic(action$, state$, { window }) {
 
       const altTextMessage = dedent(
         `**Tell us what's happening:**
+
+
+
         **Your code so far**
+
         WARNING
+
         The challenge seed code and/or your solution exceeded the maximum length we can port over from the challenge.
+
         You will need to take an additional step here so the code you wrote presents in an easy to read format.
+
         Please copy/paste all the editor code showing in the challenge from where you just linked.
+
         \`\`\`
+
         Replace these two sentences with your copied code.
         Please leave the \`\`\` line above and the \`\`\` line below,
         because they allow your code to properly format in the post.
+
         \`\`\`\n${endingText}`
       );
 

--- a/client/src/templates/Challenges/redux/create-question-epic.js
+++ b/client/src/templates/Challenges/redux/create-question-epic.js
@@ -1,3 +1,4 @@
+import dedent from 'dedent';
 import { ofType } from 'redux-observable';
 import {
   types,
@@ -38,24 +39,42 @@ function createQuestionEpic(action$, state$, { window }) {
       const projectFormValues = Object.entries(
         projectFormValuesSelector(state)
       );
-      const endingText = `**Your browser information:**\n
-      \nUser Agent is: <code>${userAgent}</code>.\n
-      \n**Challenge:** ${challengeTitle}\n
-      \n**Link to the challenge:**\n\n${href}`;
+      const endingText = dedent(
+        `**Your browser information:**
+        User Agent is: <code>${userAgent}</code>.
+        **Challenge:** ${challengeTitle}
+        **Link to the challenge:**
+        ${href}`
+      );
 
-      let textMessage = `**Tell us what's happening:**\n\n${
-        projectFormValues.length
-          ? `**Your project link(s)**\n`
-          : `**Your code so far**`
-      }${projectFormValues?.map(([key, val]) => `${key}: ${val}\n`)?.join('') ||
-        filesToMarkdown(files)}${endingText}`;
+      let textMessage = dedent(
+        `**Tell us what's happening:**
 
-      const altTextMessage = `**Tell us what's happening:**\n
-      \n**Your code so far**\n\nWARNING\n
-      \nThe challenge seed code and/or your solution exceeded the maximum length we can port over from the challenge.\n
-      \nYou will need to take an additional step here so the code you wrote presents in an easy to read format.\n
-      \nPlease copy/paste all the editor code showing in the challenge from where you just linked.\n\`\`\`\nReplace these two sentences with your copied code.\n
-      \nPlease leave the \`\`\` line above and the \`\`\` line below,\nbecause they allow your code to properly format in the post.\n\`\`\`\n${endingText}`;
+        ${
+          projectFormValues.length
+            ? `**Your project link(s)**\n`
+            : `**Your code so far**`
+        }
+        ${projectFormValues
+          ?.map(([key, val]) => `${key}: ${val}\n`)
+          ?.join('') || filesToMarkdown(files)}
+
+        ${endingText}`
+      );
+
+      const altTextMessage = dedent(
+        `**Tell us what's happening:**
+        **Your code so far**
+        WARNING
+        The challenge seed code and/or your solution exceeded the maximum length we can port over from the challenge.
+        You will need to take an additional step here so the code you wrote presents in an easy to read format.
+        Please copy/paste all the editor code showing in the challenge from where you just linked.
+        \`\`\`
+        Replace these two sentences with your copied code.
+        Please leave the \`\`\` line above and the \`\`\` line below,
+        because they allow your code to properly format in the post.
+        \`\`\`\n${endingText}`
+      );
 
       const category = window.encodeURIComponent(helpCategory || 'Help');
 

--- a/client/src/templates/Challenges/redux/create-question-epic.js
+++ b/client/src/templates/Challenges/redux/create-question-epic.js
@@ -52,17 +52,16 @@ function createQuestionEpic(action$, state$, { window }) {
 
       let textMessage = dedent(
         `**Tell us what's happening:**
-        \n\n
-        ${
-          projectFormValues.length
-            ? `**Your project link(s)**\n`
-            : `**Your code so far**`
-        }
-        ${projectFormValues
-          ?.map(([key, val]) => `${key}: ${val}\n`)
-          ?.join('') || filesToMarkdown(files)}
-        \n
-        ${endingText}`
+
+    ${
+      projectFormValues.length
+        ? `**Your project link(s)**\n`
+        : `**Your code so far**`
+    }
+    ${projectFormValues?.map(([key, val]) => `${key}: ${val}\n`)?.join('') ||
+      filesToMarkdown(files)}
+
+    ${endingText}`
       );
 
       const altTextMessage = dedent(

--- a/client/src/templates/Challenges/redux/create-question-epic.js
+++ b/client/src/templates/Challenges/redux/create-question-epic.js
@@ -53,15 +53,15 @@ function createQuestionEpic(action$, state$, { window }) {
       let textMessage = dedent(
         `**Tell us what's happening:**
 
-    ${
-      projectFormValues.length
-        ? `**Your project link(s)**\n`
-        : `**Your code so far**`
-    }
-    ${projectFormValues?.map(([key, val]) => `${key}: ${val}\n`)?.join('') ||
-      filesToMarkdown(files)}
+  ${
+    projectFormValues.length
+      ? `**Your project link(s)**\n`
+      : `**Your code so far**`
+  }
+  ${projectFormValues?.map(([key, val]) => `${key}: ${val}\n`)?.join('') ||
+    filesToMarkdown(files)}
 
-    ${endingText}`
+  ${endingText}`
       );
 
       const altTextMessage = dedent(

--- a/client/src/templates/Challenges/redux/create-question-epic.js
+++ b/client/src/templates/Challenges/redux/create-question-epic.js
@@ -1,4 +1,3 @@
-import dedent from 'dedent';
 import { ofType } from 'redux-observable';
 import {
   types,
@@ -39,54 +38,24 @@ function createQuestionEpic(action$, state$, { window }) {
       const projectFormValues = Object.entries(
         projectFormValuesSelector(state)
       );
-      const endingText = dedent(
-        `**Your browser information:**
+      const endingText = `**Your browser information:**\n
+      \nUser Agent is: <code>${userAgent}</code>.\n
+      \n**Challenge:** ${challengeTitle}\n
+      \n**Link to the challenge:**\n\n${href}`;
 
-        User Agent is: <code>${userAgent}</code>.
+      let textMessage = `**Tell us what's happening:**\n\n${
+        projectFormValues.length
+          ? `**Your project link(s)**\n`
+          : `**Your code so far**`
+      }${projectFormValues?.map(([key, val]) => `${key}: ${val}\n`)?.join('') ||
+        filesToMarkdown(files)}${endingText}`;
 
-        **Challenge:** ${challengeTitle}
-
-        **Link to the challenge:**
-        ${href}`
-      );
-
-      let textMessage = dedent(
-        `**Tell us what's happening:**
-
-  ${
-    projectFormValues.length
-      ? `**Your project link(s)**\n`
-      : `**Your code so far**`
-  }
-  ${projectFormValues?.map(([key, val]) => `${key}: ${val}\n`)?.join('') ||
-    filesToMarkdown(files)}
-
-  ${endingText}`
-      );
-
-      const altTextMessage = dedent(
-        `**Tell us what's happening:**
-
-
-
-        **Your code so far**
-
-        WARNING
-
-        The challenge seed code and/or your solution exceeded the maximum length we can port over from the challenge.
-
-        You will need to take an additional step here so the code you wrote presents in an easy to read format.
-
-        Please copy/paste all the editor code showing in the challenge from where you just linked.
-
-        \`\`\`
-
-        Replace these two sentences with your copied code.
-        Please leave the \`\`\` line above and the \`\`\` line below,
-        because they allow your code to properly format in the post.
-
-        \`\`\`\n${endingText}`
-      );
+      const altTextMessage = `**Tell us what's happening:**\n
+      \n**Your code so far**\n\nWARNING\n
+      \nThe challenge seed code and/or your solution exceeded the maximum length we can port over from the challenge.\n
+      \nYou will need to take an additional step here so the code you wrote presents in an easy to read format.\n
+      \nPlease copy/paste all the editor code showing in the challenge from where you just linked.\n\`\`\`\nReplace these two sentences with your copied code.\n
+      \nPlease leave the \`\`\` line above and the \`\`\` line below,\nbecause they allow your code to properly format in the post.\n\`\`\`\n${endingText}`;
 
       const category = window.encodeURIComponent(helpCategory || 'Help');
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes _the other issue I created :)_

Turns out dedent does the opposite of what I thought. This PR fixes an issue where this:
````text
**Tell us what's happening**

**Your code so far**

```html
<h1>Hi</h1>
```

**Your browser information**
````

Becomes this:
````
**Tell us what's happening**

  **Your code so far**

```html
<h1>Hi</h1>
```

  **Your browser information**
````
_Notice indented headings_

Should I just re-write this to not use `dedent`?