### PR TITLE
feat(client): Unify donation loading state

### DIFF
--- a/client/src/client-only-routes/show-certification.tsx
+++ b/client/src/client-only-routes/show-certification.tsx
@@ -265,7 +265,7 @@ const ShowCertification = (props: IShowCertificationProps): JSX.Element => {
         </Row>
       )}
       <Row>
-        <Col md={8} mdOffset={2} xs={12}>
+        <Col lg={8} lgOffset={2} sm={10} smOffset={1} xs={12}>
           <DonateForm
             defaultTheme='default'
             handleProcessing={handleProcessing}

--- a/client/src/components/Donation/DonateCompletion.tsx
+++ b/client/src/components/Donation/DonateCompletion.tsx
@@ -11,7 +11,6 @@ type DonateCompletionProps = {
   redirecting: boolean;
   reset: () => unknown;
   success: boolean;
-  paymentButtonsLoading: boolean;
 };
 
 function DonateCompletion({
@@ -19,19 +18,12 @@ function DonateCompletion({
   reset,
   success,
   redirecting,
-  paymentButtonsLoading,
   error = null
 }: DonateCompletionProps): JSX.Element {
   /* eslint-disable no-nested-ternary */
   const { t } = useTranslation();
   const style =
-    processing || redirecting
-      ? 'info'
-      : success
-      ? 'success'
-      : paymentButtonsLoading
-      ? ''
-      : 'danger';
+    processing || redirecting ? 'info' : success ? 'success' : 'danger';
 
   const heading = redirecting
     ? `${t('donate.redirecting')}`
@@ -39,20 +31,7 @@ function DonateCompletion({
     ? `${t('donate.processing')}`
     : success
     ? `${t('donate.thank-you')}`
-    : paymentButtonsLoading
-    ? ''
     : `${t('donate.error')}`;
-
-  if (paymentButtonsLoading)
-    return (
-      <div className=' donation-completion donation-completion-loading'>
-        <Spinner
-          className='script-loading-spinner'
-          fadeIn='none'
-          name='line-scale'
-        />
-      </div>
-    );
 
   return (
     <Alert bsStyle={style} className='donation-completion'>
@@ -64,13 +43,6 @@ function DonateCompletion({
           <Spinner
             className='user-state-spinner'
             color='#0a0a23'
-            fadeIn='none'
-            name='line-scale'
-          />
-        )}
-        {paymentButtonsLoading && (
-          <Spinner
-            className='script-loading-spinner'
             fadeIn='none'
             name='line-scale'
           />

--- a/client/src/components/Donation/DonateCompletion.tsx
+++ b/client/src/components/Donation/DonateCompletion.tsx
@@ -11,6 +11,7 @@ type DonateCompletionProps = {
   redirecting: boolean;
   reset: () => unknown;
   success: boolean;
+  paymentsNotLoaded: boolean;
 };
 
 function DonateCompletion({
@@ -18,19 +19,41 @@ function DonateCompletion({
   reset,
   success,
   redirecting,
+  paymentsNotLoaded,
   error = null
 }: DonateCompletionProps): JSX.Element {
   /* eslint-disable no-nested-ternary */
   const { t } = useTranslation();
   const style =
-    processing || redirecting ? 'info' : success ? 'success' : 'danger';
+    processing || redirecting
+      ? 'info'
+      : success
+      ? 'success'
+      : paymentsNotLoaded
+      ? ''
+      : 'danger';
+
   const heading = redirecting
     ? `${t('donate.redirecting')}`
     : processing
     ? `${t('donate.processing')}`
     : success
     ? `${t('donate.thank-you')}`
+    : paymentsNotLoaded
+    ? ''
     : `${t('donate.error')}`;
+
+  if (paymentsNotLoaded)
+    return (
+      <div className=' donation-completion donation-completion-loading'>
+        <Spinner
+          className='script-loading-spinner'
+          fadeIn='none'
+          name='line-scale'
+        />
+      </div>
+    );
+
   return (
     <Alert bsStyle={style} className='donation-completion'>
       <h4>
@@ -41,6 +64,13 @@ function DonateCompletion({
           <Spinner
             className='user-state-spinner'
             color='#0a0a23'
+            fadeIn='none'
+            name='line-scale'
+          />
+        )}
+        {paymentsNotLoaded && (
+          <Spinner
+            className='script-loading-spinner'
             fadeIn='none'
             name='line-scale'
           />

--- a/client/src/components/Donation/DonateCompletion.tsx
+++ b/client/src/components/Donation/DonateCompletion.tsx
@@ -11,7 +11,7 @@ type DonateCompletionProps = {
   redirecting: boolean;
   reset: () => unknown;
   success: boolean;
-  paymentsNotLoaded: boolean;
+  paymentButtonsLoading: boolean;
 };
 
 function DonateCompletion({
@@ -19,7 +19,7 @@ function DonateCompletion({
   reset,
   success,
   redirecting,
-  paymentsNotLoaded,
+  paymentButtonsLoading,
   error = null
 }: DonateCompletionProps): JSX.Element {
   /* eslint-disable no-nested-ternary */
@@ -29,7 +29,7 @@ function DonateCompletion({
       ? 'info'
       : success
       ? 'success'
-      : paymentsNotLoaded
+      : paymentButtonsLoading
       ? ''
       : 'danger';
 
@@ -39,11 +39,11 @@ function DonateCompletion({
     ? `${t('donate.processing')}`
     : success
     ? `${t('donate.thank-you')}`
-    : paymentsNotLoaded
+    : paymentButtonsLoading
     ? ''
     : `${t('donate.error')}`;
 
-  if (paymentsNotLoaded)
+  if (paymentButtonsLoading)
     return (
       <div className=' donation-completion donation-completion-loading'>
         <Spinner
@@ -68,7 +68,7 @@ function DonateCompletion({
             name='line-scale'
           />
         )}
-        {paymentsNotLoaded && (
+        {paymentButtonsLoading && (
           <Spinner
             className='script-loading-spinner'
             fadeIn='none'

--- a/client/src/components/Donation/DonateForm.tsx
+++ b/client/src/components/Donation/DonateForm.tsx
@@ -143,10 +143,6 @@ class DonateForm extends Component<DonateFormProps, DonateFromComponentState> {
   };
 
   onDonationStateChange(donationState: AddDonationData) {
-    console.log({
-      ...this.props.donationFormState,
-      ...donationState
-    });
     // scroll to top
     window.scrollTo(0, 0);
     this.props.updateDonationFormState({
@@ -341,18 +337,10 @@ class DonateForm extends Component<DonateFormProps, DonateFromComponentState> {
 
   render() {
     const {
-      donationFormState: {
-        processing,
-        loading: { stripe, paypal },
-        success,
-        error,
-        redirecting
-      },
+      donationFormState: { processing, success, error, redirecting },
       isMinimalForm
     } = this.props;
 
-    const paymentButtonsLoading = stripe && paypal;
-    console.log({ paymentButtonsLoading, stripe, paypal });
     if (success || error) {
       return this.renderCompletion({
         processing,

--- a/client/src/components/Donation/DonateForm.tsx
+++ b/client/src/components/Donation/DonateForm.tsx
@@ -3,8 +3,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable no-nested-ternary */
 import {
-  Col,
-  Row,
   Tab,
   Tabs,
   ToggleButton,
@@ -317,64 +315,6 @@ class DonateForm extends Component<DonateFormProps, DonateFromComponentState> {
     );
   }
 
-  renderDonationOptions() {
-    const {
-      donationFormState: {
-        loading: { stripe, paypal }
-      },
-      handleProcessing,
-      isSignedIn,
-      addDonation,
-      t,
-      defaultTheme,
-      theme
-    } = this.props;
-
-    const paymentButtonsLoading = stripe && paypal;
-    const { donationAmount, donationDuration } = this.state;
-    const isOneTime = donationDuration === 'onetime';
-    const formlabel = `${t(
-      isOneTime ? 'donate.confirm-2' : 'donate.confirm-3',
-      { usd: donationAmount / 100 }
-    )}:`;
-
-    const walletlabel = `${t(
-      isOneTime ? 'donate.wallet-label' : 'donate.wallet-label-1',
-      { usd: donationAmount / 100 }
-    )}:`;
-    const priorityTheme = defaultTheme ? defaultTheme : theme;
-
-    return (
-      <div>
-        <b>{formlabel}</b>
-        <Spacer />
-        {paymentButtonsLoading && this.paymentButtonsLoader()}
-        <div className={paymentButtonsLoading ? 'hide' : 'donate-btn-group'}>
-          <WalletsWrapper
-            amount={donationAmount}
-            handlePaymentButtonLoad={this.handlePaymentButtonLoad}
-            label={walletlabel}
-            onDonationStateChange={this.onDonationStateChange}
-            postStripeDonation={this.postStripeDonation}
-            refreshErrorMessage={t('donate.refresh-needed')}
-            theme={priorityTheme}
-          />
-          <PaypalButton
-            addDonation={addDonation}
-            donationAmount={donationAmount}
-            donationDuration={donationDuration}
-            handlePaymentButtonLoad={this.handlePaymentButtonLoad}
-            handleProcessing={handleProcessing}
-            isSubscription={isOneTime ? false : true}
-            onDonationStateChange={this.onDonationStateChange}
-            skipAddDonation={!isSignedIn}
-            theme={priorityTheme}
-          />
-        </div>
-      </div>
-    );
-  }
-
   resetDonation() {
     return this.props.updateDonationFormState({ ...defaultDonationFormState });
   }
@@ -401,21 +341,35 @@ class DonateForm extends Component<DonateFormProps, DonateFromComponentState> {
     return <DonateCompletion {...props} />;
   }
 
-  renderModalForm() {
+  renderButtonGroup() {
     const { donationAmount, donationDuration } = this.state;
-    const { handleProcessing, addDonation, defaultTheme, theme, t } =
-      this.props;
+    const {
+      donationFormState: {
+        loading: { stripe, paypal }
+      },
+      handleProcessing,
+      addDonation,
+      defaultTheme,
+      theme,
+      t,
+      isMinimalForm
+    } = this.props;
+    const paymentButtonsLoading = stripe && paypal;
     const priorityTheme = defaultTheme ? defaultTheme : theme;
     const isOneTime = donationDuration === 'onetime';
     const walletlabel = `${t(
       isOneTime ? 'donate.wallet-label' : 'donate.wallet-label-1',
       { usd: donationAmount / 100 }
     )}:`;
+
     return (
       <>
-        <b className='donation-label'>{this.getDonationButtonLabel()}:</b>
+        <b className={isMinimalForm ? 'donation-label-modal' : ''}>
+          {this.getDonationButtonLabel()}:
+        </b>
         <Spacer />
-        <div className='donate-btn-group'>
+        {paymentButtonsLoading && this.paymentButtonsLoader()}
+        <div className={paymentButtonsLoading ? 'hide' : 'donate-btn-group'}>
           <WalletsWrapper
             amount={donationAmount}
             handlePaymentButtonLoad={this.handlePaymentButtonLoad}
@@ -441,10 +395,10 @@ class DonateForm extends Component<DonateFormProps, DonateFromComponentState> {
 
   renderPageForm() {
     return (
-      <Row>
-        <Col xs={12}>{this.renderDonationDescription()}</Col>
-        <Col xs={12}>{this.renderDonationOptions()}</Col>
-      </Row>
+      <>
+        <div>{this.renderDonationDescription()}</div>
+        <div>{this.renderButtonGroup()}</div>
+      </>
     );
   }
 
@@ -484,7 +438,7 @@ class DonateForm extends Component<DonateFormProps, DonateFromComponentState> {
             reset: this.resetDonation
           })}
         <div className={processing || redirecting ? 'hide' : ''}>
-          {isMinimalForm ? this.renderModalForm() : this.renderPageForm()}
+          {isMinimalForm ? this.renderButtonGroup() : this.renderPageForm()}
         </div>
       </>
     );

--- a/client/src/components/Donation/DonateForm.tsx
+++ b/client/src/components/Donation/DonateForm.tsx
@@ -61,7 +61,7 @@ type DonateFormState = {
 type DonateFromComponentState = {
   donationAmount: number;
   donationDuration: string;
-  intervalId: null | string;
+  intervalId?: number;
 };
 
 type DonateFormProps = {
@@ -124,7 +124,7 @@ class DonateForm extends Component<DonateFormProps, DonateFromComponentState> {
       ? modalDefaultDonation
       : defaultDonation;
 
-    this.state = { ...initialAmountAndDuration, intervalId: null };
+    this.state = { ...initialAmountAndDuration };
 
     this.onDonationStateChange = this.onDonationStateChange.bind(this);
     this.getActiveDonationAmount = this.getActiveDonationAmount.bind(this);
@@ -137,7 +137,7 @@ class DonateForm extends Component<DonateFormProps, DonateFromComponentState> {
   }
 
   componentDidMount() {
-    const intervalId = setInterval(this.providerLoaderTime, 3000);
+    const intervalId = window.setInterval(this.providerLoaderTime, 3000);
     // store intervalId in the state so it can be accessed later:
     // eslint-disable-next-line react/no-did-mount-set-state
     this.setState({ intervalId });
@@ -145,7 +145,7 @@ class DonateForm extends Component<DonateFormProps, DonateFromComponentState> {
 
   componentWillUnmount() {
     this.resetDonation();
-    clearInterval(this.state.intervalId);
+    window.clearInterval(this.state.intervalId);
   }
 
   providerLoaderTime = () => {

--- a/client/src/components/Donation/DonateForm.tsx
+++ b/client/src/components/Donation/DonateForm.tsx
@@ -61,7 +61,6 @@ type DonateFormState = {
 type DonateFromComponentState = {
   donationAmount: number;
   donationDuration: string;
-  intervalId?: number;
 };
 
 type DonateFormProps = {
@@ -133,19 +132,11 @@ class DonateForm extends Component<DonateFormProps, DonateFromComponentState> {
     this.handleSelectDuration = this.handleSelectDuration.bind(this);
     this.resetDonation = this.resetDonation.bind(this);
     this.postStripeDonation = this.postStripeDonation.bind(this);
-    this.handlePaymentMethodLoad = this.handlePaymentMethodLoad.bind(this);
-  }
-
-  componentDidMount() {
-    const intervalId = window.setInterval(this.providerLoaderTime, 3000);
-    // store intervalId in the state so it can be accessed later:
-    // eslint-disable-next-line react/no-did-mount-set-state
-    this.setState({ intervalId });
+    this.handlePaymentButtonLoad = this.handlePaymentButtonLoad.bind(this);
   }
 
   componentWillUnmount() {
     this.resetDonation();
-    window.clearInterval(this.state.intervalId);
   }
 
   providerLoaderTime = () => {
@@ -167,7 +158,7 @@ class DonateForm extends Component<DonateFormProps, DonateFromComponentState> {
     });
   }
 
-  handlePaymentMethodLoad(provider: 'stripe' | 'paypal') {
+  handlePaymentButtonLoad(provider: 'stripe' | 'paypal') {
     this.props.updateDonationFormState({
       ...this.props.donationFormState,
       loading: {
@@ -355,7 +346,7 @@ class DonateForm extends Component<DonateFormProps, DonateFromComponentState> {
         <div className='donate-btn-group'>
           <WalletsWrapper
             amount={donationAmount}
-            handlePaymentMethodLoad={this.handlePaymentMethodLoad}
+            handlePaymentButtonLoad={this.handlePaymentButtonLoad}
             label={walletlabel}
             onDonationStateChange={this.onDonationStateChange}
             postStripeDonation={this.postStripeDonation}
@@ -366,7 +357,7 @@ class DonateForm extends Component<DonateFormProps, DonateFromComponentState> {
             addDonation={addDonation}
             donationAmount={donationAmount}
             donationDuration={donationDuration}
-            handlePaymentMethodLoad={this.handlePaymentMethodLoad}
+            handlePaymentButtonLoad={this.handlePaymentButtonLoad}
             handleProcessing={handleProcessing}
             isSubscription={isOneTime ? false : true}
             onDonationStateChange={this.onDonationStateChange}
@@ -387,7 +378,7 @@ class DonateForm extends Component<DonateFormProps, DonateFromComponentState> {
     redirecting: boolean;
     success: boolean;
     error: string | null;
-    paymentsNotLoaded: boolean;
+    paymentButtonsLoading: boolean;
     reset: () => unknown;
   }) {
     return <DonateCompletion {...props} />;
@@ -411,7 +402,7 @@ class DonateForm extends Component<DonateFormProps, DonateFromComponentState> {
           <div className='donate-btn-group'>
             <WalletsWrapper
               amount={donationAmount}
-              handlePaymentMethodLoad={this.handlePaymentMethodLoad}
+              handlePaymentButtonLoad={this.handlePaymentButtonLoad}
               label={walletlabel}
               onDonationStateChange={this.onDonationStateChange}
               postStripeDonation={this.postStripeDonation}
@@ -422,7 +413,7 @@ class DonateForm extends Component<DonateFormProps, DonateFromComponentState> {
               addDonation={addDonation}
               donationAmount={donationAmount}
               donationDuration={donationDuration}
-              handlePaymentMethodLoad={this.handlePaymentMethodLoad}
+              handlePaymentButtonLoad={this.handlePaymentButtonLoad}
               handleProcessing={handleProcessing}
               onDonationStateChange={this.onDonationStateChange}
               theme={defaultTheme ? defaultTheme : theme}
@@ -454,14 +445,15 @@ class DonateForm extends Component<DonateFormProps, DonateFromComponentState> {
       isMinimalForm
     } = this.props;
 
-    const paymentsNotLoaded = stripe || paypal;
+    const paymentButtonsLoading = stripe && paypal;
+    console.log({ paymentButtonsLoading, stripe, paypal });
     if (success || error) {
       return this.renderCompletion({
         processing,
         redirecting,
         success,
         error,
-        paymentsNotLoaded,
+        paymentButtonsLoading,
         reset: this.resetDonation
       });
     }
@@ -469,18 +461,18 @@ class DonateForm extends Component<DonateFormProps, DonateFromComponentState> {
     // keep payment provider elements on DOM during processing and redirect to avoid errors.
     return (
       <>
-        {(processing || redirecting || paymentsNotLoaded) &&
+        {(processing || redirecting || paymentButtonsLoading) &&
           this.renderCompletion({
             processing,
             redirecting,
             success,
             error,
-            paymentsNotLoaded,
+            paymentButtonsLoading,
             reset: this.resetDonation
           })}
         <div
           className={
-            processing || redirecting || paymentsNotLoaded ? 'hide' : ''
+            processing || redirecting || paymentButtonsLoading ? 'hide' : ''
           }
         >
           {isMinimalForm ? this.renderModalForm() : this.renderPageForm()}

--- a/client/src/components/Donation/DonateForm.tsx
+++ b/client/src/components/Donation/DonateForm.tsx
@@ -2,12 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable no-nested-ternary */
-import {
-  Tab,
-  Tabs,
-  ToggleButton,
-  ToggleButtonGroup
-} from '@freecodecamp/react-bootstrap';
+
 import type { Token } from '@stripe/stripe-js';
 import React, { Component } from 'react';
 import { withTranslation } from 'react-i18next';
@@ -235,19 +230,6 @@ class DonateForm extends Component<DonateFormProps, DonateFromComponentState> {
     this.setState({ donationAmount });
   }
 
-  renderAmountButtons(duration: 'month' | 'onetime') {
-    return this.amounts[duration].map((amount: number) => (
-      <ToggleButton
-        className='amount-value'
-        id={`${this.durations[duration]}-donation-${amount}`}
-        key={`${this.durations[duration]}-donation-${amount}`}
-        value={amount}
-      >
-        {this.getFormattedAmountLabel(amount)}
-      </ToggleButton>
-    ));
-  }
-
   renderDonationDescription() {
     const { donationAmount, donationDuration } = this.state;
     const { t } = this.props;
@@ -262,56 +244,6 @@ class DonateForm extends Component<DonateFormProps, DonateFromComponentState> {
           ? t('donate.your-donation-2', { usd: usd, hours: hours })
           : t('donate.your-donation-3', { usd: usd, hours: hours })}
       </p>
-    );
-  }
-
-  renderDurationAmountOptions() {
-    const { donationAmount, donationDuration } = this.state;
-    const { t } = this.props;
-
-    // only render when !this.props.processing
-    return (
-      <div>
-        s<h3>{t('donate.gift-frequency')}</h3>
-        <Tabs
-          activeKey={donationDuration}
-          animation={false}
-          bsStyle='pills'
-          className='donate-tabs'
-          id='Duration'
-          onSelect={this.handleSelectDuration}
-        >
-          {(Object.keys(this.durations) as ['month' | 'onetime']).map(
-            duration => (
-              <Tab
-                eventKey={duration}
-                key={duration}
-                title={this.durations[duration]}
-              >
-                <Spacer />
-                <h3>{t('donate.gift-amount')}</h3>
-                <div>
-                  <ToggleButtonGroup
-                    animation={`false`}
-                    className='amount-values'
-                    name='amounts'
-                    onChange={this.handleSelectAmount}
-                    type='radio'
-                    value={this.getActiveDonationAmount(
-                      duration,
-                      donationAmount
-                    )}
-                  >
-                    {this.renderAmountButtons(duration)}
-                  </ToggleButtonGroup>
-                  <Spacer />
-                  {this.renderDonationDescription()}
-                </div>
-              </Tab>
-            )
-          )}
-        </Tabs>
-      </div>
     );
   }
 

--- a/client/src/components/Donation/DonateForm.tsx
+++ b/client/src/components/Donation/DonateForm.tsx
@@ -276,9 +276,7 @@ class DonateForm extends Component<DonateFormProps, DonateFromComponentState> {
   renderButtonGroup() {
     const { donationAmount, donationDuration } = this.state;
     const {
-      donationFormState: {
-        loading: { stripe, paypal }
-      },
+      donationFormState: { loading },
       handleProcessing,
       addDonation,
       defaultTheme,
@@ -286,7 +284,7 @@ class DonateForm extends Component<DonateFormProps, DonateFromComponentState> {
       t,
       isMinimalForm
     } = this.props;
-    const paymentButtonsLoading = stripe && paypal;
+    const paymentButtonsLoading = loading.stripe && loading.paypal;
     const priorityTheme = defaultTheme ? defaultTheme : theme;
     const isOneTime = donationDuration === 'onetime';
     const walletlabel = `${t(
@@ -317,7 +315,7 @@ class DonateForm extends Component<DonateFormProps, DonateFromComponentState> {
             donationDuration={donationDuration}
             handlePaymentButtonLoad={this.handlePaymentButtonLoad}
             handleProcessing={handleProcessing}
-            isPaypalLoading={paypal}
+            isPaypalLoading={loading.paypal}
             onDonationStateChange={this.onDonationStateChange}
             theme={defaultTheme ? defaultTheme : theme}
           />

--- a/client/src/components/Donation/DonateForm.tsx
+++ b/client/src/components/Donation/DonateForm.tsx
@@ -412,32 +412,30 @@ class DonateForm extends Component<DonateFormProps, DonateFromComponentState> {
       { usd: donationAmount / 100 }
     )}:`;
     return (
-      <Row>
-        <Col lg={8} lgOffset={2} sm={10} smOffset={1} xs={12}>
-          <b className='donation-label'>{this.getDonationButtonLabel()}:</b>
-          <Spacer />
-          <div className='donate-btn-group'>
-            <WalletsWrapper
-              amount={donationAmount}
-              handlePaymentButtonLoad={this.handlePaymentButtonLoad}
-              label={walletlabel}
-              onDonationStateChange={this.onDonationStateChange}
-              postStripeDonation={this.postStripeDonation}
-              refreshErrorMessage={t('donate.refresh-needed')}
-              theme={priorityTheme}
-            />
-            <PaypalButton
-              addDonation={addDonation}
-              donationAmount={donationAmount}
-              donationDuration={donationDuration}
-              handlePaymentButtonLoad={this.handlePaymentButtonLoad}
-              handleProcessing={handleProcessing}
-              onDonationStateChange={this.onDonationStateChange}
-              theme={defaultTheme ? defaultTheme : theme}
-            />
-          </div>
-        </Col>
-      </Row>
+      <>
+        <b className='donation-label'>{this.getDonationButtonLabel()}:</b>
+        <Spacer />
+        <div className='donate-btn-group'>
+          <WalletsWrapper
+            amount={donationAmount}
+            handlePaymentButtonLoad={this.handlePaymentButtonLoad}
+            label={walletlabel}
+            onDonationStateChange={this.onDonationStateChange}
+            postStripeDonation={this.postStripeDonation}
+            refreshErrorMessage={t('donate.refresh-needed')}
+            theme={priorityTheme}
+          />
+          <PaypalButton
+            addDonation={addDonation}
+            donationAmount={donationAmount}
+            donationDuration={donationDuration}
+            handlePaymentButtonLoad={this.handlePaymentButtonLoad}
+            handleProcessing={handleProcessing}
+            onDonationStateChange={this.onDonationStateChange}
+            theme={defaultTheme ? defaultTheme : theme}
+          />
+        </div>
+      </>
     );
   }
 

--- a/client/src/components/Donation/DonateForm.tsx
+++ b/client/src/components/Donation/DonateForm.tsx
@@ -143,6 +143,10 @@ class DonateForm extends Component<DonateFormProps, DonateFromComponentState> {
   };
 
   onDonationStateChange(donationState: AddDonationData) {
+    console.log({
+      ...this.props.donationFormState,
+      ...donationState
+    });
     // scroll to top
     window.scrollTo(0, 0);
     this.props.updateDonationFormState({
@@ -301,7 +305,7 @@ class DonateForm extends Component<DonateFormProps, DonateFromComponentState> {
         </b>
         <Spacer />
         {paymentButtonsLoading && this.paymentButtonsLoader()}
-        <div className={paymentButtonsLoading ? 'hide' : 'donate-btn-group'}>
+        <div className={'donate-btn-group'}>
           <WalletsWrapper
             amount={donationAmount}
             handlePaymentButtonLoad={this.handlePaymentButtonLoad}
@@ -317,6 +321,7 @@ class DonateForm extends Component<DonateFormProps, DonateFromComponentState> {
             donationDuration={donationDuration}
             handlePaymentButtonLoad={this.handlePaymentButtonLoad}
             handleProcessing={handleProcessing}
+            isPaypalLoading={paypal}
             onDonationStateChange={this.onDonationStateChange}
             theme={defaultTheme ? defaultTheme : theme}
           />

--- a/client/src/components/Donation/DonateForm.tsx
+++ b/client/src/components/Donation/DonateForm.tsx
@@ -61,6 +61,7 @@ type DonateFormState = {
 type DonateFromComponentState = {
   donationAmount: number;
   donationDuration: string;
+  intervalId: null | string;
 };
 
 type DonateFormProps = {
@@ -123,7 +124,7 @@ class DonateForm extends Component<DonateFormProps, DonateFromComponentState> {
       ? modalDefaultDonation
       : defaultDonation;
 
-    this.state = { ...initialAmountAndDuration };
+    this.state = { ...initialAmountAndDuration, intervalId: null };
 
     this.onDonationStateChange = this.onDonationStateChange.bind(this);
     this.getActiveDonationAmount = this.getActiveDonationAmount.bind(this);
@@ -135,9 +136,27 @@ class DonateForm extends Component<DonateFormProps, DonateFromComponentState> {
     this.handlePaymentMethodLoad = this.handlePaymentMethodLoad.bind(this);
   }
 
+  componentDidMount() {
+    const intervalId = setInterval(this.providerLoaderTime, 3000);
+    // store intervalId in the state so it can be accessed later:
+    // eslint-disable-next-line react/no-did-mount-set-state
+    this.setState({ intervalId });
+  }
+
   componentWillUnmount() {
     this.resetDonation();
+    clearInterval(this.state.intervalId);
   }
+
+  providerLoaderTime = () => {
+    this.props.updateDonationFormState({
+      ...this.props.donationFormState,
+      loading: {
+        paypal: false,
+        stripe: false
+      }
+    });
+  };
 
   onDonationStateChange(donationState: AddDonationData) {
     // scroll to top

--- a/client/src/components/Donation/DonateForm.tsx
+++ b/client/src/components/Donation/DonateForm.tsx
@@ -132,16 +132,6 @@ class DonateForm extends Component<DonateFormProps, DonateFromComponentState> {
     this.resetDonation();
   }
 
-  providerLoaderTime = () => {
-    this.props.updateDonationFormState({
-      ...this.props.donationFormState,
-      loading: {
-        paypal: false,
-        stripe: false
-      }
-    });
-  };
-
   onDonationStateChange(donationState: AddDonationData) {
     // scroll to top
     window.scrollTo(0, 0);

--- a/client/src/components/Donation/Donation.css
+++ b/client/src/components/Donation/Donation.css
@@ -26,7 +26,7 @@
   text-align: center;
 }
 .donation-completion-loading {
-  min-height: 283px;
+  min-height: 154px;
 }
 
 .donation-completion-buttons {

--- a/client/src/components/Donation/Donation.css
+++ b/client/src/components/Donation/Donation.css
@@ -25,6 +25,9 @@
   align-items: center;
   text-align: center;
 }
+.donation-completion-loading {
+  min-height: 283px;
+}
 
 .donation-completion-buttons {
   display: flex;

--- a/client/src/components/Donation/Donation.css
+++ b/client/src/components/Donation/Donation.css
@@ -248,7 +248,7 @@ li.disabled > a {
   font-weight: 600;
   font-size: 1.2rem;
 }
-.donation-label,
+.donation-label-modal,
 .donation-modal p,
 .donation-modal b {
   text-align: center;

--- a/client/src/components/Donation/DonationModal.tsx
+++ b/client/src/components/Donation/DonationModal.tsx
@@ -158,7 +158,14 @@ function DonateModal({
       <Modal.Body>
         {recentlyClaimedBlock ? blockDonationText : progressDonationText}
         <Spacer />
-        <DonateForm handleProcessing={handleProcessing} isMinimalForm={true} />
+        <Row>
+          <Col lg={8} lgOffset={2} sm={10} smOffset={1} xs={12}>
+            <DonateForm
+              handleProcessing={handleProcessing}
+              isMinimalForm={true}
+            />
+          </Col>
+        </Row>
         <Spacer />
         <Row>
           <Col sm={4} smOffset={4} xs={8} xsOffset={2}>

--- a/client/src/components/Donation/PayPalButtonScriptLoader.tsx
+++ b/client/src/components/Donation/PayPalButtonScriptLoader.tsx
@@ -31,6 +31,7 @@ type PayPalButtonScriptLoaderProps = {
     data: AddDonationData,
     actions?: { order: { capture: () => Promise<unknown> } }
   ) => unknown;
+  isPaypalLoading: boolean;
   onCancel: () => unknown;
   onError: () => unknown;
   onLoad: () => void;
@@ -81,6 +82,8 @@ export class PayPalButtonScriptLoader extends Component<
   componentDidMount(): void {
     if (!window.paypal) {
       this.loadScript(this.props.isSubscription, false);
+    } else if (this.props.isPaypalLoading) {
+      this.props.onLoad();
     }
   }
 
@@ -139,7 +142,6 @@ export class PayPalButtonScriptLoader extends Component<
     const {
       onApprove,
       onError,
-
       onCancel,
       createSubscription,
       createOrder,

--- a/client/src/components/Donation/PayPalButtonScriptLoader.tsx
+++ b/client/src/components/Donation/PayPalButtonScriptLoader.tsx
@@ -33,7 +33,7 @@ type PayPalButtonScriptLoaderProps = {
   ) => unknown;
   onCancel: () => unknown;
   onError: () => unknown;
-  onCheck: () => void;
+  onInit: () => void;
   style: unknown;
   planId: string | null;
 };
@@ -114,7 +114,6 @@ export class PayPalButtonScriptLoader extends Component<
 
   onScriptLoad = (): void => {
     this.setState({ isSdkLoaded: true });
-    this.props.onCheck();
   };
 
   captureOneTimePayment(
@@ -139,6 +138,7 @@ export class PayPalButtonScriptLoader extends Component<
     const {
       onApprove,
       onError,
+      onInit,
       onCancel,
       createSubscription,
       createOrder,
@@ -178,9 +178,7 @@ export class PayPalButtonScriptLoader extends Component<
         }
         onCancel={onCancel}
         onError={onError}
-        onReady={() => {
-          console.log('paypal ready');
-        }}
+        onInit={onInit}
         style={style}
       />
     );

--- a/client/src/components/Donation/PayPalButtonScriptLoader.tsx
+++ b/client/src/components/Donation/PayPalButtonScriptLoader.tsx
@@ -33,7 +33,7 @@ type PayPalButtonScriptLoaderProps = {
   ) => unknown;
   onCancel: () => unknown;
   onError: () => unknown;
-  onInit: () => void;
+  onLoad: () => void;
   style: unknown;
   planId: string | null;
 };
@@ -114,6 +114,7 @@ export class PayPalButtonScriptLoader extends Component<
 
   onScriptLoad = (): void => {
     this.setState({ isSdkLoaded: true });
+    this.props.onLoad();
   };
 
   captureOneTimePayment(
@@ -138,7 +139,7 @@ export class PayPalButtonScriptLoader extends Component<
     const {
       onApprove,
       onError,
-      onInit,
+
       onCancel,
       createSubscription,
       createOrder,
@@ -178,7 +179,6 @@ export class PayPalButtonScriptLoader extends Component<
         }
         onCancel={onCancel}
         onError={onError}
-        onInit={onInit}
         style={style}
       />
     );

--- a/client/src/components/Donation/PayPalButtonScriptLoader.tsx
+++ b/client/src/components/Donation/PayPalButtonScriptLoader.tsx
@@ -2,7 +2,6 @@
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 
-import { Loader } from '../../components/helpers';
 import { scriptLoader, scriptRemover } from '../../utils/script-loaders';
 
 import type { AddDonationData } from './PaypalButton';
@@ -34,6 +33,7 @@ type PayPalButtonScriptLoaderProps = {
   ) => unknown;
   onCancel: () => unknown;
   onError: () => unknown;
+  onCheck: () => void;
   style: unknown;
   planId: string | null;
 };
@@ -114,6 +114,7 @@ export class PayPalButtonScriptLoader extends Component<
 
   onScriptLoad = (): void => {
     this.setState({ isSdkLoaded: true });
+    this.props.onCheck();
   };
 
   captureOneTimePayment(
@@ -144,7 +145,7 @@ export class PayPalButtonScriptLoader extends Component<
       style
     } = this.props;
 
-    if (!isSdkLoaded) return <Loader />;
+    if (!isSdkLoaded) return <></>;
 
     // TODO: fill in the full list of props instead of any
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -177,6 +178,9 @@ export class PayPalButtonScriptLoader extends Component<
         }
         onCancel={onCancel}
         onError={onError}
+        onReady={() => {
+          console.log('paypal ready');
+        }}
         style={style}
       />
     );

--- a/client/src/components/Donation/PayPalButtonScriptLoader.tsx
+++ b/client/src/components/Donation/PayPalButtonScriptLoader.tsx
@@ -35,7 +35,11 @@ type PayPalButtonScriptLoaderProps = {
   onCancel: () => unknown;
   onError: () => unknown;
   onLoad: () => void;
-  style: unknown;
+  style: {
+    color: string;
+    height: number;
+    tagline: boolean;
+  };
   planId: string | null;
 };
 
@@ -89,11 +93,17 @@ export class PayPalButtonScriptLoader extends Component<
 
   componentDidUpdate(prevProps: {
     isSubscription: boolean;
-    style: unknown;
+    style: {
+      color: string;
+      height: number;
+      tagline: boolean;
+    };
   }): void {
     if (
       prevProps.isSubscription !== this.state.isSubscription ||
-      prevProps.style !== this.props.style
+      prevProps.style.color !== this.props.style.color ||
+      prevProps.style.tagline !== this.props.style.tagline ||
+      prevProps.style.height !== this.props.style.height
     ) {
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ isSdkLoaded: false });

--- a/client/src/components/Donation/PaypalButton.tsx
+++ b/client/src/components/Donation/PaypalButton.tsx
@@ -193,7 +193,7 @@ export class PaypalButton extends Component<
               error: t('donate.try-again')
             });
           }}
-          onInit={() => this.props.handlePaymentButtonLoad('paypal')}
+          onLoad={() => this.props.handlePaymentButtonLoad('paypal')}
           planId={planId}
           style={{
             tagline: false,

--- a/client/src/components/Donation/PaypalButton.tsx
+++ b/client/src/components/Donation/PaypalButton.tsx
@@ -40,6 +40,7 @@ type PaypalButtonProps = {
   t: (label: string) => string;
   theme: string;
   isSubscription?: boolean;
+  handlePaymentMethodLoad: (provider: 'stripe' | 'paypal') => void;
 };
 
 type PaypalButtonState = {
@@ -53,6 +54,10 @@ export interface AddDonationData {
   processing: boolean;
   success: boolean;
   error: string | null;
+  loading?: {
+    stripe: boolean;
+    paypal: boolean;
+  };
 }
 
 const {
@@ -179,14 +184,16 @@ export class PaypalButton extends Component<
               error: t('donate.failed-pay')
             });
           }}
-          onError={() =>
+          onCheck={() => this.props.handlePaymentMethodLoad('paypal')}
+          onError={() => {
+            this.props.handlePaymentMethodLoad('paypal');
             this.props.onDonationStateChange({
               redirecting: false,
               processing: false,
               success: false,
               error: t('donate.try-again')
-            })
-          }
+            });
+          }}
           planId={planId}
           style={{
             tagline: false,

--- a/client/src/components/Donation/PaypalButton.tsx
+++ b/client/src/components/Donation/PaypalButton.tsx
@@ -40,7 +40,7 @@ type PaypalButtonProps = {
   t: (label: string) => string;
   theme: string;
   isSubscription?: boolean;
-  handlePaymentMethodLoad: (provider: 'stripe' | 'paypal') => void;
+  handlePaymentButtonLoad: (provider: 'stripe' | 'paypal') => void;
 };
 
 type PaypalButtonState = {
@@ -184,9 +184,8 @@ export class PaypalButton extends Component<
               error: t('donate.failed-pay')
             });
           }}
-          onCheck={() => this.props.handlePaymentMethodLoad('paypal')}
           onError={() => {
-            this.props.handlePaymentMethodLoad('paypal');
+            this.props.handlePaymentButtonLoad('paypal');
             this.props.onDonationStateChange({
               redirecting: false,
               processing: false,
@@ -194,6 +193,7 @@ export class PaypalButton extends Component<
               error: t('donate.try-again')
             });
           }}
+          onInit={() => this.props.handlePaymentButtonLoad('paypal')}
           planId={planId}
           style={{
             tagline: false,

--- a/client/src/components/Donation/PaypalButton.tsx
+++ b/client/src/components/Donation/PaypalButton.tsx
@@ -36,6 +36,7 @@ type PaypalButtonProps = {
     success: boolean;
     error: string | null;
   }) => void;
+  isPaypalLoading: boolean;
   skipAddDonation?: boolean;
   t: (label: string) => string;
   theme: string;
@@ -125,7 +126,7 @@ export class PaypalButton extends Component<
 
   render(): JSX.Element | null {
     const { duration, planId, amount } = this.state;
-    const { t, theme } = this.props;
+    const { t, theme, isPaypalLoading } = this.props;
     const isSubscription = duration !== 'onetime';
     const buttonColor = theme === 'night' ? 'white' : 'gold';
     if (!paypalClientId) {
@@ -172,6 +173,7 @@ export class PaypalButton extends Component<
               plan_id: planId
             });
           }}
+          isPaypalLoading={isPaypalLoading}
           isSubscription={isSubscription}
           onApprove={(data: AddDonationData) => {
             this.handleApproval(data, isSubscription);

--- a/client/src/components/Donation/duration-amount-options.tsx
+++ b/client/src/components/Donation/duration-amount-options.tsx
@@ -1,0 +1,90 @@
+import {
+  Tab,
+  Tabs,
+  ToggleButton,
+  ToggleButtonGroup
+} from '@freecodecamp/react-bootstrap';
+import React from 'react';
+
+import Spacer from '../helpers/spacer';
+
+interface OptionsProps {
+  amounts: { month: []; onetime: [] };
+  month: [];
+  onetime: [];
+  durations: { month: string; onetime: string };
+  getFormattedAmountLabel: (amount: number) => string;
+  getActiveDonationAmount: (
+    duration: 'month' | 'onetime',
+    donationAmount: number
+  ) => number;
+  handleSelectDuration: unknown;
+  handleSelectAmount: unknown;
+  donationDuration: 'month' | 'onetime';
+  donationAmount: 500 | 1000;
+  t: (
+    label: string,
+    { usd, hours }?: { usd?: string | number; hours?: string }
+  ) => string;
+}
+
+const DurationAmountOptions = ({
+  donationDuration,
+  donationAmount,
+  amounts,
+  durations,
+  getFormattedAmountLabel,
+  getActiveDonationAmount,
+  handleSelectDuration,
+  handleSelectAmount,
+  t
+}: OptionsProps): JSX.Element => {
+  const renderAmountButtons = (duration: 'month' | 'onetime'): unknown => {
+    return amounts[duration].map((amount: number) => (
+      <ToggleButton
+        className='amount-value'
+        id={`${durations[duration]}-donation-${amount}`}
+        key={`${durations[duration]}-donation-${amount}`}
+        value={amount}
+      >
+        {getFormattedAmountLabel(amount)}
+      </ToggleButton>
+    ));
+  };
+
+  return (
+    <div>
+      s<h3>{t('donate.gift-frequency')}</h3>
+      <Tabs
+        activeKey={donationDuration}
+        animation={false}
+        bsStyle='pills'
+        className='donate-tabs'
+        id='Duration'
+        onSelect={handleSelectDuration}
+      >
+        {(Object.keys(durations) as ['month' | 'onetime']).map(duration => (
+          <Tab eventKey={duration} key={duration} title={durations[duration]}>
+            <Spacer />
+            <h3>{t('donate.gift-amount')}</h3>
+            <div>
+              <ToggleButtonGroup
+                animation={`false`}
+                className='amount-values'
+                name='amounts'
+                onChange={handleSelectAmount}
+                type='radio'
+                value={getActiveDonationAmount(duration, donationAmount)}
+              >
+                {renderAmountButtons(duration)}
+              </ToggleButtonGroup>
+              <Spacer />
+            </div>
+          </Tab>
+        ))}
+      </Tabs>
+    </div>
+  );
+};
+
+export default DurationAmountOptions;

--- a/client/src/components/Donation/walletsButton.tsx
+++ b/client/src/components/Donation/walletsButton.tsx
@@ -22,6 +22,7 @@ interface WrapperProps {
   ) => void;
   onDonationStateChange: (donationState: AddDonationData) => void;
   refreshErrorMessage: string;
+  handlePaymentMethodLoad: (provider: 'stripe' | 'paypal') => void;
 }
 interface WalletsButtonProps extends WrapperProps {
   stripe: Stripe | null;
@@ -34,7 +35,8 @@ const WalletsButton = ({
   theme,
   refreshErrorMessage,
   postStripeDonation,
-  onDonationStateChange
+  onDonationStateChange,
+  handlePaymentMethodLoad
 }: WalletsButtonProps) => {
   const [token, setToken] = useState<Token | null>(null);
   const [paymentRequest, setPaymentRequest] = useState<PaymentRequest | null>(
@@ -69,9 +71,10 @@ const WalletsButton = ({
         checkpaymentPossiblity(true);
       } else {
         checkpaymentPossiblity(false);
+        handlePaymentMethodLoad('stripe');
       }
     });
-  }, [label, amount, stripe, postStripeDonation]);
+  }, [label, amount, stripe, postStripeDonation, handlePaymentMethodLoad]);
 
   const displayRefreshError = (): void => {
     onDonationStateChange({
@@ -87,10 +90,12 @@ const WalletsButton = ({
       {canMakePayment && paymentRequest && (
         <PaymentRequestButtonElement
           onClick={() => {
+            console.log('click');
             if (token) {
               displayRefreshError();
             }
           }}
+          onReady={() => handlePaymentMethodLoad('stripe')}
           options={{
             style: {
               paymentRequestButton: {

--- a/client/src/components/Donation/walletsButton.tsx
+++ b/client/src/components/Donation/walletsButton.tsx
@@ -22,7 +22,7 @@ interface WrapperProps {
   ) => void;
   onDonationStateChange: (donationState: AddDonationData) => void;
   refreshErrorMessage: string;
-  handlePaymentMethodLoad: (provider: 'stripe' | 'paypal') => void;
+  handlePaymentButtonLoad: (provider: 'stripe' | 'paypal') => void;
 }
 interface WalletsButtonProps extends WrapperProps {
   stripe: Stripe | null;
@@ -36,7 +36,7 @@ const WalletsButton = ({
   refreshErrorMessage,
   postStripeDonation,
   onDonationStateChange,
-  handlePaymentMethodLoad
+  handlePaymentButtonLoad
 }: WalletsButtonProps) => {
   const [token, setToken] = useState<Token | null>(null);
   const [paymentRequest, setPaymentRequest] = useState<PaymentRequest | null>(
@@ -71,10 +71,9 @@ const WalletsButton = ({
         checkpaymentPossiblity(true);
       } else {
         checkpaymentPossiblity(false);
-        handlePaymentMethodLoad('stripe');
       }
     });
-  }, [label, amount, stripe, postStripeDonation, handlePaymentMethodLoad]);
+  }, [label, amount, stripe, postStripeDonation, handlePaymentButtonLoad]);
 
   const displayRefreshError = (): void => {
     onDonationStateChange({
@@ -95,7 +94,7 @@ const WalletsButton = ({
               displayRefreshError();
             }
           }}
-          onReady={() => handlePaymentMethodLoad('stripe')}
+          onReady={() => handlePaymentButtonLoad('stripe')}
           options={{
             style: {
               paymentRequestButton: {

--- a/client/src/components/helpers/loader.css
+++ b/client/src/components/helpers/loader.css
@@ -6,7 +6,8 @@
   align-items: center;
 }
 
-.fcc-loader .sk-spinner {
+.fcc-loader .sk-spinner,
+.script-loading-spinner {
   color: var(--secondary-color);
 }
 

--- a/client/src/pages/donate.tsx
+++ b/client/src/pages/donate.tsx
@@ -113,7 +113,11 @@ function DonatePage({
                 </Alert>
               ) : null}
               <DonationText />
-              <DonateForm handleProcessing={handleProcessing} />
+              <Row>
+                <Col xs={12}>
+                  <DonateForm handleProcessing={handleProcessing} />
+                </Col>
+              </Row>
               <Row className='donate-support'>
                 <Col xs={12}>
                   <hr />

--- a/client/src/redux/index.js
+++ b/client/src/redux/index.js
@@ -33,7 +33,11 @@ export const defaultDonationFormState = {
   redirecting: false,
   processing: false,
   success: false,
-  error: ''
+  error: '',
+  loading: {
+    stripe: true,
+    paypal: true
+  }
 };
 
 const initialState = {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->
There is a lot of room for improvement here, but this pr tackles the following optimizations:
- Partially unified the loading state for the buttons
  (there is an internal loading state for Paypal that will be tackled in upcoming PRs)
- Made the donation buttons section reusable
- extracted some grid and unused elements out of the donateForm
