### PR TITLE
Remove backticks from around data types to ease translations

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/store-multiple-values-in-one-variable-using-javascript-arrays.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/store-multiple-values-in-one-variable-using-javascript-arrays.md
@@ -19,23 +19,23 @@ var sandwich = ["peanut butter", "jelly", "bread"]
 
 # --instructions--
 
-Modify the new array `myArray` so that it contains both a `string` and a `number` (in that order).
+Modify the new array `myArray` so that it contains both a string and a number (in that order).
 
 # --hints--
 
-`myArray` should be an `array`.
+`myArray` should be an array.
 
 ```js
 assert(typeof myArray == 'object');
 ```
 
-The first item in `myArray` should be a `string`.
+The first item in `myArray` should be a string.
 
 ```js
 assert(typeof myArray[0] !== 'undefined' && typeof myArray[0] == 'string');
 ```
 
-The second item in `myArray` should be a `number`.
+The second item in `myArray` should be a number.
 
 ```js
 assert(typeof myArray[1] !== 'undefined' && typeof myArray[1] == 'number');


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!-- Feel free to add any additional description of changes below this line -->

Proofreading the italian translation, this is the first challenge I found that has the data types surrounded by code tags/backticks, it makes for awkward sentences to have the untranslated data type in the translated sentence.
Is it really necessary to have the data types surrounded by backticks?
I would remove it also from the first `array` in the description, but I don't know if that needs focus or something