### PR TITLE
fix(docs): repair image links

### DIFF
--- a/docs/how-to-catch-outgoing-emails-locally.md
+++ b/docs/how-to-catch-outgoing-emails-locally.md
@@ -83,15 +83,15 @@ Start [using MailHog](#using-mailhog).
 
 Open a new browser tab or window and navigate to [http://localhost:8025](http://localhost:8025) to open your MailHog inbox when the MailHog installation has completed and MailHog is running. The inbox will appear similar to the screenshot below.
 
-![MailHog Screenshot 1](images/mailhog/1.jpg)
+![MailHog Screenshot 1](https://contribute.freecodecamp.org/images/mailhog/1.jpg)
 
 Emails sent by your freeCodeCamp installation will appear as below
 
-![MailHog Screenshot 2](images/mailhog/2.jpg)
+![MailHog Screenshot 2](https://contribute.freecodecamp.org/images/mailhog/2.jpg)
 
 Two tabs that allow you to view either plain text or source content will be available when you open a given email. Ensure that the plain text tab is selected as below.
 
-![MailHog Screenshot 3](images/mailhog/3.jpg)
+![MailHog Screenshot 3](https://contribute.freecodecamp.org/images/mailhog/3.jpg)
 
 All links in the email should be clickable and resolve to their URL.
 

--- a/docs/how-to-open-a-pull-request.md
+++ b/docs/how-to-open-a-pull-request.md
@@ -45,13 +45,13 @@ Some examples of good PRs titles would be:
 
 1. Once the edits have been committed, you will be prompted to create a pull request on your fork's GitHub Page.
 
-   ![Image - Compare pull request prompt on GitHub](./images/github/compare-pull-request-prompt.png)
+   ![Image - Compare pull request prompt on GitHub](https://contribute.freecodecamp.org/images/github/compare-pull-request-prompt.png)
 
 2. By default, all pull requests should be against the freeCodeCamp main repo, `main` branch.
 
    Make sure that your Base Fork is set to freeCodeCamp/freeCodeCamp when raising a Pull Request.
 
-   ![Image - Comparing forks when making a pull request](./images/github/comparing-forks-for-pull-request.png)
+   ![Image - Comparing forks when making a pull request](https://contribute.freecodecamp.org/images/github/comparing-forks-for-pull-request.png)
 
 3. Submit the pull request from your branch to freeCodeCamp's `main` branch.
 

--- a/docs/how-to-proofread-files.md
+++ b/docs/how-to-proofread-files.md
@@ -8,7 +8,7 @@ To begin proofreading, visit [our translation site](https://translate.freecodeca
 
 You should see the list of projects you have been granted access to. Select the project that you would like to proofread, then select the language.
 
-![Image - Proofreading File Tree](./images/crowdin/proof-file-tree.png)
+![Image - Proofreading File Tree](https://contribute.freecodecamp.org/images/crowdin/proof-file-tree.png)
 
 You should now see the list of available files. Choose your file by selecting the `Proofread` button on the right of that file, then choosing `Proofreading` from the drop-down menu that appears.
 
@@ -17,7 +17,7 @@ You should now see the list of available files. Choose your file by selecting th
 
 ## Proofread Translations
 
-![Image - Proofreading View](./images/crowdin/proofread.png)
+![Image - Proofreading View](https://contribute.freecodecamp.org/images/crowdin/proofread.png)
 
 <!--Add proofread/crowdsource button to the image-->
 

--- a/docs/how-to-translate-files.md
+++ b/docs/how-to-translate-files.md
@@ -11,11 +11,11 @@ You should see two "projects" available for translation: The `Contributing Docum
 
 Select which project you want to contribute to, and you will see a list of available languages for translation.
 
-![Image - List of available languages](./images/crowdin/languages.png)
+![Image - List of available languages](https://contribute.freecodecamp.org/images/crowdin/languages.png)
 
 Select the language you want to work on, and you will see the complete file tree.
 
-![Image - List of available files](./images/crowdin/file-tree.png)
+![Image - List of available files](https://contribute.freecodecamp.org/images/crowdin/file-tree.png)
 
 Each file and folder will show a progress bar. The **blue** portion of the progress bar indicates what percentage of the file has been translated, while the **green** portion of the progress bar indicates what percentage of the file has been approved by the proofreading team.
 
@@ -26,7 +26,7 @@ Select a file to work on and Crowdin will open the editor view.
 
 ## Translate the File
 
-![Image - Editor View](./images/crowdin/editor.png)
+![Image - Editor View](https://contribute.freecodecamp.org/images/crowdin/editor.png)
 
 Crowdin separates a document into translatable "strings", usually sentences. Each string is translated individually. Referring to the image above:
 
@@ -72,7 +72,7 @@ We have enabled some quality assurance steps that will verify a translation is a
 
 When you attempt to save a translation, you may see a warning message appear with a notification regarding your proposed translation.
 
-![Image - QA Warning Message](./images/crowdin/qa-message.png)
+![Image - QA Warning Message](https://contribute.freecodecamp.org/images/crowdin/qa-message.png)
 
 This message appears when Crowdin's QA system has identified a potential error in the proposed translation. In this example, we have modified the text of a `<code>` tag and Crowdin has caught that.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #41228 

<!-- Feel free to add any additional description of changes below this line -->

Replaces the relative image links with absolute links pulling from `contribute.freecodecamp.org` - currently, this fix won't resolve any issues, as we will need to merge this then upload to Crowdin then download the translated version.