### PR TITLE
feat(tools): add team reviewers

### DIFF
--- a/tools/crowdin/actions/pr-creator/action.yml
+++ b/tools/crowdin/actions/pr-creator/action.yml
@@ -30,5 +30,8 @@ inputs:
     description: 'Requested PR reviewers'
     required: false
   team_reviewers:
+    # Note that this should be a slug, not a full tag
+    # So a requested review from @freeCodeCamp/dev-team
+    # Should be passed only as 'dev-team'
     description: 'Requested organization team PR reviewers'
     required: false

--- a/tools/crowdin/actions/pr-creator/action.yml
+++ b/tools/crowdin/actions/pr-creator/action.yml
@@ -1,5 +1,5 @@
 name: 'Create Crowdin PRs'
-description: "Creates a PR by camperbot for Crowdin translation downloads"
+description: 'Creates a PR by camperbot for Crowdin translation downloads'
 runs:
   using: 'node12'
   main: './index.js'
@@ -28,4 +28,7 @@ inputs:
     required: false
   reviewers:
     description: 'Requested PR reviewers'
+    required: false
+  team_reviewers:
+    description: 'Requested organization team PR reviewers'
     required: false

--- a/tools/crowdin/actions/pr-creator/index.js
+++ b/tools/crowdin/actions/pr-creator/index.js
@@ -18,6 +18,8 @@ const githubRoot = require('@actions/github');
     const labels = labelsStr.trim().split(/,\s+/);
     const reviewersStr = core.getInput('reviewers');
     const reviewers = reviewersStr.trim().split(/,\s+/);
+    const teamStr = core.getInput('team_reviewers');
+    const team_reviewers = teamStr.trim().split(/,\s+/);
 
     const github = githubRoot.getOctokit(token);
 
@@ -83,6 +85,15 @@ const githubRoot = require('@actions/github');
         reviewers
       });
       console.log(`Requested Reviewers ${reviewers} added to PR`);
+    }
+    if (team_reviewers && team_reviewers.length) {
+      await github.pulls.requestReviewers({
+        owner,
+        repo,
+        pull_number: prNumber,
+        team_reviewers
+      });
+      console.log(`Requested Team Reviewers ${team_reviewers} added to PR`);
     }
   } catch (error) {
     core.setFailed(error.message);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This ties in to #41591, adding another optional parameter to the workflow to request team reviews (since this is a different value than reviewers in the API).

@raisedadead In order to leave this tool as universal as possible, I thought it would be better to add another parameter instead of renaming the existing one - if you agree, then we'd need to update #41591 to pass `team_reviewers` instead of `reviewers`.

@RandellDawson would you mind giving this a sanity check as well?