### PR TITLE
fix(editor): Remove keybind of intellisense

### DIFF
--- a/client/src/templates/Challenges/classic/Editor.js
+++ b/client/src/templates/Challenges/classic/Editor.js
@@ -189,7 +189,8 @@ class Editor extends Component {
       lightbulb: {
         enabled: false
       },
-      quickSuggestions: false
+      quickSuggestions: false,
+      suggestOnTriggerCharacters: false
     };
 
     this._editor = null;

--- a/client/src/templates/Challenges/classic/Editor.js
+++ b/client/src/templates/Challenges/classic/Editor.js
@@ -253,6 +253,11 @@ class Editor extends Component {
       // TODO: only one Editor should be calling for focus at once.
       editor.focus();
     } else this.focusOnHotkeys();
+    editor._standaloneKeybindingService.addDynamicKeybinding(
+      '-editor.action.triggerSuggest',
+      null,
+      () => {}
+    );
     editor.addAction({
       id: 'execute-challenge',
       label: 'Run tests',

--- a/client/src/templates/Challenges/classic/Editor.js
+++ b/client/src/templates/Challenges/classic/Editor.js
@@ -253,6 +253,7 @@ class Editor extends Component {
       // TODO: only one Editor should be calling for focus at once.
       editor.focus();
     } else this.focusOnHotkeys();
+    // Removes keybind for intellisense
     editor._standaloneKeybindingService.addDynamicKeybinding(
       '-editor.action.triggerSuggest',
       null,
@@ -298,11 +299,6 @@ class Editor extends Component {
         });
       }
     });
-    // Overrides Intellisense suggestion box
-    editor.addCommand(
-      monaco.KeyMod.CtrlCmd | monaco.KeyCode.Space,
-      function () {}
-    );
     editor.onDidFocusEditorWidget(() => this.props.setEditorFocusability(true));
     // This is to persist changes caused by the accessibility tooltip.
     editor.onDidChangeConfiguration(event => {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #41533 

<!-- Feel free to add any additional description of changes below this line -->

This fix removes the keybind itself but the user can still access it through command palette.
