### PR TITLE
feat: localize videos

### DIFF
--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -189,6 +189,12 @@ export interface BilibiliIds {
   cid: string;
 }
 
+export interface VideoLocaleIds {
+  espanol?: string;
+  italian?: string;
+  portuguese?: string;
+}
+
 export type ChallengeNodeType = {
   block: string;
   challengeOrder: number;
@@ -218,6 +224,7 @@ export type ChallengeNodeType = {
   translationPending: boolean;
   url: string;
   videoId: string;
+  videoLocaleIds?: VideoLocaleIds;
   bilibiliIds?: BilibiliIds;
   videoUrl: string;
 };

--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -183,6 +183,11 @@ type Required = {
   src: string;
   crossDomain?: boolean;
 };
+export interface BilibiliIds {
+  aid: string;
+  bvid: string;
+  cid: string;
+}
 
 export type ChallengeNodeType = {
   block: string;
@@ -213,6 +218,7 @@ export type ChallengeNodeType = {
   translationPending: boolean;
   url: string;
   videoId: string;
+  bilibiliIds?: BilibiliIds;
   videoUrl: string;
 };
 

--- a/client/src/templates/Challenges/components/VideoPlayer.tsx
+++ b/client/src/templates/Challenges/components/VideoPlayer.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import YouTube from 'react-youtube';
+
+interface VideoPlayerProps {
+  videoId: string;
+  onVideoLoad: () => void;
+  videoIsLoaded: boolean;
+}
+
+function VideoPlayer({
+  videoId,
+  onVideoLoad,
+  videoIsLoaded
+}: VideoPlayerProps): JSX.Element {
+  const { t } = useTranslation();
+  return (
+    <>
+      <YouTube
+        className={
+          videoIsLoaded ? 'display-youtube-video' : 'hide-youtube-video'
+        }
+        onReady={onVideoLoad}
+        opts={{
+          playerVars: {
+            rel: 0
+          },
+          width: 'auto',
+          height: 'auto'
+        }}
+        videoId={videoId}
+      />
+      <i>
+        <a
+          href={
+            'https://www.youtube.com/timedtext_editor?action_mde_edit_form=1&v=' +
+            videoId +
+            '&lang=en&bl=watch&ui=hd&ref=wt&tab=captions'
+          }
+          rel='noopener noreferrer'
+          target='_blank'
+        >
+          {t('learn.add-subtitles')}
+        </a>
+        .
+      </i>
+    </>
+  );
+}
+
+export default VideoPlayer;

--- a/client/src/templates/Challenges/components/VideoPlayer.tsx
+++ b/client/src/templates/Challenges/components/VideoPlayer.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 import YouTube from 'react-youtube';
 import envData from '../../../../../config/env.json';
 import type { BilibiliIds, VideoLocaleIds } from '../../../redux/prop-types';
@@ -32,8 +31,6 @@ function VideoPlayer({
   bilibiliIds,
   title
 }: VideoPlayerProps): JSX.Element {
-  const { t } = useTranslation();
-
   let bilibiliSrc = null;
 
   if (
@@ -59,36 +56,20 @@ function VideoPlayer({
           title={title}
         />
       ) : (
-        <>
-          <YouTube
-            className={
-              videoIsLoaded ? 'display-youtube-video' : 'hide-youtube-video'
-            }
-            onReady={onVideoLoad}
-            opts={{
-              playerVars: {
-                rel: 0
-              },
-              width: 'auto',
-              height: 'auto'
-            }}
-            videoId={videoId}
-          />
-          <i>
-            <a
-              href={
-                'https://www.youtube.com/timedtext_editor?action_mde_edit_form=1&v=' +
-                videoId +
-                '&lang=en&bl=watch&ui=hd&ref=wt&tab=captions'
-              }
-              rel='noopener noreferrer'
-              target='_blank'
-            >
-              {t('learn.add-subtitles')}
-            </a>
-            .
-          </i>
-        </>
+        <YouTube
+          className={
+            videoIsLoaded ? 'display-youtube-video' : 'hide-youtube-video'
+          }
+          onReady={onVideoLoad}
+          opts={{
+            playerVars: {
+              rel: 0
+            },
+            width: 'auto',
+            height: 'auto'
+          }}
+          videoId={videoId}
+        />
       )}
     </>
   );

--- a/client/src/templates/Challenges/components/VideoPlayer.tsx
+++ b/client/src/templates/Challenges/components/VideoPlayer.tsx
@@ -1,49 +1,79 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import YouTube from 'react-youtube';
+import type { BilibiliIds } from '../../../redux/prop-types';
+
+import envData from '../../../../../config/env.json';
+
+const { clientLocale } = envData;
 
 interface VideoPlayerProps {
   videoId: string;
   onVideoLoad: () => void;
   videoIsLoaded: boolean;
+  bilibiliIds?: BilibiliIds;
+  title: string;
 }
 
 function VideoPlayer({
   videoId,
   onVideoLoad,
-  videoIsLoaded
+  videoIsLoaded,
+  bilibiliIds,
+  title
 }: VideoPlayerProps): JSX.Element {
   const { t } = useTranslation();
+
+  let bilibiliSrc = null;
+
+  if (
+    bilibiliIds &&
+    ['chinese', 'chinese-traditional'].includes(clientLocale)
+  ) {
+    const { aid, bvid, cid } = bilibiliIds;
+    bilibiliSrc = `//player.bilibili.com/player.html?aid=${aid}&bvid=${bvid}&cid=${cid}`;
+  }
   return (
     <>
-      <YouTube
-        className={
-          videoIsLoaded ? 'display-youtube-video' : 'hide-youtube-video'
-        }
-        onReady={onVideoLoad}
-        opts={{
-          playerVars: {
-            rel: 0
-          },
-          width: 'auto',
-          height: 'auto'
-        }}
-        videoId={videoId}
-      />
-      <i>
-        <a
-          href={
-            'https://www.youtube.com/timedtext_editor?action_mde_edit_form=1&v=' +
-            videoId +
-            '&lang=en&bl=watch&ui=hd&ref=wt&tab=captions'
-          }
-          rel='noopener noreferrer'
-          target='_blank'
-        >
-          {t('learn.add-subtitles')}
-        </a>
-        .
-      </i>
+      {bilibiliSrc ? (
+        <iframe
+          frameBorder='no'
+          scrolling='no'
+          src={bilibiliSrc}
+          title={title}
+        />
+      ) : (
+        <>
+          <YouTube
+            className={
+              videoIsLoaded ? 'display-youtube-video' : 'hide-youtube-video'
+            }
+            onReady={onVideoLoad}
+            opts={{
+              playerVars: {
+                rel: 0
+              },
+              width: 'auto',
+              height: 'auto'
+            }}
+            videoId={videoId}
+          />
+          <i>
+            <a
+              href={
+                'https://www.youtube.com/timedtext_editor?action_mde_edit_form=1&v=' +
+                videoId +
+                '&lang=en&bl=watch&ui=hd&ref=wt&tab=captions'
+              }
+              rel='noopener noreferrer'
+              target='_blank'
+            >
+              {t('learn.add-subtitles')}
+            </a>
+            .
+          </i>
+        </>
+      )}
     </>
   );
 }

--- a/client/src/templates/Challenges/components/VideoPlayer.tsx
+++ b/client/src/templates/Challenges/components/VideoPlayer.tsx
@@ -1,14 +1,23 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import YouTube from 'react-youtube';
-import type { BilibiliIds } from '../../../redux/prop-types';
-
 import envData from '../../../../../config/env.json';
+import type { BilibiliIds, VideoLocaleIds } from '../../../redux/prop-types';
 
-const { clientLocale } = envData;
+// TODO: pull these types from all-langs
+const { clientLocale } = envData as {
+  clientLocale:
+    | 'english'
+    | 'chinese'
+    | 'chinese-traditional'
+    | 'espanol'
+    | 'italian'
+    | 'portuguese';
+};
 
 interface VideoPlayerProps {
   videoId: string;
+  videoLocaleIds?: VideoLocaleIds;
   onVideoLoad: () => void;
   videoIsLoaded: boolean;
   bilibiliIds?: BilibiliIds;
@@ -17,6 +26,7 @@ interface VideoPlayerProps {
 
 function VideoPlayer({
   videoId,
+  videoLocaleIds,
   onVideoLoad,
   videoIsLoaded,
   bilibiliIds,
@@ -33,6 +43,12 @@ function VideoPlayer({
     const { aid, bvid, cid } = bilibiliIds;
     bilibiliSrc = `//player.bilibili.com/player.html?aid=${aid}&bvid=${bvid}&cid=${cid}`;
   }
+
+  if (videoLocaleIds) {
+    const localeId = videoLocaleIds[clientLocale as keyof VideoLocaleIds];
+    videoId = localeId || videoId;
+  }
+
   return (
     <>
       {bilibiliSrc ? (

--- a/client/src/templates/Challenges/video/Show.tsx
+++ b/client/src/templates/Challenges/video/Show.tsx
@@ -179,6 +179,7 @@ class ShowVideo extends Component<ShowVideoProps, ShowVideoState> {
           block,
           translationPending,
           videoId,
+          videoLocaleIds,
           bilibiliIds,
           question: { text, answers, solution }
         }
@@ -230,6 +231,7 @@ class ShowVideo extends Component<ShowVideoProps, ShowVideoState> {
                     title={title}
                     videoId={videoId}
                     videoIsLoaded={this.state.videoIsLoaded}
+                    videoLocaleIds={videoLocaleIds}
                   />
                 </div>
               </Col>
@@ -314,6 +316,11 @@ export const query = graphql`
   query VideoChallenge($slug: String!) {
     challengeNode(fields: { slug: { eq: $slug } }) {
       videoId
+      videoLocaleIds {
+        espanol
+        italian
+        portuguese
+      }
       bilibiliIds {
         aid
         bvid

--- a/client/src/templates/Challenges/video/Show.tsx
+++ b/client/src/templates/Challenges/video/Show.tsx
@@ -179,6 +179,7 @@ class ShowVideo extends Component<ShowVideoProps, ShowVideoState> {
           block,
           translationPending,
           videoId,
+          bilibiliIds,
           question: { text, answers, solution }
         }
       },
@@ -224,7 +225,9 @@ class ShowVideo extends Component<ShowVideoProps, ShowVideoState> {
                     </div>
                   ) : null}
                   <VideoPlayer
+                    bilibiliIds={bilibiliIds}
                     onVideoLoad={this.onVideoLoad}
+                    title={title}
                     videoId={videoId}
                     videoIsLoaded={this.state.videoIsLoaded}
                   />
@@ -311,6 +314,11 @@ export const query = graphql`
   query VideoChallenge($slug: String!) {
     challengeNode(fields: { slug: { eq: $slug } }) {
       videoId
+      bilibiliIds {
+        aid
+        bvid
+        cid
+      }
       title
       description
       challengeType

--- a/client/src/templates/Challenges/video/Show.tsx
+++ b/client/src/templates/Challenges/video/Show.tsx
@@ -6,7 +6,6 @@ import Helmet from 'react-helmet';
 import { ObserveKeys } from 'react-hotkeys';
 import { TFunction, withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
-import YouTube from 'react-youtube';
 import { bindActionCreators } from 'redux';
 import type { Dispatch } from 'redux';
 import { createSelector } from 'reselect';
@@ -21,6 +20,7 @@ import {
 } from '../../../redux/prop-types';
 import ChallengeDescription from '../components/Challenge-Description';
 import Hotkeys from '../components/Hotkeys';
+import VideoPlayer from '../components/VideoPlayer';
 import ChallengeTitle from '../components/challenge-title';
 import CompletionModal from '../components/completion-modal';
 import PrismFormatted from '../components/prism-formatted';
@@ -162,7 +162,7 @@ class ShowVideo extends Component<ShowVideoProps, ShowVideoState> {
     });
   };
 
-  videoIsReady = () => {
+  onVideoLoad = () => {
     this.setState({
       videoIsLoaded: true
     });
@@ -223,22 +223,10 @@ class ShowVideo extends Component<ShowVideoProps, ShowVideoState> {
                       <Loader />
                     </div>
                   ) : null}
-                  <YouTube
-                    className={
-                      this.state.videoIsLoaded
-                        ? 'display-youtube-video'
-                        : 'hide-youtube-video'
-                    }
-                    onReady={this.videoIsReady}
-                    opts={{
-                      playerVars: {
-                        rel: 0
-                      },
-                      width: 'auto',
-                      height: 'auto'
-                    }}
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                  <VideoPlayer
+                    onVideoLoad={this.onVideoLoad}
                     videoId={videoId}
+                    videoIsLoaded={this.state.videoIsLoaded}
                   />
                 </div>
               </Col>

--- a/curriculum/challenges/english/07-scientific-computing-with-python/python-for-everybody/introduction-why-program.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/python-for-everybody/introduction-why-program.md
@@ -3,6 +3,14 @@ id: 5e6a54a558d3af90110a60a0
 title: 'Introduction: Why Program?'
 challengeType: 11
 videoId: 3muQV-Im3Z0
+bilibiliIds:
+  aid: 206882253
+  bvid: BV1Fh411z7tr
+  cid: 376314257
+videoLocaleIds:
+  espanol: 3muQV-Im3Z0
+  italian: 3muQV-Im3Z0
+  portuguese: 3muQV-Im3Z0
 dashedName: introduction-why-program
 ---
 

--- a/curriculum/schema/challengeSchema.js
+++ b/curriculum/schema/challengeSchema.js
@@ -58,6 +58,14 @@ const schema = Joi.object()
       is: challengeTypes.video,
       then: Joi.string().required()
     }),
+    videoLocaleIds: Joi.when('challengeType', {
+      is: challengeTypes.video,
+      then: Joi.object().keys({
+        espanol: Joi.string(),
+        italian: Joi.string(),
+        portuguese: Joi.string()
+      })
+    }),
     bilibiliIds: Joi.when('challengeType', {
       is: challengeTypes.video,
       then: Joi.object().keys({

--- a/curriculum/schema/challengeSchema.js
+++ b/curriculum/schema/challengeSchema.js
@@ -58,6 +58,14 @@ const schema = Joi.object()
       is: challengeTypes.video,
       then: Joi.string().required()
     }),
+    bilibiliIds: Joi.when('challengeType', {
+      is: challengeTypes.video,
+      then: Joi.object().keys({
+        aid: Joi.number().required(),
+        bvid: Joi.string().required(),
+        cid: Joi.number().required()
+      })
+    }),
     question: Joi.object().keys({
       text: Joi.string().required(),
       answers: Joi.array().items(Joi.string()).required(),


### PR DESCRIPTION
This adds support for embedding

- Language specific youtube videos
- Bilibili videos in the Chinese sites

The bilibili embed iframe comes with three ids (`aid`, `bvid` and `cid`).  It doesn't seem to be necessary to use them all, but I don't really understand what they are ids *for* so I'm hesitant to remove them.

@miyaliu666 @RafaelDavisH could I get some examples of translated videos that I could use?  I need one bilibili video and (ideally) one video for Italian, Spanish and Portuguese if they exist!