### PR TITLE
fix(tools): i18n schema linting

### DIFF
--- a/client/i18n/schema-validation.js
+++ b/client/i18n/schema-validation.js
@@ -221,8 +221,8 @@ const introSchemaValidation = languages => {
     const filePath = path.join(__dirname, `/locales/${language}/intro.json`);
     const fileJson = require(filePath);
     const fileKeys = Object.keys(flattenAnObject(fileJson));
-    findMissingKeys(fileKeys, linksSchemaKeys, `${language}/intro.json`);
-    findExtraneousKeys(fileKeys, linksSchemaKeys, `${language}/intro.json`);
+    findMissingKeys(fileKeys, introSchemaKeys, `${language}/intro.json`);
+    findExtraneousKeys(fileKeys, introSchemaKeys, `${language}/intro.json`);
     const emptyKeys = noEmptyObjectValues(fileJson);
     if (emptyKeys.length) {
       console.warn(
@@ -264,8 +264,8 @@ const linksSchemaValidation = languages => {
     const filePath = path.join(__dirname, `/locales/${language}/links.json`);
     const fileJson = require(filePath);
     const fileKeys = Object.keys(flattenAnObject(fileJson));
-    findMissingKeys(fileKeys, introSchemaKeys, `${language}/links.json`);
-    findExtraneousKeys(fileKeys, introSchemaKeys, `${language}/links.json`);
+    findMissingKeys(fileKeys, linksSchemaKeys, `${language}/links.json`);
+    findExtraneousKeys(fileKeys, linksSchemaKeys, `${language}/links.json`);
     const emptyKeys = noEmptyObjectValues(fileJson);
     if (emptyKeys.length) {
       console.warn(


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Thanks to @ojeytonwilliams for catching that the linter was generating a lot of noise - I had mistakenly swapped a couple of variables, so the objects were being compared against the wrong English base. This PR fixes that. 