### PR TITLE
docs(i18n): enable portuguese

### DIFF
--- a/.github/workflows/crowdin-i18n-docs-download..yml
+++ b/.github/workflows/crowdin-i18n-docs-download..yml
@@ -45,6 +45,40 @@ jobs:
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID_DOCS }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_CAMPERBOT_SERVICE_TOKEN }}
 
+      ##### Download Portuguese#####
+      - name: Crowdin Download Portuguese Translations
+        uses: crowdin/github-action@master
+        # options: https://github.com/crowdin/github-action/blob/master/action.yml
+        with:
+          # uploads
+          upload_sources: false
+          upload_translations: false
+          auto_approve_imported: false
+          import_eq_suggestions: false
+
+          # downloads
+          download_translations: true
+          download_language: pt-BR
+          skip_untranslated_files: false
+          export_only_approved: true
+
+          push_translations: false
+
+          # pull-request
+          create_pull_request: false
+
+          # global options
+          config: './config/crowdin/docs/crowdin.yml'
+          base_url: ${{ secrets.CROWDIN_BASE_URL_FCC }}
+
+          # Uncomment below to debug
+          # dryrun_action: true
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID_DOCS }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_CAMPERBOT_SERVICE_TOKEN }}
+
       ##### Download Espanol #####
       - name: Crowdin Espanol Download Translations
         uses: crowdin/github-action@master

--- a/docs/_translations.md
+++ b/docs/_translations.md
@@ -11,6 +11,7 @@
 - [Chinese](/i18n/chinese/index.md)
 - [English](/index.md)
 - [Español](/i18n/espanol/index.md)
+- [Portuguese](/i18n/portuguese/index.md)
 
 </div>
 

--- a/docs/i18n/portuguese/FAQ.md
+++ b/docs/i18n/portuguese/FAQ.md
@@ -1,0 +1,86 @@
+### I am new to GitHub and Open Source. Where should I start?
+
+Read our ["How to Contribute to Open Source Guide"](https://github.com/freeCodeCamp/how-to-contribute-to-open-source). It's a comprehensive reference for first-timer-friendly projects. And it includes a lot of open source contribution tips.
+
+### Can I translate freeCodeCamp's curriculum?
+
+Yes - Read [this guide](/how-to-translate-files) if you are interested in contributing to translation.
+
+Currently we have the user contributed translations being done in Chinese and Español.
+
+At this time we are building our experience hosting the curriculum in the aforementioned languages. Eventually, we intend to localize freeCodeCamp into several major world languages, like: Arabic, Hindi, Portuguese, Russian and more.
+
+We thank you for your patience while we iron out the workflow.
+
+### How can I report a new bug?
+
+If you think you've found a bug, first read the ["Help I've Found a Bug"](https://forum.freecodecamp.org/t/how-to-report-a-bug/19543) article and follow its instructions.
+
+If you're confident it's a new bug, go ahead and create a new GitHub issue. Be sure to include as much information as possible so that we can reproduce the bug. We have a pre-defined issue template to help you through this.
+
+Please note that these GitHub issues are for codebase-related issues and discussions – not for getting help with learning to code. Whenever in doubt, you should [seek assistance on the forum](https://forum.freecodecamp.org) before creating a GitHub issue.
+
+### How can I report a security issue?
+
+Please don't create GitHub issues for security issues. Instead, please send an email to `security@freecodecamp.org` and we'll look into it immediately.
+
+### I am a student. Can I work on a feature for academic credits?
+
+Yes. Please note we are unable to commit to any timelines or paperwork that may be a requirement by your college or university. We receive many pull-requests and code contributions by volunteer developers, and we respect their time and efforts. Out of respect for all of our other contributors, we will not give any PR special priority just because it happens to be school-related.
+
+We request you to plan ahead and work on code contributions with this in mind.
+
+### What do these different labels that are tagged on issues mean?
+
+The code maintainers [triage](https://en.wikipedia.org/wiki/Software_bug#Bug_management) issues and pull requests based on their priority, severity, and other factors. You can [find a complete glossary of their meanings here](https://github.com/freecodecamp/freecodecamp/labels).
+
+### Where do I start if I want to work on an issue?
+
+You should go through [**`help wanted`**](https://github.com/freeCodeCamp/freeCodeCamp/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) or [**`first timers only`**](https://github.com/freeCodeCamp/freeCodeCamp/issues?q=is%3Aopen+is%3Aissue+label%3A%22first+timers+only%22) issues for a quick overview of what is available for you to work on.
+
+> [!TIP] **`help wanted`** issues are up for grabs, and you do not need to seek permission before working on them. However, issues with the **`first timers only`** label are special issues that are designed for people who have not contributed to the freeCodeCamp codebase before.
+
+### I found a typo. Should I report an issue before I can make a pull request?
+
+For typos and other wording changes, you can directly open pull requests without creating an issue first. Please be sure to mention details in the pull request description to help us understand and review your contribution – even if it's just a minor change.
+
+Please do create an issue if you want to discuss bigger aspects of the codebase or curriculum.
+
+### How can I get an issue assigned to me?
+
+We typically do not assign issues to anyone other than long-time contributors. Instead, we follow the below policy to be fair to everyone:
+
+1. We are most likely to merge the first pull request that addresses the issue.
+2. In the case of multiple contributors opening a pull request for the same issue at around the same time, we will give priority to the pull request that best addresses the issue. Some of the things we consider:
+   - Did you include tests?
+   - Did you catch all usecases?
+   - Did you ensure all tests pass, and confirm everything works locally?
+3. Finally, we give priority to pull requests which follow our recommended guidelines.
+   - Did you follow the pull request checklist?
+   - Did you give your pull request a meaningful title?
+
+### I am stuck on something that is not included in this documentation.
+
+**Feel free to ask for help in:**
+
+- The `Contributors` category of [our community forum](https://forum.freecodecamp.org/c/contributors).
+- The `#Contributors` channel on [our chat server](https://chat.freecodecamp.org/channel/contributors).
+
+We are excited to help you contribute to any of the topics that you would like to work on. If you ask us questions on the related issue threads, we will be glad to clarify. Be sure to search for your question before posting a new one.
+
+Thanks in advance for being polite and patient. Remember – this community is run mainly by volunteers.
+
+**Additional Assistance:**
+
+If you have queries about the stack, architecture of the codebase, feel free to reach out to our staff dev team:
+
+| Staff                 | Send message on Forum                                                        |
+| :-------------------- | :--------------------------------------------------------------------------- |
+| Mrugesh Mohapatra     | [@raisedadead](https://forum.freecodecamp.org/u/raisedadead)                 |
+| Ahmad Abdolsaheb      | [@abdolsa](https://forum.freecodecamp.org/u/abdolsa)                         |
+| Kristofer Koishigawa  | [@scissorsneedfoodtoo](https://forum.freecodecamp.org/u/scissorsneedfoodtoo) |
+| Tom Mondloc           | [@moT01](https://forum.freecodecamp.org/u/moT01)                             |
+| Oliver Eyton-Williams | [@ojeytonwilliams](https://forum.freecodecamp.org/u/ojeytonwilliams)         |
+| Randell Dawson        | [@RandellDawson](https://forum.freecodecamp.org/u/randelldawson)             |
+
+**You can email our developer staff at: `dev[at]freecodecamp.org`**

--- a/docs/i18n/portuguese/_sidebar.md
+++ b/docs/i18n/portuguese/_sidebar.md
@@ -1,0 +1,31 @@
+- **Getting Started**
+  - [Introduction](index.md 'Contribute to the freeCodeCamp.org Community')
+  - [Frequently Asked Questions](FAQ.md)
+- **Code Contribution**
+  - [Set up freeCodeCamp locally](how-to-setup-freecodecamp-locally.md)
+  - [Open a pull request](how-to-open-a-pull-request.md)
+  - [Work on coding challenges](how-to-work-on-coding-challenges.md)
+  - [Work on video challenges](how-to-help-with-video-challenges.md)
+  - [Work on the news theme](how-to-work-on-the-news-theme.md)
+  - [Work on the docs theme](how-to-work-on-the-docs-theme.md)
+- **Translation Contribution**
+  - [Translating a Curriculum File](how-to-translate-files.md)
+  - [Proofreading a Curriculum File](how-to-proofread-files.md)
+  - [How to Translate the Website](how-to-translate-the-website.md)
+- **Optional Guides**
+  - [Catch outgoing emails locally](how-to-catch-outgoing-emails-locally.md)
+  - [Set up freeCodeCamp on WSL](how-to-setup-wsl.md)
+  - [Add Cypress tests](how-to-add-cypress-tests.md)
+
+---
+
+- **Flight Manuals** (for Staff & Mods)
+  - [Moderator Handbook](moderator-handbook.md)
+  - [DevOps Handbook](devops.md)
+
+---
+
+- **Our Community**
+  - [**GitHub**](https://github.com/freecodecamp/freecodecamp)
+  - [**Discourse Forum**](https://freecodecamp.org/forum/c/contributors)
+  - [**Chat Server**](https://chat.freecodecamp.org/home)

--- a/docs/i18n/portuguese/devops.md
+++ b/docs/i18n/portuguese/devops.md
@@ -1,0 +1,742 @@
+# DevOps Handbook
+
+This guide will help you understand our infrastructure stack and how we maintain our platforms. While this guide does not have exhaustive details for all operations, it could be used as a reference for your understanding of the systems.
+
+Let us know, if you have feedback or queries, and we will be happy to clarify.
+
+# Flight Manual - Code deployments
+
+This repository is continuously built, tested and deployed to **separate sets of infrastructure (Servers, Databases, CDNs, etc.)**.
+
+This involves three steps to be followed in sequence:
+
+1. New changes (both fixes and features) are merged into our primary development branch (`main`) via pull requests.
+2. These changes are run through a series of automated tests.
+3. Once the tests pass we release the changes (or update them if needed) to deployments on our infrastructure.
+
+#### Building the codebase - Mapping Git Branches to Deployments.
+
+Typically, [`main`](https://github.com/freeCodeCamp/freeCodeCamp/tree/main) (the default development branch) is merged into the [`prod-staging`](https://github.com/freeCodeCamp/freeCodeCamp/tree/prod-staging) branch once a day and is released into an isolated infrastructure.
+
+This is an intermediate release for our developers and volunteer contributors. It is also known as our "staging" or "beta" release.
+
+It is identical to our live production environment at `freeCodeCamp.org`, other than it using a separate set of databases, servers, web-proxies, etc. This isolation lets us test ongoing development and features in a "production" like scenario, without affecting regular users of freeCodeCamp.org's main platforms.
+
+Once the developer team [`@freeCodeCamp/dev-team`](https://github.com/orgs/freeCodeCamp/teams/dev-team/members) is happy with the changes on the staging platform, these changes are moved every few days to the [`prod-current`](https://github.com/freeCodeCamp/freeCodeCamp/tree/prod-current) branch.
+
+This is the final release that moves changes to our production platforms on freeCodeCamp.org.
+
+#### Testing changes - Integration and User Acceptance Testing.
+
+We employ various levels of integration and acceptance testing to check on the quality of the code. All our tests are done through software like [GitHub Actions CI](https://github.com/freeCodeCamp/freeCodeCamp/actions) and [Azure Pipelines](https://dev.azure.com/freeCodeCamp-org/freeCodeCamp).
+
+We have unit tests for testing our challenge solutions, Server APIs and Client User interfaces. These help us test the integration between different components.
+
+> [!NOTE]
+> We are also in the process of writing end user tests which will help in replicating real world scenarios like updating an email or making a call to the API or third-party services.
+
+Together these tests help in preventing issues from repeating themselves and ensure we do not introduce a bug while working on another bug or a feature.
+
+#### Deploying Changes - Pushing changes to servers.
+
+We have configured continuous delivery software to push changes to our development and production servers.
+
+Once the changes are pushed to the protected release branches, a build pipeline is automatically triggered for the branch. The build pipelines are responsible for building artifacts and keeping them in a cold storage for later use.
+
+The build pipeline goes on to trigger a corresponding release pipeline if it completes a successful run. The release pipelines are responsible for collecting the build artifacts, moving them to the servers and going live.
+
+Status of builds and releases are [available here](#build-test-and-deployment-status).
+
+## Trigger a build, test and deploy
+
+Currently, only members on the developer team can push to the production branches. The changes to the `production-*` branches can land only via fast-forward merge to the [`upstream`](https://github.com/freeCodeCamp/freeCodeCamp).
+
+> [!NOTE]
+> In the upcoming days we would improve this flow to be done via pull-requests, for better access management and transparency.
+
+### Pushing changes to Staging Applications.
+
+1. Configure your remotes correctly.
+
+   ```sh
+   git remote -v
+   ```
+
+   **Results:**
+
+   ```
+   origin	git@github.com:raisedadead/freeCodeCamp.git (fetch)
+   origin	git@github.com:raisedadead/freeCodeCamp.git (push)
+   upstream	git@github.com:freeCodeCamp/freeCodeCamp.git (fetch)
+   upstream	git@github.com:freeCodeCamp/freeCodeCamp.git (push)
+   ```
+
+2. Make sure your `maim` branch is pristine and in sync with the upstream.
+
+   ```sh
+   git checkout main
+   git fetch --all --prune
+   git reset --hard upstream/main
+   ```
+
+3. Check that the GitHub CI is passing on the `main` branch for upstream.
+
+   The [continuous integration](https://github.com/freeCodeCamp/freeCodeCamp/actions) tests should be green and PASSING for the `main` branch. Click the green check mark next to the commit hash when viewing the `main` branch code.
+
+    <details>
+      <summary>
+        Checking status on GitHub Actions (screenshot)
+      </summary>
+      <br>
+      <img src="https://raw.githubusercontent.com/freeCodeCamp/freeCodeCamp/main/docs/images/devops/github-actions.png" alt="Check build status on GitHub Actions">
+    </details>
+
+   If this is failing you should stop and investigate the errors.
+
+4. Confirm that you are able to build the repository locally.
+
+   ```
+   npm run clean-and-develop
+   ```
+
+5. Move changes from `main` to `prod-staging` via a fast-forward merge
+
+   ```
+   git checkout prod-staging
+   git merge main
+   git push upstream
+   ```
+
+   > [!NOTE]
+   > You will not be able to force push and if you have re-written the history in anyway these commands will error out.
+   >
+   > If they do, you may have done something incorrectly and you should just start over.
+
+The above steps will automatically trigger a run on the build pipeline for the `prod-staging` branch. Once the build is complete, the artifacts are saved as `.zip` files in a cold storage to be retrieved and used later.
+
+The release pipeline is triggered automatically when a fresh artifact is available from the connected build pipeline. For staging platforms, this process does not involve manual approval and the artifacts are pushed to the Client CDN and API servers.
+
+### Pushing changes to Production Applications.
+
+The process is mostly the same as the staging platforms, with a few extra checks in place. This is just to make sure, we do not break anything on freeCodeCamp.org which can see hundreds of users using it at any moment.
+
+| Do NOT execute these commands unless you have verified that everything is working on the staging platform. You should not bypass or skip any testing on staging before proceeding further. |
+| :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+
+
+1. Make sure your `prod-staging` branch is pristine and in sync with the upstream.
+
+   ```sh
+   git checkout prod-staging
+   git fetch --all --prune
+   git reset --hard upstream/prod-staging
+   ```
+
+2. Move changes from `prod-staging` to `prod-current` via a fast-forward merge
+
+   ```
+   git checkout prod-current
+   git merge prod-staging
+   git push upstream
+   ```
+
+   > [!NOTE]
+   > You will not be able to force push and if you have re-written the history in anyway these commands will error out.
+   >
+   > If they do, you may have done something incorrectly and you should just start over.
+
+The above steps will automatically trigger a run on the build pipeline for the `prod-current` branch. Once a build artifact is ready, it will trigger a run on the release pipeline.
+
+**Additional Steps for Staff Action**
+
+One a release run is triggered, members of the developer staff team will receive an automated manual intervention email. They can either _approve_ or _reject_ the release run.
+
+If the changes are working nicely and have been tested on the staging platform, then it can be approved. The approval must be given within 4 hours of the release being triggered before getting rejected automatically. A staff can re-trigger the release run manually for rejected runs, or wait for the next cycle of release.
+
+For staff use:
+
+| Check your email for a direct link or [go to the release dashboard](https://dev.azure.com/freeCodeCamp-org/freeCodeCamp/_release) after the build run is complete. |
+| :----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+
+
+Once one of the staff members approves a release, the pipeline will push the changes live to freeCodeCamp.org's production CDN and API servers.
+
+## Build, Test and Deployment Status
+
+Here is the current test, build and deployment status of the codebase.
+
+| Branch                                                                           | Unit Tests                                                                                                                                                                                                                       | Integration Tests                                                                                                                                                                                                        | Builds & Deployments                                                                                                              |
+| :------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------- |
+| [`main`](https://github.com/freeCodeCamp/freeCodeCamp/tree/main)                 | [![Node.js CI](https://github.com/freeCodeCamp/freeCodeCamp/workflows/Node.js%20CI/badge.svg?branch=main)](https://github.com/freeCodeCamp/freeCodeCamp/actions?query=workflow%3A%22Node.js+CI%22)                               | [![Cypress E2E Tests](https://img.shields.io/endpoint?url=https://dashboard.cypress.io/badge/simple/ke77ns/main&style=flat&logo=cypress)](https://dashboard.cypress.io/projects/ke77ns/analytics/runs-over-time)         | -                                                                                                                                 |
+| [`prod-staging`](https://github.com/freeCodeCamp/freeCodeCamp/tree/prod-staging) | [![Node.js CI](https://github.com/freeCodeCamp/freeCodeCamp/workflows/Node.js%20CI/badge.svg?branch=prod-staging)](https://github.com/freeCodeCamp/freeCodeCamp/actions?query=workflow%3A%22Node.js+CI%22+branch%3Aprod-staging) | [![Cypress E2E Tests](https://img.shields.io/endpoint?url=https://dashboard.cypress.io/badge/simple/ke77ns/prod-staging&style=flat&logo=cypress)](https://dashboard.cypress.io/projects/ke77ns/analytics/runs-over-time) | [Azure Pipelines](https://dev.azure.com/freeCodeCamp-org/freeCodeCamp/_dashboards/dashboard/d59f36b9-434a-482d-8dbd-d006b71713d4) |
+| [`prod-current`](https://github.com/freeCodeCamp/freeCodeCamp/tree/prod-staging) | [![Node.js CI](https://github.com/freeCodeCamp/freeCodeCamp/workflows/Node.js%20CI/badge.svg?branch=prod-current)](https://github.com/freeCodeCamp/freeCodeCamp/actions?query=workflow%3A%22Node.js+CI%22+branch%3Aprod-current) | [![Cypress E2E Tests](https://img.shields.io/endpoint?url=https://dashboard.cypress.io/badge/simple/ke77ns/prod-current&style=flat&logo=cypress)](https://dashboard.cypress.io/projects/ke77ns/analytics/runs-over-time) | [Azure Pipelines](https://dev.azure.com/freeCodeCamp-org/freeCodeCamp/_dashboards/dashboard/d59f36b9-434a-482d-8dbd-d006b71713d4) |
+| `prod-next` (experimental, upcoming)                                             | -                                                                                                                                                                                                                                | -                                                                                                                                                                                                                        | -                                                                                                                                 |
+
+## Early access and beta testing
+
+We welcome you to test these releases in a **"public beta testing"** mode and get early access to upcoming features to the platforms. Sometimes these features/changes are referred to as **next, beta, staging,** etc. interchangeably.
+
+Your contributions via feedback and issue reports will help us in making the production platforms at `freeCodeCamp.org` more **resilient**, **consistent** and **stable** for everyone.
+
+We thank you for reporting bugs that you encounter and help in making freeCodeCamp.org better. You rock!
+
+### Identifying the upcoming version of the platforms
+
+Currently a public beta testing version is available at:
+
+| Application | Language | URL                                      |
+| :---------- | :------- | :--------------------------------------- |
+| Learn       | English  | <https://www.freecodecamp.dev>           |
+|             | Espanol  | <https://www.freecodecamp.dev/espanol>   |
+|             | Chinese  | <https://chinese.freecodecamp.dev>       |
+| News        | English  | <https://www.freecodecamp.dev/news>      |
+| Forum       | English  | <https://forum.freecodecamp.dev>         |
+|             | Chinese  | <https://chinese.freecodecamp.dev/forum> |
+| API         | -        | `https://api.freecodecamp.dev`           |
+
+> [!NOTE]
+> The domain name is different than **`freeCodeCamp.org`**. This is intentional to prevent search engine indexing and avoid confusion for regular users of the platform.
+>
+> The above list not exhaustive of all the applications that we provision. Also not all language variants are deployed in staging to conserve resources.
+
+### Identifying the current version of the platforms
+
+**The current version of the platform is always available at [`freeCodeCamp.org`](https://www.freecodecamp.org).**
+
+The dev-team merges changes from the `prod-staging` branch to `prod-current` when they release changes. The top commit should be what you see live on the site.
+
+You can identify the exact version deployed by visiting the build and deployment logs available in the status section. Alternatively you can also ping us in the [contributors chat room](https://chat.freecodecamp.org/channel/contributors) for a confirmation.
+
+### Known Limitations
+
+There are some known limitations and tradeoffs when using the beta version of the platform.
+
+- #### All data / personal progress on these beta platforms `will NOT be saved or carried over` to production.
+
+  **Users on the beta version will have a separate account from the production.** The beta version uses a physically separate database from production. This gives us the ability to prevent any accidental loss of data or modifications. The dev team may purge the database on this beta version as needed.
+
+- #### There are no guarantees on the uptime and reliability of the beta platforms.
+
+  Deployment is expected to be frequent and in rapid iterations, sometimes multiple times a day. As a result there will be unexpected downtime at times or broken functionality on the beta version.
+
+- #### Do not send regular users to this site as a measure of confirming a fix
+
+  The beta site is and always has been to augment local development and testing, nothing else. It's not a promise of what’s coming, but a glimpse of what is being worked upon.
+
+- #### Sign in page may look different than production
+
+  We use a test tenant for freecodecamp.dev on Auth0, and hence do not have the ability to set a custom domain. This makes it so that all the redirect callbacks and the login page appear at a default domain like: `https://freecodecamp-dev.auth0.com/`. This does not affect the functionality is as close to production as we can get.
+
+## Reporting issues and leaving feedback
+
+Please open fresh issues for discussions and reporting bugs.
+
+You may send an email to `dev[at]freecodecamp.org` if you have any queries. As always all security vulnerabilities should be reported to `security[at]freecodecamp.org` instead of the public tracker and forum.
+
+# Flight Manual - Server Maintenance
+
+> [!WARNING]
+>
+> 1. The guide applies to the **freeCodeCamp Staff members only**.
+> 2. These instructions should not be considered exhaustive, please use caution.
+
+As a member of the staff, you may have been given access to our cloud service providers like Azure, Digital Ocean, etc.
+
+Here are some handy commands that you can use to work on the Virtual Machines (VM), for instance performing maintenance updates or doing general houeskeeping.
+
+## Get a list of the VMs
+
+> [!NOTE] While you may already have SSH access to the VMs, that alone will not
+> let you list VMs unless you been granted access to the cloud portals as well.
+
+### Azure
+
+Install Azure CLI `az`: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli
+
+> **(One-time) Install on macOS with [`homebrew`](https://brew.sh):**
+
+```
+brew install azure-cli
+```
+
+> **(One-time) Login:**
+
+```
+az login
+```
+
+> **Get the list of VM names and P addresses:**
+
+```
+az vm list-ip-addresses --output table
+```
+
+### Digital Ocean
+
+Install Digital Ocean CLI `doctl`:
+https://github.com/digitalocean/doctl#installing-doctl
+
+> **(One-time) Install on macOS with [`homebrew`](https://brew.sh):**
+
+```
+brew install doctl
+```
+
+> **(One-time) Login:**
+
+Authentication and context switching:
+https://github.com/digitalocean/doctl#authenticating-with-digitalocean
+
+```
+doctl auth init
+```
+
+> **Get the list of VM names and IP addresses:**
+
+```
+doctl compute droplet list --format "ID,Name,PublicIPv4"
+```
+
+## Spin a VM (or VM Scale Set)
+
+> Todo: Add instructions for spinning VM(s)
+
+<!--
+
+The below instructions are stale.
+
+### 0. Prerequisites (workspace Setup) for Staff
+
+Get a login session on `azure cli`, and clone the
+[`infra`](https://github.com/freeCodeCamp/infra) for setting up template
+workspace.
+
+```console
+az login
+git clone https://github.com/freeCodeCamp/infra
+cd infra
+```
+
+Use the Scratchpad subdirectory for temporary files, and making one-off edits.
+The contents in this subdirectory are intentionally ignored from source control.
+
+### 1. Provision VMs on Azure.
+
+List all Resource Groups
+
+```console
+az group list --output table
+```
+
+```console
+Name                               Location       Status
+---------------------------------  -------------  ---------
+tools-rg                           eastus         Succeeded
+```
+
+Create a Resource Group
+
+```
+az group create --location eastus --name stg-rg
+```
+
+```console
+az group list --output table
+```
+
+```console
+Name                               Location       Status
+---------------------------------  -------------  ---------
+tools-rg                           eastus         Succeeded
+stg-rg                             eastus         Succeeded
+```
+
+Next per the need, provision a single VM or a scaleset.
+
+#### A. provision single instances
+
+```console
+az vm create \
+  --resource-group stg-rg-eastus \
+  --name <VIRTUAL_MACHINE_NAME> \
+  --image UbuntuLTS \
+  --size <VIRTUAL_MACHINE_SKU>
+  --custom-data cloud-init/nginx-cloud-init.yaml \
+  --admin-username <USERNAME> \
+  --ssh-key-values <SSH_KEYS>.pub
+```
+
+#### B. provision scaleset instance
+
+```console
+az vmss create \
+  --resource-group stg-rg-eastus \
+  --name <VIRTUAL_MACHINE_SCALESET_NAME> \
+  --image UbuntuLTS \
+  --size <VIRTUAL_MACHINE_SKU>
+  --upgrade-policy-mode automatic \
+  --custom-data cloud-init/nginx-cloud-init.yaml \
+  --admin-username <USERNAME> \
+  --ssh-key-values <SSH_KEYS>.pub
+```
+
+> [!NOTE]
+>
+> - The custom-data config should allow you to configure and add SSH keys,
+>   install packages etc. via the `cloud-init` templates in your local
+>   workspace. Tweak the files in your local workspace as needed. The cloud-init
+>   config is optional and you can omit it completely to do setups manually as
+>   well.
+>
+> - The virtual machine SKU is something like: **Standard_B2s** which can be
+>   retrived by executing something like
+>   `az vm list-sizes -l eastus --output table` or checking the Azure portal
+>   pricing.
+
+-->
+
+## Keep VMs updated
+
+You should keep the VMs up to date by performing updates and upgrades. This will
+ensure that the virtual machine is patched with latest security fixes.
+
+> [!WARNING] Before you run these commands:
+>
+> - Make sure that the VM has been provisioned completely and there is no
+>   post-install steps running.
+> - If you are updating packages on a VM that is already serving an application,
+>   make sure the app has been stopped / saved. Package updates will cause
+>   network bandwidth, memory and/or CPU usage spikes leading to outages on
+>   running applications.
+
+Update package information
+
+```console
+sudo apt update
+```
+
+Upgrade installed packages
+
+```console
+sudo apt upgrade -y
+```
+
+Cleanup unused packages
+
+```console
+sudo apt autoremove -y
+```
+
+## Work on Web Servers (Proxy)
+
+We are running load balanced (Azure Load Balancer) instances for our web
+servers. These servers are running NGINX which reverse proxy all of the traffic
+to freeCodeCamp.org from various applications running on their own
+infrastructures.
+
+The NGINX config is available on
+[this repository](https://github.com/freeCodeCamp/nginx-config).
+
+### First Install
+
+Provisioning VMs with the Code
+
+#### 1. (Optional) Install NGINX and configure from repository.
+
+The basic setup should be ready OOTB, via the cloud-init configuration. SSH and
+make changes as necessary for the particular instance(s).
+
+If you did not use the cloud-init config previously use the below for manual
+setup of NGINX and error pages:
+
+```console
+sudo su
+
+cd /var/www/html
+git clone https://github.com/freeCodeCamp/error-pages
+
+cd /etc/
+rm -rf nginx
+git clone https://github.com/freeCodeCamp/nginx-config nginx
+
+cd /etc/nginx
+```
+
+#### 2. Install Cloudflare origin certificates and upstream application config.
+
+Get the Cloudflare origin certificates from the secure storage and install at
+required locations.
+
+**OR**
+
+Move over existing certificates:
+
+```console
+# Local
+scp -r username@source-server-public-ip:/etc/nginx/ssl ./
+scp -pr ./ssl username@target-server-public-ip:/tmp/
+
+# Remote
+rm -rf ./ssl
+mv /tmp/ssl ./
+```
+
+Update Upstream Configurations:
+
+```console
+vi configs/upstreams.conf
+```
+
+Add/update the source/origin application IP addresses.
+
+#### 3. Setup networking and firewalls.
+
+Configure Azure firewalls and `ufw` as needed for ingress origin addresses.
+
+#### 4. Add the VM to the load balancer backend pool.
+
+Configure and add rules to load balancer if needed. You may also need to add the
+VMs to load balancer backend pool if needed.
+
+### Logging and Monitoring
+
+1. Check status for NGINX service using the below command:
+
+```console
+sudo systemctl status nginx
+```
+
+2. Logging and monitoring for the servers are available at:
+
+> <h3 align="center"><a href='https://amplify.nginx.com' _target='blank'>https://amplify.nginx.com</a></h3>
+
+### Updating Instances (Maintenance)
+
+Config changes to our NGINX instances are maintained on GitHub, these should be
+deployed on each instance like so:
+
+1. SSH into the instance and enter sudo
+
+```console
+sudo su
+```
+
+2. Get the latest config code.
+
+```console
+cd /etc/nginx
+git fetch --all --prune
+git reset --hard origin/main
+```
+
+3. Test and reload the config
+   [with Signals](https://docs.nginx.com/nginx/admin-guide/basic-functionality/runtime-control/#controlling-nginx).
+
+```console
+nginx -t
+nginx -s reload
+```
+
+## Work on API Instances
+
+1. Install build tools for node binaries (`node-gyp`) etc.
+
+```console
+sudo apt install build-essential
+```
+
+### First Install
+
+Provisioning VMs with the Code
+
+1. Install Node LTS.
+
+2. Update `npm` and install PM2 and setup logrotate and startup on boot
+
+   ```console
+   npm i -g npm
+   npm i -g pm2
+   pm2 install pm2-logrotate
+   pm2 startup
+   ```
+
+3. Clone freeCodeCamp, setup env and keys.
+
+   ```console
+   git clone https://github.com/freeCodeCamp/freeCodeCamp.git
+   cd freeCodeCamp
+   git checkout prod-current # or any other branch to be deployed
+   ```
+
+4. Create the `.env` from the secure credentials storage.
+
+5. Create the `google-credentials.json` from the secure credentials storage.
+
+6. Install dependencies
+
+   ```console
+   npm ci
+   ```
+
+7. Build the server
+
+   ```console
+   npm run ensure-env && npm run build:server
+   ```
+
+8. Start Instances
+
+   ```console
+   cd api-server
+   pm2 start production-start.js -i max --max-memory-restart 600M --name org
+   ```
+
+### Logging and Monitoring
+
+```console
+pm2 logs
+```
+
+```console
+pm2 monit
+```
+
+### Updating Instances (Maintenance)
+
+Code changes need to be deployed to the API instances from time to time. It can
+be a rolling update or a manual update. The later is essential when changing
+dependencies or adding enviroment variables.
+
+> [!DANGER] The automated pipelines are not handling dependencies updates at the
+> minute. We need to do a manual update before any deployment pipeline runs.
+
+#### 1. Manual Updates - Used for updating dependencies, env variables.
+
+1. Stop all instances
+
+```console
+pm2 stop all
+```
+
+2. Install dependencies
+
+```console
+npm ci
+```
+
+3. Build the server
+
+```console
+npm run ensure-env && npm run build:server
+```
+
+4. Start Instances
+
+```console
+pm2 start all --update-env && pm2 logs
+```
+
+#### 2. Rolling updates - Used for logical changes to code.
+
+```console
+pm2 reload all --update-env && pm2 logs
+```
+
+> [!NOTE] We are handling rolling updates to code, logic, via pipelines. You
+> should not need to run these commands. These are here for documentation.
+
+## Work on Client Instances
+
+1. Install build tools for node binaries (`node-gyp`) etc.
+
+```console
+sudo apt install build-essential
+```
+
+### First Install
+
+Provisioning VMs with the Code
+
+1. Install Node LTS.
+
+2. Update `npm` and install PM2 and setup logrotate and startup on boot
+
+   ```console
+   npm i -g npm
+   npm i -g pm2
+   npm install -g serve
+   pm2 install pm2-logrotate
+   pm2 startup
+   ```
+
+3. Clone client config, setup env and keys.
+
+   ```console
+   git clone https://github.com/freeCodeCamp/client-config.git client
+   cd client
+   ```
+
+   ```console
+   git clone https://github.com/freeCodeCamp/client-config.git client
+   cd client
+   ```
+
+   Start placeholder instances for the web client, these will be updated with
+   artifacts from the Azure pipeline.
+
+   > Todo: This setup needs to move to S3 or Azure Blob storage
+
+   ```console
+   echo "serve -c ../../serve.json www -p 50505" >> client-start-primary.sh
+   chmod +x client-start-primary.sh
+   pm2 delete client-primary
+   pm2 start  ./client-start-primary.sh --name client-primary
+   echo "serve -c ../../serve.json www -p 52525" >> client-start-secondary.sh
+   chmod +x client-start-secondary.sh
+   pm2 delete client-secondary
+   pm2 start  ./client-start-secondary.sh --name client-secondary
+   ```
+
+### Logging and Monitoring
+
+```console
+pm2 logs
+```
+
+```console
+pm2 monit
+```
+
+### Updating Instances (Maintenance)
+
+Code changes need to be deployed to the API instances from time to time. It can
+be a rolling update or a manual update. The later is essential when changing
+dependencies or adding enviroment variables.
+
+> [!DANGER] The automated pipelines are not handling dependencies updates at the
+> minute. We need to do a manual update before any deployment pipeline runs.
+
+#### 1. Manual Updates - Used for updating dependencies, env variables.
+
+1. Stop all instances
+
+   ```console
+   pm2 stop all
+   ```
+
+2. Install or update dependencies
+
+3. Start Instances
+
+   ```console
+   pm2 start all --update-env && pm2 logs
+   ```
+
+#### 2. Rolling updates - Used for logical changes to code.
+
+```console
+pm2 reload all --update-env && pm2 logs
+```
+
+> [!NOTE] We are handling rolling updates to code, logic, via pipelines. You
+> should not need to run these commands. These are here for documentation.

--- a/docs/i18n/portuguese/how-to-add-cypress-tests.md
+++ b/docs/i18n/portuguese/how-to-add-cypress-tests.md
@@ -1,0 +1,84 @@
+# How to add Cypress tests
+
+When making changes to JavaScript, CSS, or HTML which could change the functionality or layout of a page, it's important to add corresponding [Cypress](https://docs.cypress.io) integration tests.
+
+To learn how to write Cypress tests, or 'specs', please see Cypress' official [documentation](https://docs.cypress.io/guides/getting-started/writing-your-first-test.html).
+
+> Note: When writing tests for freeCodeCamp, remember to add `/* global cy */` to the top of the file to avoid ESLint issues.
+
+## Where to add a test
+
+- Cypress tests are in the `./cypress` directory.
+
+- Cypress tests for a curriculum module are in the corresponding curriculum directory, i.e. `cypress/integration/learn/responsive-web-design/basic-css/index.js`.
+
+## How to run tests
+
+> [!NOTE]
+> If using GitPod, please see [Cypress-GitPod Setup](/how-to-add-cypress-tests#cypress-gitpod-setup)
+
+### 1. Ensure that MongoDB and client applications are running
+
+- [Start MongoDB and seed the database](/how-to-setup-freecodecamp-locally#step-3-start-mongodb-and-seed-the-database)
+
+- [Start the freeCodeCamp client application and API server](/how-to-setup-freecodecamp-locally#step-4-start-the-freecodecamp-client-application-and-api-server)
+
+### 2. Run the cypress tests
+
+To run tests against production builds, replace `dev` with `prd` below.
+
+- To run all tests in the `./cypress` directory:
+
+  ```console
+  npm run cypress:dev:run
+  ```
+
+- To run a single test:
+
+  ```console
+  npm run cypress:dev:run -- --spec=cypress/pathToYourSpec/youSpecFileName.js
+  ```
+
+- To create a development build, start the development server, and run all existing cypress end-to-end tests:
+
+  ```console
+  npm run e2e:dev:run
+  ```
+
+## Cypress-GitPod Setup
+
+### 1. Ensure you are on the _Feature Preview_ of GitPod _as of 01/02/2021_
+
+- Go to [GitPod Docs - Feature Preview](https://www.gitpod.io/docs/feature-preview/) to see how to enable _Feature Preview_
+
+### 2. Ensure Development Environment is Running
+
+If starting the GitPod environment did not automatically develop the environment:
+
+- Start the database
+
+```console
+mongod
+```
+
+- Seed the database
+
+```console
+npm run seed
+```
+
+- Develop the server and client
+
+```console
+npm run develop
+```
+
+### 3. Install Cypress Build Tools
+
+```console
+npm run cypress:install-build-tools
+```
+
+- When prompted in the terminal, select your keyboard layout by language/area
+
+Now, [Cypress can be run](/how-to-add-cypress-tests#_2-run-the-cypress-tests)

--- a/docs/i18n/portuguese/how-to-catch-outgoing-emails-locally.md
+++ b/docs/i18n/portuguese/how-to-catch-outgoing-emails-locally.md
@@ -1,0 +1,100 @@
+> **Note:** This is an **optional** step and is required only when working with email workflows
+
+## Introduction
+
+Some email workflows, like updating a user's email, requires the back-end api-server to send outgoing emails. An alternative to using an email service provider to send actual email messages, Mailhog is a developer tool for email testing that will catch the email messages sent by your freeCodeCamp instance.
+
+## Installing MailHog
+
+MailHog can be installed on macOS, Windows and Linux.
+
+- [Introduction](#introduction)
+- [Installing MailHog](#installing-mailhog)
+  - [Installing MailHog on macOS](#installing-mailhog-on-macos)
+  - [Installing MailHog on Windows](#installing-mailhog-on-windows)
+  - [Installing MailHog on Linux](#installing-mailhog-on-linux)
+- [Using MailHog](#using-mailhog)
+- [Useful Links](#useful-links)
+
+### Installing MailHog on macOS
+
+Install MailHog on macOS with [Homebrew](https://brew.sh/):
+
+```bash
+brew install mailhog
+brew services start mailhog
+```
+
+The above commands will start a mailhog service in the background.
+
+When the installation completes, you can start [using MailHog](#using-mailhog).
+
+### Installing MailHog on Windows
+
+Download the latest version of MailHog from [MailHog's official repository](https://github.com/mailhog/MailHog/releases). Locate and click on the link for your Windows version (32 or 64 bit) and a .exe file will be downloaded to your computer.
+
+When the download completes, click to open the file. A Windows firewall notification may appear, requesting access permission for MailHog. A standard Windows command line prompt will open where MailHog will be running once firewall access is granted.
+
+Close MailHog by closing the command prompt window. To start MailHog again, click on the MailHog executable (.exe) file that was downloaded initially - it is not necessary to download a new MailHog installation file.
+
+Start [using MailHog](#using-mailhog).
+
+### Installing MailHog on Linux
+
+First, install [Go](https://golang.org).
+
+Run the following commands to install GO on Debian-based systems like Ubuntu and Linux Mint.
+
+```bash
+sudo apt-get install golang
+```
+
+Run the following commands to install GO on RPM-based systems like CentOS, Fedora, Red Hat Linux, etc.
+
+```bash
+sudo dnf install golang
+```
+
+Alternatively, run the following commands to install GO.
+
+```bash
+sudo yum install golang
+```
+
+Now set the path for Go with the following commands.
+
+```bash
+echo "export GOPATH=$HOME/go" >> ~/.profile
+echo 'export PATH=$PATH:/usr/local/go/bin:$GOPATH/bin' >> ~/.profile
+source ~/.profile
+```
+
+Finally, enter the commands below to install and run MailHog.
+
+```bash
+go get github.com/mailhog/MailHog
+sudo cp /home/$(whoami)/go/bin/MailHog /usr/local/bin/mailhog
+mailhog
+```
+
+Start [using MailHog](#using-mailhog).
+
+## Using MailHog
+
+Open a new browser tab or window and navigate to [http://localhost:8025](http://localhost:8025) to open your MailHog inbox when the MailHog installation has completed and MailHog is running. The inbox will appear similar to the screenshot below.
+
+![MailHog Screenshot 1](images/mailhog/1.jpg)
+
+Emails sent by your freeCodeCamp installation will appear as below
+
+![MailHog Screenshot 2](images/mailhog/2.jpg)
+
+Two tabs that allow you to view either plain text or source content will be available when you open a given email. Ensure that the plain text tab is selected as below.
+
+![MailHog Screenshot 3](images/mailhog/3.jpg)
+
+All links in the email should be clickable and resolve to their URL.
+
+## Useful Links
+
+- Check out the [MailHog](https://github.com/mailhog/MailHog) repository for further information related to MailHog. Additional information is also available regarding custom MailHog configurations.

--- a/docs/i18n/portuguese/how-to-help-with-video-challenges.md
+++ b/docs/i18n/portuguese/how-to-help-with-video-challenges.md
@@ -1,0 +1,205 @@
+# How to help with video challenges
+
+Video challenges are a new type of challenge in the freeCodeCamp curriculum.
+
+A video challenge is a small section of a full-length video course on a particular topic. A video challenge page embeds a YouTube video. Each challenge page has a single multiple-choice question related to the video. A user must answer the question correctly before moving on to the next video challenge in the course.
+
+The video challenge pages are created by members of the freeCodeCamp team. YouTube videos are also uploaded by members of the freeCodeCamp team. Many of the video challenges do not yet have questions associated with them.
+
+You can help by creating multiple-choice questions related to video sections and adding the questions to the markdown files for the video challenges.
+
+
+## Challenge Template
+
+Below is a template of what the challenge markdown files look like.
+
+````md
+---
+id: Unique identifier (alphanumerical, MongoDB_id)
+title: Challenge Title
+challengeType: 11
+videoId: 'YouTube videoId for video challenge'
+forumTopicId: 12345
+---
+
+# --description--
+
+Challenge description text, in markdown
+
+```html
+<div>
+  example code
+</div>
+```
+
+# --question--
+
+These fields are currently used for the multiple-choice Python challenges.
+
+## --text--
+
+The question text goes here.
+
+## --answers--
+
+Answer 1
+
+---
+
+Answer 2
+
+---
+
+More answers
+
+## --video-solution--
+
+The number for the correct answer goes here.
+
+````
+
+## Creating questions for video challenges
+
+### Access the video challenge markdown files
+
+You can find the markdown files for video challenges at the following locations in the curriculum:
+
+- [Data Analysis with Python Course](https://github.com/freeCodeCamp/freeCodeCamp/tree/main/curriculum/challenges/english/08-data-analysis-with-python/data-analysis-with-python-course)
+- [TensorFlow 2.0 Course](https://github.com/freeCodeCamp/freeCodeCamp/tree/main/curriculum/challenges/english/11-machine-learning-with-python/tensorflow)
+- [Numpy Course](https://github.com/freeCodeCamp/freeCodeCamp/tree/main/curriculum/challenges/english/08-data-analysis-with-python/numpy)
+- [How Neural Networks Work Course](https://github.com/freeCodeCamp/freeCodeCamp/tree/main/curriculum/challenges/english/11-machine-learning-with-python/how-neural-networks-work)
+
+Pick a challenge markdown file from the options above.
+
+### Skim through the video associated with the challenge and create a multiple-choice question
+
+First, find the videoId.
+
+For example, in the following code from the header of a video challenge markdown file, the videoId is "nVAaxZ34khk". On GitHub, the information should be laid out in a table format.
+```
+---
+id: 5e9a093a74c4063ca6f7c14d
+title: Data Analysis Example A
+challengeType: 11
+videoId: nVAaxZ34khk
+---
+```
+
+Next, access the YouTube video with that `videoId`. The URL for the video will be:
+https://www.youtube.com/watch?v=[videoId]    (replace `videoId` in the URL with the video's ID - without square brackets)
+
+In the example above, the URL is https://www.youtube.com/watch?v=nVAaxZ34khk
+
+Skim the YouTube video with that videoId and think of a multiple-choice question based on the content of the video.
+
+### Add the question to the markdown file
+
+You can add the question locally or using the GitHub interface. To add the question locally, you need to [set up freeCodeCamp locally](how-to-setup-freecodecamp-locally.md). You can also find the file on GitHub and click the edit button to add the question right in your browser.
+
+If a question has not yet been added to a particular video challenge, it will have the following default question:
+
+```md
+# --question--
+
+## --text--
+
+Question text
+
+## --answers--
+
+Answer 1
+
+---
+
+Answer 2
+
+---
+
+More answers
+
+## --video-solution--
+
+1
+```
+
+Add/Update the  question text under the part that shows:
+```
+# --question--
+
+## --text--
+```
+Add/Update answers (`Answer 1`, `Answer 2`, and so on) under `## --answers--`. Make sure to update the number under `## --video-solution--` with the correct answer number. You can add more possible answers using the same format. The question and answers can be surrounded with quotation marks.
+
+### Question examples
+
+````md
+# --question--
+
+## --text--
+What does this JavaScript code log to the console?
+```js
+console.log('hello world');
+```
+
+## --answers--
+
+hello *world*
+
+---
+
+**hello** world
+
+---
+
+hello world
+
+---
+
+## --video-solution--
+3
+````
+
+````md
+
+# --question--
+
+## --text--
+
+What will print out after running this code:
+
+```py
+width = 15
+height = 12.0
+print(height/3)
+```
+
+## --answers--
+
+39
+
+---
+
+4
+
+---
+
+4.0
+
+---
+
+5.0
+
+---
+
+5
+
+## --video-solution--
+
+3
+````
+
+For more examples, you can look at the markdown files for the following video course. All the challenges already have questions: [Python for Everybody Course](https://github.com/freeCodeCamp/freeCodeCamp/tree/main/curriculum/challenges/english/07-scientific-computing-with-python/python-for-everybody)
+
+## Open a pull request
+
+After creating one or more questions, you can commit the changes to a new branch and [open a pull request](how-to-open-a-pull-request.md).

--- a/docs/i18n/portuguese/how-to-open-a-pull-request.md
+++ b/docs/i18n/portuguese/how-to-open-a-pull-request.md
@@ -1,0 +1,186 @@
+# How to open a Pull Request (PR)
+
+A pull request (PR) enables you to send changes from your fork on GitHub to freeCodeCamp.org's main repository. Once you are done making changes to the code, you can follow these guidelines to open a PR.
+
+> [!NOTE]
+> Your PR should be in English. See [here](#index.md?id=translations) for how to contribute translations.
+
+## Prepare a good PR title
+
+We recommend using [conventional title and messages](https://www.conventionalcommits.org/) for commits and pull request. The convention has the following format:
+
+> `<type>([optional scope(s)]): <description>`
+>
+> For example:
+>
+> `fix(learn): tests for the do...while loop challenge`
+
+When opening a Pull Request(PR), you can use the below to determine the type, scope (optional), and description.
+
+**Type:**
+
+| Type  | When to select                                                               |
+| :---- | :--------------------------------------------------------------------------- |
+| fix   | Changed or updated/improved functionality, tests, the verbiage of a lesson, etc. |
+| feat  | Only if you are adding new functionality, tests, etc.                        |
+| chore | Changes that are not related to code, tests, or verbiage of a lesson.         |
+| docs  | Changes to `/docs` directory or the contributing guidelines, etc.            |
+
+**Scope:**
+
+You can select a scope from [this list of labels](https://github.com/freeCodeCamp/freeCodeCamp/labels?q=scope).
+
+**Description:**
+
+Keep it short (less than 30 characters) and simple, you can add more information in the PR description box and comments.
+
+Some examples of good PRs titles would be:
+
+- `fix(a11y): improved search bar contrast`
+- `feat: add more tests to HTML and CSS challenges`
+- `fix(api,client): prevent CORS errors on form submission`
+- `docs(i18n): Chinese translation of local setup`
+
+## Proposing a Pull Request
+
+1. Once the edits have been committed, you will be prompted to create a pull request on your fork's GitHub Page.
+
+   ![Image - Compare pull request prompt on GitHub](./images/github/compare-pull-request-prompt.png)
+
+2. By default, all pull requests should be against the freeCodeCamp main repo, `main` branch.
+
+   Make sure that your Base Fork is set to freeCodeCamp/freeCodeCamp when raising a Pull Request.
+
+   ![Image - Comparing forks when making a pull request](./images/github/comparing-forks-for-pull-request.png)
+
+3. Submit the pull request from your branch to freeCodeCamp's `main` branch.
+
+4. In the body of your PR include a more detailed summary of the changes you made and why.
+
+   - You will be presented with a pull request template. This is a checklist that you should have followed before opening the pull request.
+
+   - Fill in the details as you see fit. This information will be reviewed and the reviewers will decide whether or not your pull request is accepted.
+
+   - If the PR is meant to address an existing GitHub Issue then, at the end of
+     your PR's description body, use the keyword _Closes_ with the issue number to [automatically close that issue if the PR is accepted and merged](https://help.github.com/en/articles/closing-issues-using-keywords).
+
+     > Example: `Closes #123` will close issue 123
+
+5. Indicate if you have tested on a local copy of the site or not.
+
+   - This is very important when making changes that are not just edits to text content like documentation or a challenge description. Examples of changes that need local testing include JavaScript, CSS, or HTML which could change the functionality or layout of a page.
+
+   - If your PR affects the behaviour of a page it should be accompanied by corresponding [Cypress integration tests](/how-to-add-cypress-tests).
+
+## Feedback on pull requests
+
+> Congratulations! :tada: on making a PR and thanks a lot for taking the time to contribute.
+
+Our moderators will now take a look and leave you feedback. Please be patient with the fellow moderators and respect their time. All pull requests are reviewed in due course.
+
+And as always, feel free to ask questions on the ['Contributors' category on our forum](https://forum.freecodecamp.org/c/contributors) or [the contributors chat room](https://chat.freecodecamp.org/channel/contributors).
+
+> [!TIP]
+> If you are to be contributing more pull requests, we recommend you read the [making changes and syncing](https://contribute.freecodecamp.org/#/how-to-setup-freecodecamp-locally?id=making-changes-locally) guidelines to avoid having to delete your fork.
+
+## Conflicts on a pull request
+
+Conflicts can arise because many contributors work on the repository, and changes can break your PR which is pending a review and merge.
+
+More often than not you may not require a rebase, because we squash all commits, however if a rebase is requested here is what you should do.
+
+### For usual bug fixes and features
+
+When you are working on regular bugs and features on our development branch `main`, you are able to do a simple rebase:
+
+1. Rebase your local copy:
+
+   ```console
+   git checkout <pr-branch>
+   git pull --rebase upstream main
+   ```
+
+2. Resolve any conflicts and add / edit commits
+
+   ```console
+   # Either
+   git add .
+   git commit -m "chore: resolve conflicts"
+
+   # Or
+   git add .
+   git commit --amend --no-edit
+   ```
+
+3. Push back your changes to the PR
+
+   ```console
+   git push --force origin <pr-branch>
+   ```
+
+### For upcoming curriculum and features
+
+When you are working on features for our upcoming curriculum `next-*` branches, you have to do a cherry pick:
+
+1. Make sure your upstream comes in sync with your local:
+
+   ```console
+   git checkout main
+   git fetch --all --prune
+   git checkout next-python-projects
+   git reset --hard upstream/next-python-projects
+   ```
+
+2. Take backup
+
+   a. Either delete your local branch after taking a backup (if you still have it locally):
+
+      ```console
+      git checkout <pr-branch-name>
+
+      # example:
+      # git checkout feat/add-numpy-video-question
+
+      git checkout -b <backup-branch-name>
+
+      # example:
+      #  git checkout -b backup-feat/add-numpy-video-question
+
+      git branch -D <pr-branch-name>
+      ```
+
+   b. Or just a backup of your pr branch (if you do not have it locally):
+
+      ```console
+      git checkout -b <backup-branch-name> origin/<pr-branch-name>
+
+      # example:
+      #  git checkout -b backup-feat/add-numpy-video-question origin/feat/add-numpy-video-question
+      ```
+
+4. Start off with a clean slate:
+
+   ```console
+   git checkout -b <pr-branch-name> next-python-projects
+   git cherry-pick <commit-hash>
+   ```
+
+5. Resolve any conflicts, and cleanup, install run tests
+
+   ```console
+   npm run clean
+
+   npm ci
+   npm run test:curriculum --superblock=<superblock-name>
+
+   # example:
+
+   # npm run test:curriculum --superblock=python-for-everybody
+
+   ```
+
+6. If everything looks good push back to the PR
+
+   ```console
+   git push --force origin <pr-branch-name>
+   ```

--- a/docs/i18n/portuguese/how-to-proofread-files.md
+++ b/docs/i18n/portuguese/how-to-proofread-files.md
@@ -1,0 +1,43 @@
+# How to Proofread Translations
+
+Our proofreading team is responsible for ensuring that translations accurately reflect the source text.
+
+To begin proofreading, visit [our translation site](https://translate.freecodecamp.org) and login. Then select "Go to console" in the top navigation bar to switch from the public view to the workspace view.
+
+## Select a File
+
+You should see the list of projects you have been granted access to. Select the project that you would like to proofread, then select the language.
+
+![Image - Proofreading File Tree](./images/crowdin/proof-file-tree.png)
+
+You should now see the list of available files. Choose your file by selecting the `Proofread` button on the right of that file, then choosing `Proofreading` from the drop-down menu that appears.
+
+> [!NOTE]
+> If you are in this workspace view, but want to work on [translating a file](./how-to-translate-files.md) instead of proofreading, you may select `Crowdsourcing` from the dropdown menu instead.
+
+## Proofread Translations
+
+![Image - Proofreading View](./images/crowdin/proofread.png)
+
+<!--Add proofread/crowdsource button to the image-->
+
+Here you will see the list of strings in the selected file, with their related translations. The translation that is displayed here is the translation that has received the highest score (between upvotes and downvotes) from the translation community.
+
+While you can view *all* proposed translations for a given string, the community scores (determined by the upvotes and downvotes) should be taken into consideration when choosing which translation to approve. The community can review proposed translations and recommend which one is most accurate and clear.
+
+1. This is the original string (in English).
+2. This is the matching translated string. The most popular translation proposal, based on upvotes and downvotes, will be displayed here.
+3. Clicking this checkmark button will approve that translation.
+4. Crowdin will display the status of each string. `Done` means a translation has been approved and will be downloaded on our next Crowdin pull. `Todo` means the string has not been proofread. `Hidden` means the string is locked and *should not be translated*. `Comment` means the string has a related comment.
+5. Translations can be selected with the checkboxes and approved here in one bulk action.
+6. You can view the community proposed translations, their popularity scores, and Crowdin suggested translations here.
+7. This button shows/hides the right-hand side display pane, where you can view translations, comments, translation memory, and glossary terms.
+8. Crowdin displays error messages here from the quality assurance checks. In other words, if something does not seem correct in the translation, Crowdin will notify you. These translations should be approved with care.
+
+> [!WARNING]
+> Approving a string in the proofreading view will mark it as complete and it will be downloaded in our next pull from Crowdin to GitHub.
+
+No additional actions are required once a file has been proofread. If you have any questions, or are interested in becoming a proofreader, feel free to reach out to us in our [translators chat room](https://chat.freecodecamp.org/channel/translators).
+
+> [!NOTE]
+> Crowdin will allow you to approve your translations. In general, it is best to allow another proofreader to review your proposed translations as extra safety to ensure there are no errors.

--- a/docs/i18n/portuguese/how-to-setup-freecodecamp-locally.md
+++ b/docs/i18n/portuguese/how-to-setup-freecodecamp-locally.md
@@ -1,0 +1,561 @@
+Follow these guidelines for setting up freeCodeCamp locally on your system. This is highly recommended if you want to contribute regularly.
+
+Some of these contribution workflows – like fixing bugs in the codebase or curriculum – need you to run freeCodeCamp locally on your computer.
+
+> [!TIP]
+> If you are not interested in setting up freeCodeCamp locally, consider using Gitpod, a free online dev environment.
+>
+> [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/freeCodeCamp/freeCodeCamp)
+>
+> (Starts a ready-to-code dev environment for freeCodeCamp in your browser.)
+
+### How to prepare your local machine
+
+Start by installing the prerequisite software for your operating system.
+
+We primarily support development on Linux and Unix-based systems. Our staff and community contributors regularly work with the codebase using tools installed on Ubuntu and macOS.
+
+We also support Windows 10 via WSL2, which you can prepare by [reading this guide](/how-to-setup-wsl).
+
+Some community members also develop on Windows 10 natively with Git for Windows (Git Bash), and other tools installed on Windows. We do not have official support for such a setup at this time, we recommend using WSL2 instead.
+
+**Prerequisites:**
+
+| Prerequisite                  | Version | Notes                                                                |
+| ----------------------------- | ------- | -------------------------------------------------------------------- |
+| [Node.js](http://nodejs.org)  | `12.x`  | [LTS Schedule](https://github.com/nodejs/Release#release-schedule)   |
+| npm (comes bundled with Node) | `6.x`   | Does not have LTS releases, we use the version bundled with Node LTS |
+| [MongoDB Community Server](https://docs.mongodb.com/manual/administration/install-community/) | `3.6`   | [Release Notes](https://docs.mongodb.com/manual/release-notes/), Note: We are currently on `3.6`, an [upgrade is planned](https://github.com/freeCodeCamp/freeCodeCamp/issues/18275). |
+
+> [!DANGER]
+> If you have a different version, please install the recommended version. We can only support installation issues for recommended versions. See [troubleshooting](#troubleshooting) for details.
+
+If Node.js is already installed on your machine, run the following commands to validate the versions:
+
+```console
+node -v
+npm -v
+```
+
+> [!TIP]
+> We highly recommend updating to the latest stable releases of the software listed above, also known as Long Term Support (LTS) releases.
+
+Once you have the prerequisites installed, you need to prepare your development environment. This is common for many development workflows, and you will only need to do this once.
+
+**Follow these steps to get your development environment ready:**
+
+1. Install [Git](https://git-scm.com/) or your favorite Git client, if you haven't already. Update to the latest version; the version that came bundled with your OS may be outdated.
+
+2. (Optional but recommended) [Set up an SSH Key](https://help.github.com/articles/generating-an-ssh-key/) for GitHub.
+
+3. Install a code editor of your choice.
+
+   We highly recommend using [Visual Studio Code](https://code.visualstudio.com/) or [Atom](https://atom.io/). These are great, free and open source code editors.
+
+4. Set up linting for your code editor.
+
+   You should have [ESLint running in your editor](http://eslint.org/docs/user-guide/integrations.html), and it will highlight anything that doesn't conform to [freeCodeCamp's JavaScript Style Guide](http://forum.freecodecamp.org/t/free-code-camp-javascript-style-guide/19121).
+
+   > [!TIP]
+   > Please do not ignore any linting errors. They are meant to **help** you and to ensure a clean and simple codebase.
+
+## Fork the repository on GitHub
+
+[Forking](https://help.github.com/articles/about-forks/) is a step where you get your own copy of freeCodeCamp's main repository (a.k.a _repo_) on GitHub.
+
+This is essential, as it allows you to work on your own copy of freeCodeCamp on GitHub, or to download (clone) your repository to work on locally. Later, you will be able to request changes to be pulled into the main repository from your fork via a pull request (PR).
+
+> [!TIP]
+> The main repository at `https://github.com/freeCodeCamp/freeCodeCamp` is often referred to as the `upstream` repository.
+>
+> Your fork at `https://github.com/YOUR_USER_NAME/freeCodeCamp` is often referred to as the `origin` repository. `YOUR_USER_NAME` would be replaced with your GitHub username.
+
+**Follow these steps to fork the `https://github.com/freeCodeCamp/freeCodeCamp` repository:**
+
+1. Go to the freeCodeCamp repository on GitHub: <https://github.com/freeCodeCamp/freeCodeCamp>
+
+2. Click the "Fork" Button in the upper right-hand corner of the interface ([More Details Here](https://help.github.com/articles/fork-a-repo/))
+
+3. After the repository has been forked, you will be taken to your copy of the freeCodeCamp repository at `https://github.com/YOUR_USER_NAME/freeCodeCamp` (`YOUR_USER_NAME` would be replaced with your GitHub user name.)
+
+<details>
+   <summary>
+      How to fork freeCodeCamp on GitHub (screenshot)
+   </summary>
+   <br>
+   <img src="https://raw.githubusercontent.com/freeCodeCamp/freeCodeCamp/main/docs/images/github/how-to-fork-freeCodeCamp.gif" alt="How to fork freeCodeCamp on GitHub">
+</details>
+
+## Clone your fork from GitHub
+
+[Cloning](https://help.github.com/articles/cloning-a-repository/) is where you **download** a copy of a repository from a `remote` location that is either owned by you or by someone else. In your case, this remote location is your `fork` of freeCodeCamp's repository that should be available at `https://github.com/YOUR_USER_NAME/freeCodeCamp`. (`YOUR_USER_NAME` would be replaced with your GitHub user name.)
+
+> [!WARNING]
+> If you are working on a WSL2 Linux Distro, you might get performance and stability issues by running this project in a folder which is shared between Windows and WSL2 (e.g. `/mnt/c/Users/`).
+> Therefore we recommend to clone this repo into a folder which is mainly used by your WSL2 Linux Distro and not directly shared with Windows (e.g. `~/PROJECTS/`).
+>
+> See [this GitHub Issue](https://github.com/freeCodeCamp/freeCodeCamp/issues/40632) for further Information about this problem.
+
+Run these commands on your local machine:
+
+1. Open a Terminal / Command Prompt / Shell in your projects directory
+
+   _i.e.: `/yourprojectsdirectory/`_
+
+2. Clone your fork of freeCodeCamp, replacing `YOUR_USER_NAME` with your GitHub Username
+
+   ```console
+   git clone --depth=1 https://github.com/YOUR_USER_NAME/freeCodeCamp.git
+   ```
+
+This will download the entire freeCodeCamp repository to your projects directory.
+
+Note: `--depth=1` creates a shallow clone of your fork, with only the most recent history/commit.
+
+## Set up syncing from parent
+
+Now that you have downloaded a copy of your fork, you will need to set up an `upstream` remote to the parent repository.
+
+[As mentioned earlier](#fork-the-repository-on-github), the main repository is referred `upstream` repository. Your fork referred to as the `origin` repository.
+
+You need a reference from your local clone to the `upstream` repository in addition to the `origin` repository. This is so that you can sync changes from the main repository without the requirement of forking and cloning repeatedly.
+
+1. Change directory to the new freeCodeCamp directory:
+
+   ```console
+   cd freeCodeCamp
+   ```
+
+2. Add a remote reference to the main freeCodeCamp repository:
+
+   ```console
+   git remote add upstream https://github.com/freeCodeCamp/freeCodeCamp.git
+   ```
+
+3. Ensure the configuration looks correct:
+
+   ```console
+   git remote -v
+   ```
+
+   The output should look something like below (replacing `YOUR_USER_NAME` with your GitHub username):
+
+   ```console
+   origin    https://github.com/YOUR_USER_NAME/freeCodeCamp.git (fetch)
+   origin    https://github.com/YOUR_USER_NAME/freeCodeCamp.git (push)
+   upstream    https://github.com/freeCodeCamp/freeCodeCamp.git (fetch)
+   upstream    https://github.com/freeCodeCamp/freeCodeCamp.git (push)
+   ```
+
+## Running freeCodeCamp locally
+
+Now that you have a local copy of freeCodeCamp, you can follow these instructions to run it locally. This will allow you to:
+
+- Preview edits to pages as they would appear on the learning platform.
+- Work on UI related issues and enhancements.
+- Debug and fix issues with the application servers and client apps.
+
+If you do run into issues, first perform a web search for your issue and see if it has already been answered. If you cannot find a solution, please search our [GitHub issues](https://github.com/freeCodeCamp/freeCodeCamp/issues) page for a solution and report the issue if it has not yet been reported.
+
+And as always, feel free to ask questions on the ['Contributors' category on our forum](https://forum.freecodecamp.org/c/contributors) or [our chat server](https://chat.freecodecamp.org/home).
+
+> [!TIP]
+> You may skip running freeCodeCamp locally if you are simply editing files. For instance, performing a `rebase`, or resolving `merge` conflicts.
+>
+> You can always return to this part of the instructions later. You should **only** skip this step if you do not need to run the apps on your machine.
+>
+> [Skip to making changes](#making-changes-locally).
+
+### Configuring dependencies
+
+#### Step 1: Set up the environment variable file
+
+The default API keys and environment variables are stored in the file `sample.env`. This file needs to be copied to a new file named `.env` that is accessed dynamically during the installation step.
+
+```console
+# Create a copy of the "sample.env" and name it ".env".
+# Populate it with the necessary API keys and secrets:
+
+# macOS / Linux
+cp sample.env .env
+
+# Windows
+copy sample.env .env
+```
+
+The keys in the `.env` file are _not_ required to be changed to run the app locally. You can leave the default values copied over from `sample.env` as-is.
+
+> [!TIP]
+> Keep in mind if you want to use services like Auth0 or Algolia, you'll have to acquire your own API keys for those services and edit the entries accordingly in the `.env` file.
+
+#### Step 2: Install dependencies
+
+This step will install the dependencies required for the application to run:
+
+```console
+npm ci
+```
+
+#### Step 3: Start MongoDB and seed the database
+
+Before you can run the application locally, you will need to start the MongoDB service.
+
+> [!NOTE]
+> Unless you have MongoDB running in a setup different than the default, the URL stored as the `MONGOHQ_URL` value in the `.env` file should work fine. If you are using a custom configuration, modify this value as needed.
+
+Start the MongoDB server in a separate terminal:
+
+- On macOS & Ubuntu:
+
+  ```console
+  mongod
+  ```
+
+- On Windows, you must specify the full path to the `mongod` binary
+
+  ```console
+  "C:\Program Files\MongoDB\Server\3.6\bin\mongod"
+  ```
+
+  Make sure to replace `3.6` with the version you have installed
+
+> [!TIP]
+> You can avoid having to start MongoDB every time by installing it as a background service. You can [learn more about it in their documentation for your OS](https://docs.mongodb.com/manual/administration/install-community/)
+
+Next, let's seed the database. In this step, we run the below command that fills the MongoDB server with some initial data sets that are required by services. These include a few schemas, among other things.
+
+```console
+npm run seed
+```
+
+#### Step 4: Start the freeCodeCamp client application and API server
+
+You can now start up the API server and the client applications.
+
+```console
+npm run develop
+```
+
+This single command will fire up all the services, including the API server and the client applications available for you to work on.
+
+> [!NOTE]
+> Once ready, open a web browser and **visit <http://localhost:8000>**. If the app loads, congratulations – you're all set! You now have a copy of freeCodeCamp's entire learning platform running on your local machine.
+
+> [!TIP]
+> The API Server serves APIs at `http://localhost:3000`. The Gatsby app serves the client application at `http://localhost:8000`
+
+> If you visit <http://localhost:3000/explorer> you should see the available APIs.
+
+## Sign in with a local user
+
+Your local setup automatically populates a local user in the database. Clicking the `Sign In` button will automatically authenticate you into the local application.
+
+However, accessing the user portfolio page is a little tricky. In development, Gatsby takes over serving the client-side pages and hence you will get a `404` page for the user portfolio when working locally.
+
+Simply clicking the **"Preview Custom 404 Page"** button will forward you to the correct page.
+
+<details>
+   <summary>
+      How to sign in when working locally (screenshot)
+   </summary>
+   <br>
+   <img src="https://user-images.githubusercontent.com/29990697/71541249-f63cdf00-2923-11ea-8a85-cefb6f9c9977.gif" alt="How to sign in when working locally">
+</details>
+
+## Making changes locally
+
+You can now make changes to files and commit your changes to your local clone of your fork.
+
+Follow these steps:
+
+1. Validate that you are on the `main` branch:
+
+   ```console
+   git status
+   ```
+
+   You should get an output like this:
+
+   ```console
+   On branch main
+   Your branch is up-to-date with 'origin/main'.
+
+   nothing to commit, working directory clean
+   ```
+
+   If you are not on main or your working directory is not clean, resolve any outstanding files/commits and checkout `main`:
+
+   ```console
+   git checkout main
+   ```
+
+2. Sync the latest changes from the freeCodeCamp upstream `main` branch to your local main branch:
+
+   > [!WARNING]
+   > If you have any outstanding pull request that you made from the `main` branch of your fork, you will lose them at the end of this step.
+   >
+   > You should ensure your pull request is merged by a moderator before performing this step. To avoid this scenario, you should **always** work on a branch other than the `main`.
+
+   This step **will sync the latest changes** from the main repository of freeCodeCamp. It is important that you rebase your branch on top of the latest `upstream/main` as often as possible to avoid conflicts later.
+
+   Update your local copy of the freeCodeCamp upstream repository:
+
+   ```console
+   git fetch upstream
+   ```
+
+   Hard reset your main branch with the freeCodeCamp main:
+
+   ```console
+   git reset --hard upstream/main
+   ```
+
+   Push your main branch to your origin to have a clean history on your fork on GitHub:
+
+   ```console
+   git push origin main --force
+   ```
+
+   You can validate your current main matches the upstream/main by performing a diff:
+
+   ```console
+   git diff upstream/main
+   ```
+
+   The resulting output should be empty.
+
+3. Create a fresh new branch:
+
+   Working on a separate branch for each issue helps you keep your local work copy clean. You should never work on the `main`. This will soil your copy of freeCodeCamp and you may have to start over with a fresh clone or fork.
+
+   Check that you are on `main` as explained previously, and branch off from there:
+
+   ```console
+   git checkout -b fix/update-guide-for-xyz
+   ```
+
+   Your branch name should start with a `fix/`, `feat/`, `docs/`, etc. Avoid using issue numbers in branches. Keep them short, meaningful and unique.
+
+   Some examples of good branch names are:
+
+   ```md
+   fix/update-challenges-for-react
+   fix/update-guide-for-html-css
+   fix/platform-bug-sign-in-issues
+   feat/add-guide-article-for-javascript
+   translate/add-spanish-basic-html
+   ```
+
+4. Edit pages and work on code in your favorite text editor.
+
+5. Once you are happy with the changes you should optionally run freeCodeCamp locally to preview the changes.
+
+6. Make sure you fix any errors and check the formatting of your changes.
+
+7. Check and confirm the files you are updating:
+
+   ```console
+   git status
+   ```
+
+   This should show a list of `unstaged` files that you have edited.
+
+   ```console
+   On branch feat/documentation
+   Your branch is up to date with 'upstream/feat/documentation'.
+
+   Changes were not staged for commit:
+   (use "git add/rm <file>..." to update what will be committed)
+   (use "git checkout -- <file>..." to discard changes in the working directory)
+
+       modified:   CONTRIBUTING.md
+       modified:   docs/README.md
+       modified:   docs/how-to-setup-freecodecamp-locally.md
+       modified:   docs/how-to-work-on-guide-articles.md
+   ...
+   ```
+
+8. Stage the changes and make a commit:
+
+   In this step, you should only mark files that you have edited or added yourself. You can perform a reset and resolve files that you did not intend to change if needed.
+
+   ```console
+   git add path/to/my/changed/file.ext
+   ```
+
+   Or you can add all the `unstaged` files to the staging area:
+
+   ```console
+   git add .
+   ```
+
+   Only the files that were moved to the staging area will be added when you make a commit.
+
+   ```console
+   git status
+   ```
+
+   Output:
+
+   ```console
+   On branch feat/documentation
+   Your branch is up to date with 'upstream/feat/documentation'.
+
+   Changes to be committed:
+   (use "git reset HEAD <file>..." to unstage)
+
+       modified:   CONTRIBUTING.md
+       modified:   docs/README.md
+       modified:   docs/how-to-setup-freecodecamp-locally.md
+       modified:   docs/how-to-work-on-guide-articles.md
+   ```
+
+   Now, you can commit your changes with a short message like so:
+
+   ```console
+   git commit -m "fix: my short commit message"
+   ```
+
+   Some examples:
+
+   ```md
+   fix: update guide article for Java - for loop
+   feat: add guide article for alexa skills
+   ```
+
+   Optional:
+
+   We highly recommend making a conventional commit message. This is a good practice that you will see on some of the popular Open Source repositories. As a developer, this encourages you to follow standard practices.
+
+   Some examples of conventional commit messages are:
+
+   ```md
+   fix: update HTML guide article
+   fix: update build scripts for Travis-CI
+   feat: add article for JavaScript hoisting
+   docs: update contributing guidelines
+   ```
+
+   Keep these short, not more than 50 characters. You can always add additional information in the description of the commit message.
+
+   This does not take any additional time than an unconventional message like 'update file' or 'add index.md'
+
+   You can learn more about why you should use conventional commits [here](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#why-use-conventional-commits).
+
+9. If you realize that you need to edit a file or update the commit message after making a commit you can do so after editing the files with:
+
+   ```console
+   git commit --amend
+   ```
+
+   This will open up a default text editor like `nano` or `vi` where you can edit the commit message title and add/edit the description.
+
+10. Next, you can push your changes to your fork:
+
+    ```console
+    git push origin branch/name-here
+    ```
+
+## Proposing a Pull Request (PR)
+
+After you've committed your changes, check here for [how to open a Pull Request](how-to-open-a-pull-request.md).
+
+## Quick commands reference
+
+A quick reference to the commands that you will need when working locally.
+
+| command                                                        | description                                                                         |
+| -------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `npm ci`                                                       | Installs / re-install all dependencies and bootstraps the different services.       |
+| `npm run seed`                                                 | Parses all the challenge markdown files and inserts them into MongoDB.              |
+| `npm run develop`                                              | Starts the freeCodeCamp API Server and Client Applications.                         |
+| `npm test`                                                     | Run all JS tests in the system, including client, server, lint and challenge tests. |
+| `npm run test:client`                                          | Run the client test suite.                                                          |
+| `npm run test:curriculum`                                      | Run the curriculum test suite.                                                      |
+| `npm run test:curriculum --block='Basic HTML and HTML5'`       | Test a specific Block.                                                              |
+| `npm run test:curriculum --superblock='responsive-web-design'` | Test a specific SuperBlock.                                                         |
+| `npm run test-curriculum-full-output`                          | Run the curriculum test suite, without bailing after the first error                |
+| `npm run test:server`                                          | Run the server test suite.                                                          |
+| `npm run e2e`                                                  | Run the Cypress end to end tests.                                                   |
+| `npm run clean`                                                | Uninstalls all dependencies and cleans up caches.                                   |
+
+## Troubleshooting
+
+### Issues with installing the recommended prerequisites
+
+We regularly develop on the latest or most popular operating systems like macOS 10.15 or later, Ubuntu 18.04 or later, and Windows 10 (with WSL2).
+
+It is recommended to research your specific issue on resources such as Google, Stack Overflow, and Stack Exchange. There is a good chance that someone has faced the same issue and there is already an answer to your specific query.
+
+If you are on a different OS and/or are still running into issues, see [getting help](#getting-help).
+
+> [!WARNING]
+>
+> Please avoid creating GitHub issues for prerequisite issues. They are out of the scope of this project.
+
+### Issues with the UI, Fonts, build errors, etc.
+
+If you face issues with the UI, Fonts or see builds errors a cleanup can be useful:
+
+```console
+npm run clean
+npm ci
+npm run seed
+npm run develop
+```
+
+OR
+
+Use the shortcut
+
+```
+npm run clean-and-develop
+```
+
+If you continue to face issues with the build, cleaning up the workspace is recommend.
+
+Use `git clean` in interactive mode:
+
+```
+git clean -ifdX
+```
+
+<details>
+   <summary>
+      How to clean git untracked files (screenshot)
+   </summary>
+   <br>
+   <img src="https://user-images.githubusercontent.com/1884376/94270515-ca579400-ff5d-11ea-8ff1-152cade31654.gif" alt="How to clean git untracked files">
+</details>
+
+### Issues with API, login, Challenge Submissions, etc.
+
+If you can't sign in, and instead you see a banner with an error message that it will be reported to freeCodeCamp, please double-check that your local port `3000` is not in use by a different program.
+
+**On Linux / macOS / WSL on Windows - From Terminal:**
+
+```console
+netstat -ab | grep "3000"
+
+tcp4    0   0    0.0.0.0:3000           DESKTOP      LISTEN
+```
+
+**On Windows - From Elevated PowerShell:**
+
+```powershell
+netstat -ab | Select-String "3000"
+
+TCP    0.0.0.0:3000           DESKTOP      LISTENING
+```
+
+### Issues installing dependencies
+
+If you get errors while installing the dependencies, please make sure that you are not in a restricted network or your firewall settings do not prevent you from accessing resources.
+
+The first time setup can take a while depending on your network bandwidth. Be patient, and if you are still stuck we recommend using GitPod instead of an offline setup.
+
+## Getting Help
+
+If you are stuck and need help, feel free to ask questions on the ['Contributors' category on our forum](https://forum.freecodecamp.org/c/contributors) or [the contributors chat room](https://chat.freecodecamp.org/channel/contributors).
+
+There might be an error in the console of your browser or in Bash / Terminal / Command Line that will help identify the problem. Provide this error message in your problem description so others can more easily identify the issue and help you find a resolution.

--- a/docs/i18n/portuguese/how-to-setup-wsl.md
+++ b/docs/i18n/portuguese/how-to-setup-wsl.md
@@ -1,0 +1,130 @@
+# Set up freeCodeCamp on Windows Subsystem for Linux (WSL)
+
+> [!NOTE]
+> Before you follow these instructions make sure your system meets the requirements
+>
+> **WSL 2**: Windows 10 64-bit (Version 2004, Build 19041 or higher) - available for all distributions including Windows 10 Home.
+>
+> **Docker Desktop for Windows**: See respective requirements for [Windows 10 Pro](https://docs.docker.com/docker-for-windows/install/#system-requirements) and [Windows 10 Home](https://docs.docker.com/docker-for-windows/install-windows-home/#system-requirements)
+
+This guide covers some common steps with the setup of WSL2. Once some of the common issues with WSL2 are addressed, you should be able to follow the our local setup guide to work with freeCodeCamp on Windows running a WSL distro like Ubuntu.
+
+## Enable WSL
+
+Follow the instructions on the [official documentation](https://docs.microsoft.com/en-us/windows/wsl/install-win10) to install WSL1 and followed by upgrading to WSL2.
+
+## Install Ubuntu
+
+1. We recommended using Ubuntu-18.04 or above with WSL2.
+
+   > [!NOTE]
+   >
+   > While you may use other non-debian based distros, they all come with their own gotchas and are beyond the scope of this guide.
+
+2. Update the dependencies for the OS
+
+   ```console
+   sudo apt update
+   sudo apt upgrade -y
+
+   # cleanup
+   sudo apt autoremove -y
+   ```
+
+## Set up Git
+
+Git comes pre-installed with Ubuntu 18.04, verify that your Git version with `git --version`.
+
+```output
+~
+❯ git --version
+git version 2.25.1
+```
+
+(Optional but recommended) You can now proceed to [setting up your ssh keys](https://help.github.com/articles/generating-an-ssh-key) with GitHub.
+
+## Installing a Code Editor
+
+We highly recommend installing [Visual Studio Code](https://code.visualstudio.com) on Windows 10. It has great support for WSL and automatically installs all the necessary extensions on your WSL distro.
+
+Essentially, you will edit and store your code on Ubuntu-18.04 with VS Code installed on Windows.
+
+## Installing Docker Desktop
+
+**Docker Desktop for Windows** allows you to install and run database and services like MongoDB, NGINX, etc. This is useful to avoid common pitfalls with installing MongoDB or other services directly on Windows or WSL2.
+
+Follow the instructuction on the [official documentation](https://docs.docker.com/docker-for-windows/install) and install Docker Desktop for your Windows distribution.
+
+There are some minimum hardware requirements for the best experience.
+
+## Configure Docker Desktop for WSL
+
+Once Docker Desktop is installed, [follow these instructions](https://docs.docker.com/docker-for-windows/wsl) and configure it to use the Ubuntu-18.04 installation as a backend.
+
+This makes it so that the containers run on WSL side instead of running on Windows. You will be able to access the services over `http://localhost` on both Windows and Ubuntu.
+
+## Install MongoDB from Docker Hub
+
+Once you have configured Docker Desktop to work with WSL2, follow these steps to start a MongoDB service:
+
+1. Launch a new Ubuntu-18.04 terminal
+
+2. Pull `MongoDB 3.6` from dockerhub
+
+   ```console
+   docker pull mongo:3
+   ```
+
+3. Start the MongoDB service at port `27017`, and configure it to run automatically on system restarts
+
+   ```console
+   docker run -it \
+     -v mongodata:/data/db \
+     -p 27017:27017 \
+     --name mongodb \
+     --restart unless-stopped \
+     -d mongo:3
+   ```
+
+4. You can now access the service from both Windows or Ubuntu at `mongodb://localhost:27017`.
+
+## Installing Node.js and npm
+
+We recommend you install the LTS release for Node.js with a node version manager - [nvm](https://github.com/nvm-sh/nvm#installing-and-updating).
+
+Once installed use these commands to install and use the Node.js version as needed
+
+```console
+nvm install --lts
+
+# OR
+# nvm install <version>
+
+nvm install 14
+
+# Usage
+# nvm use <version>
+
+nvm use 12
+```
+
+Node.js comes bundled with `npm`, you can update to the latest versions of `npm` with:
+
+```console
+npm install -g npm@latest
+```
+
+## Set up freeCodeCamp locally
+
+Now that you have installed the pre-requisites, follow [our local setup guide](https://contribute.freecodecamp.org/#/how-to-setup-freecodecamp-locally) to clone, install and setup freeCodeCamp locally on your machine.
+
+> [!WARNING]
+>
+> Please note, at this time the set up for Cypress tests (and related GUI needs) are a work in progress. You should still be able to work on most of the codebase.
+
+## Useful Links
+
+- [A WSL2 Dev Setup with Ubuntu 20.04, Node.js, MongoDB, VS Code and Docker](https://devlog.sh/wsl2-dev-setup-with-ubuntu-nodejs-mongodb-and-docker) - an article by Mrugesh Mohapatra (Staff Developer at freeCodeCamp.org)
+- Frequently asked questions on:
+  - [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/faq)
+  - [Docker Desktop for Windows](https://docs.docker.com/docker-for-windows/faqs)

--- a/docs/i18n/portuguese/how-to-translate-files.md
+++ b/docs/i18n/portuguese/how-to-translate-files.md
@@ -1,0 +1,90 @@
+# How to Translate a File
+
+> [!NOTE]
+> All translations are handled through https://translate.freecodecamp.org - we are no longer using GitHub to translate files directly.
+
+To begin, head to our translation website and login (if you have not contributed to translations before, you will need to create an account).
+
+## Select a Project and File
+
+You should see two "projects" available for translation: The `Contributing Documentation` project, which contains the files for this documentation site, and the `Coding Curriculum` project, which contains our challenge files for `/learn`.
+
+Select which project you want to contribute to, and you will see a list of available languages for translation.
+
+![Image - List of available languages](./images/crowdin/languages.png)
+
+Select the language you want to work on, and you will see the complete file tree.
+
+![Image - List of available files](./images/crowdin/file-tree.png)
+
+Each file and folder will show a progress bar. The **blue** portion of the progress bar indicates what percentage of the file has been translated, while the **green** portion of the progress bar indicates what percentage of the file has been approved by the proofreading team.
+
+Select a file to work on and Crowdin will open the editor view.
+
+> [!NOTE]
+> When the editor view opens, you will need to click the settings icon (shown as a gear) and switch the 'HTML tags displaying' setting to 'SHOW'. This will ensure you can see tags such as `<code></code>` instead of `<0></0>`.
+
+## Translate the File
+
+![Image - Editor View](./images/crowdin/editor.png)
+
+Crowdin separates a document into translatable "strings", usually sentences. Each string is translated individually. Referring to the image above:
+
+1. A string highlighted in green already has a proposed translation.
+2. A string highlighted in red does _not_ have a proposed translation.
+3. A string with greyed out text is not translatable. This is the case for code blocks and other content that must not be translated. You will be unable to select these strings in the editor.
+4. If a contributor has proposed a translation to a string, Crowdin will display those proposals here. You will not be able to save an identical translation - instead, if a translation is accurate, you should click the `+` icon to "upvote" it. An inaccurate translation can be "downvoted" with the `-` icon.
+5. Crowdin will recommend translations based on Translation Memory (TM) or Machine Translation (MT). Translation Memory refers to similar or identical strings that we have translated/approved in other files. Machine Translation refers to translations recommended by their integrated library.
+6. This is the editor pane, where you may write your proposed translation for the selected string.
+7. The currently selected string in the editor will be highlighted in yellow.
+8. Here you will see tags indicating the state of the string. `Done` means the string has at least one proposed translation. `Todo` means the string does not have any proposed translations.
+9. Here you can see the comments window. If you have questions or concerns about a particular string, you can leave a comment on the string here for other translators to see.
+10. These two "pane" buttons will hide the left (document) and right (comments) views.
+
+> [!NOTE]
+> If you see a hidden string that includes translations, please notify us in the [translators chat room](https://chat.freecodecamp.org/channel/translators) so we can remove the translation from memory.
+
+When you have completed a translation for a string, select the `Save` button to store your translation on Crowdin. Other contributors will then be able to vote on your translation and proofreaders will be able to approve it.
+
+You are welcome to translate as many strings as you like - there are no additional steps required when you complete a full file or propose a new translation. Clicking the `Save` button is all that is needed to store a translation.
+
+> [!NOTE]
+> If you see something in the English source file that is inaccurate or incorrect, please do not fix it through the translation flow. Instead, leave a comment on the string to notify us that there is a discrepancy, or create a GitHub issue.
+
+### Translating Documentation
+
+Translating our contributing documentation is a similar flow to translating our curriculum files.
+
+> [!NOTE]
+> Our contributing documentation is powered by `docsify`, and we have special parsing for message boxes like this one. If you see strings that start with `[!NOTE]`, `[!WARNING]`, or `[!TIP]`, these words should NOT be translated.
+
+## Rate Translations
+
+Crowdin allows you to rate the existing proposed translations. If you attempt to save a translation, you may see a message indicating that you cannot save a duplicate translation - this means another contributor has proposed that identical translation. If you agree with that translation, click the `+` button to "upvote" the translation.
+
+If you see a translation that is inaccurate or does not provide the same clarity as the original string, click the `-` button to "downvote" the translation.
+
+Crowdin uses these votes to give a score to each proposed translation for a string, which helps the proofreading team determine which translation is the best fit for each string.
+
+## Quality Assurance Checks
+
+We have enabled some quality assurance steps that will verify a translation is as accurate as possible - this helps our proofreaders review proposed translations.
+
+When you attempt to save a translation, you may see a warning message appear with a notification regarding your proposed translation.
+
+![Image - QA Warning Message](./images/crowdin/qa-message.png)
+
+This message appears when Crowdin's QA system has identified a potential error in the proposed translation. In this example, we have modified the text of a `<code>` tag and Crowdin has caught that.
+
+> [!WARNING]
+> You have the option to save a translation in spite of errors. If you do, by clicking "Save Anyway", you should also tag a proofreader or project manager and explain why the QA message needs to be ignored in this case.
+
+## Translation Best Practices
+
+Follow these guidelines to ensure our translations are as accurate as possible:
+
+- Do not translate the content within `<code>` tags. These tags indicate text that is found in code and should be left in English.
+- Do not add additional content. If you feel a challenge requires changes in the text content or additional information, you should propose the changes through a GitHub issue or a pull request that modifies the English file.
+- Do not change the order of content.
+
+If you have any questions, feel free to reach out to us in our [translators chat room](https://chat.freecodecamp.org/channel/translators) and we will be happy to assist you.

--- a/docs/i18n/portuguese/how-to-translate-the-website.md
+++ b/docs/i18n/portuguese/how-to-translate-the-website.md
@@ -1,0 +1,204 @@
+The client/react side of our website is translated into various world languages using [react-i18next](https://react.i18next.com/) and [i18next](https://www.i18next.com/).
+
+> [!NOTE]
+> Curriculum lesson content is [translated separately](./how-to-translate-files.md).
+
+## File Structure
+
+The files for translating the website are located in the `client/i18n` folder. Each language has a folder within that containing JSON files with the translations.
+
+The values in the `translations.json` file contain the majority of the text that appears on the website. The keys are used in the codebase to get the correct text for whatever language is set. This file needs to have the exact same keys in all languages.
+
+The `intro.json` file contains the key-value pairs for the introduction text on the certification pages.
+
+The `motivation.json` files are not required to have the same quotes, compliments, or array length. Just the same JSON structure. These are not translated via Crowdin.
+
+The `trending.json` file contians the titles and links for the trending news articles in the website's footer. These are not translated via Crowdin.
+
+The `meta-tags.json` file contains the information for our website's meta tag information. These are not translated via Crowdin.
+
+## Adding a Language
+
+To add a new language, create a folder with the language name as the title next to the other languages and copy the JSON files from another language into your new folder.
+
+In the `all-langs.js` file, add the language to the `client` array in the first variable. Then, follow the instructions in the comments to add the rest of the necessary variables.
+
+## How to Translate
+
+Translating the `intro.json` and `translations.json` are done through [our translation site](https://translate.freecodecamp.org). View our [translation documentation for that site](/how-to-translate-files.md).
+
+Modifications to the `trending.json`, `meta-tags.json`, and `motivation.json` files should typically only be done by staff.
+
+## Running it Locally
+
+Set the `CLIENT_LOCALE` variable in your `.env` file to the locale you want to build.
+
+> [!NOTE]
+> The value needs to be one of the client languages available in `config/i18n/all-langs.js`
+
+## How to Structure Components
+
+### Functional Component
+
+```js
+import { useTranslation } from 'react-i18next';
+
+// in the render method:
+const { t } = useTranslation();
+
+// call the "t" function with a key from the JSON file:
+<p>{t('key')}</p> // more details below
+```
+
+### Class Component
+```js
+import { withTranslation } from 'react-i18next';
+
+// withTranslation adds the "t" function to props:
+const { t } = this.props;
+
+// call the "t" function with a key from the JSON file:
+<h1>{t('key')}</h1> // more details below
+
+// export without redux:
+export default withTranslation()(Component);
+
+// or with redux:
+export default connect(...)(withTranslation()(Component));
+```
+
+## Translate Using the "t" Function
+
+### Basic Translation
+
+```js
+// in the component:
+<p>{t('p1')}</p>
+
+// in the JSON file:
+{
+  "p1": "My paragraph"
+}
+
+// output:
+<p>My paragraph</p>
+```
+
+### With Dynamic Data
+
+```js
+// in the component:
+const username = 'moT';
+
+<p>{t('welcome', { username: username })}</p>
+
+// in the JSON file:
+{
+  "welcome": "Welcome {{username}}"
+}
+
+// output:
+<p>Welcome moT</p>
+```
+
+The above example passes an object to the `t` function with a `username` variable. The variable will be used in the JSON value where `{{username}}` is.
+
+## Translate with the \<Trans\> Component
+
+The general rule is to use the "t" function when you can. But there's a `Trans` component for when that isn't enough, usually when you have elements embedded in the text. You can use the `Trans` component with any type of react component.
+
+### Basic Elements Nested
+
+```js
+// in the component:
+import { Trans } from 'react-i18next'
+
+<p>
+  <Trans>fcc.greeting</Trans>
+</p>
+
+// in the JSON file:
+{ 
+  "fcc": {
+    "greeting": "Welcome to <strong>freeCodeCamp</strong>"
+  }
+}
+
+// output:
+<p>Welcome to <strong>freeCodeCamp</strong></p>
+```
+
+You can place the key inside the component tags like the above example if the text contains "simple" tags with no attributes. `br`, `strong`, `i`, and `p` are the default, but that list can be expanded in the i18n config.
+
+### Complex Elements Nested
+
+Other times, you will want to have certain text inside another element, an anchor tag is a good example:
+
+```js
+// in the component:
+<p>
+  <Trans i18nKey='check-forum'>
+    <a href='https://forum.freecodecamp.org/'>placeholder</a>
+  </Trans>
+</p>
+
+// in the JSON file:
+{ 
+  "check-forum": "Check out <0>our forum</0>."
+}
+
+// output:
+<p>Check out <a href='https://forum.freecodecamp.org/'>our forum</a></p>
+```
+
+In the above example, the key is set in the attributes of the `Trans` component. The `<0>` and `</0>` in the JSON represent the first child of the component, in this case, the anchor element. If there were more children, they would just count up from there using the same syntax. You can find the children of a component in the react dev tools by inspecting it. `placeholder` is simply there because the linter was complaining at me about an empty `<a>` element.
+
+### With a Variable
+
+```js
+// in the component:
+const email = 'team@freecodecamp.org';
+
+<p>
+  <Trans email={email} i18nKey='fcc.email'>
+    <a href={`mailto:${email}`}>
+      {{ email }}
+    </a>
+  </Trans>
+</p>
+
+// in the JSON file:
+{
+  "fcc": {
+    "email": "Send us an email at: <0>{{email}}</0>"
+  }
+}
+
+// output:
+<p>Send us an email at: <a href='mailto:team@freecodecamp.org'>team@freecodecamp.org</a><p>
+```
+
+In the above example, the key and a variable are set in the attributes of the `Trans` component. `{{ email }}` needs to be somewhere in the `Trans` component as well, it doesn't matter where.
+
+## Changing Text
+
+To change text on the client side of things, go to the relevant `.json` file, find the key that is being used in the React component, and change the value to the new text you want. You should search the codebase for that key to make sure it isn't being used elsewhere. Or, if it is, that the changes make sense in all places.
+
+## Adding Text
+
+If the text you want to add to the client exists in the relevant `.json` file, use the existing key. Otherwise, create a new key.
+
+The English file is the "source of truth" for all of the `.json` files sharing the same name. If you need to add a new key, add it there. Then, add the key to **all** of the `translations.json` files.
+
+> [!NOTE]
+> Use English text for all languages if the file is translated through Crowdin. The tests will fail if you don't.
+
+It would be nice to keep the keys in the same order across all the files as well. Also, try to put all punctuation, spacing, quotes, etc in the JSON files and not in the components or server files. 
+
+> [!NOTE]
+> The underscore (`_`) is a reserved character for keys in the client side files. See [the documentation](https://www.i18next.com/translation-function/plurals) for how they are used.
+
+## Helpful Documentation
+
+- [react-i18next docs](https://react.i18next.com/latest/usetranslation-hook)
+- [i18next docs](https://www.i18next.com/translation-function/essentials)

--- a/docs/i18n/portuguese/how-to-use-docker-on-windows-home.md
+++ b/docs/i18n/portuguese/how-to-use-docker-on-windows-home.md
@@ -1,0 +1,15 @@
+# How to use Docker on Windows Home
+
+There are a few pitfalls to be avoided when setting up Docker on Windows Home. First of all, you have to use [Docker Toolbox](https://docs.docker.com/toolbox/toolbox_install_windows/) as Administrator. Unfortunately Windows Home does not support Docker for Windows Desktop, so Toolbox must be used instead. It has to be run as Administrator as the installation uses symlinks, which cannot be created otherwise.
+
+Once you've installed the toolbox, run Docker Quickstart Terminal as Administrator. This will create a `default` virtual machine if it does not already exist. Once that has happened, close the terminal and open VirtualBox (again as Administrator). You should be able to see the `default` machine. The site is quite resource-intensive, so stop the virtual machine and raise the settings as much as you can - memory in particular. It has been confirmed to work with 4GB of ram.
+
+Once you're happy that Docker is working, clone the freeCodeCamp repository to a directory inside `C:\Users`. These directories are shared giving Docker access to the local directories, which it needs during installation.
+
+If you see messages like
+
+```shell
+bash: change_volumes_owner.sh: No such file or directory
+```
+
+when you `npm run docker:init` this is likely the culprit.

--- a/docs/i18n/portuguese/how-to-work-on-coding-challenges.md
+++ b/docs/i18n/portuguese/how-to-work-on-coding-challenges.md
@@ -1,0 +1,493 @@
+# How to work on coding challenges
+
+Our goal is to develop a fun and clear interactive learning experience.
+
+Designing interactive coding challenges is difficult. It would be much easier to write a lengthy explanation or to create a video tutorial. But for our core curriculum, we're sticking with what works best for most people - a fully interactive, video game-like experience.
+
+We want campers to achieve a flow state. We want them to build momentum and blast through our curriculum with as few snags as possible. We want them to go into the projects with confidence and gain a wide exposure to programming concepts.
+
+Note that for Version 7.0 of the freeCodeCamp curriculum, we are moving toward [an entirely project-focused model with a lot more repetition](https://www.freecodecamp.org/news/python-curriculum-is-live/).
+
+Creating these challenges requires immense creativity and attention to detail. There's plenty of help available. You'll have support from a whole team of contributors to whom you can bounce ideas off and demo your challenges.
+
+And as always, feel free to ask questions on the ['Contributors' category on our forum](https://forum.freecodecamp.org/c/contributors) or [the contributors chat room](https://chat.freecodecamp.org/channel/contributors).
+
+With your help, we can design an interactive coding curriculum that will help millions of people learn to code for years to come.
+
+The content for each challenge is stored in its markdown file. This markdown file is later converted to HTML using our tools to create interactive web pages.
+
+You can find all of freeCodeCamp.org's curricular content in the [`/curriculum/challenges`](https://github.com/freeCodeCamp/freeCodeCamp/tree/main/curriculum/challenges) directory.
+
+## Set up the tooling for the curriculum
+
+Before you work on the curriculum, you would need to set up some tooling to help you test your changes. You can use any option from the below:
+
+- You can [set up freeCodeCamp locally](how-to-setup-freecodecamp-locally.md). This is **highly recommended** for regular/repeat contributions. This setup allows you to work and test your changes.
+- Use Gitpod, a free online dev environment. Clicking the button below will start a ready-to-code dev environment for freeCodeCamp in your browser. It only takes a few minutes.
+
+  [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/freeCodeCamp/freeCodeCamp)
+
+- Edit the files on GitHub's interface by clicking the pencil icon for the corresponding file. While this is the quickest way, It is **not recommended**, because you are unable to test your changes on GitHub. If our maintainers conclude that the changes you made need to be tested locally, you would need to follow the methods above instead.
+
+## Challenge Template
+
+````md
+
+---
+id: Unique identifier (alphanumerical, MongoDB_id)
+title: 'Challenge Title'
+challengeType: Integer, defined in `client/utils/challengeTypes.js`
+videoUrl: 'url of video explanation'
+forumTopicId: 12345
+---
+
+# --description--
+
+Challenge description text, in markdown
+
+```html
+<div>
+  example code
+</div>
+```
+
+# --instructions--
+
+Challenge instruction text, in markdown
+
+# --hints--
+
+Tests to run against user code, in pairs of markdown text and code block test code.
+
+```js
+Code for test one
+```
+
+More instructions in markdown syntax
+
+```js
+More code
+```
+
+# --seed--
+
+## --before-user-code--
+
+```lang
+Code evaluated before the user’s code.
+```
+
+## --after-user-code--
+
+```lang
+Code evaluated after the user’s code, and just before the tests
+```
+
+## --seed-contents--
+
+Boilerplate code to render to the editor. This section should only contain code inside backticks, like the following:
+
+```html
+<body>
+  <p class="main-text">
+    Hello world!
+  </p>
+</body>
+```
+
+```css
+body {
+  margin: 0;
+  background-color: #3a3240;
+}
+
+.main-text {
+  color: #aea8d3;
+}
+```
+
+```js
+console.log('freeCodeCamp is awesome!');
+```
+
+# --solutions--
+
+Solutions are used for the CI tests to ensure that changes to the hints will still pass as intended
+
+```js
+// first solution - the language(s) should match the seed.
+```
+
+---
+
+```js
+// second solution - so if the seed is written in HTML...
+```
+
+---
+
+```js
+// third solution etc. - Your solutions should be in HTML.
+```
+
+# --question--
+
+These fields are currently used for the multiple-choice Python challenges.
+
+## --text--
+
+The question text goes here.
+
+## --answers--
+
+Answer 1
+
+---
+
+Answer 2
+
+---
+
+More answers
+
+## --video-solution--
+
+The number for the correct answer goes here.
+
+
+````
+
+> [!NOTE]
+>
+> 1. In the above sections, examples of `lang` are:
+>
+>   - `html` - HTML/CSS
+>   - `js` - JavaScript
+>   - `jsx` - JSX
+
+## Numbering Challenges
+
+Every challenge needs an `id`. If you don't specify one, then MongoDB will create a new random one when it saves the data; however, we don't want it to do that, since we want the challenge ids to be consistent across different environments (staging, production, lots of different developers, etc.).
+
+To generate a new one in a shell (assuming MongoDB is running separately):
+
+1. Run `mongo` command.
+2. Run `ObjectId()` command.
+
+For example:
+
+```bash
+$ mongo
+MongoDB shell version v3.6.1
+connecting to: mongodb://127.0.0.1:27017
+MongoDB server version: 3.4.10
+...
+$ ObjectId()
+ObjectId("5a474d78df58bafeb3535d34")
+```
+
+The result is a new id, for example `5a474d78df58bafeb3535d34` above.
+
+Once you have your id, put it into the markdown file as the `id` field at the top, e.g.
+
+```yml
+---
+id: 5a474d78df58bafeb3535d34
+title: Challenge Title
+```
+
+## Naming challenges
+
+Naming things is hard. We've made it easier by imposing some constraints.
+
+All challenge titles should be explicit and should follow this pattern:
+
+[verb][object clause]
+
+Here are some example challenge names:
+
+- Use Clockwise Notation to Specify the Padding of an Element
+- Condense arrays with .reduce
+- Use Bracket Notation to Find the First Character in a String
+
+## Challenge descriptions/instructions
+
+Sentences should be clear and concise with minimal jargon. If used, jargon should be immediately defined in plain English.
+
+Keep paragraphs short (around 1-4 sentences). People are more likely to read several short paragraphs than a wall of text.
+
+Challenge text should use the second person ("you") to help to give it a conversational tone. This way the text and instructions seem to speak directly to the camper working through the challenge. Try to avoid using the first person ("I", "we", "let's", and "us").
+
+Don't use outbound links. These interrupt the flow. Campers should never have to google anything during these challenges. If there are resources you think campers would benefit from, add them to the challenge's Guide-related article.
+
+You can add diagrams if necessary.
+
+Don't use emojis or emoticons in challenges. freeCodeCamp has a global community, and the cultural meaning of an emoji or emoticon may be different around the world. Also, emojis can render differently on different systems.
+
+Proper nouns should use correct capitalization when possible. Below is a list of words as they should appear in the challenges.
+
+- JavaScript (capital letters in "J" and "S" and no abbreviations)
+- Node.js
+- Front-end development (adjective form with a dash) is when you're working on the front end (noun form with no dash). The same goes with "back end", "full stack", and many other compound terms.
+
+### The 2-minute rule
+
+Each challenge should be solvable within 120 seconds by a native English speaker who has completed the challenges leading up to it. This includes the amount of time it takes to read the directions/instructions understand the seeded code, write their code and get all the tests to pass.
+
+If it takes longer than two minutes to complete the challenge, you have two options:
+
+- Simplify the challenge, or
+- Split the challenge into two challenges.
+
+The 2-minute rule forces you, the challenge designer, to make your directions concise, your seed code clear, and your tests straight-forward.
+
+We track how long it takes for campers to solve changes and use this information to identify challenges that need to be simplified or split.
+
+### Modularity
+
+Each challenge should teach exactly one concept, and that concept should be apparent from the challenge's name.
+
+We can reinforce previously covered concepts through repetition and variations - for example, introducing h1 elements in one challenge, then h3 elements a few challenges later.
+
+Our goal is to have thousands of 2-minute challenges. These can flow together and reiterate previously-covered concepts.
+
+### Formatting challenge text
+
+Here are specific formatting guidelines for challenge text and examples:
+
+- Language keywords go in `\`` backticks. For example, HTML tag names or CSS property names.
+- References to code parts (i.e. function, method, or variable names) should be wrapped in `\`` backticks. See example below:
+```md
+Use `parseInt` to convert the variable `realNumber` into an integer.
+```
+- References to file names and path directories (e.g. `package.json`, `src/components`) should be wrapped in `\`` backticks.
+- Multi-line code blocks **must be preceded by an empty line**. The next line must start with three backticks followed immediately by one of the [supported languages](https://prismjs.com/#supported-languages). To complete the code block, you must start a new line which only has three backticks and **another empty line**. See example below:
+- Whitespace matters in Markdown, so we recommend that you make it visible in your editor. 
+
+**Note:** If you are going to use an example code in YAML, use `yaml` instead of `yml` for the language to the right of the backticks.
+
+The following is an example of code:
+````md
+```{language}
+
+[YOUR CODE HERE]
+
+```
+````
+
+- Additional information in the form of a note should be surrounded by blank lines, and formatted: `**Note:** Rest of note text...`
+- If multiple notes are needed, then list all of the notes in separate sentences using the format: `**Notes:** First note text. Second note text.`
+- Use single-quotes where applicable
+
+**Note:** The equivalent _Markdown_ should be used in place of _HTML_ tags.
+
+## Writing tests
+
+Challenges should have the minimum number of tests necessary to verify that a camper understands a concept.
+
+Our goal is to communicate the single point that the challenge is trying to teach, and test that they have understood that point.
+
+Challenge tests can make use of the Node.js and Chai.js assertion libraries. Also, if needed, user-generated code can be accessed in the `code` variable.
+
+## Formatting seed code
+
+Here are specific formatting guidelines for the challenge seed code:
+
+- Use two spaces to indent
+- JavaScript statements end with a semicolon
+- Use double quotes where applicable
+
+### Seed code comments
+
+We have a [comment dictionary](/curriculum/dictionaries/english/comments.js) that contains the only comments that can be used within the seed code. The exact case and spacing of the dictionary comment must be used. The comment dictionary should not be expanded without prior discussion with the dev-team.
+
+Comments used should have a space between the comment characters and the comment themselves.  In general, comments should be used sparingly. Always consider rewriting a challenge's description or instructions if it could avoid using a seed code comment.
+
+Example of valid single line JavaScript comment:
+
+```js
+// Only change code below this line
+```
+
+Example of a valid CSS comment:
+
+```css
+/* Only change code above this line */
+```
+
+If a challenge only has a single place where code changes are needed, please use the comments in the following example to instruct the user where changes should be made.
+
+```js
+var a = 3;
+var b = 17;
+var c = 12;
+
+// Only change code below this line
+a = a + 12;
+b = 9 + b;
+c = c + 7;
+```
+
+If a challenge has multiple places where the user is expected to change code (i.e. the React challenges)
+
+```jsx
+class MyComponent extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      text: "Hello"
+    };
+    // Change code below this line
+
+    // Change code above this line
+  }
+  handleClick() {
+    this.setState({
+      text: "You clicked!"
+    });
+  }
+  render() {
+    return (
+      <div>
+        { /* Change code below this line */ }
+        <button>Click Me</button>
+        { /* Change code above this line */ }
+        <h1>{this.state.text}</h1>
+      </div>
+    );
+  }
+};
+```
+
+### Translation of seed code comments
+
+There are separate comment dictionaries for each language. The [English version of the comment dictionary](/curriculum/dictionaries/english/comments.js) is the basis for the translations found in the corresponding non-English versions of the files. The non-English version of the Chinese comment dictionary would be located at `/curriculum/dictionaries/chinese/comments.js`.  Each dictionary consists of an array of objects with a unique `id` property and a `text` property.  Only the `text` should be modified to encompass the translation of the corresponding English comment.
+
+Some comments may contain a word/phrase that should not be translated. For example, variable names or proper library names like "React" should not be translated.  See the comment below as an example. The word `myGlobal` should not be translated. 
+
+```text
+Declare the myGlobal variable below this line
+```
+
+>[!NOTE]
+>
+> We are working on an integration to make it possible to work on i18n for the comment dictionary.
+
+## Hints and Solutions
+
+Each challenge has a `Get a Hint` button, so a user can access any hints/solutions which have been created for the challenge. Curriculum hints/solutions topics are located on [our forum](https://forum.freecodecamp.org/c/guide) under the `Guide` category.
+
+If you find a problem with an existing challenge's hints/solutions topic, you can make suggestions in the [contributors category](https://forum.freecodecamp.org/c/contributors) on the forum. Moderators and users with trust level 3 will review the comments and decide whether or not to include the changes in the corresponding hint/solutions topic.
+
+### Adding new Challenge hints/solutions Topics
+
+Take the following steps when adding a new challenge hints/solutions related topic.
+
+1. Start by following the same steps for creating a new topic but review the next for creating the title.
+2. The title of the topic should start with `freeCodeCamp Challenge Guide: ` concatenated with the actual title of the curriculum challenge. For example, if the challenge is named "`Chunky Monkey`", the topic title would be "`freeCodeCamp Challenge Guide: Chunky Monkey`".
+3. `camperbot` should be the owner of these topics/posts, so you will need to request an admin to change the ownership of the main post to `camperbot`.
+4. Once the new topic is created, a forum topic id is created. It is located at the end of the forum topic URL. This id must be added to the frontmatter of the curriculum challenge file via the normal pull request process for the `Get a Hint` button to link to the topic.
+
+### Guidelines for content of hints and solutions topics
+
+When proposing a solution for a curriculum challenge related Guide topic, the full code must be added. This includes all the original seed code plus any changes needed to pass all the challenge tests. The following template should be used when creating new hints/solutions topics:
+
+````md
+# Challenge Name Goes Here
+
+---
+
+## Problem Explanation
+
+This summarizes what needs to be done without just restating the challenge description and/or instructions. This is an optional section
+
+#### Relevant Links
+
+- [Link Text](link_url_goes_here)
+- [Link Text](link_url_goes_here)
+
+---
+
+## Hints
+
+### Hint 1
+
+Hint goes here
+
+### Hint 2
+
+Hint goes here
+
+---
+
+## Solutions
+
+<details><summary>Solution 1 (Click to Show/Hide)</summary>
+
+```js
+function myFunc() {
+  console.log('Hello World!');
+}
+```
+
+#### Code Explanation
+
+- Code explanation goes here
+- Code explanation goes here
+
+#### Relevant Links
+
+- [Link Text](link_url_goes_here)
+- [Link Text](link_url_goes_here)
+
+</details>
+````
+
+## Testing Challenges
+
+Before you [create a pull request](how-to-open-a-pull-request.md) for your changes, you need to validate that the changes you have made do not inadvertently cause problems with the challenge. 
+
+1. To test all challenges run the below command from the root directory
+
+```
+npm run test:curriculum
+``` 
+
+2. You can also test a block or a superblock of challenges with these commands
+
+```
+npm run test:curriculum --block='Basic HTML and HTML5'
+```
+
+```
+npm run test:curriculum --superblock=responsive-web-design
+```
+
+You are also able to test one challenge individually by performing the following steps:
+
+1. Switch to the `curriculum` directory:
+
+   ```
+   cd curriculum
+   ```
+
+2. Run the following for each challenge file for which you have changed (replacing `challenge-title-goes-here` with the full title of the challenge):
+
+   ```
+   npm run test -- -g challenge-title-goes-here
+   ```
+
+Once you have verified that each challenge you've worked on passes the tests, [please create a pull request](https://github.com/freeCodeCamp/freeCodeCamp/blob/main/docs/how-to-open-a-pull-request.md).
+
+> [!TIP]
+> You can set the environment variable `LOCALE` in the `.env` to the language of the challenge(s) you need to test.
+> 
+> The currently accepted values are `english` and `chinese`, with `english` being set by default.
+
+### Useful Links
+
+Creating and Editing Challenges:
+
+1. [Challenge types](https://github.com/freeCodeCamp/freeCodeCamp/blob/main/client/utils/challengeTypes.js#L1-L13) - what the numeric challenge type values mean (enum).
+
+2. [Contributing to FreeCodeCamp - Writing ES6 Challenge Tests](https://www.youtube.com/watch?v=iOdD84OSfAE#t=2h49m55s) - a video following [Ethan Arrowood](https://twitter.com/ArrowoodTech) as he contributes to the old version of the curriculum.

--- a/docs/i18n/portuguese/how-to-work-on-the-docs-theme.md
+++ b/docs/i18n/portuguese/how-to-work-on-the-docs-theme.md
@@ -1,0 +1,55 @@
+# How to work on the docs theme
+
+> [!NOTE]
+> A quick reminder that you do not need to setup anything for working on the content for the documentation site.
+>
+> To work on the contributing guidelines, you can edit or add files in the `docs` directory [available here](https://github.com/freeCodeCamp/freeCodeCamp/tree/main/docs). When your changes are merged, it will be made available automatically at the documentation site.
+
+## Structure of the docs website
+
+The site is generated using [`docsify`](https://docsify.js.org), and served using GitHub pages.
+
+Typically you would not need to change any configuration or build the site locally. In case you are interested, here is how it works:
+
+- The homepage's source for this site is available in [`docs/index.html`](index.html).
+- We serve this file as a SPA using `docsify` and GitHub Pages.
+- The `docsify` script generates the content of `markdown` files in `docs` directory on demand.
+- The homepage is generated from the [`_coverpage.md`](_coverpage.md).
+- the sidebar navigation is generated from [`_sidebar.md`](_sidebar.md).
+
+## Serving the documentation site locally
+
+Clone freeCodeCamp:
+
+```console
+git clone https://github.com/freeCodeCamp/freeCodeCamp.git
+docsify serve docs
+```
+
+Install `docsify`:
+
+```console
+npm install -g docsify
+```
+
+and serve the `/docs` directory
+
+```console
+docsify serve docs
+```
+
+Alternatively, if you have installed freeCodeCamp locally (see the local setup guide), we bundle the CLI with the development tools so you can run any of the below commands as needed from the root of the repo:
+
+### Serve and launch the documentation site only
+
+```console
+npm run docs:serve
+```
+
+### Serve the documentation site alongside freeCodeCamp locally:
+
+```console
+npm run develop
+```
+
+> The documentation site should be available at <http://localhost:3200>

--- a/docs/i18n/portuguese/how-to-work-on-the-news-theme.md
+++ b/docs/i18n/portuguese/how-to-work-on-the-news-theme.md
@@ -1,0 +1,99 @@
+# How to work on freeCodeCamp.org's developer news theme
+
+The developer news also known as [`/news`](https://www.freecodecamp.org/news) site is powered by [Ghost](https://ghost.org/). We use a custom theme for the look and feel of the site. The source code of the theme is available here: <https://github.com/freeCodeCamp/news-theme>.
+
+## The Theme
+
+Ghost uses a simple templating language called [Handlebars](http://handlebarsjs.com/) for its themes. The theme used on `/news` is based off of the default [casper theme](https://github.com/TryGhost/Casper).
+
+The default theme is commented pretty heavily so that it should be fairly easy to work out what's going on just by reading the code and the comments. Once you feel comfortable with how everything works, Ghost also has a full [theme API documentation](https://themes.ghost.org) which explains every possible Handlebars helper and template.
+
+**The main files are:**
+
+- `default.hbs` - The main template file
+- `index.hbs` - Used for the home page
+- `post.hbs` - Used for individual posts
+- `page.hbs` - Used for individual pages
+- `tag.hbs` - Used for tag archives
+- `author.hbs` - Used for author archives
+
+One really neat trick is that you can also create custom one-off templates just by adding the slug of a page to a template file. For example:
+
+- `page-about.hbs` - Custom template for the `/about/` page
+- `tag-news.hbs` - Custom template for `/tag/news/` archive
+- `author-ali.hbs` - Custom template for `/author/ali/` archive
+
+## Development
+
+1. Get Ghost installed locally.
+
+   ```sh
+   npm install -g ghost-cli@latest
+   mkdir ghost-local-site
+   cd ghost-local-site
+   ```
+
+   ```sh
+   ghost install local
+   ghost start
+   ```
+
+   > Note: Currently freeCodeCamp uses Ghost version `2.9.0`, so make sure you are using a version higher than that.
+
+   Be sure to run `ghost` commands from the `ghost-local-site` directory. Follow additional instructions on [Ghost's official documentation](https://docs.ghost.org) if are not familiar with its interface.
+
+2. Fork and clone the repository in your theme directory (replacing `YOUR_USERNAME` with your GitHub username):
+
+   ```sh
+   cd content/themes/
+   git clone https://github.com/YOUR_USERNAME/news-theme.git
+   ```
+
+3. Make sure you have all the pre-requisites.
+
+   The theme styles are compiled using Gulp/PostCSS to polyfill future CSS spec. You'll need [Node.js](https://nodejs.org/). Make sure that your Node.js version is compatible with `ghost`.
+
+4. Install dependencies and develop the theme
+
+   ```sh
+   npm ci
+   npm run develop
+   ```
+
+5. Now you can edit `/assets/css/` files, which will be compiled to `/assets/built/` automatically.
+
+6. Access the development site.
+
+   a. Enter `http://localhost:2368/ghost/` into your address bar. Continue with the setup prompted on the page (if running ghost for the first time).
+
+   b. _(One-time only, during setup)_ Restart Ghost, on a separate terminal once to ensure the theme is available.
+
+   ```sh
+   cd ghost-local-site
+   ghost restart
+   ```
+
+   c. _(One-time only, during setup)_ Once you've done this, go to `http://localhost:2368/ghost/#/settings/design` and scroll to the bottom. Make sure you click activate on the `freecodecamp-news-theme`.
+
+7. Zip the final code and make a pull-request
+
+   The `zip` Gulp task packages the theme files into `dist/<theme-name>.zip`, which we can then upload to the production site.
+
+   When you make a PR, please make sure you have run the below script prior to commiting the code and sending a PR.
+
+   ```sh
+   npm run zip
+   ```
+## Other Reference and resources
+
+### PostCSS Features Used
+
+- Autoprefixer - Don't worry about writing browser prefixes of any kind, it's all done automatically with support for the latest 2 major versions of every browser.
+- Variables - Simple pure CSS variables
+- [Color Function](https://github.com/postcss/postcss-color-function)
+
+### SVG Icons
+
+The theme uses inline SVG icons, included via Handlebars partials. You can find all icons inside `/partials/icons`. To use an icon just include the name of the relevant file, eg. To include the SVG icon in `/partials/icons/rss.hbs` - use `{{> "icons/rss"}}`.
+
+You can add your own SVG icons in the same manner.

--- a/docs/i18n/portuguese/index.md
+++ b/docs/i18n/portuguese/index.md
@@ -1,0 +1,52 @@
+The [freeCodeCamp.org](https://freecodecamp.org) community is possible thanks to thousands of kind volunteers like you. If you want to contribute your time and expertise, we would be excited to welcome you aboard.
+
+> [!NOTE]
+> Before you proceed, please take a quick 2 minutes to read our [Code of Conduct](https://www.freecodecamp.org/code-of-conduct). We strictly enforce it across our community so that contributing to freeCodeCamp.org is a safe, inclusive experience for everyone.
+
+Happy contributing.
+
+You are welcome to:
+
+- Create, update and fix bugs in our [curriculum](#curriculum).
+- Help us fix bugs in freeCodeCamp.org's [learning platform](#learning-platform).
+- [Help us translate](#translations) freeCodeCamp.org to world languages.
+
+We answer the most common questions about contributing [in our contributor FAQ](/FAQ.md).
+
+## Curriculum
+
+Our curriculum is curated by the global freeCodeCamp community. This way, we are able to incorporate expert knowledge from volunteers like you.
+
+You can help expand and improve the curriculum. You can also update project user stories to better-explain concepts. And you can improve our automated tests so that we can more accurately test people's code.
+
+**If you're interested in improving our curriculum, here's [how to contribute to the curriculum](how-to-work-on-coding-challenges.md).**
+
+## Translations
+
+We are localizing freeCodeCamp.org to world languages starting with Chinese and Espanol. We will be expanding the translations to more languages. It's our dream to provide you with resources to learn, no matter the world language you speak.
+
+To help us with this massive effort, we have integrated our open-source code-base & curriculum with [Crowdin](https://crowdin.com/).
+
+**If you're interested in translating, here are the guides to translate our [curriculum](how-to-translate-files.md), the [learning platform](how-to-translate-the-website.md) and our [Contributing guidelines](https://translate.freecodecamp.org/contributing-docs).**
+
+## Learning Platform
+
+Our learning platform runs on a modern JavaScript stack. It has various components, tools, and libraries. These include Node.js, MongoDB, OAuth 2.0, React, Gatsby, Webpack, and more.
+
+Broadly, we use
+
+- a Node.js based API server
+- a set of React-based client applications
+- and testing scripts to evaluate camper-submitted curriculum projects.
+
+If you want to productively contribute to the curriculum, we recommend some familiarity with these tools.
+
+If you want to help us improve our codebase...
+
+**you can either use Gitpod, a free online dev environment that starts a ready-to-code dev environment for freeCodeCamp in your browser.**
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/freeCodeCamp/freeCodeCamp)
+
+Or you can...
+
+**[set up freeCodeCamp locally](how-to-setup-freecodecamp-locally.md) on your machine.**

--- a/docs/i18n/portuguese/moderator-handbook.md
+++ b/docs/i18n/portuguese/moderator-handbook.md
@@ -1,0 +1,505 @@
+# The official freeCodeCamp Moderator Handbook.
+
+This will help you moderate different places in our community, including:
+
+- GitHub issues & pull requests
+- The forum, chat rooms, Facebook groups, and other online meeting places
+- In-person events like study groups, hackathons, and conferences
+
+**All freeCodeCamp Moderators are community-wide moderators. That means that we trust you to oversee any of these places.**
+
+This said you can serve as a moderator in whichever places are of the most interest to you. Some moderators just help out on GitHub. Others just help out on the forum. Some moderators are active everywhere.
+
+The bottom line is that we want you to enjoy being a moderator, and invest your scarce time in places that are of interest to you.
+
+> [!NOTE]
+> "With great power comes great responsibility." - Uncle Ben
+
+As a moderator, temperament is more important than technical skill.
+
+Listen. Be Helpful. Don't abuse your power.
+
+freeCodeCamp is an inclusive community, and we need to keep it that way.
+
+We have a single code of conduct that governs our entire community. The fewer the rules, the easier they are to remember. You can read those rules and commit them to memory [here](https://code-of-conduct.freecodecamp.org).
+
+## Moderating GitHub
+
+Moderators have the ability to close issues and accept or close pull requests.
+
+Moderators have two primary responsibilities regarding GitHub:
+
+1. QA'ing and merging pull requests
+2. Evaluating and responding to issues
+
+### Moderating Pull Requests
+
+Pull Requests (PRs) are how contributors submit changes to freeCodeCamp's repository. We must perform Quality Assurance (QA) on pull requests before we decide whether to merge them or close them.
+
+#### Types of Pull Requests
+
+1. **Challenge Instruction Edits** These are changes to the text of challenges - the Description, Instructions, or Test Text. You can also review these right on GitHub and decide whether to merge them. We need to be a bit more careful about these because millions of people will encounter this text as they work through the freeCodeCamp curriculum. Does the pull request make the text more clear without making it much longer? Are the edits relevant and not overly pedantic? Remember that our goal is for challenges to be as clear and as short as possible. They aren't the place for obscure details. Also, contributors may try to add links to resources to the challenges. You can close these pull requests and reply to them with this:
+
+```markdown
+Thank you for your pull request.
+
+We are closing this pull request. Please add links and other details to the challenge's corresponding guide article instead.
+
+If you think we're wrong in closing this issue, please request for it to be reopened and add further clarification. Thank you, and happy coding.
+```
+
+2. **Challenge Code Edits** These are changes to the code in a challenge - the Challenge Seed, Challenge Solution, and Test Strings. These pull requests need to be pulled down from GitHub and tested on your local computer to make sure the challenge tests can still be passed with the current solution, and the new code doesn't introduce any errors. Some contributors may try to add additional tests to cover pedantic corner-cases. We need to be careful to not make the challenge too complicated. These challenges and their tests should be as simple and intuitive as possible. Aside from the algorithm challenges and interview prep section, learners should be able to solve each challenge within about 2 minutes.
+
+3. **Codebase Changes** These code edits change the functionality of the freeCodeCamp platform itself. Sometimes contributors try to make changes without much explanation, but for code changes, we need to make sure there's a genuine need for the change. So these pull requests should reference an existing GitHub issue where the reasons for the change are discussed. Then you can open the pull request on your computer and test them out locally. After you've done so, if the changes look good, don't merge them quite yet. You can comment on the pull request saying "LGTM", then mention @raisedadead so he can take a final look.
+
+#### How to merge or close pull requests
+
+First of all, when you choose a pull request to QA, you should assign yourself to it. You can do this by clicking the "assign yourself" link below the "assignees" part on the right-hand column of GitHub's interface.
+
+Depending on the type of pull request it is, follow the corresponding rules listed above.
+
+Before merging any pull request, make sure that GitHub has green checkmarks for everything. If there are any X's, investigate them first and figure out how to get them turned into green checkmarks first.
+
+Sometimes there will be a Merge Conflict. This means that another pull request has made a change to that same part of that same file. GitHub has a tool for addressing these merge conflicts right on GitHub. You can try to address these conflicts. Just use your best judgment. The pull request's changes will be on top, and the Master branch's changes will be on the bottom. Sometimes there will be redundant information in there that can be deleted. Before you finish, be sure to delete the `<<<<<<`, `======`, and `>>>>>>` that Git adds to indicate areas of conflict.
+
+If the pull request looks ready to merge (and doesn't require approval from @raisedadead), you can go ahead and merge it. Be sure to use the default "Squash and Merge" functionality on GitHub. This will squash all the pull requests commits down into a single commit, which makes the Git history much easier to read.
+
+You should then comment on the pull request, thanking the contributor in your own personal way.
+
+If the author of the pull request is a "first-time contributor" you should also congratulate them on their first merged pull request to the repository. You can look at the upper right-hand corner of the PR's body to determine a first-time contributor. It will show `First-time contributor` as shown below:
+
+![Copy_edits_for_Java_arrays_article_by_karentobo_%C2%B7_Pull_Request__20615_%C2%B7_freeCodeCamp_freeCodeCamp|690x281](https://i.imgur.com/dTQMjGM.png)
+
+If the pull request doesn't look ready to merge you can politely reply telling the author what they should do to get it ready. Hopefully, they will reply and get their pull request closer to ready.
+
+Often, a pull request will be obviously low effort. You can often tell this immediately when the contributor didn't bother checking the checkboxes in the Pull Request Template or used a generic pull request title like "made changes" or "Update index.md".
+
+There are also situations where the contributor is trying to add a link to their own website, or include a library they themselves created, or has a frivolous edit that doesn't serve to help anyone but themselves.
+
+In both of these situations, you should go ahead and close their pull request and reply with this standard message:
+
+```markdown
+Thank you for opening this pull request.
+
+This is a standard message notifying you that we've reviewed your pull request and have decided not to merge it. We would welcome future pull requests from you.
+
+Thank you and happy coding.
+```
+
+If you need a second opinion on a pull request, go ahead and leave your comments on the pull request, then add the "discussing" label to the pull request.
+
+### Moderating GitHub Issues
+
+freeCodeCamp is an active open source project. We get new issues every day, all of which need to be triaged and labeled.
+
+#### Types of GitHub Issues
+
+1. **Code Help Requests**, which people have mistakenly created GitHub issues for. If someone is asking for help, paste the following message, then close the issue.
+
+```markdown
+Thank you for reporting this issue.
+
+This is a standard message notifying you that this issue seems to be a request for help. Instead of asking for help here, please click the **"Help"** button on the challenge on freeCodeCamp, which will help you create a question in the right part of the forum. Volunteers on the forum usually respond to questions within a few hours and can help determine if there is an issue with your code or the challenge's tests.
+
+If the forum members determine there is nothing wrong with your code, you can request this issue to be reopened.
+
+Thank you and happy coding.
+```
+
+2. **Bug or Clarification issues** Try to reproduce the bug yourself if you can. If not, ask them for the steps to reproduce the bug, and whether they have any screenshots, videos, or additional details that can help you reproduce the issue. Once you can reproduce the issue - or at least confirm it's a legit issue - label it `confirmed`. Then:
+
+- If it's a simple change to an existing challenge, label it as `first timers only`, otherwise label it as `help wanted`. Use other labels as appropriate.
+- If the issue is more significant, flag it as `bug`.
+  &nbsp;
+  If there is any ambiguity as to the proper course of action on an issue, feel free to tag @raisedadead on the issue get his opinion on it, then add the `Discussing` label.
+
+3. **Duplicate Issues** If an issue is the same as another reported issue, the prior reported issue should take precedence. Flag as `Duplicate`, paste the following message replacing `#XXXXX` with the issue number, then close the issue.
+
+```markdown
+Thank you for reporting this issue.
+
+This is a standard message notifying you that this issue appears to be very similar to issue #XXXXX, so we are closing it as a duplicate.
+
+If you think we're wrong in closing this issue, please request for it to be reopened and add further clarification. Thank you and happy coding.
+```
+
+4. **Fixed in staging** Some problems may have already been fixed in staging, but don't have a GitHub issue associated with them. If this is the case, you can paste the following message, close the issue, and add a `status: resolved/shipping` label:
+
+```markdown
+Thank you for reporting this issue.
+
+This is a standard message notifying you that the problem you mentioned here is present in production, but that it has already been fixed in staging. This means that the next time we push our staging branch to production, this problem should be fixed. Because of this, we're closing this issue.
+
+If you think we're wrong in closing this issue, please request for it to be reopened and add further clarification. Thank you and happy coding.
+```
+
+#### Closing Stale, Outdated, Inactive Issues and Pull Requests
+
+- Stale issues or PRs are those that have not seen any activity from the OP for 21 days (3 weeks from the last activity), but only after a moderator has requested more information/changes. These can be closed in an automated/bot script or by the moderators themselves.
+
+- Activity is defined as: Comments requesting an update on the PR and triages like `status: update needed` label etc.
+
+- If the OP asks for additional assistance or even time, the above can be relaxed and revisited after a response is given. In any case, the mods should use their best judgment to resolve the outstanding PR's status.
+
+#### Other guidelines for Moderators on GitHub
+
+Though you will have write access to freeCodeCamp's repository, **you should never push code directly to freeCodeCamp repositories**. All code should enter freeCodeCamp's codebase in the form of a pull request from a fork of the repository.
+
+Also, you should never accept your own PRs. They must be QA'd by another moderator, just like with any other PR.
+
+If you notice anyone breaking the [code of conduct](https://code-of-conduct.freecodecamp.org) on GitHub issues, or opening pull requests with malicious content or code, email dev@freecodecamp.org with a link to the offending pull request and we can consider banning them from freeCodeCamp's GitHub organization entirely.
+
+## Moderating the Forum
+
+As a Moderator, you help keep our community an enjoyable place for anyone to learn and get help. You will deal with flagged posts and handle spam, off-topic, and other inappropriate conversations.
+
+Note that once you are a moderator on the forum, you will start to see blue moderator hints about forum members, like "this is the first time [person] has posted - let's welcome them to the community!" or "[person] hasn't posted in a long time - let's welcome them back."
+
+![A blue text message saying "this is the first time [person] has posted - let's welcome them to the community!](https://i.imgur.com/mPmVgzK.png)
+
+These are opportunities for you to welcome them and make them feel extra special. You never know which person who's marginally involved may become our next super-helper, helping many other people in their coding journey. Even the smallest kindness may trigger a cascade of good deeds.
+
+### Deleting forum posts
+
+Forum moderators have the ability to delete user's posts. You should only do this for the following instances:
+
+1. Someone has posted a pornographic or graphically violent image.
+2. Someone has posted a link or code that is malicious in nature and could harm other campers who click on it.
+3. Someone has flooded a thread with lots of spam messages.
+
+### Dealing with spam
+
+For the first spam post of a user, send them a message explaining the problem, and remove the link or post as appropriate. Leave a note on the user's profile explaining the action you have taken. If the problem persists, then follow the process above. Quietly block the user from posting (using the silence option on the User Admin panel), then send a warning with the Code of Conduct. Check the box in the private message indicating that your message is a "formal warning."
+
+You can ask questions and report incidents in the in the [staff forum section](https://forum.freecodecamp.com/c/staff).
+
+### Dealing with off-topic conversations
+
+Posts or topics that seems to be in the wrong place can be re-categorized or renamed to whatever would be appropriate.
+
+In exceptional circumstances, it may be appropriate for a moderator to fork a discussion into multiple threads.
+
+Again, if you have any problems or questions, make a post with your actions in the Staff category, and tag another moderator if you want them to review your moderating actions.
+
+### Underage Users
+
+Our Terms of Service require that freeCodeCamp users be at least 13 years of age. In the event that a user reveals that they are under the age of 13, send them the below message and delete their forum account (if deletion is not available, suspending the account is sufficient). Then email [Quincy](https://forum.freecodecamp.org/u/QuincyLarson) (quincy@freecodecamp.org) or [Mrugesh](https://forum.freecodecamp.org/u/raisedadead) (mrugesh@freecodecamp.org) to delete the user's freeCodeCamp account as well.
+
+```markdown
+SUBJECT: Users under 13 are not allowed to use the forum per Terms of Service
+
+It has come to our attention that you are under 13 years of age. Per the [freeCodeCamp terms of service](https://www.freecodecamp.org/news/terms-of-service), you must be at least 13 years old to use the site or the forum. We will be deleting both your freeCodeCamp account and your forum account. This restriction keeps us in compliance with United States laws.
+
+Please rejoin once you have reached at least 13 years of age.
+
+Thank you for understanding.
+```
+
+## Moderating Facebook
+
+If you see anything that seems to break our [Code of Conduct](https://code-of-conduct.freecodecamp.org/), you should delete it immediately.
+
+Sometimes people will post things that they think are funny. They don't realize that what they said or what they shared could be interpreted as offensive. In these cases, their post should be deleted, but the person who posted it doesn't necessarily need to be banned. By getting their post deleted, they will hopefully come to understand that what they posted was inappropriate.
+
+But if it is an egregious offense that can't reasonably be attributed to a cultural difference or a misunderstanding of the English language, then you should strongly consider blocking the member from the Facebook group.
+
+## Moderating Discord
+
+Here's how moderators deal with violations of our [Code of Conduct](https://code-of-conduct.freecodecamp.org/) on Discord:
+
+1. **Make sure it was intended to violate the Code of Conduct.**
+   Not all violations of the CoC were intended as such. A new camper might post a large amount of code for help, unaware that this can be considered spamming. In these cases, you can just ask them to paste their code with services like Codepen or Pastebin.
+
+2. **If the camper clearly and intentionally violates the Code of Conduct, the moderator will proceed as follows:**
+
+- Ban the offending person from the Discord Server. In order to ban someone, right-click on their username/profile picture and select "Ban username". You will be given the option to delete their previous messages - select "Don't delete any", as the messages should remain present as a historic record.
+- Report a short summary of the event in the #mod-log channel. Here's an example of what such a summary might look like:
+
+```
+Banned: _@username_
+Reason(s): _Spamming, trolling_
+Evidence: _One or more links to the offending message(s)_
+```
+
+- If you decide to ban someone, it means they're unwilling to abide to our Code of Conduct. Therefore unbanning a Camper should rarely occur. However, if the need arises, you can do so by clicking on the server name, choosing "Server Settings", choosing "Bans", selecting the user you wish to unban, and clicking "Revoke Ban".
+
+Discord Bans are global - you cannot ban a user from a specific channel, only from the entire server.
+
+3. **Creating a Private Discussion**
+
+There may be situations where you need to address a concern with a camper privately. This should not be done through DMs, as this can lead to situations where you claim one thing and the camper claims another. Instead, use the bot's functionality to create a private discussion:
+
+- Call the `!fCC moderate private @username` command, where `@username` is the _Discord mention_ of the user. If you are calling this command from a private channel (such as #mod-chat), you will need to parse the mention manually: Ensure you have Developer Mode turned on in your Discord settings, then right-click on the user's avatar and select `Copy ID`. Replace the `@username` parameter with `<@!ID>`, where `ID` is the value you copied earlier. The result should look like: `!fCC moderate private <@!465650873650118659>`.
+- The bot will create a new channel under the `private` category and add the `@username`-mentioned camper and all moderators with the `Your Friendly Moderator` role. While all moderators are added to the channel for transparency, the moderator who calls this command should be the only one to interact with the camper unless they request assistance.
+- When the conversation is complete, call the `!fCC moderate close` command _in the private channel_ to have the bot close and delete that channel.
+
+4. **Deleting messages**
+   Moderators have the ability to delete messages on Discord. They should only exercise this ability in four very specific situations:
+
+- Someone has posted a pornographic or graphically violent image.
+- Someone has posted a link or code that is malicious in nature and could harm other campers who click on it.
+- Someone has flooded the chat with lots of spam messages to such an extreme extent (usually involving bots) as to render chat completely unusable.
+- Someone has posted an advertisement and/or a self-promoting message/image (social media).
+
+In all other situations - even situations where the code of conduct is violated - Moderators should not delete the message as these are an important historic record. When you do delete a message, make sure you take a screenshot of it first! The screenshot can be logged in the #mod-log channel, but for the #activity-log it is sufficient to say the evidence was "removed due to sensitive content". Note: If the message contains material that would be illegal to take a screenshot of, copy the message link instead - provide that message link to @raisedadead to forward to Discord's Trust and Safety team.
+
+5. **Don’t use @everyone or @here**
+   Don’t use @everyone or @here under any circumstances! Every single person in that chat room will get a notification. In some cases, tens of thousands of people.
+   Instead, if you want people to see an announcement, you can pin it to the channel to allow everyone to read it.
+
+6. **Don’t threaten to ban** If a camper is breaking the code of conduct, don’t threaten to ban them, and never warn them in public. Instead, talk to them privately using the bot's `private` command. No one else in that channel needs to know that you banned/suspended the person - campers can view the summary in the #activity-log channel if they want to keep up on that information. If a violation was clearly unintended and doesn't warrant a suspension or private conversation, make the offending camper aware of his / her actions without making it come across as a warning. For example:
+
+- Camper posts a wall of code to request help
+
+  Moderator: @username Please use Codepen or Pastebin when posting large amounts of code.
+
+- Or if you really have to explain why:
+
+  Moderator: @username Please use Codepen or Pastebin when posting large amounts of code, because it disrupts the chat for everyone and could be considered spamming according to our Code of Conduct.
+
+- For mild and unintentional violations of the code of conduct
+
+  Moderator: This is a friendly reminder for everyone to follow the code of conduct: https://code-of-conduct.freecodecamp.org/
+
+7. **Don’t brag about being a moderator**
+   Do not see yourself as above the community. You are the community. And the community has trusted you to help protect something rare that we all share - a _welcoming_ place for new developers.
+   If you brag about being a moderator, people may feel uneasy around you, in the same way, that people may feel uneasy around a police officer, even if they’re doing nothing wrong. This is just human nature.
+
+8. **Don’t contradict other moderators**
+   If you disagree with the action of a moderator, talk with them in private or bring it up in the #mod-chat channel. Never override a ban, and never contradict the other moderator(s) publicly. Instead, have a cool-headed discussion in mod-chat and convince the moderator that they themselves should reverse their ban or change their point of view.
+   Remember: we’re all on the same team. We want to dignify the role of moderators and present a unified front.
+
+9. **Talk with other moderators**
+   We have a room for moderators only. Use it! If you feel uncomfortable with how to handle a certain situation, ask other moderators for help. If you think something should be discussed, do it. You're part of the team and we value the input of every team member! Even if you totally disagree with anything in these guidelines or the Code of Conduct!
+
+10. **Temporarily inactive**
+    If you're not going to be active as a Moderator for a while due to vacation, illness, or any other reason, make sure to let the others know in the #mod-chat channel. This is so we know if we can count on you to be regularly active on the server or not.
+
+## Moderating our Chat Server
+
+Moderating the chat server is very similar to moderating the Discord server, but there are a few key differences:
+
+1. **No Ban functionality**
+   At this time, Rocket.Chat does not have a flow for banning users. Users can be muted (so they are prevented from chatting in a room) or kicked from a room.
+2. **Modified Bot Commands**
+   The moderation bot in the chat server was developed with a smoother UX in mind. Some of the commands have been modified. Use the `!fCC modHelp` command to view the available functionality. Bot commands in the chat server do NOT require a user mention as they do with Discord.
+3. **No Role Mentions**
+   Unlike Discord, Rocket.Chat does not allow you to mention all users by a specific role - this means you cannot ping all moderators at once.
+
+## How to become a moderator
+
+If you are helping people in the community consistently over time, our Moderator Team will eventually take notice, and one of them will mention you as a possible moderator to [our staff](https://forum.freecodecamp.org/g/Team). There are no shortcuts to becoming a moderator.
+
+If you are approved, we will add you to our Moderator Teams on [GitHub](https://github.com/orgs/freeCodeCamp/teams/moderators), [forum](https://forum.freecodecamp.org/g/moderators), etc.
+
+> [!NOTE] > **For GitHub:** After you've been accepted as a moderator, you will receive a Github repository invitation. You'll need to head over towards [freeCodeCamp GitHub Organisation Invitation](https://github.com/orgs/freeCodeCamp/invitation) to be able to accept the invitation. This is required for us to be able to give you write access to some of our repositories.
+
+## How we retire inactive moderators
+
+Please note that we will frequently remove mods whom we think are inactive. When we do this we will send the following message:
+
+> This is a standard message notifying you that, since you don't seem to have been an active moderator recently, we're removing you from our Moderator team. We deeply appreciate your help in the past.
+
+> If you think we did this in error, or once you're ready to come back and contribute more, just reply to this message letting me know.
+
+## How our Contributors room works
+
+Anyone is welcome in the [Contributors room on our chat server](https://chat.freecodecamp.org/channel/contributors). It is the designated chat room for moderators and other campers who are contributing to our community in any number of ways, including through study groups.
+
+Our assumption is that contributors will read anything in this room that directly mentions them with an `@username`. Everything else is optional. But feel free to read anything anyone posts in there and interact.
+
+## Dealing with solicitors
+
+You may be approached by organizations who want to partner or co-brand with freeCodeCamp in some way. Once you realize that this is what they're after, please stop talking to them and tell them to email quincy@freecodecamp.org. He gets proposals like this all the time and is in the best position to judge whether such a relationship will be worth it for our community (and it rarely is).
+
+## Dealing with (mental) health inquiries
+
+You may come across situations where users are seeking medical advice or are dealing with mental health issues and are looking for support. As a matter of policy, you should avoid talking privately about these matters. Should the situation at some point reflect back to fCC, we want to have the conversation(s) on record. Make it clear that we are not medical professionals and that you encourage the user to find professional help. As difficult as it sometimes can be, avoid giving any tips or advice other than pointing the user in the direction of professional help!
+
+If this happens on Discord: Create a private channel for the user and the mod team. This can be done with the bot's `private` command.
+
+- The user is guaranteed some privacy
+- Public chat is no longer disrupted
+- Other team members can pitch in, should you be uncomfortable dealing with the situation yourself
+
+If you believe the user is capable of rejoining the community, right-click on the private channel and copy the ID. Put the following message in #mod-log:
+
+> Reference medical advice: `<channel ID> <username>`
+
+Helpful URLs:
+
+http://www.suicide.org/international-suicide-hotlines.html
+
+## A note on free speech
+
+Sometimes people will defend something offensive or incendiary that they said as "free speech."
+
+This XKCD comic perfectly summarizes most communities' thoughts on free speech. So if someone defends something they're saying as "free speech" feel free to send it to them.
+
+<div align="center"><img src='https://aws1.discourse-cdn.com/freecodecamp/original/3X/4/3/43a8b2eafe4c8622e02838f66f1dc6227de32c70.png' width="400" height="400" /></div>
+
+Thanks for reading this, and thanks for helping the developer community!
+
+## Reply Templates
+
+These are some of the standard reply templates that you may use while reviewing pull requests and triaging issues.
+
+> You can make your own with GitHub's built-in [**Saved replies**](https://github.com/settings/replies/) feature or use the ones below.
+
+### Thank you
+
+```markdown
+Thank you for your contribution to the page! 👍
+We are happy to accept these changes and look forward to future contributions. 🎉
+```
+
+### Thank you and congrats
+
+> For thanking and encouraging first-time contributors.
+
+```markdown
+Hi @username. Congrats on your first pull request (PR)! 🎉
+
+Thank you for your contribution to the page! 👍
+We are happy to accept these changes and look forward to future contributions. 📝
+```
+
+### Build Error
+
+```markdown
+Hey @username
+
+We would love to be able to merge your changes but it looks like there is an error with the CI build. ⚠️
+
+Once you resolve these issues, We will be able to review your PR and merge it. 😊
+
+---
+
+Feel free to reference the [contributing guidelines](https://contribute.freecodecamp.org/#/how-to-work-on-coding-challenges?id=testing-challenges) for instructions on running the CI build locally. ✅
+```
+
+### Syncing Fork
+
+> When PR is not up to date with the `main` branch.
+
+````markdown
+Hey @username
+
+We would love to be able to merge your changes but it looks like the branch is not up to date. ⚠️
+
+To resolve this error, you will have to sync the latest changes from the `main` branch of the `freeCodeCamp/freeCodeCamp` repo.
+
+Using the command line, you can do this in three easy steps:
+
+```bash
+git remote add upstream git://github.com/freeCodeCamp/freeCodeCamp.git
+
+git fetch upstream
+
+git pull upstream master
+```
+
+If you're using a GUI, you can simply `Add a new remote...` and use the link `git://github.com/freeCodeCamp/freeCodeCamp.git` from above.
+
+Once you sync your fork and pass the build, we will be able to review your PR and merge it. 😊
+
+---
+
+Feel free to reference the [Syncing a Fork](https://help.github.com/articles/syncing-a-fork/) article on GitHub for more insight on how to keep your fork up-to-date with the upstream repository. 🔄
+````
+
+### Merge Conflicts
+
+> When PR has merge conflicts that need to be resolved.¹
+
+```markdown
+Hey @username
+
+We would love to be able to merge your changes but it looks like you have some merge conflicts. ⚠️
+
+Once you resolve these conflicts, We will be able to review your PR and merge it. 😊
+
+---
+
+If you're not familiar with the merge conflict process, feel free to look over GitHub's guide on ["Resolving a merge conflict"](https://help.github.com/articles/resolving-a-merge-conflict-on-github/). 🔍️
+
+Also, it's good practice on GitHub to write a brief description of your changes when creating a PR. 📝
+```
+
+¹ If a first-time-contributor has a merge conflict, maintainers will resolve the conflict for them.
+
+### Duplicate
+
+> When PR is repetitive or a duplicate.
+
+```markdown
+Hey @username
+
+This PR seems to make similar changes as the existing PR <#number>. As such, we are going to close this as duplicate.
+
+If you feel you have additional changes to expand upon this PR, please feel free to push your commits and request this PR be reopened.
+
+Thanks again! 😊
+
+---
+
+If you have any questions, feel free to ask questions on the ['Contributors' category on our forum](https://forum.freecodecamp.org/c/contributors) or [the contributors chat room](https://chat.freecodecamp.org/channel/contributors).
+```
+
+### Closing invalid pull requests
+
+> When PR is invalid.
+
+```markdown
+Hey @username
+
+Thank you for opening this pull request.
+
+This is a standard message notifying you that we've reviewed your pull request and have decided not to merge it. We would welcome future pull requests from you.
+
+Thank you and happy coding.
+```
+
+> When PR adds links to external resources.
+
+```markdown
+Thank you for your pull request.
+
+We are closing this pull request. Please suggest links and other details to add the challenge's corresponding guide post through [a forum topic](https://forum.freecodecamp.org/new-topic?category=Contributors&title=&body=**What%20is%20your%20hint%20or%20solution%20suggestion%3F**%0A%0A%0A%0A%0A**Challenge%3A**%0A%0A%0A**Link%20to%20the%20challenge%3A**) instead.
+
+If you think we're wrong in closing this issue, please request for it to be reopened and add further clarification. Thank you, and happy coding.
+```
+
+### Closing Invalid Issues
+
+> When an issue relates to the camper's code.
+
+```markdown
+Thank you for reporting this issue.
+
+This is a standard message notifying you that this issue seems to be a request for help. Instead of asking for help here, please click the **"Get Help"** button on the challenge on freeCodeCamp and choose the **"Ask for help"** option, which will help you create a question in the right part of the forum. Volunteers on the forum usually respond to questions within a few hours and can help determine if there is an issue with your code or the challenge's tests.
+
+If the forum members determine there is nothing wrong with your code, you can request this issue to be reopened.
+
+Thank you and happy coding.
+```
+
+> When an issue is duplicate of an earlier issue
+
+```markdown
+Thank you for reporting this issue.
+
+This is a standard message notifying you that this issue appears to be very similar to issue #XXXXX, so we are closing it as a duplicate.
+
+If you think we're wrong in closing this issue, please request for it to be reopened and add further clarification. Thank you and happy coding.
+```
+
+> When an issue is fixed in staging.
+
+```markdown
+Thank you for reporting this issue.
+
+This is a standard message notifying you that the problem you mentioned here is present in production, but that it has already been fixed in staging. This means that the next time we push our staging branch to production, this problem should be fixed. Because of this, we're closing this issue.
+
+If you think we're wrong in closing this issue, please request for it to be reopened and add further clarification. Thank you and happy coding.
+```


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

- Adds Portuguese to the translation links
- Enables the Portuguese download in the Crowdin docs workflow (@RandellDawson when you have a chance do you want to take a peek at that?)
- Copies the English files into a Portuguese i18n directory to avoid 404s between the time this lands and the time we run our next docs download.

I've added the appropriate setting on the Crowdin project to map the downloaded files to the correct directory as well.