### PR TITLE
fix(tools): Skip untranslated files for curriculum download

### DIFF
--- a/.github/workflows/crowdin-i18n-curriculum-download.yml
+++ b/.github/workflows/crowdin-i18n-curriculum-download.yml
@@ -24,7 +24,7 @@ jobs:
 
           # downloads
           download_translations: true
-          skip_untranslated_files: false
+          skip_untranslated_files: true
           export_only_approved: true
 
           commit_message: 'chore(i8n,learn): processed translations'


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

Now that 100% of the Responsive Web Design section is 100% translated, we need to change the workflow back to skip files that are not 100% translated, otherwise we end up with challenges that have a mix of English and non-English, if after an upload, we do a download before the translations have been made and approved on a file. 