### PR TITLE
fix(client): helper function regex s flag causing error

### DIFF
--- a/client/src/utils/curriculum-helpers.js
+++ b/client/src/utils/curriculum-helpers.js
@@ -1,7 +1,7 @@
 import { parse } from '@babel/parser';
 import generate from '@babel/generator';
 
-const removeHtmlComments = str => str.replace(/<!--[\s\S]*?-->/g, '');
+const removeHtmlComments = str => str.replace(/<!--[\s\S]*?(-->|$)/g, '');
 
 const removeCssComments = str => str.replace(/\/\*[\s\S]+?\*\//g, '');
 

--- a/client/src/utils/curriculum-helpers.js
+++ b/client/src/utils/curriculum-helpers.js
@@ -1,7 +1,7 @@
 import { parse } from '@babel/parser';
 import generate from '@babel/generator';
 
-const removeHtmlComments = str => str.replace(/<!--.*?-->/gs, '');
+const removeHtmlComments = str => str.replace(/<!--[\s\S]*?-->/g, '');
 
 const removeCssComments = str => str.replace(/\/\*[\s\S]+?\*\//g, '');
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #40311

I couldn't actually reproduce the issue to verify that this is working. I think we should find someone who can to make sure. I can try and find a way at some point here as well. But it get's rid of the regex flag that was causing the issue and should remove comments the same. Also, it appears like this function isn't being used at the moment.

<!-- Feel free to add any additional description of changes below this line -->
