### PR TITLE
feat: make api only return json

### DIFF
--- a/api-server/src/server/boot/challenge.js
+++ b/api-server/src/server/boot/challenge.js
@@ -286,7 +286,7 @@ function projectCompleted(req, res, next) {
         })
       );
       return Observable.fromPromise(updatePromise).doOnNext(() => {
-        return res.send({
+        return res.json({
           alreadyCompleted,
           points: alreadyCompleted ? user.points : user.points + 1,
           completedDate: completedChallenge.completedDate
@@ -320,7 +320,7 @@ function backendChallengeCompleted(req, res, next) {
         })
       );
       return Observable.fromPromise(updatePromise).doOnNext(() => {
-        return res.send({
+        return res.json({
           alreadyCompleted,
           points: alreadyCompleted ? user.points : user.points + 1,
           completedDate: completedChallenge.completedDate

--- a/api-server/src/server/boot/donate.js
+++ b/api-server/src/server/boot/donate.js
@@ -20,7 +20,7 @@ export default function donateBoot(app, done) {
     if (!user || !body) {
       return res
         .status(500)
-        .send({ error: 'User must be signed in for this request.' });
+        .json({ error: 'User must be signed in for this request.' });
     }
     return Promise.resolve(req)
       .then(
@@ -31,7 +31,7 @@ export default function donateBoot(app, done) {
       .then(() => res.status(200).json({ isDonating: true }))
       .catch(err => {
         log(err.message);
-        return res.status(500).send({
+        return res.status(500).json({
           type: 'danger',
           message: 'Something went wrong.'
         });

--- a/api-server/src/server/boot/randomAPIs.js
+++ b/api-server/src/server/boot/randomAPIs.js
@@ -193,7 +193,7 @@ module.exports = function (app) {
               pulls === parseInt(pulls, 10) && issues
                 ? Object.keys(JSON.parse(issues)).length - pulls
                 : "Can't connect to GitHub";
-            return res.send({
+            return res.json({
               issues: issues,
               pulls: pulls
             });

--- a/api-server/src/server/boot/user.js
+++ b/api-server/src/server/boot/user.js
@@ -185,7 +185,7 @@ function postResetProgress(req, res, next) {
       if (err) {
         return next(err);
       }
-      return res.sendStatus(200);
+      return res.status(200).json({});
     }
   );
 }
@@ -199,7 +199,7 @@ function createPostDeleteAccount(app) {
       }
       req.logout();
       removeCookies(req, res);
-      return res.sendStatus(200);
+      return res.status(200).json({});
     });
   };
 }

--- a/api-server/src/server/boot/z-not-found.js
+++ b/api-server/src/server/boot/z-not-found.js
@@ -8,16 +8,11 @@ export default function fourOhFour(app) {
     const { path } = req;
     const { origin } = getRedirectParams(req);
 
-    if (type === 'html') {
+    if (type === 'json') {
+      return res.status('404').json({ error: 'path not found' });
+    } else {
       req.flash('danger', `We couldn't find path ${path}`);
       return res.redirectWithFlash(`${origin}/404`);
     }
-
-    if (type === 'json') {
-      return res.status('404').json({ error: 'path not found' });
-    }
-
-    res.setHeader('Content-Type', 'text/plain');
-    return res.send('404 path not found');
   });
 }

--- a/api-server/src/server/boot/z-not-found.js
+++ b/api-server/src/server/boot/z-not-found.js
@@ -4,7 +4,8 @@ import { getRedirectParams } from '../utils/redirection';
 export default function fourOhFour(app) {
   app.all('*', function (req, res) {
     const accept = accepts(req);
-    const type = accept.type('html', 'json', 'text');
+    // prioritise returning json
+    const type = accept.type('json', 'html', 'text');
     const { path } = req;
     const { origin } = getRedirectParams(req);
 

--- a/api-server/src/server/middlewares/error-handlers.js
+++ b/api-server/src/server/middlewares/error-handlers.js
@@ -37,7 +37,8 @@ export default function prodErrorHandler() {
 
     // parse res type
     const accept = accepts(req);
-    const type = accept.type('html', 'json', 'text');
+    // prioritise returning json
+    const type = accept.type('json', 'html', 'text');
 
     const redirectTo = handled.redirectTo || `${origin}/`;
     const message =

--- a/api-server/src/server/middlewares/error-handlers.js
+++ b/api-server/src/server/middlewares/error-handlers.js
@@ -56,7 +56,7 @@ export default function prodErrorHandler() {
       // json
     } else if (type === 'json') {
       res.setHeader('Content-Type', 'application/json');
-      return res.send({
+      return res.json({
         type: handled.type || 'errors',
         message
       });

--- a/api-server/src/server/middlewares/error-handlers.js
+++ b/api-server/src/server/middlewares/error-handlers.js
@@ -48,22 +48,16 @@ export default function prodErrorHandler() {
       console.error(errTemplate(err, req));
     }
 
-    if (type === 'html') {
-      if (typeof req.flash === 'function') {
-        req.flash(handled.type || 'danger', message);
-      }
-      return res.redirectWithFlash(redirectTo);
-      // json
-    } else if (type === 'json') {
-      res.setHeader('Content-Type', 'application/json');
+    if (type === 'json') {
       return res.json({
         type: handled.type || 'errors',
         message
       });
-      // plain text
     } else {
-      res.setHeader('Content-Type', 'text/plain');
-      return res.send(message);
+      if (typeof req.flash === 'function') {
+        req.flash(handled.type || 'danger', message);
+      }
+      return res.redirectWithFlash(redirectTo);
     }
   };
 }


### PR DESCRIPTION
Following on from https://github.com/freeCodeCamp/freeCodeCamp/pull/41944#issuecomment-851565089, this only includes the api changes.  

Since the client doesn't use the responses to delete and reset-progress, they can return json without needing to modify the client.

Finally, the client should already be `Accept`ing json while making an AJAX request.