### PR TITLE
docs: fix netstat command for Linux/MacOS/WSL

### DIFF
--- a/docs/how-to-setup-freecodecamp-locally.md
+++ b/docs/how-to-setup-freecodecamp-locally.md
@@ -535,7 +535,7 @@ If you can't sign in, and instead you see a banner with an error message that it
 **On Linux / macOS / WSL on Windows - From Terminal:**
 
 ```console
-netstat -ab | grep "3000"
+netstat -a | grep "3000"
 
 tcp4    0   0    0.0.0.0:3000           DESKTOP      LISTEN
 ```


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
The netstat command in Linux and WSL doesn't have a `b` flag and in MacOS the `b` flag is to see received and sent bytes in the console output.