### PR TITLE
fix(tools): implement better error handling

### DIFF
--- a/.github/workflows/crowdin-i18n-client-ui-download.yml
+++ b/.github/workflows/crowdin-i18n-client-ui-download.yml
@@ -90,6 +90,25 @@ jobs:
         with:
           github-token: ${{ secrets.CROWDIN_CAMPERBOT_PAT }}
           script: |
+            const branchExists = await github.repos.getBranch({
+              owner: 'freeCodeCamp',
+              repo: 'freeCodeCamp',
+              branch: 'i18n-sync-client'
+            }).catch(err => {
+              console.info("Branch does not exist. Likely no changes in download?");
+            });
+            if (!branchExists || branchExists.status !== 200) {
+              return;
+            }
+            const pullRequestExists = await github.pulls.list({
+              owner: 'freeCodeCamp',
+              repo: 'freeCodeCamp',
+              head: 'freeCodeCamp:i18n-sync-client'
+            });
+            if (pullRequestExists.data.length) {
+              console.info("It looks like you have an open pull request for this branch.");
+              return;
+            }
             const PR = await github.pulls.create({
               owner: 'freeCodeCamp',
               repo: 'freeCodeCamp',
@@ -97,7 +116,13 @@ jobs:
               base: 'main',
               title: 'chore(i18n,client): processed translations',
               body: 'This PR was opened auto-magically by Crowdin.'
+            }).catch(err => {
+              console.info("Unpredicted error occurred when trying to create the PR.");
+              console.error(err);
             });
+            if (!PR || PR.status !== 201) {
+              return;
+            }
             const PRNumber = PR.data.number;
             await github.issues.addLabels({
               owner: 'freeCodeCamp',

--- a/.github/workflows/crowdin-i18n-client-ui-download.yml
+++ b/.github/workflows/crowdin-i18n-client-ui-download.yml
@@ -106,7 +106,7 @@ jobs:
               head: 'freeCodeCamp:i18n-sync-client'
             });
             if (pullRequestExists.data.length) {
-              console.info("It looks like you have an open pull request for this branch.");
+              console.info("It looks like a pull request already exists for this branch.");
               return;
             }
             const PR = await github.pulls.create({

--- a/.github/workflows/crowdin-i18n-curriculum-download.yml
+++ b/.github/workflows/crowdin-i18n-curriculum-download.yml
@@ -107,7 +107,7 @@ jobs:
               head: 'freeCodeCamp:i18n-sync-learn'
             });
             if (pullRequestExists.data.length) {
-              console.info("It looks like you have an open pull request for this branch.");
+              console.info("It looks like a pull request already exists for this branch.");
               return;
             }
             const PR = await github.pulls.create({

--- a/.github/workflows/crowdin-i18n-curriculum-download.yml
+++ b/.github/workflows/crowdin-i18n-curriculum-download.yml
@@ -91,6 +91,25 @@ jobs:
         with:
           github-token: ${{ secrets.CROWDIN_CAMPERBOT_PAT }}
           script: |
+            const branchExists = await github.repos.getBranch({
+              owner: 'freeCodeCamp',
+              repo: 'freeCodeCamp',
+              branch: 'i18n-sync-learn'
+            }).catch(err => {
+              console.info("Branch does not exist. Likely no changes in download?");
+            });
+            if (!branchExists || branchExists.status !== 200) {
+              return;
+            }
+            const pullRequestExists = await github.pulls.list({
+              owner: 'freeCodeCamp',
+              repo: 'freeCodeCamp',
+              head: 'freeCodeCamp:i18n-sync-learn'
+            });
+            if (pullRequestExists.data.length) {
+              console.info("It looks like you have an open pull request for this branch.");
+              return;
+            }
             const PR = await github.pulls.create({
               owner: 'freeCodeCamp',
               repo: 'freeCodeCamp',
@@ -98,7 +117,13 @@ jobs:
               base: 'main',
               title: 'chore(i18n,learn): processed translations',
               body: 'This PR was opened auto-magically by Crowdin.'
+            }).catch(err => {
+              console.info("Unpredicted error occurred when trying to create the PR.");
+              console.error(err);
             });
+            if (!PR || PR.status !== 201) {
+              return;
+            }
             const PRNumber = PR.data.number;
             await github.issues.addLabels({
               owner: 'freeCodeCamp',

--- a/.github/workflows/crowdin-i18n-docs-download..yml
+++ b/.github/workflows/crowdin-i18n-docs-download..yml
@@ -124,6 +124,25 @@ jobs:
         with:
           github-token: ${{ secrets.CROWDIN_CAMPERBOT_PAT }}
           script: |
+            const branchExists = await github.repos.getBranch({
+              owner: 'freeCodeCamp',
+              repo: 'freeCodeCamp',
+              branch: 'i18n-sync-docs'
+            }).catch(err => {
+              console.info("Branch does not exist. Likely no changes in download?");
+            });
+            if (!branchExists || branchExists.status !== 200) {
+              return;
+            }
+            const pullRequestExists = await github.pulls.list({
+              owner: 'freeCodeCamp',
+              repo: 'freeCodeCamp',
+              head: 'freeCodeCamp:i18n-sync-docs'
+            });
+            if (pullRequestExists.data.length) {
+              console.info("It looks like you have an open pull request for this branch.");
+              return;
+            }
             const PR = await github.pulls.create({
               owner: 'freeCodeCamp',
               repo: 'freeCodeCamp',
@@ -131,7 +150,13 @@ jobs:
               base: 'main',
               title: 'chore(i18n,docs): processed translations',
               body: 'This PR was opened auto-magically by Crowdin.'
+            }).catch(err => {
+              console.info("Unpredicted error occurred when trying to create the PR.");
+              console.error(err);
             });
+            if (!PR || PR.status !== 201) {
+              return;
+            }
             const PRNumber = PR.data.number;
             await github.issues.addLabels({
               owner: 'freeCodeCamp',

--- a/.github/workflows/crowdin-i18n-docs-download..yml
+++ b/.github/workflows/crowdin-i18n-docs-download..yml
@@ -140,7 +140,7 @@ jobs:
               head: 'freeCodeCamp:i18n-sync-docs'
             });
             if (pullRequestExists.data.length) {
-              console.info("It looks like you have an open pull request for this branch.");
+              console.info("It looks like a pull request already exists for this branch.");
               return;
             }
             const PR = await github.pulls.create({


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Currently, the actions trigger a failure message at the PR step if:
- The branch does not exist (the Crowdin step won't create the branch if there are no changes detected in the download)
- A pull request already exists (You can't create two pull requests with the same head and base).

This was not blocking anything or creating issues, but it would be nice to not have the action fail.

I've modified the workflow step to now check if the branch exists first, and return early if it does not. Then it checks for an existing PR, and returns early if there is one (Crowdin force-pushes to the branch so the existing PR will be up to date). Finally it creates a PR if needed.

/cc @RandellDawson 