### PR TITLE
docs: use of language in tests

### DIFF
--- a/docs/how-to-work-on-coding-challenges.md
+++ b/docs/how-to-work-on-coding-challenges.md
@@ -289,6 +289,10 @@ Our goal is to communicate the single point that the challenge is trying to teac
 
 Challenge tests can make use of the Node.js and Chai.js assertion libraries. Also, if needed, user-generated code can be accessed in the `code` variable.
 
+### Use of language
+
+In contrast to the description, which should talk directly to the user, the test text should talk about the code.  It should describe what is wrong with the code, rather than what the user did wrong.  For example "The `h1` element should..." instead of "Your `h1` element should..."
+
 ## Formatting seed code
 
 Here are specific formatting guidelines for the challenge seed code:


### PR DESCRIPTION
I've been thinking about changing how we use language in tests (which are implicitly criticising the user) to make them less off-putting.  The idea being that being told that you've made a coding mistake is more frustrating than that there is a mistake in the code.  

If we can slightly change how we phrase things it might ease new learners into something that can be quite daunting.

That's the justification, anyway.  What do people think?