### PR TITLE
chore: rework the language audits for build

### DIFF
--- a/client/src/components/Map/index.js
+++ b/client/src/components/Map/index.js
@@ -7,7 +7,7 @@ import { generateIconComponent } from '../../assets/icons';
 import { Link, Spacer } from '../helpers';
 import LinkButton from '../../assets/icons/LinkButton';
 import './map.css';
-import { isAuditedCert } from '../../../../config/is-audited';
+import { isAuditedCert } from '../../../../utils/is-audited';
 import envData from '../../../../config/env.json';
 
 const { curriculumLocale } = envData;

--- a/client/src/templates/Introduction/components/Block.js
+++ b/client/src/templates/Introduction/components/Block.js
@@ -12,7 +12,7 @@ import Challenges from './Challenges';
 import Caret from '../../../assets/icons/Caret';
 import GreenPass from '../../../assets/icons/GreenPass';
 import GreenNotCompleted from '../../../assets/icons/GreenNotCompleted';
-import { isAuditedCert } from '../../../../../config/is-audited';
+import { isAuditedCert } from '../../../../../utils/is-audited';
 import envData from '../../../../../config/env.json';
 import { Link } from '../../../components/helpers/';
 

--- a/config/i18n/all-langs.js
+++ b/config/i18n/all-langs.js
@@ -1,4 +1,11 @@
-/* An error will be thrown if the CLIENT_LOCALE and CURRICULUM_LOCALE variables
+// ---------------------------------------------------------------------------
+
+/*
+ * List of languages with localizations enabled for builds.
+ *
+ * Client is the UI, and Curriculum is the Challenge Content.
+ *
+ * An error will be thrown if the CLIENT_LOCALE and CURRICULUM_LOCALE variables
  * from the .env file aren't found in their respective arrays below
  */
 const availableLangs = {
@@ -12,6 +19,44 @@ const availableLangs = {
     'portuguese'
   ]
 };
+
+/*
+ * List of certifications with localization enabled in their world language.
+ *
+ * These certifications have been approved 100% on Crowdin at least during
+ * their launch, and hence meet the QA standard to be published live. Other
+ * certifications which have not been audited & approved will fallback to
+ * English equivalent.
+ */
+const auditedCerts = {
+  espanol: [
+    'responsive-web-design',
+    'javascript-algorithms-and-data-structures'
+  ],
+  chinese: [
+    'responsive-web-design',
+    'javascript-algorithms-and-data-structures',
+    'front-end-libraries',
+    'data-visualization',
+    'apis-and-microservices',
+    'quality-assurance'
+  ],
+  'chinese-traditional': [
+    'responsive-web-design',
+    'javascript-algorithms-and-data-structures',
+    'front-end-libraries',
+    'data-visualization',
+    'apis-and-microservices',
+    'quality-assurance'
+  ],
+  italian: [
+    'responsive-web-design',
+    'javascript-algorithms-and-data-structures'
+  ],
+  portuguese: ['responsive-web-design']
+};
+
+// ---------------------------------------------------------------------------
 
 // Each client language needs an entry in the rest of the variables below
 
@@ -55,3 +100,4 @@ exports.availableLangs = availableLangs;
 exports.i18nextCodes = i18nextCodes;
 exports.langDisplayNames = langDisplayNames;
 exports.langCodes = langCodes;
+exports.auditedCerts = auditedCerts;

--- a/curriculum/getChallenges.js
+++ b/curriculum/getChallenges.js
@@ -11,7 +11,7 @@ const {
 } = require('../tools/challenge-parser/translation-parser');
 /* eslint-enable max-len*/
 
-const { isAuditedCert } = require('../config/is-audited');
+const { isAuditedCert } = require('../utils/is-audited');
 const { dasherize } = require('../utils/slugs');
 const { createPoly } = require('../utils/polyvinyl');
 const { helpCategoryMap } = require('../client/utils/challengeTypes');

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -2,7 +2,7 @@
 const path = require('path');
 const liveServer = require('live-server');
 const stringSimilarity = require('string-similarity');
-const { isAuditedCert } = require('../../config/is-audited');
+const { isAuditedCert } = require('../../utils/is-audited');
 
 const spinner = require('ora')();
 

--- a/utils/is-audited.js
+++ b/utils/is-audited.js
@@ -9,32 +9,7 @@
 // translated, but when they are they can be included by adding 'certificates'
 // to the arrays below
 
-const auditedCerts = {
-  espanol: [
-    'responsive-web-design',
-    'javascript-algorithms-and-data-structures'
-  ],
-  chinese: [
-    'responsive-web-design',
-    'javascript-algorithms-and-data-structures',
-    'front-end-libraries',
-    'data-visualization',
-    'apis-and-microservices',
-    'quality-assurance'
-  ],
-  'chinese-traditional': [
-    'responsive-web-design',
-    'javascript-algorithms-and-data-structures',
-    'front-end-libraries',
-    'data-visualization',
-    'apis-and-microservices',
-    'quality-assurance'
-  ],
-  italian: [
-    'responsive-web-design',
-    'javascript-algorithms-and-data-structures'
-  ]
-};
+const { auditedCerts } = require('../config/i18n/all-langs');
 
 function isAuditedCert(lang, cert) {
   if (!lang || !cert)


### PR DESCRIPTION
I intended to make the config be pure configs instead. This also reverts commit cd5c28b332154cbecd4edf2d25b38ceb6ede771b, and recreates it with Portuguese disabled for client and enabled for the curriculum.

