### PR TITLE
feat: use en as i18n fallback

### DIFF
--- a/client/i18n/config.js
+++ b/client/i18n/config.js
@@ -7,7 +7,7 @@ const { i18nextCodes } = require('../../config/i18n/all-langs');
 const i18nextCode = i18nextCodes[clientLocale];
 
 i18n.use(initReactI18next).init({
-  fallbackLng: i18nextCode,
+  fallbackLng: 'fallback',
   lng: i18nextCode,
   // we only load one language since each language will have it's own server
   resources: {
@@ -16,6 +16,12 @@ i18n.use(initReactI18next).init({
       trending: require(`./locales/${clientLocale}/trending.json`),
       intro: require(`./locales/${clientLocale}/intro.json`),
       metaTags: require(`./locales/${clientLocale}/meta-tags.json`)
+    },
+    fallback: {
+      translations: require('./locales/english/translations.json'),
+      trending: require('./locales/english/trending.json'),
+      intro: require('./locales/english/intro.json'),
+      metaTags: require('./locales/english/meta-tags.json')
     }
   },
   ns: ['translations', 'trending', 'intro', 'metaTags'],

--- a/client/i18n/config.js
+++ b/client/i18n/config.js
@@ -7,7 +7,7 @@ const { i18nextCodes } = require('../../config/i18n/all-langs');
 const i18nextCode = i18nextCodes[clientLocale];
 
 i18n.use(initReactI18next).init({
-  fallbackLng: 'fallback',
+  fallbackLng: 'en',
   lng: i18nextCode,
   // we only load one language since each language will have it's own server
   resources: {
@@ -17,7 +17,7 @@ i18n.use(initReactI18next).init({
       intro: require(`./locales/${clientLocale}/intro.json`),
       metaTags: require(`./locales/${clientLocale}/meta-tags.json`)
     },
-    fallback: {
+    en: {
       translations: require('./locales/english/translations.json'),
       trending: require('./locales/english/trending.json'),
       intro: require('./locales/english/intro.json'),


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Loads the English versions of the files as a "fallback" language to avoid displaying keys when a translation is missing.