### PR TITLE
test: E2E Tests for Email-Sign-Up

### DIFF
--- a/client/src/pages/email-sign-up.tsx
+++ b/client/src/pages/email-sign-up.tsx
@@ -64,7 +64,10 @@ function AcceptPrivacyTerms({
       <Helmet>
         <title>{t('misc.email-signup')} | freeCodeCamp.org</title>
       </Helmet>
-      <Grid className='default-page-wrapper email-sign-up'>
+      <Grid
+        className='default-page-wrapper email-sign-up'
+        data-cy='email-sign-up'
+      >
         <SectionHeader>{t('misc.email-signup')}</SectionHeader>
         <Row>
           <IntroDescription />

--- a/cypress/integration/user/privacy-terms.js
+++ b/cypress/integration/user/privacy-terms.js
@@ -1,0 +1,30 @@
+describe('Privacy terms', () => {
+  it('should not redirect away from email sign up page on login', () => {
+    // Flag used to identify if the `/update-privacy-terms` have been called
+    let privacyTermsUpdated = false;
+    cy.intercept('PUT', '/update-privacy-terms', () => {
+      privacyTermsUpdated = true;
+    }).as('updatePrivacyTerms');
+
+    // Seed dev user with `acceptedPrivacyTerms` unset
+    cy.exec('npm run seed -- --unset-privacy-terms');
+    // Go to the homepage and log in manually so we can assert the following:
+    // 1. Redirection to /email-sign-up works properly
+    // 2. The /update-privacy-terms has not been requested
+    cy.visit('/');
+    cy.get('[data-test-label="landing-small-cta"]').click();
+    cy.location('pathname').should('contain', '/email-sign-up');
+    cy.wrap(privacyTermsUpdated).should('eq', false);
+    // Assert email sign up elements and make sure we don't get redirected somewhere else
+    cy.title().should('contain', 'Email Sign Up');
+    cy.get('[data-cy="email-sign-up"]').should('exist');
+    // Navigate away from this page via quincy emails which should unmount the component
+    // and request /update-privacy-terms
+    cy.get('button:contains("Yes please")').click();
+    cy.wait('@updatePrivacyTerms').then(() => {
+      expect(privacyTermsUpdated).to.eq(true);
+      cy.contains('Welcome back');
+      cy.location('pathname').should('contain', '/learn');
+    });
+  });
+});

--- a/tools/scripts/seed/seedAuthUser.js
+++ b/tools/scripts/seed/seedAuthUser.js
@@ -25,7 +25,6 @@ function handleError(err, client) {
   }
 }
 
-/* eslint-disable max-len */
 const authUser = {
   _id: ObjectId('5bd30e0f1caf6ac3ddddddb5'),
   email: 'foo@bar.com',
@@ -38,7 +37,9 @@ const authUser = {
   name: 'Development User',
   location: '',
   picture: defaultUserImage,
-  acceptedPrivacyTerms: true,
+  acceptedPrivacyTerms: envVariables.includes('--unset-privacy-terms')
+    ? null
+    : true,
   sendQuincyEmail: false,
   currentChallengeId: '',
   isHonest: false,
@@ -84,6 +85,7 @@ const authUser = {
   emailAuthLinkTTL: null,
   emailVerifyTTL: null
 };
+
 const blankUser = {
   _id: ObjectId('5bd30e0f1caf6ac3ddddddb9'),
   email: 'bar@bar.com',


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #42946

<!-- Feel free to add any additional description of changes below this line -->

This PR adds a new e2e test to make sure a user who logs in, with `acceptedPrivacyTerms` unset, does not redirect somewhere else automatically (#42708).

<!-- This also includes a change for mapping `LOCAL_MOCK_AUTH` to `Cypress.env` to be able to locally run tests that involve visiting the portfolio page (https://contribute.freecodecamp.org/#/how-to-setup-freecodecamp-locally?id=sign-in-with-a-local-user) -->
