### PR TITLE
fix(learn): specify connect-mongo version in adnode

### DIFF
--- a/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/authentication-with-socket.io.md
+++ b/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/authentication-with-socket.io.md
@@ -10,7 +10,7 @@ dashedName: authentication-with-socket-io
 
 Currently, you cannot determine who is connected to your web socket. While `req.user` contains the user object, that's only when your user interacts with the web server, and with web sockets you have no `req` (request) and therefore no user data. One way to solve the problem of knowing who is connected to your web socket is by parsing and decoding the cookie that contains the passport session then deserializing it to obtain the user object. Luckily, there is a package on NPM just for this that turns a once complex task into something simple!
 
-Add `passport.socketio`, `connect-mongo`, and `cookie-parser` as dependencies and require them as `passportSocketIo`, `MongoStore`, and `cookieParser` respectively. Also, we need to initialize a new memory store, from `express-session` which we previously required. It should look like this:
+Add `passport.socketio`, `connect-mongo@~3.2.0`, and `cookie-parser` as dependencies and require them as `passportSocketIo`, `MongoStore`, and `cookieParser` respectively. Also, we need to initialize a new memory store, from `express-session` which we previously required. It should look like this:
 
 ```js
 const MongoStore = require('connect-mongo')(session);


### PR DESCRIPTION
This is a quick-fix to a show-stopper.

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related: #39521 

Specify the version needed to complete the challenge. Tilde is used, as discussed with Nicholas, but I would be fine to use caret versioning, especially for `connect-mongo`.