### PR TITLE
fix: require a link element in html

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/import-a-google-font.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/import-a-google-font.md
@@ -40,7 +40,11 @@ Import the `Lobster` font to your web page. Then, use an element selector to set
 You should import the `Lobster` font.
 
 ```js
-assert(new RegExp('googleapis', 'gi').test(code));
+assert(
+  $('link[href]')
+    .toArray()
+    .some((element) => new RegExp('googleapis', 'gi').test(element.href))
+);
 ```
 
 Your `h2` element should use the font `Lobster`.

--- a/curriculum/challenges/english/01-responsive-web-design/basic-css/import-a-google-font.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-css/import-a-google-font.md
@@ -40,11 +40,7 @@ Import the `Lobster` font to your web page. Then, use an element selector to set
 You should import the `Lobster` font.
 
 ```js
-assert(
-  $('link[href]')
-    .toArray()
-    .some((element) => new RegExp('googleapis', 'gi').test(element.href))
-);
+assert($('link[href*="googleapis" i]').length);
 ```
 
 Your `h2` element should use the font `Lobster`.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #42324

<!-- Feel free to add any additional description of changes below this line -->
This changes the test to look for all `link` element with the `href` attribute, (`link[href]`) and checks if at least one is from `googleapis`.

Technically, the test can be made more strict, but I kept it to the original logic.