### PR TITLE
fix(client): use strip-comments library for js comments removal

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -23847,6 +23847,11 @@
       "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
       "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI="
     },
+    "strip-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-2.0.1.tgz",
+      "integrity": "sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw=="
+    },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -118,6 +118,7 @@
     "sass.js": "0.11.1",
     "store": "2.0.12",
     "stream-browserify": "3.0.0",
+    "strip-comments": "^2.0.1",
     "typescript": "4.2.4",
     "validator": "13.6.0"
   },

--- a/client/src/utils/__fixtures/curriculum-helpers-javascript.js
+++ b/client/src/utils/__fixtures/curriculum-helpers-javascript.js
@@ -12,10 +12,7 @@ nonMutatingPush(first, second);`;
 
 const jsCodeWithSingleAndMultLineCommentsRemoved = `
 function nonMutatingPush(original, newItem) {
-
-
-
-  return original.push(newItem);
+    return original.push(newItem);
 }
 var first = [1, 2, 3];
 
@@ -30,7 +27,7 @@ function nonMutatingPush(original, newItem) {
 
 const jsCodeWithUrlUnchanged = `
 function nonMutatingPush(original, newItem) {
-  var url = 'https://freecodecamp.org';
+  var url = 'https://freecodecamp.org'; 
   return original.push(newItem);
 }`;
 

--- a/client/src/utils/curriculum-helpers.js
+++ b/client/src/utils/curriculum-helpers.js
@@ -1,27 +1,16 @@
-import { parse } from '@babel/parser';
-import generate from '@babel/generator';
-
-const removeHtmlComments = str => str.replace(/<!--[\s\S]*?(-->|$)/g, '');
-
-const removeCssComments = str => str.replace(/\/\*[\s\S]+?\*\//g, '');
+import strip from 'strip-comments';
 
 export const removeJSComments = codeStr => {
-  // Note: removes trailing new lines and tailing spaces at end of lines
-  const options = {
-    comments: false,
-    retainLines: true,
-    compact: false,
-    concise: false,
-    minified: false
-  };
   try {
-    const ast = parse(codeStr);
-    const { code } = generate(ast, options, codeStr);
-    return code;
+    return strip(codeStr);
   } catch (err) {
     return codeStr;
   }
 };
+
+const removeHtmlComments = str => str.replace(/<!--[\s\S]*?(-->|$)/g, '');
+
+const removeCssComments = str => str.replace(/\/\*[\s\S]+?\*\//g, '');
 
 const removeWhiteSpace = (str = '') => {
   return str.replace(/\s/g, '');


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I rearranged the function order in `curriculum-helpers.js` and updated the unit tests to make `npm test` pass.

I didn't add more tests. Simply taking the output from running the lib against some code and testing it against the output of the lib again seems a little counter-intuitive to me.

Related issue https://github.com/freeCodeCamp/freeCodeCamp/issues/41951

---

BTW, is the `config` folder and files inside `client` supposed to be gitignoreed?