### PR TITLE
revert: remove nowrap rule (2f0b9ec)

### DIFF
--- a/client/src/components/layouts/prism.css
+++ b/client/src/components/layouts/prism.css
@@ -7,10 +7,6 @@ pre[class*='language-'] {
   background: var(--primary-background);
 }
 
-pre[class*='language'] code[class*='language-'] {
-  white-space: nowrap;
-}
-
 * {
   text-shadow: none !important;
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This is a partial revert of PR #41438 - the changes made in the PR caused our multi-line code blocks to be rendered on a single line. Removing the added `white-space: nowrap` rule seems to resolve that.