### PR TITLE
fix: Remove forward slash from <source> tag

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/applied-accessibility/improve-accessibility-of-audio-content-with-the-audio-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-accessibility/improve-accessibility-of-audio-content-with-the-audio-element.md
@@ -17,8 +17,8 @@ Here's an example:
 
 ```html
 <audio id="meowClip" controls>
-  <source src="audio/meow.mp3" type="audio/mpeg" />
-  <source src="audio/meow.ogg" type="audio/ogg" />
+  <source src="audio/meow.mp3" type="audio/mpeg">
+  <source src="audio/meow.ogg" type="audio/ogg">
 </audio>
 ```
 


### PR DESCRIPTION
The forward slash at the end of the <source> tag in the example should be removed.

Both W3 and MDN follow these standards:
https://www.w3schools.com/tags/tag_source.asp
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source

HTML5 has an optional self-closing slash. However, to make things parallel, other HTML tutorials/examples with similar elements on freeCodeCamp do not use the self-closing slash.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
