### PR TITLE
fix: prevent early redirection from email-signup

### DIFF
--- a/client/src/pages/email-sign-up.tsx
+++ b/client/src/pages/email-sign-up.tsx
@@ -37,18 +37,22 @@ function AcceptPrivacyTerms({
   acceptedPrivacyTerms,
   t
 }: AcceptPrivacyTermsProps) {
-  // if a user navigates away from here we should set acceptedPrivacyTerms
-  // to true (so they do not get pulled back) without changing their email
-  // preferences (hence the null payload)
-  // This ensures the user has to click the checkbox and then click the
-  // 'Continue...' button to sign up.
   useEffect(() => {
     return () => {
+      // if a user navigates away from here we should set acceptedPrivacyTerms
+      // to true (so they do not get pulled back) without changing their email
+      // preferences (hence the null payload)
+      // This makes sure that the user has to opt in to Quincy's emails and that
+      // they are only asked twice
       if (!acceptedPrivacyTerms) {
         acceptTerms(null);
       }
     };
-  }, [acceptTerms, acceptedPrivacyTerms]);
+    // We're ignoring all dependencies, since this effect must only run once
+    // (when the user leaves the page).
+    // TODO: figure out how to useCallback to only run this effect once.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   function onClick(isWeeklyEmailAccepted: boolean) {
     acceptTerms(isWeeklyEmailAccepted);


### PR DESCRIPTION
@victor-duarte we wanted to give you credit for this, since it was your PR https://github.com/freeCodeCamp/freeCodeCamp/pull/42832 that alerted us to the issue in the first place.  So, thank you for that, it's much appreciated.

The bug was introduced during the conversion to hooks.  Prior to that `acceptTerms` was only called once, but, the useEffect hook ran once during the initial render (since the `acceptedPrivacyTerms` flag is initially `undefined`).  This calls the api, sets the flag to `false` and triggers a second render.  This second render immediately redirects the user to /learn.  Many thanks to @ShaunSHamilton for debugging this.