### PR TITLE
docs: establish i18n for message boxes

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -93,28 +93,28 @@
       'flexibleAlerts': {
           note: {
             label: {
-              '/i18n/chinese': '笔记',
+              '/i18n/chinese/': '笔记',
               '/i18n/espanol/': 'Nota',
               '/': 'Note'
             }
           },
           tip: {
             label: {
-              '/i18n/chinese': '小费',
+              '/i18n/chinese/': '小费',
               '/i18n/espanol/': 'Tipo',
               '/': 'Tip'
             }
           },
           warning: {
             label: {
-              '/i18n/chinese': '警告',
+              '/i18n/chinese/': '警告',
               '/i18n/espanol/': 'Aviso',
               '/': 'Warning'
             }
           },
           attention: {
             label: {
-              '/i18n/chinese': '注意力',
+              '/i18n/chinese/': '注意力',
               '/i18n/espanol/': 'Atención',
               '/': 'Attention'
             }

--- a/docs/index.html
+++ b/docs/index.html
@@ -89,9 +89,37 @@
         placeholder: 'Search...'
       },
 
-      'flexible-alerts': {
-        style: 'callout'
-      },
+      // Add languages here for message box translations
+      'flexibleAlerts': {
+          note: {
+            label: {
+              '/i18n/chinese': '笔记',
+              '/i18n/espanol/': 'Nota',
+              '/': 'Note'
+            }
+          },
+          tip: {
+            label: {
+              '/i18n/chinese': '小费',
+              '/i18n/espanol/': 'Tipo',
+              '/': 'Tip'
+            }
+          },
+          warning: {
+            label: {
+              '/i18n/chinese': '警告',
+              '/i18n/espanol/': 'Aviso',
+              '/': 'Warning'
+            }
+          },
+          attention: {
+            label: {
+              '/i18n/chinese': '注意力',
+              '/i18n/espanol/': 'Atención',
+              '/': 'Attention'
+            }
+          }
+        },
 
       pagination: {
         crossChapter: true
@@ -176,7 +204,6 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.14.0/js/all.min.js"
     integrity="sha512-YSdqvJoZr83hj76AIVdOcvLWYMWzy6sJyIMic2aQz5kh2bPTd9dzY3NtdeEAzPp/PhgZqr4aJObB3ym/vsItMg=="
     crossorigin="anonymous"></script>
-
 </body>
 
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -93,14 +93,14 @@
       'flexibleAlerts': {
           note: {
             label: {
-              '/i18n/chinese/': '笔记',
+              '/i18n/chinese/': '注意',
               '/i18n/espanol/': 'Nota',
               '/': 'Note'
             }
           },
           tip: {
             label: {
-              '/i18n/chinese/': '小费',
+              '/i18n/chinese/': '提示',
               '/i18n/espanol/': 'Tipo',
               '/': 'Tip'
             }
@@ -114,7 +114,7 @@
           },
           attention: {
             label: {
-              '/i18n/chinese/': '注意力',
+              '/i18n/chinese/': '注意',
               '/i18n/espanol/': 'Atención',
               '/': 'Attention'
             }

--- a/docs/index.html
+++ b/docs/index.html
@@ -101,14 +101,14 @@
           tip: {
             label: {
               '/i18n/chinese/': '提示',
-              '/i18n/espanol/': 'Tipo',
+              '/i18n/espanol/': 'Sugerencia',
               '/': 'Tip'
             }
           },
           warning: {
             label: {
               '/i18n/chinese/': '警告',
-              '/i18n/espanol/': 'Aviso',
+              '/i18n/espanol/': 'Advertencia',
               '/': 'Warning'
             }
           },


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #41324 

<!-- Feel free to add any additional description of changes below this line -->

Sets up the i18n mapping for Chinese and Spanish for the message/alert boxes. Based on a discussion with Oliver, I think the best flow here is to:

- Add a language mapping when we are ready to download and serve the docs in that language
- Have a proofreader(s) provide the translations for that language 
- No need to upload on crowdin as these translations shouldn't change
