### PR TITLE
fix(tools): ignore renovate

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,6 +2,8 @@ name: CodeQL
 
 on:
   push:
+    branches-ignore:
+      - 'renovate/**'
   pull_request:
   schedule:
     - cron: '0 20 * * 5'

--- a/.github/workflows/cypress-push.yml
+++ b/.github/workflows/cypress-push.yml
@@ -1,5 +1,8 @@
 name: Cypress - Push
-on: [push]
+on:
+  push:
+    branches-ignore:
+      - 'renovate/**'
 
 jobs:
   cypress-run:

--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -1,5 +1,9 @@
 name: Node.js CI
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - 'renovate/**'
+  pull_request:
 
 jobs:
   lint:


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
This should prevent Renovate's PRs from triggering multiple workflow runs.

Docs for reference: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-ignoring-branches-and-tags