### PR TITLE
fix(tools): new token

### DIFF
--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/github-script@v3
         with:
-          github-token: ${{secrets.GITHUB_ACTIONS_CAMPERBOT_PA_TOKEN}}
+          github-token: ${{secrets.CROWDIN_CAMPERBOT_PAT}}
           script: |
             if (context.payload.pull_request.user.login === "renovate[bot]") {
               github.pulls.createReview({


### PR DESCRIPTION
Use the newer camperbot token.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

@raisedadead I completely overlooked this in #41591 - not sure what's up with the old Camperbot PAT in the secrets, but it seems to be outdated or missing permissions. When Randy and I were building the Crowdin automation we had to create a new token to get the authentication in place.

Perhaps not the most fitting secret name for this workflow, but the token should work and have the requisite permissions to perform the approval action.