### PR TITLE
chore(tools): split color tokens to separate layers

### DIFF
--- a/tools/ui-components/src/button.css
+++ b/tools/ui-components/src/button.css
@@ -32,5 +32,5 @@
 }
 
 .fcc-style {
-  @apply bg-darkGreen;
+  @apply bg-fccSecondary;
 }

--- a/tools/ui-components/src/color-system.js
+++ b/tools/ui-components/src/color-system.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import colorList from './colors.css';
+
+// ---------------------------------------------------------- //
+//                      HELPER FUNCTIONS                      //
+// ---------------------------------------------------------- //
+// Transform colorList from an object to an array of objects
+const transformedColorList = Object.keys(colorList).map(colorName => ({
+  label: colorName.replace('--', ''),
+  value: colorList[colorName]
+}));
+
+// Get the background and text color values of each palette item
+const getPaletteItemStyle = color => {
+  const itemTextColor = color.label.substring(color.label.length - 2);
+
+  return {
+    backgroundColor: color.value,
+    // Extract the scale from the color label.
+    // If the scale is greater or equal to 50, use white text for the label; otherwise, use dark text.
+    color: parseInt(itemTextColor, 10) >= 50 ? '#ffffff' : '#0a0a23'
+  };
+};
+
+const getPaletteByColorName = name =>
+  transformedColorList.filter(color => color.label.includes(name));
+
+// ---------------------------------------------------------- //
+//                         COMPONENTS                         //
+// ---------------------------------------------------------- //
+const Palette = ({ colors }) => {
+  return (
+    <div className='inline-flex flex-col m-4 w-3/12'>
+      {colors.map(color => (
+        <div
+          className='flex items-center p-2 h-8'
+          key={color.label}
+          style={getPaletteItemStyle(color)}
+        >
+          {color.label}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+Palette.propTypes = {
+  colors: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string,
+      value: PropTypes.string
+    })
+  )
+};
+
+export const AllPalettes = () => {
+  return (
+    <>
+      <Palette colors={getPaletteByColorName('gray')} />
+      <Palette colors={getPaletteByColorName('purple')} />
+      <Palette colors={getPaletteByColorName('yellow')} />
+      <Palette colors={getPaletteByColorName('blue')} />
+      <Palette colors={getPaletteByColorName('green')} />
+      <Palette colors={getPaletteByColorName('red')} />
+    </>
+  );
+};

--- a/tools/ui-components/src/color-system.stories.js
+++ b/tools/ui-components/src/color-system.stories.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { AllPalettes } from './color-system';
+
+const story = {
+  title: 'Design System/Color',
+  component: AllPalettes
+};
+
+export const ColorSystem = () => <AllPalettes />;
+
+export default story;

--- a/tools/ui-components/src/colors.css
+++ b/tools/ui-components/src/colors.css
@@ -1,0 +1,69 @@
+:root {
+  --gray00: #ffffff;
+  --gray05: #f5f6f7;
+  --gray10: #dfdfe2;
+  --gray15: #d0d0d5;
+  --gray45: #858591;
+  --gray75: #3b3b4f;
+  --gray80: #2a2a40;
+  --gray85: #1b1b32;
+  --gray90: #0a0a23;
+
+  --purple10: #dbb8ff;
+  --purple50: #9400d3;
+  --purple90: #5a01a7;
+
+  --yellow10: #ffc300;
+  --yellow20: #ffbf00;
+  --yellow50: #f1be32;
+  --yellow90: #4d3800;
+
+  --blue10: rgba(153, 201, 255, 0.3);
+  --blue20: rgba(0, 46, 173, 0.3);
+  --blue30: #99c9ff;
+  --blue50: #198eee;
+  --blue90: #002ead;
+
+  --green10: #acd157;
+  --green90: #00471b;
+
+  --red10: #ffadad;
+  --red20: #f8577c;
+  --red80: #f82153;
+  --red90: #850000;
+}
+
+:export {
+  --gray00: var(--gray00);
+  --gray05: var(--gray05);
+  --gray10: var(--gray10);
+  --gray15: var(--gray15);
+  --gray45: var(--gray45);
+  --gray75: var(--gray75);
+  --gray80: var(--gray80);
+  --gray85: var(--gray85);
+  --gray90: var(--gray90);
+
+  --purple10: var(--purple10);
+  --purple50: var(--purple50);
+  --purple90: var(--purple90);
+
+  --yellow10: var(--yellow10);
+  --yellow20: var(--yellow20);
+  --yellow50: var(--yellow50);
+  --yellow90: var(--yellow90);
+
+  --blue10: var(--blue10);
+  --blue20: var(--blue20);
+  --blue30: var(--blue30);
+  --blue50: var(--blue50);
+  --blue90: var(--blue90);
+
+  --green10: var(--green10);
+  --green90: var(--green90);
+
+  --red10: var(--red10);
+  --red20: var(--red20);
+  --red80: var(--red80);
+  --red90: var(--red90);
+}

--- a/tools/ui-components/src/global.css
+++ b/tools/ui-components/src/global.css
@@ -1,3 +1,4 @@
 @import 'tailwindcss/base';
 @import 'tailwindcss/components';
 @import 'tailwindcss/utilities';
+@import './colors';

--- a/tools/ui-components/tailwind.config.js
+++ b/tools/ui-components/tailwind.config.js
@@ -3,40 +3,7 @@ module.exports = {
   darkMode: false,
   theme: {
     colors: {
-      // Configure the color palette here
-      // Layout Colors
-      gray00: '#ffffff',
-      gray05: '#f5f6f7',
-      gray10: '#dfdfe2',
-      gray15: '#d0d0d5',
-      gray45: '#858591',
-      gray75: '#3b3b4f',
-      gray80: '#2a2a40',
-      gray85: '#1b1b32',
-      gray90: '#0a0a23',
-      // Accent Colors - Primary
-      blue: '#99c9ff',
-      green: '#acd157',
-      purple: '#dbb8ff',
-      yellow: '#f1be32',
-      // Accent Colors - Secondary
-      darkBlue: '#002ead',
-      darkGreen: '#00471b',
-      darkPurple: '#5a01a7',
-      darkYellow: '#4d3800',
-      // Colors in variables.css
-      blueMid: '#198eee',
-      blueTranslucent: 'rgba(0, 46, 173, 0.3)',
-      blueTranslucentDark: 'rgba(153, 201, 255, 0.3)',
-      editorBackgroundDark: '#2a2b40',
-      loveDark: '#f82153',
-      darkRed: '#850000',
-      editorBackground: '#fffffe',
-      love: '#f8577c',
-      purpleMid: '#9400d3',
-      red: '#ffadad',
-      yellowGold: '#ffbf00',
-      yellowLight: '#ffc300'
+      fccSecondary: 'var(--green90)'
     }
   },
   variants: {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

In https://github.com/freeCodeCamp/freeCodeCamp/issues/42186#issuecomment-845829904, we decided to split the color variables into 2 layers: one keeps them with their actual color names (red, blue, green,...); and the other refers to the color by their usage (background, foreground,...). Furthermore, @ahmadabdolsaheb and I decided to use numbers in the color names (similar to `gray10`, `gray20`) in place of `lightGreen`, `darkGreen`, etc. This will keep the naming consistent, as well as allowing us to add more shades to the colors in the future.

This PR partially addresses that by:
- Creating a `colors.css` in `ui-components` to store the color values, which is the first layer I mentioned above
- Moving all the colors in `tailwind.config.js` to `colors.css`. The config file will contain color tokens, which is the second layer
- Creating a Storybook page to help visualize the color palettes

What this PR does not address are:
- Mapping color name to colors tokens in `tailwind.config.js`. I might need some help with this part, as I haven't been working a lot with our design system. Though I think I could try to propose/add the tokens in as we move to the component development phase
- Support for dark theme. This is a tricky part and I need to discuss a bit more before moving further. I'll comment in the issue thread

## Screenshot

<img width="1680" alt="Screen Shot 2021-06-07 at 01 40 31" src="https://user-images.githubusercontent.com/25715018/120936965-fb1ada80-c734-11eb-90a5-09b40ea39765.png">
