### PR TITLE
fix(curriculum): intellisense suggenstion box should not be visible

### DIFF
--- a/client/src/templates/Challenges/classic/Editor.js
+++ b/client/src/templates/Challenges/classic/Editor.js
@@ -293,6 +293,11 @@ class Editor extends Component {
         });
       }
     });
+    // Overrides Intellisense suggestion box
+    editor.addCommand(
+      monaco.KeyMod.CtrlCmd | monaco.KeyCode.Space,
+      function () {}
+    );
     editor.onDidFocusEditorWidget(() => this.props.setEditorFocusability(true));
     // This is to persist changes caused by the accessibility tooltip.
     editor.onDidChangeConfiguration(event => {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #41533

<!-- Feel free to add any additional description of changes below this line -->
This fix disables the intellisense suggestion box by overriding the shortcut `ctrl` + `space`  whith an empty function. 

Only tested on Windows.
