### PR TITLE
fix(client): use @freecodecamp/strip-comments for js comments

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1569,6 +1569,11 @@
         }
       }
     },
+    "@freecodecamp/strip-comments": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@freecodecamp/strip-comments/-/strip-comments-3.0.0.tgz",
+      "integrity": "sha512-Bc7IYRrYa45NBw2f6yhJpuPXFBRqLQ7zpQOdGKlAcq8YyRsUsN4K3XNwfLAYYYxyksBH8pEqg24t5py8VpwiGA=="
+    },
     "@gatsbyjs/reach-router": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/@gatsbyjs/reach-router/-/reach-router-1.3.6.tgz",
@@ -3840,6 +3845,15 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bl": {
       "version": "4.1.0",
@@ -7534,6 +7548,12 @@
         "token-types": "^2.0.0",
         "typedarray-to-buffer": "^3.1.5"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "filesize": {
       "version": "6.1.0",
@@ -12528,6 +12548,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/name-all-modules-plugin/-/name-all-modules-plugin-1.0.1.tgz",
       "integrity": "sha1-Cr+2rYNXGLn7Te8GdOBmV6lUN1w="
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "optional": true
     },
     "nanoid": {
       "version": "3.1.23",
@@ -18630,7 +18656,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/client/package.json
+++ b/client/package.json
@@ -49,6 +49,7 @@
     "@freecodecamp/loop-protect": "2.2.1",
     "@freecodecamp/react-bootstrap": "0.32.3",
     "@freecodecamp/react-calendar-heatmap": "1.0.0",
+    "@freecodecamp/strip-comments": "3.0.0",
     "@loadable/component": "5.15.0",
     "@reach/router": "1.3.4",
     "algoliasearch": "4.9.1",

--- a/client/src/declarations.d.ts
+++ b/client/src/declarations.d.ts
@@ -1,2 +1,3 @@
 // eslint-disable-next-line import/unambiguous
 declare module '@freecodecamp/react-bootstrap';
+declare module '@freecodecamp/strip-comments';

--- a/client/src/utils/__fixtures/curriculum-helpers-javascript.js
+++ b/client/src/utils/__fixtures/curriculum-helpers-javascript.js
@@ -12,10 +12,7 @@ nonMutatingPush(first, second);`;
 
 const jsCodeWithSingleAndMultLineCommentsRemoved = `
 function nonMutatingPush(original, newItem) {
-
-
-
-  return original.push(newItem);
+    return original.push(newItem);
 }
 var first = [1, 2, 3];
 
@@ -30,7 +27,7 @@ function nonMutatingPush(original, newItem) {
 
 const jsCodeWithUrlUnchanged = `
 function nonMutatingPush(original, newItem) {
-  var url = 'https://freecodecamp.org';
+  var url = 'https://freecodecamp.org'; 
   return original.push(newItem);
 }`;
 

--- a/client/src/utils/curriculum-helpers.ts
+++ b/client/src/utils/curriculum-helpers.ts
@@ -1,6 +1,5 @@
-import { parse } from '@babel/parser';
-import generate from '@babel/generator';
 import CSSHelp from './css-help';
+import strip from '@freecodecamp/strip-comments';
 
 const removeHtmlComments = (str: string): string =>
   str.replace(/<!--[\s\S]*?(-->|$)/g, '');
@@ -9,19 +8,10 @@ const removeCssComments = (str: string): string =>
   str.replace(/\/\*[\s\S]+?\*\//g, '');
 
 export const removeJSComments = (codeStr: string): string => {
-  // Note: removes trailing new lines and tailing spaces at end of lines
-  const options = {
-    comments: false,
-    retainLines: true,
-    compact: false,
-    concise: false,
-    minified: false
-  };
+  // TODO: publish type declarations and reenable eslint
   try {
-    const ast = parse(codeStr);
-    // TODO: Sort out type error on ast
-    const { code } = generate(ast, options, codeStr);
-    return code;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    return strip(codeStr) as string;
   } catch (err) {
     return codeStr;
   }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This reverts https://github.com/freeCodeCamp/freeCodeCamp/pull/42103, switches to @freecodecamp/strip-comments and ignores the type issues (for now).

Closes https://github.com/freeCodeCamp/strip-comments/issues/10

<!-- Feel free to add any additional description of changes below this line -->
