### PR TITLE
feat(Cypress): reduce test time by disabling video upload on pass

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,6 @@
 {
   "projectId": "ke77ns",
   "baseUrl": "http://localhost:8000",
+  "videoUploadOnPasses": false,
   "retries": 4
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

As I discussed with Oliver, disabling video upload on pass should reduce testing time.
Should still upload when test fails.

<!-- Feel free to add any additional description of changes below this line -->
