### PR TITLE
fix(client): removes cut off in certificate page

### DIFF
--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -20,9 +20,9 @@ body {
 }
 
 .page-wrapper {
-  height: 100%;
   display: flex;
   flex-direction: column;
+  min-height: 100%;
 }
 
 .btn-cta-big {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #43060

<!-- Feel free to add any additional description of changes below this line -->

The change is tested against `production` in dev tools since I was not able to reproduce it in `develop`.

I had a hiccup when trying to reproduce the issue. The markup output after the redirection when pasting the URL is different between `develop` and `production`, it seems the conditions are manage differently ([see layout-selector.tsx](https://github.com/freeCodeCamp/freeCodeCamp/blob/main/client/utils/gatsby/layout-selector.tsx)). Not sure if this is an issue or simply a configuration I was not able to figure out.

Regarding the issue, there seems to be a conflict due to the nesting and how the props `flex`, `height` are being used throughout the different wrappers. In a previous [PR](https://github.com/freeCodeCamp/freeCodeCamp/pull/39154) some styles were added which seems to be in part contributing to the experienced behavior. I was not able to understand what exactly was the intention so the fix being provided tries to be the least invasive after trying different approaches.

Went through a couple of pages and it seems it is not affecting any layouts.