### PR TITLE
fix(curriculum): rework Project Euler 38

### DIFF
--- a/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-38-pandigital-multiples.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-38-pandigital-multiples.md
@@ -58,27 +58,26 @@ pandigitalMultiples(8);
 # --solutions--
 
 ```js
-function pandigitalMultiples() {
-
-  function get9DigitConcatenatedProduct(num) {
-    // returns false if concatenated product is not 9 digits
+function pandigitalMultiples(k) {
+  function getKDigitConcatenatedProduct(num, k) {
+    // returns false if concatenated product is not k digits
     let concatenatedProduct = num.toString();
-    for (let i = 2; concatenatedProduct.length < 9; i++) {
+    for (let i = 2; concatenatedProduct.length < k; i++) {
       concatenatedProduct += num * i;
     }
-    return concatenatedProduct.length === 9 ? concatenatedProduct : false;
+    return concatenatedProduct.length === k ? concatenatedProduct : false;
   }
 
-  function is1to9Pandigital(num) {
+  function is1toKPandigital(num, k) {
     const numStr = num.toString();
 
-    // check if length is not 9
-    if (numStr.length !== 9) {
+    // check if length is not k
+    if (numStr.length !== k) {
       return false;
     }
 
     // check if pandigital
-    for (let i = 9; i > 0; i--) {
+    for (let i = k; i > 0; i--) {
       if (numStr.indexOf(i.toString()) === -1) {
         return false;
       }
@@ -87,11 +86,13 @@ function pandigitalMultiples() {
   }
 
   let largestNum = 0;
-  for (let i = 9999; i >= 9000; i--) {
-    const concatenatedProduct =  get9DigitConcatenatedProduct(i);
-    if (is1to9Pandigital(concatenatedProduct) && concatenatedProduct > largestNum) {
-      largestNum = parseInt(concatenatedProduct);
-      break;
+  for (let i = 10 ** Math.floor(k / 2) + 1; i >= 1; i--) {
+    const concatenatedProduct = getKDigitConcatenatedProduct(i, k);
+    if (is1toKPandigital(concatenatedProduct, k)) {
+      const number = parseInt(concatenatedProduct, 10);
+      if (number > largestNum) {
+        largestNum = number;
+      }
     }
   }
   return largestNum;

--- a/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-38-pandigital-multiples.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-38-pandigital-multiples.md
@@ -20,20 +20,26 @@ By concatenating each product we get the 1 to 9 pandigital, 192384576. We will c
 
 The same can be achieved by starting with 9 and multiplying by 1, 2, 3, 4, and 5, giving the pandigital, 918273645, which is the concatenated product of 9 and (1, 2, 3, 4, 5).
 
-What is the largest 1 to 9 pandigital 9-digit number that can be formed as the concatenated product of an integer with (1, 2, ... , `n`) where `n` > 1?
+What is the largest 1 to `k` pandigital `k`-digit number that can be formed as the concatenated product of an integer with (1, 2, ..., `n`) where `n` > 1?
 
 # --hints--
 
-`pandigitalMultiples()` should return a number.
+`pandigitalMultiples(8)` should return a number.
 
 ```js
-assert(typeof pandigitalMultiples() === 'number');
+assert(typeof pandigitalMultiples(8) === 'number');
 ```
 
-`pandigitalMultiples()` should return 932718654.
+`pandigitalMultiples(8)` should return `78156234`.
 
 ```js
-assert.strictEqual(pandigitalMultiples(), 932718654);
+assert.strictEqual(pandigitalMultiples(8), 78156234);
+```
+
+`pandigitalMultiples(9)` should return `932718654`.
+
+```js
+assert.strictEqual(pandigitalMultiples(9), 932718654);
 ```
 
 # --seed--
@@ -41,12 +47,12 @@ assert.strictEqual(pandigitalMultiples(), 932718654);
 ## --seed-contents--
 
 ```js
-function pandigitalMultiples() {
+function pandigitalMultiples(k) {
 
   return true;
 }
 
-pandigitalMultiples();
+pandigitalMultiples(8);
 ```
 
 # --solutions--

--- a/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-38-pandigital-multiples.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-38-pandigital-multiples.md
@@ -10,11 +10,11 @@ dashedName: problem-38-pandigital-multiples
 
 Take the number 192 and multiply it by each of 1, 2, and 3:
 
-<div style='margin-left: 4em;'>
-  192 × 1 = 192<br>
-  192 × 2 = 384<br>
-  192 × 3 = 576<br>
-</div>
+$$\begin{align}
+  192 × 1 = 192\\\\
+  192 × 2 = 384\\\\
+  192 × 3 = 576\\\\
+\end{align}$$
 
 By concatenating each product we get the 1 to 9 pandigital, 192384576. We will call 192384576 the concatenated product of 192 and (1, 2, 3).
 


### PR DESCRIPTION
- Reworks challenge to use argument in function call.
- Adds test, only one, as for lower `k` there's no way to receive pandigital `1` to `k` number, created after concatenating products of multiplication of integer by `(1, 2, ..., n)` where `n > 1`.
- Changes solution to conform change in challenge.
- Uses MathJax to improve look of math notation.
- Related to #40896.

Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.