### PR TITLE
feat(client): style code block scrollbar

### DIFF
--- a/client/src/templates/Challenges/video/show.css
+++ b/client/src/templates/Challenges/video/show.css
@@ -37,7 +37,23 @@
 .video-quiz-options > label {
   margin: 0;
   align-items: center;
-  overflow-x: scroll;
+  overflow-x: auto;
+}
+
+.video-quiz-options > label::-webkit-scrollbar {
+  height: 11px;
+}
+.video-quiz-options > label {
+  scrollbar-width: thin;
+  scrollbar-color: var(--secondary-background) var(--tertiary-background);
+}
+.video-quiz-options > label::-webkit-scrollbar-track {
+  background: var(--tertiary-background);
+}
+.video-quiz-options > label::-webkit-scrollbar-thumb {
+  background-color: var(--tertiary-background);
+  border-radius: 6px;
+  border: 3px solid var(--secondary-background);
 }
 
 .video-quiz-option-label {

--- a/client/src/templates/Challenges/video/show.css
+++ b/client/src/templates/Challenges/video/show.css
@@ -41,19 +41,17 @@
 }
 
 .video-quiz-options > label::-webkit-scrollbar {
-  height: 11px;
+  height: 15px;
 }
 .video-quiz-options > label {
   scrollbar-width: thin;
-  scrollbar-color: var(--secondary-background) var(--tertiary-background);
+  scrollbar-color: var(--quaternary-background) var(--secondary-background);
 }
 .video-quiz-options > label::-webkit-scrollbar-track {
-  background: var(--tertiary-background);
+  background: var(--secondary-background);
 }
 .video-quiz-options > label::-webkit-scrollbar-thumb {
-  background-color: var(--tertiary-background);
-  border-radius: 6px;
-  border: 3px solid var(--secondary-background);
+  background-color: var(--quaternary-background);
 }
 
 .video-quiz-option-label {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Tweaking the CSS on the horizontal scrollbar for video challenge answer blocks, to make the scrollbar a little less obtrusive.

@ahmadabdolsaheb feel free to close if you have a better approach 🙂 

Example on:
Chrome  - Firefox - Edge (I can't test on safari 🙁 )

![image](https://user-images.githubusercontent.com/63889819/112096467-8a174e00-8b5b-11eb-8e48-455c190bdc3f.png)
