### PR TITLE
fix(client): store challenge panes sizes

### DIFF
--- a/client/src/templates/Challenges/classic/DesktopLayout.js
+++ b/client/src/templates/Challenges/classic/DesktopLayout.js
@@ -8,12 +8,23 @@ import envData from '../../../../../config/env.json';
 
 const { showUpcomingChanges } = envData;
 
+const paneType = {
+  flex: PropTypes.number
+};
+
 const propTypes = {
   challengeFiles: PropTypes.object,
   editor: PropTypes.element,
   hasEditableBoundries: PropTypes.bool,
   hasPreview: PropTypes.bool,
   instructions: PropTypes.element,
+  layoutState: PropTypes.shape({
+    codePane: paneType,
+    editorPane: paneType,
+    instructionPane: paneType,
+    previewPane: paneType,
+    testsPane: paneType
+  }),
   preview: PropTypes.element,
   resizeProps: PropTypes.shape({
     onStopResize: PropTypes.func,
@@ -55,6 +66,7 @@ class DesktopLayout extends Component {
       editor,
       testOutput,
       hasPreview,
+      layoutState,
       preview,
       hasEditableBoundries
     } = this.props;
@@ -67,6 +79,8 @@ class DesktopLayout extends Component {
       ? showPreview && hasPreview
       : hasPreview;
     const isConsoleDisplayable = projectBasedChallenge ? showConsole : true;
+    const { codePane, editorPane, instructionPane, previewPane, testsPane } =
+      layoutState;
 
     return (
       <Fragment>
@@ -75,7 +89,11 @@ class DesktopLayout extends Component {
         )}
         <ReflexContainer className='desktop-layout' orientation='vertical'>
           {!projectBasedChallenge && (
-            <ReflexElement flex={1} {...resizeProps}>
+            <ReflexElement
+              flex={instructionPane.flex}
+              name='instructionPane'
+              {...resizeProps}
+            >
               {instructions}
             </ReflexElement>
           )}
@@ -83,20 +101,34 @@ class DesktopLayout extends Component {
             <ReflexSplitter propagate={true} {...resizeProps} />
           )}
 
-          <ReflexElement flex={1} {...resizeProps}>
+          <ReflexElement
+            flex={editorPane.flex}
+            name='editorPane'
+            {...resizeProps}
+          >
             {challengeFile && showUpcomingChanges && !hasEditableBoundries && (
               <EditorTabs />
             )}
             {challengeFile && (
               <ReflexContainer key={challengeFile.key} orientation='horizontal'>
-                <ReflexElement flex={1} {...reflexProps} {...resizeProps}>
+                <ReflexElement
+                  flex={codePane.flex}
+                  name='codePane'
+                  {...reflexProps}
+                  {...resizeProps}
+                >
                   {<Fragment>{editor}</Fragment>}
                 </ReflexElement>
                 {isConsoleDisplayable && (
                   <ReflexSplitter propagate={true} {...resizeProps} />
                 )}
                 {isConsoleDisplayable && (
-                  <ReflexElement flex={0.25} {...reflexProps} {...resizeProps}>
+                  <ReflexElement
+                    flex={testsPane.flex}
+                    name='testsPane'
+                    {...reflexProps}
+                    {...resizeProps}
+                  >
                     {testOutput}
                   </ReflexElement>
                 )}
@@ -107,7 +139,11 @@ class DesktopLayout extends Component {
             <ReflexSplitter propagate={true} {...resizeProps} />
           )}
           {isPreviewDisplayable && (
-            <ReflexElement flex={0.7} {...resizeProps}>
+            <ReflexElement
+              flex={previewPane.flex}
+              name='previewPane'
+              {...resizeProps}
+            >
               {preview}
             </ReflexElement>
           )}

--- a/client/src/templates/Challenges/classic/Show.js
+++ b/client/src/templates/Challenges/classic/Show.js
@@ -22,7 +22,7 @@ import DesktopLayout from './DesktopLayout';
 import Hotkeys from '../components/Hotkeys';
 
 import { getGuideUrl } from '../utils';
-import { isBrowser } from '../../../../utils';
+import store from 'store';
 import { challengeTypes } from '../../../../utils/challengeTypes';
 import { isContained } from '../../../utils/is-contained';
 import { ChallengeNode } from '../../../redux/prop-types';
@@ -133,21 +133,20 @@ class ShowClassic extends Component {
   }
 
   getLayoutState() {
-    const item = isBrowser() && window.localStorage.getItem(REFLEX_LAYOUT);
+    const reflexLayout = store.get(REFLEX_LAYOUT);
 
     // Validate if user has not done any resize of the panes
-    if (!item) return BASE_LAYOUT;
+    if (!reflexLayout) return BASE_LAYOUT;
 
-    const itemJson = JSON.parse(item);
     // Check that the layout values stored are valid (exist in base layout). If
     // not valid, it will fallback to the base layout values and be set on next
     // user resize.
-    const itemIsContained = isContained(
+    const isValidLayout = isContained(
       Object.keys(BASE_LAYOUT),
-      Object.keys(itemJson)
+      Object.keys(reflexLayout)
     );
 
-    return itemIsContained ? itemJson : BASE_LAYOUT;
+    return isValidLayout ? reflexLayout : BASE_LAYOUT;
   }
 
   onResize() {
@@ -166,10 +165,7 @@ class ShowClassic extends Component {
 
     this.layoutState[name].flex = flex;
 
-    window.localStorage.setItem(
-      REFLEX_LAYOUT,
-      JSON.stringify(this.layoutState)
-    );
+    store.set(REFLEX_LAYOUT, this.layoutState);
   }
 
   componentDidMount() {

--- a/client/src/templates/Challenges/classic/Show.js
+++ b/client/src/templates/Challenges/classic/Show.js
@@ -106,7 +106,7 @@ const BASE_LAYOUT = {
     flex: 1
   },
   previewPane: {
-    flex: 0.5
+    flex: 0.7
   },
   testsPane: {
     flex: 0.25

--- a/client/src/templates/Challenges/classic/Show.js
+++ b/client/src/templates/Challenges/classic/Show.js
@@ -22,6 +22,7 @@ import DesktopLayout from './DesktopLayout';
 import Hotkeys from '../components/Hotkeys';
 
 import { getGuideUrl } from '../utils';
+import { isBrowser } from '../../../../utils';
 import { challengeTypes } from '../../../../utils/challengeTypes';
 import { isContained } from '../../../utils/is-contained';
 import { ChallengeNode } from '../../../redux/prop-types';
@@ -132,7 +133,7 @@ class ShowClassic extends Component {
   }
 
   getLayoutState() {
-    const item = window.localStorage.getItem(REFLEX_LAYOUT);
+    const item = isBrowser() && window.localStorage.getItem(REFLEX_LAYOUT);
 
     // Validate if user has not done any resize of the panes
     if (!item) return BASE_LAYOUT;

--- a/client/src/utils/is-contained.test.ts
+++ b/client/src/utils/is-contained.test.ts
@@ -1,0 +1,15 @@
+import { isContained } from './is-contained';
+
+describe('client/src isContained', () => {
+  it('returns true if `arr1` values are contained in `arr2`', () => {
+    const arr1 = ['dog', 'cat'];
+    const arr2 = ['cat', 'dog'];
+    expect(isContained(arr1, arr2)).toEqual(true);
+  });
+
+  it('returns true if `arr1` values are not contained in `arr2`', () => {
+    const arr1 = ['dog', 'cat'];
+    const arr2 = ['cat', 'monkey', 'bird'];
+    expect(isContained(arr1, arr2)).toEqual(false);
+  });
+});

--- a/client/src/utils/is-contained.ts
+++ b/client/src/utils/is-contained.ts
@@ -1,0 +1,4 @@
+// Performs a check if the items in `value` exist in `other`
+export function isContained(value: string[], other: string[]): boolean {
+  return value.every(i => other.includes(i));
+}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #39088

<!-- Feel free to add any additional description of changes below this line -->

- Base on [Re-Flex Storage demo](https://github.com/leefsmp/Re-Flex/blob/master/src/demo/demo.jsx#L711) example
- Aims to add functionality on desktop view

### Steps to test

1. Open challenge view
2. Resize a pane
3. Either refresh window or go to next challenge

**Ouput**
Window should retain resize made by user