### PR TITLE
fix: css and html issues

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/adjust-the-hue-of-a-color.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/adjust-the-hue-of-a-color.md
@@ -30,19 +30,19 @@ Change the `background-color` of each `div` element based on the class names (`g
 Your code should use the `hsl()` property to declare the color `green`.
 
 ```js
-assert(code.match(/\.green\s*?{\s*?background-color:\s*?hsl/gi));
+assert(code.match(/\.green\s*?{\s*?background-color\s*:\s*?hsl/gi));
 ```
 
 Your code should use the `hsl()` property to declare the color `cyan`.
 
 ```js
-assert(code.match(/\.cyan\s*?{\s*?background-color:\s*?hsl/gi));
+assert(code.match(/\.cyan\s*?{\s*?background-color\s*:\s*?hsl/gi));
 ```
 
 Your code should use the `hsl()` property to declare the color `blue`.
 
 ```js
-assert(code.match(/\.blue\s*?{\s*?background-color:\s*?hsl/gi));
+assert(code.match(/\.blue\s*?{\s*?background-color\s*:\s*?hsl/gi));
 ```
 
 The `div` element with class `green` should have a `background-color` of green.

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/give-a-background-color-to-a-div-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/give-a-background-color-to-a-div-element.md
@@ -40,7 +40,7 @@ assert($('div').css('background-color') === 'rgb(192, 192, 192)');
 A class named `silver-background` should be defined within the `style` element and the value of `silver` should be assigned to the `background-color` property.
 
 ```js
-assert(code.match(/\.silver-background\s*{\s*background-color\s*:\s*silver;?\s*}/));
+assert(code.match(/\.silver-background\s*{\s*background-color\s*:\s*silver\s*;?\s*}/));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/give-a-background-color-to-a-div-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/give-a-background-color-to-a-div-element.md
@@ -40,7 +40,7 @@ assert($('div').css('background-color') === 'rgb(192, 192, 192)');
 A class named `silver-background` should be defined within the `style` element and the value of `silver` should be assigned to the `background-color` property.
 
 ```js
-assert(code.match(/\.silver-background\s*{\s*background-color:\s*silver;\s*}/));
+assert(code.match(/\.silver-background\s*{\s*background-color\s*:\s*silver;?\s*}/));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/prioritize-one-style-over-another.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/prioritize-one-style-over-another.md
@@ -32,7 +32,7 @@ assert($('h1').hasClass('pink-text'));
 Your `<style>` should have a `pink-text` CSS class that changes the `color`.
 
 ```js
-assert(code.match(/\.pink-text\s*\{\s*color\s*:\s*.+\s*;\s*\}/g));
+assert(code.match(/\.pink-text\s*\{\s*color\s*:\s*.+\s*;?\s*\}/g));
 ```
 
 Your `h1` element should be pink.

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/size-your-images.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/size-your-images.md
@@ -31,8 +31,8 @@ Your `img` element should have the class `smaller-image`.
 
 ```js
 assert(
-  $("img[src='https://bit.ly/fcc-relaxing-cat']").attr('class') ===
-    'smaller-image'
+  $("img[src='https://bit.ly/fcc-relaxing-cat']").attr('class')
+    .trim().split(/\s+/g).includes('smaller-image')
 );
 ```
 

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/specify-how-fonts-should-degrade.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/specify-how-fonts-should-degrade.md
@@ -47,7 +47,7 @@ Your h2 element should degrade to the font `monospace` when `Lobster` is not ava
 
 ```js
 assert(
-  /\s*h2\s*\{\s*font-family\:\s*(\'|")?Lobster(\'|")?,\s*monospace\s*;\s*\}/gi.test(
+  /\s*h2\s*\{\s*font-family\s*\:\s*(\'|"|)Lobster\1\s*,\s*monospace\s*;?\s*\}/gi.test(
     code
   )
 );

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/understand-absolute-versus-relative-units.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/understand-absolute-versus-relative-units.md
@@ -37,7 +37,7 @@ assert(
 Your `red-box` class should give elements 1.5em of `padding`.
 
 ```js
-assert(code.match(/\.red-box\s*?{[\s\S]*padding:\s*?1\.5em/gi));
+assert(code.match(/\.red-box\s*?{[\s\S]*padding\s*:\s*?1\.5em/gi));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-a-css-class-to-style-an-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-a-css-class-to-style-an-element.md
@@ -46,7 +46,7 @@ assert($('h2').hasClass('red-text'));
 Your stylesheet should declare a `red-text` class and have its color set to `red`.
 
 ```js
-assert(code.match(/\.red-text\s*\{\s*color\s*:\s*red;\s*\}/g));
+assert(code.match(/\.red-text\s*\{\s*color\s*:\s*red;?\s*\}/g));
 ```
 
 You should not use inline style declarations like `style="color: red"` in your `h2` element.

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-abbreviated-hex-code.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-abbreviated-hex-code.md
@@ -32,7 +32,7 @@ assert($('.red-text').css('color') === 'rgb(255, 0, 0)');
 The abbreviated `hex code` for the color red should be used instead of the hex code `#FF0000`.
 
 ```js
-assert(code.match(/\.red-text\s*?{\s*?color:\s*?#F00\s*?;\s*?}/gi));
+assert(code.match(/\.red-text\s*?{\s*?color\s*:\s*?#F00\s*?;?\s*?}/gi));
 ```
 
 Your `h1` element with the text `I am green!` should be given the `color` green.
@@ -44,7 +44,7 @@ assert($('.green-text').css('color') === 'rgb(0, 255, 0)');
 The abbreviated `hex code` for the color green should be used instead of the hex code `#00FF00`.
 
 ```js
-assert(code.match(/\.green-text\s*?{\s*?color:\s*?#0F0\s*?;\s*?}/gi));
+assert(code.match(/\.green-text\s*?{\s*?color\s*:\s*?#0F0\s*?;?\s*?}/gi));
 ```
 
 Your `h1` element with the text `I am cyan!` should be given the `color` cyan.
@@ -56,7 +56,7 @@ assert($('.cyan-text').css('color') === 'rgb(0, 255, 255)');
 The abbreviated `hex code` for the color cyan should be used instead of the hex code `#00FFFF`.
 
 ```js
-assert(code.match(/\.cyan-text\s*?{\s*?color:\s*?#0FF\s*?;\s*?}/gi));
+assert(code.match(/\.cyan-text\s*?{\s*?color\s*:\s*?#0FF\s*?;?\s*?}/gi));
 ```
 
 Your `h1` element with the text `I am fuchsia!` should be given the `color` fuchsia.
@@ -68,7 +68,7 @@ assert($('.fuchsia-text').css('color') === 'rgb(255, 0, 255)');
 The abbreviated `hex code` for the color fuchsia should be used instead of the hex code `#FF00FF`.
 
 ```js
-assert(code.match(/\.fuchsia-text\s*?{\s*?color:\s*?#F0F\s*?;\s*?}/gi));
+assert(code.match(/\.fuchsia-text\s*?{\s*?color\s*:\s*?#F0F\s*?;?\s*?}/gi));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-hex-code-to-mix-colors.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-hex-code-to-mix-colors.md
@@ -36,7 +36,7 @@ assert($('.red-text').css('color') === 'rgb(255, 0, 0)');
 The `hex code` for the color red should be used instead of the word `red`.
 
 ```js
-assert(code.match(/\.red-text\s*?{\s*?color:\s*?(#FF0000|#F00)\s*?;\s*?}/gi));
+assert(code.match(/\.red-text\s*?{\s*?color\s*:\s*?(#FF0000|#F00)\s*?;?\s*?}/gi));
 ```
 
 Your `h1` element with the text `I am green!` should be given the `color` green.
@@ -48,7 +48,7 @@ assert($('.green-text').css('color') === 'rgb(0, 255, 0)');
 The `hex code` for the color green should be used instead of the word `green`.
 
 ```js
-assert(code.match(/\.green-text\s*?{\s*?color:\s*?(#00FF00|#0F0)\s*?;\s*?}/gi));
+assert(code.match(/\.green-text\s*?{\s*?color\s*:\s*?(#00FF00|#0F0)\s*?;?\s*?}/gi));
 ```
 
 Your `h1` element with the text `I am dodger blue!` should be given the `color` dodger blue.
@@ -60,7 +60,7 @@ assert($('.dodger-blue-text').css('color') === 'rgb(30, 144, 255)');
 The `hex code` for the color dodger blue should be used instead of the word `dodgerblue`.
 
 ```js
-assert(code.match(/\.dodger-blue-text\s*?{\s*?color:\s*?#1E90FF\s*?;\s*?}/gi));
+assert(code.match(/\.dodger-blue-text\s*?{\s*?color\s*:\s*?#1E90FF\s*?;?\s*?}/gi));
 ```
 
 Your `h1` element with the text `I am orange!` should be given the `color` orange.
@@ -72,7 +72,7 @@ assert($('.orange-text').css('color') === 'rgb(255, 165, 0)');
 The `hex code` for the color orange should be used instead of the word `orange`.
 
 ```js
-assert(code.match(/\.orange-text\s*?{\s*?color:\s*?#FFA500\s*?;\s*?}/gi));
+assert(code.match(/\.orange-text\s*?{\s*?color\s*:\s*?#FFA500\s*?;?\s*?}/gi));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/use-rgb-to-mix-colors.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/use-rgb-to-mix-colors.md
@@ -30,7 +30,7 @@ You should use `rgb` for the color red.
 ```js
 assert(
   code.match(
-    /\.red-text\s*?{\s*?color:\s*?rgb\(\s*?255\s*?,\s*?0\s*?,\s*?0\s*?\)\s*?;\s*?}/gi
+    /\.red-text\s*{\s*color\s*:\s*rgb\(\s*255\s*,\s*0\s*,\s*0\s*\)\s*;?\s*}/gi
   )
 );
 ```
@@ -46,7 +46,7 @@ You should use `rgb` for the color orchid.
 ```js
 assert(
   code.match(
-    /\.orchid-text\s*?{\s*?color:\s*?rgb\(\s*?218\s*?,\s*?112\s*?,\s*?214\s*?\)\s*?;\s*?}/gi
+    /\.orchid-text\s*{\s*color\s*:\s*rgb\(\s*218\s*,\s*112\s*,\s*214\s*\)\s*;?\s*}/gi
   )
 );
 ```
@@ -62,7 +62,7 @@ You should use `rgb` for the color blue.
 ```js
 assert(
   code.match(
-    /\.blue-text\s*?{\s*?color:\s*?rgb\(\s*?0\s*?,\s*?0\s*?,\s*?255\s*?\)\s*?;\s*?}/gi
+    /\.blue-text\s*{\s*color\s*:\s*rgb\(\s*0\s*,\s*0\s*,\s*255\s*\)\s*;?\s*}/gi
   )
 );
 ```
@@ -78,7 +78,7 @@ You should use `rgb` for the color sienna.
 ```js
 assert(
   code.match(
-    /\.sienna-text\s*?{\s*?color:\s*?rgb\(\s*?160\s*?,\s*?82\s*?,\s*?45\s*?\)\s*?;\s*?}/gi
+    /\.sienna-text\s*{\s*color\s*:\s*rgb\(\s*160\s*,\s*82\s*,\s*45\s*\)\s*;?\s*}/gi
   )
 );
 ```

--- a/curriculum/challenges/english/03-front-end-libraries/sass/store-data-with-sass-variables.md
+++ b/curriculum/challenges/english/03-front-end-libraries/sass/store-data-with-sass-variables.md
@@ -39,13 +39,13 @@ Create a variable `$text-color` and set it to `red`. Then change the value of th
 Your code should have a Sass variable declared for `$text-color` with a value of `red`.
 
 ```js
-assert(code.match(/\$text-color\s*:\s*?red;/g));
+assert(code.match(/\$text-color\s*:\s*?red\s*;/g));
 ```
 
 Your code should use the `$text-color` variable to change the `color` for the `.blog-post` and `h2` items.
 
 ```js
-assert(code.match(/color:\s*?\$text-color;/g));
+assert(code.match(/color\s*:\s*\$text-color\s*;?/g));
 ```
 
 Your `.blog-post` element should have a `color` of red.

--- a/curriculum/challenges/english/03-front-end-libraries/sass/store-data-with-sass-variables.md
+++ b/curriculum/challenges/english/03-front-end-libraries/sass/store-data-with-sass-variables.md
@@ -39,7 +39,7 @@ Create a variable `$text-color` and set it to `red`. Then change the value of th
 Your code should have a Sass variable declared for `$text-color` with a value of `red`.
 
 ```js
-assert(code.match(/\$text-color:\s*?red;/g));
+assert(code.match(/\$text-color\s*:\s*?red;/g));
 ```
 
 Your code should use the `$text-color` variable to change the `color` for the `.blog-post` and `h2` items.

--- a/curriculum/challenges/english/04-data-visualization/data-visualization-with-d3/add-a-hover-effect-to-a-d3-element.md
+++ b/curriculum/challenges/english/04-data-visualization/data-visualization-with-d3/add-a-hover-effect-to-a-d3-element.md
@@ -21,7 +21,7 @@ Use the `attr()` method to add a class of `bar` to all the `rect` elements. This
 Your `rect` elements should have a class of `bar`.
 
 ```js
-assert($('rect').attr('class') == 'bar');
+assert($('rect').attr('class').trim().split(/\s+/g).includes('bar'));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/04-data-visualization/data-visualization-with-d3/add-classes-with-d3.md
+++ b/curriculum/challenges/english/04-data-visualization/data-visualization-with-d3/add-classes-with-d3.md
@@ -27,7 +27,7 @@ Add the `attr()` method to the code in the editor and put a class of `bar` on th
 Your `div` elements should have a class of `bar`.
 
 ```js
-assert($('div').attr('class') == 'bar');
+assert($('div').attr('class').trim().split(/\s+/g).includes('bar'));
 ```
 
 Your code should use the `attr()` method.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #41921

<!-- Feel free to add any additional description of changes below this line -->

Trims the class attr on HTML elements before assertion.

> A string containing a set of space-separated tokens may have leading or trailing ASCII whitespace.
> \- https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#set-of-space-separated-tokens

Allows whitespaces before the colon between the CSS property and value.

> Both properties and values are case-insensitive by default in CSS. The pair is separated by a colon, ':' (U+003A COLON), and white spaces before, between, and after properties and values, but not necessarily inside, are ignored.
> \- https://developer.mozilla.org/en-US/docs/Web/CSS/Syntax#css_declarations

Makes the semi-colon of tests that test a block with a single property optional.

> The last declaration of a block doesn't need to be terminated by a semi-colon, though it is often considered good style to do it as it prevents forgetting to add it when extending the block with another declaration.
> \- https://developer.mozilla.org/en-US/docs/Web/CSS/Syntax#css_declarations

Previously tests that checked if an HTML element had a class would only check the literal value of the attribute. That behavior makes the test fail if the user added multiple classes to the element. This checks if it has _at least_ the target class, and still passes if the element has other classes.