### PR TITLE
Record Collection - variable names shouldn't be keywords

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/record-collection.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/record-collection.md
@@ -140,7 +140,7 @@ function updateRecords(records, id, prop, value) {
   return records;
 }
 
-updateRecords(myRecords, 5439, 'artist', 'ABBA');
+updateRecords(recordCollection, 5439, 'artist', 'ABBA');
 ```
 
 # --solutions--

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/record-collection.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/record-collection.md
@@ -8,21 +8,21 @@ dashedName: record-collection
 
 # --description--
 
-You are given a JSON object representing a part of your musical album collection. Each album has a unique id number as its key and several other properties. Not all albums have complete information.
+You are given an object representing a part of your musical album collection. Each album has a unique id number as its key and several other properties. Not all albums have complete information.
 
-You start with an `updateRecords` function that takes an object like `collection`, an `id`, a `prop` (like `artist` or `tracks`), and a `value`. Complete the function using the rules below to modify the object passed to the function.
+You start with an `updateRecords` function that takes an object containing `records`, an `id`, a `prop` (like `artist` or `tracks`), and a `value`. Complete the function using the rules below to modify the object passed to the function.
 
--   Your function must always return the entire object.
+-   Your function must always return the entire record collection object.
 -   If `prop` isn't `tracks` and `value` isn't an empty string, update or set that album's `prop` to `value`.
 -   If `prop` is `tracks` but the album doesn't have a `tracks` property, create an empty array and add `value` to it.
 -   If `prop` is `tracks` and `value` isn't an empty string, add `value` to the end of the album's existing `tracks` array.
 -   If `value` is an empty string, delete the given `prop` property from the album.
 
-**Note:** A copy of the `collection` object is used for the tests.
+**Note:** A copy of the `recordCollection` object is used for the tests.
 
 # --hints--
 
-After `updateRecords(collection, 5439, "artist", "ABBA")`, `artist` should be the string `ABBA`
+After `updateRecords(recordCollection, 5439, "artist", "ABBA")`, `artist` should be the string `ABBA`
 
 ```js
 assert(
@@ -31,7 +31,7 @@ assert(
 );
 ```
 
-After `updateRecords(collection, 5439, "tracks", "Take a Chance on Me")`, `tracks` should have the string `Take a Chance on Me` as the last element.
+After `updateRecords(recordCollection, 5439, "tracks", "Take a Chance on Me")`, `tracks` should have the string `Take a Chance on Me` as the last element.
 
 ```js
 assert(
@@ -41,14 +41,14 @@ assert(
 );
 ```
 
-After `updateRecords(collection, 2548, "artist", "")`, `artist` should not be set
+After `updateRecords(recordCollection, 2548, "artist", "")`, `artist` should not be set
 
 ```js
 updateRecords(_recordCollection, 2548, 'artist', '');
 assert(!_recordCollection[2548].hasOwnProperty('artist'));
 ```
 
-After `updateRecords(collection, 1245, "tracks", "Addicted to Love")`, `tracks` should have the string `Addicted to Love` as the last element.
+After `updateRecords(recordCollection, 1245, "tracks", "Addicted to Love")`, `tracks` should have the string `Addicted to Love` as the last element.
 
 ```js
 assert(
@@ -58,7 +58,7 @@ assert(
 );
 ```
 
-After `updateRecords(collection, 2468, "tracks", "Free")`, `tracks` should have the string `1999` as the first element.
+After `updateRecords(recordCollection, 2468, "tracks", "Free")`, `tracks` should have the string `1999` as the first element.
 
 ```js
 assert(
@@ -68,14 +68,14 @@ assert(
 );
 ```
 
-After `updateRecords(collection, 2548, "tracks", "")`, `tracks` should not be set
+After `updateRecords(recordCollection, 2548, "tracks", "")`, `tracks` should not be set
 
 ```js
 updateRecords(_recordCollection, 2548, 'tracks', '');
 assert(!_recordCollection[2548].hasOwnProperty('tracks'));
 ```
 
-After `updateRecords(collection, 1245, "albumTitle", "Riptide")`, `albumTitle` should be the string `Riptide`
+After `updateRecords(recordCollection, 1245, "albumTitle", "Riptide")`, `albumTitle` should be the string `Riptide`
 
 ```js
 assert(
@@ -115,7 +115,7 @@ const _recordCollection = {
 
 ```js
 // Setup
-var collection = {
+var recordCollection = {
   2548: {
     albumTitle: 'Slippery When Wet',
     artist: 'Bon Jovi',
@@ -136,17 +136,17 @@ var collection = {
 };
 
 // Only change code below this line
-function updateRecords(object, id, prop, value) {
-  return object;
+function updateRecords(records, id, prop, value) {
+  return records;
 }
 
-updateRecords(collection, 5439, 'artist', 'ABBA');
+updateRecords(myRecords, 5439, 'artist', 'ABBA');
 ```
 
 # --solutions--
 
 ```js
-var collection = {
+var recordCollection = {
   2548: {
     albumTitle: 'Slippery When Wet',
     artist: 'Bon Jovi',
@@ -167,15 +167,15 @@ var collection = {
 };
 
 // Only change code below this line
-function updateRecords(object, id, prop, value) {
-  if (value === '') delete object[id][prop];
+function updateRecords(records, id, prop, value) {
+  if (value === '') delete records[id][prop];
   else if (prop === 'tracks') {
-    object[id][prop] = object[id][prop] || [];
-    object[id][prop].push(value);
+    records[id][prop] = records[id][prop] || [];
+    records[id][prop].push(value);
   } else {
-    object[id][prop] = value;
+    records[id][prop] = value;
   }
 
-  return object;
+  return records;
 }
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/record-collection.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/record-collection.md
@@ -8,9 +8,9 @@ dashedName: record-collection
 
 # --description--
 
-You are given an object representing a part of your musical album collection. Each album has a unique id number as its key and several other properties. Not all albums have complete information.
+You are given an object literal representing a part of your musical album collection. Each album has a unique id number as its key and several other properties. Not all albums have complete information.
 
-You start with an `updateRecords` function that takes an object containing `records`, an `id`, a `prop` (like `artist` or `tracks`), and a `value`. Complete the function using the rules below to modify the object passed to the function.
+You start with an `updateRecords` function that takes an object literal, `records`, containing the musical album collection, an `id`, a `prop` (like `artist` or `tracks`), and a `value`. Complete the function using the rules below to modify the object passed to the function.
 
 -   Your function must always return the entire record collection object.
 -   If `prop` isn't `tracks` and `value` isn't an empty string, update or set that album's `prop` to `value`.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes: N/A

<!-- Feel free to add any additional description of changes below this line -->

I'd be happy with any other variable names, but we really shouldn't show learners naming a variable after a keyword.

Using a proper variable name has the side benefit of fixing the syntax highlighting for this problem.