### PR TITLE
feat(tool): Script to mark translated strings on Crowdin as "Done"

### DIFF
--- a/tools/crowdin/one-off-scripts/mark-translated-strings-as-done.js
+++ b/tools/crowdin/one-off-scripts/mark-translated-strings-as-done.js
@@ -1,0 +1,54 @@
+/*
+This one-off script can be used to make any string in a Crowdin project to be marked as "Done" in case a workflow
+change inadvertently causes strings, which already have translations (and even an approved translation), to be
+reverted to "To Do".
+
+Specifying a projectId in the .env file allows the script to find any string with at least one translation, 
+adds a new temporary translation to it, and then delete the newly added translation.  It is the addition of a
+new translation that switches the status back to "Done" in the Crowdsourcing view on Crowdin.
+
+*/
+
+require('dotenv').config({ path: `${__dirname}/../.env` });
+
+const getLanguages = require('../utils/get-languages');
+
+const {
+  addTranslation,
+  deleteTranslation,
+  getLanguageTranslations
+} = require('../utils/strings');
+
+const markTranslatedStringsAsDone = async projectId => {
+  console.log('starting script...');
+  const languageIds = await getLanguages(projectId);
+  for (let languageId of languageIds) {
+    const translations = await getLanguageTranslations({
+      projectId,
+      languageId
+    });
+    if (translations && translations.length) {
+      console.log(
+        `${languageId} has ${translations.length} strings with at least one translation`
+      );
+      for (let translation of translations) {
+        const { stringId } = translation.data;
+        const newTranslation = await addTranslation(
+          projectId,
+          stringId,
+          languageId,
+          'this is a camperbot test translation'
+        );
+        if (newTranslation && newTranslation.id);
+        console.log(
+          `added new translation (translationId: ${newTranslation.id}) for stringId: ${stringId}`
+        );
+        await deleteTranslation(projectId, newTranslation.id);
+      }
+    }
+  }
+  console.log('complete');
+};
+
+const projectId = process.env.CROWDIN_PROJECT_ID;
+markTranslatedStringsAsDone(projectId);

--- a/tools/crowdin/utils/get-languages.js
+++ b/tools/crowdin/utils/get-languages.js
@@ -1,0 +1,17 @@
+const authHeader = require('./auth-header');
+const makeRequest = require('./make-request');
+
+const getLanguages = async projectId => {
+  let headers = { ...authHeader };
+  const endPoint = `projects/${projectId}?limit=500`;
+  const response = await makeRequest({ method: 'get', endPoint, headers });
+  if (response.data && response.data.targetLanguageIds.length) {
+    return response.data.targetLanguageIds;
+  } else {
+    const { error, errors } = response;
+    console.error(error ? error : errors);
+    return null;
+  }
+};
+
+module.exports = getLanguages;

--- a/tools/crowdin/utils/strings.js
+++ b/tools/crowdin/utils/strings.js
@@ -128,9 +128,97 @@ const updateFileString = async ({
   }
 };
 
+const getStringTranslations = async ({ projectId, stringId, languageId }) => {
+  let headers = { ...authHeader };
+  let done = false;
+  let offset = 0;
+  let translations = [];
+  while (!done) {
+    let endPoint = `projects/${projectId}/translations?stringId=${stringId}&languageId=${languageId}&limit=500&offset=${offset}`;
+    const response = await makeRequest({ method: 'get', endPoint, headers });
+    if (response.data) {
+      if (response.data.length) {
+        translations = [...translations, ...response.data];
+        offset += 500;
+      } else {
+        done = true;
+        return translations;
+      }
+    } else {
+      const { error, errors } = response;
+      console.error(
+        error ? JSON.stringify(error, null, 2) : JSON.stringify(errors, null, 2)
+      );
+    }
+  }
+  return null;
+};
+
+const deleteTranslation = async (projectId, translationId) => {
+  let headers = { ...authHeader };
+  const endPoint = `projects/${projectId}/translations/${translationId}`;
+  await makeRequest({
+    method: 'delete',
+    endPoint,
+    headers
+  });
+  console.log(`Deleted translationId ${translationId} from Crowdin project`);
+  return null;
+};
+
+const addTranslation = async (projectId, stringId, languageId, text) => {
+  let headers = { ...authHeader };
+  const endPoint = `projects/${projectId}/translations`;
+  const body = {
+    stringId,
+    languageId,
+    text
+  };
+  const response = await makeRequest({
+    method: 'post',
+    endPoint,
+    headers,
+    body
+  });
+  if (response.data) {
+    return response.data;
+  }
+  return null;
+};
+
+const getLanguageTranslations = async ({ projectId, languageId }) => {
+  let headers = { ...authHeader };
+  let done = false;
+  let offset = 0;
+  let translations = [];
+  while (!done) {
+    let endPoint = `projects/${projectId}/languages/${languageId}/translations?limit=500&offset=${offset}`;
+    const response = await makeRequest({ method: 'get', endPoint, headers });
+    if (response.data) {
+      if (response.data.length) {
+        translations = [...translations, ...response.data];
+        offset += 500;
+      } else {
+        done = true;
+        return translations;
+      }
+    } else {
+      const { error, errors } = response;
+      console.error(
+        error ? JSON.stringify(error, null, 2) : JSON.stringify(errors, null, 2)
+      );
+    }
+  }
+  return null;
+};
+
 module.exports = {
   getStrings,
   updateString,
   updateFileStrings,
-  updateFileString
+  updateFileString,
+  getStringTranslations,
+  addTranslation,
+  deleteTranslation,
+  getLanguageTranslations
 };


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

This PR creates a one-off script can be used to make any string in a Crowdin project to be marked as "Done" in case a workflow change inadvertently causes strings, which already have translations (and even an approved translation), to be reverted to "To Do".

Specifying a `projectId` in the `.env` file allows the script to find any string with at least one translation, adds a new temporary translation to it, and then delete the newly added translation.  It is the addition of a new translation that switches the status back to "Done" in the Crowdsourcing view on Crowdin.

I tested the script on the Test Project on Crowdin.  I also ran it with the add translation and delete translation step out and console logged the strings that would have had new translations added/deleted just to make sure it captured only strings with translations.