### PR TITLE
fix(client): open curriculum links in new tabs

### DIFF
--- a/client/src/components/layouts/learn.tsx
+++ b/client/src/components/layouts/learn.tsx
@@ -86,6 +86,7 @@ class LearnLayout extends Component<LearnLayoutProps> {
       <>
         <Helmet>
           <meta content='noindex' name='robots' />
+          <base target='_blank' />
         </Helmet>
         <main id='learn-app-wrapper'>{children}</main>
         {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */


### PR DESCRIPTION
I think I found a simple solution to this issue. The result seems to be exactly what we would want. It seems to open all external links a new tab - i.e. codepen, replit, wikipedia, .rocks, etc. The links/buttons using the `Link` component or the `navigate` function seem to stay in the same tab - i.e. breadcrumbs.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #39739

<!-- Feel free to add any additional description of changes below this line -->
