### PR TITLE
fix: suppress warning for seedless challenges

### DIFF
--- a/curriculum/getChallenges.js
+++ b/curriculum/getChallenges.js
@@ -228,9 +228,10 @@ async function buildChallenges({ path }, curriculum, lang) {
 async function parseTranslation(transPath, dict, lang, parse = parseMD) {
   const translatedChal = await parse(transPath);
 
-  // challengeType 11 is for video challenges, which have no seeds, so we skip
-  // them.
-  return translatedChal.challengeType !== 11
+  const { challengeType } = translatedChal;
+  // challengeType 11 is for video challenges and 3 is for front-end projects
+  // neither of which have seeds.
+  return challengeType !== 11 && challengeType !== 3
     ? translateCommentsInChallenge(translatedChal, lang, dict)
     : translatedChal;
 }

--- a/tools/challenge-parser/translation-parser/index.js
+++ b/tools/challenge-parser/translation-parser/index.js
@@ -17,7 +17,7 @@ exports.translateComments = (text, lang, dict, codeLang) => {
 exports.translateCommentsInChallenge = (challenge, lang, dict) => {
   const challClone = cloneDeep(challenge);
   if (!challClone.files) {
-    console.warn(`Challenge ${challClone.title} has no comments to translate`);
+    console.warn(`Challenge ${challClone.title} has no seed to translate`);
   } else {
     Object.keys(challClone.files).forEach(key => {
       if (challClone.files[key].contents) {


### PR DESCRIPTION
Both challengeType 11 and challengeType 3 have no seeds, so there's no need to warn about a lack of seed.

The warning has been updated to better reflect the problem (lack of seed, not lack of comments)