### PR TITLE
fix(client): split Editor panes correctly

### DIFF
--- a/client/src/templates/Challenges/classic/MultifileEditor.js
+++ b/client/src/templates/Challenges/classic/MultifileEditor.js
@@ -185,7 +185,12 @@ class MultifileEditor extends Component {
       renderOnResizeRate: 20
     };
 
-    let splitterHTMLRight, splitterCSSRight;
+    let splitterJSXRight, splitterHTMLRight, splitterCSSRight;
+    if (indexjsx) {
+      if (indexhtml || indexcss || indexjs) {
+        splitterJSXRight = true;
+      }
+    }
     if (indexhtml) {
       if (indexcss || indexjs) {
         splitterHTMLRight = true;
@@ -210,6 +215,22 @@ class MultifileEditor extends Component {
       >
         <ReflexElement flex={10} {...reflexProps} {...resizeProps}>
           <ReflexContainer orientation='vertical'>
+            {indexjsx && (
+              <ReflexElement {...reflexProps} {...resizeProps}>
+                <Editor
+                  challengeFiles={challengeFiles}
+                  containerRef={containerRef}
+                  description={targetEditor === 'indexjsx' ? description : null}
+                  fileKey='indexjsx'
+                  key='indexjsx'
+                  resizeProps={resizeProps}
+                  theme={editorTheme}
+                />
+              </ReflexElement>
+            )}
+            {splitterJSXRight && (
+              <ReflexSplitter propagate={true} {...resizeProps} />
+            )}
             {indexhtml && (
               <ReflexElement {...reflexProps} {...resizeProps}>
                 <Editor
@@ -254,19 +275,6 @@ class MultifileEditor extends Component {
                   description={targetEditor === 'indexjs' ? description : null}
                   fileKey='indexjs'
                   key='indexjs'
-                  resizeProps={resizeProps}
-                  theme={editorTheme}
-                />
-              </ReflexElement>
-            )}
-            {indexjsx && (
-              <ReflexElement {...reflexProps} {...resizeProps}>
-                <Editor
-                  challengeFiles={challengeFiles}
-                  containerRef={containerRef}
-                  description={targetEditor === 'indexjsx' ? description : null}
-                  fileKey='indexjsx'
-                  key='indexjsx'
                   resizeProps={resizeProps}
                   theme={editorTheme}
                 />

--- a/client/src/templates/Challenges/classic/MultifileEditor.js
+++ b/client/src/templates/Challenges/classic/MultifileEditor.js
@@ -169,7 +169,7 @@ class MultifileEditor extends Component {
       editorRef,
       theme,
       resizeProps,
-      visibleEditors
+      visibleEditors: { indexcss, indexhtml, indexjs, indexjsx }
     } = this.props;
     const editorTheme = theme === 'night' ? 'vs-dark-custom' : 'vs-custom';
     // TODO: the tabs mess up the rendering (scroll doesn't work properly and
@@ -185,11 +185,9 @@ class MultifileEditor extends Component {
       renderOnResizeRate: 20
     };
 
-    // TODO: this approach (||ing the visibleEditors) isn't great.
-    const splitCSS = visibleEditors.indexhtml && visibleEditors.indexcss;
-    const splitJS =
-      visibleEditors.indexcss ||
-      (visibleEditors.indexhtml && visibleEditors.indexjs);
+    // TODO: this approach (||ing the visible editors) isn't great.
+    const splitterHTMLRight = indexhtml && indexcss;
+    const splitterCSSRight = indexcss || (indexhtml && indexjs);
 
     // TODO: tabs should be dynamically created from the challengeFiles
     // TODO: the tabs mess up the rendering (scroll doesn't work properly and
@@ -204,7 +202,7 @@ class MultifileEditor extends Component {
       >
         <ReflexElement flex={10} {...reflexProps} {...resizeProps}>
           <ReflexContainer orientation='vertical'>
-            {visibleEditors.indexhtml && (
+            {indexhtml && (
               <ReflexElement {...reflexProps} {...resizeProps}>
                 <Editor
                   challengeFiles={challengeFiles}
@@ -220,8 +218,10 @@ class MultifileEditor extends Component {
                 />
               </ReflexElement>
             )}
-            {splitCSS && <ReflexSplitter propagate={true} {...resizeProps} />}
-            {visibleEditors.indexcss && (
+            {splitterHTMLRight && (
+              <ReflexSplitter propagate={true} {...resizeProps} />
+            )}
+            {indexcss && (
               <ReflexElement {...reflexProps} {...resizeProps}>
                 <Editor
                   challengeFiles={challengeFiles}
@@ -234,9 +234,11 @@ class MultifileEditor extends Component {
                 />
               </ReflexElement>
             )}
-            {splitJS && <ReflexSplitter propagate={true} {...resizeProps} />}
+            {splitterCSSRight && (
+              <ReflexSplitter propagate={true} {...resizeProps} />
+            )}
 
-            {visibleEditors.indexjs && (
+            {indexjs && (
               <ReflexElement {...reflexProps} {...resizeProps}>
                 <Editor
                   challengeFiles={challengeFiles}
@@ -249,7 +251,7 @@ class MultifileEditor extends Component {
                 />
               </ReflexElement>
             )}
-            {visibleEditors.indexjsx && (
+            {indexjsx && (
               <ReflexElement {...reflexProps} {...resizeProps}>
                 <Editor
                   challengeFiles={challengeFiles}

--- a/client/src/templates/Challenges/classic/MultifileEditor.js
+++ b/client/src/templates/Challenges/classic/MultifileEditor.js
@@ -185,9 +185,17 @@ class MultifileEditor extends Component {
       renderOnResizeRate: 20
     };
 
-    // TODO: this approach (||ing the visible editors) isn't great.
-    const splitterHTMLRight = indexhtml && indexcss;
-    const splitterCSSRight = indexcss || (indexhtml && indexjs);
+    let splitterHTMLRight, splitterCSSRight;
+    if (indexhtml) {
+      if (indexcss || indexjs) {
+        splitterHTMLRight = true;
+      }
+    }
+    if (indexcss) {
+      if (indexjs) {
+        splitterCSSRight = true;
+      }
+    }
 
     // TODO: tabs should be dynamically created from the challengeFiles
     // TODO: the tabs mess up the rendering (scroll doesn't work properly and


### PR DESCRIPTION
Fixes the logic for when `ReflexSplitter`s should appear between panes.  @RandellDawson as a side-effect, this seems to have cured the browser slow down issue.  Could you try it out and see?

Related to https://github.com/freeCodeCamp/freeCodeCamp/issues/39348
