### PR TITLE
fix(tools): adjust ownership of files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # -------------------------------------------------
-# CODEOWNERS - For automated review request for 
+# CODEOWNERS - For automated review request for
 # high impact files.
 #
 # Important: The order in this file cascades.
@@ -8,10 +8,13 @@
 # -------------------------------------------------
 
 # -------------------------------------------------
-# All files except a few here are owned by dev team
+# All files are owned by dev team
 # -------------------------------------------------
 
 * @freecodecamp/dev-team
+
+# --- Owned by none (negate rule above) ---
+
 *.md
 package.json
 package-lock.json
@@ -22,8 +25,15 @@ package-lock.json
 
 /* @freecodecamp/dev-team
 
+# --- Owned by none (negate rule above) ---
+
+/package.json
+/package-lock.json
+
 # -------------------------------------------------
-# Critical files that need attention from Staff
+# Files that need attention from Staff
 # -------------------------------------------------
-/README.md @freeCodeCamp/Staff
-/config/motivational-quotes.json @freeCodeCamp/Staff
+/*.md @freeCodeCamp/staff
+/client/i18n/locales/english/motivation.json @freeCodeCamp/staff @freeCodeCamp/i18n
+/client/i18n/locales/chinese/motivation.json @freeCodeCamp/staff @freeCodeCamp/i18n
+/client/i18n/locales/espanol/motivation.json @freeCodeCamp/staff @freeCodeCamp/i18n


### PR DESCRIPTION
Adjusts the ownership of files. We will also shortly consider adding the @freeCodeCamp/moderators team to a list of files, but wanted to check in with you all first. 

Note, the goal for this PR is to hopefully result in less noise for the upcoming renovate-bot PRs.