### PR TITLE
feat(tools): use camperbot for commit

### DIFF
--- a/.github/workflows/crowdin-i18n-client-ui-download.yml
+++ b/.github/workflows/crowdin-i18n-client-ui-download.yml
@@ -87,12 +87,12 @@ jobs:
         env:
           EMAIL: ${{ secrets.ACTIONS_CAMPERBOT_EMAIL }}
         run: |
-          git checkout -b i18n-sync-curriculum
+          git checkout -b i18n-sync-client
           git config --global user.name "camperbot"
           git config --global user.email "$EMAIL"
           git add .
           git commit -m "chore: update translations"
-          git push -u origin i18n-sync-curriculum -f
+          git push -u origin i18n-sync-client -f
 
       - name: Install Dependencies
         working-directory: ./tools

--- a/.github/workflows/crowdin-i18n-client-ui-download.yml
+++ b/.github/workflows/crowdin-i18n-client-ui-download.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   schedule:
     # runs every day at 12:15 PM UTC
-    - cron: "15 12 * * *"
+    - cron: '15 12 * * *'
 
 jobs:
   i18n-download-client-ui-translations:
@@ -65,9 +65,7 @@ jobs:
           skip_untranslated_files: false
           export_only_approved: true
 
-          commit_message: 'chore(i8n,client): processed translations'
-          localization_branch_name: i18n-sync-client
-          push_translations: true
+          push_translations: false
 
           # pull-request
           create_pull_request: false
@@ -83,6 +81,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID_CLIENT }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_CAMPERBOT_SERVICE_TOKEN }}
+
+      # Create Commit
+      - name: Commit Changes
+        env:
+          EMAIL: ${{ secrets.ACTIONS_CAMPERBOT_EMAIL }}
+        run: |
+          git checkout -b i18n-sync-curriculum
+          git config --global user.name "camperbot"
+          git config --global user.email "$EMAIL"
+          git add .
+          git commit -m "chore: update translations"
+          git push -u origin i18n-sync-curriculum -f
 
       - name: Install Dependencies
         working-directory: ./tools

--- a/.github/workflows/crowdin-i18n-curriculum-download.yml
+++ b/.github/workflows/crowdin-i18n-curriculum-download.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   schedule:
     # runs every day at 12:30 PM UTC
-    - cron: "30 12 * * *"
+    - cron: '30 12 * * *'
 
 jobs:
   i18n-download-curriculum-translations:
@@ -65,10 +65,7 @@ jobs:
           skip_untranslated_files: true
           export_only_approved: true
 
-
-          commit_message: 'chore(i8n,curriculum): processed translations'
-          localization_branch_name: i18n-sync-curriculum
-          push_translations: true
+          push_translations: false
 
           # pull-request
           create_pull_request: false
@@ -84,6 +81,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID_CURRICULUM }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_CAMPERBOT_SERVICE_TOKEN }}
+
+      # Create Commit
+      - name: Commit Changes
+        env:
+          EMAIL: ${{ secrets.ACTIONS_CAMPERBOT_EMAIL }}
+        run: |
+          git checkout -b i18n-sync-curriculum
+          git config --global user.name "camperbot"
+          git config --global user.email "$EMAIL"
+          git add .
+          git commit -m "chore: update translations"
+          git push -u origin i18n-sync-curriculum -f
 
       - name: Install Dependencies
         working-directory: ./tools

--- a/.github/workflows/crowdin-i18n-docs-download..yml
+++ b/.github/workflows/crowdin-i18n-docs-download..yml
@@ -121,12 +121,12 @@ jobs:
         env:
           EMAIL: ${{ secrets.ACTIONS_CAMPERBOT_EMAIL }}
         run: |
-          git checkout -b i18n-sync-curriculum
+          git checkout -b i18n-sync-docs
           git config --global user.name "camperbot"
           git config --global user.email "$EMAIL"
           git add .
           git commit -m "chore: update translations"
-          git push -u origin i18n-sync-curriculum -f
+          git push -u origin i18n-sync-docs -f
 
       - name: Install Dependencies
         working-directory: ./tools

--- a/.github/workflows/crowdin-i18n-docs-download..yml
+++ b/.github/workflows/crowdin-i18n-docs-download..yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   schedule:
     # runs every day at 12:00 noon UTC
-    - cron: "0 12 * * *"
+    - cron: '0 12 * * *'
 
 jobs:
   i18n-download-docs-translations:
@@ -99,9 +99,7 @@ jobs:
           skip_untranslated_files: false
           export_only_approved: true
 
-          commit_message: 'chore(i8n,docs): processed translations'
-          localization_branch_name: i18n-sync-docs
-          push_translations: true
+          push_translations: false
 
           # pull-request
           create_pull_request: false
@@ -117,6 +115,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID_DOCS }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_CAMPERBOT_SERVICE_TOKEN }}
+
+      # Create Commit
+      - name: Commit Changes
+        env:
+          EMAIL: ${{ secrets.ACTIONS_CAMPERBOT_EMAIL }}
+        run: |
+          git checkout -b i18n-sync-curriculum
+          git config --global user.name "camperbot"
+          git config --global user.email "$EMAIL"
+          git add .
+          git commit -m "chore: update translations"
+          git push -u origin i18n-sync-curriculum -f
 
       - name: Install Dependencies
         working-directory: ./tools


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

As noted in [the last PR](https://github.com/freeCodeCamp/freeCodeCamp/pull/41617#issuecomment-809350605), there are issues with using the GitHub Actions credentials when creating the commit. The Crowdin GitHub action pre-sets the git config and doesn't accept a flag to change it, so this PR adds a step to the workflow to modify the git config and create the commit manually.

I've added camperbot's email to the repository secrets.