### PR TITLE
fix: use more memory for gatsby develop

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -24,7 +24,7 @@
     "build:workers": "node --max_old_space_size=7168 node_modules/webpack-cli/bin/cli --config ./webpack-workers.js",
     "clean": "gatsby clean",
     "predevelop": "node ../tools/scripts/build/ensure-env.js && npm run build:workers -- --env development",
-    "develop": "gatsby develop --inspect=9230",
+    "develop": "node --max_old_space_size=4000 node_modules/gatsby-cli develop --inspect=9230",
     "format": "npm run format:gatsby && npm run format:src && npm run format:utils",
     "format:gatsby": "prettier-eslint --write --trailing-comma none --single-quote './gatsby-*.js'",
     "format:src": "prettier-eslint --write --trailing-comma none --single-quote './src/**/*.js'",


### PR DESCRIPTION
The latest Babel update makes Gatsby more memory hungry, so more needs
providing, at least for GitPod
