### PR TITLE
fix(docs): add missing step and fix typo

### DIFF
--- a/docs/curriculum-file-structure.md
+++ b/docs/curriculum-file-structure.md
@@ -96,9 +96,10 @@ When renaming a single challenge file, you need to:
 
 1. Change the name of the challenge file in the `curriculum/challenges/english` directory.
 1. Change the name of the `title` and `dashedName` within that file.
-1. Change the of the file, and the `dashedName` in those files for *all* of the other language directories to match.
+1. Change the name of the file, and the `dashedName` in those files for *all* of the other language directories to match.
 1. Update the name of the challenge in the relevant `meta.json` file. The challenge names here are not used in the build, but provide a user-friendly way to identify the challenge order.
 1. If the challenge is a certificate project, update the YAML file in `curriculum/english/12-certificates/<superBlock>` to the new name.
+1. If the challenge is a certificate project, update the `title` and `link` in `client/src/resources/cert-and-project-map.ts`
 1. If the challenge is a certificate project, update the main `README.md` file to the new name.
 
 ## The `dashedName` Property


### PR DESCRIPTION
Adds a missing step to new docs that I found when renaming challenge with [this PR](https://github.com/freeCodeCamp/freeCodeCamp/pull/43042)

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
