### PR TITLE
fix(client): no submit on server fail

### DIFF
--- a/client/src/redux/failed-updates-epic.js
+++ b/client/src/redux/failed-updates-epic.js
@@ -20,6 +20,7 @@ import {
 import postUpdate$ from '../templates/Challenges/utils/postUpdate$';
 import { isGoodXHRStatus } from '../templates/Challenges/utils';
 import { backEndProject } from '../../utils/challengeTypes';
+import { createFlashMessage } from '../components/Flash/redux';
 
 const key = 'fcc-failed-updates';
 
@@ -41,7 +42,15 @@ function failedUpdateEpic(action$, state$) {
         store.set(key, [...failures, payload]);
       }
     }),
-    map(() => onlineStatusChange(false))
+    map(({ payload }) => {
+      if (payload?.type === 'error') {
+        return createFlashMessage({
+          type: 'danger',
+          message: payload.message
+        });
+      }
+      return onlineStatusChange(false);
+    })
   );
 
   const flushUpdates = action$.pipe(

--- a/client/src/redux/index.js
+++ b/client/src/redux/index.js
@@ -578,6 +578,10 @@ export const reducer = handleActions(
         }
       };
     },
+    [types.updateFailed]: (state, { payload }) => {
+      console.log(payload);
+      return { ...state };
+    },
     [challengeTypes.challengeMounted]: (state, { payload }) => ({
       ...state,
       currentChallengeId: payload

--- a/client/src/redux/index.js
+++ b/client/src/redux/index.js
@@ -579,8 +579,15 @@ export const reducer = handleActions(
       };
     },
     [types.updateFailed]: (state, { payload }) => {
-      console.log(payload);
-      return { ...state };
+      return {
+        ...state,
+        updateFetchState: {
+          pending: false,
+          complete: false,
+          errored: true,
+          error: payload
+        }
+      };
     },
     [challengeTypes.challengeMounted]: (state, { payload }) => ({
       ...state,

--- a/client/src/templates/Challenges/projects/backend/Show.tsx
+++ b/client/src/templates/Challenges/projects/backend/Show.tsx
@@ -237,7 +237,7 @@ class BackEnd extends Component<BackEndProps> {
                   challengeType={challengeType}
                   // eslint-disable-next-line @typescript-eslint/unbound-method
                   onSubmit={this.handleSubmit}
-                  updateSolutionForm={updateSolutionFormValues}
+                  updateSolutionFormValues={updateSolutionFormValues}
                 />
                 <ProjectToolPanel
                   guideUrl={getGuideUrl({ forumTopicId, title })}

--- a/client/src/templates/Challenges/projects/frontend/Show.tsx
+++ b/client/src/templates/Challenges/projects/frontend/Show.tsx
@@ -185,7 +185,7 @@ class Project extends Component<ProjectProps> {
                   description={description}
                   // eslint-disable-next-line @typescript-eslint/unbound-method
                   onSubmit={this.handleSubmit}
-                  updateSolutionForm={updateSolutionFormValues}
+                  updateSolutionFormValues={updateSolutionFormValues}
                 />
                 <ProjectToolPanel
                   guideUrl={getGuideUrl({ forumTopicId, title })}

--- a/client/src/templates/Challenges/projects/solution-form.tsx
+++ b/client/src/templates/Challenges/projects/solution-form.tsx
@@ -18,7 +18,7 @@ interface FormProps extends WithTranslation {
   challengeType: number;
   description?: string;
   onSubmit: (arg0: SubmitProps) => void;
-  updateSolutionForm: (arg0: Record<string, unknown>) => void;
+  updateSolutionFormValues: (arg0: Record<string, unknown>) => void;
 }
 
 interface ValidatedValues {
@@ -34,14 +34,14 @@ export class SolutionForm extends Component<FormProps> {
   }
 
   componentDidMount(): void {
-    this.props.updateSolutionForm({});
+    this.props.updateSolutionFormValues({});
   }
 
   handleSubmit = (validatedValues: ValidatedValues): void => {
     // Do not execute challenge, if errors
     if (validatedValues.errors.length === 0) {
       // updates values on store
-      this.props.updateSolutionForm(validatedValues.values);
+      this.props.updateSolutionFormValues({}); // validatedValues.values);
       if (validatedValues.invalidValues.length === 0) {
         this.props.onSubmit({ isShouldCompletionModalOpen: true });
       } else {

--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -57,6 +57,7 @@ export const types = createTypes(
     'initLogs',
     'updateConsole',
     'updateChallengeMeta',
+    'updateFailed',
     'updateFile',
     'updateJSEnabled',
     'updateSolutionFormValues',


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #37615 

**22/07/2021** This includes the change in `solution-form` to fail a submission - for testing.

This does not make use of the `updateFetchState` state, as I am leaving this open for some discussion as how best to use it. ?

This was largely possible thanks to the help of these developer: Oliver