### PR TITLE
fix(curriculum): rework Project Euler 52

### DIFF
--- a/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-52-permuted-multiples.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-52-permuted-multiples.md
@@ -48,7 +48,7 @@ permutedMultiples(2);
 # --solutions--
 
 ```js
-function permutedMultiples() {
+function permutedMultiples(n) {
     const isPermutation = (a, b) =>
         a.length !== b.length
             ? false
@@ -61,9 +61,9 @@ function permutedMultiples() {
 
     while (!found) {
         start *= 10;
-        for (let i = start; i < start * 10 / 6; i++) {
+        for (let i = start; i < start * 10 / n; i++) {
             found = true;
-            for (let j = 2; j <= 6; j++) {
+            for (let j = 2; j <= n; j++) {
                 if (!isPermutation(i + '', j * i + '')) {
                     found = false;
                     break;

--- a/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-52-permuted-multiples.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-52-permuted-multiples.md
@@ -10,20 +10,26 @@ dashedName: problem-52-permuted-multiples
 
 It can be seen that the number, 125874, and its double, 251748, contain exactly the same digits, but in a different order.
 
-Find the smallest positive integer, `x`, such that `2x`, `3x`, `4x`, `5x`, and `6x`, contain the same digits.
+Find the smallest positive integer, such that multiplied by integers $\\{2, 3, \ldots, n\\}$, contain the same digits.
 
 # --hints--
 
-`permutedMultiples()` should return a number.
+`permutedMultiples(2)` should return a number.
 
 ```js
-assert(typeof permutedMultiples() === 'number');
+assert(typeof permutedMultiples(2) === 'number');
 ```
 
-`permutedMultiples()` should return 142857.
+`permutedMultiples(2)` should return `125874`.
 
 ```js
-assert.strictEqual(permutedMultiples(), 142857);
+assert.strictEqual(permutedMultiples(2), 125874);
+```
+
+`permutedMultiples(6)` should return `142857`.
+
+```js
+assert.strictEqual(permutedMultiples(6), 142857);
 ```
 
 # --seed--
@@ -31,12 +37,12 @@ assert.strictEqual(permutedMultiples(), 142857);
 ## --seed-contents--
 
 ```js
-function permutedMultiples() {
+function permutedMultiples(n) {
 
   return true;
 }
 
-permutedMultiples();
+permutedMultiples(2);
 ```
 
 # --solutions--


### PR DESCRIPTION
- Reworks challenge to use argument in function call.
- Adds example from description to tests. For `n = 3, 4, 5` result would be the same as for `n = 6`, so adding them all doesn't make sense.
- Updates solution.
- Related to #40896.

Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.