### PR TITLE
Fix: Typo on motivation json file for spanish

### DIFF
--- a/client/i18n/locales/espanol/motivation.json
+++ b/client/i18n/locales/espanol/motivation.json
@@ -8,7 +8,7 @@
     "¡Otra más!",
     "¡Hacia adelante!",
     "¡Objectivo destruido!",
-    "¡Record de juego!",
+    "¡Récord de juego!",
     "¿Nivel de poder? ¡Supera los 9000!",
     "Programa mucho y prospera.",
     "¡La tribuna se enloquece!",
@@ -85,7 +85,7 @@
       "author": "Miguel de Cervantes Saavedra"
     },
     {
-      "quote": "Una persona que nunca cometió un error nunca intento nada nuevo.",
+      "quote": "Una persona que nunca cometió un error nunca intentó nada nuevo.",
       "author": "Albert Einstein"
     },
     {


### PR DESCRIPTION
Checklist:
- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

Fixed missing accents on compliments and motivationalQuotes for spanish.