### PR TITLE
refactor: remove sinon

### DIFF
--- a/api-server/src/server/boot_tests/challenge.test.js
+++ b/api-server/src/server/boot_tests/challenge.test.js
@@ -21,16 +21,17 @@ import {
   mockCompletedChallenges
 } from './fixtures';
 
-const mockReq = opts => {
+export const mockReq = opts => {
   const req = {};
   return { ...req, ...opts };
 };
 
-const mockRes = opts => {
+export const mockRes = opts => {
   const res = {};
   res.status = jest.fn().mockReturnValue(res);
   res.json = jest.fn().mockReturnValue(res);
   res.redirect = jest.fn().mockReturnValue(res);
+  res.set = jest.fn().mockReturnValue(res);
   return { ...res, ...opts };
 };
 

--- a/api-server/src/server/boot_tests/challenge.test.js
+++ b/api-server/src/server/boot_tests/challenge.test.js
@@ -32,6 +32,8 @@ export const mockRes = opts => {
   res.json = jest.fn().mockReturnValue(res);
   res.redirect = jest.fn().mockReturnValue(res);
   res.set = jest.fn().mockReturnValue(res);
+  res.clearCookie = jest.fn().mockReturnValue(res);
+  res.cookie = jest.fn().mockReturnValue(res);
   return { ...res, ...opts };
 };
 

--- a/api-server/src/server/boot_tests/challenge.test.js
+++ b/api-server/src/server/boot_tests/challenge.test.js
@@ -1,7 +1,5 @@
-/* global describe xdescribe it expect */
+/* global describe xdescribe it expect jest */
 import { first, find } from 'lodash';
-import sinon from 'sinon';
-import { mockReq, mockRes } from 'sinon-express-mock';
 
 import {
   buildUserUpdate,
@@ -22,6 +20,19 @@ import {
   mockCompletedChallenge,
   mockCompletedChallenges
 } from './fixtures';
+
+const mockReq = opts => {
+  const req = {};
+  return { ...req, ...opts };
+};
+
+const mockRes = opts => {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  res.redirect = jest.fn().mockReturnValue(res);
+  return { ...res, ...opts };
+};
 
 describe('boot/challenge', () => {
   xdescribe('backendChallengeCompleted', () => {});
@@ -221,37 +232,35 @@ describe('boot/challenge', () => {
     const validObjectId = '5c716d1801013c3ce3aa23e6';
 
     it('declares a 403 for an invalid id in the body', () => {
-      expect.assertions(3);
+      expect.assertions(2);
       const req = mockReq({
         body: { id: 'not-a-real-id' }
       });
       const res = mockRes();
-      const next = sinon.spy();
+      const next = jest.fn();
 
       isValidChallengeCompletion(req, res, next);
 
-      expect(res.status.called).toBe(true);
-      expect(res.status.getCall(0).args[0]).toBe(403);
-      expect(next.called).toBe(false);
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(next).not.toHaveBeenCalled();
     });
 
     it('declares a 403 for an invalid challengeType in the body', () => {
-      expect.assertions(3);
+      expect.assertions(2);
       const req = mockReq({
         body: { id: validObjectId, challengeType: 'ponyfoo' }
       });
       const res = mockRes();
-      const next = sinon.spy();
+      const next = jest.fn();
 
       isValidChallengeCompletion(req, res, next);
 
-      expect(res.status.called).toBe(true);
-      expect(res.status.getCall(0).args[0]).toBe(403);
-      expect(next.called).toBe(false);
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(next).not.toHaveBeenCalled();
     });
 
     it('declares a 403 for an invalid solution in the body', () => {
-      expect.assertions(3);
+      expect.assertions(2);
       const req = mockReq({
         body: {
           id: validObjectId,
@@ -260,13 +269,12 @@ describe('boot/challenge', () => {
         }
       });
       const res = mockRes();
-      const next = sinon.spy();
+      const next = jest.fn();
 
       isValidChallengeCompletion(req, res, next);
 
-      expect(res.status.called).toBe(true);
-      expect(res.status.getCall(0).args[0]).toBe(403);
-      expect(next.called).toBe(false);
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(next).not.toHaveBeenCalled();
     });
 
     it('calls next if the body is valid', () => {
@@ -278,11 +286,11 @@ describe('boot/challenge', () => {
         }
       });
       const res = mockRes();
-      const next = sinon.spy();
+      const next = jest.fn();
 
       isValidChallengeCompletion(req, res, next);
 
-      expect(next.called).toBe(true);
+      expect(next).toHaveBeenCalled();
     });
 
     it('calls next if only the id is provided', () => {
@@ -292,11 +300,11 @@ describe('boot/challenge', () => {
         }
       });
       const res = mockRes();
-      const next = sinon.spy();
+      const next = jest.fn();
 
       isValidChallengeCompletion(req, res, next);
 
-      expect(next.called).toBe(true);
+      expect(next).toHaveBeenCalled();
     });
 
     it('can handle an "int" challengeType', () => {
@@ -307,11 +315,11 @@ describe('boot/challenge', () => {
         }
       });
       const res = mockRes();
-      const next = sinon.spy();
+      const next = jest.fn();
 
       isValidChallengeCompletion(req, res, next);
 
-      expect(next.called).toBe(true);
+      expect(next).toHaveBeenCalled();
     });
   });
 
@@ -337,10 +345,10 @@ describe('boot/challenge', () => {
       );
       const req = mockReq();
       const res = mockRes();
-      const next = sinon.spy();
+      const next = jest.fn();
       await redirectToCurrentChallenge(req, res, next);
 
-      expect(res.redirect.calledWith(mockLearnUrl));
+      expect(res.redirect).toHaveBeenCalledWith(mockLearnUrl);
       done();
     });
 
@@ -362,10 +370,10 @@ describe('boot/challenge', () => {
         user: mockUser
       });
       const res = mockRes();
-      const next = sinon.spy();
+      const next = jest.fn();
       await redirectToCurrentChallenge(req, res, next);
 
-      expect(res.redirect.calledWith(expectedUrl)).toBe(true);
+      expect(res.redirect).toHaveBeenCalledWith(expectedUrl);
       done();
     });
 
@@ -386,10 +394,10 @@ describe('boot/challenge', () => {
         user: { ...mockUser, currentChallengeId: '' }
       });
       const res = mockRes();
-      const next = sinon.spy();
+      const next = jest.fn();
       await redirectToCurrentChallenge(req, res, next);
       const expectedUrl = `${mockHomeLocation}${firstChallengeUrl}`;
-      expect(res.redirect.calledWith(expectedUrl)).toBe(true);
+      expect(res.redirect).toHaveBeenCalledWith(expectedUrl);
       done();
     });
   });

--- a/api-server/src/server/middlewares/request-authorization.test.js
+++ b/api-server/src/server/middlewares/request-authorization.test.js
@@ -1,6 +1,5 @@
-/* global describe it expect */
-import sinon from 'sinon';
-import { mockReq as mockRequest, mockRes } from 'sinon-express-mock';
+/* global describe it expect jest */
+import { mockReq as mockRequest, mockRes } from '../boot_tests/challenge.test';
 import jwt from 'jsonwebtoken';
 
 import { homeLocation } from '../../../../config/env';
@@ -110,11 +109,11 @@ describe('request-authorization', () => {
         expect.assertions(2);
         const req = mockReq({ path: '/some-path/that-needs/auth' });
         const res = mockRes();
-        const next = sinon.spy();
+        const next = jest.fn();
         expect(() => requestAuthorization(req, res, next)).toThrowError(
           'Access token is required for this request'
         );
-        expect(next.called).toBe(false);
+        expect(next).not.toHaveBeenCalled();
       });
 
       it('throws when the access token is invalid', () => {
@@ -126,12 +125,12 @@ describe('request-authorization', () => {
           cookie: { jwt_access_token: invalidJWT }
         });
         const res = mockRes();
-        const next = sinon.spy();
+        const next = jest.fn();
 
         expect(() => requestAuthorization(req, res, next)).toThrowError(
           'Access token is invalid'
         );
-        expect(next.called).toBe(false);
+        expect(next).not.toHaveBeenCalled();
       });
 
       it('throws when the access token has expired', () => {
@@ -146,12 +145,12 @@ describe('request-authorization', () => {
           cookie: { jwt_access_token: invalidJWT }
         });
         const res = mockRes();
-        const next = sinon.spy();
+        const next = jest.fn();
 
         expect(() => requestAuthorization(req, res, next)).toThrowError(
           'Access token is no longer valid'
         );
-        expect(next.called).toBe(false);
+        expect(next).not.toHaveBeenCalled();
       });
 
       it('adds the user to the request object', async done => {
@@ -163,9 +162,9 @@ describe('request-authorization', () => {
           cookie: { jwt_access_token: validJWT }
         });
         const res = mockRes();
-        const next = sinon.spy();
+        const next = jest.fn();
         await requestAuthorization(req, res, next);
-        expect(next.called).toBe(true);
+        expect(next).toHaveBeenCalled();
         expect(req).toHaveProperty('user');
         expect(req.user).toEqual(users['456def']);
         return done();
@@ -179,9 +178,9 @@ describe('request-authorization', () => {
           cookie: { jwt_access_token: validJWT }
         });
         const res = mockRes();
-        const next = sinon.spy();
+        const next = jest.fn();
         await requestAuthorization(req, res, next);
-        expect(res.set.calledWith('X-fcc-access-token', validJWT)).toBe(true);
+        expect(res.set).toHaveBeenCalledWith('X-fcc-access-token', validJWT);
         return done();
       });
 
@@ -189,9 +188,9 @@ describe('request-authorization', () => {
         // currently /unsubscribe does not require authorization
         const req = mockReq({ path: '/unsubscribe/another/route' });
         const res = mockRes();
-        const next = sinon.spy();
+        const next = jest.fn();
         await requestAuthorization(req, res, next);
-        expect(next.called).toBe(true);
+        expect(next).toHaveBeenCalled();
       });
     });
 
@@ -200,11 +199,11 @@ describe('request-authorization', () => {
         expect.assertions(2);
         const req = mockReq({ path: '/some-path/that-needs/auth' });
         const res = mockRes();
-        const next = sinon.spy();
+        const next = jest.fn();
         expect(() => requestAuthorization(req, res, next)).toThrowError(
           'Access token is required for this request'
         );
-        expect(next.called).toBe(false);
+        expect(next).not.toHaveBeenCalled();
       });
 
       it('throws when the access token is invalid', () => {
@@ -215,12 +214,12 @@ describe('request-authorization', () => {
           headers: { 'X-fcc-access-token': invalidJWT }
         });
         const res = mockRes();
-        const next = sinon.spy();
+        const next = jest.fn();
 
         expect(() => requestAuthorization(req, res, next)).toThrowError(
           'Access token is invalid'
         );
-        expect(next.called).toBe(false);
+        expect(next).not.toHaveBeenCalled();
       });
 
       it('throws when the access token has expired', () => {
@@ -234,12 +233,12 @@ describe('request-authorization', () => {
           headers: { 'X-fcc-access-token': invalidJWT }
         });
         const res = mockRes();
-        const next = sinon.spy();
+        const next = jest.fn();
 
         expect(() => requestAuthorization(req, res, next)).toThrowError(
           'Access token is no longer valid'
         );
-        expect(next.called).toBe(false);
+        expect(next).not.toHaveBeenCalled();
       });
 
       it('adds the user to the request object', async done => {
@@ -250,9 +249,9 @@ describe('request-authorization', () => {
           headers: { 'X-fcc-access-token': validJWT }
         });
         const res = mockRes();
-        const next = sinon.spy();
+        const next = jest.fn();
         await requestAuthorization(req, res, next);
-        expect(next.called).toBe(true);
+        expect(next).toHaveBeenCalled();
         expect(req).toHaveProperty('user');
         expect(req.user).toEqual(users['456def']);
         return done();
@@ -266,9 +265,9 @@ describe('request-authorization', () => {
           cookie: { jwt_access_token: validJWT }
         });
         const res = mockRes();
-        const next = sinon.spy();
+        const next = jest.fn();
         await requestAuthorization(req, res, next);
-        expect(res.set.calledWith('X-fcc-access-token', validJWT)).toBe(true);
+        expect(res.set).toHaveBeenCalledWith('X-fcc-access-token', validJWT);
         return done();
       });
 
@@ -276,9 +275,9 @@ describe('request-authorization', () => {
         // currently /unsubscribe does not require authorization
         const req = mockReq({ path: '/unsubscribe/another/route' });
         const res = mockRes();
-        const next = sinon.spy();
+        const next = jest.fn();
         await requestAuthorization(req, res, next);
-        expect(next.called).toBe(true);
+        expect(next).toHaveBeenCalled();
       });
     });
   });

--- a/api-server/src/server/utils/getSetAccessToken.test.js
+++ b/api-server/src/server/utils/getSetAccessToken.test.js
@@ -5,7 +5,7 @@ import {
   setAccessTokenToResponse,
   removeCookies
 } from './getSetAccessToken';
-import { mockReq, mockRes } from 'sinon-express-mock';
+import { mockReq, mockRes } from '../boot_tests/challenge.test';
 import jwt from 'jsonwebtoken';
 
 describe('getSetAccessToken', () => {
@@ -130,7 +130,8 @@ describe('getSetAccessToken', () => {
 
       setAccessTokenToResponse({ accessToken }, req, res, validJWTSecret);
 
-      expect(res.cookie.getCall(0).args).toEqual([
+      expect(res.cookie).toHaveBeenNthCalledWith(
+        1,
         'jwt_access_token',
         expectedJWT,
         {
@@ -138,7 +139,7 @@ describe('getSetAccessToken', () => {
           domain,
           maxAge: accessToken.ttl
         }
-      ]);
+      );
     });
   });
 
@@ -152,16 +153,18 @@ describe('getSetAccessToken', () => {
 
       removeCookies(req, res);
 
-      expect(res.clearCookie.getCall(0).args).toEqual([
+      expect(res.clearCookie).toHaveBeenNthCalledWith(
+        1,
         'jwt_access_token',
         jwtOptions
-      ]);
-      expect(res.clearCookie.getCall(1).args).toEqual([
+      );
+      expect(res.clearCookie).toHaveBeenNthCalledWith(
+        2,
         'access_token',
         jwtOptions
-      ]);
-      expect(res.clearCookie.getCall(2).args).toEqual(['userId', jwtOptions]);
-      expect(res.clearCookie.getCall(3).args).toEqual(['_csrf', jwtOptions]);
+      );
+      expect(res.clearCookie).toHaveBeenNthCalledWith(3, 'userId', jwtOptions);
+      expect(res.clearCookie).toHaveBeenNthCalledWith(4, '_csrf', jwtOptions);
     });
   });
 });

--- a/api-server/src/server/utils/in-memory-cache.test.js
+++ b/api-server/src/server/utils/in-memory-cache.test.js
@@ -1,6 +1,5 @@
-/* global describe beforeEach expect it */
+/* global describe beforeEach expect it jest */
 import inMemoryCache from './in-memory-cache';
-import sinon from 'sinon';
 
 describe('InMemoryCache', () => {
   let reportErrorStub;
@@ -10,7 +9,7 @@ describe('InMemoryCache', () => {
   const emptyCacheValue = null;
 
   beforeEach(() => {
-    reportErrorStub = sinon.spy();
+    reportErrorStub = jest.fn();
   });
 
   it('throws if no report function is passed as a second argument', () => {
@@ -43,7 +42,6 @@ describe('InMemoryCache', () => {
     });
 
     it('reports errors thrown from the update function', () => {
-      const reportErrorStub = sinon.spy();
       const cache = inMemoryCache(before, reportErrorStub);
 
       const updateError = new Error('An update error');
@@ -52,7 +50,7 @@ describe('InMemoryCache', () => {
       };
 
       cache.update(updateThatThrows);
-      expect(reportErrorStub.calledWith(updateError)).toBe(true);
+      expect(reportErrorStub).toHaveBeenCalledWith(updateError);
     });
   });
 

--- a/api-server/src/server/utils/user-stats.test.js
+++ b/api-server/src/server/utils/user-stats.test.js
@@ -1,6 +1,5 @@
-/* global describe it expect afterAll  */
+/* global describe it expect jest  */
 import moment from 'moment-timezone';
-import sinon from 'sinon';
 
 import {
   prepUniqueDaysByHours,
@@ -10,13 +9,13 @@ import {
 } from './user-stats';
 import { mockUserID, mockApp, mockUser } from '../boot_tests/fixtures';
 
-// setting now to 2016-02-03T11:00:00 (PST)
-const clock = sinon.useFakeTimers(1454526000000);
+jest.useFakeTimers('modern');
 const PST = 'America/Los_Angeles';
 
 describe('user stats', () => {
-  afterAll(() => {
-    clock.restore();
+  beforeEach(() => {
+    // setting now to 2016-02-03T11:00:00 (PST)
+    jest.setSystemTime(1454526000000);
   });
 
   describe('prepUniqueDaysByHours', () => {

--- a/client/src/utils/handled-error.test.js
+++ b/client/src/utils/handled-error.test.js
@@ -1,6 +1,5 @@
-/* global expect */
+/* global expect jest */
 import { isObject } from 'lodash-es';
-import sinon from 'sinon';
 import {
   isHandledError,
   wrapHandledError,
@@ -75,7 +74,7 @@ describe('client/src utilities', () => {
     describe('handleAPIError', () => {
       let reportMock;
       beforeEach(() => {
-        reportMock = sinon.spy();
+        reportMock = jest.fn();
       });
 
       it('returns handled error data', () => {
@@ -105,7 +104,7 @@ describe('client/src utilities', () => {
           };
           handleAPIError(axiosErrorMock, { redirectTo: '/' }, reportMock);
         }
-        expect(reportMock.called).toBe(false);
+        expect(reportMock).not.toHaveBeenCalled();
       });
 
       it('reports on 5** errors', () => {
@@ -115,7 +114,7 @@ describe('client/src utilities', () => {
           }
         };
         handleAPIError(axiosErrorMock, { redirectTo: '/' }, reportMock);
-        expect(reportMock.calledOnce).toBe(true);
+        expect(reportMock).toHaveBeenCalledTimes(1);
       });
 
       it('returns a `reportedErrorMessage` for a 5** error', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5337,15 +5337,6 @@
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
       "dev": true
     },
-    "@sinonjs/commons": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
-      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
-      "dev": true,
-      "requires": {
-        "type-detect": "4.0.8"
-      }
-    },
     "@sinonjs/fake-timers": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
@@ -5365,23 +5356,6 @@
           }
         }
       }
-    },
-    "@sinonjs/samsam": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.3.1.tgz",
-      "integrity": "sha512-1Hc0b1TtyfBu8ixF/tpfSHTVWKwCBLY4QJbkgnE7HcwyvT2xArDxb4K7dMgqRm3szI+LJbzmW/s4xxEhv6hwDg==",
-      "dev": true,
-      "requires": {
-        "@sinonjs/commons": "^1.6.0",
-        "lodash.get": "^4.4.2",
-        "type-detect": "^4.0.8"
-      }
-    },
-    "@sinonjs/text-encoding": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
-      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
-      "dev": true
     },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
@@ -9226,12 +9200,6 @@
         "asap": "^2.0.0",
         "wrappy": "1"
       }
-    },
-    "diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true
     },
     "diff-sequences": {
       "version": "26.6.2",
@@ -14728,12 +14696,6 @@
         }
       }
     },
-    "just-extend": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
-      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
-      "dev": true
-    },
     "keyv": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
@@ -15660,12 +15622,6 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-      "dev": true
-    },
     "lodash.ismatch": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
@@ -16542,19 +16498,6 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
-    },
-    "nise": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-4.1.0.tgz",
-      "integrity": "sha512-eQMEmGN/8arp0xsvGoQ+B1qvSkR73B1nWSCh7nOt5neMCtwcQVYQGdzQMhcNscktTsWB54xnlSQFzOAPJD8nXA==",
-      "dev": true,
-      "requires": {
-        "@sinonjs/commons": "^1.7.0",
-        "@sinonjs/fake-timers": "^6.0.0",
-        "@sinonjs/text-encoding": "^0.7.1",
-        "just-extend": "^4.0.2",
-        "path-to-regexp": "^1.7.0"
-      }
     },
     "node-fetch": {
       "version": "2.6.1",
@@ -18210,23 +18153,6 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
-    "path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "dev": true,
-      "requires": {
-        "isarray": "0.0.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        }
-      }
-    },
     "path-type": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
@@ -19465,43 +19391,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-      "dev": true
-    },
-    "sinon": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-10.0.0.tgz",
-      "integrity": "sha512-XAn5DxtGVJBlBWYrcYKEhWCz7FLwZGdyvANRyK06419hyEpdT0dMc5A8Vcxg5SCGHc40CsqoKsc1bt1CbJPfNw==",
-      "dev": true,
-      "requires": {
-        "@sinonjs/commons": "^1.8.1",
-        "@sinonjs/fake-timers": "^6.0.1",
-        "@sinonjs/samsam": "^5.3.1",
-        "diff": "^4.0.2",
-        "nise": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "dependencies": {
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
-    "sinon-express-mock": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/sinon-express-mock/-/sinon-express-mock-2.2.1.tgz",
-      "integrity": "sha512-z1wqaPMwEnfn0SpigFhVYVS/ObX1tkqyRzRdccX99FgQaLkxGSo4684unr3NCqWeYZ1zchxPw7oFIDfzg1cAjg==",
       "dev": true
     },
     "sirv": {

--- a/package.json
+++ b/package.json
@@ -132,8 +132,6 @@
     "prettier": "2.3.0",
     "prismjs": "1.23.0",
     "shx": "0.3.3",
-    "sinon": "10.0.0",
-    "sinon-express-mock": "2.2.1",
     "start-server-and-test": "1.12.3",
     "typescript": "4.3.2",
     "webpack-bundle-analyzer": "4.4.2"


### PR DESCRIPTION
A little bit more spring (summer?) cleaning.  Everything we were using sinon for can now be done via jest, so I replaced it all.
