### PR TITLE
fix: remove unused polyvinyl functions

### DIFF
--- a/client/src/templates/Challenges/rechallenge/transformers.js
+++ b/client/src/templates/Challenges/rechallenge/transformers.js
@@ -12,7 +12,12 @@ import {
 
 import protect from '@freecodecamp/loop-protect';
 
-import * as vinyl from '../../../../../utils/polyvinyl.js';
+import {
+  transformContents,
+  transformHeadTailAndContents,
+  setExt,
+  compileHeadTail
+} from '../../../../../utils/polyvinyl';
 import createWorker from '../utils/worker-executor';
 
 // the config files are created during the build, but not before linting
@@ -114,7 +119,7 @@ export const testJS$JSX = overSome(testJS, testJSX);
 export const replaceNBSP = cond([
   [
     testHTML$JS$JSX,
-    partial(vinyl.transformContents, contents => contents.replace(NBSPReg, ' '))
+    partial(transformContents, contents => contents.replace(NBSPReg, ' '))
   ],
   [stubTrue, identity]
 ]);
@@ -142,7 +147,7 @@ const babelTransformer = options => {
         await loadPresetEnv();
         const babelOptions = getBabelOptions(options);
         return partial(
-          vinyl.transformHeadTailAndContents,
+          transformHeadTailAndContents,
           tryTransform(babelTransformCode(babelOptions))
         )(code);
       }
@@ -154,10 +159,10 @@ const babelTransformer = options => {
         await loadPresetReact();
         return flow(
           partial(
-            vinyl.transformHeadTailAndContents,
+            transformHeadTailAndContents,
             tryTransform(babelTransformCode(babelOptionsJSX))
           ),
-          partial(vinyl.setExt, 'js')
+          partial(setExt, 'js')
         )(code);
       }
     ],
@@ -205,19 +210,19 @@ const transformHtml = async function (file) {
   const div = document.createElement('div');
   div.innerHTML = file.contents;
   await Promise.all([transformSASS(div), transformScript(div)]);
-  return vinyl.transformContents(() => div.innerHTML, file);
+  return transformContents(() => div.innerHTML, file);
 };
 
 export const composeHTML = cond([
   [
     testHTML,
     flow(
-      partial(vinyl.transformHeadTailAndContents, source => {
+      partial(transformHeadTailAndContents, source => {
         const div = document.createElement('div');
         div.innerHTML = source;
         return div.innerHTML;
       }),
-      partial(vinyl.compileHeadTail, '')
+      partial(compileHeadTail, '')
     )
   ],
   [stubTrue, identity]

--- a/utils/polyvinyl.js
+++ b/utils/polyvinyl.js
@@ -1,44 +1,11 @@
 // originally based off of https://github.com/gulpjs/vinyl
 const invariant = require('invariant');
-const { of, from, isObservable } = require('rxjs');
-const { map, switchMap } = require('rxjs/operators');
 
 function isPromise(value) {
   return (
     value &&
     typeof value.subscribe !== 'function' &&
     typeof value.then === 'function'
-  );
-}
-
-function castToObservable(maybe) {
-  if (isObservable(maybe)) {
-    return maybe;
-  }
-  if (isPromise(maybe)) {
-    return from(maybe);
-  }
-  return of(maybe);
-}
-
-// createFileStream(
-//   files: [...PolyVinyl]
-// ) => Observable[...Observable[...PolyVinyl]]
-function createFileStream(files = []) {
-  return of(from(files));
-}
-
-// Observable::pipe(
-//  project(
-//    file: PolyVinyl
-//  ) => PolyVinyl|Observable[PolyVinyl]|Promise[PolyVinyl]
-// ) => Observable[...Observable[...PolyVinyl]]
-function pipe(project) {
-  const source = this;
-  return source.pipe(
-    map(files => {
-      return files.pipe(switchMap(file => castToObservable(project(file))));
-    })
   );
 }
 
@@ -227,9 +194,6 @@ function updateFileFromSpec(spec, poly) {
 
 module.exports = {
   isPromise,
-  castToObservable,
-  createFileStream,
-  pipe,
   createPoly,
   isPoly,
   checkPoly,

--- a/utils/polyvinyl.js
+++ b/utils/polyvinyl.js
@@ -1,14 +1,6 @@
 // originally based off of https://github.com/gulpjs/vinyl
 const invariant = require('invariant');
 
-function isPromise(value) {
-  return (
-    value &&
-    typeof value.subscribe !== 'function' &&
-    typeof value.then === 'function'
-  );
-}
-
 // interface PolyVinyl {
 //   source: String,
 //   contents: String,
@@ -101,33 +93,6 @@ function setExt(ext, poly) {
   return newPoly;
 }
 
-// setName(name: String, poly: PolyVinyl) => PolyVinyl
-function setName(name, poly) {
-  checkPoly(poly);
-  const newPoly = {
-    ...poly,
-    name,
-    path: name + '.' + poly.ext,
-    key: name + poly.ext
-  };
-  newPoly.history = [...poly.history, newPoly.path];
-  return newPoly;
-}
-
-// setError(error: Object, poly: PolyVinyl) => PolyVinyl
-function setError(error, poly) {
-  invariant(
-    typeof error === 'object',
-    'error must be an object or null, but got %',
-    error
-  );
-  checkPoly(poly);
-  return {
-    ...poly,
-    error
-  };
-}
-
 // clearHeadTail(poly: PolyVinyl) => PolyVinyl
 function clearHeadTail(poly) {
   checkPoly(poly);
@@ -135,15 +100,6 @@ function clearHeadTail(poly) {
     ...poly,
     head: '',
     tail: ''
-  };
-}
-
-// appendToTail (tail: String, poly: PolyVinyl) => PolyVinyl
-function appendToTail(tail, poly) {
-  checkPoly(poly);
-  return {
-    ...poly,
-    tail: poly.tail.concat(tail)
   };
 }
 
@@ -184,29 +140,13 @@ function transformHeadTailAndContents(wrap, poly) {
   };
 }
 
-function testContents(predicate, poly) {
-  return !!predicate(poly.contents);
-}
-
-function updateFileFromSpec(spec, poly) {
-  return setContent(poly.contents, createPoly(spec));
-}
-
 module.exports = {
-  isPromise,
   createPoly,
   isPoly,
-  checkPoly,
   isEmpty,
   setContent,
   setExt,
-  setName,
-  setError,
-  clearHeadTail,
-  appendToTail,
   compileHeadTail,
   transformContents,
-  transformHeadTailAndContents,
-  testContents,
-  updateFileFromSpec
+  transformHeadTailAndContents
 };

--- a/utils/polyvinyl.js
+++ b/utils/polyvinyl.js
@@ -63,12 +63,6 @@ function checkPoly(poly) {
   );
 }
 
-// isEmpty(poly: PolyVinyl) => Boolean, throws
-function isEmpty(poly) {
-  checkPoly(poly);
-  return !!poly.contents;
-}
-
 // setContent(contents: String, poly: PolyVinyl) => PolyVinyl
 // setContent will loose source if set
 function setContent(contents, poly) {
@@ -143,7 +137,6 @@ function transformHeadTailAndContents(wrap, poly) {
 module.exports = {
   createPoly,
   isPoly,
-  isEmpty,
   setContent,
   setExt,
   compileHeadTail,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

As far as I can see, these were in the original vinyl which ours was based off, but we don't use them.

<!-- Feel free to add any additional description of changes below this line -->
