### PR TITLE
docs: change node alias from stable to lts

### DIFF
--- a/docs/devops.md
+++ b/docs/devops.md
@@ -847,10 +847,10 @@ Verify installed packages
 npm ls -g --depth=0
 ```
 
-Alias `default` Node.js versions to the current `stable`
+Alias the `default` Node.js version to the current LTS
 
 ```console
-nvm alias default stable
+nvm alias default lts/*
 ```
 
 


### PR DESCRIPTION
As discussed in
https://freecodecamp.crowdin.com/translate/457d487b1586f10d2fba3c4ccb9c5453/5364/en-esem?filter=basic&value=0#q=732016
the `stable` alias just points to the latest version of node you have installed.  See the [nvm docs](https://github.com/nvm-sh/nvm#usage) for confirmation.