### PR TITLE
fix(client): change editable regions to not start on line 0

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -365,11 +365,11 @@ const Editor = (props: EditorProps): JSX.Element => {
       keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_E],
       run: () => {
         const currentAccessibility = storedAccessibilityMode();
-        
+
         store.set('accessibilityMode', !currentAccessibility);
 
         editor.updateOptions({
-          accessibilitySupport: storedAccessibilityMode() ? 'on' : 'auto',
+          accessibilitySupport: storedAccessibilityMode() ? 'on' : 'auto'
         });
       }
     });
@@ -591,7 +591,8 @@ const Editor = (props: EditorProps): JSX.Element => {
 
     const editableRegion = getCurrentEditableRegion();
     const editableRegionBoundaries = editableRegion && [
-      editableRegion.startLineNumber - 1,
+      // TEST: editableRegion.startLineNumber,
+      Math.max(editableRegion.startLineNumber - 1, 1),
       editableRegion.endLineNumber + 1
     ];
     updateFile({ fileKey, editorValue, editableRegionBoundaries });

--- a/curriculum/challenges/english/01-responsive-web-design/css-variables-skyline/part-001.md
+++ b/curriculum/challenges/english/01-responsive-web-design/css-variables-skyline/part-001.md
@@ -43,5 +43,4 @@ assert(code.match(/html\s*>/gi));
 --fcc-editable-region--
 
 --fcc-editable-region--
-
 ```

--- a/tools/challenge-parser/parser/plugins/add-seed.js
+++ b/tools/challenge-parser/parser/plugins/add-seed.js
@@ -10,8 +10,8 @@ const editableRegionMarker = '--fcc-editable-region--';
 function findRegionMarkers(challengeFile) {
   const lines = challengeFile.contents.split('\n');
   const editableLines = lines
-    .map((line, id) => (line.trim() === editableRegionMarker ? id : -1))
-    .filter(id => id >= 0);
+    .map((line, id) => (line.trim() === editableRegionMarker ? id + 1 : -1))
+    .filter(id => id > 0);
 
   if (editableLines.length > 2) {
     throw Error('Editable region has too many markers: ' + editableLines);
@@ -28,7 +28,7 @@ function findRegionMarkers(challengeFile) {
 
 function removeLines(contents, toRemove) {
   const lines = contents.split('\n');
-  return lines.filter((_, id) => !toRemove.includes(id)).join('\n');
+  return lines.filter((_, id) => !toRemove.includes(id + 1)).join('\n');
 }
 
 // TODO: DRY this.  Start with an array of markers and go from there.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Fixes the bug crashing Gatsby by having ERMs on the first/last line of a code-block.
````markdown
```html
--fcc-editable-region--
<h1>This used to break freeCodeCamp</h1>
---fcc-editable-region--
```
````

Currently, this suffers from the upper-jaw (description) being hidden from view.