### PR TITLE
fix: restore navatar class

### DIFF
--- a/client/src/components/Header/components/menu-button.tsx
+++ b/client/src/components/Header/components/menu-button.tsx
@@ -30,7 +30,9 @@ const MenuButton = ({
       >
         {t('buttons.menu')}
       </button>
-      <AuthOrProfile user={user} />
+      <span className='navatar'>
+        <AuthOrProfile user={user} />
+      </span>
     </>
   );
 };


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Resolves issue where navigation bar had overlap.

![image](https://user-images.githubusercontent.com/63889819/128955613-74bf1825-e1c1-4b13-ab86-35b06c213183.png)

This is a quick fix that reverts a change to a class name to allow our previous CSS to function.