### PR TITLE
fix(curriculum): tabindex order lesson

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/applied-accessibility/use-tabindex-to-specify-the-order-of-keyboard-focus-for-several-elements.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-accessibility/use-tabindex-to-specify-the-order-of-keyboard-focus-for-several-elements.md
@@ -29,7 +29,7 @@ Here's an example:
 
 Camper Cat has a search field on his Inspirational Quotes page that he plans to position in the upper right corner with CSS. He wants the search `input` and submit `input` form controls to be the first two items in the tab order. Add a `tabindex` attribute set to `1` to the `search` `input`, and a `tabindex` attribute set to `2` to the `submit` `input`.
 
-Another thing to note is that some browsers may place a you in the middle of your tab order when an element is clicked. An element has been added to the page that ensures you will always start at the beginning of your tab order.
+Another thing to note is that some browsers may place you in the middle of your tab order when an element is clicked. An element has been added to the page that ensures you will always start at the beginning of your tab order.
 
 # --hints--
 

--- a/curriculum/challenges/english/01-responsive-web-design/applied-accessibility/use-tabindex-to-specify-the-order-of-keyboard-focus-for-several-elements.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-accessibility/use-tabindex-to-specify-the-order-of-keyboard-focus-for-several-elements.md
@@ -29,6 +29,8 @@ Here's an example:
 
 Camper Cat has a search field on his Inspirational Quotes page that he plans to position in the upper right corner with CSS. He wants the search `input` and submit `input` form controls to be the first two items in the tab order. Add a `tabindex` attribute set to `1` to the `search` `input`, and a `tabindex` attribute set to `2` to the `submit` `input`.
 
+Another thing to note is that some browsers may place a you in the middle of your tab order when an element is clicked. An element has been added to the page that ensures you will always start at the beginning of your tab order.
+
 # --hints--
 
 Your code should add a `tabindex` attribute to the `search` `input` tag.
@@ -61,6 +63,7 @@ assert($('#submit').attr('tabindex') == '2');
 
 ```html
 <body>
+  <div tabindex="1" class="overlay"></div>
   <header>
     <h1>Even Deeper Thoughts with Master Camper Cat</h1>
     <nav>
@@ -91,12 +94,26 @@ assert($('#submit').attr('tabindex') == '2');
   </blockquote>
   <footer>&copy; 2018 Camper Cat</footer>
 </body>
+<style>
+  body {
+    height: 100%;
+    margin: 0 !important;
+    padding: 8px;
+  }
+  .overlay {
+    margin: -8px;
+    position: absolute;
+    width: 100%;
+    height: 100%;
+  }
+</style>
 ```
 
 # --solutions--
 
 ```html
 <body>
+  <div tabindex="1" class="overlay"></div>
   <header>
     <h1>Even Deeper Thoughts with Master Camper Cat</h1>
     <nav>
@@ -127,4 +144,17 @@ assert($('#submit').attr('tabindex') == '2');
   </blockquote>
   <footer>&copy; 2018 Camper Cat</footer>
 </body>
+<style>
+  body {
+    height: 100%;
+    margin: 0 !important;
+    padding: 8px;
+  }
+  .overlay {
+    margin: -8px;
+    position: absolute;
+    width: 100%;
+    height: 100%;
+  }
+</style>
 ```


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #36066

<!-- Feel free to add any additional description of changes below this line -->

Tried a creative solution on this one. Added an element to the page so users always start at the beginning of their tab order.