### PR TITLE
fix(actions): include docs in no-translation

### DIFF
--- a/.github/workflows/no-prs-to-translation.yml
+++ b/.github/workflows/no-prs-to-translation.yml
@@ -9,6 +9,7 @@ on:
       - 'client/i18n/locales/**/intro.json'
       - 'client/i18n/locales/**/translations.json'
       - '!client/i18n/locales/english/**'
+      - 'docs/i18n/**'
 
 jobs:
   has-translation:


### PR DESCRIPTION
Including the `docs/i18n/**` paths in the no-translations workflows. Ref: #41357