### PR TITLE
feat(tools): Script to delete all translations of a language on Crowdin

### DIFF
--- a/tools/crowdin/one-off-scripts/delete-all-translations-for-a-language.js
+++ b/tools/crowdin/one-off-scripts/delete-all-translations-for-a-language.js
@@ -1,0 +1,30 @@
+/*
+This one-off script can be used to delete all existing translations for a specified language on Crowdin.
+
+Specifying a projectId and lanaguageId in the .env file allows the script to accomplish this task.
+*/
+
+require('dotenv').config({ path: `${__dirname}/../.env` });
+
+const {
+  getLanguageTranslations,
+  deleteLanguageTranslations
+} = require('../utils/strings');
+
+const projectId = process.env.CROWDIN_PROJECT_ID;
+const languageId = process.env.CROWDIN_LANGUAGE_ID;
+
+(async (projectId, languageId) => {
+  console.log('starting script...');
+  const translations = await getLanguageTranslations({
+    projectId,
+    languageId
+  });
+  if (translations && translations.length) {
+    for (let translation of translations) {
+      const { stringId } = translation.data;
+      await deleteLanguageTranslations(projectId, languageId, stringId);
+    }
+  }
+  console.log('complete');
+})(projectId, languageId);

--- a/tools/crowdin/sample.env
+++ b/tools/crowdin/sample.env
@@ -1,0 +1,4 @@
+CROWDIN_PROJECT_ID=
+CROWDIN_PERSONAL_TOKEN=
+CROWDIN_API_URL='https://freecodecamp.crowdin.com/api/v2/'
+CROWDIN_LANGUAGE_ID=

--- a/tools/crowdin/utils/strings.js
+++ b/tools/crowdin/utils/strings.js
@@ -212,6 +212,18 @@ const getLanguageTranslations = async ({ projectId, languageId }) => {
   return null;
 };
 
+const deleteLanguageTranslations = async (projectId, languageId, stringId) => {
+  let headers = { ...authHeader };
+  const endPoint = `projects/${projectId}/translations?languageId=${languageId}&stringId=${stringId}`;
+  console.log(`deleting ${stringId}...`);
+  await makeRequest({
+    method: 'delete',
+    endPoint,
+    headers
+  });
+  return null;
+};
+
 module.exports = {
   getStrings,
   updateString,
@@ -220,5 +232,6 @@ module.exports = {
   getStringTranslations,
   addTranslation,
   deleteTranslation,
-  getLanguageTranslations
+  getLanguageTranslations,
+  deleteLanguageTranslations
 };


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

Per @raisedadead's request, here is a one-off script that we can specify a `projectId` and `languageId` to delete all translations for all strings in a Crowdin project.  I tested it on the Test Project and seems to work as expected.  There are currently about 424 strings with translations in the Docs project, so it will not take long to delete the translations for those strings.