### PR TITLE
chore(ci): deprecate node 12

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         browsers: [chrome, firefox]
-        node-version: [14.x, 12.x]
+        node-version: [14.x]
     services:
       mongodb:
         image: mongo:3.6.19

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 12.x]
+        node-version: [14.x]
 
     steps:
       - name: Checkout Source Files

--- a/.github/workflows/node.js-tests-upcoming.yml
+++ b/.github/workflows/node.js-tests-upcoming.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 12.x]
+        node-version: [14.x]
 
     steps:
       - name: Checkout Source Files

--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 12.x]
+        node-version: [14.x]
 
     steps:
       - name: Checkout Source Files


### PR DESCRIPTION
Required checks have been moved to Node.js 14.x and all production instances upgraded to Node.js 14.x 