### PR TITLE
fix(learn): correct the instructions for functional tests

### DIFF
--- a/curriculum/challenges/english/09-information-security/information-security-projects/anonymous-message-board.md
+++ b/curriculum/challenges/english/09-information-security/information-security-projects/anonymous-message-board.md
@@ -33,8 +33,8 @@ Write the following tests in `tests/2_functional-tests.js`:
 -   Reporting a thread: PUT request to `/api/threads/{board}`
 -   Creating a new reply: POST request to `/api/replies/{board}`
 -   Viewing a single thread with all replies: GET request to `/api/replies/{board}`
--   Deleting a reply with the incorrect password: DELETE request to `/api/threads/{board}` with an invalid `delete_password`
--   Deleting a reply with the correct password: DELETE request to `/api/threads/{board}` with a valid `delete_password`
+-   Deleting a reply with the incorrect password: DELETE request to `/api/replies/{board}` with an invalid `delete_password`
+-   Deleting a reply with the correct password: DELETE request to `/api/replies/{board}` with a valid `delete_password`
 -   Reporting a reply: PUT request to `/api/replies/{board}`
 
 # --hints--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->



<!-- Feel free to add any additional description of changes below this line -->
The instructions for writing the functional tests for the anonymous message board project contains two typographical errors. The instructions for deleting a reply have `/api/threads/{board}` instead of `/api/replies/{board}`.

The hints section of the file has the correct information.