### PR TITLE
fix(tools): Add new required workflow config options for Crowdin uploads

### DIFF
--- a/.github/workflows/crowdin-i18n-client-ui-upload.yml
+++ b/.github/workflows/crowdin-i18n-client-ui-upload.yml
@@ -35,6 +35,8 @@ jobs:
 
           # Uncomment below to debug
           # dryrun_action: true
+          project_id: ${{ secrets.CROWDIN_PROJECT_ID_CLIENT }}
+          token: ${{ secrets.CROWDIN_CAMPERBOT_SERVICE_TOKEN }}
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/crowdin-i18n-curriculum-upload.yml
+++ b/.github/workflows/crowdin-i18n-curriculum-upload.yml
@@ -42,6 +42,8 @@ jobs:
 
           # Uncomment below to debug
           # dryrun_action: true
+          project_id: ${{ secrets.CROWDIN_PROJECT_ID_CURRICULUM }}
+          token: ${{ secrets.CROWDIN_CAMPERBOT_SERVICE_TOKEN }}
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/crowdin-i18n-docs-upload.yml
+++ b/.github/workflows/crowdin-i18n-docs-upload.yml
@@ -35,6 +35,9 @@ jobs:
 
           # Uncomment below to debug
           # dryrun_action: true
+          project_id: ${{ secrets.CROWDIN_PROJECT_ID_DOCS }}
+          token: ${{ secrets.CROWDIN_CAMPERBOT_SERVICE_TOKEN }}
+
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

@nhcarrigan It appears Crowdin added two required workflow options (`token` and `project_id`) (their docs were updated 4 days ago but change apparently was made 10+ days ago).  [Their docs for the config file settings] does not seemed to have changed(https://github.com/crowdin/github-action/blob/master/README.md#crowdin-configuration-file), but I am not sure we even need to specify the following anymore in the config file (`crowdin.yml` for each project).
```yaml
"project_id_env": "CROWDIN_PROJECT_ID"
"api_token_env": "CROWDIN_PERSONAL_TOKEN"
```

Also, if that is the case, we should theoretically be able to remove the following from each upload step for each language under `env:`.

```yaml
          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID_CLIENT }}
          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_CAMPERBOT_SERVICE_TOKEN }}
```

I can remove all of these in a separate commit if you think that is fine.