### PR TITLE
fix(learn): unmangle challenge description

### DIFF
--- a/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/sum-of-a-series.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/sum-of-a-series.md
@@ -8,7 +8,7 @@ dashedName: sum-of-a-series
 
 # --description--
 
-Compute the **n**<sup>th</sup> term of a [series](<https://en.wikipedia.org/wiki/Series (mathematics)>), i.e. the sum of the **n** first terms of the corresponding [sequence](https://en.wikipedia.org/wiki/sequence). Informally this value, or its limit when **n** tends to infinity, is also called the *sum of the series*, thus the title of this task. For this task, use: $S*n = \\sum*{k=1}^n \\frac{1}{k^2}$ and compute $S\_{1000}$ This approximates the [zeta function](<https://en.wikipedia.org/wiki/Riemann zeta function>) for S=2, whose exact value $\\zeta(2) = {\\pi^2\\over 6}$ is the solution of the [Basel problem](<https://en.wikipedia.org/wiki/Basel problem>).
+Compute the **n**<sup>th</sup> term of a [series](<https://en.wikipedia.org/wiki/Series (mathematics)>), i.e. the sum of the **n** first terms of the corresponding [sequence](https://en.wikipedia.org/wiki/sequence). Informally this value, or its limit when **n** tends to infinity, is also called the *sum of the series*, thus the title of this task. For this task, use: $S*n = \\sum*{k=1}^n \\frac{1}{k^2}$.
 
 # --instructions--
 

--- a/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/sum-of-a-series.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/sum-of-a-series.md
@@ -8,7 +8,7 @@ dashedName: sum-of-a-series
 
 # --description--
 
-Compute the **n**<sup>th</sup> term of a [series](<https://en.wikipedia.org/wiki/Series (mathematics)>), i.e. the sum of the **n** first terms of the corresponding [sequence](https://en.wikipedia.org/wiki/sequence). Informally this value, or its limit when **n** tends to infinity, is also called the *sum of the series*, thus the title of this task. For this task, use: $S*n = \\sum*{k=1}^n \\frac{1}{k^2}$.
+Compute the **n**<sup>th</sup> term of a [series](<https://en.wikipedia.org/wiki/Series (mathematics)>), i.e. the sum of the **n** first terms of the corresponding [sequence](https://en.wikipedia.org/wiki/sequence). Informally this value, or its limit when **n** tends to infinity, is also called the *sum of the series*, thus the title of this task. For this task, use: $S_n = \displaystyle\sum_{k=1}^n \frac{1}{k^2}$.
 
 # --instructions--
 


### PR DESCRIPTION
[Learn Rosetta Code: Sum of a series](https://www.freecodecamp.org/learn/coding-interview-prep/rosetta-code/sum-of-a-series)
* Removes part of description that's not relevant to challenge in current form and is a leftover from the goal of original [Sum of a series - Rosetta Code](https://rosettacode.org/wiki/Sum_of_a_series)
* Fixes display of the equation
* Tested on local fork
* There's no outstanding issue regarding this problem

#### Before
![sum-of-a-series-mangled](https://user-images.githubusercontent.com/60067306/108462525-07aa1e80-727d-11eb-8892-41a82c77011f.png)
#### After
![sum-of-a-series-fixed](https://user-images.githubusercontent.com/60067306/108462532-0c6ed280-727d-11eb-927c-5595cf7570d8.png)


Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.