### PR TITLE
fix(tools, i18n): Configure Crowdin to only download docs for specific languages for which we currently accept translations

### DIFF
--- a/.github/workflows/crowdin-i18n-docs-download..yml
+++ b/.github/workflows/crowdin-i18n-docs-download..yml
@@ -11,8 +11,8 @@ jobs:
       - name: Checkout Source Files
         uses: actions/checkout@v2
 
-      ##### Download #####
-      - name: Crowdin Download for Translations
+      ##### Download Chinese #####
+      - name: Crowdin Download Chinese Translations
         uses: crowdin/github-action@master
         # options: https://github.com/crowdin/github-action/blob/master/action.yml
         with:
@@ -24,17 +24,50 @@ jobs:
 
           # downloads
           download_translations: true
+          download_language: zh-CN
+          skip_untranslated_files: false
+          export_only_approved: true
+
+          push_translations: false
+
+          # pull-request
+          create_pull_request: false
+
+          # global options
+          config: './config/crowdin/docs/crowdin.yml'
+          base_url: ${{ secrets.CROWDIN_BASE_URL_FCC }}
+
+          # Uncomment below to debug
+          # dryrun_action: true
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID_DOCS }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_CAMPERBOT_SERVICE_TOKEN }}
+
+      ##### Download Espanol #####
+      - name: Crowdin Espanol Download Translations
+        uses: crowdin/github-action@master
+        # options: https://github.com/crowdin/github-action/blob/master/action.yml
+        with:
+          # uploads
+          upload_sources: false
+          upload_translations: false
+          auto_approve_imported: false
+          import_eq_suggestions: false
+
+          # downloads
+          download_translations: true
+          download_language: es-EM
           skip_untranslated_files: false
           export_only_approved: true
 
           commit_message: 'chore(i8n,docs): processed translations'
+          localization_branch_name: i18n-sync-docs
+          push_translations: true
 
           # pull-request
-          localization_branch_name: i18n-sync-docs
           create_pull_request: false
-          pull_request_title: 'chore(i18n,docs): Processed translations from crowdin'
-          pull_request_body: ''
-          pull_request_labels: 'scope: i18n, scope: docs, crowdin-sync'
 
           # global options
           config: './config/crowdin/docs/crowdin.yml'

--- a/config/crowdin/docs/crowdin.yml
+++ b/config/crowdin/docs/crowdin.yml
@@ -9,7 +9,6 @@ files: [
  {
   "source" : "/docs/*.md",
   "translation" : "/docs/i18n/%language%/%original_file_name%",
-
   "ignore" : [
     "/docs/_coverpage.md",
     "/docs/_navbar.md",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

After several adjustments to the mapping and the config file and several correspondences with @nhcarrigan, we can now download only Chinese and Spanish docs.  This proves out that we can add a new language to download from the 25+ languages we are currently accepting translations on.  We just have to remember to add the language mapping under the project settings (see below):

![image](https://user-images.githubusercontent.com/5313213/107885482-d4037900-6eb7-11eb-8ee9-1359abd47d45.png)

