### PR TITLE
fix(docs): Easy readability of documentation in mobile view

### DIFF
--- a/docs/_theme.css
+++ b/docs/_theme.css
@@ -60,6 +60,10 @@ body .content {
   .universal-nav a.translations-link {
     visibility: hidden;
   }
+
+  body .content {
+    max-width: 100%;
+  }
 }
 
 /****** Cover Page ******/
@@ -314,6 +318,13 @@ body.close .github-corner {
 .markdown-section em,
 .markdown-section blockquote {
   color: var(--text-color-tertiary);
+}
+
+@media screen and (max-width: 768px) {
+  .markdown-section {
+    max-width: 90%;
+    padding: 40px 15px 40px 15px;
+  }
 }
 
 /****** CODE HIGHLIGHTING ******/


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #42571

<!-- Feel free to add any additional description of changes below this line -->

I am not sure what to keep article max-width is 90% or 85%. There is slight overlap of menu icon on text as bellow images. I thick better to keep 90%. As it stays on top.

![Screenshot 2021-06-19 at 11 29 39 PM](https://user-images.githubusercontent.com/42613882/122651523-09b2ba00-d157-11eb-9ffa-e6d4134ecca3.png)
![Screenshot 2021-06-19 at 11 29 51 PM](https://user-images.githubusercontent.com/42613882/122651524-0e776e00-d157-11eb-8f83-4d1e68032357.png)
