### PR TITLE
fix(curriculum): add test for event.preventDefault()

### DIFF
--- a/curriculum/challenges/english/03-front-end-libraries/react/create-a-controlled-form.md
+++ b/curriculum/challenges/english/03-front-end-libraries/react/create-a-controlled-form.md
@@ -107,8 +107,8 @@ assert(
   // And is not block commented out /* */
   // And is not line commented out //
   handleSubmit.match(/\bevent\.preventDefault\(\s*?\)/g)
-  && !handleSubmit.match(/\/\*\s*?\bevent\.preventDefault\(\s*?\)\s*?\*\//g)
-  && !handleSubmit.match(/\/\/\s*?\bevent\.preventDefault\(\s*?\)/g)
+  && !handleSubmit.match(/\/\*\s*?\bevent\.preventDefault\(\s*?\);?\s*?\*\//g)
+  && !handleSubmit.match(/\/\/\s*?\bevent\.preventDefault\(\s*?\);?/g)
 );
 ```
 

--- a/curriculum/challenges/english/03-front-end-libraries/react/create-a-controlled-form.md
+++ b/curriculum/challenges/english/03-front-end-libraries/react/create-a-controlled-form.md
@@ -107,8 +107,8 @@ assert(
   // And is not block commented out /* */
   // And is not line commented out //
   handleSubmit.match(/\bevent\.preventDefault\(\s*?\)/g)
-  && !handleSubmit.match(/\/\*.*?\bevent\.preventDefault\(\s*?\).*?\*\//gs)
-  && !handleSubmit.match(/\/\/.*?\bevent\.preventDefault\(\s*?\)/g)
+  && !handleSubmit.match(/\/\*\s*?\bevent\.preventDefault\(\s*?\)\s*?\*\//g)
+  && !handleSubmit.match(/\/\/\s*?\bevent\.preventDefault\(\s*?\)/g)
 );
 ```
 

--- a/curriculum/challenges/english/03-front-end-libraries/react/create-a-controlled-form.md
+++ b/curriculum/challenges/english/03-front-end-libraries/react/create-a-controlled-form.md
@@ -16,7 +16,7 @@ The `MyForm` component is set up with an empty `form` with a submit handler. The
 
 We've added a button which submits the form. You can see it has the `type` set to `submit` indicating it is the button controlling the form. Add the `input` element in the `form` and set its `value` and `onChange()` attributes like the last challenge. You should then complete the `handleSubmit` method so that it sets the component state property `submit` to the current input value in the local `state`.
 
-**Note:** You also must call `event.preventDefault()` in the submit handler, to prevent the default form submit behavior which will refresh the web page.
+**Note:** You also must call `event.preventDefault()` in the submit handler, to prevent the default form submit behavior which will refresh the web page. For camper convenience, the default behavior has been disabled here to prevent refreshes from resetting challenge code.
 
 Finally, create an `h1` tag after the `form` which renders the `submit` value from the component's `state`. You can then type in the form and click the button (or press enter), and you should see your input rendered to the page.
 
@@ -98,6 +98,17 @@ Submitting the form should run `handleSubmit` which should set the `submit` prop
 })();
 ```
 
+`handleSubmit` should call `event.preventDefault`
+
+```js
+assert(
+  MyForm.prototype.handleSubmit.toString()
+    .match(/(?<!\/\*\s*?)(?<!\/\/ *?)\bevent\.preventDefault\(\s*?\)/gs)
+    // First negative lookbehind checks for block comment start /*
+    // Second negative lookbehind checks for line comment start //
+);
+```
+
 The `h1` header should render the value of the `submit` field from the component's state.
 
 ```js
@@ -149,7 +160,7 @@ class MyForm extends React.Component {
   }
   handleSubmit(event) {
     // Change code below this line
-    
+
     // Change code above this line
   }
   render() {

--- a/curriculum/challenges/english/03-front-end-libraries/react/create-a-controlled-form.md
+++ b/curriculum/challenges/english/03-front-end-libraries/react/create-a-controlled-form.md
@@ -108,7 +108,7 @@ assert(
   // And is not line commented out //
   handleSubmit.match(/\bevent\.preventDefault\(\s*?\)/g)
   && !handleSubmit.match(/\/\*\s*?\bevent\.preventDefault\(\s*?\);?\s*?\*\//g)
-  && !handleSubmit.match(/\/\/\s*?\bevent\.preventDefault\(\s*?\);?/g)
+  && !handleSubmit.match(/\/\/\s*?\bevent\.preventDefault\(\s*?\);?\s*?\n/g)
 );
 ```
 

--- a/curriculum/challenges/english/03-front-end-libraries/react/create-a-controlled-form.md
+++ b/curriculum/challenges/english/03-front-end-libraries/react/create-a-controlled-form.md
@@ -101,11 +101,14 @@ Submitting the form should run `handleSubmit` which should set the `submit` prop
 `handleSubmit` should call `event.preventDefault`
 
 ```js
+const handleSubmit = MyForm.prototype.handleSubmit.toString();
 assert(
-  MyForm.prototype.handleSubmit.toString()
-    .match(/(?<!\/\*\s*?)(?<!\/\/ *?)\bevent\.preventDefault\(\s*?\)/gs)
-    // First negative lookbehind checks for block comment start /*
-    // Second negative lookbehind checks for line comment start //
+  // Method call exists
+  // And is not block commented out /* */
+  // And is not line commented out //
+  handleSubmit.match(/\bevent\.preventDefault\(\s*?\)/g)
+  && !handleSubmit.match(/\/\*.*?\bevent\.preventDefault\(\s*?\).*?\*\//gs)
+  && !handleSubmit.match(/\/\/.*?\bevent\.preventDefault\(\s*?\)/g)
 );
 ```
 

--- a/curriculum/challenges/english/03-front-end-libraries/react/create-a-controlled-form.md
+++ b/curriculum/challenges/english/03-front-end-libraries/react/create-a-controlled-form.md
@@ -102,13 +102,18 @@ Submitting the form should run `handleSubmit` which should set the `submit` prop
 
 ```js
 const handleSubmit = MyForm.prototype.handleSubmit.toString();
+const allMatches = handleSubmit.match(/\bevent\.preventDefault\(\s*?\)/g) ?? [];
+const blockCommented = handleSubmit.match(
+  /\/\*.*?\bevent\.preventDefault\(\s*?\).*?\*\//gs
+);
+const lineCommented = handleSubmit.match(
+  /\/\/.*?\bevent\.preventDefault\(\s*?\)/g
+);
+const commentedMatches = [...(blockCommented ?? []), ...(lineCommented ?? [])];
+
 assert(
-  // Method call exists
-  // And is not block commented out /* */
-  // And is not line commented out //
-  handleSubmit.match(/\bevent\.preventDefault\(\s*?\)/g)
-  && !handleSubmit.match(/\/\*\s*?\bevent\.preventDefault\(\s*?\);?\s*?\*\//g)
-  && !handleSubmit.match(/\/\/\s*?\bevent\.preventDefault\(\s*?\);?\s*?\n/g)
+  // At least one event.preventDefault() call exists and is not commented out
+  allMatches.length && (allMatches.length > commentedMatches.length)
 );
 ```
 

--- a/curriculum/challenges/english/03-front-end-libraries/react/create-a-controlled-form.md
+++ b/curriculum/challenges/english/03-front-end-libraries/react/create-a-controlled-form.md
@@ -113,7 +113,7 @@ const commentedMatches = [...(blockCommented ?? []), ...(lineCommented ?? [])];
 
 assert(
   // At least one event.preventDefault() call exists and is not commented out
-  allMatches.length && (allMatches.length > commentedMatches.length)
+  allMatches.length > commentedMatches.length
 );
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #42204

<!-- Feel free to add any additional description of changes below this line -->

Regex works here, but spying on the `event` parameter and asserting that it's `.preventDefault()` method was called would be better (any suggestions on how to do that?).
