### PR TITLE
fix: generate csrf tokens on server not client

### DIFF
--- a/api-server/src/server/middlewares/csurf.js
+++ b/api-server/src/server/middlewares/csurf.js
@@ -24,7 +24,7 @@ export default function getCsurf() {
       protection(req, res, next);
       // use the middleware to generate a token. The client sends this back via
       // a header
-      res.cookie('CSRF-Server-Token', req.csrfToken(), opts);
+      res.cookie('csrf_token', req.csrfToken(), opts);
     }
   };
 }

--- a/api-server/src/server/middlewares/csurf.js
+++ b/api-server/src/server/middlewares/csurf.js
@@ -16,8 +16,13 @@ export default function getCsurf() {
         path
       )
     ) {
-      return next();
+      next();
+    } else {
+      // add the middleware
+      protection(req, res, next);
+      // use the middleware to generate a token. The client sends this back via
+      // a header
+      res.cookie('CSRF-Server-Token', req.csrfToken());
     }
-    return protection(req, res, next);
   };
 }

--- a/api-server/src/server/middlewares/csurf.js
+++ b/api-server/src/server/middlewares/csurf.js
@@ -1,12 +1,14 @@
 import csurf from 'csurf';
 
+const opts = {
+  domain: process.env.COOKIE_DOMAIN || 'localhost',
+  sameSite: 'strict',
+  secure: process.env.FREECODECAMP_NODE_ENV === 'production'
+};
+
 export default function getCsurf() {
   const protection = csurf({
-    cookie: {
-      domain: process.env.COOKIE_DOMAIN || 'localhost',
-      sameSite: 'strict',
-      secure: process.env.FREECODECAMP_NODE_ENV === 'production'
-    }
+    cookie: opts
   });
   return function csrf(req, res, next) {
     const { path } = req;
@@ -22,7 +24,7 @@ export default function getCsurf() {
       protection(req, res, next);
       // use the middleware to generate a token. The client sends this back via
       // a header
-      res.cookie('CSRF-Server-Token', req.csrfToken());
+      res.cookie('CSRF-Server-Token', req.csrfToken(), opts);
     }
   };
 }

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -5236,6 +5236,15 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -6702,16 +6711,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA=="
-    },
-    "csrf": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.1.0.tgz",
-      "integrity": "sha512-uTqEnCvWRk042asU6JtapDTcJeeailFy4ydOQS28bj1hcLnYRiqi8SsD2jS412AY1I/4qdOwWZun774iqywf9w==",
-      "requires": {
-        "rndm": "1.2.0",
-        "tsscmp": "1.0.6",
-        "uid-safe": "2.1.5"
-      }
     },
     "css": {
       "version": "3.0.0",
@@ -9764,6 +9763,12 @@
         "token-types": "^2.0.0",
         "typedarray-to-buffer": "^3.1.5"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "filesize": {
       "version": "6.1.0",
@@ -18133,6 +18138,12 @@
       "resolved": "https://registry.npmjs.org/name-all-modules-plugin/-/name-all-modules-plugin-1.0.1.tgz",
       "integrity": "sha1-Cr+2rYNXGLn7Te8GdOBmV6lUN1w="
     },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "optional": true
+    },
     "nanoid": {
       "version": "3.1.22",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.22.tgz",
@@ -20693,11 +20704,6 @@
         "ret": "~0.1.10"
       }
     },
-    "random-bytes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
-      "integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs="
-    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -22192,11 +22198,6 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
       }
-    },
-    "rndm": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.2.0.tgz",
-      "integrity": "sha1-8z/pz7Urv9UgqhgyO8ZdsRCht2w="
     },
     "rst-selector-parser": {
       "version": "2.2.3",
@@ -24229,11 +24230,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
-    "tsscmp": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
-      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="
-    },
     "tsutils": {
       "version": "3.19.1",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.19.1.tgz",
@@ -24332,14 +24328,6 @@
       "integrity": "sha512-Zcr0lbt8z5ZdEzERHAMAniTiIKerFCMgd7yjq1fPnDJ43et/k9twIFQMUYff9k5oXcsQ0WpvFcgzK2ZKASoW6Q==",
       "requires": {
         "typescript-compare": "^0.0.2"
-      }
-    },
-    "uid-safe": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
-      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
-      "requires": {
-        "random-bytes": "~1.0.0"
       }
     },
     "unbox-primitive": {
@@ -25479,7 +25467,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "globby": {
           "version": "6.1.0",

--- a/client/package.json
+++ b/client/package.json
@@ -62,7 +62,6 @@
     "buffer": "6.0.3",
     "chai": "4.3.4",
     "crypto-browserify": "3.12.0",
-    "csrf": "3.1.0",
     "date-fns": "2.21.1",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.6",

--- a/client/src/utils/ajax.js
+++ b/client/src/utils/ajax.js
@@ -11,8 +11,7 @@ axios.defaults.withCredentials = true;
 // CSRF-Server-Token is passed to the client as a cookie. The client must send
 // this back as a header.
 function setCSRFTokens() {
-  const csrfToken =
-    typeof window !== 'undefined' && cookies.get('csrf_token');
+  const csrfToken = typeof window !== 'undefined' && cookies.get('csrf_token');
   if (!csrfToken) return;
   axios.defaults.headers.post['CSRF-Token'] = csrfToken;
   axios.defaults.headers.put['CSRF-Token'] = csrfToken;

--- a/client/src/utils/ajax.js
+++ b/client/src/utils/ajax.js
@@ -1,22 +1,21 @@
 import envData from '../../../config/env.json';
 import axios from 'axios';
-import Tokens from 'csrf';
 import cookies from 'browser-cookies';
 
 const { apiLocation } = envData;
 
 const base = apiLocation;
-const tokens = new Tokens();
 
 axios.defaults.withCredentials = true;
 
-// _csrf is passed to the client as a cookie. Tokens are sent back to the server
-// via headers:
+// CSRF-Server-Token is passed to the client as a cookie. The client must send
+// this back as a header.
 function setCSRFTokens() {
-  const _csrf = typeof window !== 'undefined' && cookies.get('_csrf');
-  if (!_csrf) return;
-  axios.defaults.headers.post['CSRF-Token'] = tokens.create(_csrf);
-  axios.defaults.headers.put['CSRF-Token'] = tokens.create(_csrf);
+  const csrfToken =
+    typeof window !== 'undefined' && cookies.get('CSRF-Server-Token');
+  if (!csrfToken) return;
+  axios.defaults.headers.post['CSRF-Token'] = csrfToken;
+  axios.defaults.headers.put['CSRF-Token'] = csrfToken;
 }
 
 function get(path) {

--- a/client/src/utils/ajax.js
+++ b/client/src/utils/ajax.js
@@ -12,7 +12,7 @@ axios.defaults.withCredentials = true;
 // this back as a header.
 function setCSRFTokens() {
   const csrfToken =
-    typeof window !== 'undefined' && cookies.get('CSRF-Server-Token');
+    typeof window !== 'undefined' && cookies.get('csrf_token');
   if (!csrfToken) return;
   axios.defaults.headers.post['CSRF-Token'] = csrfToken;
   axios.defaults.headers.put['CSRF-Token'] = csrfToken;


### PR DESCRIPTION
This is part of the set of changes we need to remove `crypto` in the client.  It was never necessary, since we can always send the token out from the server as a cookie and back as a header, never needing to use `_csrf` (and `crypto` to generate tokens) on the client.