### PR TITLE
quickfix: curriculum test regex now covers new line format

### DIFF
--- a/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/implementation-of-social-authentication-ii.md
+++ b/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/implementation-of-social-authentication-ii.md
@@ -78,7 +78,7 @@ GitHub strategy should be setup correctly thus far.
     (data) => {
       assert.match(
         data,
-        /passport\.use.*new GitHubStrategy/gi,
+        /passport\.use.*new GitHubStrategy/gis,
         'Passport should use a new GitHubStrategy'
       );
       assert.match(


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #42473

Added s flag in regex test to pass even when new line is used in the code.
For reproducing the bug and testing the quickfix you can check in [this comment](https://github.com/freeCodeCamp/freeCodeCamp/issues/42473#issuecomment-868155671) the steps I followed.
I tested it locally too.