### PR TITLE
fix(tools): allow partial translation

### DIFF
--- a/.github/workflows/crowdin-i18n-client-ui-download.yml
+++ b/.github/workflows/crowdin-i18n-client-ui-download.yml
@@ -23,7 +23,8 @@ jobs:
 
           # downloads
           download_translations: true
-          skip_untranslated_files: true
+          skip_untranslated_strings: true
+          skip_untranslated_files: false
           export_only_approved: true
 
           commit_message: 'chore(i8n,client): processed translations'
@@ -40,7 +41,7 @@ jobs:
           base_url: ${{ secrets.CROWDIN_BASE_URL_FCC }}
 
           # Uncomment below to debug
-          # dryrun_action: true
+          dryrun_action: true
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/crowdin-i18n-client-ui-download.yml
+++ b/.github/workflows/crowdin-i18n-client-ui-download.yml
@@ -41,7 +41,7 @@ jobs:
           base_url: ${{ secrets.CROWDIN_BASE_URL_FCC }}
 
           # Uncomment below to debug
-          dryrun_action: true
+          # dryrun_action: true
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Modifies the workflow to allow for partial download of translations
to ensure we get all keys in the translation object even if they
still have english values.

NOTE: Sets workflow to dry run for testing purposes. Will need to
revert that setting.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
