### PR TITLE
fix: prevent parser throwing when err is null

### DIFF
--- a/tools/challenge-parser/parser/index.js
+++ b/tools/challenge-parser/parser/index.js
@@ -55,10 +55,10 @@ exports.parseMD = function parseMD(filename) {
       if (!err) {
         delete file.contents;
         resolve(file.data);
+      } else {
+        err.message += ' in file ' + filename;
+        reject(err);
       }
-
-      err.message += ' in file ' + filename;
-      reject(err);
     });
   });
 };


### PR DESCRIPTION
@raisedadead I didn't think about the fact that err can be null, so `err.message` would throw.