### PR TITLE
fix: navbar avatar height, background colors

### DIFF
--- a/client/src/components/Header/components/universalNav.css
+++ b/client/src/components/Header/components/universalNav.css
@@ -196,6 +196,11 @@
   width: 31px;
 }
 
+.navatar .avatar-nav-link:hover,
+.navatar .avatar-nav-link:focus {
+  background-color: var(--theme-color);
+}
+
 .navatar .default-border {
   border: none;
 }

--- a/client/src/components/Header/components/universalNav.css
+++ b/client/src/components/Header/components/universalNav.css
@@ -205,6 +205,10 @@
   background: var(--secondary-background);
 }
 
+.navatar .avatar-container {
+  height: 100%;
+}
+
 .navatar .avatar-container svg,
 .navatar .avatar-container img {
   object-fit: cover;

--- a/cypress/integration/learn/common-components/navbar.js
+++ b/cypress/integration/learn/common-components/navbar.js
@@ -6,7 +6,8 @@ const selectors = {
   navigationLinks: '.nav-list',
   avatarContainer: '.avatar-container',
   defaultAvatar: '.avatar-container',
-  menuButton: '.toggle-button-nav'
+  menuButton: '.toggle-button-nav',
+  avatarImage: '.avatar-container .avatar'
 };
 
 let appHasStarted;
@@ -98,5 +99,11 @@ describe('Navbar', () => {
     cy.login();
     cy.get(selectors.avatarContainer).should('have.class', 'default-border');
     cy.get(selectors.defaultAvatar).should('exist');
+  });
+
+  it('Should have a profile image with dimensions that are <= 31px', () => {
+    cy.login();
+    cy.get(selectors.avatarImage).invoke('width').should('lte', 31);
+    cy.get(selectors.avatarImage).invoke('height').should('lte', 31);
   });
 });


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

We got a report in the support inbox that profile photos that aren't square may overflow the navbar container:

![image](https://user-images.githubusercontent.com/2051070/117620684-ad4d9980-b1ab-11eb-9e5c-df604d71ddb0.png)

This fix does a few things:
- Adds `height: 100%` to `.navatar .avatar-container`
- Adds a test to check the height of the navbar avatar image
- Prevents `.avatar-nav-link` from changing colors when the navbar avatar is hovered over.

For the last point, there seems to be a slight gap between the border (if a donor or team memeber) and the avatar image in Chrome, which may cause the background color to change in light mode:

![image](https://user-images.githubusercontent.com/2051070/117622824-07e7f500-b1ae-11eb-89a3-51895f37d93e.png)

Here's the image I used for testing: https://images.unsplash.com/photo-1620575472918-82cb3be4f0b2?ixid=MnwxMjA3fDB8MHxlZGl0b3JpYWwtZmVlZHwzMnx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=600&q=60

Not sure if this is the best approach, so just let me know if there's a better way to limit the image height or handle the slight gap in Chrome.