### PR TITLE
Fix: remove a colon in rosetta-code/happy-numbers

### DIFF
--- a/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/happy-numbers.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/happy-numbers.md
@@ -84,7 +84,7 @@ assert(happy(28));
 assert(happy(31));
 ```
 
-`happy(32)` should return true.
+`happy(32)` should return `true`.
 
 ```js
 assert(happy(32));

--- a/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/happy-numbers.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/happy-numbers.md
@@ -30,55 +30,55 @@ assert(typeof happy === 'function');
 assert(typeof happy(1) === 'boolean');
 ```
 
-`happy(1)` should return true.
+`happy(1)` should return `true`.
 
 ```js
 assert(happy(1));
 ```
 
-`happy(2)` should return false.
+`happy(2)` should return `false`.
 
 ```js
 assert(!happy(2));
 ```
 
-`happy(7)` should return true.
+`happy(7)` should return `true`.
 
 ```js
 assert(happy(7));
 ```
 
-`happy(10)` should return true.
+`happy(10)` should return `true`.
 
 ```js
 assert(happy(10));
 ```
 
-`happy(13)` should return true.
+`happy(13)` should return `true`.
 
 ```js
 assert(happy(13));
 ```
 
-`happy(19)` should return true.
+`happy(19)` should return `true`.
 
 ```js
 assert(happy(19));
 ```
 
-`happy(23)` should return true.
+`happy(23)` should return `true`.
 
 ```js
 assert(happy(23));
 ```
 
-`happy(28)` should return true.
+`happy(28)` should return `true`.
 
 ```js
 assert(happy(28));
 ```
 
-`happy(31)` should return true.
+`happy(31)` should return `true`.
 
 ```js
 assert(happy(31));
@@ -90,7 +90,7 @@ assert(happy(31));
 assert(happy(32));
 ```
 
-`happy(33)` should return false.
+`happy(33)` should return `false`.
 
 ```js
 assert(!happy(33));

--- a/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/happy-numbers.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/happy-numbers.md
@@ -84,7 +84,7 @@ assert(happy(28));
 assert(happy(31));
 ```
 
-`happy(32)` should return true:.
+`happy(32)` should return true.
 
 ```js
 assert(happy(32));


### PR DESCRIPTION
I removed a colon that shouldn't be there.

Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.


