### PR TITLE
Emphasize that solution links need to be of form https:// especially …

### DIFF
--- a/curriculum/challenges/english/05-apis-and-microservices/basic-node-and-express/get-route-parameter-input-from-the-client.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/basic-node-and-express/get-route-parameter-input-from-the-client.md
@@ -16,6 +16,8 @@ When building an API, we have to allow users to communicate to us what they want
 
 Build an echo server, mounted at the route `GET /:word/echo`. Respond with a JSON object, taking the structure `{echo: word}`. You can find the word to be repeated at `req.params.word`. You can test your route from your browser's address bar, visiting some matching routes, e.g. `your-app-rootpath/freecodecamp/echo`.
 
+Make sure the link you submit starts with https:// or else, if it starts with http:// it will not pass the tests. 
+
 # --hints--
 
 Test 1 : Your echo server should repeat words correctly


### PR DESCRIPTION
…for Glitch users

I found out about this the frustrating way. The URL I pasted from glitch was of the form http:// and that's why my solution was not able to pass the tests, even though it worked. 
Once I changed the URL to https:// it passed the tests. 
I think other students should be very aware of this to not cause unnecessary confusion about their solutions.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
