### PR TITLE
removed un-used client e2e script from root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "start": "npm-run-all ensure-env -p develop:server serve:client",
     "test": "npm-run-all -p test:*",
     "test:client": "cd ./client && npm test && cd ../",
-    "test:client:e2e": "cd ./client && npm run e2e:ci && cd ../",
     "test:curriculum": "cd ./curriculum && npm test && cd ../",
     "test:guide-formatting": "node ./tools/scripts/ci/ensure-guide-formatting.js",
     "test:lint": "echo 'Warning: TODO - Define Linting tests.'",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

I was poking around in the project, and I was curious about running end to end tests and how they were set up. I tried to run the e2e script that was defined int he root package.json and got an error. Then I noticed that the root script was trying to run another script inside the client project, which did not exist. 

I think this is an error, since I did not see any end to end tests inside of the client project, so I thought deleting it made sense. Feel free to reject this PR though if I missed something which is totally possible. This is my first time really taking a look at the codebase. 

Thanks!