### PR TITLE
feat(client): ESLint Fragments rule

### DIFF
--- a/.eslintrc-base.json
+++ b/.eslintrc-base.json
@@ -144,6 +144,7 @@
     "react/jsx-uses-react": 2,
     "react/jsx-uses-vars": 2,
     "react/jsx-wrap-multilines": 2,
+    "react/jsx-fragments": 2,
     "react/no-did-mount-set-state": 2,
     "react/no-did-update-set-state": 2,
     "react/no-multi-comp": [2, { "ignoreStateless": true }],

--- a/client/src/assets/icons/green-not-completed.tsx
+++ b/client/src/assets/icons/green-not-completed.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 function GreenNotCompleted(

--- a/client/src/client-only-routes/show-settings.tsx
+++ b/client/src/client-only-routes/show-settings.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 import { Grid } from '@freecodecamp/react-bootstrap';

--- a/client/src/components/settings/toggle-setting.tsx
+++ b/client/src/components/settings/toggle-setting.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import {
   FormGroup,
   ControlLabel,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

The use of Fragment shorthand (`<>`) over tags (`<Fragment>`) was approved in #42796, this PR adds a [rule](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-fragments.md) to enforce shorthand use. I also removed some unused Fragment imports.
