### PR TITLE
fix/Remove broken twitter links in python curriculum

### DIFF
--- a/curriculum/challenges/english/08-data-analysis-with-python/data-analysis-with-python-course/how-to-use-jupyter-notebooks-intro.md
+++ b/curriculum/challenges/english/08-data-analysis-with-python/data-analysis-with-python-course/how-to-use-jupyter-notebooks-intro.md
@@ -14,7 +14,6 @@ More resources:
 
 -   [Notebooks on GitHub](https://github.com/ine-rmotr-curriculum/ds-content-interactive-jupyterlab-tutorial)
 -   [How to open Notebooks from GitHub using Google Colab.](https://colab.research.google.com/github/googlecolab/colabtools/blob/master/notebooks/colab-github-demo.ipynb)
--   [Twitter Cheat Sheet](https://twitter.com/rmotr_com/status/1122176794696847361)
 
 # --question--
 

--- a/curriculum/challenges/english/08-data-analysis-with-python/data-analysis-with-python-course/jupyter-notebooks-cells.md
+++ b/curriculum/challenges/english/08-data-analysis-with-python/data-analysis-with-python-course/jupyter-notebooks-cells.md
@@ -14,7 +14,6 @@ More resources:
 
 -   [Notebooks on GitHub](https://github.com/ine-rmotr-curriculum/ds-content-interactive-jupyterlab-tutorial)
 -   [How to open Notebooks from GitHub using Google Colab.](https://colab.research.google.com/github/googlecolab/colabtools/blob/master/notebooks/colab-github-demo.ipynb)
--   [Twitter Cheat Sheet](https://twitter.com/rmotr_com/status/1122176794696847361)
 
 # --question--
 

--- a/curriculum/challenges/english/08-data-analysis-with-python/data-analysis-with-python-course/jupyter-notebooks-importing-and-exporting-data.md
+++ b/curriculum/challenges/english/08-data-analysis-with-python/data-analysis-with-python-course/jupyter-notebooks-importing-and-exporting-data.md
@@ -14,7 +14,6 @@ More resources:
 
 -   [Notebooks on GitHub](https://github.com/ine-rmotr-curriculum/ds-content-interactive-jupyterlab-tutorial)
 -   [How to open Notebooks from GitHub using Google Colab.](https://colab.research.google.com/github/googlecolab/colabtools/blob/master/notebooks/colab-github-demo.ipynb)
--   [Twitter Cheat Sheet](https://twitter.com/rmotr_com/status/1122176794696847361)
 
 # --question--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to #41127

<!-- Feel free to add any additional description of changes below this line -->
The twitter link provided to the cheatsheet does not work anymore because the twitter account has deleted all their tweets including the cheatsheet that we used. In this event, we have to delete this link and on a later PR, a new link to another article will be added.
