### PR TITLE
fix(curriculum): clarify React challenge test text

### DIFF
--- a/curriculum/challenges/english/03-front-end-libraries/react/render-state-in-the-user-interface.md
+++ b/curriculum/challenges/english/03-front-end-libraries/react/render-state-in-the-user-interface.md
@@ -28,8 +28,7 @@ In the code editor, `MyComponent` is already stateful. Define an `h1` tag in the
 
 ```js
 assert(
-  Enzyme.mount(React.createElement(MyComponent)).state('name') ===
-    'freeCodeCamp'
+  Enzyme.mount(React.createElement(MyComponent)).state('name').indexOf('freeCodeCamp') > -1
 );
 ```
 

--- a/curriculum/challenges/english/03-front-end-libraries/react/render-state-in-the-user-interface.md
+++ b/curriculum/challenges/english/03-front-end-libraries/react/render-state-in-the-user-interface.md
@@ -28,7 +28,8 @@ In the code editor, `MyComponent` is already stateful. Define an `h1` tag in the
 
 ```js
 assert(
-  Enzyme.mount(React.createElement(MyComponent)).state('name').indexOf('freeCodeCamp') > -1
+  Enzyme.mount(React.createElement(MyComponent)).state('name') ===
+    'freeCodeCamp'
 );
 ```
 
@@ -42,7 +43,7 @@ assert(
 );
 ```
 
-The rendered `h1` header should contain text rendered from the component's state.
+The rendered `h1` header should only contain text rendered from the component's state.
 
 ```js
 async () => {


### PR DESCRIPTION
Checklist:
- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod. ![image](https://user-images.githubusercontent.com/25173414/122673402-36eb8080-d1c8-11eb-8c3b-fa4b0427309a.png)


I was working on "Render State in the User Interface" React challenge in the "Front End Libraries Development" certification

The tests read as such: 
MyComponent should have a key name with value freeCodeCamp stored in its state.
MyComponent should render an h1 header enclosed in a single div.
The rendered h1 header should contain text rendered from the component's state.

I passed the first two, but didn't pass the third.
My code looked like the below:

![ok1](https://user-images.githubusercontent.com/25173414/122673396-2affbe80-d1c8-11eb-9346-7bf03d8c91f2.JPG)
![ok2](https://user-images.githubusercontent.com/25173414/122673398-2b985500-d1c8-11eb-9340-8d513684c868.JPG)

I looked at the test's code and saw why I failed the third. I could ONLY include the string "freeCodeCamp" but that isn't explained in the test.
The test isn't descriptive as by the tests definition, my h1 header did contain the name rendered from the state.

I think it would be helpful if we either:
1) Rename the test to explain the h1 header should ONLY contain the name rendered from the state
2) Just check that the word appears somewhere in the string

I personally thought number 2 made more sense, and this prompted me to create the attached PR.

Thanks!

