### PR TITLE
fix(tool): Added more files to restrict from direct translations

### DIFF
--- a/.github/workflows/no-prs-to-translation.yml
+++ b/.github/workflows/no-prs-to-translation.yml
@@ -24,7 +24,7 @@ jobs:
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: "Thanks for your pull-request. We are no longer accepting changes to the non-English versions of curriculum files or intro.json or translations.json. Please visit [our contributing guidelines](https://contribute.freecodecamp.org) to learn more about translating freeCodeCamp's resources."
+                body: "Thanks for your pull-request. We are no longer accepting changes to the non-English versions of files in parts of this codebase. This pull-request seems to change some of those. Please visit [our contributing guidelines](https://contribute.freecodecamp.org) to learn more about translating freeCodeCamp's resources."
               })
             } else {
               github.issues.createComment({

--- a/.github/workflows/no-prs-to-translation.yml
+++ b/.github/workflows/no-prs-to-translation.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - 'curriculum/challenges/**'
       - '!curriculum/challenges/english/**'
+      - 'client/i18n/locales/**'
+      - '!client/i18n/locales/english/**'
 
 jobs:
   has-translation:
@@ -21,13 +23,13 @@ jobs:
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: "Thanks for your pull-request. We are no longer accepting curriculum-related changes to non-English files. Please visit [our contributing guidelines](https://contribute.freecodecamp.org) to learn more about translating freeCodeCamp's resources."
+                body: "Thanks for your pull-request. We are no longer accepting changes to the non-English versions of curriculum files or intro.json or translations.json. Please visit [our contributing guidelines](https://contribute.freecodecamp.org) to learn more about translating freeCodeCamp's resources."
               })
             } else {
               github.issues.createComment({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: 'WAIT! This message serves as a sanity check. Your PR appears to come from the base freeCodeCamp repository and modifies translated curriculum files. Before merging, please confirm that the commits on this PR originated from the Crowdin download action.'
+                body: 'WAIT! This message serves as a sanity check. Your PR appears to come from the base freeCodeCamp repository and modifies translated curriculum files or intro.json or translations.json. Before merging, please confirm that the commits on this PR originated from the Crowdin download action.'
               })
             }

--- a/.github/workflows/no-prs-to-translation.yml
+++ b/.github/workflows/no-prs-to-translation.yml
@@ -6,7 +6,8 @@ on:
     paths:
       - 'curriculum/challenges/**'
       - '!curriculum/challenges/english/**'
-      - 'client/i18n/locales/**'
+      - 'client/i18n/locales/**/intro.json'
+      - 'client/i18n/locales/**/translations.json'
       - '!client/i18n/locales/english/**'
 
 jobs:


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

This PR adds the non-English versions of `intro.json` and `translations.json` to the files restricted from PRs coming from forked repos.