### PR TITLE
fix(curriculum): added 4th test to amb challenge

### DIFF
--- a/curriculum/challenges/english/09-information-security/information-security-projects/anonymous-message-board.md
+++ b/curriculum/challenges/english/09-information-security/information-security-projects/anonymous-message-board.md
@@ -84,7 +84,29 @@ async (getUserInput) => {
 You can send a POST request to `/api/threads/{board}` with form data including `text` and `delete_password`. The saved database record will have at least the fields `_id`, `text`, `created_on`(date & time), `bumped_on`(date & time, starts same as `created_on`), `reported` (boolean), `delete_password`, & `replies` (array).
 
 ```js
-
+async (getUserInput) => {
+  const data = {"text":"fcc_test", "delete_password":"delete_me"};
+  const url = getUserInput('url');
+  const res = await fetch(url + '/api/threads/fcc_test', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+  if (res.ok) {
+    const checkData = await fetch(getUserInput('url') + '/api/threads/general');
+    const parsed = await checkData.json();
+    assert.isTrue(parsed[0].text == "fcc_test");
+    assert.isNotNull(parsed[0]._id);
+    assert.isNotNull(parsed[0].text);
+    assert.isNotNull(parsed[0].created_on);
+    assert.isNotNull(parsed[0].bumped_on);
+    assert.isNotNull(parsed[0].reported);
+    assert.isNotNull(parsed[0].delete_password);
+    assert.isNotNull(parsed[0].replies);
+  } else {
+    throw new Error(`${res.status} ${res.statusText}`);
+  }
+};
 ```
 
 You can send a POST request to `/api/replies/{board}` with form data including `text`, `delete_password`, & `thread_id`. This will update the `bumped_on` date to the comment's date. In the thread's `replies` array, an object will be saved with at least the properties `_id`, `text`, `created_on`, `delete_password`, & `reported`.

--- a/curriculum/challenges/english/09-information-security/information-security-projects/anonymous-message-board.md
+++ b/curriculum/challenges/english/09-information-security/information-security-projects/anonymous-message-board.md
@@ -93,7 +93,7 @@ async (getUserInput) => {
     body: JSON.stringify(data)
   });
   if (res.ok) {
-    const checkData = await fetch(getUserInput('url') + '/api/threads/general');
+    const checkData = await fetch(getUserInput('url') + '/api/threads/fcc_test');
     const parsed = await checkData.json();
     assert.isTrue(parsed[0].text == "fcc_test");
     assert.isNotNull(parsed[0]._id);

--- a/curriculum/challenges/english/09-information-security/information-security-projects/anonymous-message-board.md
+++ b/curriculum/challenges/english/09-information-security/information-security-projects/anonymous-message-board.md
@@ -85,7 +85,10 @@ You can send a POST request to `/api/threads/{board}` with form data including `
 
 ```js
 async (getUserInput) => {
-  const data = {"text":"fcc_test", "delete_password":"delete_me"};
+  const date = new Date();
+  const text = `fcc_test_${date}`;
+  const deletePassword = 'delete_me';
+  const data = { text, delete_password: deletePassword };
   const url = getUserInput('url');
   const res = await fetch(url + '/api/threads/fcc_test', {
     method: 'POST',
@@ -93,16 +96,19 @@ async (getUserInput) => {
     body: JSON.stringify(data)
   });
   if (res.ok) {
-    const checkData = await fetch(getUserInput('url') + '/api/threads/fcc_test');
+    const checkData = await fetch(url + '/api/threads/fcc_test');
     const parsed = await checkData.json();
-    assert.isTrue(parsed[0].text == "fcc_test");
-    assert.isNotNull(parsed[0]._id);
-    assert.isNotNull(parsed[0].text);
-    assert.isNotNull(parsed[0].created_on);
-    assert.isNotNull(parsed[0].bumped_on);
-    assert.isNotNull(parsed[0].reported);
-    assert.isNotNull(parsed[0].delete_password);
-    assert.isNotNull(parsed[0].replies);
+    try {
+      assert.equal(parsed[0].text, text);
+      assert.isNotNull(parsed[0]._id);
+      assert.equal(new Date(parsed[0].created_on).toDateString(), date.toDateString());
+      assert.equal(parsed[0].bumped_on, parsed[0].created_on);
+      assert.isBoolean(parsed[0].reported);
+      assert.equal(parsed[0].delete_password, deletePassword);
+      assert.isArray(parsed[0].replies);
+    } catch (err) {
+      throw new Error(err.responseText || err.message);
+    }
   } else {
     throw new Error(`${res.status} ${res.statusText}`);
   }


### PR DESCRIPTION
This is the 4th test in the amb project: #41323

`You can send a POST request to /api/threads/{board} with form data including text and delete_password. The saved database record will have at least the fields _id, text, created_on(date & time), bumped_on(date & time, starts same as created_on), reported (boolean), delete_password, & replies (array).`

Tested locally.

I'm happy to complete the rest of these tests in a single further pull request given that you are happy with the way i have done this one.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Does not close but is related to: #41323 

<!-- Feel free to add any additional description of changes below this line -->
