### PR TITLE
fix(renovate): balance out dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
   "labels": ["renovate"],
   "extends": ["config:base"],
-  "schedule": ["every weekend"],
   "branchConcurrentLimit": 20,
   "dependencyDashboard": true,
   "major": {

--- a/renovate.json
+++ b/renovate.json
@@ -1,18 +1,17 @@
 {
   "labels": ["renovate"],
   "extends": ["config:base"],
+  "schedule": ["every weekend"],
+  "branchConcurrentLimit": 20,
+  "dependencyDashboard": true,
+  "major": {
+    "dependencyDashboardApproval": true
+  },
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "matchCurrentVersion": "!/^0/",
-      "automerge": true,
-      "rebaseWhen": "behind-base-branch"
-    },
-    {
-      "matchUpdateTypes": ["major"],
-      "baseBranches": ["renovate-major"],
-      "automerge": false,
-      "rebaseWhen": "behind-base-branch"
+      "automerge": true
     }
   ],
   "ignorePaths": [


### PR DESCRIPTION
This PR adds some config updates to manage dep PRs better. When merged the final config will ensure that `renovate` bot: 

 - will not bother us on weekdays.
 - will not exceed creating more than 20 branches at any given time.
 - will add updates to a list on an umbrella issue thread (a.k.a "Dependency Dashboard").
 - will not create any updates for any major version bumps unless someone approves it on the umbrella issue. This means we will be able to hold all major updates even before branches are created. Pretty neat actually.
 - will continue to automerge < Major bumps.