### PR TITLE
fix(client): remove extra slash when redirecting to client

### DIFF
--- a/api-server/src/server/boot/challenge.js
+++ b/api-server/src/server/boot/challenge.js
@@ -17,8 +17,8 @@ import { fixCompletedChallengeItem } from '../../common/utils';
 import { getChallenges } from '../utils/get-curriculum';
 import {
   getRedirectParams,
-  getRedirectBase,
-  normalizeParams
+  normalizeParams,
+  getPrefixedLandingPath
 } from '../utils/redirection';
 
 const log = debug('fcc:boot:challenges');
@@ -341,7 +341,7 @@ export function createRedirectToCurrentChallenge(
     const { user } = req;
     const { origin, pathPrefix } = getRedirectParams(req, normalizeParams);
 
-    const redirectBase = getRedirectBase(origin, pathPrefix);
+    const redirectBase = getPrefixedLandingPath(origin, pathPrefix);
     if (!user) {
       return res.redirect(redirectBase + '/learn');
     }

--- a/api-server/src/server/utils/redirection.js
+++ b/api-server/src/server/utils/redirection.js
@@ -50,10 +50,7 @@ function normalizeParams(
   return { returnTo, origin, pathPrefix };
 }
 
-// TODO: tests!
-// TODO: ensure origin and pathPrefix validation happens first
-// (it needs a dedicated function that can be called from here and getReturnTo)
-function getRedirectBase(origin, pathPrefix) {
+function getPrefixedLandingPath(origin, pathPrefix) {
   const redirectPathSegment = pathPrefix ? `/${pathPrefix}` : '';
   return `${origin}${redirectPathSegment}`;
 }
@@ -70,14 +67,14 @@ function getRedirectParams(req, _normalizeParams = normalizeParams) {
   return _normalizeParams({ returnTo: returnUrl.href, origin, pathPrefix });
 }
 
-function isRootPath(redirectBase, returnUrl) {
+function haveSamePath(redirectBase, returnUrl) {
   const base = new URL(redirectBase);
   const url = new URL(returnUrl);
   return base.pathname === url.pathname;
 }
 
 module.exports.getReturnTo = getReturnTo;
-module.exports.getRedirectBase = getRedirectBase;
+module.exports.getPrefixedLandingPath = getPrefixedLandingPath;
 module.exports.normalizeParams = normalizeParams;
 module.exports.getRedirectParams = getRedirectParams;
-module.exports.isRootPath = isRootPath;
+module.exports.haveSamePath = haveSamePath;

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -36,7 +36,7 @@
 Cypress.Commands.add('login', () => {
   cy.visit('/');
   cy.contains("Get started (it's free)").click();
-  cy.url().should('eq', Cypress.config().baseUrl + '/learn');
+  cy.url().should('eq', Cypress.config().baseUrl + '/learn/');
   cy.contains('Welcome back');
 });
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -36,6 +36,7 @@
 Cypress.Commands.add('login', () => {
   cy.visit('/');
   cy.contains("Get started (it's free)").click();
+  cy.url().should('eq', Cypress.config().baseUrl + '/learn');
   cy.contains('Welcome back');
 });
 


### PR DESCRIPTION
I also refactored a little to, hopefully, improve how things are named as well as making prod and dev implementations closer. 

Also, I updated Cypress to (sort of) check for this. It's tricky to get Cypress to check if it *never* goes to a url, but it at least gives you a hint if you're debugging.