### PR TITLE
chore: separate News articles issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/03--issues-with-content-on-articles-and-docs.md
+++ b/.github/ISSUE_TEMPLATE/03--issues-with-content-on-articles-and-docs.md
@@ -1,5 +1,5 @@
 ---
-name: 'Report issues with content on /news, guide articles or documentation'
+name: 'Report issues with content on guide articles or documentation'
 about: Report issues with content on a specific article, like broken links, typos, missing parts, etc.
 title: ''
 labels: 'type: bug, status: waiting triage'
@@ -10,6 +10,8 @@ assignees: ''
 <!--
 NOTE: If you want to become an author on freeCodeCamp, you can find everything here: https://www.freecodecamp.org/news/developer-news-style-guide/
 -->
+<!-- If you are reporting an issue with an article on our News publication,
+please follow this link to send an email to our editorial team https://mailxto.com/lkj5n7 -->
 
 **Describe your problem and how to reproduce it:**
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,9 @@ contact_links:
   - name: Request programming help with coding challenges
     url: https://forum.freecodecamp.org
     about: Please visit this page for general support and programming help on coding challenges.
+  - name: Report issues with content on /news articles
+    url: https://mailxto.com/lkj5n7
+    about: Please fill out an email to our editorial team to report issues on specific articles on our technical publication (link opens an email template)
   - name: Request technical support for your freeCodeCamp account
     url: https://www.freecodecamp.org/support
     about: Please visit this page for requesting technical support related to your freeCodeCamp account.


### PR DESCRIPTION
Updates to News articles are resolved by sending emails to the editorial
team. This commit reflects this decision in creating a distinct link
about News articles and removing mention of it in an existing issue.

This is motivated by the discussion found here 
https://github.com/freeCodeCamp/freeCodeCamp/issues/42240#issuecomment-848897634.

Quote:

> We just streamlined the process a bit, and the fastest way to resolve typo and content errors are to send issues like these to the `editorial<at>freecodecamp.org`

Mail link was created using https://mailxto.com/.

The MailxTo website is designed to

>  Generate a short mailto link that can be shared on social medias easily and embed it to your website. 

Happy to change the contents of the email template if people have suggestions. Open to general feedback as well, like the appropriateness of making this change. Similarly, even though some/most people may still create issues for News article updates, this could still help inform people who take the time to read all the issue templates.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Preview of email template when you click on https://mailxto.com/lkj5n7

![image](https://user-images.githubusercontent.com/2754821/120875082-cf45fc00-c55e-11eb-9352-afec2feca45a.png)

