### PR TITLE
fix: ensure babel presets load

### DIFF
--- a/client/src/templates/Challenges/rechallenge/transformers.js
+++ b/client/src/templates/Challenges/rechallenge/transformers.js
@@ -59,7 +59,6 @@ async function loadBabel() {
 }
 
 async function loadPresetEnv() {
-  if (babelOptionsJSBase && babelOptionsJSBase.presets) return;
   /* eslint-disable no-inline-comments */
   if (!presetEnv)
     presetEnv = await import(
@@ -81,11 +80,11 @@ async function loadPresetEnv() {
 }
 
 async function loadPresetReact() {
-  if (presetReact) return;
   /* eslint-disable no-inline-comments */
-  presetReact = await import(
-    /* webpackChunkName: "@babel/preset-react" */ '@babel/preset-react'
-  );
+  if (!presetReact)
+    presetReact = await import(
+      /* webpackChunkName: "@babel/preset-react" */ '@babel/preset-react'
+    );
   if (!presetEnv)
     presetEnv = await import(
       /* webpackChunkName: "@babel/preset-env" */ '@babel/preset-env'


### PR DESCRIPTION
In rare cases, loadPresetReact could get into a race with itself. In
these cases the first call would set presetReact and the second call
would exit early as a result.  This would mean babelOptionsJSX would be
undefined and the transformation would fail.
