### PR TITLE
fixed tests for link to external pages challenge

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/link-to-external-pages-with-anchor-elements.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/link-to-external-pages-with-anchor-elements.md
@@ -32,7 +32,7 @@ assert(/cat photos/gi.test($('a').text()));
 You need an `a` element that links to `https://freecatphotoapp.com`
 
 ```js
-assert(/https:\/\/(www\.)?freecatphotoapp\.com/gi.test($('a').attr('href')));
+assert(/^https?:\/\/(www\.)?freecatphotoapp\.com$/i.test($('a').attr('href')));
 ```
 
 Your `a` element should have a closing tag.

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/link-to-external-pages-with-anchor-elements.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/link-to-external-pages-with-anchor-elements.md
@@ -32,7 +32,7 @@ assert(/cat photos/gi.test($('a').text()));
 You need an `a` element that links to `https://freecatphotoapp.com`
 
 ```js
-assert(/^https?:\/\/(www\.)?freecatphotoapp\.com\/?$/i.test($('a').attr('href')));
+assert(/^https?:\/\/freecatphotoapp\.com\/?$/i.test($('a').attr('href')));
 ```
 
 Your `a` element should have a closing tag.

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/link-to-external-pages-with-anchor-elements.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/link-to-external-pages-with-anchor-elements.md
@@ -32,7 +32,7 @@ assert(/cat photos/gi.test($('a').text()));
 You need an `a` element that links to `https://freecatphotoapp.com`
 
 ```js
-assert(/^https?:\/\/(www\.)?freecatphotoapp\.com$/i.test($('a').attr('href')));
+assert(/^https?:\/\/(www\.)?freecatphotoapp\.com\/?$/i.test($('a').attr('href')));
 ```
 
 Your `a` element should have a closing tag.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #41173 

<!-- Feel free to add any additional description of changes below this line -->

I've made the discussed changes:
 - added anchors to the regex to make sure nothing around the required url is allowed
 - removed the `g` because useless
 - allowed both `http` and `https` as per in the discussion in the issue