### PR TITLE
fix(client): polyfill path with path-browserify

### DIFF
--- a/client/gatsby-node.js
+++ b/client/gatsby-node.js
@@ -204,7 +204,7 @@ exports.onCreateWebpackConfig = ({ stage, plugins, actions }) => {
     resolve: {
       fallback: {
         fs: false,
-        path: false,
+        path: require.resolve('path-browserify'),
         assert: require.resolve('assert'),
         crypto: require.resolve('crypto-browserify'),
         util: false,

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -18989,6 +18989,11 @@
         "cross-spawn": "^6.0.5"
       }
     },
+    "path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
+    },
     "path-dirname": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -50,6 +50,7 @@
     "lodash": "^4.17.21",
     "monaco-editor": "^0.22.3",
     "nanoid": "^3.1.22",
+    "path-browserify": "^1.0.1",
     "prismjs": "^1.23.0",
     "process": "^0.11.10",
     "query-string": "^6.14.1",


### PR DESCRIPTION
path is being used by webpack to transform `import`s into `require`s. Since
some challenges rely on this transformation, path has to exist in the
browser.

@raisedadead as you suspected, our tests miss this because they're all running on node.

related to https://github.com/freeCodeCamp/freeCodeCamp/issues/41608