### PR TITLE
feat(curriculum): add tests to anonymous-message-board

### DIFF
--- a/curriculum/challenges/english/09-information-security/information-security-projects/anonymous-message-board.md
+++ b/curriculum/challenges/english/09-information-security/information-security-projects/anonymous-message-board.md
@@ -305,7 +305,7 @@ async (getUserInput) => {
 };
 ```
 
-You can send a PUT request to `/api/threads/{board}` and pass along the `thread_id`. Returned will be the string `success`. The `reported` value of the `thread_id` will be changed to `true`.
+You can send a PUT request to `/api/threads/{board}` and pass along the `thread_id`. Returned will be the string `reported`. The `reported` value of the `thread_id` will be changed to `true`.
 
 ```js
 async (getUserInput) => {
@@ -326,7 +326,7 @@ async (getUserInput) => {
     const reported = await res.text();
     try {
       assert.equal(res.status, 200);
-      assert.equal(reported, "success");
+      assert.equal(reported, "reported");
     } catch (err) {
       throw new Error(err.responseText || err.message);
     }
@@ -336,7 +336,7 @@ async (getUserInput) => {
 };
 ```
 
-You can send a PUT request to `/api/replies/{board}` and pass along the `thread_id` & `reply_id`. Returned will be the string `success`. The `reported` value of the `reply_id` will be changed to `true`.
+You can send a PUT request to `/api/replies/{board}` and pass along the `thread_id` & `reply_id`. Returned will be the string `reported`. The `reported` value of the `reply_id` will be changed to `true`.
 
 ```js
 async (getUserInput) => {
@@ -358,7 +358,7 @@ async (getUserInput) => {
     const reported = await res.text();
     try {
       assert.equal(res.status, 200);
-      assert.equal(reported, "success");
+      assert.equal(reported, "reported");
     } catch (err) {
       throw new Error(err.responseText || err.message);
     }

--- a/curriculum/challenges/english/09-information-security/information-security-projects/anonymous-message-board.md
+++ b/curriculum/challenges/english/09-information-security/information-security-projects/anonymous-message-board.md
@@ -377,6 +377,7 @@ async (getUserInput) => {
   assert.isTrue(parsed.length >= 10);
   parsed.forEach((test) => {
     assert.equal(test.state, 'passed');
+    assert.isAtLeast(test.assertions.length, 1);
   });
 };
 ```

--- a/curriculum/challenges/english/09-information-security/information-security-projects/anonymous-message-board.md
+++ b/curriculum/challenges/english/09-information-security/information-security-projects/anonymous-message-board.md
@@ -125,7 +125,7 @@ async (getUserInput) => {
   const text = `fcc_test_reply_${date}`;
   const delete_password = 'delete_me';
   const thread_id = thread[0]._id;
-  const replyCount = thread[0].replycount;
+  const replyCount = thread[0].replies.length;
 
   const data = { text, delete_password, thread_id };
   const res = await fetch(url + '/api/replies/fcc_test', {
@@ -137,7 +137,7 @@ async (getUserInput) => {
     const checkData = await fetch(`${url}/api/replies/fcc_test?thread_id=${thread_id}`);
     const parsed = await checkData.json();
     try {
-      assert.equal(parsed.replycount, replyCount + 1);
+      assert.equal(parsed.replies.length, replyCount + 1);
       assert.equal(parsed.replies[0].text, text);
       assert.equal(parsed._id, thread_id);
       assert.equal(parsed.bumped_on, parsed.replies[0].created_on);
@@ -153,43 +153,232 @@ async (getUserInput) => {
 You can send a GET request to `/api/threads/{board}`. Returned will be an array of the most recent 10 bumped threads on the board with only the most recent 3 replies for each. The `reported` and `delete_password` fields will not be sent to the client.
 
 ```js
+async (getUserInput) => {
+  const url = getUserInput('url');
+  const res = await fetch(url + '/api/threads/fcc_test');
 
+  if (res.ok) {
+    const threads = await res.json();
+    try {
+      assert.equal(res.status, 200);
+      assert.isAtMost(threads.length, 10);
+      for (let i = 0; i < threads.length; i++) {
+        assert.containsAllKeys(threads[i], ["_id", "text", "created_on", "bumped_on", "replies"]);
+        assert.isAtMost(threads[i].replies.length, 3);
+        assert.notExists(threads[i].delete_password);
+        assert.notExists(threads[i].reported);
+        for (let j = 0; j < threads[i].replies.length; j++) {
+          assert.notExists(threads[i].replies[j].delete_password);
+          assert.notExists(threads[i].replies[j].reported);
+        }
+      }
+    } catch (err) {
+      throw new Error(err.responseText || err.message);
+    }
+  } else {
+    throw new Error(`${res.status} ${res.statusText}`);
+  }
+};
 ```
 
 You can send a GET request to `/api/replies/{board}?thread_id={thread_id}`. Returned will be the entire thread with all its replies, also excluding the same fields from the client as the previous test.
 
 ```js
+async (getUserInput) => {
+  const url = getUserInput('url');
+  let res = await fetch(url + '/api/threads/fcc_test');
+  const threads = await res.json();
+  const thread_id = threads[0]._id;
+  res = await fetch(`${url}/api/replies/fcc_test?thread_id=${thread_id}`);
 
+  if (res.ok) {
+    const thread = await res.json();
+    try {
+      assert.equal(res.status, 200);
+      assert.isObject(thread);
+      assert.containsAllKeys(thread, ["_id", "text", "created_on", "bumped_on", "replies"]);
+      assert.isArray(thread.replies);
+      assert.notExists(thread.delete_password);
+      assert.notExists(thread.reported);
+      for (let i = 0; i < thread.replies.length; i++) {
+        assert.notExists(thread.replies[i].delete_password);
+        assert.notExists(thread.replies[i].reported);
+      }
+    } catch (err) {
+      throw new Error(err.responseText || err.message);
+    }
+  } else {
+    throw new Error(`${res.status} ${res.statusText}`);
+  }
+};
 ```
 
 You can send a DELETE request to `/api/threads/{board}` and pass along the `thread_id` & `delete_password` to delete the thread. Returned will be the string `incorrect password` or `success`.
 
 ```js
+async (getUserInput) => {
+  const url = getUserInput('url');
+  let res = await fetch(url + '/api/threads/fcc_test');
+  const threads = await res.json();
+  const thread_id = threads[0]._id;
+  let data = { thread_id, delete_password: "wrong_password" };
+  const res_invalid = await fetch(url + '/api/threads/fcc_test', {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+  data = { thread_id, delete_password: "delete_me" };
+  res = await fetch(url + '/api/threads/fcc_test', {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
 
+  if (res.ok) {
+    const deleted = await res.text();
+    const not_deleted = await res_invalid.text();
+    try {
+      assert.equal(res.status, 200);
+      assert.equal(deleted, "success");
+      assert.equal(not_deleted, "incorrect password");
+    } catch (err) {
+      throw new Error(err.responseText || err.message);
+    }
+  } else {
+    throw new Error(`${res.status} ${res.statusText}`);
+  }
+};
 ```
 
 You can send a DELETE request to `/api/replies/{board}` and pass along the `thread_id`, `reply_id`, & `delete_password`. Returned will be the string `incorrect password` or `success`. On success, the text of the `reply_id` will be changed to `[deleted]`.
 
 ```js
+async (getUserInput) => {
+  const url = getUserInput('url');
 
+  const thread_data = {
+    text: "fcc_test_thread",
+    delete_password: "delete_me",
+  };
+  await fetch(`${url}/api/threads/fcc_test`, {
+    method: "POST",
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(thread_data)
+  });
+  let res = await fetch(`${url}/api/threads/fcc_test`);
+  let threads = await res.json();
+  const thread_id = threads[0]._id;
+  
+  const reply_data = { thread_id, text: "fcc_test_reply", delete_password: "delete_me" };
+  await fetch(`${url}/api/replies/fcc_test`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(reply_data)
+  });
+  res = await fetch(`${url}/api/threads/fcc_test`);
+  threads = await res.json();
+  const reply_id = threads[0].replies[0]._id;
+
+  const data = { thread_id, reply_id, delete_password: "delete_me" };
+  res = await fetch(url + '/api/replies/fcc_test', {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+
+  if (res.ok) {
+    const deleted = await res.text();
+    try {
+      assert.equal(res.status, 200);
+      assert.equal(deleted, "success");
+      res = await fetch(`${url}/api/replies/fcc_test?thread_id=${thread_id}`);
+      const thread = await res.json();
+      assert.equal(thread._id, thread_id);
+      assert.equal(thread.replies[0]._id, reply_id);
+      assert.equal(thread.replies[0].text, "[deleted]");
+    } catch (err) {
+      throw new Error(err.responseText || err.message);
+    }
+  } else {
+    throw new Error(`${res.status} ${res.statusText}`);
+  }
+};
 ```
 
 You can send a PUT request to `/api/threads/{board}` and pass along the `thread_id`. Returned will be the string `success`. The `reported` value of the `thread_id` will be changed to `true`.
 
 ```js
+async (getUserInput) => {
+  const url = getUserInput('url');
 
+  let res = await fetch(`${url}/api/threads/fcc_test`);
+  const threads = await res.json();
+  const report_id = threads[0]._id;
+  const data = { report_id };
+  
+  res = await fetch(`${url}/api/threads/fcc_test`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+
+  if (res.ok) {
+    const reported = await res.text();
+    try {
+      assert.equal(res.status, 200);
+      assert.equal(reported, "success");
+    } catch (err) {
+      throw new Error(err.responseText || err.message);
+    }
+  } else {
+    throw new Error(`${res.status} ${res.statusText}`);
+  }
+};
 ```
 
 You can send a PUT request to `/api/replies/{board}` and pass along the `thread_id` & `reply_id`. Returned will be the string `success`. The `reported` value of the `reply_id` will be changed to `true`.
 
 ```js
+async (getUserInput) => {
+  const url = getUserInput('url');
 
+  let res = await fetch(`${url}/api/threads/fcc_test`);
+  const threads = await res.json();
+  const thread_id = threads[0]._id;
+  const reply_id = threads[0].replies[0]._id;
+  const data = { thread_id, reply_id };
+  
+  res = await fetch(`${url}/api/replies/fcc_test`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+
+  if (res.ok) {
+    const reported = await res.text();
+    try {
+      assert.equal(res.status, 200);
+      assert.equal(reported, "success");
+    } catch (err) {
+      throw new Error(err.responseText || err.message);
+    }
+  } else {
+    throw new Error(`${res.status} ${res.statusText}`);
+  }
+};
 ```
 
 All 10 functional tests are complete and passing.
 
 ```js
-
+async (getUserInput) => {
+  const tests = await fetch(getUserInput('url') + '/_api/get-tests');
+  const parsed = await tests.json();
+  assert.isTrue(parsed.length >= 10);
+  parsed.forEach((test) => {
+    assert.equal(test.state, 'passed');
+  });
+};
 ```
 
 # --solutions--


### PR DESCRIPTION
This is the 5th task from the task lists in #41323 
You can send a POST request to `/api/replies/{board}` with form data including `text`, `delete_password`, & `thread_id`.
This will update the `bumped_on` date to the comment's date. In the thread's replies array, an object will be saved with at least the properties `_id`, `text`, `created_on`, `delete_password`, & `reported`.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

The second commit solves all the issues.
Closes #41323 
