### PR TITLE
chore: add jest global variables

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,8 @@
     "es6": true,
     "browser": true,
     "mocha": true,
-    "node": true
+    "node": true,
+    "jest": true
   },
   "parser": "babel-eslint",
   "root": true,

--- a/api-server/src/common/models/User-Identity.test.js
+++ b/api-server/src/common/models/User-Identity.test.js
@@ -1,4 +1,3 @@
-/* global expect */
 import { ensureLowerCaseEmail } from './User-Identity';
 
 test('returns lowercase email when one exists', () => {

--- a/api-server/src/server/boot_tests/certificate.test.js
+++ b/api-server/src/server/boot_tests/certificate.test.js
@@ -1,5 +1,3 @@
-/* global it expect */
-
 import { getFallbackFrontEndDate } from '../boot/certificate';
 import { fullStackChallenges } from './fixtures';
 

--- a/api-server/src/server/boot_tests/challenge.test.js
+++ b/api-server/src/server/boot_tests/challenge.test.js
@@ -1,4 +1,3 @@
-/* global describe xdescribe it expect jest */
 import { first, find } from 'lodash';
 
 import {

--- a/api-server/src/server/boot_tests/fixtures.js
+++ b/api-server/src/server/boot_tests/fixtures.js
@@ -1,4 +1,3 @@
-/* global jest*/
 import { isEqual } from 'lodash';
 import { isEmail } from 'validator';
 

--- a/api-server/src/server/middlewares/request-authorization.test.js
+++ b/api-server/src/server/middlewares/request-authorization.test.js
@@ -1,4 +1,3 @@
-/* global describe it expect jest */
 import { mockReq as mockRequest, mockRes } from '../boot_tests/challenge.test';
 import jwt from 'jsonwebtoken';
 

--- a/api-server/src/server/utils/date-utils.test.js
+++ b/api-server/src/server/utils/date-utils.test.js
@@ -1,4 +1,3 @@
-/* global describe expect it */
 import moment from 'moment-timezone';
 
 import { dayCount } from './date-utils';

--- a/api-server/src/server/utils/donation.test.js
+++ b/api-server/src/server/utils/donation.test.js
@@ -1,7 +1,4 @@
 /* eslint-disable camelcase */
-/* global describe it expect */
-/* global jest*/
-
 import axios from 'axios';
 import keys from '../../../../config/secrets';
 import {

--- a/api-server/src/server/utils/getSetAccessToken.test.js
+++ b/api-server/src/server/utils/getSetAccessToken.test.js
@@ -1,4 +1,3 @@
-/* global describe it expect */
 import {
   getAccessTokenFromRequest,
   errorTypes,

--- a/api-server/src/server/utils/in-memory-cache.test.js
+++ b/api-server/src/server/utils/in-memory-cache.test.js
@@ -1,4 +1,3 @@
-/* global describe beforeEach expect it jest */
 import inMemoryCache from './in-memory-cache';
 
 describe('InMemoryCache', () => {

--- a/api-server/src/server/utils/redirection.test.js
+++ b/api-server/src/server/utils/redirection.test.js
@@ -1,5 +1,3 @@
-/* global describe expect it jest */
-
 const jwt = require('jsonwebtoken');
 
 const { getReturnTo, normalizeParams } = require('./redirection');

--- a/api-server/src/server/utils/user-stats.test.js
+++ b/api-server/src/server/utils/user-stats.test.js
@@ -1,4 +1,3 @@
-/* global describe it expect jest  */
 import moment from 'moment-timezone';
 
 import {

--- a/client/i18n/locales.test.js
+++ b/client/i18n/locales.test.js
@@ -1,4 +1,3 @@
-/* global expect */
 import {
   availableLangs,
   langDisplayNames,

--- a/client/src/__mocks__/react-i18nextMock.js
+++ b/client/src/__mocks__/react-i18nextMock.js
@@ -1,6 +1,5 @@
 /* eslint-disable react/prop-types */
 /* eslint-disable react/display-name */
-/* global jest */
 import React from 'react';
 
 const reactI18next = jest.genMockFromModule('react-i18next');

--- a/client/src/__tests__/integration/handled-error.test.js
+++ b/client/src/__tests__/integration/handled-error.test.js
@@ -1,4 +1,3 @@
-/* global describe it expect */
 import {
   wrapHandledError,
   unwrapHandledError

--- a/client/src/client-only-routes/ShowSettings.test.js
+++ b/client/src/client-only-routes/ShowSettings.test.js
@@ -1,4 +1,3 @@
-/* global jest, expect */
 import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 import envData from '../../../config/env.json';

--- a/client/src/components/Footer/Footer.test.js
+++ b/client/src/components/Footer/Footer.test.js
@@ -1,4 +1,3 @@
-/* global expect */
 import React from 'react';
 import renderer from 'react-test-renderer';
 

--- a/client/src/components/Header/Header.test.js
+++ b/client/src/components/Header/Header.test.js
@@ -1,4 +1,3 @@
-/* global expect jest */
 import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 

--- a/client/src/components/Intro/Intro.test.js
+++ b/client/src/components/Intro/Intro.test.js
@@ -1,4 +1,3 @@
-/* global expect jest */
 import React from 'react';
 import renderer from 'react-test-renderer';
 import { Provider } from 'react-redux';

--- a/client/src/components/Map/Map.test.js
+++ b/client/src/components/Map/Map.test.js
@@ -1,5 +1,3 @@
-/* global expect jest */
-
 import React from 'react';
 import { useStaticQuery } from 'gatsby';
 import { render } from '@testing-library/react';

--- a/client/src/components/createExternalRedirects.test.js
+++ b/client/src/components/createExternalRedirects.test.js
@@ -1,5 +1,3 @@
-/* global expect */
-
 import createExternalRedirect from './createExternalRedirects';
 
 describe('createExternalRedirects', () => {

--- a/client/src/components/createLanguageRedirect.test.js
+++ b/client/src/components/createLanguageRedirect.test.js
@@ -1,5 +1,3 @@
-/* global expect */
-
 import createLanguageRedirect from './createLanguageRedirect';
 
 describe('createLanguageRedirect for clientLocale === english', () => {

--- a/client/src/components/formHelpers/BlockSaveButton.test.js
+++ b/client/src/components/formHelpers/BlockSaveButton.test.js
@@ -1,5 +1,3 @@
-/* global expect */
-
 import React from 'react';
 import { render } from '@testing-library/react';
 

--- a/client/src/components/formHelpers/BlockSaveWrapper.test.js
+++ b/client/src/components/formHelpers/BlockSaveWrapper.test.js
@@ -1,5 +1,3 @@
-/* global expect */
-
 import React from 'react';
 import { render } from '@testing-library/react';
 

--- a/client/src/components/formHelpers/Form.test.js
+++ b/client/src/components/formHelpers/Form.test.js
@@ -1,5 +1,3 @@
-/* global jest, expect */
-
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 

--- a/client/src/components/helpers/Link.test.js
+++ b/client/src/components/helpers/Link.test.js
@@ -1,4 +1,3 @@
-/* global expect */
 import React from 'react';
 import renderer from 'react-test-renderer';
 

--- a/client/src/components/helpers/Loader.test.js
+++ b/client/src/components/helpers/Loader.test.js
@@ -1,4 +1,3 @@
-/* global expect */
 import React from 'react';
 import { render, cleanup } from '@testing-library/react';
 

--- a/client/src/components/landing/Landing.test.js
+++ b/client/src/components/landing/Landing.test.js
@@ -1,4 +1,3 @@
-/* global expect jest */
 import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 

--- a/client/src/components/profile/Profile.test.js
+++ b/client/src/components/profile/Profile.test.js
@@ -1,5 +1,3 @@
-/* global expect jest */
-
 import React from 'react';
 import { render } from '@testing-library/react';
 

--- a/client/src/components/profile/components/HeatMap.test.js
+++ b/client/src/components/profile/components/HeatMap.test.js
@@ -1,5 +1,3 @@
-/* global expect jest */
-
 import React from 'react';
 import { render } from '@testing-library/react';
 

--- a/client/src/components/profile/components/TimeLine.test.js
+++ b/client/src/components/profile/components/TimeLine.test.js
@@ -1,5 +1,3 @@
-/* global expect */
-
 import React from 'react';
 import { render } from '@testing-library/react';
 import TimeLine from './TimeLine';

--- a/client/src/components/search/searchBar/SearchBar.test.js
+++ b/client/src/components/search/searchBar/SearchBar.test.js
@@ -1,4 +1,3 @@
-/* global jest, expect */
 import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 

--- a/client/src/components/settings/Certification.test.js
+++ b/client/src/components/settings/Certification.test.js
@@ -1,5 +1,3 @@
-/* global expect jest */
-
 import React from 'react';
 import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';

--- a/client/src/components/settings/Honesty.test.js
+++ b/client/src/components/settings/Honesty.test.js
@@ -1,4 +1,3 @@
-/* global expect jest */
 import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 import TestRenderer from 'react-test-renderer';

--- a/client/src/pages/challenges.test.js
+++ b/client/src/pages/challenges.test.js
@@ -1,4 +1,3 @@
-/* global expect */
 import toLearnPath from '../utils/to-learn-path';
 import { withPrefix } from 'gatsby';
 

--- a/client/src/redux/failed-updates-epic.test.js
+++ b/client/src/redux/failed-updates-epic.test.js
@@ -1,5 +1,3 @@
-/* global expect jest */
-
 import { Subject } from 'rxjs';
 import { ActionsObservable, StateObservable } from 'redux-observable';
 import failedUpdatesEpic from './failed-updates-epic';

--- a/client/src/redux/ga-saga.test.js
+++ b/client/src/redux/ga-saga.test.js
@@ -1,5 +1,3 @@
-/* global jest */
-
 import { types } from '.';
 import { createGaSaga } from './ga-saga';
 import ga from '../analytics';

--- a/client/src/templates/Challenges/components/ChallengeTitle.test.js
+++ b/client/src/templates/Challenges/components/ChallengeTitle.test.js
@@ -1,5 +1,3 @@
-/* global expect */
-
 import React from 'react';
 import renderer from 'react-test-renderer';
 

--- a/client/src/templates/Challenges/components/CompletionModal.test.js
+++ b/client/src/templates/Challenges/components/CompletionModal.test.js
@@ -1,5 +1,3 @@
-/* global expect jest */
-
 import { getCompletedPercent } from './CompletionModal';
 
 jest.mock('../../../analytics');

--- a/client/src/templates/Challenges/components/CompletionModalBody.test.js
+++ b/client/src/templates/Challenges/components/CompletionModalBody.test.js
@@ -1,5 +1,3 @@
-/* global jest, expect */
-
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 

--- a/client/src/templates/Challenges/rechallenge/builders.test.js
+++ b/client/src/templates/Challenges/rechallenge/builders.test.js
@@ -1,4 +1,3 @@
-/* global expect */
 import { findIndexHtml } from './builders.js';
 
 const withHTML = [

--- a/client/src/templates/Challenges/redux/create-question-epic.test.js
+++ b/client/src/templates/Challenges/redux/create-question-epic.test.js
@@ -1,5 +1,3 @@
-/* global expect */
-
 import { transformEditorLink } from '../utils';
 
 describe('create-question-epic', () => {

--- a/client/src/templates/Challenges/utils/index.test.js
+++ b/client/src/templates/Challenges/utils/index.test.js
@@ -1,5 +1,3 @@
-/* global expect */
-
 import envData from '../../../../../config/env.json';
 
 const { forumLocation } = envData;

--- a/client/src/templates/Challenges/utils/worker-executor.test.js
+++ b/client/src/templates/Challenges/utils/worker-executor.test.js
@@ -1,5 +1,3 @@
-/* global expect, jest */
-
 import createWorker from './worker-executor';
 
 function mockWorker({ init, postMessage, terminate } = {}) {

--- a/client/src/utils/css-help.test.ts
+++ b/client/src/utils/css-help.test.ts
@@ -1,4 +1,3 @@
-/* global describe it expect */
 import { cssString } from './__fixtures/curriculum-helpers-css';
 import CSSHelp from './css-help';
 

--- a/client/src/utils/curriculum-helpers.test.js
+++ b/client/src/utils/curriculum-helpers.test.js
@@ -1,5 +1,3 @@
-/* global describe it expect */
-
 import __testHelpers, { removeJSComments } from './curriculum-helpers';
 import jsTestValues from './__fixtures/curriculum-helpers-javascript';
 import cssTestValues from './__fixtures/curriculum-helpers-css';

--- a/client/src/utils/format.test.js
+++ b/client/src/utils/format.test.js
@@ -1,4 +1,4 @@
-/* global expect BigInt */
+/* global BigInt */
 
 const { format } = require('./format');
 

--- a/client/src/utils/handled-error.test.js
+++ b/client/src/utils/handled-error.test.js
@@ -1,4 +1,3 @@
-/* global expect jest */
 import { isObject } from 'lodash-es';
 import {
   isHandledError,

--- a/client/utils/gatsby/layoutSelector.test.js
+++ b/client/utils/gatsby/layoutSelector.test.js
@@ -1,4 +1,3 @@
-/* global expect jest */
 import React from 'react';
 import { Provider } from 'react-redux';
 import ShallowRenderer from 'react-test-renderer/shallow';

--- a/client/utils/tags.test.js
+++ b/client/utils/tags.test.js
@@ -1,5 +1,3 @@
-/* global expect */
-
 import { injectConditionalTags } from './tags';
 
 describe('Tags', () => {

--- a/curriculum/getChallenges.acceptance.test.js
+++ b/curriculum/getChallenges.acceptance.test.js
@@ -1,4 +1,3 @@
-/* global expect */
 // TODO: reinstate these tests
 
 // // TODO: update these to use the new parser

--- a/curriculum/getChallenges.test.js
+++ b/curriculum/getChallenges.test.js
@@ -1,4 +1,3 @@
-/* global expect */
 const path = require('path');
 
 const {

--- a/curriculum/test/utils/extract-css-comments.test.js
+++ b/curriculum/test/utils/extract-css-comments.test.js
@@ -1,4 +1,3 @@
-/* global expect */
 const extractCSSComments = require('./extract-css-comments');
 
 const someHTMLWithCSS = `<body>

--- a/curriculum/test/utils/extract-html-comments.test.js
+++ b/curriculum/test/utils/extract-html-comments.test.js
@@ -1,4 +1,3 @@
-/* global expect */
 const extractHTMLComments = require('./extract-html-comments');
 
 const someHTML = `<body>

--- a/curriculum/test/utils/extract-js-comments.test.js
+++ b/curriculum/test/utils/extract-js-comments.test.js
@@ -1,4 +1,3 @@
-/* global expect */
 const extractJSComments = require('./extract-js-comments');
 
 const someJS = `

--- a/curriculum/test/utils/extract-jsx-comments.test.js
+++ b/curriculum/test/utils/extract-jsx-comments.test.js
@@ -1,4 +1,3 @@
-/* global expect */
 const extractJSXComments = require('./extract-jsx-comments');
 
 const someJSX = `<Link

--- a/curriculum/test/utils/extract-script-js-comments.test.js
+++ b/curriculum/test/utils/extract-script-js-comments.test.js
@@ -1,4 +1,3 @@
-/* global expect */
 const extractScriptJSComments = require('./extract-script-js-comments');
 
 const inlineComments = `<body>

--- a/curriculum/test/utils/sort-challenges.test.js
+++ b/curriculum/test/utils/sort-challenges.test.js
@@ -1,4 +1,3 @@
-/* global expect */
 const { sortChallenges } = require('./sort-challenges');
 
 const challenges = [

--- a/cypress/integration/learn/index.js
+++ b/cypress/integration/learn/index.js
@@ -1,4 +1,4 @@
-/* global cy expect */
+/* global cy */
 
 const selectors = {
   challengeMap: "[data-test-label='learn-curriculum-map']"

--- a/cypress/integration/learn/redirects/challenges.js
+++ b/cypress/integration/learn/redirects/challenges.js
@@ -1,4 +1,4 @@
-/* global cy expect */
+/* global cy */
 
 const locations = {
   chalSuper: '/challenges/responsive-web-design/',

--- a/cypress/integration/settings/certifications.js
+++ b/cypress/integration/settings/certifications.js
@@ -1,4 +1,4 @@
-/* global cy expect */
+/* global cy */
 
 import '@testing-library/cypress/add-commands';
 

--- a/cypress/integration/settings/settings.js
+++ b/cypress/integration/settings/settings.js
@@ -1,4 +1,4 @@
-/* global cy expect */
+/* global cy */
 
 describe('Settings', () => {
   it('should be possible to reset your progress', () => {

--- a/cypress/integration/user/report-user.js
+++ b/cypress/integration/user/report-user.js
@@ -1,4 +1,4 @@
-/* global cy expect */
+/* global cy */
 
 describe('Report User', () => {
   beforeEach(() => {

--- a/tools/challenge-parser/parser/index.acceptance.test.js
+++ b/tools/challenge-parser/parser/index.acceptance.test.js
@@ -1,5 +1,3 @@
-/* global expect */
-
 const path = require('path');
 
 const { parseMD } = require('.');

--- a/tools/challenge-parser/parser/plugins/add-frontmatter.test.js
+++ b/tools/challenge-parser/parser/plugins/add-frontmatter.test.js
@@ -1,5 +1,3 @@
-/* global describe it expect beforeEach */
-
 const { isObject } = require('lodash');
 
 const mockAST = require('../__fixtures__/ast-yaml-challenge.json');

--- a/tools/challenge-parser/parser/plugins/add-seed.test.js
+++ b/tools/challenge-parser/parser/plugins/add-seed.test.js
@@ -1,4 +1,3 @@
-/* global describe it expect beforeEach */
 const isArray = require('lodash/isArray');
 
 const simpleAST = require('../__fixtures__/ast-simple.json');

--- a/tools/challenge-parser/parser/plugins/add-solution.test.js
+++ b/tools/challenge-parser/parser/plugins/add-solution.test.js
@@ -1,4 +1,3 @@
-/* global describe it expect beforeEach */
 const mockAST = require('../__fixtures__/ast-simple.json');
 const editableSolutionAST = require('../__fixtures__/ast-erm-in-solution.json');
 const multiSolnsAST = require('../__fixtures__/ast-multiple-solutions.json');

--- a/tools/challenge-parser/parser/plugins/add-tests.test.js
+++ b/tools/challenge-parser/parser/plugins/add-tests.test.js
@@ -1,4 +1,3 @@
-/* global describe it expect beforeEach */
 const simpleAST = require('../__fixtures__/ast-simple.json');
 const brokenHintsAST = require('../__fixtures__/ast-broken-hints.json');
 const addTests = require('./add-tests');

--- a/tools/challenge-parser/parser/plugins/add-text.test.js
+++ b/tools/challenge-parser/parser/plugins/add-text.test.js
@@ -1,4 +1,3 @@
-/* global describe it expect */
 const mockAST = require('../__fixtures__/ast-simple.json');
 // eslint-disable-next-line max-len
 const incorrectMarkersAST = require('../__fixtures__/ast-incorrect-markers.json');

--- a/tools/challenge-parser/parser/plugins/add-video-question.test.js
+++ b/tools/challenge-parser/parser/plugins/add-video-question.test.js
@@ -1,4 +1,3 @@
-/* global describe it expect beforeEach */
 const simpleAST = require('../__fixtures__/ast-simple.json');
 const mockVideoAST = require('../__fixtures__/ast-video-challenge.json');
 // eslint-disable-next-line max-len

--- a/tools/challenge-parser/parser/plugins/replace-imports.test.js
+++ b/tools/challenge-parser/parser/plugins/replace-imports.test.js
@@ -1,4 +1,3 @@
-/* global describe it expect jest */
 const path = require('path');
 const cloneDeep = require('lodash/cloneDeep');
 const toVfile = require('to-vfile');

--- a/tools/challenge-parser/parser/plugins/restore-directives.test.js
+++ b/tools/challenge-parser/parser/plugins/restore-directives.test.js
@@ -1,4 +1,3 @@
-/* global describe it expect */
 const cloneDeep = require('lodash/cloneDeep');
 const { selectAll } = require('unist-util-select');
 const find = require('unist-util-find');

--- a/tools/challenge-parser/parser/plugins/utils/between-headings.test.js
+++ b/tools/challenge-parser/parser/plugins/utils/between-headings.test.js
@@ -1,4 +1,3 @@
-/* global expect*/
 const isArray = require('lodash/isArray');
 const find = require('unist-util-find');
 const { root } = require('mdast-builder');

--- a/tools/challenge-parser/parser/plugins/utils/get-id.test.js
+++ b/tools/challenge-parser/parser/plugins/utils/get-id.test.js
@@ -1,4 +1,3 @@
-/* global expect*/
 const getId = require('./get-id');
 const idNode = require('./__fixtures__/id-node.json');
 const imageNode = require('./__fixtures__/image-node.json');

--- a/tools/challenge-parser/parser/plugins/utils/mdast-to-html.test.js
+++ b/tools/challenge-parser/parser/plugins/utils/mdast-to-html.test.js
@@ -1,4 +1,3 @@
-/* global expect*/
 const mdastToHTML = require('./mdast-to-html');
 const mdastMixedNodes = require('./__fixtures__/mdast-mixed-nodes.json');
 const mdastWithEmNode = require('./__fixtures__/mdast-with-em.json');

--- a/tools/challenge-parser/translation-parser/index.test.js
+++ b/tools/challenge-parser/translation-parser/index.test.js
@@ -1,4 +1,3 @@
-/* global expect jest */
 const {
   translateComments,
   translateCommentsInChallenge,

--- a/tools/scripts/lint/index.test.js
+++ b/tools/scripts/lint/index.test.js
@@ -1,4 +1,3 @@
-/* global describe it expect jest beforeEach */
 const path = require('path');
 
 const lint = require('.');

--- a/tools/ui-components/src/button.test.js
+++ b/tools/ui-components/src/button.test.js
@@ -1,6 +1,3 @@
-/* global expect */
-/* global jest */
-
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/utils/get-lines.test.js
+++ b/utils/get-lines.test.js
@@ -1,5 +1,3 @@
-/* global describe expect it */
-
 const { getLines } = require('./get-lines');
 
 const content = 'one\ntwo\nthree';

--- a/utils/slugs.test.js
+++ b/utils/slugs.test.js
@@ -1,5 +1,3 @@
-/* global describe expect it */
-
 const slugs = require('./slugs');
 
 describe('dasherize', () => {

--- a/utils/sort-files.test.js
+++ b/utils/sort-files.test.js
@@ -1,5 +1,3 @@
-/* global expect */
-
 const { toSortedArray } = require('./sort-files');
 const { challengeFiles } = require('./__fixtures__/challenges');
 

--- a/utils/validate.test.js
+++ b/utils/validate.test.js
@@ -1,5 +1,3 @@
-/* global describe expect it */
-
 const {
   isValidUsername,
   usernameTooShort,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Improves DX a bit by adding Jest to the Eslint `env` config. This means we can use its global variables straight away and the `/* global [insert a jest variable] */` is no longer needed.

I also wanted to include [eslint-plugin-jest](https://github.com/jest-community/eslint-plugin-jest) and [eslint-plugin-cypress](https://github.com/cypress-io/eslint-plugin-cypress), as their recommended configs can help enforce best practices in writing unit tests. However, their presence will break some of our tests, so I would prefer dealing with them separately (maybe as part of https://github.com/freeCodeCamp/freeCodeCamp/issues/42229).
