### PR TITLE
fix(actions): update workflows, add auto-approval

### DIFF
--- a/.github/workflows/crowdin-i18n-client-ui-download.yml
+++ b/.github/workflows/crowdin-i18n-client-ui-download.yml
@@ -89,7 +89,7 @@ jobs:
         run: |
           cd ./crowdin
           npm ci
-          
+
       # Generate PR - all languages should go ABOVE this. #
       - name: Create PR
         uses: ./tools/crowdin/actions/pr-creator
@@ -101,4 +101,4 @@ jobs:
           title: 'chore(i18n,client): processed translations'
           body: 'This PR was opened auto-magically by Crowdin.'
           labels: 'crowdin-sync, scope: UI'
-          reviewers: 'RandellDawson, nhcarrigan'
+          reviewers: '@freeCodeCamp/i18n'

--- a/.github/workflows/crowdin-i18n-client-ui-download.yml
+++ b/.github/workflows/crowdin-i18n-client-ui-download.yml
@@ -101,4 +101,4 @@ jobs:
           title: 'chore(i18n,client): processed translations'
           body: 'This PR was opened auto-magically by Crowdin.'
           labels: 'crowdin-sync, scope: UI'
-          reviewers: '@freeCodeCamp/i18n'
+          team_reviewers: 'i18n'

--- a/.github/workflows/crowdin-i18n-curriculum-download.yml
+++ b/.github/workflows/crowdin-i18n-curriculum-download.yml
@@ -102,4 +102,4 @@ jobs:
           title: 'chore(i18n,curriculum): processed translations'
           body: 'This PR was opened auto-magically by Crowdin.'
           labels: 'crowdin-sync'
-          reviewers: 'RandellDawson, nhcarrigan'
+          reviewers: '@freeCodeCamp/i18n'

--- a/.github/workflows/crowdin-i18n-curriculum-download.yml
+++ b/.github/workflows/crowdin-i18n-curriculum-download.yml
@@ -102,4 +102,4 @@ jobs:
           title: 'chore(i18n,curriculum): processed translations'
           body: 'This PR was opened auto-magically by Crowdin.'
           labels: 'crowdin-sync'
-          reviewers: '@freeCodeCamp/i18n'
+          team_reviewers: 'i18n'

--- a/.github/workflows/crowdin-i18n-docs-download..yml
+++ b/.github/workflows/crowdin-i18n-docs-download..yml
@@ -123,7 +123,7 @@ jobs:
         run: |
           cd ./crowdin
           npm ci
-          
+
       # Generate PR - all languages should go ABOVE this. #
       - name: Create PR
         uses: ./tools/crowdin/actions/pr-creator
@@ -135,4 +135,4 @@ jobs:
           title: 'chore(i18n,docs): processed translations'
           body: 'This PR was opened auto-magically by Crowdin.'
           labels: 'crowdin-sync'
-          reviewers: 'RandellDawson, nhcarrigan'
+          reviewers: '@freeCodeCamp/i18n'

--- a/.github/workflows/crowdin-i18n-docs-download..yml
+++ b/.github/workflows/crowdin-i18n-docs-download..yml
@@ -135,4 +135,4 @@ jobs:
           title: 'chore(i18n,docs): processed translations'
           body: 'This PR was opened auto-magically by Crowdin.'
           labels: 'crowdin-sync'
-          reviewers: '@freeCodeCamp/i18n'
+          team_reviewers: 'i18n'

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -33,7 +33,7 @@ jobs:
               github.pulls.requestReviewers({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                pull_number,: context.issue.number
+                pull_number: context.issue.number,
                 reviewers: ['raisedadead']
                 // team_reviewers: [`dev-team`]
               });

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -1,0 +1,40 @@
+# This workflow allows us to reach the merging requirements
+name: Deps update auto approval
+on:
+  pull_request_target:
+    branches:
+      - 'main'
+    paths:
+      - 'docs/index.html'
+      - '.github/workflows/*.yml'
+      - 'client/package.json'
+      - 'client/plugins/**/package.json'
+      - 'curriculum/package.json'
+      - 'package.json'
+      - 'tools/**/package.json'
+      # - 'api-server/**/package.json'
+
+jobs:
+  auto-approve-renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GITHUB_ACTIONS_CAMPERBOT_PA_TOKEN}}
+          script: |
+            if (context.payload.pull_request.user.login === "renovate[bot]") {
+              github.pulls.createReview({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+                event: 'APPROVE',
+                body: "To be approved by `@freeCodeCamp/dev-team`"
+              });
+              github.pulls.requestReviewers({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number,: context.issue.number
+                reviewers: ['raisedadead']
+                // team_reviewers: [`dev-team`]
+              });
+            }


### PR DESCRIPTION
This PR updates the workflows to add one automatic approval by @camperbot for all renovate bot PRs, reducing the requirements to one additional reviewer with write access. It will also add a review request from me (for the moment, we can switch to dev-team if needed later). 

Secondly, I moved the i18n workflows to review requests from i18n team instead for transparency and as responsibilities shift within team. 

This when merged in tandem with #41590 should be a balance of notifications and turn around on a PR from staff.