### PR TITLE
fix(curriculum): fluid containers test not specific

### DIFF
--- a/curriculum/challenges/english/03-front-end-libraries/bootstrap/use-responsive-design-with-bootstrap-fluid-containers.md
+++ b/curriculum/challenges/english/03-front-end-libraries/bootstrap/use-responsive-design-with-bootstrap-fluid-containers.md
@@ -45,7 +45,7 @@ assert(
 All HTML elements after the closing `style` tag should be nested in `.container-fluid`.
 
 ```js
-assert($('.container-fluid').children().length === 8 && !$('.container-fluid').has("style").length);
+assert($('.container-fluid').children().length === 8 && !$('.container-fluid').has("style").length && !$('.container-fluid').has("link").length);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/03-front-end-libraries/bootstrap/use-responsive-design-with-bootstrap-fluid-containers.md
+++ b/curriculum/challenges/english/03-front-end-libraries/bootstrap/use-responsive-design-with-bootstrap-fluid-containers.md
@@ -45,7 +45,7 @@ assert(
 All HTML elements after the closing `style` tag should be nested in `.container-fluid`.
 
 ```js
-assert($('.container-fluid').children().length === 8 && !$('.container-fluid').has("style").length && !$('.container-fluid').has("link").length);
+assert($('.container-fluid').children().length >= 8 && !$('.container-fluid').has("style").length && !$('.container-fluid').has("link").length);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/03-front-end-libraries/bootstrap/use-responsive-design-with-bootstrap-fluid-containers.md
+++ b/curriculum/challenges/english/03-front-end-libraries/bootstrap/use-responsive-design-with-bootstrap-fluid-containers.md
@@ -45,7 +45,7 @@ assert(
 All HTML elements after the closing `style` tag should be nested in `.container-fluid`.
 
 ```js
-assert($('.container-fluid').children().length >= 8);
+assert($('.container-fluid').children().length === 8 && !$('.container-fluid').has("style").length);
 ```
 
 # --seed--


### PR DESCRIPTION
This resolves an issue where a user could pass the bootstrap fluid containers lesson by including `style` and/ or `link` in their `div` as well as not nesting all elements after the closing tag going against the test:

`All HTML elements after the closing style tag should be nested in`



Tested locally.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #41863

<!-- Feel free to add any additional description of changes below this line -->
