### PR TITLE
chore: prevent major bumps to normalize-url

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,13 @@
     {
       "matchPackageNames": ["normalize-url"],
       "allowedVersions": "<5.0.0"
+    },
+    {
+      "groupName": "CodeSee",
+      "matchPackagePrefixes": [
+        "@codesee/"
+      ],
+      "automerge": true
     }
   ],
   "ignorePaths": [

--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,10 @@
     {
       "groupName": "Monaco Editor",
       "matchPackageNames": ["monaco-editor", "monaco-editor-webpack-plugin"]
+    },
+    {
+      "matchPackageNames": ["normalize-url"],
+      "allowedVersions": "<5.0.0"
     }
   ],
   "ignorePaths": [


### PR DESCRIPTION
The highest version that can be used in a browser is 4, after which
Safari is likely to break.
