### PR TITLE
fix: force mocha to exit when 0 tests

### DIFF
--- a/curriculum/package.json
+++ b/curriculum/package.json
@@ -25,7 +25,7 @@
     "delete-step": "cross-env CALLING_DIR=$INIT_CWD node ../tools/challenge-helper-scripts/delete-step",
     "lint": "gulp lint",
     "reorder-steps": "cross-env CALLING_DIR=$INIT_CWD node ../tools/challenge-helper-scripts/reorder-steps",
-    "test": "mocha --delay --reporter progress --bail",
+    "test": "mocha --delay --exit  --reporter progress --bail",
     "pretest:full-output": "npm run pretest",
     "test:full-output": "cross-env FULL_OUTPUT=true mocha --delay --reporter progress"
   },


### PR DESCRIPTION
Otherwise a command like

npm run test:curriculum -- -g 'Not a real title'

will spin forever

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
