### PR TITLE
test(e2e): re-enable output tests

### DIFF
--- a/cypress/integration/learn/challenges/output.js
+++ b/cypress/integration/learn/challenges/output.js
@@ -18,55 +18,47 @@ const defaultOutput = `
 * Your test output will go here
 */`;
 
-// Disabled for https://github.com/freeCodeCamp/freeCodeCamp/issues/41009
-
-// const runningOutput = '// running tests';
-// const finishedOutput = '// tests completed';
+const runningOutput = '// running tests';
+const finishedOutput = '// tests completed';
 
 describe('Classic challenge', function () {
-  it('renders', () => {
+  before(() => {
     cy.visit(locations.index);
+  });
 
+  it('renders the default output text', () => {
     cy.title().should(
       'eq',
       'Learn Basic HTML and HTML5: Say Hello to HTML Elements |' +
         ' freeCodeCamp.org'
     );
-  });
-
-  it('renders the default output text', () => {
-    cy.visit(locations.index);
     cy.get(selectors.defaultOutput).contains(defaultOutput);
   });
 
-  // Disabled for https://github.com/freeCodeCamp/freeCodeCamp/issues/41009
+  it('shows test output when the tests are run', () => {
+    // first wait for the editor to load
+    cy.get(selectors.editor, { timeout: 15000 });
+    cy.get(selectors.runTestsButton)
+      .click()
+      .then(() => {
+        cy.get(selectors.defaultOutput)
+          .contains(runningOutput)
+          .contains(finishedOutput);
+      });
+  });
 
-  // it('shows test output when the tests are run', () => {
-  //   cy.visit(locations.index);
-  //   // first wait for the editor to load
-  //   cy.get(selectors.editor, { timeout: 15000 });
-  //   cy.get(selectors.runTestsButton)
-  //     .click()
-  //     .then(() => {
-  //       cy.get(selectors.defaultOutput)
-  //         .contains(runningOutput)
-  //         .contains(finishedOutput);
-  //     });
-  // });
-
-  // it('shows test output when the tests are triggered by the keyboard', () => {
-  //   cy.visit(locations.index);
-  //   // first wait for the editor to load
-  //   cy.get(selectors.editor, {
-  //     timeout: 15000
-  //   });
-  //   cy.get(selectors.hotkeys)
-  //     .focus()
-  //     .type('{ctrl}{enter}')
-  //     .then(() => {
-  //       cy.get(selectors.defaultOutput)
-  //         .contains(runningOutput)
-  //         .contains(finishedOutput);
-  //     });
-  // });
+  it('shows test output when the tests are triggered by the keyboard', () => {
+    // first wait for the editor to load
+    cy.get(selectors.editor, {
+      timeout: 15000
+    });
+    cy.get(selectors.hotkeys)
+      .focus()
+      .type('{ctrl}{enter}')
+      .then(() => {
+        cy.get(selectors.defaultOutput)
+          .contains(runningOutput)
+          .contains(finishedOutput);
+      });
+  });
 });


### PR DESCRIPTION
All being well, this should not have the same flakiness.  It seems that Cypress 7's default of failing on errors is a massive boon to us. It was unclear what the source of flakiness on earlier versions, but I suspect it's been ChunkLoadErrors all along.