### PR TITLE
fix(client): open all certs in same tab

### DIFF
--- a/client/src/components/profile/components/Certifications.tsx
+++ b/client/src/components/profile/components/Certifications.tsx
@@ -53,7 +53,6 @@ function renderCertShow(username: string, cert: ICert): React.ReactNode {
         <Col className='certifications' sm={10} smPush={1}>
           <Link
             className='btn btn-lg btn-primary btn-block'
-            external={true}
             to={`/certification/${username}/${cert.certSlug}`}
           >
             View {cert.title}

--- a/client/src/components/profile/components/TimeLine.tsx
+++ b/client/src/components/profile/components/TimeLine.tsx
@@ -200,8 +200,7 @@ class TimelineInner extends Component<
           {certPath ? (
             <Link
               className='timeline-cert-link'
-              external={true}
-              to={`certification/${username}/${certPath}`}
+              to={`/certification/${username}/${certPath}`}
             >
               {challengeTitle}
               <CertificationIcon />


### PR DESCRIPTION
The decision for the linked issue was to open certs in the same tab for the reason @ahmadabdolsaheb gave. Makes sense. 

I found four places to open a cert:
- superblock pages : already opens in same tab
- settings page : already opens in same tab
- cert area in profile - opened in new tab
- timeline in profile - opened in new tab

I don't think there's any other places - but I may be mistaken. This PR makes the last two open in the same tab.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #40402

<!-- Feel free to add any additional description of changes below this line -->
