### PR TITLE
fix(curriculum): Add 3 more certs to Chinese curriculum

### DIFF
--- a/utils/is-audited.js
+++ b/utils/is-audited.js
@@ -11,7 +11,12 @@
 
 const auditedCerts = {
   espanol: ['responsive-web-design'],
-  chinese: ['responsive-web-design']
+  chinese: [
+    'responsive-web-design',
+    'javascript-algorithms-and-data-structures',
+    'front-end-libraries',
+    'data-visualization'
+  ]
 };
 
 function isAuditedCert(lang, cert) {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

Per discussion in dev-team chat, I am proposing we go ahead and add 3 more certifications to the Chinese curriculum, since they are now 100% translated and approved on Crowdin and have had audits performed regarding inline code blocks and removal of Description and Instruction section code block comments.

<!-- Feel free to add any additional description of changes below this line -->
