### PR TITLE
fix: insert user html more consistently

### DIFF
--- a/client/src/templates/Challenges/rechallenge/builders.js
+++ b/client/src/templates/Challenges/rechallenge/builders.js
@@ -14,13 +14,6 @@ import {
   transformContents
 } from '../../../../../utils/polyvinyl';
 
-const defaultTemplate = ({ source }) => {
-  return `
-  <body id='display-body'>
-    ${source}
-  </body>`;
-};
-
 const wrapInScript = partial(
   transformContents,
   content => `<script>${content}</script>`
@@ -67,7 +60,7 @@ export function concatHtml({
   template,
   challengeFiles = []
 } = {}) {
-  const createBody = template ? _template(template) : defaultTemplate;
+  const embedSource = template ? _template(template) : ({ source }) => source;
   const head = required
     .map(({ link, src }) => {
       if (link && src) {
@@ -99,5 +92,5 @@ A required file can not have both a src and a link: src = ${src}, link = ${link}
     }
   }, '');
 
-  return `<head>${head}</head>${createBody({ source })}`;
+  return `<head>${head}</head>${embedSource({ source })}`;
 }

--- a/client/src/templates/Challenges/utils/frame.js
+++ b/client/src/templates/Challenges/utils/frame.js
@@ -152,6 +152,7 @@ const waitForFrame = ctx => {
   });
 };
 
+// TODO: try replacing with frame.documentElement.innerHTML = content;
 function writeToFrame(content, frame) {
   frame.open();
   frame.write(content);

--- a/client/src/templates/Challenges/utils/frame.js
+++ b/client/src/templates/Challenges/utils/frame.js
@@ -152,7 +152,6 @@ const waitForFrame = ctx => {
   });
 };
 
-// TODO: try replacing with frame.documentElement.innerHTML = content;
 function writeToFrame(content, frame) {
   frame.open();
   frame.write(content);

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/step-002.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/step-002.md
@@ -19,13 +19,13 @@ You should create a `meta` element within the `head` element.
 
 ```js
 // TODO: Once builder is fixed so head info is not in body
-assert.exists(document.querySelector('body > meta'));
+assert.exists(document.querySelector('head > meta'));
 ```
 
 You should give the `meta` tag a `charset` of `UTF-8`.
 
 ```js
-assert.equal(document.querySelector('body > meta')?.getAttribute('charset'), 'UTF-8');
+assert.equal(document.querySelector('head > meta')?.getAttribute('charset'), 'UTF-8');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/step-003.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/step-003.md
@@ -16,20 +16,20 @@ Add a `viewport` definition with a `content` attribute detailing the `width` and
 You should create another `meta` element in the `head`.
 
 ```js
-assert.equal(document.querySelectorAll('body > meta')?.length, 2);
+assert.equal(document.querySelectorAll('head > meta')?.length, 2);
 ```
 
 You should give the `meta` a `name` attribute of `viewport`.
 
 ```js
-assert.equal(document.querySelectorAll('body > meta[name="viewport"]')?.length, 1);
+assert.equal(document.querySelectorAll('head > meta[name="viewport"]')?.length, 1);
 ```
 
 You should give the `meta` a `content` attribute of `width=device-width, initial-scale=1`.
 
 ```js
 // TODO: Double-check this is the only correct answer
-assert.equal(document.querySelectorAll('body > meta[content="width=device-width, initial-scale=1.0"]')?.length || document.querySelectorAll('body > meta[content="width=device-width, initial-scale=1"]')?.length, 1);
+assert.equal(document.querySelectorAll('head > meta[content="width=device-width, initial-scale=1.0"]')?.length || document.querySelectorAll('body > meta[content="width=device-width, initial-scale=1"]')?.length, 1);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/step-005.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/step-005.md
@@ -17,19 +17,19 @@ You should add a `title` element to the `head`.
 
 ```js
 // TODO: Fix once builder puts head in the right place
-assert.exists(document.querySelector('body > title'));
+assert.exists(document.querySelector('head > title'));
 ```
 
 You should not make the `title` longer than 60 characters.
 
 ```js
-assert.isAtMost(document.querySelector('body > title')?.textContent?.length, 60);
+assert.isAtMost(document.querySelector('head > title')?.textContent?.length, 60);
 ```
 
 Try being more descriptive with your `title` element. _Hint: At least 20 characters_
 
 ```js
-assert.isAtLeast(document.querySelector('body > title')?.textContent?.length, 20);
+assert.isAtLeast(document.querySelector('head > title')?.textContent?.length, 20);
 ```
 
 # --seed--

--- a/curriculum/package.json
+++ b/curriculum/package.json
@@ -25,7 +25,7 @@
     "delete-step": "cross-env CALLING_DIR=$INIT_CWD node ../tools/challenge-helper-scripts/delete-step",
     "lint": "gulp lint",
     "reorder-steps": "cross-env CALLING_DIR=$INIT_CWD node ../tools/challenge-helper-scripts/reorder-steps",
-    "test": "mocha --delay --exit --global Worker --reporter progress --bail",
+    "test": "mocha --delay --exit --global Worker --reporter --timeout 10000 progress --bail",
     "test:full-output": "cross-env FULL_OUTPUT=true mocha --delay --reporter progress"
   },
   "devDependencies": {

--- a/curriculum/package.json
+++ b/curriculum/package.json
@@ -25,7 +25,7 @@
     "delete-step": "cross-env CALLING_DIR=$INIT_CWD node ../tools/challenge-helper-scripts/delete-step",
     "lint": "gulp lint",
     "reorder-steps": "cross-env CALLING_DIR=$INIT_CWD node ../tools/challenge-helper-scripts/reorder-steps",
-    "test": "mocha --delay --exit --global Worker --timeout 10000 s--reporter progress --bail",
+    "test": "mocha --delay --exit --global Worker --timeout 10000 --reporter progress --bail",
     "test:full-output": "cross-env FULL_OUTPUT=true mocha --delay --reporter progress"
   },
   "devDependencies": {

--- a/curriculum/package.json
+++ b/curriculum/package.json
@@ -25,7 +25,7 @@
     "delete-step": "cross-env CALLING_DIR=$INIT_CWD node ../tools/challenge-helper-scripts/delete-step",
     "lint": "gulp lint",
     "reorder-steps": "cross-env CALLING_DIR=$INIT_CWD node ../tools/challenge-helper-scripts/reorder-steps",
-    "test": "mocha --delay --exit --global Worker --timeout 10000 --reporter progress --bail",
+    "test": "mocha --delay --exit --reporter progress --bail",
     "test:full-output": "cross-env FULL_OUTPUT=true mocha --delay --reporter progress"
   },
   "devDependencies": {

--- a/curriculum/package.json
+++ b/curriculum/package.json
@@ -25,7 +25,7 @@
     "delete-step": "cross-env CALLING_DIR=$INIT_CWD node ../tools/challenge-helper-scripts/delete-step",
     "lint": "gulp lint",
     "reorder-steps": "cross-env CALLING_DIR=$INIT_CWD node ../tools/challenge-helper-scripts/reorder-steps",
-    "test": "mocha --delay --exit  --reporter progress --bail",
+    "test": "mocha --delay --exit --global Worker --reporter progress --bail",
     "test:full-output": "cross-env FULL_OUTPUT=true mocha --delay --reporter progress"
   },
   "devDependencies": {

--- a/curriculum/package.json
+++ b/curriculum/package.json
@@ -25,7 +25,7 @@
     "delete-step": "cross-env CALLING_DIR=$INIT_CWD node ../tools/challenge-helper-scripts/delete-step",
     "lint": "gulp lint",
     "reorder-steps": "cross-env CALLING_DIR=$INIT_CWD node ../tools/challenge-helper-scripts/reorder-steps",
-    "test": "mocha --delay --exit --global Worker --reporter --timeout 10000 progress --bail",
+    "test": "mocha --delay --exit --global Worker --timeout 10000 s--reporter progress --bail",
     "test:full-output": "cross-env FULL_OUTPUT=true mocha --delay --reporter progress"
   },
   "devDependencies": {

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -73,6 +73,14 @@ const { flatten, isEmpty, cloneDeep, isEqual } = lodash;
 
 // rethrow unhandled rejections to make sure the tests exit with -1
 process.on('unhandledRejection', err => handleRejection(err));
+// If an uncaught exception gets here, then mocha is in an unexpected state. All
+// we can do is log the exception and exit with a non-zero code.
+process.on('uncaughtException', err => {
+  console.error('Uncaught exception:', err.message);
+  console.error(err.stack);
+  // eslint-disable-next-line no-process-exit
+  process.exit(1);
+});
 
 const handleRejection = err => {
   // setting the error code because node does not (yet) exit with a non-zero

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -649,15 +649,10 @@ async function getContextEvaluator(build, sources, code, loadEnzyme) {
   await initializeTestRunner(build, sources, code, loadEnzyme);
 
   return {
-    evaluate: async (testString, timeout) =>
-      Promise.race([
-        new Promise((_, reject) =>
-          setTimeout(() => reject('timeout'), timeout)
-        ),
-        await page.evaluate(async testString => {
-          return await document.__runTest(testString);
-        }, testString)
-      ])
+    evaluate: async testString =>
+      await page.evaluate(async testString => {
+        return await document.__runTest(testString);
+      }, testString)
   };
 }
 

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -657,10 +657,15 @@ async function getContextEvaluator(build, sources, code, loadEnzyme) {
   await initializeTestRunner(build, sources, code, loadEnzyme);
 
   return {
-    evaluate: async testString =>
-      await page.evaluate(async testString => {
-        return await document.__runTest(testString);
-      }, testString)
+    evaluate: async (testString, timeout) =>
+      Promise.race([
+        new Promise((_, reject) =>
+          setTimeout(() => reject('timeout'), timeout)
+        ),
+        await page.evaluate(async testString => {
+          return await document.__runTest(testString);
+        }, testString)
+      ])
   };
 }
 

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -88,7 +88,7 @@ const handleRejection = err => {
   }
 };
 
-const dom = new jsdom.JSDOM('');
+const dom = new jsdom.JSDOM('', { resources: 'usable' });
 global.document = dom.window.document;
 
 const oldRunnerFail = Mocha.Runner.prototype.fail;

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -73,6 +73,14 @@ const { flatten, isEmpty, cloneDeep, isEqual } = lodash;
 
 // rethrow unhandled rejections to make sure the tests exit with -1
 process.on('unhandledRejection', err => handleRejection(err));
+// If an uncaught exception gets here, then mocha is in an unexpected state. All
+// we can do is log the exception and exit with a non-zero code.
+process.on('uncaughtException', err => {
+  console.error('Uncaught exception:', err.message);
+  console.error(err.stack);
+  // eslint-disable-next-line no-process-exit
+  process.exit(1);
+});
 
 const handleRejection = err => {
   // setting the error code because node does not (yet) exit with a non-zero
@@ -88,7 +96,7 @@ const handleRejection = err => {
   }
 };
 
-const dom = new jsdom.JSDOM('', { resources: 'usable' });
+const dom = new jsdom.JSDOM('');
 global.document = dom.window.document;
 
 const oldRunnerFail = Mocha.Runner.prototype.fail;

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -92,6 +92,8 @@ const handleRejection = err => {
     // first error and that starts shutting down the browser and the server.
     console.error(err);
   } else {
+    console.error('Unhandled exception:', err.message);
+    console.error(err.stack);
     throw err;
   }
 };

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -299,7 +299,7 @@ function populateTestsForLang({ lang, challenges, meta }) {
   });
 
   describe(`Check challenges (${lang})`, function () {
-    this.timeout(5000);
+    this.timeout(10000);
     challenges.forEach((challenge, id) => {
       const dashedBlockName = challenge.block;
       // TODO: once certifications are not included in the list of challenges,

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -553,7 +553,7 @@ ${inspect(commentMap)}
               it(`Solution ${
                 index + 1
               } must pass the tests`, async function () {
-                this.timeout(5000 * tests.length + 2000);
+                this.timeout(10000 * tests.length + 2000);
                 const testRunner = await createTestRunner(
                   challenge,
                   solution,

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -299,7 +299,6 @@ function populateTestsForLang({ lang, challenges, meta }) {
   });
 
   describe(`Check challenges (${lang})`, function () {
-    this.timeout(10000);
     challenges.forEach((challenge, id) => {
       const dashedBlockName = challenge.block;
       // TODO: once certifications are not included in the list of challenges,

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -307,6 +307,7 @@ function populateTestsForLang({ lang, challenges, meta }) {
   });
 
   describe(`Check challenges (${lang})`, function () {
+    this.timeout(5000);
     challenges.forEach((challenge, id) => {
       const dashedBlockName = challenge.block;
       // TODO: once certifications are not included in the list of challenges,


### PR DESCRIPTION
## The issue
One of the problems we've had while writing challenges that inspect the DOM is that everything ends up in the `body` element, even if a user explicitly writes it in the `head`

To reproduce:

1. Go to https://www.freecodecamp.org/learn/responsive-web-design/basic-html-and-html5/say-hello-to-html-elements
2. paste the following into the editor
```html
<head><title>head title</title></head>
<body><title>body title</title></body>
<h1>Hello World</h1>
```
3. inspect the preview pane
4. see (link, script and comments removed for clarity)
```html
<html>
<head></head>
<body id="display-body" style="margin:8px;">
<title>head title</title>
<title>body title</title>
<h1>Hello World</h1>
</body>
</html>
```
5. create an index.html file and insert the original code, you will see:
```html
<html>
<head>
<title>head title</title>
</head>
<body>
<title>body title</title>
<h1>Hello World</h1>
</body>
</html>
```

As a result, we can't tell where `<title>head title</title>` was, it will end up in the body regardless.

## What this PR fixes

By using an `iframe` to parse the user's HTML (which needs to happen for SASS and Babel to work) we can overwrite a `html` element without wiping the entire page.  This preserves the user's `head` tags.

## What this PR doesn't fix

`html` tags are still ignored.  It doesn't seem to be possible to replace the root element entirely. `replaceWith(newHtml)` and similar methods either fail entirely or are no better than replacing the `innerHTML`.

## Why is this a draft?

Since we're not pushing everything into the body, the inline style that sets the body margin to `8px` had to be removed.  We're still discussing what to do about normalise and the inline style was used to restore the Chrome default of `8px`.