### PR TITLE
fix(ajax): use 'same-origin' credentials

### DIFF
--- a/client/src/utils/ajax.js
+++ b/client/src/utils/ajax.js
@@ -9,7 +9,7 @@ const tokens = new Tokens();
 
 // TODO: test on staging.  Do we need 'include' everywhere?
 const defaultOptions = {
-  credentials: environment === 'development' ? 'include' : 'same-site'
+  credentials: environment === 'development' ? 'include' : 'same-origin'
 };
 
 // _csrf is passed to the client as a cookie. Tokens are sent back to the server


### PR DESCRIPTION
This will still need testing on staging, but at least I used the correct string this time.