### PR TITLE
Fix: Redundant word on english devops.md

### DIFF
--- a/docs/devops.md
+++ b/docs/devops.md
@@ -899,7 +899,7 @@ Navigate to [Azure Devops](https://dev.azure.com/freeCodeCamp-org) and register 
 
 ### Updating agents
 
-Currently updating agents requires them to be removed and reconfigured. This is required for them to correctly pick up `PATH` values and other system environment variables correctly. We need to do this for instance updating Node.js on our deployment target VMs.
+Currently updating agents requires them to be removed and reconfigured. This is required for them to correctly pick up `PATH` values and other system environment variables. We need to do this for instance updating Node.js on our deployment target VMs.
 
 1. Navigate and check status of the service
 


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.


I suggest remove the last redundant word: "correctly" in phrase: 
This is required for them to correctly pick up `PATH` values and other system environment variables correctly.
