### PR TITLE
fix: replace JS algorithms and data structures bitly links

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/arguments-optional.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/arguments-optional.md
@@ -42,10 +42,10 @@ assert.deepEqual(addTogether(23, 30), 53);
 assert.deepEqual(addTogether(5)(7), 12);
 ```
 
-`addTogether("http://bit.ly/IqT6zt")` should return `undefined`.
+`addTogether("https://www.youtube.com/watch?v=dQw4w9WgXcQ")` should return `undefined`.
 
 ```js
-assert.isUndefined(addTogether('http://bit.ly/IqT6zt'));
+assert.isUndefined(addTogether('https://www.youtube.com/watch?v=dQw4w9WgXcQ'));
 ```
 
 `addTogether(2, "3")` should return `undefined`.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
This replaces the lone bit.ly link in the JS algorithms and data structures section. Turns out the link is really just a Rickroll.

Not sure if we want to leave this as is or change it out to point to one of the videos on the fCC channel.