### PR TITLE
fix: clarify case for already placed valid number

### DIFF
--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/sudoku-solver.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/sudoku-solver.md
@@ -207,7 +207,7 @@ If `value` submitted to `/api/check` is already placed in `puzzle` on that `coor
 ```js
 async (getUserInput) => {
   const input =
-  '9..5.1.85.4....2432......1...69.83.9.....6.62.71...9......1945....4.37.4.3..6..';
+  '..9..5.1.85.4....2432......1...69.83.9.....6.62.71...9......1945....4.37.4.3..6..';
   const coordinate = 'C3';
   const value = '2';
   const data = await fetch(getUserInput('url') + '/api/check', {

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/sudoku-solver.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/sudoku-solver.md
@@ -202,6 +202,25 @@ async (getUserInput) => {
 };
 ```
 
+If `value` submitted to `/api/check` is already placed in `puzzle` on that `coordinate`, the returned value will be an object containing a `valid` property with `true` if `value` is not conflicting.
+
+```js
+async (getUserInput) => {
+  const input =
+  '9..5.1.85.4....2432......1...69.83.9.....6.62.71...9......1945....4.37.4.3..6..';
+  const coordinate = 'C3';
+  const value = '2';
+  const data = await fetch(getUserInput('url') + '/api/check', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ puzzle: input, coordinate, value })
+  });
+  const parsed = await data.json();
+  assert.property(parsed, 'valid');
+  assert.isTrue(parsed.valid);
+};
+```
+
 If the puzzle submitted to `/api/check` contains values which are not numbers or periods, the returned value will be `{ error: 'Invalid characters in puzzle' }`
 
 ```js


### PR DESCRIPTION
* Adds new test to clarify checking number already placed in puzzle.
* Changes tested on local fork.
* Can close linked issue, however demo on https://sudoku-solver.freecodecamp.rocks/ still needs to be updated to reflect the change in expected response. Related PR - https://github.com/freeCodeCamp/demo-projects/pull/49

Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

Closes #40359
