### PR TITLE
fix(i18n, client): use placeholder on map

### DIFF
--- a/client/i18n/locales/chinese/translations.json
+++ b/client/i18n/locales/chinese/translations.json
@@ -283,8 +283,8 @@
     "scrimba-tip": "注意：如果这个小浏览器窗口覆盖了代码，点击拖动它。同时，你可以随时暂停，在视频中编辑代码。",
     "chal-preview": "挑战预览",
     "cert-map-estimates": {
-      "certs": "认证（300 小时）",
-      "coding-prep": "（数千小时的挑战）"
+      "certs": "{{title}} 认证（300 小时）",
+      "coding-prep": "{{title}}（数千小时的挑战）"
     },
     "editor-tabs": {
       "info": "Info",

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -283,8 +283,8 @@
     "scrimba-tip": "Tip: If the mini-browser is covering the code, click and drag to move it. Also, feel free to stop and edit the code in the video at any time.",
     "chal-preview": "Challenge Preview",
     "cert-map-estimates": {
-      "certs": "Certification (300\u00A0hours)",
-      "coding-prep": "(Thousands of hours of challenges)"
+      "certs": "{{title}} Certification (300\u00A0hours)",
+      "coding-prep": "{{title}} (Thousands of hours of challenges)"
     },
     "editor-tabs": {
       "info": "Info",

--- a/client/i18n/locales/espanol/translations.json
+++ b/client/i18n/locales/espanol/translations.json
@@ -283,8 +283,8 @@
     "scrimba-tip": "Sugerencia: Si el mini-navegador cubre el código, haz clic y arrastra para moverlo. Además, siéntate libre de detener y editar el código en el video en cualquier momento.",
     "chal-preview": "Vista previa del desafío",
     "cert-map-estimates": {
-      "certs": "(300 horas)",
-      "coding-prep": "(Miles de horas de desafíos)"
+      "certs": "Certificación {{title}} (300 horas)",
+      "coding-prep": "{{title}} (Miles de horas de desafíos)"
     },
     "editor-tabs": {
       "info": "Info",

--- a/client/src/components/Map/index.js
+++ b/client/src/components/Map/index.js
@@ -21,8 +21,10 @@ const codingPrepRE = new RegExp('Interview Prep');
 function createSuperBlockTitle(str) {
   const superBlockTitle = i18next.t(`intro:${dasherize(str)}.title`);
   return codingPrepRE.test(str)
-    ? `${superBlockTitle} ${i18next.t('learn.cert-map-estimates.coding-prep')}`
-    : `${superBlockTitle} ${i18next.t('learn.cert-map-estimates.certs')}`;
+    ? i18next.t('learn.cert-map-estimates.coding-prep', {
+        title: superBlockTitle
+      })
+    : i18next.t('learn.cert-map-estimates.certs', { title: superBlockTitle });
 }
 
 const linkSpacingStyle = {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Modifies the translation flow for the certification buttons on the
learn/landing map to pass the superBlock title to the string as a
placeholder. This will allow translators to restructure the order
of the sentence (i.e. certification and hours) based on language-
specific grammar structures.
