### PR TITLE
fix(curriculum): rework Project Euler 75

### DIFF
--- a/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-75-singular-integer-right-triangles.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-75-singular-integer-right-triangles.md
@@ -75,5 +75,43 @@ singularIntRightTriangles(48);
 # --solutions--
 
 ```js
-// solution required
+function singularIntRightTriangles(limit) {
+  function euclidFormula(m, n) {
+    return [m ** 2 - n ** 2, 2 * m * n, m ** 2 + n ** 2];
+  }
+
+  function gcd(numberA, numberB) {
+    if (numberB === 0) {
+      return numberA;
+    }
+    return gcd(numberB, numberA % numberB);
+  }
+
+  function notBothOdd(numberA, numberB) {
+    return (numberA + numberB) % 2 === 1;
+  }
+
+  function areCoprime(numberA, numberB) {
+    return gcd(numberA, numberB) === 1;
+  }
+
+  const trianglesWithPerimeter = new Array(limit + 1).fill(0);
+  const mLimit = Math.sqrt(limit / 2);
+
+  for (let m = 2; m < mLimit; m++) {
+    for (let n = 1; n < m; n++) {
+      if (notBothOdd(m, n) && areCoprime(m, n)) {
+        const [sideA, sideB, sideC] = euclidFormula(m, n);
+        const perimeter = sideA + sideB + sideC;
+        let curPerimeter = perimeter;
+        while (curPerimeter <= limit) {
+          trianglesWithPerimeter[curPerimeter]++;
+          curPerimeter += perimeter;
+        }
+      }
+    }
+  }
+  return trianglesWithPerimeter.filter(trianglesCount => trianglesCount === 1)
+    .length;
+}
 ```

--- a/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-75-singular-integer-right-triangles.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-75-singular-integer-right-triangles.md
@@ -16,13 +16,13 @@ It turns out that 12 cm is the smallest length of wire that can be bent to form 
   <strong>30 cm:</strong> (5,12,13)<br>
   <strong>36 cm:</strong> (9,12,15)<br>
   <strong>40 cm:</strong> (8,15,17)<br>
-  <strong>48 cm:</strong> (12,16,20)<br>
+  <strong>48 cm:</strong> (12,16,20)<br><br>
 </div>
 
 In contrast, some lengths of wire, like 20 cm, cannot be bent to form an integer sided right angle triangle, and other lengths allow more than one solution to be found; for example, using 120 cm it is possible to form exactly three different integer sided right angle triangles.
 
 <div style='margin-left: 4em;'>
-  <strong>120 cm:</strong> (30,40,50), (20,48,52), (24,45,51)
+  <strong>120 cm:</strong> (30,40,50), (20,48,52), (24,45,51)<br><br>
 </div>
 
 Given that L is the length of the wire, for how many values of L ≤ `n` can exactly one, integer sided right angle, triangle be formed?

--- a/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-75-singular-integer-right-triangles.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-75-singular-integer-right-triangles.md
@@ -25,20 +25,38 @@ In contrast, some lengths of wire, like 20 cm, cannot be bent to form an integer
   <strong>120 cm:</strong> (30,40,50), (20,48,52), (24,45,51)
 </div>
 
-Given that L is the length of the wire, for how many values of L ≤ 1,500,000 can exactly one integer sided right angle triangle be formed?
+Given that L is the length of the wire, for how many values of L ≤ `n` can exactly one, integer sided right angle, triangle be formed?
 
 # --hints--
 
-`singularIntRightTriangles()` should return a number.
+`singularIntRightTriangles(48)` should return a number.
 
 ```js
-assert(typeof singularIntRightTriangles() === 'number');
+assert(typeof singularIntRightTriangles(48) === 'number');
 ```
 
-`singularIntRightTriangles()` should return 161667.
+`singularIntRightTriangles(48)` should return `6`.
 
 ```js
-assert.strictEqual(singularIntRightTriangles(), 161667);
+assert.strictEqual(singularIntRightTriangles(48), 6);
+```
+
+`singularIntRightTriangles(700000)` should return `75783`.
+
+```js
+assert.strictEqual(singularIntRightTriangles(700000), 75783);
+```
+
+`singularIntRightTriangles(1000000)` should return `107876`.
+
+```js
+assert.strictEqual(singularIntRightTriangles(1000000), 107876);
+```
+
+`singularIntRightTriangles(1500000)` should return `161667`.
+
+```js
+assert.strictEqual(singularIntRightTriangles(1500000), 161667);
 ```
 
 # --seed--
@@ -46,12 +64,12 @@ assert.strictEqual(singularIntRightTriangles(), 161667);
 ## --seed-contents--
 
 ```js
-function singularIntRightTriangles() {
+function singularIntRightTriangles(n) {
 
   return true;
 }
 
-singularIntRightTriangles();
+singularIntRightTriangles(48);
 ```
 
 # --solutions--


### PR DESCRIPTION
- Reworks challenge to use argument in function call.
- Adds two commas to make instructions more readable.
- Adds `<br>` in two places to make blocks appear evenly between adjoin paragraphs. This is a bit hacky, not sure if too hacky.
- Adds more tests.
- Adds solution.
- Related to #40896.
- Tested on local fork.

Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.