### PR TITLE
fix(curriculum): update object keys referenced in instructions to match provided object

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/use-the-map-method-to-extract-data-from-an-array.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/use-the-map-method-to-extract-data-from-an-array.md
@@ -37,7 +37,7 @@ The console would display the value ` [ 'John', 'Amy', 'camperCat' ]`.
 
 # --instructions--
 
-The `watchList` array holds objects with information on several movies. Use `map` on `watchList` to assign a new array of objects with only `Title` and `imdbRating` keys to the `ratings` variable. The code in the editor currently uses a `for` loop to do this, so you should replace the loop functionality with your `map` expression.
+The `watchList` array holds objects with information on several movies. Use `map` on `watchList` to assign a new array of objects to the `ratings` variable. Each movie in the new array should have a `title` key with the name of the film and a `rating` key with the IMDB rating. The code in the editor currently uses a `for` loop to do this, so you should replace the loop functionality with your `map` expression.
 
 # --hints--
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/use-the-map-method-to-extract-data-from-an-array.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/use-the-map-method-to-extract-data-from-an-array.md
@@ -37,7 +37,7 @@ The console would display the value ` [ 'John', 'Amy', 'camperCat' ]`.
 
 # --instructions--
 
-The `watchList` array holds objects with information on several movies. Use `map` on `watchList` to assign a new array of objects to the `ratings` variable. Each movie in the new array should have a `title` key with the name of the film and a `rating` key with the IMDB rating. The code in the editor currently uses a `for` loop to do this, so you should replace the loop functionality with your `map` expression.
+The `watchList` array holds objects with information on several movies. Use `map` on `watchList` to assign a new array of objects to the `ratings` variable. Each movie in the new array should have only a `title` key with the name of the film, and a `rating` key with the IMDB rating. The code in the editor currently uses a `for` loop to do this, so you should replace the loop functionality with your `map` expression.
 
 # --hints--
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/use-the-map-method-to-extract-data-from-an-array.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/use-the-map-method-to-extract-data-from-an-array.md
@@ -61,15 +61,15 @@ Your code should use the `map` method.
 assert(code.match(/\.map/g));
 ```
 
-`ratings` should equal `[{"Title":"Inception","imdbRating":"8.8"},{"Title":"Interstellar","imdbRating":"8.6"},{"Title":"The Dark Knight","imdbRating":"9.0"},{"Title":"Batman Begins","imdbRating":"8.3"},{"Title":"Avatar","imdbRating":"7.9"}]`.
+`ratings` should equal `[{"title":"Inception","rating":"8.8"},{"title":"Interstellar","rating":"8.6"},{"title":"The Dark Knight","rating":"9.0"},{"title":"Batman Begins","rating":"8.3"},{"title":"Avatar","rating":"7.9"}]`.
 
 ```js
 assert.deepEqual(ratings, [
-  { Title: 'Inception', imdbRating: '8.8' },
-  { Title: 'Interstellar', imdbRating: '8.6' },
-  { Title: 'The Dark Knight', imdbRating: '9.0' },
-  { Title: 'Batman Begins', imdbRating: '8.3' },
-  { Title: 'Avatar', imdbRating: '7.9' }
+  { title: 'Inception', rating: '8.8' },
+  { title: 'Interstellar', rating: '8.6' },
+  { title: 'The Dark Knight', rating: '9.0' },
+  { title: 'Batman Begins', rating: '8.3' },
+  { title: 'Avatar', rating: '7.9' }
 ]);
 ```
 
@@ -196,7 +196,7 @@ var watchList = [
 
 var ratings = [];
 for(var i=0; i < watchList.length; i++){
-  ratings.push({Title: watchList[i]["Title"],  imdbRating: watchList[i]["imdbRating"]});
+  ratings.push({title: watchList[i]["Title"],  rating: watchList[i]["imdbRating"]});
 }
 
 // Only change code above this line
@@ -323,8 +323,8 @@ var watchList = [
 
 var ratings = watchList.map(function(movie) {
   return {
-    Title: movie["Title"],
-    imdbRating: movie["imdbRating"]
+    title: movie["Title"],
+    rating: movie["imdbRating"]
   }
 });
 ```

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/use-the-map-method-to-extract-data-from-an-array.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/use-the-map-method-to-extract-data-from-an-array.md
@@ -37,7 +37,7 @@ The console would display the value ` [ 'John', 'Amy', 'camperCat' ]`.
 
 # --instructions--
 
-The `watchList` array holds objects with information on several movies. Use `map` on `watchList` to assign a new array of objects with only `title` and `rating` keys to the `ratings` variable. The code in the editor currently uses a `for` loop to do this, so you should replace the loop functionality with your `map` expression.
+The `watchList` array holds objects with information on several movies. Use `map` on `watchList` to assign a new array of objects with only `Title` and `imdbRating` keys to the `ratings` variable. The code in the editor currently uses a `for` loop to do this, so you should replace the loop functionality with your `map` expression.
 
 # --hints--
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/use-the-map-method-to-extract-data-from-an-array.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/use-the-map-method-to-extract-data-from-an-array.md
@@ -61,15 +61,15 @@ Your code should use the `map` method.
 assert(code.match(/\.map/g));
 ```
 
-`ratings` should equal `[{"title":"Inception","rating":"8.8"},{"title":"Interstellar","rating":"8.6"},{"title":"The Dark Knight","rating":"9.0"},{"title":"Batman Begins","rating":"8.3"},{"title":"Avatar","rating":"7.9"}]`.
+`ratings` should equal `[{"Title":"Inception","imdbRating":"8.8"},{"Title":"Interstellar","imdbRating":"8.6"},{"Title":"The Dark Knight","imdbRating":"9.0"},{"Title":"Batman Begins","imdbRating":"8.3"},{"Title":"Avatar","imdbRating":"7.9"}]`.
 
 ```js
 assert.deepEqual(ratings, [
-  { title: 'Inception', rating: '8.8' },
-  { title: 'Interstellar', rating: '8.6' },
-  { title: 'The Dark Knight', rating: '9.0' },
-  { title: 'Batman Begins', rating: '8.3' },
-  { title: 'Avatar', rating: '7.9' }
+  { Title: 'Inception', imdbRating: '8.8' },
+  { Title: 'Interstellar', imdbRating: '8.6' },
+  { Title: 'The Dark Knight', imdbRating: '9.0' },
+  { Title: 'Batman Begins', imdbRating: '8.3' },
+  { Title: 'Avatar', imdbRating: '7.9' }
 ]);
 ```
 
@@ -196,7 +196,7 @@ var watchList = [
 
 var ratings = [];
 for(var i=0; i < watchList.length; i++){
-  ratings.push({title: watchList[i]["Title"],  rating: watchList[i]["imdbRating"]});
+  ratings.push({Title: watchList[i]["Title"],  imdbRating: watchList[i]["imdbRating"]});
 }
 
 // Only change code above this line
@@ -323,8 +323,8 @@ var watchList = [
 
 var ratings = watchList.map(function(movie) {
   return {
-    title: movie["Title"],
-    rating: movie["imdbRating"]
+    Title: movie["Title"],
+    imdbRating: movie["imdbRating"]
   }
 });
 ```


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!-- Feel free to add any additional description of changes below this line -->
Because each movie object has both `Rated` and `imdbRating` key/value pairs, simply referencing `rating` could be confusing to campers. IMO explicitly referencing the keys by name (`Title` and `imdbRating`) removes ambiguity in the non-important part of this challenge and helps campers focus on learning about `.map()`. Admittedly not a mission-critical change.
