### PR TITLE
fix(learn): Added more robust logic for the remove test case in Create A Hash Table

### DIFF
--- a/curriculum/challenges/english/10-coding-interview-prep/data-structures/create-a-hash-table.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/data-structures/create-a-hash-table.md
@@ -16,7 +16,7 @@ Here, we won't be concerned with the details of hashing or hash table implementa
 
 # --instructions--
 
-Let's create the basic functionality of a hash table. We've created a naive hashing function for you to use. You can pass a string value to the function `hash` and it will return a hashed value you can use as a key for storage. Store items based on this hashed value in the `this.collection` object. Create these three methods: `add`, `remove`, and `lookup`. The first should accept a key value pair to add to the hash table. The second should remove a key-value pair when passed a key. The third should accept a key and return the associated value or `null` if the key is not present.
+Let's create the basic functionality of a hash table. We've created a naive hashing function for you to use. You can pass a string value to the function `hash` and it will return a hashed value you can use as a key for storage. Store items based on this hashed value in the `this.collection` object. Create these three methods in the following order: `add`, `lookup`, and `remove`. The first should accept a key value pair to add to the hash table. The second should accept a key and return the associated value or `null` if the key is not present. The third should remove a key-value pair when passed a key.
 
 Be sure to write your code to account for collisions!
 
@@ -50,20 +50,6 @@ assert(
 );
 ```
 
-The HashTable should have a remove method.
-
-```js
-assert(
-  (function () {
-    var test = false;
-    if (typeof HashTable !== 'undefined') {
-      test = new HashTable();
-    }
-    return typeof test.remove === 'function';
-  })()
-);
-```
-
 The HashTable should have a lookup method.
 
 ```js
@@ -74,6 +60,20 @@ assert(
       test = new HashTable();
     }
     return typeof test.lookup === 'function';
+  })()
+);
+```
+
+The HashTable should have a remove method.
+
+```js
+assert(
+  (function () {
+    var test = false;
+    if (typeof HashTable !== 'undefined') {
+      test = new HashTable();
+    }
+    return typeof test.remove === 'function';
   })()
 );
 ```
@@ -103,19 +103,36 @@ assert(
     if (typeof HashTable !== 'undefined') {
       test = new HashTable();
     }
-    test.add = addMethodSolution;
     test.add('key', 'value');
-    test.add('yek', 'value');
 
-    test.remove('yek');
-    if (test.collection.hasOwnProperty(hashValue) && test.collection[hashValue].hasOwnProperty('yek')) {
-      return false;
-    }
-    if (!test.collection.hasOwnProperty(hashValue)) {
-      return false;
-    }
     test.remove('key');
     return !test.collection.hasOwnProperty(hashValue);
+  })()
+);
+```
+
+The remove method should only remove the value with the associated key.
+
+```js
+assert(
+  (function () {
+    var test = false;
+    var hashValue = hash('key');
+    if (typeof HashTable !== 'undefined') {
+      test = new HashTable();
+    }
+    test.add('key', 'value');
+    test.add('yek', 'value');
+    test.add('altKey', 'value');
+
+    test.remove('yek');
+    if (test.lookup('yek') || !test.lookup('key') || !test.lookup('altKey')) {
+      return false;
+    }
+
+    test.remove('key');
+
+    return !test.collection.hasOwnProperty(hashValue) && test.lookup('altKey');
   })()
 );
 ```
@@ -174,14 +191,6 @@ var hash = string => {
   }
   return hash;
 };
-
-var addMethodSolution = function(key, val) {
-    var theHash = hash(key);
-    if (!this.collection.hasOwnProperty(theHash)) {
-      this.collection[theHash] = {};
-    }
-    this.collection[theHash][key] = val;
-}
 ```
 
 ## --seed-contents--

--- a/curriculum/challenges/english/10-coding-interview-prep/data-structures/create-a-hash-table.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/data-structures/create-a-hash-table.md
@@ -108,7 +108,7 @@ assert(
     test.add('yek', 'value');
 
     test.remove('yek');
-    if (test.collection.hasOwnProperty(hashValue) && test.collection[hashValue].yek) {
+    if (test.collection.hasOwnProperty(hashValue) && test.collection[hashValue].hasOwnProperty('yek')) {
       return false;
     }
     if (!test.collection.hasOwnProperty(hashValue)) {

--- a/curriculum/challenges/english/10-coding-interview-prep/data-structures/create-a-hash-table.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/data-structures/create-a-hash-table.md
@@ -16,9 +16,11 @@ Here, we won't be concerned with the details of hashing or hash table implementa
 
 # --instructions--
 
-Let's create the basic functionality of a hash table. We've created a naive hashing function for you to use. You can pass a string value to the function `hash` and it will return a hashed value you can use as a key for storage. Store items based on this hashed value in the `this.collection` object. Create these three methods in the following order: `add`, `lookup`, and `remove`. The first should accept a key value pair to add to the hash table. The second should accept a key and return the associated value or `null` if the key is not present. The third should remove a key-value pair when passed a key.
+Let's create the basic functionality of a hash table. We've created a naive hashing function for you to use. You can pass a string value to the function `hash` and it will return a hashed value you can use as a key for storage. Store items based on this hashed value in the `this.collection` object. Create these three methods: `add`, `remove`, and `lookup`. The first should accept a key value pair to add to the hash table. The second should remove a key-value pair when passed a key. The third should accept a key and return the associated value or `null` if the key is not present.
 
 Be sure to write your code to account for collisions!
+
+Note: The `remove` method tests won't pass until the `add` and `lookup` methods are correctly implemented.
 
 # --hints--
 

--- a/curriculum/challenges/english/10-coding-interview-prep/data-structures/create-a-hash-table.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/data-structures/create-a-hash-table.md
@@ -20,7 +20,7 @@ Let's create the basic functionality of a hash table. We've created a naive hash
 
 Be sure to write your code to account for collisions!
 
-Note: The `remove` method tests won't pass until the `add` and `lookup` methods are correctly implemented.
+**Note:** The `remove` method tests won't pass until the `add` and `lookup` methods are correctly implemented.
 
 # --hints--
 

--- a/curriculum/challenges/english/10-coding-interview-prep/data-structures/create-a-hash-table.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/data-structures/create-a-hash-table.md
@@ -105,6 +105,15 @@ assert(
     }
     test.add = addMethodSolution;
     test.add('key', 'value');
+    test.add('yek', 'value');
+
+    test.remove('yek');
+    if (test.collection.hasOwnProperty(hashValue) && test.collection[hashValue].yek) {
+      return false;
+    }
+    if (!test.collection.hasOwnProperty(hashValue)) {
+      return false;
+    }
     test.remove('key');
     return !test.collection.hasOwnProperty(hashValue);
   })()

--- a/curriculum/challenges/english/10-coding-interview-prep/data-structures/create-a-hash-table.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/data-structures/create-a-hash-table.md
@@ -111,7 +111,7 @@ assert(
 );
 ```
 
-The remove method should only remove the value with the associated key.
+The remove method should only remove the correct key value pair.
 
 ```js
 assert(


### PR DESCRIPTION
Checklist:

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

Closes #41136

Related Challenge: https://www.freecodecamp.org/learn/coding-interview-prep/data-structures/create-a-hash-table
Related Test Case Name: **The remove method should accept a key as input and should remove the associated key value pair.**

The test for the HashTable remove function does not properly handle when a value previously had a collision. For example, this code is incorrect, but still passes:
```js
this.remove = function(key) {
  let h = hash (key);
  if (this.collection.hasOwnProperty(h)) {
    delete this.collection[h];
  }
}
```
When you add multiple keys that hash to the same value, this remove function deletes all associated keys instead of deleting only the key that is intended. This PR addresses this by adding two key value pairs that have the same hash value and checking that they both get removed properly.

