### PR TITLE
fix(client): update search results links to open in new tab

### DIFF
--- a/client/src/components/search/searchBar/SearchSuggestion.js
+++ b/client/src/components/search/searchBar/SearchSuggestion.js
@@ -14,7 +14,6 @@ const Suggestion = ({ hit, handleMouseEnter, handleMouseLeave }) => {
       href={hit.url}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
-      target={hit.url && '_blank'}
     >
       <span className='hit-name'>
         {dropdownFooter ? (

--- a/client/src/components/search/searchBar/SearchSuggestion.js
+++ b/client/src/components/search/searchBar/SearchSuggestion.js
@@ -14,6 +14,7 @@ const Suggestion = ({ hit, handleMouseEnter, handleMouseLeave }) => {
       href={hit.url}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
+      target='_blank'
     >
       <span className='hit-name'>
         {dropdownFooter ? (

--- a/client/src/components/search/searchBar/SearchSuggestion.js
+++ b/client/src/components/search/searchBar/SearchSuggestion.js
@@ -14,6 +14,7 @@ const Suggestion = ({ hit, handleMouseEnter, handleMouseLeave }) => {
       href={hit.url}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
+      target={hit.url && '_blank'}
     >
       <span className='hit-name'>
         {dropdownFooter ? (

--- a/client/src/components/search/searchBar/SearchSuggestion.js
+++ b/client/src/components/search/searchBar/SearchSuggestion.js
@@ -14,6 +14,7 @@ const Suggestion = ({ hit, handleMouseEnter, handleMouseLeave }) => {
       href={hit.url}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
+      rel='noopener noreferrer'
       target='_blank'
     >
       <span className='hit-name'>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #41729

<!-- Feel free to add any additional description of changes below this line -->

After a short discussion on the issue page, I saw the need for the change so I made the smallest change to have the results link open in a new tab. I have tested this change both on my local machine and gitpod.


