### PR TITLE
fix(curriculum): move RDBMS cert to proper order

### DIFF
--- a/curriculum/challenges/_meta/advanced-node-and-express/meta.json
+++ b/curriculum/challenges/_meta/advanced-node-and-express/meta.json
@@ -7,7 +7,7 @@
   "template": "",
   "required": [],
   "superBlock": "quality-assurance",
-  "superOrder": 6,
+  "superOrder": 7,
   "challengeOrder": [
     [
       "5895f700f9fc0f352b528e63",

--- a/curriculum/challenges/_meta/algorithms/meta.json
+++ b/curriculum/challenges/_meta/algorithms/meta.json
@@ -7,7 +7,7 @@
   "template": "",
   "required": [],
   "superBlock": "coding-interview-prep",
-  "superOrder": 11,
+  "superOrder": 12,
   "challengeOrder": [
     [
       "a3f503de51cf954ede28891d",

--- a/curriculum/challenges/_meta/apis-and-microservices-certificate/meta.json
+++ b/curriculum/challenges/_meta/apis-and-microservices-certificate/meta.json
@@ -2,12 +2,12 @@
   "name": "APIs and Microservices Certificate",
   "isUpcomingChange": false,
   "dashedName": "apis-and-microservices-certificate",
-  "order": 5,
+  "order": 6,
   "time": "",
   "template": "",
   "required": [],
   "superBlock": "certificates",
-  "superOrder": 12,
+  "superOrder": 0,
   "challengeOrder": [
     [
       "561add10cb82ac38a17523bc",

--- a/curriculum/challenges/_meta/apis-and-microservices-projects/meta.json
+++ b/curriculum/challenges/_meta/apis-and-microservices-projects/meta.json
@@ -5,7 +5,7 @@
   "order": 4,
   "time": "150 hours",
   "superBlock": "apis-and-microservices",
-  "superOrder": 5,
+  "superOrder": 6,
   "challengeOrder": [
     [
       "bd7158d8c443edefaeb5bdef",

--- a/curriculum/challenges/_meta/basic-node-and-express/meta.json
+++ b/curriculum/challenges/_meta/basic-node-and-express/meta.json
@@ -5,7 +5,7 @@
   "order": 2,
   "time": "5 hours",
   "superBlock": "apis-and-microservices",
-  "superOrder": 5,
+  "superOrder": 6,
   "challengeOrder": [
     [
       "587d7fb0367417b2b2512bed",

--- a/curriculum/challenges/_meta/data-analysis-with-python-certificate/meta.json
+++ b/curriculum/challenges/_meta/data-analysis-with-python-certificate/meta.json
@@ -2,12 +2,12 @@
   "name": "Data Analysis with Python Certificate",
   "isUpcomingChange": false,
   "dashedName": "data-analysis-with-python-v7-certificate",
-  "order": 8,
+  "order": 9,
   "time": "",
   "template": "",
   "required": [],
   "superBlock": "certificates",
-  "superOrder": 12,
+  "superOrder": 0,
   "challengeOrder": [
     [
       "5e46fc95ac417301a38fb934",

--- a/curriculum/challenges/_meta/data-analysis-with-python-course/meta.json
+++ b/curriculum/challenges/_meta/data-analysis-with-python-course/meta.json
@@ -7,7 +7,7 @@
   "template": "",
   "required": [],
   "superBlock": "data-analysis-with-python",
-  "superOrder": 8,
+  "superOrder": 9,
   "challengeOrder": [
     [
       "5e9a093a74c4063ca6f7c14c",

--- a/curriculum/challenges/_meta/data-analysis-with-python-projects/meta.json
+++ b/curriculum/challenges/_meta/data-analysis-with-python-projects/meta.json
@@ -5,7 +5,7 @@
   "order": 3,
   "time": "150 hours",
   "superBlock": "data-analysis-with-python",
-  "superOrder": 8,
+  "superOrder": 9,
   "challengeOrder": [
     [
       "5e46f7e5ac417301a38fb928",

--- a/curriculum/challenges/_meta/data-structures/meta.json
+++ b/curriculum/challenges/_meta/data-structures/meta.json
@@ -7,7 +7,7 @@
   "template": "",
   "required": [],
   "superBlock": "coding-interview-prep",
-  "superOrder": 11,
+  "superOrder": 12,
   "challengeOrder": [
     [
       "587d8253367417b2b2512c6a",

--- a/curriculum/challenges/_meta/data-visualization-certificate/meta.json
+++ b/curriculum/challenges/_meta/data-visualization-certificate/meta.json
@@ -7,7 +7,7 @@
   "template": "",
   "required": [],
   "superBlock": "certificates",
-  "superOrder": 12,
+  "superOrder": 0,
   "challengeOrder": [
     [
       "5a553ca864b52e1d8bceea14",

--- a/curriculum/challenges/_meta/front-end-libraries-certificate/meta.json
+++ b/curriculum/challenges/_meta/front-end-libraries-certificate/meta.json
@@ -7,7 +7,7 @@
   "template": "",
   "required": [],
   "superBlock": "certificates",
-  "superOrder": 12,
+  "superOrder": 0,
   "challengeOrder": [
     [
       "561acd10cb82ac38a17513bc",

--- a/curriculum/challenges/_meta/how-neural-networks-work/meta.json
+++ b/curriculum/challenges/_meta/how-neural-networks-work/meta.json
@@ -7,7 +7,7 @@
   "template": "",
   "required": [],
   "superBlock": "machine-learning-with-python",
-  "superOrder": 10,
+  "superOrder": 11,
   "challengeOrder": [
     [
       "5e9a0e9ef99a403d019610ca",

--- a/curriculum/challenges/_meta/information-security-certificate/meta.json
+++ b/curriculum/challenges/_meta/information-security-certificate/meta.json
@@ -2,12 +2,12 @@
   "name": "Information Security Certificate",
   "isUpcomingChange": false,
   "dashedName": "information-security-v7-certificate",
-  "order": 9,
+  "order": 10,
   "time": "",
   "template": "",
   "required": [],
   "superBlock": "certificates",
-  "superOrder": 12,
+  "superOrder": 0,
   "challengeOrder": [
     [
       "5e6021435ac9d0ecd8b94b00",

--- a/curriculum/challenges/_meta/information-security-projects/meta.json
+++ b/curriculum/challenges/_meta/information-security-projects/meta.json
@@ -7,7 +7,7 @@
   "template": "",
   "required": [],
   "superBlock": "information-security",
-  "superOrder": 9,
+  "superOrder": 10,
   "challengeOrder": [
     [
       "587d824a367417b2b2512c44",

--- a/curriculum/challenges/_meta/information-security-with-helmetjs/meta.json
+++ b/curriculum/challenges/_meta/information-security-with-helmetjs/meta.json
@@ -7,7 +7,7 @@
   "template": "",
   "required": [],
   "superBlock": "information-security",
-  "superOrder": 9,
+  "superOrder": 10,
   "challengeOrder": [
     [
       "587d8247367417b2b2512c36",

--- a/curriculum/challenges/_meta/javascript-algorithms-and-data-structures-certificate/meta.json
+++ b/curriculum/challenges/_meta/javascript-algorithms-and-data-structures-certificate/meta.json
@@ -7,7 +7,7 @@
   "template": "",
   "required": [],
   "superBlock": "certificates",
-  "superOrder": 12,
+  "superOrder": 0,
   "challengeOrder": [
     [
       "561abd10cb81ac38a17513bc",

--- a/curriculum/challenges/_meta/learn-relational-databases/meta.json
+++ b/curriculum/challenges/_meta/learn-relational-databases/meta.json
@@ -7,7 +7,7 @@
   "template": "",
   "required": [],
   "superBlock": "relational-databases",
-  "superOrder": 12,
+  "superOrder": 5,
   "challengeOrder": [
     [
       "5ea8adfab628f68d805bfc5e",

--- a/curriculum/challenges/_meta/machine-learning-with-python-certificate/meta.json
+++ b/curriculum/challenges/_meta/machine-learning-with-python-certificate/meta.json
@@ -2,12 +2,12 @@
   "name": "Machine Learning with Python Certificate",
   "isUpcomingChange": false,
   "dashedName": "machine-learning-with-python-v7-certificate",
-  "order": 10,
+  "order": 11,
   "time": "",
   "template": "",
   "required": [],
   "superBlock": "certificates",
-  "superOrder": 12,
+  "superOrder": 0,
   "challengeOrder": [
     [
       "5e46fc95ac417301a38fb935",

--- a/curriculum/challenges/_meta/machine-learning-with-python-projects/meta.json
+++ b/curriculum/challenges/_meta/machine-learning-with-python-projects/meta.json
@@ -5,7 +5,7 @@
   "order": 3,
   "time": "150 hours",
   "superBlock": "machine-learning-with-python",
-  "superOrder": 10,
+  "superOrder": 11,
   "challengeOrder": [
     [
       "5e46f8d6ac417301a38fb92d",

--- a/curriculum/challenges/_meta/managing-packages-with-npm/meta.json
+++ b/curriculum/challenges/_meta/managing-packages-with-npm/meta.json
@@ -5,7 +5,7 @@
   "order": 1,
   "time": "5 hours",
   "superBlock": "apis-and-microservices",
-  "superOrder": 5,
+  "superOrder": 6,
   "challengeOrder": [
     [
       "587d7fb3367417b2b2512bfb",

--- a/curriculum/challenges/_meta/mongodb-and-mongoose/meta.json
+++ b/curriculum/challenges/_meta/mongodb-and-mongoose/meta.json
@@ -5,7 +5,7 @@
   "order": 3,
   "time": "5 hours",
   "superBlock": "apis-and-microservices",
-  "superOrder": 5,
+  "superOrder": 6,
   "challengeOrder": [
     [
       "587d7fb6367417b2b2512c06",

--- a/curriculum/challenges/_meta/numpy/meta.json
+++ b/curriculum/challenges/_meta/numpy/meta.json
@@ -7,7 +7,7 @@
   "template": "",
   "required": [],
   "superBlock": "data-analysis-with-python",
-  "superOrder": 8,
+  "superOrder": 9,
   "challengeOrder": [
     [
       "5e9a0a8e09c5df3cc3600ed2",

--- a/curriculum/challenges/_meta/project-euler/meta.json
+++ b/curriculum/challenges/_meta/project-euler/meta.json
@@ -7,7 +7,7 @@
   "template": "",
   "required": [],
   "superBlock": "coding-interview-prep",
-  "superOrder": 11,
+  "superOrder": 12,
   "challengeOrder": [
     [
       "5900f36e1000cf542c50fe80",

--- a/curriculum/challenges/_meta/python-for-everybody/meta.json
+++ b/curriculum/challenges/_meta/python-for-everybody/meta.json
@@ -5,7 +5,7 @@
   "order": 1,
   "time": "15 hours",
   "superBlock": "scientific-computing-with-python",
-  "superOrder": 7,
+  "superOrder": 8,
   "challengeOrder": [
     [
       "5e6a54a558d3af90110a60a0",

--- a/curriculum/challenges/_meta/python-for-penetration-testing/meta.json
+++ b/curriculum/challenges/_meta/python-for-penetration-testing/meta.json
@@ -7,7 +7,7 @@
   "template": "",
   "required": [],
   "superBlock": "information-security",
-  "superOrder": 9,
+  "superOrder": 10,
   "challengeOrder": [
     [
       "5ea9997bbec2e9bc47e94dae",

--- a/curriculum/challenges/_meta/quality-assurance-and-testing-with-chai/meta.json
+++ b/curriculum/challenges/_meta/quality-assurance-and-testing-with-chai/meta.json
@@ -7,7 +7,7 @@
   "template": "",
   "required": [],
   "superBlock": "quality-assurance",
-  "superOrder": 6,
+  "superOrder": 7,
   "challengeOrder": [
     [
       "587d824a367417b2b2512c46",

--- a/curriculum/challenges/_meta/quality-assurance-certificate/meta.json
+++ b/curriculum/challenges/_meta/quality-assurance-certificate/meta.json
@@ -2,12 +2,12 @@
   "name": "Quality Assurance Certificate",
   "isUpcomingChange": false,
   "dashedName": "quality-assurance-v7-certificate",
-  "order": 6,
+  "order": 7,
   "time": "",
   "template": "",
   "required": [],
   "superBlock": "certificates",
-  "superOrder": 12,
+  "superOrder": 0,
   "challengeOrder": [
     [
       "5e611829481575a52dc59c0e",

--- a/curriculum/challenges/_meta/quality-assurance-projects/meta.json
+++ b/curriculum/challenges/_meta/quality-assurance-projects/meta.json
@@ -7,7 +7,7 @@
   "template": "",
   "required": [],
   "superBlock": "quality-assurance",
-  "superOrder": 6,
+  "superOrder": 7,
   "challengeOrder": [
     [
       "587d8249367417b2b2512c41",

--- a/curriculum/challenges/_meta/relational-databases-certificate/meta.json
+++ b/curriculum/challenges/_meta/relational-databases-certificate/meta.json
@@ -1,20 +1,18 @@
 {
-    "name": "Relational Databases Certificate",
-    "isUpcomingChange": true,
-    "dashedName": "relational-databases-v8-certificate",
-    "order": 11,
-    "time": "",
-    "template": "",
-    "required": [],
-    "superBlock": "certificates",
-    "superOrder": 12,
-    "challengeOrder": [
-      [
-        "606243f50267e718b1e755f4",
-        "Relational Databases Certificate"
-      ]
-    ],
-    "isPrivate": true,
-    "fileName": "12-certificates/relational-databases-v8-certificate.json"
-  }
-  
+  "name": "Relational Databases Certificate",
+  "isUpcomingChange": true,
+  "dashedName": "relational-databases-v8-certificate",
+  "order": 5,
+  "time": "",
+  "template": "",
+  "required": [],
+  "superBlock": "certificates",
+  "superOrder": 0,
+  "challengeOrder": [
+    [
+      "606243f50267e718b1e755f4",
+      "Relational Databases Certificate"
+    ]
+  ],
+  "isPrivate": true
+}

--- a/curriculum/challenges/_meta/responsive-web-design-certificate/meta.json
+++ b/curriculum/challenges/_meta/responsive-web-design-certificate/meta.json
@@ -7,7 +7,7 @@
   "template": "",
   "required": [],
   "superBlock": "certificates",
-  "superOrder": 12,
+  "superOrder": 0,
   "challengeOrder": [
     [
       "561add10cb82ac38a17513bc",

--- a/curriculum/challenges/_meta/rosetta-code/meta.json
+++ b/curriculum/challenges/_meta/rosetta-code/meta.json
@@ -7,7 +7,7 @@
   "template": "",
   "required": [],
   "superBlock": "coding-interview-prep",
-  "superOrder": 11,
+  "superOrder": 12,
   "challengeOrder": [
     [
       "594810f028c0303b75339acb",

--- a/curriculum/challenges/_meta/scientific-computing-with-python-certificate/meta.json
+++ b/curriculum/challenges/_meta/scientific-computing-with-python-certificate/meta.json
@@ -2,12 +2,12 @@
   "name": "Scientific Computing with Python Certificate",
   "isUpcomingChange": false,
   "dashedName": "scientific-computing-with-python-v7-certificate",
-  "order": 7,
+  "order": 8,
   "time": "",
   "template": "",
   "required": [],
   "superBlock": "certificates",
-  "superOrder": 12,
+  "superOrder": 0,
   "challengeOrder": [
     [
       "5e44431b903586ffb414c951",

--- a/curriculum/challenges/_meta/scientific-computing-with-python-projects/meta.json
+++ b/curriculum/challenges/_meta/scientific-computing-with-python-projects/meta.json
@@ -5,7 +5,7 @@
   "order": 2,
   "time": "150 hours",
   "superBlock": "scientific-computing-with-python",
-  "superOrder": 7,
+  "superOrder": 8,
   "challengeOrder": [
     [
       "5e44412c903586ffb414c94c",

--- a/curriculum/challenges/_meta/take-home-projects/meta.json
+++ b/curriculum/challenges/_meta/take-home-projects/meta.json
@@ -7,7 +7,7 @@
   "template": "",
   "required": [],
   "superBlock": "coding-interview-prep",
-  "superOrder": 11,
+  "superOrder": 12,
   "challengeOrder": [
     [
       "bd7158d8c442eddfaeb5bd10",

--- a/curriculum/challenges/_meta/tensorflow/meta.json
+++ b/curriculum/challenges/_meta/tensorflow/meta.json
@@ -5,7 +5,7 @@
   "order": 1,
   "time": "15 hours",
   "superBlock": "machine-learning-with-python",
-  "superOrder": 10,
+  "superOrder": 11,
   "challengeOrder": [
     [
       "5e8f2f13c4cdbe86b5c72d87",


### PR DESCRIPTION
This moves the Relational Database cert to right after the Data Viz. In order to do this I...
- Added 1 to the `order` in all the `meta/{superBlock}-certificate/meta.json` files from API's and Microservices on. This is the certificate order.
- Added 1 to the `superOrder` in all the `meta/{block}/meta.json` files for all blocks from API's and Microservices and on. This is the order of the superBlock each block belongs to.

Side addition: In **all** the `meta/{superBlock}-certificate/meta.json` files, I change the `superOrder` to `0`. This is the `certificate` superblock and is not shown anywhere. Changing it to zero should keep it from getting in the way in the future. I didn't see any issues with it.

You will need to set `showUpcomingChange` to `true` in the `.env` to see it. Everything seems to be working whether or not they are shown.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to #42509

<!-- Feel free to add any additional description of changes below this line -->
