### PR TITLE
fix(curriculum): Remove end of line chars after code blocks

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/import-a-google-font.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/import-a-google-font.md
@@ -19,8 +19,11 @@ To import a Google Font, you can copy the font's URL from the Google Fonts libra
 
 `<link href="https://fonts.googleapis.com/css?family=Lobster" rel="stylesheet" type="text/css">`
 
-Now you can use the `Lobster` font in your CSS by using `Lobster` as the FAMILY_NAME as in the following example:  
-`font-family: FAMILY_NAME, GENERIC_NAME;`.
+Now you can use the `Lobster` font in your CSS by using `Lobster` as the FAMILY_NAME as in the following example:
+
+```css
+font-family: FAMILY_NAME, GENERIC_NAME;
+```
 
 The GENERIC_NAME is optional, and is a fallback font in case the other specified font is not available. This is covered in the next challenge.
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/add-placeholder-text-to-a-text-field.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/add-placeholder-text-to-a-text-field.md
@@ -13,7 +13,9 @@ Placeholder text is what is displayed in your `input` element before your user h
 
 You can create placeholder text like so:
 
-`<input type="text" placeholder="this is placeholder text">`  
+```html
+<input type="text" placeholder="this is placeholder text">
+```
 
 **Note:** Remember that `input` elements are self-closing.
 

--- a/curriculum/challenges/english/03-front-end-libraries/jquery/target-elements-by-id-using-jquery.md
+++ b/curriculum/challenges/english/03-front-end-libraries/jquery/target-elements-by-id-using-jquery.md
@@ -20,7 +20,9 @@ Then use jQuery's `.addClass()` function to add the classes `animated` and `fade
 
 Here's how you'd make the `button` element with the id `target6` fade out:
 
-`$("#target6").addClass("animated fadeOut")`.
+```js
+$("#target6").addClass("animated fadeOut");
+```
 
 # --hints--
 

--- a/curriculum/challenges/english/10-coding-interview-prep/data-structures/create-a-priority-queue-class.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/data-structures/create-a-priority-queue-class.md
@@ -12,11 +12,15 @@ In this challenge you will be creating a Priority Queue. A Priority Queue is a s
 
 For instance, let’s imagine we have a priority queue with three items:
 
-`[['kitten', 2], ['dog', 2], ['rabbit', 2]]`
+```js
+[['kitten', 2], ['dog', 2], ['rabbit', 2]]
+```
 
 Here the second value (an integer) represents item priority. If we enqueue `['human', 1]` with a priority of `1` (assuming lower priorities are given precedence) it would then be the first item to be dequeued. The collection would look like this:
 
-`[['human', 1], ['kitten', 2], ['dog', 2], ['rabbit', 2]]`.
+```js
+[['human', 1], ['kitten', 2], ['dog', 2], ['rabbit', 2]]
+````
 
 We’ve started writing a `PriorityQueue` in the code editor. You will need to add an `enqueue` method for adding items with a priority, a `dequeue` method for removing and returning items, a `size` method to return the number of items in the queue, a `front` method to return the element at the front of the queue, and finally an `isEmpty` method that will return `true` if the queue is empty or `false` if it is not.
 

--- a/curriculum/challenges/english/10-coding-interview-prep/data-structures/create-a-priority-queue-class.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/data-structures/create-a-priority-queue-class.md
@@ -20,7 +20,7 @@ Here the second value (an integer) represents item priority. If we enqueue `['hu
 
 ```js
 [['human', 1], ['kitten', 2], ['dog', 2], ['rabbit', 2]]
-````
+```
 
 We’ve started writing a `PriorityQueue` in the code editor. You will need to add an `enqueue` method for adding items with a priority, a `dequeue` method for removing and returning items, a `size` method to return the number of items in the queue, a `front` method to return the element at the front of the queue, and finally an `isEmpty` method that will return `true` if the queue is empty or `false` if it is not.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

This PR fixes a bug on Crowdin that does not allow us to hide these single line code blocks which have characters (included extra white space) at the end of them.
