### PR TITLE
fix(curriculum): change projects hint article links

### DIFF
--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/american-british-translator.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/american-british-translator.md
@@ -2,6 +2,7 @@
 id: 5e601c0d5ac9d0ecd8b94afe
 title: American British Translator
 challengeType: 4
+forumTopicId: 462358
 dashedName: american-british-translator
 ---
 

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/sudoku-solver.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/sudoku-solver.md
@@ -2,6 +2,7 @@
 id: 5e601bf95ac9d0ecd8b94afd
 title: Sudoku Solver
 challengeType: 4
+forumTopicId: 462357
 dashedName: sudoku-solver
 ---
 

--- a/curriculum/challenges/english/07-scientific-computing-with-python/scientific-computing-with-python-projects/arithmetic-formatter.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/scientific-computing-with-python-projects/arithmetic-formatter.md
@@ -2,6 +2,7 @@
 id: 5e44412c903586ffb414c94c
 title: Arithmetic Formatter
 challengeType: 10
+forumTopicId: 462359
 dashedName: arithmetic-formatter
 ---
 

--- a/curriculum/challenges/english/07-scientific-computing-with-python/scientific-computing-with-python-projects/budget-app.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/scientific-computing-with-python-projects/budget-app.md
@@ -2,6 +2,7 @@
 id: 5e44413e903586ffb414c94e
 title: Budget App
 challengeType: 10
+forumTopicId: 462361
 dashedName: budget-app
 ---
 

--- a/curriculum/challenges/english/07-scientific-computing-with-python/scientific-computing-with-python-projects/polygon-area-calculator.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/scientific-computing-with-python-projects/polygon-area-calculator.md
@@ -2,6 +2,7 @@
 id: 5e444147903586ffb414c94f
 title: Polygon Area Calculator
 challengeType: 10
+forumTopicId: 462363
 dashedName: polygon-area-calculator
 ---
 

--- a/curriculum/challenges/english/07-scientific-computing-with-python/scientific-computing-with-python-projects/probability-calculator.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/scientific-computing-with-python-projects/probability-calculator.md
@@ -2,6 +2,7 @@
 id: 5e44414f903586ffb414c950
 title: Probability Calculator
 challengeType: 10
+forumTopicId: 462364
 dashedName: probability-calculator
 ---
 

--- a/curriculum/challenges/english/07-scientific-computing-with-python/scientific-computing-with-python-projects/time-calculator.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/scientific-computing-with-python-projects/time-calculator.md
@@ -2,6 +2,7 @@
 id: 5e444136903586ffb414c94d
 title: Time Calculator
 challengeType: 10
+forumTopicId: 462360
 dashedName: time-calculator
 ---
 

--- a/curriculum/challenges/english/08-data-analysis-with-python/data-analysis-with-python-projects/demographic-data-analyzer.md
+++ b/curriculum/challenges/english/08-data-analysis-with-python/data-analysis-with-python-projects/demographic-data-analyzer.md
@@ -2,6 +2,7 @@
 id: 5e46f7e5ac417301a38fb929
 title: Demographic Data Analyzer
 challengeType: 10
+forumTopicId: 462367
 dashedName: demographic-data-analyzer
 ---
 

--- a/curriculum/challenges/english/08-data-analysis-with-python/data-analysis-with-python-projects/mean-variance-standard-deviation-calculator.md
+++ b/curriculum/challenges/english/08-data-analysis-with-python/data-analysis-with-python-projects/mean-variance-standard-deviation-calculator.md
@@ -2,6 +2,7 @@
 id: 5e46f7e5ac417301a38fb928
 title: Mean-Variance-Standard Deviation Calculator
 challengeType: 10
+forumTopicId: 462366
 dashedName: mean-variance-standard-deviation-calculator
 ---
 

--- a/curriculum/challenges/english/08-data-analysis-with-python/data-analysis-with-python-projects/medical-data-visualizer.md
+++ b/curriculum/challenges/english/08-data-analysis-with-python/data-analysis-with-python-projects/medical-data-visualizer.md
@@ -2,6 +2,7 @@
 id: 5e46f7f8ac417301a38fb92a
 title: Medical Data Visualizer
 challengeType: 10
+forumTopicId: 462368
 dashedName: medical-data-visualizer
 ---
 

--- a/curriculum/challenges/english/08-data-analysis-with-python/data-analysis-with-python-projects/page-view-time-series-visualizer.md
+++ b/curriculum/challenges/english/08-data-analysis-with-python/data-analysis-with-python-projects/page-view-time-series-visualizer.md
@@ -2,6 +2,7 @@
 id: 5e46f802ac417301a38fb92b
 title: Page View Time Series Visualizer
 challengeType: 10
+forumTopicId: 462369
 dashedName: page-view-time-series-visualizer
 ---
 

--- a/curriculum/challenges/english/08-data-analysis-with-python/data-analysis-with-python-projects/sea-level-predictor.md
+++ b/curriculum/challenges/english/08-data-analysis-with-python/data-analysis-with-python-projects/sea-level-predictor.md
@@ -2,6 +2,7 @@
 id: 5e4f5c4b570f7e3a4949899f
 title: Sea Level Predictor
 challengeType: 10
+forumTopicId: 462370
 dashedName: sea-level-predictor
 ---
 

--- a/curriculum/challenges/english/09-information-security/information-security-projects/port-scanner.md
+++ b/curriculum/challenges/english/09-information-security/information-security-projects/port-scanner.md
@@ -2,6 +2,7 @@
 id: 5e46f979ac417301a38fb932
 title: Port Scanner
 challengeType: 10
+forumTopicId: 462372
 helpCategory: Python
 dashedName: port-scanner
 ---

--- a/curriculum/challenges/english/09-information-security/information-security-projects/secure-real-time-multiplayer-game.md
+++ b/curriculum/challenges/english/09-information-security/information-security-projects/secure-real-time-multiplayer-game.md
@@ -2,6 +2,7 @@
 id: 5e601c775ac9d0ecd8b94aff
 title: Secure Real Time Multiplayer Game
 challengeType: 4
+forumTopicId: 462375
 dashedName: secure-real-time-multiplayer-game
 ---
 

--- a/curriculum/challenges/english/09-information-security/information-security-projects/sha-1-password-cracker.md
+++ b/curriculum/challenges/english/09-information-security/information-security-projects/sha-1-password-cracker.md
@@ -2,6 +2,7 @@
 id: 5e46f983ac417301a38fb933
 title: SHA-1 Password Cracker
 challengeType: 10
+forumTopicId: 462374
 helpCategory: Python
 dashedName: sha-1-password-cracker
 ---

--- a/curriculum/challenges/english/11-machine-learning-with-python/machine-learning-with-python-projects/book-recommendation-engine-using-knn.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/machine-learning-with-python-projects/book-recommendation-engine-using-knn.md
@@ -2,6 +2,7 @@
 id: 5e46f8e3ac417301a38fb92f
 title: Book Recommendation Engine using KNN
 challengeType: 10
+forumTopicId: 462378
 dashedName: book-recommendation-engine-using-knn
 ---
 

--- a/curriculum/challenges/english/11-machine-learning-with-python/machine-learning-with-python-projects/cat-and-dog-image-classifier.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/machine-learning-with-python-projects/cat-and-dog-image-classifier.md
@@ -2,6 +2,7 @@
 id: 5e46f8dcac417301a38fb92e
 title: Cat and Dog Image Classifier
 challengeType: 10
+forumTopicId: 462377
 dashedName: cat-and-dog-image-classifier
 ---
 

--- a/curriculum/challenges/english/11-machine-learning-with-python/machine-learning-with-python-projects/linear-regression-health-costs-calculator.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/machine-learning-with-python-projects/linear-regression-health-costs-calculator.md
@@ -2,6 +2,7 @@
 id: 5e46f8edac417301a38fb930
 title: Linear Regression Health Costs Calculator
 challengeType: 10
+forumTopicId: 462379
 dashedName: linear-regression-health-costs-calculator
 ---
 

--- a/curriculum/challenges/english/11-machine-learning-with-python/machine-learning-with-python-projects/neural-network-sms-text-classifier.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/machine-learning-with-python-projects/neural-network-sms-text-classifier.md
@@ -2,6 +2,7 @@
 id: 5e46f8edac417301a38fb931
 title: Neural Network SMS Text Classifier
 challengeType: 10
+forumTopicId: 462380
 dashedName: neural-network-sms-text-classifier
 ---
 

--- a/curriculum/challenges/english/11-machine-learning-with-python/machine-learning-with-python-projects/rock-paper-scissors.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/machine-learning-with-python-projects/rock-paper-scissors.md
@@ -2,6 +2,7 @@
 id: 5e46f8d6ac417301a38fb92d
 title: Rock Paper Scissors
 challengeType: 10
+forumTopicId: 462376
 dashedName: rock-paper-scissors
 ---
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #40472

<!-- Feel free to add any additional description of changes below this line -->
Make "Get a Hint" links of the remaining 20 projects to point to their corresponding forum topics by setting the `forumTopicId` in the front matter of the project files.

Ref: https://github.com/freeCodeCamp/freeCodeCamp/issues/40472#issuecomment-850496017

I have also manually double-checked the changes by clicking on the "Get a Hint" links of the projects.