### PR TITLE
fix(learn): Improve tests for the Nest an Anchor Element within a Paragraph challenge

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/nest-an-anchor-element-within-a-paragraph.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/nest-an-anchor-element-within-a-paragraph.md
@@ -43,11 +43,19 @@ Nest the existing `a` element within a new `p` element. The new paragraph should
 
 # --hints--
 
-You should have an `a` element that links to "`https://freecatphotoapp.com`".
+You should only have one `a` element.
 
 ```js
 assert(
-  $('a[href="https://freecatphotoapp.com"]').length > 0 
+  $('a').length  === 1 
+);
+```
+
+The `a` element should link to "`https://freecatphotoapp.com`".
+
+```js
+assert(
+  $('a[href="https://freecatphotoapp.com"]').length  === 1 
 );
 ```
 
@@ -61,7 +69,7 @@ assert(
 );
 ```
 
-You should create a new `p` element around your `a` element. There should be at least 3 total `p` tags in your HTML code.
+You should create a new `p` element. There should be at least 3 total `p` tags in your HTML code.
 
 ```js
 assert($('p') && $('p').length > 2);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

I created this PR to address a recurring confusion I see in the [Nest an Anchor Element within a Paragraph](https://www.freecodecamp.org/learn/responsive-web-design/basic-html-and-html5/nest-an-anchor-element-within-a-paragraph) challenge.  This is the first challenge where the user is introduced to the concept of nesting an existing element into a newly created element.  So many times, a user ends up creating another anchor element instead of just using the existing anchor element.  Creating a new anchor element without the exact attributes/text of the original can lead to problems such as the one [in this forum topic](https://forum.freecodecamp.org/t/hi-thanks-in-advance-im-pulling-my-hair-out/450826). 

This PR aims to better guide the user into writing the correct code.  This is similar to the approach we are taking in the v7 curriculum.