### PR TITLE
fix(tools): set homepage for CRA builds

### DIFF
--- a/tools/contributor/dashboard-app/server/package.json
+++ b/tools/contributor/dashboard-app/server/package.json
@@ -15,7 +15,7 @@
   "bugs": {
     "url": "https://github.com/freeCodeCamp/freeCodeCamp/issues"
   },
-  "homepage": "https://github.com/freeCodeCamp/freeCodeCamp#readme",
+  "homepage": "https://tools.freecodecamp.org",
   "author": "freeCodeCamp <team@freecodecamp.org>",
   "main": "none",
   "scripts": {


### PR DESCRIPTION
The result of this change is already deployed on the tool's dashboard.