### PR TITLE
chore(curriculum): remove redundant babel plugin

### DIFF
--- a/curriculum/.babelrc
+++ b/curriculum/.babelrc
@@ -2,7 +2,6 @@
   "presets": [ "env", "react", "stage-0" ],
   "plugins": [
     "transform-runtime",
-    "babel-plugin-add-module-exports",
     "lodash"
   ]
 }

--- a/curriculum/package-lock.json
+++ b/curriculum/package-lock.json
@@ -1792,12 +1792,6 @@
         "babel-runtime": "^6.22.0"
       }
     },
-    "babel-plugin-add-module-exports": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-0.2.1.tgz",
-      "integrity": "sha1-mumh9KjcZ/DN7E9K7aHkOl/2XiU=",
-      "dev": true
-    },
     "babel-plugin-check-es2015-constants": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",

--- a/curriculum/package.json
+++ b/curriculum/package.json
@@ -37,7 +37,6 @@
     "@babel/register": "7.13.14",
     "acorn": "8.1.1",
     "acorn-jsx": "5.3.1",
-    "babel-plugin-add-module-exports": "0.2.1",
     "babel-plugin-dynamic-import-node": "2.3.3",
     "babel-plugin-lodash": "3.3.4",
     "babel-plugin-transform-runtime": "6.23.0",


### PR DESCRIPTION
I'm not sure why this stopped being needed, but it is not something that would fail quietly.