### PR TITLE
fix(renovate): update configs and behaviour

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,17 @@
 {
   "extends": ["config:base"],
+  "prCreation": "not-pending",
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "matchCurrentVersion": "!/^0/",
       "automerge": true
     }
   ],
   "ignorePaths": [
-    "api-server"
+    "api-server",
+    "tools/contributor",
+    "tools/contributor/dashboard-app/client",
+    "tools/contributor/dashboard-app/server"
   ]
 }


### PR DESCRIPTION
Temporarily disabling renovate PRs on contributor tools which is way outdated. Also modifying some behaviors for creating a PR.