### PR TITLE
Revert "fix(client): use strip-comments library for js comments removal (#41960)"

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -23673,11 +23673,6 @@
       "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
       "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI="
     },
-    "strip-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-2.0.1.tgz",
-      "integrity": "sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw=="
-    },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -119,7 +119,6 @@
     "sass.js": "0.11.1",
     "store": "2.0.12",
     "stream-browserify": "3.0.0",
-    "strip-comments": "2.0.1",
     "typescript": "4.2.4",
     "validator": "13.6.0"
   },

--- a/client/src/utils/__fixtures/curriculum-helpers-javascript.js
+++ b/client/src/utils/__fixtures/curriculum-helpers-javascript.js
@@ -12,7 +12,10 @@ nonMutatingPush(first, second);`;
 
 const jsCodeWithSingleAndMultLineCommentsRemoved = `
 function nonMutatingPush(original, newItem) {
-    return original.push(newItem);
+
+
+
+  return original.push(newItem);
 }
 var first = [1, 2, 3];
 
@@ -27,7 +30,7 @@ function nonMutatingPush(original, newItem) {
 
 const jsCodeWithUrlUnchanged = `
 function nonMutatingPush(original, newItem) {
-  var url = 'https://freecodecamp.org'; 
+  var url = 'https://freecodecamp.org';
   return original.push(newItem);
 }`;
 

--- a/client/src/utils/curriculum-helpers.js
+++ b/client/src/utils/curriculum-helpers.js
@@ -1,16 +1,27 @@
-import strip from 'strip-comments';
-
-export const removeJSComments = codeStr => {
-  try {
-    return strip(codeStr);
-  } catch (err) {
-    return codeStr;
-  }
-};
+import { parse } from '@babel/parser';
+import generate from '@babel/generator';
 
 const removeHtmlComments = str => str.replace(/<!--[\s\S]*?(-->|$)/g, '');
 
 const removeCssComments = str => str.replace(/\/\*[\s\S]+?\*\//g, '');
+
+export const removeJSComments = codeStr => {
+  // Note: removes trailing new lines and tailing spaces at end of lines
+  const options = {
+    comments: false,
+    retainLines: true,
+    compact: false,
+    concise: false,
+    minified: false
+  };
+  try {
+    const ast = parse(codeStr);
+    const { code } = generate(ast, options, codeStr);
+    return code;
+  } catch (err) {
+    return codeStr;
+  }
+};
 
 const removeWhiteSpace = (str = '') => {
   return str.replace(/\s/g, '');


### PR DESCRIPTION
…al (#41960)"

This reverts commit b16fadb4361ea8b753c9c6213ce47d92d943dd49.

Temporary mitigation of https://github.com/freeCodeCamp/freeCodeCamp/issues/42101