### PR TITLE
fix(tools): Rename job names for Crowdin Docs project workflows

### DIFF
--- a/.github/workflows/crowdin-i18n-docs-download..yml
+++ b/.github/workflows/crowdin-i18n-docs-download..yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   i18n-download-docs-translations:
-    name: Learn
+    name: Docs
     runs-on: ubuntu-18.04
 
     steps:

--- a/.github/workflows/crowdin-i18n-docs-upload.yml
+++ b/.github/workflows/crowdin-i18n-docs-upload.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   i18n-upload-docs-files:
-    name: Learn
+    name: Docs
     runs-on: ubuntu-18.04
 
     steps:


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

This PR renames the job names from `Learn` to `Docs` for the Crowdin upload and download workflows.  It is a small change, but I noticed when I was looking at the action log and got confused at which action log I was actually looking at.  Then I realized I was in the correct action log but the name did not match.