### PR TITLE
fix(curriculum): ensure async test times out as expected

### DIFF
--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/personal-library.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/personal-library.md
@@ -18,7 +18,7 @@ When you are done, make sure a working demo of your project is hosted somewhere 
 
 # --instructions--
 
-1.  Add your MongoDB connection string to `.env` without quotes as `DB`  
+1.  Add your MongoDB connection string to `.env` without quotes as `DB`
     Example: `DB=mongodb://admin:pass@1234.mlab.com:1234/fccpersonallib`
 2.  In your `.env` file set `NODE_ENV` to `test`, without quotes
 3.  You need to create all routes within `routes/api.js`
@@ -66,7 +66,7 @@ async (getUserInput) => {
     let a = $.post(url, { title: 'Faux Book A' });
     let b = $.post(url, { title: 'Faux Book B' });
     let c = $.post(url, { title: 'Faux Book C' });
-    Promise.all([a, b, c]).then(async () => {
+    await Promise.all([a, b, c]).then(async () => {
       let data = await $.get(url);
       assert.isArray(data);
       assert.isAtLeast(data.length, 3);
@@ -214,8 +214,8 @@ async (getUserInput) => {
 
 ```js
 /**
-  Backend challenges don't need solutions, 
-  because they would need to be tested against a full working project. 
+  Backend challenges don't need solutions,
+  because they would need to be tested against a full working project.
   Please check our contributing guidelines to learn more.
 */
 ```


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #42363

<!-- Feel free to add any additional description of changes below this line -->
Implemented @gikf's solution of adding `await` before `Promise.all()`. Tested with Gitpod and fresh copy of Replit starter no longer passes test 3.
