### PR TITLE
feat(tools): Add a PR labeler action to the repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report--issues-with-coding-challenges.md
+++ b/.github/ISSUE_TEMPLATE/bug-report--issues-with-coding-challenges.md
@@ -2,7 +2,7 @@
 name: 'Bug Report: Issues with Coding challenges'
 about: Report issue with a specific challenge, like broken tests, unclear instructions.
 title: ''
-labels: 'scope: learn, status: needs help for triage'
+labels: 'scope: curriculum, status: needs help for triage'
 assignees: ''
 
 ---

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,4 +27,4 @@ updates:
     open-pull-requests-limit: 20
     labels:
       - 'dependabot'
-      - 'scope: learn'
+      - 'scope: curriculum'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,25 @@
+"scope: docs":
+  - docs/**/*
+
+"scope: curriculum":
+  - curriculum/challenges/**/*
+
+"platform: client":
+  - client/**/*
+
+"platform: api":
+  - api-server/**/*
+
+"scope: tools/scripts":
+  - cypress/**/*
+  - tools/**/*
+  - .github/**/*
+  - utils/**/*
+
+"scope: i18n":
+  - any: ['curriculum/challenges/**/*', '!curriculum/challenges/english/**/*']
+  - docs/i18n/**/*
+  - client/i18n/**/*
+  - config/crowdin/**/*
+  - config/i18n/**/*
+  - tools/crowdin/**/*

--- a/.github/workflows/crowdin-i18n-client-ui-download.yml
+++ b/.github/workflows/crowdin-i18n-client-ui-download.yml
@@ -100,5 +100,5 @@ jobs:
           base: 'main'
           title: 'chore(i18n,client): processed translations'
           body: 'This PR was opened auto-magically by Crowdin.'
-          labels: 'crowdin-sync, scope: i18n, scope: UI'
+          labels: 'crowdin-sync, scope: UI'
           reviewers: 'RandellDawson, nhcarrigan'

--- a/.github/workflows/crowdin-i18n-curriculum-download.yml
+++ b/.github/workflows/crowdin-i18n-curriculum-download.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   i18n-download-curriculum-translations:
-    name: Learn
+    name: Curriculum
     runs-on: ubuntu-18.04
 
     steps:
@@ -66,8 +66,8 @@ jobs:
           export_only_approved: true
 
 
-          commit_message: 'chore(i8n,learn): processed translations'
-          localization_branch_name: i18n-sync-learn
+          commit_message: 'chore(i8n,curriculum): processed translations'
+          localization_branch_name: i18n-sync-curriculum
           push_translations: true
 
           # pull-request
@@ -96,10 +96,10 @@ jobs:
         uses: ./tools/crowdin/actions/pr-creator
         with:
           github-token: ${{ secrets.CROWDIN_CAMPERBOT_PAT }}
-          branch: 'i18n-sync-learn'
+          branch: 'i18n-sync-curriculum'
           owner-repo: 'freeCodeCamp/freeCodeCamp'
           base: 'main'
-          title: 'chore(i18n,learn): processed translations'
+          title: 'chore(i18n,curiculum): processed translations'
           body: 'This PR was opened auto-magically by Crowdin.'
-          labels: 'crowdin-sync, scope: i18n, scope: learn'
+          labels: 'crowdin-sync'
           reviewers: 'RandellDawson, nhcarrigan'

--- a/.github/workflows/crowdin-i18n-docs-download..yml
+++ b/.github/workflows/crowdin-i18n-docs-download..yml
@@ -134,5 +134,5 @@ jobs:
           base: 'main'
           title: 'chore(i18n,docs): processed translations'
           body: 'This PR was opened auto-magically by Crowdin.'
-          labels: 'crowdin-sync, scope: i18n, scope: docs'
+          labels: 'crowdin-sync'
           reviewers: 'RandellDawson, nhcarrigan'

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v3
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        sync-labels: true

--- a/tools/contributor/lib/validation/valid-labels.js
+++ b/tools/contributor/lib/validation/valid-labels.js
@@ -5,7 +5,7 @@ const validLabels = {
   portuguese: 'language: Portuguese',
   russian: 'language: Russian',
   spanish: 'language: Spanish',
-  curriculum: 'scope: learn',
+  curriculum: 'scope: curriculum',
   docs: 'scope: docs',
 };
 

--- a/tools/contributor/one-off-scripts/add-test-locally-label.js
+++ b/tools/contributor/one-off-scripts/add-test-locally-label.js
@@ -1,7 +1,7 @@
 /*
 This is a one-off script to run on all open PRs to add the
 "status: need to test locally" label to any PR with an existing
-"scope: learn" label on it.
+"scope: curriculum" label on it.
 */
 
 const {
@@ -38,7 +38,7 @@ const log = new ProcessingLog('all-locally-tested-labels');
       // holds potential labels to add based on file path
       const labelsToAdd = {};
       const existingLabels = labels.map(({ name }) => name);
-      if (existingLabels.includes('scope: learn')) {
+      if (existingLabels.includes('scope: curriculum')) {
         labelsToAdd['status: need to test locally'] = 1;
       }
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

Finally got around to adding an action to the repo that will correctly label PRs based on the file paths of the files that are changed.

@raisedadead Per our discussion, I also have changed to the `scope: learn` label to be `scope: curriculum`, so before this PR is merged, we need to also change this label on the repo itself.  I ended up going with [GitHub's own Labeler action](https://github.com/actions/labeler).  Let me know, if we need to change/add any labels for certain folders.  I believe I tested all the label scenarios on a personal repo that has the same structure as freeCodeCamp and it worked perfectly.  This action also will to remove labels if files are removed via other committed, using a `sync` parameter that I set in the workflow file (`.github/workflows/crowdin-i18n-curriculum-download.yml`). 
