### PR TITLE
fix(curriculum): improve description and tests descriptions

### DIFF
--- a/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/topological-sort.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/topological-sort.md
@@ -12,7 +12,7 @@ Given a mapping between items, and items they depend on, a topological sort orde
 
 # --instructions--
 
-Write a function that will return list with valid compile order of libraries from their dependencies.
+Write a function that will return a list with valid compile order of libraries from their dependencies.
 
 - Assume library names are single words.
 - Items mentioned as only dependents have no dependents of their own, but their order of compiling must be given.
@@ -41,7 +41,7 @@ synopsys
 
 The compiling of a library in the VHDL language has the constraint that a library must be compiled after any library it depends on. The above data would be un-orderable if, for example, `dw04` is added to the list of dependencies of `dw01`.
 
-Input of the function will be a multiline string, each line will consist of name of the library, followed by it dependencies (if exist).
+The input of the function will be a multiline string, each line will consist of the name of the library, followed by its dependencies (if exist).
 
 For example:
 

--- a/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/topological-sort.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/topological-sort.md
@@ -111,26 +111,17 @@ const libsVHDL =
   std_cell_lib     ieee std_cell_lib
   synopsys`;
 
-const solutionVHDL = [
-  'ieee', 'std_cell_lib', 'gtech', 'dware', 'dw07', 'dw06',
-  'dw05', 'dw02', 'dw01', 'dw04', 'std', 'ramlib', 'synopsys',
-  'dw03', 'des_system_lib'
-];
-
 const libsCustom =
   `a b c d
   b c d
   d c
   c base
   base`;
-const solutionCustom = ['base', 'c', 'd', 'b', 'a'];
 
 const libsUnorderable =
   `TestLib Base MainLib
   MainLib TestLib
   Base`;
-
-const solutionUnorderable = ['Base'];
 ```
 
 ## --seed-contents--

--- a/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/topological-sort.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/topological-sort.md
@@ -57,28 +57,34 @@ There are two popular algorithms for topological sorting:
 assert(typeof topologicalSort === 'function');
 ```
 
-`topologicalSort` should return correct library order.
+`topologicalSort(libsSimple)` should return an array.
+
+```js
+assert(Array.isArray(topologicalSort(libsSimple)));
+```
+
+`topologicalSort(libsSimple)` should return `['bbb', 'aaa']`.
 
 ```js
 assert.deepEqual(topologicalSort(libsSimple), ['bbb', 'aaa']);
 ```
 
-`topologicalSort` should return correct library order.
+`topologicalSort(libsVHDL)` should return `['ieee', 'std_cell_lib', 'gtech', 'dware', 'dw07', 'dw06', 'dw05', 'dw02', 'dw01', 'dw04', 'std', 'ramlib', 'synopsys', 'dw03', 'des_system_lib']`.
 
 ```js
-assert.deepEqual(topologicalSort(libsVHDL), solutionVHDL);
+assert.deepEqual(topologicalSort(libsVHDL), ['ieee', 'std_cell_lib', 'gtech', 'dware', 'dw07', 'dw06', 'dw05', 'dw02', 'dw01', 'dw04', 'std', 'ramlib', 'synopsys', 'dw03', 'des_system_lib']);
 ```
 
-`topologicalSort` should return correct library order.
+`topologicalSort(libsCustom)` should return `['base', 'c', 'd', 'b', 'a']`.
 
 ```js
-assert.deepEqual(topologicalSort(libsCustom), solutionCustom);
+assert.deepEqual(topologicalSort(libsCustom), ['base', 'c', 'd', 'b', 'a']);
 ```
 
 `topologicalSort` should ignore unorderable dependencies.
 
 ```js
-assert.deepEqual(topologicalSort(libsUnorderable), solutionUnorderable);
+assert.deepEqual(topologicalSort(libsUnorderable), ['Base']);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/topological-sort.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/topological-sort.md
@@ -8,19 +8,19 @@ dashedName: topological-sort
 
 # --description--
 
-Given a mapping between items, and items they depend on, a [topological sort](<https://en.wikipedia.org/wiki/Topological sorting> "wp: Topological sorting") orders items so that no item precedes an item it depends upon. The compiling of a library in the [VHDL](https://en.wikipedia.org/wiki/VHDL "wp: VHDL") language has the constraint that a library must be compiled after any library it depends on.
+Given a mapping between items, and items they depend on, a topological sort orders items so that no item precedes an item it depends upon. There are two popular algorithms for topological sorting: Kahn's (1962) topological sort and depth-first search.
 
 # --instructions--
 
-Write a function that will return a valid compile order of VHDL libraries from their dependencies.
+Write a function that will return list with valid compile order of libraries from their dependencies.
 
-<ul>
-  <li>Assume library names are single words.</li>
-  <li>Items mentioned as only dependents have no dependents of their own, but their order of compiling must be given.</li>
-  <li>Any self dependencies should be ignored.</li>
-  <li>Any un-orderable dependencies should be ignored.</li>
-</ul>
+- Assume library names are single words.
+- Items mentioned as only dependents have no dependents of their own, but their order of compiling must be given.
+- Any self dependencies should be ignored.
+- Any un-orderable dependencies should be ignored.
+
 Use the following data as an example:
+
 <pre>
 LIBRARY          LIBRARY DEPENDENCIES
 =======          ====================
@@ -38,16 +38,18 @@ ramlib           std ieee
 std_cell_lib     ieee std_cell_lib
 synopsys
 </pre>
-<small>Note: the above data would be un-orderable if, for example, <code>dw04</code> is added to the list of dependencies of <code>dw01</code>.</small>
-<strong>C.f.:</strong>
-<ul>
-  <li><a href="https://rosettacode.org/wiki/Topological sort/Extracted top item" title="Topological sort/Extracted top item" target="_blank">Topological sort/Extracted top item</a>.</li>
-</ul>
-There are two popular algorithms for topological sorting:
-<ul>
-  <li><a href="https://en.wikipedia.org/wiki/Topological sorting" title="wp: Topological sorting" target="_blank">Kahn's 1962 topological sort</a></li>
-  <li><a href="https://www.embeddedrelated.com/showarticle/799.php" target="_blank">depth-first search</a></li>
-</ul>
+
+The compiling of a library in the VHDL language has the constraint that a library must be compiled after any library it depends on. The above data would be un-orderable if, for example, `dw04` is added to the list of dependencies of `dw01`.
+
+Input of the function will be a multiline string, each line will consist of name of the library, followed by it dependencies (if exist).
+
+For example:
+
+```js
+const libsSimple =
+  `aaa bbb
+  bbb`;
+```
 
 # --hints--
 


### PR DESCRIPTION
- Makes tests descriptions more explicit.
- Adds example of input string to description.
- Moves few sentences to separate general case from example.
- Adds test for expected return type.
- Removes external links, per #40749.

Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.