### PR TITLE
fix: adjust big cta size

### DIFF
--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -30,6 +30,9 @@ body {
   font-size: 1.5rem;
   white-space: normal;
   width: 100%;
+  max-width: 500px;
+  padding: 5px;
+  margin: 0 auto;
 }
 
 /*


### PR DESCRIPTION
 Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This pr reshapes the large cta button.


<img width="1440" alt="Screen Shot 2021-07-26 at 3 27 41 PM" src="https://user-images.githubusercontent.com/4591597/126988903-db5f6ea1-e980-45ce-9395-7519ba43aac7.png">
