### PR TITLE
fix(client,i18n): Use block for front end / back end projects and back end challenge right breadcrumb

### DIFF
--- a/client/src/templates/Challenges/projects/backend/Show.js
+++ b/client/src/templates/Challenges/projects/backend/Show.js
@@ -168,7 +168,8 @@ export class BackEnd extends Component {
           description,
           instructions,
           translationPending,
-          superBlock
+          superBlock,
+          block
         }
       },
       isChallengeCompleted,
@@ -198,7 +199,7 @@ export class BackEnd extends Component {
               <Col md={8} mdOffset={2} sm={10} smOffset={1} xs={12}>
                 <Spacer />
                 <ChallengeTitle
-                  block={blockName}
+                  block={block}
                   isCompleted={isChallengeCompleted}
                   superBlock={superBlock}
                   translationPending={translationPending}
@@ -260,6 +261,7 @@ export const query = graphql`
       challengeType
       helpCategory
       superBlock
+      block
       translationPending
       fields {
         blockName

--- a/client/src/templates/Challenges/projects/frontend/Show.js
+++ b/client/src/templates/Challenges/projects/frontend/Show.js
@@ -127,6 +127,7 @@ export class Project extends Component {
           title,
           description,
           superBlock,
+          block,
           translationPending
         }
       },
@@ -155,7 +156,7 @@ export class Project extends Component {
               <Col md={8} mdOffset={2} sm={10} smOffset={1} xs={12}>
                 <Spacer />
                 <ChallengeTitle
-                  block={blockName}
+                  block={block}
                   isCompleted={isChallengeCompleted}
                   superBlock={superBlock}
                   translationPending={translationPending}
@@ -202,6 +203,7 @@ export const query = graphql`
       challengeType
       helpCategory
       superBlock
+      block
       translationPending
       fields {
         blockName


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

Closes #41271

`blockName` was being passed to the translation function instead of `block`.  This should fix the bug in described in #41271 for not only the projects but the backend challenges as well (which were also not showing correctly).