### PR TITLE
fix(client, i18n): use block for video challenge right breadcrumb

### DIFF
--- a/client/src/templates/Challenges/video/Show.js
+++ b/client/src/templates/Challenges/video/Show.js
@@ -162,6 +162,7 @@ export class Project extends Component {
           title,
           description,
           superBlock,
+          block,
           translationPending,
           videoId,
           question: { text, answers, solution }
@@ -193,7 +194,7 @@ export class Project extends Component {
             <Row>
               <Spacer />
               <ChallengeTitle
-                block={blockName}
+                block={block}
                 isCompleted={isChallengeCompleted}
                 superBlock={superBlock}
                 translationPending={translationPending}
@@ -323,6 +324,7 @@ export const query = graphql`
       challengeType
       helpCategory
       superBlock
+      block
       fields {
         blockName
         slug


### PR DESCRIPTION
One more place affected by wrong link text in breadcrumb-right as in #41271

Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.