### PR TITLE
fix(client): footer inconsistency when visiting /learn 

### DIFF
--- a/client/utils/gatsby/layoutSelector.js
+++ b/client/utils/gatsby/layoutSelector.js
@@ -26,11 +26,12 @@ export default function layoutSelector({ element, props }) {
   }
 
   const splitPath = pathname.split('/').filter(x => x);
-  const isSuperBlock =
-    (splitPath.length === 2 && splitPath[0]) === 'learn' ||
-    (splitPath.length === 3 && splitPath[1]) === 'learn';
 
-  if (/\/learn\//.test(pathname) && !isSuperBlock) {
+  const isChallenge =
+    (splitPath.length === 4 && splitPath[0]) === 'learn' ||
+    (splitPath.length === 5 && splitPath[1]) === 'learn';
+
+  if (isChallenge) {
     return (
       <DefaultLayout pathname={pathname} showFooter={false}>
         {element}

--- a/cypress/integration/learn/common-components/footer.js
+++ b/cypress/integration/learn/common-components/footer.js
@@ -1,0 +1,31 @@
+/* global cy */
+
+const selectors = {
+  footer: '.site-footer'
+};
+
+describe('Footer', () => {
+  it('Should render on landing page', () => {
+    cy.visit('/');
+    cy.get(selectors.footer).should('be.visible');
+  });
+
+  it('Should render on learn page', () => {
+    cy.visit('/learn');
+    cy.get(selectors.footer).should('be.visible');
+    cy.visit('/learn/');
+    cy.get(selectors.footer).should('be.visible');
+  });
+
+  it('Should render on superblock page', () => {
+    cy.visit('/learn/responsive-web-design/');
+    cy.get(selectors.footer).should('be.visible');
+  });
+
+  it('Should not render on challenge page', () => {
+    cy.visit(
+      '/learn/responsive-web-design/basic-html-and-html5/say-hello-to-html-elements'
+    );
+    cy.get(selectors.footer).should('not.exist');
+  });
+});


### PR DESCRIPTION
Before this If we navigate to menu and select curriculum we saw Footer and then if we refresh the page the browser would put / at the end of URL and it would look like **/learn/** and this time we wont see the Footer. So I edit the regex and make it to not show Footer even if it has / at the end of URL.

Look at the example which run in prev code and new one:
```diff
- /\/learn\//.test('/learn') // false
+ /\/learn\/?/.test('/learn/') // true
```
So in both situation we wont see Footer on this page.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

Closes #41922 
