### PR TITLE
fix: make renovate rebase when behind on major

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,11 @@
       "matchCurrentVersion": "!/^0/",
       "automerge": true,
       "rebaseWhen": "behind-base-branch"
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "automerge": false,
+      "rebaseWhen": "behind-base-branch"
     }
   ],
   "ignorePaths": [


### PR DESCRIPTION
Tested with the validator this time:

```console
freeCodeCamp on  renovate/rebase-config via ⬢ v14.16.0
❯ renovate-config-validator
 INFO: Validating renovate.json
 INFO: Config validated successfully
`````````
