### PR TITLE
fix: remove JS comments revisited

### DIFF
--- a/client/src/client/workers/test-evaluator.js
+++ b/client/src/client/workers/test-evaluator.js
@@ -2,7 +2,9 @@ import chai from 'chai';
 import '@babel/polyfill';
 import { toString as __toString } from 'lodash-es';
 import { format as __format } from '../../utils/format';
-import curriculumHelpers from '../../utils/curriculum-helpers';
+import curriculumHelpers, {
+  removeJSComments
+} from '../../utils/curriculum-helpers';
 
 const __utils = (() => {
   const MAX_LOGS_SIZE = 64 * 1024;
@@ -56,8 +58,12 @@ const __utils = (() => {
 /* Run the test if there is one.  If not just evaluate the user code */
 self.onmessage = async e => {
   /* eslint-disable no-unused-vars */
-  const code = (e.data?.code?.contents || '').slice();
-  const editableContents = (e.data?.code?.editableContents || '').slice();
+  let code = (e.data?.code?.contents || '').slice();
+  code = e.data?.removeComments ? removeJSComments(code) : code;
+  let editableContents = (e.data?.code?.editableContents || '').slice();
+  editableContents = e.data?.removeComments
+    ? removeJSComments(editableContents)
+    : editableContents;
 
   const assert = chai.assert;
   const __helpers = curriculumHelpers;
@@ -74,7 +80,9 @@ self.onmessage = async e => {
     try {
       // Logging is proxyed after the build to catch console.log messages
       // generated during testing.
-      testResult = eval(`${e.data.build}
+      testResult = eval(`${
+        e.data?.removeComments ? removeJSComments(e.data.build) : e.data.build
+      }
 __utils.flushLogs();
 __userCodeWasExecuted = true;
 __utils.toggleProxyLogger(true);

--- a/client/src/templates/Challenges/classic/Show.js
+++ b/client/src/templates/Challenges/classic/Show.js
@@ -172,7 +172,7 @@ class ShowClassic extends Component {
     updateChallengeMeta({
       ...challengeMeta,
       title,
-      removeComments,
+      removeComments: removeComments !== false,
       challengeType,
       helpCategory
     });

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -87,14 +87,13 @@ export function* executeChallengeSaga({
     const protect = isLoopProtected(challengeMeta);
     const buildData = yield buildChallengeData(challengeData, {
       preview: false,
-      removeComments: challengeMeta.removeComments,
       protect
     });
     const document = yield getContext('document');
     const testRunner = yield call(
       getTestRunner,
       buildData,
-      { proxyLogger },
+      { proxyLogger, removeComments: challengeMeta.removeComments },
       document
     );
     const testResults = yield executeTests(testRunner, tests);
@@ -202,7 +201,6 @@ function* previewChallengeSaga({ flushLogs = true } = {}) {
       const protect = isLoopProtected(challengeMeta);
       const buildData = yield buildChallengeData(challengeData, {
         preview: true,
-        removeComments: challengeMeta.removeComments,
         protect
       });
       // evaluate the user code in the preview frame or in the worker
@@ -210,7 +208,10 @@ function* previewChallengeSaga({ flushLogs = true } = {}) {
         const document = yield getContext('document');
         yield call(updatePreview, buildData, document, proxyLogger);
       } else if (isJavaScriptChallenge(challengeData)) {
-        const runUserCode = getTestRunner(buildData, { proxyLogger });
+        const runUserCode = getTestRunner(buildData, {
+          proxyLogger,
+          removeComments: challengeMeta.removeComments
+        });
         // without a testString the testRunner just evaluates the user's code
         yield call(runUserCode, null, previewTimeout);
       }

--- a/client/src/utils/curriculum-helpers.test.js
+++ b/client/src/utils/curriculum-helpers.test.js
@@ -52,6 +52,11 @@ describe('removeJSComments', () => {
     );
   });
 
+  it('leaves malformed JS unchanged', () => {
+    const actual = '/ unclosed regex';
+    expect(removeJSComments(actual)).toBe(actual);
+  });
+
   it('does not remove a url found in JS code', () => {
     expect(removeJSComments(jsCodeWithUrl)).toBe(jsCodeWithUrlUnchanged);
   });


### PR DESCRIPTION
Another performance PR. This time the objective is to stop @babel libraries from being included everywhere.  To achieve this, I moved the removeJSComments call to just before evaluation from during the build.