### PR TITLE
fix(tools): only camperbot translates

### DIFF
--- a/.github/workflows/no-prs-to-translation.yml
+++ b/.github/workflows/no-prs-to-translation.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            if (context.payload.pull_request.head.repo.fork) {
+            if (context.payload.pull_request.user.login !== "camperbot") {
               core.setFailed('This PR appears to touch translated curriculum files.')
               github.issues.createComment({
                 issue_number: context.issue.number,

--- a/.github/workflows/no-prs-to-translation.yml
+++ b/.github/workflows/no-prs-to-translation.yml
@@ -32,6 +32,6 @@ jobs:
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: 'WAIT! This message serves as a sanity check. You should *only* see this message if the PR was created as part of the Crowdin download actions.'
+                body: 'WAIT! This message serves as a sanity check. You should *only* see this message if the PR was created as part of a Crowdin download action.'
               })
             }

--- a/.github/workflows/no-prs-to-translation.yml
+++ b/.github/workflows/no-prs-to-translation.yml
@@ -32,6 +32,6 @@ jobs:
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: 'WAIT! This message serves as a sanity check. Your PR appears to come from the base freeCodeCamp repository and modifies translated curriculum files or intro.json or translations.json. Before merging, please confirm that the commits on this PR originated from the Crowdin download action.'
+                body: 'WAIT! This message serves as a sanity check. You should *only* see this message if the PR was created as part of the Crowdin download actions.'
               })
             }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Note: Should not merge until #41365 merges.

This PR updates the workflow to fail when a pull request is submitted, modifies files translated through Crowdin, and is not created by camperbot.

With the linked PR, the download scripts will now use Camperbot's credentials to generate the pull requests, so no other PRs should be needed.