### PR TITLE
fix(curriculum): Removing genitive from inside backticks and backticks from word own

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/inherit-behaviors-from-a-supertype.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/inherit-behaviors-from-a-supertype.md
@@ -17,7 +17,7 @@ Animal.prototype.eat = function() {
 };
 ```
 
-This and the next challenge will cover how to reuse `Animal's` methods inside `Bird` and `Dog` without defining them again. It uses a technique called inheritance. This challenge covers the first step: make an instance of the `supertype` (or parent). You already know one way to create an instance of `Animal` using the `new` operator:
+This and the next challenge will cover how to reuse `Animal`'s methods inside `Bird` and `Dog` without defining them again. It uses a technique called inheritance. This challenge covers the first step: make an instance of the `supertype` (or parent). You already know one way to create an instance of `Animal` using the `new` operator:
 
 ```js
 let animal = new Animal();
@@ -29,7 +29,7 @@ There are some disadvantages when using this syntax for inheritance, which are t
 let animal = Object.create(Animal.prototype);
 ```
 
-`Object.create(obj)` creates a new object, and sets `obj` as the new object's `prototype`. Recall that the `prototype` is like the "recipe" for creating an object. By setting the `prototype` of `animal` to be `Animal's` `prototype`, you are effectively giving the `animal` instance the same "recipe" as any other instance of `Animal`.
+`Object.create(obj)` creates a new object, and sets `obj` as the new object's `prototype`. Recall that the `prototype` is like the "recipe" for creating an object. By setting the `prototype` of `animal` to be `Animal`'s `prototype`, you are effectively giving the `animal` instance the same "recipe" as any other instance of `Animal`.
 
 ```js
 animal.eat();

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/inherit-behaviors-from-a-supertype.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/inherit-behaviors-from-a-supertype.md
@@ -17,7 +17,7 @@ Animal.prototype.eat = function() {
 };
 ```
 
-This and the next challenge will cover how to reuse `Animal`'s methods inside `Bird` and `Dog` without defining them again. It uses a technique called inheritance. This challenge covers the first step: make an instance of the `supertype` (or parent). You already know one way to create an instance of `Animal` using the `new` operator:
+This and the next challenge will cover how to reuse the methods of `Animal` inside `Bird` and `Dog` without defining them again. It uses a technique called inheritance. This challenge covers the first step: make an instance of the `supertype` (or parent). You already know one way to create an instance of `Animal` using the `new` operator:
 
 ```js
 let animal = new Animal();
@@ -29,7 +29,7 @@ There are some disadvantages when using this syntax for inheritance, which are t
 let animal = Object.create(Animal.prototype);
 ```
 
-`Object.create(obj)` creates a new object, and sets `obj` as the new object's `prototype`. Recall that the `prototype` is like the "recipe" for creating an object. By setting the `prototype` of `animal` to be `Animal`'s `prototype`, you are effectively giving the `animal` instance the same "recipe" as any other instance of `Animal`.
+`Object.create(obj)` creates a new object, and sets `obj` as the new object's `prototype`. Recall that the `prototype` is like the "recipe" for creating an object. By setting the `prototype` of `animal` to be the `prototype` of `Animal`, you are effectively giving the `animal` instance the same "recipe" as any other instance of `Animal`.
 
 ```js
 animal.eat();

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/override-inherited-methods.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/override-inherited-methods.md
@@ -36,7 +36,7 @@ Bird.prototype.eat = function() {
 };
 ```
 
-If you have an instance `let duck = new Bird();` and you call `duck.eat()`, this is how JavaScript looks for the method on `duck`'s `prototype` chain:
+If you have an instance `let duck = new Bird();` and you call `duck.eat()`, this is how JavaScript looks for the method on the `prototype` chain of `duck`:
 
 1.  `duck` => Is `eat()` defined here? No.
 2.  `Bird` => Is `eat()` defined here? => Yes. Execute it and stop searching.

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/override-inherited-methods.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/override-inherited-methods.md
@@ -36,7 +36,7 @@ Bird.prototype.eat = function() {
 };
 ```
 
-If you have an instance `let duck = new Bird();` and you call `duck.eat()`, this is how JavaScript looks for the method on `duck’s` `prototype` chain:
+If you have an instance `let duck = new Bird();` and you call `duck.eat()`, this is how JavaScript looks for the method on `duck`'s `prototype` chain:
 
 1.  `duck` => Is `eat()` defined here? No.
 2.  `Bird` => Is `eat()` defined here? => Yes. Execute it and stop searching.

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/reset-an-inherited-constructor-property.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/reset-an-inherited-constructor-property.md
@@ -19,7 +19,7 @@ let duck = new Bird();
 duck.constructor
 ```
 
-But `duck` and all instances of `Bird` should show that they were constructed by `Bird` and not `Animal`. To do so, you can manually set `Bird's` constructor property to the `Bird` object:
+But `duck` and all instances of `Bird` should show that they were constructed by `Bird` and not `Animal`. To do so, you can manually set `Bird`'s constructor property to the `Bird` object:
 
 ```js
 Bird.prototype.constructor = Bird;

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/reset-an-inherited-constructor-property.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/reset-an-inherited-constructor-property.md
@@ -19,7 +19,7 @@ let duck = new Bird();
 duck.constructor
 ```
 
-But `duck` and all instances of `Bird` should show that they were constructed by `Bird` and not `Animal`. To do so, you can manually set `Bird`'s constructor property to the `Bird` object:
+But `duck` and all instances of `Bird` should show that they were constructed by `Bird` and not `Animal`. To do so, you can manually set the constructor property of `Bird` to the `Bird` object:
 
 ```js
 Bird.prototype.constructor = Bird;

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/use-prototype-properties-to-reduce-duplicate-code.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/use-prototype-properties-to-reduce-duplicate-code.md
@@ -12,7 +12,7 @@ Since `numLegs` will probably have the same value for all instances of `Bird`, y
 
 This may not be an issue when there are only two instances, but imagine if there are millions of instances. That would be a lot of duplicated variables.
 
-A better way is to use `Bird`'s `prototype`. Properties in the `prototype` are shared among ALL instances of `Bird`. Here's how to add `numLegs` to the `Bird prototype`:
+A better way is to use the `prototype` of `Bird`. Properties in the `prototype` are shared among ALL instances of `Bird`. Here's how to add `numLegs` to the `Bird prototype`:
 
 ```js
 Bird.prototype.numLegs = 2;

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/use-prototype-properties-to-reduce-duplicate-code.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/use-prototype-properties-to-reduce-duplicate-code.md
@@ -45,7 +45,7 @@ assert(beagle.numLegs !== undefined);
 assert(typeof beagle.numLegs === 'number');
 ```
 
-`numLegs` should be a `prototype` property not an `own` property.
+`numLegs` should be a `prototype` property not an own property.
 
 ```js
 assert(beagle.hasOwnProperty('numLegs') === false);

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/use-prototype-properties-to-reduce-duplicate-code.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/object-oriented-programming/use-prototype-properties-to-reduce-duplicate-code.md
@@ -12,7 +12,7 @@ Since `numLegs` will probably have the same value for all instances of `Bird`, y
 
 This may not be an issue when there are only two instances, but imagine if there are millions of instances. That would be a lot of duplicated variables.
 
-A better way is to use `Bird’s` `prototype`. Properties in the `prototype` are shared among ALL instances of `Bird`. Here's how to add `numLegs` to the `Bird prototype`:
+A better way is to use `Bird`'s `prototype`. Properties in the `prototype` are shared among ALL instances of `Bird`. Here's how to add `numLegs` to the `Bird prototype`:
 
 ```js
 Bird.prototype.numLegs = 2;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to #42421 

<!-- Feel free to add any additional description of changes below this line -->
there where a few occurences in which a variable name followed by the genitive had it inside the backticks, and a case in which there was an "own" inside backticks that doesn't seem necessary