### PR TITLE
fix: only log errors when challenges update

### DIFF
--- a/tools/challenge-parser/parser/index.js
+++ b/tools/challenge-parser/parser/index.js
@@ -50,9 +50,10 @@ exports.parseMD = function parseMD(filename) {
       if (err) {
         err.message += ' in file ' + filename;
         reject(err);
+      } else {
+        delete file.contents;
+        resolve(file.data);
       }
-      delete file.contents;
-      return resolve(file.data);
     });
   });
 };

--- a/tools/challenge-parser/parser/index.js
+++ b/tools/challenge-parser/parser/index.js
@@ -47,13 +47,13 @@ exports.parseMD = function parseMD(filename) {
     const file = readSync(filename);
     const tree = processor.parse(file);
     processor.run(tree, file, function(err, node, file) {
-      if (err) {
-        err.message += ' in file ' + filename;
-        reject(err);
-      } else {
+      if (!err) {
         delete file.contents;
         resolve(file.data);
       }
+
+      err.message += ' in file ' + filename;
+      reject(err);
     });
   });
 };


### PR DESCRIPTION
Prior to this change, parsing errors were not handled properly and Gatsby would exit if a file could not be parsed.  With this change the initial sourcing (on `npm run develop`) will still exit(1), but `watch` only warns if there's a problem with parsing.