### PR TITLE
feat(e2e): Add cypress globals to eslint overrides

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -59,6 +59,13 @@
     {
       "files": ["./tools/ui-components/**/*.test.[jt]s?(x)", "./client/**/*.test.[jt]s?(x)"],
       "extends": ["plugin:testing-library/react", "plugin:jest-dom/recommended"]
+    },
+    {
+      "files": ["cypress/**/*.js"],
+      "globals": {
+        "cy": true,
+        "Cypress": true
+      }
     }
   ]
 }

--- a/cypress/integration/ShowCertification.js
+++ b/cypress/integration/ShowCertification.js
@@ -1,4 +1,3 @@
-/* global cy */
 const certificationUrl = '/certification/developmentuser/responsive-web-design';
 const projects = {
   superBlock: 'responsive-web-design',

--- a/cypress/integration/landing.js
+++ b/cypress/integration/landing.js
@@ -1,4 +1,3 @@
-/* global cy */
 const selectors = {
   heading: "[data-test-label='landing-header']",
   callToAction: "[data-test-label='landing-big-cta']",

--- a/cypress/integration/learn/challenges/backend.js
+++ b/cypress/integration/learn/challenges/backend.js
@@ -1,5 +1,3 @@
-/* global cy */
-
 const locations = {
   index:
     'learn/back-end-development-and-apis/managing-packages-with-npm/' +

--- a/cypress/integration/learn/challenges/code-storage.js
+++ b/cypress/integration/learn/challenges/code-storage.js
@@ -1,5 +1,3 @@
-/* global cy */
-
 const selectors = {
   defaultOutput: '.output-text',
   editor: '.react-monaco-editor-container'

--- a/cypress/integration/learn/challenges/output.js
+++ b/cypress/integration/learn/challenges/output.js
@@ -1,5 +1,3 @@
-/* global cy */
-
 const selectors = {
   defaultOutput: '.output-text',
   editor: '.monaco-editor',

--- a/cypress/integration/learn/challenges/projects.js
+++ b/cypress/integration/learn/challenges/projects.js
@@ -1,5 +1,3 @@
-/* global cy */
-
 const projects = {
   superBlock: 'machine-learning-with-python',
   block: 'machine-learning-with-python-projects',

--- a/cypress/integration/learn/coding-interview-prep/intro-page.js
+++ b/cypress/integration/learn/coding-interview-prep/intro-page.js
@@ -1,5 +1,3 @@
-/* global cy */
-
 describe('Certification intro page', () => {
   before(() => {
     cy.clearCookies();

--- a/cypress/integration/learn/common-components/footer.js
+++ b/cypress/integration/learn/common-components/footer.js
@@ -1,5 +1,3 @@
-/* global cy */
-
 const selectors = {
   footer: '.site-footer'
 };

--- a/cypress/integration/learn/common-components/helpButton.js
+++ b/cypress/integration/learn/common-components/helpButton.js
@@ -1,5 +1,3 @@
-/* global cy */
-
 describe('Help Button', () => {
   it('should be visible', () => {
     cy.visit(

--- a/cypress/integration/learn/common-components/navbar.js
+++ b/cypress/integration/learn/common-components/navbar.js
@@ -1,5 +1,3 @@
-/* global cy */
-
 const selectors = {
   heading: "[data-test-label='landing-header']",
   smallCallToAction: "[data-test-label='landing-small-cta']",

--- a/cypress/integration/learn/common-components/searchBar.js
+++ b/cypress/integration/learn/common-components/searchBar.js
@@ -1,5 +1,3 @@
-/* global cy */
-
 const search = query => {
   cy.get('.ais-SearchBox').within(() => {
     cy.get('input').type(query);

--- a/cypress/integration/learn/donate/donate-page-default.js
+++ b/cypress/integration/learn/donate/donate-page-default.js
@@ -1,5 +1,3 @@
-/* global cy */
-
 const selectors = {
   donateSupport: {
     firstTitle: '.donate-support h4:first-of-type b',

--- a/cypress/integration/learn/donate/donate-page-donor.js
+++ b/cypress/integration/learn/donate/donate-page-donor.js
@@ -1,5 +1,3 @@
-/* global cy */
-
 const selectors = {
   donateAlert: {
     firstText: '.alert-info p:first-child',

--- a/cypress/integration/learn/donate/donation-block-completion-modal.js
+++ b/cypress/integration/learn/donate/donation-block-completion-modal.js
@@ -1,5 +1,3 @@
-/* global cy */
-
 describe('Donate page', () => {
   before(() => {
     cy.clearCookies();

--- a/cypress/integration/learn/header/header-nav-links.js
+++ b/cypress/integration/learn/header/header-nav-links.js
@@ -1,5 +1,3 @@
-/* global cy */
-
 describe('Navigation links', () => {
   it('should render the expected forum and news links.', () => {
     cy.visit('/learn');

--- a/cypress/integration/learn/index.js
+++ b/cypress/integration/learn/index.js
@@ -1,5 +1,3 @@
-/* global cy */
-
 const selectors = {
   challengeMap: "[data-test-label='learn-curriculum-map']"
 };

--- a/cypress/integration/learn/redirects/breadcrumbs.js
+++ b/cypress/integration/learn/redirects/breadcrumbs.js
@@ -1,5 +1,3 @@
-/* global cy */
-
 const challengeUrl =
   '/learn/responsive-web-design/basic-html-and-html5/say-hello-to-html-elements';
 

--- a/cypress/integration/learn/responsive-web-design/basic-css/index.js
+++ b/cypress/integration/learn/responsive-web-design/basic-css/index.js
@@ -1,5 +1,3 @@
-/* global cy */
-
 const selectors = {
   tableOfContents: '.intro-toc',
   warningMessage: '.flash-message-enter-active'

--- a/cypress/integration/learn/responsive-web-design/claim-cert-from-learn.js
+++ b/cypress/integration/learn/responsive-web-design/claim-cert-from-learn.js
@@ -1,5 +1,3 @@
-/* global cy */
-
 const projects = {
   superBlock: 'responsive-web-design',
   block: 'responsive-web-design-projects',

--- a/cypress/integration/learn/responsive-web-design/intro-page.js
+++ b/cypress/integration/learn/responsive-web-design/intro-page.js
@@ -1,5 +1,3 @@
-/* global cy */
-
 const selectors = {
   firstBlock: '.block-ui > .block:nth-child(1) > .map-title'
 };

--- a/cypress/integration/legacy/redirects/adding-development.js
+++ b/cypress/integration/legacy/redirects/adding-development.js
@@ -1,5 +1,3 @@
-/* global cy */
-
 describe('Legacy redirects', () => {
   it('should redirect from front-end-libraries to front-end-development-libraries', () => {
     cy.visit('learn/front-end-libraries');

--- a/cypress/integration/legacy/redirects/challenges.js
+++ b/cypress/integration/legacy/redirects/challenges.js
@@ -1,5 +1,3 @@
-/* global cy */
-
 const locations = {
   chalSuper: '/challenges/responsive-web-design/',
   chalBlock: '/challenges/responsive-web-design/basic-html-and-html5',

--- a/cypress/integration/settings/certifications.js
+++ b/cypress/integration/settings/certifications.js
@@ -1,5 +1,3 @@
-/* global cy */
-
 import '@testing-library/cypress/add-commands';
 
 describe('Settings certifications area', () => {

--- a/cypress/integration/settings/email-change.js
+++ b/cypress/integration/settings/email-change.js
@@ -1,4 +1,3 @@
-/* global cy */
 describe('Email input field', () => {
   beforeEach(() => {
     cy.exec('npm run seed');

--- a/cypress/integration/settings/image-picture-check.js
+++ b/cypress/integration/settings/image-picture-check.js
@@ -1,5 +1,3 @@
-/* global cy */
-
 describe('Picture input field', () => {
   beforeEach(() => {
     cy.login();

--- a/cypress/integration/settings/settings.js
+++ b/cypress/integration/settings/settings.js
@@ -1,5 +1,3 @@
-/* global cy */
-
 describe('Settings', () => {
   it('should be possible to reset your progress', () => {
     cy.login();

--- a/cypress/integration/settings/username-change.js
+++ b/cypress/integration/settings/username-change.js
@@ -1,5 +1,3 @@
-/* global cy */
-
 describe('Username input field', () => {
   beforeEach(() => {
     cy.login();

--- a/cypress/integration/tags.js
+++ b/cypress/integration/tags.js
@@ -1,4 +1,3 @@
-/* global cy */
 describe('The Document Metadata', () => {
   before(() => {
     cy.visit('/');

--- a/cypress/integration/top-contributor.js
+++ b/cypress/integration/top-contributor.js
@@ -1,5 +1,3 @@
-/* global cy */
-
 describe('Top contributor in user profile', () => {
   before(() => {
     cy.clearCookies();

--- a/cypress/integration/user/report-user.js
+++ b/cypress/integration/user/report-user.js
@@ -1,5 +1,3 @@
-/* global cy */
-
 describe('Report User', () => {
   beforeEach(() => {
     cy.exec('npm run seed');
@@ -21,5 +19,3 @@ describe('Report User', () => {
     cy.contains('A report was sent to the team with foo@bar.com in copy');
   });
 });
-
-// A report was sent to the team with foo@bar.com in copy

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,4 +1,3 @@
-/* global cy Cypress*/
 // ***********************************************
 // This example commands.js shows you how to
 // create various custom commands and overwrite

--- a/docs/how-to-add-cypress-tests.md
+++ b/docs/how-to-add-cypress-tests.md
@@ -4,8 +4,6 @@ When making changes to JavaScript, CSS, or HTML which could change the functiona
 
 To learn how to write Cypress tests, or 'specs', please see Cypress' official [documentation](https://docs.cypress.io/guides/getting-started/writing-your-first-test.html).
 
-> Note: When writing tests for freeCodeCamp, remember to add `/* global cy */` to the top of the file to avoid ESLint issues.
-
 ## Where to add a test
 
 - Cypress tests are in the `./cypress` directory.


### PR DESCRIPTION
This diff eliminates the need to add `/* global cy */` on top of cypress tests.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Closes #XXXXX -->

<!-- Feel free to add any additional description of changes below this line -->
