### PR TITLE
fix(client): Private timeline doesn't hide certs 

### DIFF
--- a/client/src/components/settings/Privacy.js
+++ b/client/src/components/settings/Privacy.js
@@ -142,7 +142,6 @@ class PrivacySettings extends Component {
             />
             <ToggleSetting
               action={t('settings.labels.my-timeline')}
-              explain={t('settings.disabled')}
               flag={!showTimeLine}
               flagName='showTimeLine'
               offLabel={t('buttons.public')}


### PR DESCRIPTION
In this Pull Request, we are removing the `timeline` option which says `"Your certifications will be disabled, if set to private."` as making private doesn't hide the certificates which in turn fixes issue #41171

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #41171

<!-- Feel free to add any additional description of changes below this line -->
