### PR TITLE
fix: error reporting

### DIFF
--- a/client/src/client/frame-runner.js
+++ b/client/src/client/frame-runner.js
@@ -82,15 +82,13 @@ async function initTestFrame(e = { code: {} }) {
           try {
             // eslint-disable-next-line no-eval
             const test = eval(testString);
-            resolve({ test });
+            resolve(test);
           } catch (err) {
-            reject({ err });
+            reject(err);
           }
         })
       );
-      const { test, err } = await testPromise;
-      if (err) throw err;
-
+      const test = await testPromise;
       if (typeof test === 'function') {
         await test(e.getUserInput);
       }
@@ -99,8 +97,11 @@ async function initTestFrame(e = { code: {} }) {
       if (!(err instanceof chai.AssertionError)) {
         console.error(err);
       }
-      // return the error so that the curriculum tests are more informative
-      return { err };
+      // to provide useful debugging information when debugging the tests, we
+      // have to extract the message and stack before returning
+      return {
+        err: { message: err.message, stack: err.stack }
+      };
     }
   };
 }


### PR DESCRIPTION
This should reduce some noise in the console, due to a regression I created quite some time ago. Specifically, errors thrown by `assert` during tests will be hidden again and the error in the console will just be `error` not `{ err: error }`.

Finally, this improves things a little, by including the stack trace and the error type (`Error` vs `AssertionError` etc) when you `npm run test:curriculum` so it's a little easier to see what's breaking.