### PR TITLE
fix(client): remove odd snap of editor panels

### DIFF
--- a/client/src/templates/Challenges/classic/Show.tsx
+++ b/client/src/templates/Challenges/classic/Show.tsx
@@ -93,6 +93,7 @@ interface ShowClassicProps {
 }
 
 interface ShowClassicState {
+  layout: IReflexLayout | string;
   resizing: boolean;
 }
 
@@ -121,8 +122,6 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
   editorRef: React.RefObject<unknown>;
   instructionsPanelRef: React.RefObject<HTMLElement>;
   resizeProps: ResizePropsType;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  layoutState: any;
 
   constructor(props: ShowClassicProps) {
     super(props);
@@ -132,15 +131,15 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
       onResize: this.onResize.bind(this)
     };
 
+    // layout: Holds the information of the panes sizes for desktop view
     this.state = {
+      layout: this.getLayoutState(),
       resizing: false
     };
 
     this.containerRef = React.createRef();
     this.editorRef = React.createRef();
     this.instructionsPanelRef = React.createRef();
-    // Holds the information of the panes sizes for desktop view
-    this.layoutState = this.getLayoutState();
   }
 
   getLayoutState(): IReflexLayout | string {
@@ -161,23 +160,36 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
   }
 
   onResize() {
-    this.setState({ resizing: true });
+    this.setState(state => ({ ...state, resizing: true }));
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onStopResize(event: any) {
     const { name, flex } = event.component.props;
 
-    this.setState({ resizing: false });
+    this.setState(state => ({ ...state, resizing: false }));
 
     // Only interested in tracking layout updates for ReflexElement's
     if (!name) {
       return;
     }
 
-    this.layoutState[name].flex = flex;
+    // Forcing a state update with the value of each panel since on stop resize
+    // is executed per each panel.
+    const newLayout =
+      typeof this.state.layout === 'object'
+        ? {
+            ...this.state.layout,
+            [name]: { flex }
+          }
+        : this.state.layout;
 
-    store.set(REFLEX_LAYOUT, this.layoutState);
+    this.setState(state => ({
+      ...state,
+      layout: newLayout
+    }));
+
+    store.set(REFLEX_LAYOUT, this.state.layout);
   }
 
   componentDidMount() {
@@ -391,7 +403,7 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
               instructions={this.renderInstructionsPanel({
                 showToolPanel: true
               })}
-              layoutState={this.layoutState}
+              layoutState={this.state.layout}
               preview={this.renderPreview()}
               resizeProps={this.resizeProps}
               testOutput={this.renderTestOutput()}

--- a/client/src/templates/Challenges/classic/Show.tsx
+++ b/client/src/templates/Challenges/classic/Show.tsx
@@ -167,10 +167,9 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
   onStopResize(event: any) {
     const { name, flex } = event.component.props;
 
-    this.setState(state => ({ ...state, resizing: false }));
-
     // Only interested in tracking layout updates for ReflexElement's
     if (!name) {
+      this.setState(state => ({ ...state, resizing: false }));
       return;
     }
 
@@ -184,10 +183,10 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
           }
         : this.state.layout;
 
-    this.setState(state => ({
-      ...state,
-      layout: newLayout
-    }));
+    this.setState({
+      layout: newLayout,
+      resizing: false
+    });
 
     store.set(REFLEX_LAYOUT, this.state.layout);
   }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #42924

<!-- Feel free to add any additional description of changes below this line -->

Moved layout information to be stored in the state so that on stop resize triggers a re-render of the component with the new values of each panel.

**Alternate solutions**

- Keep `react-reflex` on `4.0.1`
- Add a new `cooldown` prop on state and update it on resize stop method so it causes a re-render. Similar to the suggested approach but less invasive 🤷🏻 since it is just a string

**Notes**

The issue became visible after the `react-reflex` package got updated to version `4.0.2` in [fix(deps): update dependency react-reflex to v4.0.2](https://github.com/freeCodeCamp/freeCodeCamp/commit/e97c302c3d69325afab22491d026dd0f3c8c1762)

Internally they fixed some state management regarding how props were being handled and cause some conflicts with the implementation in place.