### PR TITLE
fix(learn): rework Rosetta Code Harshad or Niven series

### DIFF
--- a/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/harshad-or-niven-series.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/harshad-or-niven-series.md
@@ -10,7 +10,7 @@ dashedName: harshad-or-niven-series
 
 The Harshad or Niven numbers are positive integers ≥ 1 that are divisible by the sum of their digits.
 
-For example, `42` is a [Harshad number](https://rosettacode.org/wiki/Harshad_or_Niven_series "Harshad or Niven series") as `42` is divisible by `(4 + 2)` without remainder.
+For example, `42` is a Harshad number as `42` is divisible by `(4 + 2)` without remainder.
 
 Assume that the series is defined as the numbers in increasing order.
 

--- a/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/harshad-or-niven-series.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/harshad-or-niven-series.md
@@ -18,7 +18,7 @@ Assume that the series is defined as the numbers in increasing order.
 
 Implement a function to generate successive members of the Harshad sequence.
 
-Use it to return list with ten members of the sequence, starting with first Harshad number greater than `n`.
+Use it to return an array with ten members of the sequence, starting with first Harshad number greater than `n`.
 
 # --hints--
 

--- a/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/harshad-or-niven-series.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/harshad-or-niven-series.md
@@ -18,7 +18,7 @@ Assume that the series is defined as the numbers in increasing order.
 
 Implement a function to generate successive members of the Harshad sequence.
 
-Use it to list the first twenty members of the sequence and list the first Harshad number greater than 1000.
+Use it to return list with ten members of the sequence, starting with first Harshad number greater than `n`.
 
 # --hints--
 
@@ -28,32 +28,31 @@ Use it to list the first twenty members of the sequence and list the first Harsh
 assert(typeof isHarshadOrNiven === 'function');
 ```
 
-`isHarshadOrNiven()` should return `{"firstTwenty": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 18, 20, 21, 24, 27, 30, 36, 40, 42],"firstOver1000": 1002}`
+`isHarshadOrNiven(10)` should return `[12, 18, 20, 21, 24, 27, 30, 36, 40, 42]`
 
 ```js
-assert.deepEqual(isHarshadOrNiven(), res);
+assert.deepEqual(isHarshadOrNiven(10), [12, 18, 20, 21, 24, 27, 30, 36, 40, 42]);
+```
+
+`isHarshadOrNiven(400)` should return `[402, 405, 407, 408, 410, 414, 420, 423, 432, 440]`
+
+```js
+assert.deepEqual(isHarshadOrNiven(400), [402, 405, 407, 408, 410, 414, 420, 423, 432, 440]);
+```
+
+`isHarshadOrNiven(1000)` should return `[1002, 1008, 1010, 1011, 1012, 1014, 1015, 1016, 1017, 1020]`
+
+```js
+assert.deepEqual(isHarshadOrNiven(1000), [1002, 1008, 1010, 1011, 1012, 1014, 1015, 1016, 1017, 1020]);
 ```
 
 # --seed--
 
-## --after-user-code--
-
-```js
-const res = {
-  firstTwenty: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 18, 20, 21, 24, 27, 30, 36, 40, 42],
-  firstOver1000: 1002
-};
-```
-
 ## --seed-contents--
 
 ```js
-function isHarshadOrNiven() {
-  const res = {
-    firstTwenty: [],
-    firstOver1000: undefined
-  };
-  // Only change code below this line
+function isHarshadOrNiven(n) {
+  const res = [];
 
   return res;
 }
@@ -62,36 +61,26 @@ function isHarshadOrNiven() {
 # --solutions--
 
 ```js
-function isHarshadOrNiven() {
-  const res = {
-    firstTwenty: [],
-    firstOver1000: undefined
-  };
-
-  function isHarshad(n) {
+function isHarshadOrNiven(n) {
+  function isHarshad(num) {
     let s = 0;
-    const nStr = n.toString();
+    const nStr = num.toString();
     for (let i = 0; i < nStr.length; ++i) {
       s += parseInt(nStr.charAt(i), 10);
     }
     return n % s === 0;
   }
 
+  const res = [];
   let count = 0;
-  const harshads = [];
 
-  for (let n = 1; count < 20; ++n) {
+  while (count < 10) {
+    n++;
     if (isHarshad(n)) {
       count++;
-      harshads.push(n);
+      res.push(n);
     }
   }
-
-  res.firstTwenty = harshads;
-
-  let h = 1000;
-  while (!isHarshad(++h));
-  res.firstOver1000 = h;
 
   return res;
 }


### PR DESCRIPTION
* Reworks challenge to use argument in function call. I've joined two parts of the original challenge - finding 20 numbers of sequence and first number greater than - into finding 10 numbers, starting from one greater than. Limiting required numbers to 10 allows to keep test descriptions cleaner, while not affecting difficulty of challenge.
* Adds two tests.
* Removes unnecessary link.
* Changes tested on local fork.
* Related to #40896.

Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.
