### PR TITLE
fix(tools): no i18n workflow

### DIFF
--- a/.github/workflows/no-prs-to-translation.yml
+++ b/.github/workflows/no-prs-to-translation.yml
@@ -2,7 +2,7 @@ name: No translate on GitHub
 on:
   pull_request_target:
     branches:
-      - 'master'
+      - 'main'
     paths:
       - 'curriculum/challenges/**'
       - '!curriculum/challenges/english/**'
@@ -16,10 +16,12 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            await github.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: 'We have implemented a new policy of no longer accepting curriculum-related PRs with changes to non-English files. We plan to implement a better way to translate the English challenges in the near future. We will make an announcement when it is ready. For now, please revert your changes to the non-English challenge files. Thank you.'
-            })
-            throw new Error('This PR appears to touch translated challenge files.')
+            if (context.payload.pull_request.head.repo.fork) {
+              await github.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: 'We have implemented a new policy of no longer accepting curriculum-related PRs with changes to non-English files. We plan to implement a better way to translate the English challenges in the near future. We will make an announcement when it is ready. For now, please revert your changes to the non-English challenge files. Thank you.'
+              })
+              throw new Error('This PR appears to touch translated challenge files.')
+            }

--- a/.github/workflows/no-prs-to-translation.yml
+++ b/.github/workflows/no-prs-to-translation.yml
@@ -21,7 +21,7 @@ jobs:
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: 'We have implemented a new policy of no longer accepting curriculum-related PRs with changes to non-English files. Please visit https://translate.freecodecamp.org to make translations to the curriculum. Thank you.'
+                body: 'We have implemented a new policy of no longer accepting curriculum-related PRs with changes to non-English files. Please visit [our contributing documentation](https://contribute.freecodecamp.org) for instructions on translating the curriculum. Thank you.'
               })
               core.setFailed('This PR appears to touch translated challenge files.')
             } else {

--- a/.github/workflows/no-prs-to-translation.yml
+++ b/.github/workflows/no-prs-to-translation.yml
@@ -17,15 +17,15 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             if (context.payload.pull_request.head.repo.fork) {
-              await github.issues.createComment({
+              github.issues.createComment({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 body: 'We have implemented a new policy of no longer accepting curriculum-related PRs with changes to non-English files. We plan to implement a better way to translate the English challenges in the near future. We will make an announcement when it is ready. For now, please revert your changes to the non-English challenge files. Thank you.'
               })
-              throw new Error('This PR appears to touch translated challenge files.')
+              core.setFailed('This PR appears to touch translated challenge files.')
             } else {
-                await github.issues.createComment({
+                github.issues.createComment({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/.github/workflows/no-prs-to-translation.yml
+++ b/.github/workflows/no-prs-to-translation.yml
@@ -21,7 +21,7 @@ jobs:
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: 'We have implemented a new policy of no longer accepting curriculum-related PRs with changes to non-English files. We plan to implement a better way to translate the English challenges in the near future. We will make an announcement when it is ready. For now, please revert your changes to the non-English challenge files. Thank you.'
+                body: 'We have implemented a new policy of no longer accepting curriculum-related PRs with changes to non-English files. Please visit https://translate.freecodecamp.org to make translations to the curriculum. Thank you.'
               })
               core.setFailed('This PR appears to touch translated challenge files.')
             } else {

--- a/.github/workflows/no-prs-to-translation.yml
+++ b/.github/workflows/no-prs-to-translation.yml
@@ -24,4 +24,11 @@ jobs:
                 body: 'We have implemented a new policy of no longer accepting curriculum-related PRs with changes to non-English files. We plan to implement a better way to translate the English challenges in the near future. We will make an announcement when it is ready. For now, please revert your changes to the non-English challenge files. Thank you.'
               })
               throw new Error('This PR appears to touch translated challenge files.')
+            } else {
+                await github.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: 'WAIT! This message serves as a sanity check. Your PR appears to come from the base freeCodeCamp repository and modifies translated curriculum files. Before merging, please confirm that the commits on this PR originated from the Crowdin download action.'
+              })
             }

--- a/.github/workflows/no-prs-to-translation.yml
+++ b/.github/workflows/no-prs-to-translation.yml
@@ -21,7 +21,7 @@ jobs:
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: 'We have implemented a new policy of no longer accepting curriculum-related PRs with changes to non-English files. Please visit [our contributing documentation](https://contribute.freecodecamp.org) for instructions on translating the curriculum. Thank you.'
+                body: 'Thanks for your pull-request. We are no longer accepting curriculum-related changes to non-English files. Please visit [our contributing guidelines](https://contribute.freecodecamp.org) to learn more about translating freeCodeCamp's resources.'
               })
               core.setFailed('This PR appears to touch translated challenge files.')
             } else {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This PR re-enables our workflow that verifies no changes are made to translated curriculum files through GitHub. Here's the logic for the workflow:

- If PR does *not* touch translated curriculum files:
  - Do nothing. Workflow won't show on list of PR checks, even.
- If PR touches translated curriculum files:
  - If PR comes from a forked repository:
    - Comment on issue explaining new process.
    - Throw `Error` to cause workflow to fail.
  - Else:
    - Comment on issue requesting sanity check (this reminds us to verify that the changes are from a crowdin download, *just in case* we work off a branch on this repo and accidentally change something translated).
    - Do *not* throw `Error`, workflow will still pass to avoid blocking the merge.
- If PR touches translated AND English files:
  - Do same as above.

I tested the logic in the PR on my own test repository, and have some open PRs there for review: https://github.com/nhcarrigan/actions-testing/pulls

@RandellDawson we may need to update the message for the translation flow?

@raisedadead mind giving this an extra look as well?