### PR TITLE
fix(gitpod): add curriculum build to GitPod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -40,6 +40,7 @@ tasks:
       mongo --eval "db.fsyncLock(); db.fsyncUnlock()"
     command: >
       npm run ensure-env &&
+      npm run build:curriculum --if-present &&
       gp await-port 27017 &&
       npm run develop:server
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -40,7 +40,7 @@ tasks:
       mongo --eval "db.fsyncLock(); db.fsyncUnlock()"
     command: >
       npm run ensure-env &&
-      npm run build:curriculum --if-present &&
+      npm run build:curriculum &&
       gp await-port 27017 &&
       npm run develop:server
 


### PR DESCRIPTION
_Oliver broke my setup_ 😛 

```console
Failed loading boot script: /workspace/freeCodeCamp/api-server/src/server/boot/certificate.js
Error: Cannot find module '../../../../config/curriculum.json'
Require stack:
- /workspace/freeCodeCamp/api-server/src/server/utils/get-curriculum.js
```

Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

Adds curriculum build step to GitPod container setup.