### PR TITLE
fix(api): stop ignored files (tests) being copied

### DIFF
--- a/api-server/package.json
+++ b/api-server/package.json
@@ -20,7 +20,7 @@
   "main": "none",
   "scripts": {
     "babel-dev-server": "babel-node --inspect=0.0.0.0 ./src/server/index.js",
-    "build": "babel src --out-dir lib --ignore 'node_modules /**/*','/**/*.test.js' --copy-files",
+    "build": "babel src --out-dir lib --ignore 'node_modules /**/*','/**/*.test.js' --copy-files --no-copy-ignored",
     "develop": "cross-env DEBUG=fcc* node src/development-start.js",
     "start": "cross-env DEBUG=fcc* node lib/production-start.js",
     "test": "jest"


### PR DESCRIPTION
I noticed that `npm t` was failing locally, because it was running on duplicated tests.