### PR TITLE
fix(client): add key to Fragment in SuperBlockIntro

### DIFF
--- a/client/src/templates/Introduction/SuperBlockIntro.js
+++ b/client/src/templates/Introduction/SuperBlockIntro.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 import { graphql } from 'gatsby';
@@ -165,7 +165,7 @@ export class SuperBlockIntroductionPage extends Component {
               <Spacer />
               <div className='block-ui'>
                 {blockDashedNames.map(blockDashedName => (
-                  <>
+                  <Fragment key={blockDashedName}>
                     <Block
                       blockDashedName={blockDashedName}
                       challenges={nodesForSuperBlock.filter(
@@ -174,7 +174,7 @@ export class SuperBlockIntroductionPage extends Component {
                       superBlockDashedName={superBlockDashedName}
                     />
                     {blockDashedName !== 'project-euler' ? <Spacer /> : null}
-                  </>
+                  </Fragment>
                 ))}
                 {superBlock !== 'Coding Interview Prep' && (
                   <div>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Fixes the following error:
<details>
  <summary>Error</summary>

```console
Warning: Each child in a list should have a unique "key" prop.

Check the render method of `SuperBlockIntroductionPage`. See https://fb.me/react-warning-keys for more information.
    in Fragment (created by SuperBlockIntroductionPage)
    in SuperBlockIntroductionPage (created by withI18nextTranslation(SuperBlockIntroductionPage))
```

</details>

Let me know if there is a better key value I should use.