### PR TITLE
fix(curriculum): remove inaccessible fields from anon test

### DIFF
--- a/curriculum/challenges/english/09-information-security/information-security-projects/anonymous-message-board.md
+++ b/curriculum/challenges/english/09-information-security/information-security-projects/anonymous-message-board.md
@@ -103,8 +103,6 @@ async (getUserInput) => {
       assert.isNotNull(parsed[0]._id);
       assert.equal(new Date(parsed[0].created_on).toDateString(), date.toDateString());
       assert.equal(parsed[0].bumped_on, parsed[0].created_on);
-      assert.isBoolean(parsed[0].reported);
-      assert.equal(parsed[0].delete_password, deletePassword);
       assert.isArray(parsed[0].replies);
     } catch (err) {
       throw new Error(err.responseText || err.message);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to #41323 

The `reported` and `delete_password` fields are, rightly, not accessible via a `GET` request, as this would go against a non-implemented user story.