### PR TITLE
fix: eslint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,7 @@
     "mocha": true,
     "node": true
   },
-  "parser": "@typescript-eslint/parser",
+  "parser": "babel-eslint",
   "root": true,
   "extends": [
     "./.eslintrc-base.json",
@@ -46,6 +46,7 @@
   },
   "overrides": [{
     "files": ["**/*.ts?(x)"],
+    "parser": "@typescript-eslint/parser",
     "parserOptions": {
       "tsconfigRootDir": "./client",
       "project": ["./tsconfig.json"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,31 @@
         }
       }
     },
+    "@babel/eslint-parser": {
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.14.3.tgz",
+      "integrity": "sha512-IfJXKEVRV/Gisvgmih/+05gkBzzg4Dy0gcxkZ84iFiLK8+O+fI1HLnGJv3UrUMPpsMmmThNa69v+UnF80XP+kA==",
+      "dev": true,
+      "requires": {
+        "eslint-scope": "^5.1.0",
+        "eslint-visitor-keys": "^2.1.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
     "@babel/generator": {
       "version": "7.14.1",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.1.tgz",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "invariant": "2.2.4"
   },
   "devDependencies": {
+    "@babel/eslint-parser": "7.14.3",
     "@babel/plugin-proposal-function-bind": "7.12.13",
     "@babel/preset-env": "7.14.2",
     "@babel/preset-react": "7.13.13",


### PR DESCRIPTION
The typescript parser does not work properly on pure JS and is only
needed for TS files, so this commit restricts @typescript-eslint/parser
to .ts and .tsx files

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
