### PR TITLE
fix(curriculum): add condition for mediaText in Safari

### DIFF
--- a/client/src/utils/css-help.ts
+++ b/client/src/utils/css-help.ts
@@ -77,6 +77,12 @@ class CSSHelp {
   }
   getRuleListsWithinMedia(conditionText: string): CSSStyleRule[] {
     const medias = this.getCSSRules('media') as CSSMediaRule[];
+    if (!medias?.[0]?.conditionText) {
+      // Safari does not have conditionText.
+      return Array.from(
+        medias?.find(x => x?.media?.mediaText === conditionText)?.cssRules || []
+      ) as CSSStyleRule[];
+    }
     const cond = medias?.find(x => x.conditionText === conditionText);
     const cssRules = cond?.cssRules;
     return Array.from(cssRules || []) as CSSStyleRule[];

--- a/curriculum/challenges/english/01-responsive-web-design/responsive-web-design-principles/create-a-media-query.md
+++ b/curriculum/challenges/english/01-responsive-web-design/responsive-web-design-principles/create-a-media-query.md
@@ -37,7 +37,7 @@ You should declare a `@media` query for devices with a `height` less than or equ
 
 ```js
 const media = new __helpers.CSSHelp(document).getCSSRules('media');
-assert(media.some(x => x.conditionText?.includes('(max-height: 800px)')));
+assert(media?.some(x => x.conditionText?.includes('(max-height: 800px)') || x.media?.mediaText?.includes('(max-height: 800px)')));
 ```
 
 Your `p` element should have a `font-size` of `10px` when the device `height` is less than or equal to `800px`.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #42354 

This is a quickfix. If someone can think of a way to write tests for this, I think it would be helpful.