### PR TITLE
fix(client): add if private warning to the name

### DIFF
--- a/client/i18n/locales/chinese-traditional/translations.json
+++ b/client/i18n/locales/chinese-traditional/translations.json
@@ -96,6 +96,7 @@
     "privacy": "你可以通過在本節設置來管理你展示在 freeCodeCamp 公開作品集中的內容。",
     "data": "請點擊下面的 \"下載你的數據\" 按鈕，查看我們在你的賬號上保存的數據",
     "disabled": "如果設置爲僅自己可見，其他人將無法訪問你的認證。",
+    "private-name": "Your name will not appear on your certifications, if this is set to private.",
     "claim-legacy": "當你獲得下列 freeCodeCamp 認證之後，你可以申請 {{cert}}:",
     "for": "{{username}} 賬號設置",
     "username": {

--- a/client/i18n/locales/chinese/translations.json
+++ b/client/i18n/locales/chinese/translations.json
@@ -96,6 +96,7 @@
     "privacy": "你可以通过在本节设置来管理你展示在 freeCodeCamp 公开作品集中的内容。",
     "data": "请点击下面的 \"下载你的数据\" 按钮，查看我们在你的账号上保存的数据",
     "disabled": "如果设置为仅自己可见，其他人将无法访问你的认证。",
+    "private-name": "Your name will not appear on your certifications, if this is set to private.",
     "claim-legacy": "当你获得下列 freeCodeCamp 认证之后，你可以申请 {{cert}}:",
     "for": "{{username}} 账号设置",
     "username": {

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -96,6 +96,7 @@
     "privacy": "The settings in this section enable you to control what is shown on your freeCodeCamp public portfolio.",
     "data": "To see what data we hold on your account, click the \"Download your data\" button below",
     "disabled": "Your certifications will be disabled, if set to private.",
+    "private-name": "Your name will not appear on your certifications, if this is set to private.",
     "claim-legacy": "Once you've earned the following freeCodeCamp certifications, you'll be able to claim the {{cert}}:",
     "for": "Account Settings for {{username}}",
     "username": {

--- a/client/i18n/locales/espanol/translations.json
+++ b/client/i18n/locales/espanol/translations.json
@@ -96,6 +96,7 @@
     "privacy": "Los ajustes de esta sección te permiten controlar lo que se muestra en tu portafolio público de freeCodeCamp.",
     "data": "Para ver qué datos tenemos en tu cuenta, haz clic en el botón \"Descarga tus datos\" a continuación",
     "disabled": "Tus certificaciones se deshabilitarán si se configuran como privadas.",
+    "private-name": "Your name will not appear on your certifications, if this is set to private.",
     "claim-legacy": "Una vez que hayas obtenido las siguientes certificaciones de FreeCodeCamp, podrás reclamar la {{cert}}:",
     "for": "Ajustes de cuenta de {{username}}",
     "username": {

--- a/client/i18n/locales/italian/translations.json
+++ b/client/i18n/locales/italian/translations.json
@@ -96,6 +96,7 @@
     "privacy": "Le impostazioni di questa sezione ti permettono di controllare quello che viene mostrato sul tuo portfolio pubblico di freeCodeCamp.",
     "data": "Per vedere quali dati teniamo nel tuo account, clicca sul pulsante \"Scarica i tuoi dati\" qui sotto",
     "disabled": "Le tue certificazioni saranno disabilitate, se impostato su privato.",
+    "private-name": "Your name will not appear on your certifications, if this is set to private.",
     "claim-legacy": "Una volta che avrai ottenuto le seguenti certificazioni gratuite di freeCodeCamp, sarai in grado di richiedere la {{cert}}:",
     "for": "Impostazioni Account per {{username}}",
     "username": {

--- a/client/i18n/locales/portuguese/translations.json
+++ b/client/i18n/locales/portuguese/translations.json
@@ -96,6 +96,7 @@
     "privacy": "The settings in this section enable you to control what is shown on your freeCodeCamp public portfolio.",
     "data": "To see what data we hold on your account, click the \"Download your data\" button below",
     "disabled": "Your certifications will be disabled, if set to private.",
+    "private-name": "Your name will not appear on your certifications, if this is set to private.",
     "claim-legacy": "Once you've earned the following freeCodeCamp certifications, you'll be able to claim the {{cert}}:",
     "for": "Account Settings for {{username}}",
     "username": {

--- a/client/src/components/settings/privacy.tsx
+++ b/client/src/components/settings/privacy.tsx
@@ -90,6 +90,7 @@ class PrivacySettings extends Component<PrivacyProps> {
             />
             <ToggleSetting
               action={t('settings.labels.my-name')}
+              explain={t('settings.disabled')}
               flag={!showName}
               flagName='name'
               offLabel={t('buttons.public')}

--- a/client/src/components/settings/privacy.tsx
+++ b/client/src/components/settings/privacy.tsx
@@ -90,7 +90,7 @@ class PrivacySettings extends Component<PrivacyProps> {
             />
             <ToggleSetting
               action={t('settings.labels.my-name')}
-              explain={t('settings.disabled')}
+              explain={t('settings.private-name')}
               flag={!showName}
               flagName='name'
               offLabel={t('buttons.public')}


### PR DESCRIPTION
With the updated cert claiming UX, we should add the warning for name to not be private like for others
