### PR TITLE
fix(renovate): push major bumps to a non-default branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,7 @@
     },
     {
       "matchUpdateTypes": ["major"],
+      "baseBranches": ["renovate-major"],
       "automerge": false,
       "rebaseWhen": "behind-base-branch"
     }


### PR DESCRIPTION
We would want to use a non-default branch ([`renovate-major`](https://github.com/freeCodeCamp/freeCodeCamp/tree/renovate-major)) for the major bumps. 

This way we can gatekeep the major versions to land when we want, and reduce the CI usage quite a bit, by targeting only crucial updates which need automatic rebasing for instance when the conflict.