### PR TITLE
feat(gitpod): prevent port notification, remove pr comment

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,6 +10,8 @@ ports:
     onOpen: ignore
   - port: 9229 # node debug
     onOpen: ignore
+  - port: 9230 # client node debug
+    onOpen: ignore
 
 tasks:
   - before: |
@@ -71,7 +73,7 @@ github:
     # add a check to pull requests (defaults to true)
     addCheck: false
     # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
-    addComment: true
+    addComment: false
     # add a "Review in Gitpod" button to the pull request's description (defaults to false)
     addBadge: false
     # add a label once the prebuild is ready to pull requests (defaults to false)


### PR DESCRIPTION
Checklist:

Just a _"while I am here..."_

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

Small update which should prevent the benign port notification, and stop the PR comments with the broken GitPod image.