### PR TITLE
proof-of-concept: unit tests with actual translation strings

### DIFF
--- a/client/src/components/dummy-component.test.tsx
+++ b/client/src/components/dummy-component.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { I18nextProvider } from 'react-i18next';
+import { render, screen } from '@testing-library/react';
+
+import i18nConfig from '../../i18n/config';
+import { DummyComponent } from './dummy-component';
+
+jest.mock('react-ga');
+jest.unmock('react-i18next');
+
+describe('<DummyComponent />', () => {
+  const setup = () => {
+    render(
+      <I18nextProvider i18n={i18nConfig}>
+        <DummyComponent />
+      </I18nextProvider>
+    );
+  };
+
+  it('should render a heading', () => {
+    setup();
+
+    expect(screen.getByText(/learn to code — for free/i)).toBeInTheDocument();
+  });
+
+  it('should render a forum link', () => {
+    setup();
+
+    // screen.debug();
+
+    expect(
+      screen.getByRole('link', { name: /link to the forum/i })
+    ).toHaveAttribute('href', 'https://forum.freecodecamp.org/');
+  });
+});

--- a/client/src/components/dummy-component.tsx
+++ b/client/src/components/dummy-component.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+export const DummyComponent = (): JSX.Element => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <h1>{t('landing.big-heading-1')}</h1>
+      <a href={t('links:nav.forum')}>Link to the forum</a>
+    </>
+  );
+};


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I got annoyed that we couldn't write tests with actual strings (https://github.com/freeCodeCamp/freeCodeCamp/pull/42995#discussion_r676028824) so I dug a bit. I noticed that Nick already covered the tests in question using Cypress, which I think makes prefect sense in this case because the hassles are just not worth it. But I was trying to find a solution for general cases, and it turns out waaay simpler than I thought. I followed [this Stackoverflow post](https://stackoverflow.com/a/59171040) and it works like a charm.

The test setup is pretty much based on the previous tests for [AppMountNotifier](https://github.com/freeCodeCamp/freeCodeCamp/blob/main/client/src/components/app-mount-notifier.test.tsx) that I wrote, in which we need to:
- Mock `react-ga`
- Unmock `react-i18next` - We need its real implementation, and the library is being stub globally (I'm not sure what the intention is)
- Render the component with `I18nextProvider`
- Pass `i18nConfig` to `I18nextProvider` - This step is what's different from the `AppMountNotifier`. We need to use the real config in order to have the full [string resources](https://github.com/freeCodeCamp/freeCodeCamp/blob/main/client/i18n/config.js#L20)

---

I would love to hear inputs from everyone, but I'm thinking about un-stubbing `react-i18next` globally so that we won't have to unmock it in every test file, and perhaps I'll add an example for this to our doc page.

