### PR TITLE
revert: remove nowrap rule (2f0b9ec)

### DIFF
--- a/client/src/components/layouts/prism.css
+++ b/client/src/components/layouts/prism.css
@@ -7,10 +7,6 @@ pre[class*='language-'] {
   background: var(--primary-background);
 }
 
-pre[class*='language'] code[class*='language-'] {
-  white-space: nowrap;
-}
-
 * {
   text-shadow: none !important;
 }


### PR DESCRIPTION
Revert the white-space: nowrap rule introduced in commit
2f0b9ec4a54f2981ecc478f60a9773e32ee799ab which was breaking multi-
line code block rendering.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ × ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [× ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ ×] My pull request targets the `main` branch of freeCodeCamp.
- [× ] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
