### PR TITLE
feat: silently commit when automerging

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,8 @@
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "matchCurrentVersion": "!/^0/",
-      "automerge": true
+      "automerge": true,
+      "automergeType": "branch"
     },
     {
       "groupName": "Monaco Editor",
@@ -22,10 +23,9 @@
     },
     {
       "groupName": "CodeSee",
-      "matchPackagePrefixes": [
-        "@codesee/"
-      ],
-      "automerge": true
+      "matchPackagePrefixes": ["@codesee/"],
+      "automerge": true,
+      "automergeType": "branch"
     }
   ],
   "ignorePaths": [


### PR DESCRIPTION
@raisedadead this should considerably reduce the amount of noise that automerging generates.  We've been running with this config over on Chapter for a couple of months now with no problems.