### PR TITLE
feat(client): add common links to formValidators regex

### DIFF
--- a/client/src/components/formHelpers/FormFields.js
+++ b/client/src/components/formHelpers/FormFields.js
@@ -14,7 +14,8 @@ import { Field } from 'react-final-form';
 import {
   editorValidator,
   localhostValidator,
-  composeValidators
+  composeValidators,
+  fCCValidator
 } from './FormValidators';
 
 const propTypes = {
@@ -52,6 +53,7 @@ function FormFields(props) {
     }
     const validationWarning = composeValidators(
       name === 'githubLink' || isEditorLinkAllowed ? null : editorValidator,
+      fCCValidator,
       localhostValidator
     )(value);
     const message = error || validationError || validationWarning;

--- a/client/src/components/formHelpers/FormValidators.js
+++ b/client/src/components/formHelpers/FormValidators.js
@@ -1,9 +1,13 @@
 // Matches editor links for: Repl.it, Glitch, CodeSandbox, GitHub
 const editorRegex = /repl\.it\/(@|join\/)|glitch\.com\/edit\/#!|codesandbox\.io\/s\/|github\.com/;
+const fCCRegex = /codepen\.io\/freecodecamp|freecodecamp\.rocks|github\.com\/freecodecamp/i;
 const localhostRegex = /localhost:/;
 
 export const editorValidator = value =>
   editorRegex.test(value) ? 'Remember to submit the Live App URL.' : null;
+
+export const fCCValidator = value =>
+  fCCRegex.test(value) ? 'Remember to submit your own work.' : null;
 
 export const localhostValidator = value =>
   localhostRegex.test(value)

--- a/client/src/components/formHelpers/FormValidators.js
+++ b/client/src/components/formHelpers/FormValidators.js
@@ -1,5 +1,5 @@
 // Matches editor links for: Repl.it, Glitch, CodeSandbox, GitHub
-const editorRegex = /repl\.it\/@|glitch\.com\/edit\/#!|codesandbox\.io\/s\/|github\.com/;
+const editorRegex = /repl\.it\/(@|join\/)|glitch\.com\/edit\/#!|codesandbox\.io\/s\/|github\.com/;
 const localhostRegex = /localhost:/;
 
 export const editorValidator = value =>

--- a/client/src/components/formHelpers/index.js
+++ b/client/src/components/formHelpers/index.js
@@ -2,7 +2,8 @@ import normalizeUrl from 'normalize-url';
 import {
   localhostValidator,
   editorValidator,
-  composeValidators
+  composeValidators,
+  fCCValidator
 } from './FormValidators';
 
 export { default as BlockSaveButton } from './BlockSaveButton.js';
@@ -20,6 +21,7 @@ export function formatUrlValues(values, options) {
   const urlValues = Object.keys(values).reduce((result, key) => {
     let value = values[key];
     const nullOrWarning = composeValidators(
+      fCCValidator,
       localhostValidator,
       key === 'githubLink' || isEditorLinkAllowed ? null : editorValidator
     )(value);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

This PR adds links like `https://repl.it/join/Sky020` to the editor validation. As well as freeCodeCamp related links:
- CodePen links
- GitHub boilerplate links
- `freeCodeCamp.rocks` links

Never ceases to amaze how many different links Campers will submit before the correct one.