### PR TITLE
fix(client): change repl.it validation to replit for migration

### DIFF
--- a/client/src/components/formHelpers/FormValidators.js
+++ b/client/src/components/formHelpers/FormValidators.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Trans } from 'react-i18next';
 
-// Matches editor links for: Repl.it, Glitch, CodeSandbox, GitHub
-const editorRegex = /repl\.it\/(@|join\/)|glitch\.com\/edit\/#!|codesandbox\.io\/s\/|github\.com/;
+// Matches editor links for: Replit, Glitch, CodeSandbox, GitHub
+const editorRegex = /replit\.com\/(@|join\/)|glitch\.com\/edit\/#!|codesandbox\.io\/s\/|github\.com/;
 const fCCRegex = /codepen\.io\/freecodecamp|freecodecamp\.rocks|github\.com\/freecodecamp/i;
 const localhostRegex = /localhost:/;
 const httpRegex = /http(?!s|([^s]+?localhost))/;

--- a/client/src/components/formHelpers/FormValidators.js
+++ b/client/src/components/formHelpers/FormValidators.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Trans } from 'react-i18next';
 
 // Matches editor links for: Replit, Glitch, CodeSandbox, GitHub
-const editorRegex = /replit\.com\/(@|join\/)|glitch\.com\/edit\/#!|codesandbox\.io\/s\/|github\.com/;
+const editorRegex = /repl\.?it(\.com)?\/(@|join\/)|glitch\.com\/edit\/#!|codesandbox\.io\/s\/|github\.com/;
 const fCCRegex = /codepen\.io\/freecodecamp|freecodecamp\.rocks|github\.com\/freecodecamp/i;
 const localhostRegex = /localhost:/;
 const httpRegex = /http(?!s|([^s]+?localhost))/;


### PR DESCRIPTION
Checklist:

The migration has already taken place. As far as I can tell, all old URLs are redirected to `replit.com`. So, there should be no reason someone submits a `repl.it/@...` url

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

Related to #41444 

Changes the editor URL validation to match new Replit.com migration