### PR TITLE
Fix letter-frequency.md: remove wrong spaces and make quotes consistent

### DIFF
--- a/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/letter-frequency.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/letter-frequency.md
@@ -34,7 +34,7 @@ assert(typeof letterFrequency == 'function');
 assert(Array.isArray(letterFrequency('Not all that Mrs. Bennet, however')));
 ```
 
-`letterFrequency("Not all that Mrs. Bennet, however")` should return `[[" ", 5], [", ", 1], [".", 1], ["B", 1], ["M", 1], ["N", 1], ["a", 2], ["e", 4], ["h", 2], ["l", 2], ["n", 2], ["o", 2], ["r", 2], ["s", 1], ["t", 4], ["v", 1], ["w", 1]]`.
+`letterFrequency("Not all that Mrs. Bennet, however")` should return `[[" ", 5], [",", 1], [".", 1], ["B", 1], ["M", 1], ["N", 1], ["a", 2], ["e", 4], ["h", 2], ["l", 2], ["n", 2], ["o", 2], ["r", 2], ["s", 1], ["t", 4], ["v", 1], ["w", 1]]`.
 
 ```js
 assert.deepEqual(letterFrequency('Not all that Mrs. Bennet, however'), [
@@ -58,7 +58,7 @@ assert.deepEqual(letterFrequency('Not all that Mrs. Bennet, however'), [
 ]);
 ```
 
-`letterFrequency("daughters, could ask on the ")` should return `[[' ',5],[',',1],['a',2],['c',1],['d',2],['e',2],['g',1],['h',2],['k',1],['l',1],['n',1],['o',2],['r',1],['s',2],['t',2],['u',2]]`.
+`letterFrequency("daughters, could ask on the ")` should return `[[" ",5],[",",1],["a",2],["c",1],["d",2],["e",2],["g",1],["h",2],["k",1],["l",1],["n",1],["o",2],["r",1],["s",2],["t",2],["u",2]]`.
 
 ```js
 assert.deepEqual(letterFrequency('daughters, could ask on the '), [
@@ -131,7 +131,7 @@ assert.deepEqual(letterFrequency('in various ways--with barefaced'), [
 ]);
 ```
 
-`letterFrequency("distant surmises; but he eluded")` should return `[[" ", 4], ["; ", 1], ["a", 1], ["b", 1], ["d", 3], ["e", 4], ["h", 1], ["i", 2], ["l", 1], ["m", 1], ["n", 1], ["r", 1], ["s", 4], ["t", 3], ["u", 3]]`.
+`letterFrequency("distant surmises; but he eluded")` should return `[[" ", 4], [";", 1], ["a", 1], ["b", 1], ["d", 3], ["e", 4], ["h", 1], ["i", 2], ["l", 1], ["m", 1], ["n", 1], ["r", 1], ["s", 4], ["t", 3], ["u", 3]]`.
 
 ```js
 assert.deepEqual(letterFrequency('distant surmises; but he eluded'), [
@@ -153,7 +153,7 @@ assert.deepEqual(letterFrequency('distant surmises; but he eluded'), [
 ]);
 ```
 
-`letterFrequency("last obliged to accept the second-hand,")` should return `[[" ", 5], [", ", 1], ["-", 1], ["a", 3], ["b", 1], ["c", 3], ["d", 3], ["e", 4], ["g", 1], ["h", 2], ["i", 1], ["l", 2], ["n", 2], ["o", 3], ["p", 1], ["s", 2], ["t", 4]]`.
+`letterFrequency("last obliged to accept the second-hand,")` should return `[[" ", 5], [",", 1], ["-", 1], ["a", 3], ["b", 1], ["c", 3], ["d", 3], ["e", 4], ["g", 1], ["h", 2], ["i", 1], ["l", 2], ["n", 2], ["o", 3], ["p", 1], ["s", 2], ["t", 4]]`.
 
 ```js
 assert.deepEqual(letterFrequency('last obliged to accept the second-hand,'), [

--- a/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/letter-frequency.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/letter-frequency.md
@@ -58,7 +58,7 @@ assert.deepEqual(letterFrequency('Not all that Mrs. Bennet, however'), [
 ]);
 ```
 
-`letterFrequency("daughters, could ask on the ")` should return `[[" ",5],[",",1],["a",2],["c",1],["d",2],["e",2],["g",1],["h",2],["k",1],["l",1],["n",1],["o",2],["r",1],["s",2],["t",2],["u",2]]`.
+`letterFrequency("daughters, could ask on the ")` should return `[[" ", 5],[",", 1],["a", 2],["c", 1],["d", 2],["e", 2],["g", 1],["h", 2],["k", 1],["l", 1],["n", 1],["o", 2],["r", 1],["s", 2],["t", 2],["u", 2]]`.
 
 ```js
 assert.deepEqual(letterFrequency('daughters, could ask on the '), [


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

In the tests the spaces aren't there but they were in the test description.

Remove spaces that are not meant to be there (L37, L134, L156)
Make quotes consistent across the file (L61)