### PR TITLE
test: run sequentially

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "start-ci": "npm-run-all ensure-env -p start:server serve:client",
     "start:server": "cd ./api-server && npm start",
     "storybook": "cd ./tools/ui-components && npm run storybook",
-    "test": "npm-run-all ensure-env build:curriculum build-workers -p test:*",
+    "test": "run-s ensure-env build:curriculum build-workers test:*",
     "test-curriculum-full-output": "cd ./curriculum && npm run test:full-output",
     "test:client": "cd ./client && npm test",
     "test:curriculum": "cd ./curriculum && npm test",


### PR DESCRIPTION
Running tests in parallel while outputting to a single console can
result in confusing output.  Results can get interleaved and, more
importantly, if one test fails, the rest get killed. This can create
unpredictable error messages.

See, for example: https://github.com/freeCodeCamp/freeCodeCamp/pull/42124#issuecomment-841217255
