### PR TITLE
Removed the extra space from the seed content helper text in "Learn About SVG with D3" challenge

### DIFF
--- a/curriculum/challenges/english/04-data-visualization/data-visualization-with-d3/learn-about-svg-in-d3.md
+++ b/curriculum/challenges/english/04-data-visualization/data-visualization-with-d3/learn-about-svg-in-d3.md
@@ -60,11 +60,11 @@ assert($('svg').attr('height') == '100' || $('svg').css('height') == '100px');
     const h = 100;
 
     const svg = d3.select("body")
-                  // Add your code below this line
+    // Add your code below this line
 
 
 
-                  // Add your code above this line
+    // Add your code above this line
   </script>
 </body>
 ```


### PR DESCRIPTION
I removed the extra unnecessary space before the  "Add code below this line" and "Add code above this line" helper text om the seed content for this challenge 

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
