### PR TITLE
update(curriculum): clarify Replit use of env files

### DIFF
--- a/curriculum/challenges/english/05-apis-and-microservices/basic-node-and-express/use-the-.env-file.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/basic-node-and-express/use-the-.env-file.md
@@ -16,7 +16,11 @@ The environment variables are accessible from the app as `process.env.VAR_NAME`.
 
 Let's add an environment variable as a configuration option.
 
-Create a `.env` file in the root of your project directory, and store the variable `MESSAGE_STYLE=uppercase` in it. Then, in the GET `/json` route handler that you created in the last challenge, transform the response object’s message to uppercase if `process.env.MESSAGE_STYLE` equals `uppercase`. The response object should become `{"message": "HELLO JSON"}`.
+Create a `.env` file in the root of your project directory, and store the variable `MESSAGE_STYLE=uppercase` in it.
+
+Then, in the `/json` GET route handler you created in the last challenge, transform the response object's message to uppercase if `process.env.MESSAGE_STYLE` equals `uppercase`. The response object should either be `{"message": "Hello json"}` or `{"message": "HELLO JSON"}`, depending on the `MESSAGE_STYLE` value.
+
+**Note:** If you are using Replit, you cannot create a `.env` file. Instead, use the built-in <dfn>SECRETS</dfn> tab to add the variable.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

- Adds note about Replit changing their editor to no longer allow `.env` files to be created 😞 
- Adds more information to clarify the instructions of the challenge, as this challenge still gets many forum posts. Specifically, Campers forget what the previous challenge expected the initial response string to be.

EDIT: I forgot to add context: https://forum.freecodecamp.org/t/replit-create-a-env-file-changed/456125