### PR TITLE
fix(curriculum): rework Project Euler 97

### DIFF
--- a/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-97-large-non-mersenne-prime.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-97-large-non-mersenne-prime.md
@@ -8,9 +8,9 @@ dashedName: problem-97-large-non-mersenne-prime
 
 # --description--
 
-The first known prime found to exceed one million digits was discovered in 1999, and is a Mersenne prime of the form 2<sup>6972593</sup>−1; it contains exactly 2,098,960 digits. Subsequently other Mersenne primes, of the form 2<sup><var>p</var></sup>−1, have been found which contain more digits.
+The first known prime found to exceed one million digits was discovered in 1999, and is a Mersenne prime of the form $2^{6972593} − 1$; it contains exactly 2,098,960 digits. Subsequently other Mersenne primes, of the form $2^p − 1$, have been found which contain more digits.
 
-However, in 2004 there was found a massive non-Mersenne prime which contains 2,357,207 digits: 28433×2<sup>7830457</sup>+1.
+However, in 2004 there was found a massive non-Mersenne prime which contains 2,357,207 digits: $28433 × 2^{7830457} + 1$.
 
 Find the last ten digits of non-Mersenne prime in the form $multiplier × 2^{power} + 1$.
 

--- a/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-97-large-non-mersenne-prime.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-97-large-non-mersenne-prime.md
@@ -12,20 +12,38 @@ The first known prime found to exceed one million digits was discovered in 1999,
 
 However, in 2004 there was found a massive non-Mersenne prime which contains 2,357,207 digits: 28433×2<sup>7830457</sup>+1.
 
-Find the last ten digits of this prime number.
+Find the last ten digits of non-Mersenne prime in the form $multiplier × 2^{power} + 1$.
 
 # --hints--
 
-`lrgNonMersennePrime()` should return a number.
+`largeNonMersennePrime(19, 6833086)` should return a string.
 
 ```js
-assert(typeof lrgNonMersennePrime() === 'number');
+assert(typeof largeNonMersennePrime(19, 6833086) === 'string');
 ```
 
-`lrgNonMersennePrime()` should return 8739992577.
+`largeNonMersennePrime(19, 6833086)` should return string `3637590017`.
 
 ```js
-assert.strictEqual(lrgNonMersennePrime(), 8739992577);
+assert.strictEqual(largeNonMersennePrime(19, 6833086), '3637590017');
+```
+
+`largeNonMersennePrime(27, 7046834)` should return string `0130771969`.
+
+```js
+assert.strictEqual(largeNonMersennePrime(27, 7046834), '0130771969');
+```
+
+`largeNonMersennePrime(6679881, 6679881)` should return string `4455386113`.
+
+```js
+assert.strictEqual(largeNonMersennePrime(6679881, 6679881), '4455386113');
+```
+
+`largeNonMersennePrime(28433, 7830457)` should return string `8739992577`.
+
+```js
+assert.strictEqual(largeNonMersennePrime(28433, 7830457), '8739992577');
 ```
 
 # --seed--
@@ -33,12 +51,12 @@ assert.strictEqual(lrgNonMersennePrime(), 8739992577);
 ## --seed-contents--
 
 ```js
-function lrgNonMersennePrime() {
+function largeNonMersennePrime(multiplier, power) {
 
   return true;
 }
 
-lrgNonMersennePrime();
+largeNonMersennePrime(19, 6833086);
 ```
 
 # --solutions--

--- a/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-97-large-non-mersenne-prime.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-97-large-non-mersenne-prime.md
@@ -62,5 +62,27 @@ largeNonMersennePrime(19, 6833086);
 # --solutions--
 
 ```js
-// solution required
+function largeNonMersennePrime(multiplier, power) {
+  function modStepsResults(number, other, mod, startValue, step) {
+    let result = startValue;
+    for (let i = 0; i < other; i++) {
+      result = step(number, result) % mod;
+    }
+    return result;
+  }
+
+  const numOfDigits = 10;
+  const mod = 10 ** numOfDigits;
+  const digitsAfterPower = modStepsResults(2, power, mod, 1, (a, b) => a * b);
+  const digitsAfterMultiply = modStepsResults(
+    digitsAfterPower,
+    multiplier,
+    mod,
+    0,
+    (a, b) => a + b
+  );
+  const lastDigits = (digitsAfterMultiply + 1) % mod;
+
+  return lastDigits.toString().padStart(10, '0');
+}
 ```

--- a/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-97-large-non-mersenne-prime.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-97-large-non-mersenne-prime.md
@@ -12,7 +12,7 @@ The first known prime found to exceed one million digits was discovered in 1999,
 
 However, in 2004 there was found a massive non-Mersenne prime which contains 2,357,207 digits: $28433 × 2^{7830457} + 1$.
 
-Find the last ten digits of non-Mersenne prime in the form $multiplier × 2^{power} + 1$.
+Find the last ten digits of that non-Mersenne prime in the form $multiplier × 2^{power} + 1$.
 
 # --hints--
 
@@ -22,25 +22,25 @@ Find the last ten digits of non-Mersenne prime in the form $multiplier × 2^{pow
 assert(typeof largeNonMersennePrime(19, 6833086) === 'string');
 ```
 
-`largeNonMersennePrime(19, 6833086)` should return string `3637590017`.
+`largeNonMersennePrime(19, 6833086)` should return the string `3637590017`.
 
 ```js
 assert.strictEqual(largeNonMersennePrime(19, 6833086), '3637590017');
 ```
 
-`largeNonMersennePrime(27, 7046834)` should return string `0130771969`.
+`largeNonMersennePrime(27, 7046834)` should return the string `0130771969`.
 
 ```js
 assert.strictEqual(largeNonMersennePrime(27, 7046834), '0130771969');
 ```
 
-`largeNonMersennePrime(6679881, 6679881)` should return string `4455386113`.
+`largeNonMersennePrime(6679881, 6679881)` should return the string `4455386113`.
 
 ```js
 assert.strictEqual(largeNonMersennePrime(6679881, 6679881), '4455386113');
 ```
 
-`largeNonMersennePrime(28433, 7830457)` should return string `8739992577`.
+`largeNonMersennePrime(28433, 7830457)` should return the string `8739992577`.
 
 ```js
 assert.strictEqual(largeNonMersennePrime(28433, 7830457), '8739992577');


### PR DESCRIPTION
- Reworks challenge to use argument in function call.
- Adds solution.
- Changes expected return type to string, otherwise for cases where 10th digit from the end is `0`, it wasn't possible to show all 10 last digits.
- Changes slightly challenge to allow adding more tests.
- Adds more tests. Primes for tests are taken from short list at https://primes.utm.edu/primes/download.php
- Changes function name to include word `large` instead of shortened `lrg`.
- Uses MathJax to improve look of math notation.
- Related to #40896.

Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.