### PR TITLE
feat: update titles for certification pages

### DIFF
--- a/client/src/templates/Introduction/SuperBlockIntro.js
+++ b/client/src/templates/Introduction/SuperBlockIntro.js
@@ -148,11 +148,14 @@ class SuperBlockIntroductionPage extends Component {
     const nodesForSuperBlock = edges.map(({ node }) => node);
     const blockDashedNames = uniq(nodesForSuperBlock.map(({ block }) => block));
     const i18nSuperBlock = t(`intro:${superBlock}.title`);
+    const i18nCertText = t(`intro:misc-text.certification`, {
+      cert: i18nSuperBlock
+    });
 
     return (
       <>
         <Helmet>
-          <title>{i18nSuperBlock} | freeCodeCamp.org</title>
+          <title>{i18nCertText} | freeCodeCamp.org</title>
         </Helmet>
         <Grid>
           <Row className='super-block-intro-page'>

--- a/client/src/templates/Introduction/SuperBlockIntro.js
+++ b/client/src/templates/Introduction/SuperBlockIntro.js
@@ -148,14 +148,17 @@ class SuperBlockIntroductionPage extends Component {
     const nodesForSuperBlock = edges.map(({ node }) => node);
     const blockDashedNames = uniq(nodesForSuperBlock.map(({ block }) => block));
     const i18nSuperBlock = t(`intro:${superBlock}.title`);
-    const i18nCertText = t(`intro:misc-text.certification`, {
-      cert: i18nSuperBlock
-    });
+    const i18nTitle =
+      superBlock === 'coding-interview-prep'
+        ? i18nSuperBlock
+        : t(`intro:misc-text.certification`, {
+            cert: i18nSuperBlock
+          });
 
     return (
       <>
         <Helmet>
-          <title>{i18nCertText} | freeCodeCamp.org</title>
+          <title>{i18nTitle} | freeCodeCamp.org</title>
         </Helmet>
         <Grid>
           <Row className='super-block-intro-page'>

--- a/cypress/integration/learn/coding-interview-prep/intro-page.js
+++ b/cypress/integration/learn/coding-interview-prep/intro-page.js
@@ -1,0 +1,19 @@
+/* global cy */
+
+describe('Certification intro page', () => {
+  before(() => {
+    cy.clearCookies();
+    cy.login();
+    cy.visit('/learn/coding-interview-prep');
+  });
+
+  it('Should render', () => {
+    cy.contains(
+      "If you're looking for free coding exercises to prepare for your next job interview, we've got you covered."
+    ).should('be.visible');
+  });
+
+  it('Title should not include the word "Certification"', () => {
+    cy.title().should('eq', 'Coding Interview Prep | freeCodeCamp.org');
+  });
+});

--- a/cypress/integration/learn/redirects/challenges.js
+++ b/cypress/integration/learn/redirects/challenges.js
@@ -17,7 +17,10 @@ describe('challenges/superblock redirect', function () {
   it('redirects to learn/superblock', () => {
     cy.visit(locations.chalSuper);
 
-    cy.title().should('eq', 'Responsive Web Design | freeCodeCamp.org');
+    cy.title().should(
+      'eq',
+      'Responsive Web Design Certification | freeCodeCamp.org'
+    );
     cy.location().should(loc => {
       expect(loc.pathname).to.eq(locations.learnSuper);
     });

--- a/cypress/integration/learn/responsive-web-design/intro-page.js
+++ b/cypress/integration/learn/responsive-web-design/intro-page.js
@@ -4,7 +4,7 @@ const selectors = {
   firstBlock: '.block-ui > .block:nth-child(1) > .map-title'
 };
 
-describe('Certificate intro page', () => {
+describe('Certification intro page', () => {
   before(() => {
     cy.clearCookies();
     cy.login();
@@ -18,7 +18,7 @@ describe('Certificate intro page', () => {
     );
   });
 
-  it('Should have certificate intro text', () => {
+  it('Should have certification intro text', () => {
     cy.contains(
       "In this Responsive Web Design Certification, you'll learn the languages that developers use to build webpages"
     ).should('be.visible');

--- a/cypress/integration/learn/responsive-web-design/intro-page.js
+++ b/cypress/integration/learn/responsive-web-design/intro-page.js
@@ -12,7 +12,10 @@ describe('Certificate intro page', () => {
   });
 
   it('Should render', () => {
-    cy.title().should('eq', 'Responsive Web Design | freeCodeCamp.org');
+    cy.title().should(
+      'eq',
+      'Responsive Web Design Certification | freeCodeCamp.org'
+    );
   });
 
   it('Should have certificate intro text', () => {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This PR updates the `<title>` for each certification page to include the word "Certification" for SEO purposes.

For example, `Responsive Web Design Certification | freeCodeCamp.org` rather than `Responsive Web Design | freeCodeCamp.org` like we currently have.
