### PR TITLE
fix(client): handle challenge creation

### DIFF
--- a/client/utils/buildChallenges.js
+++ b/client/utils/buildChallenges.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const path = require('path');
 
 const {
   getChallengesForLang,
@@ -14,7 +15,21 @@ exports.localeChallengesRootDir = getChallengesDirForLang(curriculumLocale);
 
 exports.replaceChallengeNode = () => {
   return async function replaceChallengeNode(filePath) {
-    return await createChallenge(challengesDir, filePath, curriculumLocale);
+    // get the meta so that challengeOrder is accurate
+    const blockNameRe = /\d\d-[-\w]+\/([^/]+)\//;
+    const blockName = filePath.match(blockNameRe)[1];
+    const metaPath = path.resolve(
+      __dirname,
+      `../../curriculum/challenges/_meta/${blockName}/meta.json`
+    );
+    delete require.cache[require.resolve(metaPath)];
+    const meta = require(metaPath);
+    return await createChallenge(
+      challengesDir,
+      filePath,
+      curriculumLocale,
+      meta
+    );
   };
 };
 


### PR DESCRIPTION
This lets us create new challenges/steps without having to restart the
client

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I feel like there was an open issue for this, but I can't find it!

<!-- Feel free to add any additional description of changes below this line -->
