### PR TITLE
fix(curriculum): allow any response status for error response

### DIFF
--- a/curriculum/challenges/english/05-apis-and-microservices/apis-and-microservices-projects/timestamp-microservice.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/apis-and-microservices-projects/timestamp-microservice.md
@@ -107,7 +107,7 @@ If the input date string is invalid, the api returns an object having the struct
       assert.equal(data.error.toLowerCase(), 'invalid date');
     },
     (xhr) => {
-      throw new Error(xhr.responseText);
+      assert(xhr.responseJSON.error.toLowerCase() === 'invalid date');
     }
   );
 ```

--- a/curriculum/challenges/english/05-apis-and-microservices/apis-and-microservices-projects/timestamp-microservice.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/apis-and-microservices-projects/timestamp-microservice.md
@@ -107,7 +107,7 @@ If the input date string is invalid, the api returns an object having the struct
       assert.equal(data.error.toLowerCase(), 'invalid date');
     },
     (xhr) => {
-      assert(xhr.responseJSON.error.toLowerCase() === 'invalid date', 'received: ' + xhr.responseJSON.error);
+      assert(xhr.responseJSON.error.toLowerCase() === 'invalid date');
     }
   );
 ```

--- a/curriculum/challenges/english/05-apis-and-microservices/apis-and-microservices-projects/timestamp-microservice.md
+++ b/curriculum/challenges/english/05-apis-and-microservices/apis-and-microservices-projects/timestamp-microservice.md
@@ -107,7 +107,7 @@ If the input date string is invalid, the api returns an object having the struct
       assert.equal(data.error.toLowerCase(), 'invalid date');
     },
     (xhr) => {
-      assert(xhr.responseJSON.error.toLowerCase() === 'invalid date');
+      assert(xhr.responseJSON.error.toLowerCase() === 'invalid date', 'received: ' + xhr.responseJSON.error);
     }
   );
 ```


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #37966

<!-- Feel free to add any additional description of changes below this line -->
Seemed reasonable to allow any response code when it's supposed to be an error.