### PR TITLE
fix: scrollable nav

### DIFF
--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -233,6 +233,14 @@
   display: inherit;
   text-align: left;
   margin-top: calc(-1 * var(--header-height));
+  max-height: calc(100vh - var(--header-height));
+  overflow-y: scroll;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+.display-menu::-webkit-scrollbar {
+  display: none;
 }
 
 .toggle-button-nav {

--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -331,6 +331,10 @@
   .ais-Hits {
     min-width: calc(100% - 30px);
   }
+
+  .display-menu {
+    max-height: calc(100vh - var(--header-height) * 2);
+  }
 }
 
 @media (max-width: 455px) {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/43180

<!-- Feel free to add any additional description of changes below this line -->
This came up in a meeting with Quincy yesterday - on smaller screens, or with the page view zoomed in, the drop down navigation menu is too large and not scrollable.

I've added a max height to the menu, set the `overflow-y` to scroll, and hidden the scrollbar for (I believe) all browsers. 