### PR TITLE
fix(learn): Clarify date format expectations for the Date Format challenge

### DIFF
--- a/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/date-format.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/date-format.md
@@ -8,10 +8,10 @@ dashedName: date-format
 
 # --description--
 
-Return an array with 2 date strings of the current date with the following specifications:
+Return an array with two date strings of the current date with the following specifications:
 
 - The first string's date order should be the year number, month number, and day number separated by dashes (`-`).
-- The first string's year should be 4 digits in length.
+- The first string's year should be four digits in length.
 - The first string's month and day should not contain any leading zeros.
 - The second string's weekday and month names should not be abbreviated.
 - The second string's day should not contain any leading zeros.

--- a/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/date-format.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/date-format.md
@@ -8,14 +8,20 @@ dashedName: date-format
 
 # --description--
 
-Return an array with the current date in the formats:
+Return an array with 2 date strings of the current date with the following specifications:
 
-<ul>
-  <li>2007-11-23</li>
-  <li>Friday, November 23, 2007</li>
-</ul>
+- The first string's date order should be the year number, month number, and day number separated by dashes (`-`).
+- The first string's year should be 4 digits in length.
+- The first string's month and day should not contain any leading zeros.
+- The second string's weekday and month names should not be abbreviated.
+- The second string's day should not contain any leading zeros.
 
-Example output: `['2007-11-23', 'Friday, November 23, 2007']`
+Example outputs:
+
+```js
+['2007-11-23', 'Friday, November 23, 2007']
+['2021-3-2', 'Tuesday, March 2, 2021']
+```
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

The [Date Format challenge](https://www.freecodecamp.org/learn/coding-interview-prep/rosetta-code/date-format) does not currently give enough information about the expected format for the two dates.  See [this forum discussion](https://forum.freecodecamp.org/t/date-format-challenge-in-rosetta-code-not-passing-despite-fulfilling-requirements/449086).  I could definitely see how it could be confusing for users, so I have tried to clarify the format expectations for the challenge's return value.
