### PR TITLE
fix(client): update navbar for Chinese Simplified and Traditional

### DIFF
--- a/client/i18n/locales.test.js
+++ b/client/i18n/locales.test.js
@@ -1,7 +1,6 @@
 /* global expect */
 import {
   availableLangs,
-  i18nextCodes,
   langDisplayNames,
   langCodes
 } from '../../config/i18n/all-langs';
@@ -43,10 +42,6 @@ describe('Locale tests:', () => {
           const exists = fs.existsSync(`${path}/${lang}/${file.name}`);
           expect(exists).toBeTruthy();
         });
-      });
-
-      test(`has a two character entry in the i18nextCodes variable`, () => {
-        expect(i18nextCodes[lang].length).toBe(2);
       });
 
       test(`has an entry in the langDisplayNames variable`, () => {

--- a/config/i18n/all-langs.js
+++ b/config/i18n/all-langs.js
@@ -16,7 +16,7 @@ const i18nextCodes = {
   english: 'en',
   espanol: 'es',
   chinese: 'zh',
-  'chinese-traditional': 'zh'
+  'chinese-traditional': 'zh-Hant'
 };
 
 // These are for the language selector dropdown menu in the footer

--- a/config/i18n/all-langs.js
+++ b/config/i18n/all-langs.js
@@ -23,8 +23,8 @@ const i18nextCodes = {
 const langDisplayNames = {
   english: 'English',
   espanol: 'Español',
-  chinese: '中文',
-  'chinese-traditional': '古文'
+  chinese: '中文（简体字）',
+  'chinese-traditional': '中文（繁體字）'
 };
 
 /* These are for formatting dates and numbers. Used with JS .toLocaleString().


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Should resolve the current bug on staging with the nav bar. The comments in `all-langs.js` say the language code needs to be the two character code, but checking the i18next docs that doesn't seem to be the case. 