### PR TITLE
fix(learn): revert backslash change

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript-rpg-game/part-026.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript-rpg-game/part-026.md
@@ -7,7 +7,7 @@ dashedName: part-26
 
 # --description--
 
-Add double quote marks around the word "Store" in the line "You see a sign that says Store." Before each quotation mark add a <code>\\</code> to signal that the following quote is not the end of the string, but should instead appear inside the string. This is called escaping.
+Add double quote marks around the word "Store" in the line "You see a sign that says Store." Before each quotation mark add a `\` to signal that the following quote is not the end of the string, but should instead appear inside the string. This is called escaping.
 
 # --hints--
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/escape-sequences-in-strings.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/escape-sequences-in-strings.md
@@ -58,7 +58,7 @@ assert(/FirstLine\n/.test(myStr));
 assert(/\n\t/.test(myStr));
 ```
 
-`SecondLine` should be preceded by the backslash character <code>\\</code>
+`SecondLine` should be preceded by the backslash character `\`
 
 ```js
 assert(/\\SecondLine/.test(myStr));

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/escaping-literal-quotes-in-strings.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/escaping-literal-quotes-in-strings.md
@@ -11,7 +11,7 @@ dashedName: escaping-literal-quotes-in-strings
 
 When you are defining a string you must start and end with a single or double quote. What happens when you need a literal quote: `"` or `'` inside of your string?
 
-In JavaScript, you can <dfn>escape</dfn> a quote from considering it as an end of string quote by placing a <dfn>backslash</dfn> (<code>\\</code>) in front of the quote.
+In JavaScript, you can <dfn>escape</dfn> a quote from considering it as an end of string quote by placing a <dfn>backslash</dfn> (`\`) in front of the quote.
 
 `var sampleStr = "Alan said, \"Peter is learning JavaScript\".";`
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/debugging/catch-mixed-usage-of-single-and-double-quotes.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/debugging/catch-mixed-usage-of-single-and-double-quotes.md
@@ -22,7 +22,7 @@ const uhOhGroucho = 'I've had a perfectly wonderful evening, but this wasn't it.
 
 The first two are correct, but the third is incorrect.
 
-Of course, it is okay to use only one style of quotes. You can escape the quotes inside the string by using the backslash (<code>\\</code>) escape character:
+Of course, it is okay to use only one style of quotes. You can escape the quotes inside the string by using the backslash (`\`) escape character:
 
 ```js
 const allSameQuotes = 'I\'ve had a perfectly wonderful evening, but this wasn\'t it.';

--- a/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/s-expressions.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/s-expressions.md
@@ -22,9 +22,9 @@ Newlines and other whitespace may be ignored unless contained within a quoted st
 
 Handling escaped quotes inside a string is optional; thus "`(foo"bar)`" may be treated as a string "`foo"bar`", or as an error.
 
-For this, the reader need not recognize "<code>\\</code>" for escaping, but should, in addition, recognize numbers if the language has appropriate data types.
+For this, the reader need not recognize `\` for escaping, but should, in addition, recognize numbers if the language has appropriate data types.
 
-Note that with the exception of "`()"`" ("<code>\\</code>" if escaping is supported) and whitespace there are no special characters. Anything else is allowed without quotes.
+Note that with the exception of `()"` (`\` if escaping is supported) and whitespace there are no special characters. Anything else is allowed without quotes.
 
 The reader should be able to read the following input
 

--- a/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/s-expressions.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/s-expressions.md
@@ -24,7 +24,7 @@ Handling escaped quotes inside a string is optional; thus "`(foo"bar)`" may be t
 
 For this, the reader need not recognize `\` for escaping, but should, in addition, recognize numbers if the language has appropriate data types.
 
-Note that with the exception of `()"` (`\` if escaping is supported) and whitespace there are no special characters. Anything else is allowed without quotes.
+Note that with the exception of `()"` (`\` if escaping is supported) and whitespace, there are no special characters. Anything else is allowed without quotes.
 
 The reader should be able to read the following input
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Crowdin resolved the issue with backslashes escaping backtics in
the markdown parser, so this reverts the workaround we implemented
for that bug.