### PR TITLE
fix(curriculum): correct 'text-transform' example

### DIFF
--- a/curriculum/challenges/espanol/01-responsive-web-design/applied-visual-design/use-the-text-transform-property-to-make-text-uppercase.md
+++ b/curriculum/challenges/espanol/01-responsive-web-design/applied-visual-design/use-the-text-transform-property-to-make-text-uppercase.md
@@ -13,7 +13,7 @@ La propiedad `text-transform` en CSS se utiliza para cambiar la apariencia del t
 
 La siguiente tabla muestra como los diferentes valores de `text-transform` cambian el texto de ejemplo "Transformame".
 
-<table class='table table-striped'><thead><tr><th>Valor</th><th>Resultado</th></tr></thead><tbody><tr><td><code>lowercase</code></td><td>"Transformame"</td></tr><tr><td><code>uppercase</code></td><td>"TRANSFORMAME"</td></tr><tr><td><code>capitalize</code></td><td>"Transformame"</td></tr><tr><td><code>initial</code></td><td>Usa el valor predeterminado</td></tr><tr><td><code>inherit</code></td><td>Utiliza el valor <code>text-transform</code> del elemento principal</td></tr><tr><td><code>none</code></td><td><strong>Predeterminado:</strong> Usa el texto original</td></tr></tbody></table>
+<table class='table table-striped'><thead><tr><th>Valor</th><th>Resultado</th></tr></thead><tbody><tr><td><code>lowercase</code></td><td>"transformame"</td></tr><tr><td><code>uppercase</code></td><td>"TRANSFORMAME"</td></tr><tr><td><code>capitalize</code></td><td>"Transformame"</td></tr><tr><td><code>initial</code></td><td>Usa el valor predeterminado</td></tr><tr><td><code>inherit</code></td><td>Utiliza el valor <code>text-transform</code> del elemento principal</td></tr><tr><td><code>none</code></td><td><strong>Predeterminado:</strong> Usa el texto original</td></tr></tbody></table>
 
 # --instructions--
 


### PR DESCRIPTION
Changes 'Transformame' to 'transformame' as an example of the 'text-transform' value of 'lowercase'.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
