### PR TITLE
testing bug: give-links-meaning-by-using-descriptive-text

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/applied-accessibility/give-links-meaning-by-using-descriptive-link-text.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-accessibility/give-links-meaning-by-using-descriptive-link-text.md
@@ -40,7 +40,7 @@ The `a` element should have a closing tag.
 ```js
 assert(
   code.match(/<\/a>/g) &&
-    code.match(/<\/a>/g).length === code.match(/<a href=(''|"")>/g).length
+    code.match(/<\/a>/g).length === code.match(/<a/g).length
 );
 ```
 


### PR DESCRIPTION
The assertion for "The a element should have a closing tag" test needs the formatting to be exactly as it is written, so no extra spaces when assigning (href = ""). I don't know if the assertion was written to also make sure that the href was empty with the (''||"") part, so changing it to match the same test from link-to-external-pages-with-anchor-elements could mess something up. The contributing guidelines have ways to download and test but i figured the maintainers could read this and know what to do better.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
