### PR TITLE
fix(curriculum): typo in a correct answer in ML curriculum

### DIFF
--- a/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/natural-language-processing-with-rnns-create-a-play-generator.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/natural-language-processing-with-rnns-create-a-play-generator.md
@@ -18,7 +18,7 @@ char_dataset = tf.data.__A__.__B__(text_as_int)
 
 ## --answers--
 
-A: `DataSet`
+A: `Dataset`
 
 B: `from_tensor_slices`
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

I noticed that an answer marked as correct in one of the questions in the Machine Learning in Python curriculum is in fact wrong. Python is case-sensitive so the word 'DataSet' in this answer should be replaced with 'Dataset' in order to make it truly correct. Otherwise, none of the answers is correct.