### PR TITLE
chore: pin mongodb for warnings - again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'sunday'
+    ignore:
+      - dependency-name: 'mongodb'
     open-pull-requests-limit: 20
     labels:
       - 'dependabot'

--- a/api-server/package-lock.json
+++ b/api-server/package-lock.json
@@ -14458,9 +14458,9 @@
       }
     },
     "mongodb": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.4.tgz",
-      "integrity": "sha512-Y+Ki9iXE9jI+n9bVtbTOOdK0B95d6wVGSucwtBkvQ+HIvVdTCfpVRp01FDC24uhC/Q2WXQ8Lpq3/zwtB5Op9Qw==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.3.tgz",
+      "integrity": "sha512-rOZuR0QkodZiM+UbQE5kDsJykBqWi0CL4Ec2i1nrGrUI3KO11r6Fbxskqmq3JK2NH7aW4dcccBuUujAP0ERl5w==",
       "requires": {
         "bl": "^2.2.1",
         "bson": "^1.1.4",

--- a/api-server/package.json
+++ b/api-server/package.json
@@ -43,7 +43,7 @@
     "method-override": "^3.0.0",
     "moment": "^2.29.1",
     "moment-timezone": "^0.5.33",
-    "mongodb": "3.6.4",
+    "mongodb": "3.6.3",
     "morgan": "^1.10.0",
     "nanoid": "^1.3.4",
     "nodemailer-ses-transport": "^1.5.1",


### PR DESCRIPTION
I missed updating the dependabot configs to ignore the mongodb driver in the API package, I have added an internal trello card for me to remember removing this when we are able to update the package.
