### PR TITLE
fix: signout redirect

### DIFF
--- a/api-server/src/server/boot/authentication.js
+++ b/api-server/src/server/boot/authentication.js
@@ -63,7 +63,7 @@ module.exports = function enableAuthentication(app) {
   }
 
   api.get('/signout', (req, res) => {
-    const { origin } = getRedirectParams(req);
+    const { origin, returnTo } = getRedirectParams(req);
     req.logout();
     req.session.destroy(err => {
       if (err) {
@@ -74,7 +74,7 @@ module.exports = function enableAuthentication(app) {
         });
       }
       removeCookies(req, res);
-      res.redirect(origin);
+      res.redirect(returnTo);
     });
   });
 

--- a/api-server/src/server/component-passport.js
+++ b/api-server/src/server/component-passport.js
@@ -16,6 +16,7 @@ import {
   isRootPath
 } from './utils/redirection';
 import { jwtSecret } from '../../../config/secrets';
+import { availableLangs } from '../../../config/i18n/all-langs';
 
 const passportOptions = {
   emailOptional: true,
@@ -85,13 +86,22 @@ export const devSaveResponseAuthCookies = () => {
 
 export const devLoginRedirect = () => {
   return (req, res) => {
-    // this mirrors the production approach, but without any validation
+    // this mirrors the production approach, but only validates the prefix
     let { returnTo, origin, pathPrefix } = getRedirectParams(
       req,
-      params => params
+      ({ returnTo, origin, pathPrefix }) => {
+        pathPrefix = availableLangs.client.includes(pathPrefix)
+          ? pathPrefix
+          : '';
+        return {
+          returnTo,
+          origin,
+          pathPrefix
+        };
+      }
     );
     returnTo += isRootPath(getRedirectBase(origin, pathPrefix), returnTo)
-      ? 'learn'
+      ? '/learn'
       : '';
     return res.redirect(returnTo);
   };

--- a/api-server/src/server/utils/redirection.js
+++ b/api-server/src/server/utils/redirection.js
@@ -66,7 +66,7 @@ function getRedirectParams(req, _normalizeParams = normalizeParams) {
   const origin = returnUrl.origin;
   // if this is not one of the client languages, validation will convert
   // this to '' before it is used.
-  const pathPrefix = returnUrl.pathname.split('/')[0];
+  const pathPrefix = returnUrl.pathname.split('/')[1];
   return _normalizeParams({ returnTo: returnUrl.href, origin, pathPrefix });
 }
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #41898

<!-- Feel free to add any additional description of changes below this line -->
Think this should address the redirect on signout bug.

The issues I saw were:
- pathPrefix was not grabbing correct array element (the `split` call was grabbing the empty string that comes from the path starting with `/`).
- /signout redirect was not using returnTo URL. Instead it redirected to origin, which (except for chinese) will always be www.freecodecamp.org with no path.
