### PR TITLE
chore: group together monaco-editor and plugin

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,10 @@
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "matchCurrentVersion": "!/^0/",
       "automerge": true
+    },
+    {
+      "groupName": "Monaco Editor",
+      "matchPackageNames": ["monaco-editor", "monaco-editor-webpack-plugin"]
     }
   ],
   "ignorePaths": [


### PR DESCRIPTION
This should get renovate to create PRs where both are modified.  I'm not 100% sure what happens if they're published out of sync, though.