### PR TITLE
fix: make missing scripts fail linting/testing

### DIFF
--- a/.github/workflows/node.js-tests-upcoming.yml
+++ b/.github/workflows/node.js-tests-upcoming.yml
@@ -50,8 +50,8 @@ jobs:
       - name: Lint Source Files
         run: |
           npm ci
-          npm run ensure-env --if-present
-          npm run lint --if-present
+          npm run ensure-env
+          npm run lint
 
   test:
     name: Test
@@ -93,7 +93,7 @@ jobs:
       - name: Install Dependencies
         run: |
           npm ci
-          npm run ensure-env --if-present
+          npm run ensure-env
 
       - name: Run Tests
         run: npm test

--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Lint Source Files
         run: |
           npm ci
-          npm run ensure-env --if-present
-          npm run lint --if-present
+          npm run ensure-env
+          npm run lint
 
   test:
     name: Test
@@ -78,7 +78,7 @@ jobs:
       - name: Install Dependencies
         run: |
           npm ci
-          npm run ensure-env --if-present
+          npm run ensure-env
 
       - name: Run Tests
         run: npm test


### PR DESCRIPTION
If a script is not present, we would like an error letting us know.

@raisedadead I couldn't think of a situation where we'd want a process to continue if a script wasn't present.  Am I missing something?