### PR TITLE
fix: update the fastest page with meta

### DIFF
--- a/client/static/the-fastest-web-page-on-the-internet/index.html
+++ b/client/static/the-fastest-web-page-on-the-internet/index.html
@@ -5,13 +5,14 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <meta name="description"
+    content="This is the fastest web page on the internet, written in raw HTML with no CSS and no JavaScript.">
   <title>The Fastest Web Page on the Internet</title>
 </head>
 
 <body>
   <h1>This is the fastest web page on the internet.</h1>
   <p>This is raw HTML with no CSS and no JavaScript.</p>
-  <p>This is served to you lightning fast from the cloud using Netlify and a global Content Delivery Network.</p>
   <p>Unfortunately, this doesn't do anything.</p>
   <p>I guess speed isn't everything, after all.</p>
   <p><a href="https://www.freecodecamp.org">Learn to code more useful websites than this one</a></p>


### PR DESCRIPTION
This pr removes the reference to netlify, because we have been selfhosting for a long while now and also adds some critical meta to give us a 100/100/100/100 lighthouse score.
