### PR TITLE
fix: improve cert claiming test

### DIFF
--- a/cypress/integration/learn/responsive-web-design/claim-cert-from-learn.js
+++ b/cypress/integration/learn/responsive-web-design/claim-cert-from-learn.js
@@ -62,7 +62,13 @@ describe('Responsive Web Design Superblock', () => {
         cy.contains("I've completed this challenge")
           .should('not.be.disabled')
           .click();
+        cy.intercept('http://localhost:3000/project-completed').as(
+          'challengeCompleted'
+        );
         cy.contains('Submit and go to next challenge').click();
+        cy.wait('@challengeCompleted')
+          .its('response.statusCode')
+          .should('eq', 200);
         cy.location().should(loc => {
           expect(loc.pathname).to.not.eq(url);
         });
@@ -74,7 +80,7 @@ describe('Responsive Web Design Superblock', () => {
       });
       cy.get('.donation-modal').should('be.visible');
       cy.contains('Ask me later').click();
-      cy.get('.donation-modal').should('not.be.visible');
+      cy.get('.donation-modal').should('not.exist');
       // directed to claim-cert-block section
       cy.url().should('include', '#claim-cert-block');
       cy.contains('Claim Certification').should('not.be.disabled').click();


### PR DESCRIPTION
cy.intercept to ensure that the server has saved the submission

should('not.exist') since the modal leaves the dom