### PR TITLE
feat: translation demo

### DIFF
--- a/client/i18n/config.js
+++ b/client/i18n/config.js
@@ -53,6 +53,13 @@ i18n.use(initReactI18next).init({
       if (clientLocale !== 'english') {
         module.exports = require('./locales/' + clientLocale + '/links.json');
       }
+    `,
+      certs: preval`
+      const envData = require('../../config/env.json');
+      const { clientLocale } = envData;
+      if (clientLocale !== 'english') {
+        module.exports = require('./locales/' + clientLocale + '/certs.json');
+      }
     `
     },
     en: {
@@ -60,14 +67,15 @@ i18n.use(initReactI18next).init({
       trending: preval`module.exports = require('./locales/english/trending.json')`,
       intro: preval`module.exports = require('./locales/english/intro.json')`,
       metaTags: preval`module.exports = require('./locales/english/meta-tags.json')`,
-      links: preval`module.exports = require('./locales/english/links.json')`
+      links: preval`module.exports = require('./locales/english/links.json')`,
+      certs: preval`module.exports = require('./locales/english/certs.json')`
     }
   },
-  ns: ['translations', 'trending', 'intro', 'metaTags', 'links'],
+  ns: ['translations', 'trending', 'intro', 'metaTags', 'links', 'certs'],
   defaultNS: 'translations',
   returnObjects: true,
   // Uncomment the next line for debug logging
-  // debug: true,
+  debug: true,
   interpolation: {
     escapeValue: false
   },

--- a/client/i18n/locales/english/certs.json
+++ b/client/i18n/locales/english/certs.json
@@ -1,8 +1,10 @@
 {
   "certNames": {
-    "Responsive Web Design": "RWD Hacked by nhcarrigan"
+    "Responsive Web Design": "RWD Hacked by nhcarrigan",
+    "responsive-web-design": "RWD Hacked by Shaun"
   },
   "projectNames": {
-    "Build a Tribute Page": "Tribute to nhcarrigan"
+    "Build a Tribute Page": "Tribute to nhcarrigan",
+    "build-a-tribute-page": "Tribute to Shaun"
   }
 }

--- a/client/i18n/locales/english/certs.json
+++ b/client/i18n/locales/english/certs.json
@@ -1,0 +1,8 @@
+{
+  "certNames": {
+    "Responsive Web Design": "RWD Hacked by nhcarrigan"
+  },
+  "projectNames": {
+    "Build a Tribute Page": "Tribute to nhcarrigan"
+  }
+}

--- a/client/src/client-only-routes/show-certification.tsx
+++ b/client/src/client-only-routes/show-certification.tsx
@@ -341,14 +341,17 @@ const ShowCertification = (props: IShowCertificationProps): JSX.Element => {
 
         <main className='information'>
           <div className='information-container'>
-            <Trans i18nKey='certification.fulltext' title={certTitle}>
+            <Trans
+              i18nKey='certification.fulltext'
+              title={t(`certificate-names.${certTitle}`)}
+            >
               <h3>placeholder</h3>
               <h1>
                 <strong>{{ user: displayName }}</strong>
               </h1>
               <h3>placeholder</h3>
               <h1>
-                <strong>{{ title: certTitle }}</strong>
+                <strong>{{ title: t(`certs:certNames.${certTitle}`) }}</strong>
               </h1>
               <h4>{{ time: completionTime }}</h4>
             </Trans>

--- a/client/src/client-only-routes/show-certification.tsx
+++ b/client/src/client-only-routes/show-certification.tsx
@@ -8,7 +8,6 @@ import { createSelector } from 'reselect';
 
 import envData from '../../../config/env.json';
 import { langCodes } from '../../../config/i18n/all-langs';
-import { dasherize } from '../../../utils/slugs';
 import FreeCodeCampLogo from '../assets/icons/FreeCodeCamp-logo';
 import DonateForm from '../components/Donation/DonateForm';
 
@@ -353,7 +352,11 @@ const ShowCertification = (props: IShowCertificationProps): JSX.Element => {
               <h3>placeholder</h3>
               <h1>
                 <strong>
-                  {{ title: t(`certs:certNames.${dasherize(certTitle)}`) }}
+                  {{
+                    title: t(
+                      `certs:certNames.${pathname.split('/').reverse()[0]}`
+                    )
+                  }}
                 </strong>
               </h1>
               <h4>{{ time: completionTime }}</h4>

--- a/client/src/client-only-routes/show-certification.tsx
+++ b/client/src/client-only-routes/show-certification.tsx
@@ -8,6 +8,7 @@ import { createSelector } from 'reselect';
 
 import envData from '../../../config/env.json';
 import { langCodes } from '../../../config/i18n/all-langs';
+import { dasherize } from '../../../utils/slugs';
 import FreeCodeCampLogo from '../assets/icons/FreeCodeCamp-logo';
 import DonateForm from '../components/Donation/DonateForm';
 
@@ -351,7 +352,9 @@ const ShowCertification = (props: IShowCertificationProps): JSX.Element => {
               </h1>
               <h3>placeholder</h3>
               <h1>
-                <strong>{{ title: t(`certs:certNames.${certTitle}`) }}</strong>
+                <strong>
+                  {{ title: t(`certs:certNames.${dasherize(certTitle)}`) }}
+                </strong>
               </h1>
               <h4>{{ time: completionTime }}</h4>
             </Trans>

--- a/client/src/client-only-routes/show-project-links.tsx
+++ b/client/src/client-only-routes/show-project-links.tsx
@@ -2,7 +2,6 @@ import { find, first } from 'lodash-es';
 import React, { useState } from 'react';
 import '../components/layouts/project-links.css';
 import { Trans, useTranslation } from 'react-i18next';
-import { dasherize } from '../../../utils/slugs';
 import ProjectModal from '../components/SolutionViewer/ProjectModal';
 import { Spacer, Link } from '../components/helpers';
 import {
@@ -147,7 +146,7 @@ const ShowProjectLinks = (props: IShowProjectLinksProps): JSX.Element => {
       ({ link, title, id }) => (
         <li key={id}>
           <Link className='project-link' to={link}>
-            {t(`certs:projectNames.${dasherize(title as string)}`)}
+            {t(`certs:projectNames.${link.split('/').reverse()[0] as string}`)}
           </Link>
           : {getProjectSolution(id, title)}
         </li>

--- a/client/src/client-only-routes/show-project-links.tsx
+++ b/client/src/client-only-routes/show-project-links.tsx
@@ -146,7 +146,7 @@ const ShowProjectLinks = (props: IShowProjectLinksProps): JSX.Element => {
       ({ link, title, id }) => (
         <li key={id}>
           <Link className='project-link' to={link}>
-            {t(`certification.project.title.${title as string}`, title)}
+            {t(`certs:projectNames.${title as string}`)}
           </Link>
           : {getProjectSolution(id, title)}
         </li>

--- a/client/src/client-only-routes/show-project-links.tsx
+++ b/client/src/client-only-routes/show-project-links.tsx
@@ -2,6 +2,7 @@ import { find, first } from 'lodash-es';
 import React, { useState } from 'react';
 import '../components/layouts/project-links.css';
 import { Trans, useTranslation } from 'react-i18next';
+import { dasherize } from '../../../utils/slugs';
 import ProjectModal from '../components/SolutionViewer/ProjectModal';
 import { Spacer, Link } from '../components/helpers';
 import {
@@ -146,7 +147,7 @@ const ShowProjectLinks = (props: IShowProjectLinksProps): JSX.Element => {
       ({ link, title, id }) => (
         <li key={id}>
           <Link className='project-link' to={link}>
-            {t(`certs:projectNames.${title as string}`)}
+            {t(`certs:projectNames.${dasherize(title as string)}`)}
           </Link>
           : {getProjectSolution(id, title)}
         </li>

--- a/client/src/components/profile/components/Certifications.tsx
+++ b/client/src/components/profile/components/Certifications.tsx
@@ -1,5 +1,4 @@
 import { Col, Row } from '@freecodecamp/react-bootstrap';
-import { curry } from 'lodash-es';
 import React, { Fragment } from 'react';
 import { useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -46,11 +45,15 @@ interface ICertificationProps {
   username: string;
 }
 
-function renderCertShow(username: string, cert: ICert): React.ReactNode {
-  // eslint-disable-next-line react-hooks/rules-of-hooks
+interface CertLinkProps {
+  username: string;
+  cert: ICert;
+}
+
+function CertLink({ username, cert }: CertLinkProps): JSX.Element {
   const { t } = useTranslation();
-  return cert.show ? (
-    <Fragment key={cert.title}>
+  return (
+    <>
       <Row>
         <Col className='certifications' sm={10} smPush={1}>
           <Link
@@ -62,8 +65,8 @@ function renderCertShow(username: string, cert: ICert): React.ReactNode {
         </Col>
       </Row>
       <ButtonSpacer />
-    </Fragment>
-  ) : null;
+    </>
+  );
 }
 
 function Certificates({
@@ -74,13 +77,16 @@ function Certificates({
   username
 }: ICertificationProps): JSX.Element {
   const { t } = useTranslation();
-  const renderCertShowWithUsername = curry(renderCertShow)(username);
   return (
     <FullWidthRow className='certifications'>
       <h2 className='text-center'>{t('profile.fcc-certs')}</h2>
       <br />
       {hasModernCert && currentCerts ? (
-        currentCerts.map(renderCertShowWithUsername)
+        currentCerts
+          .filter(({ show }) => show)
+          .map(cert => (
+            <CertLink cert={cert} key={cert.title} username={username} />
+          ))
       ) : (
         <p className='text-center'>{t('profile.no-certs')}</p>
       )}
@@ -89,7 +95,12 @@ function Certificates({
           <br />
           <h3 className='text-center'>{t('settings.headings.legacy-certs')}</h3>
           <br />
-          {legacyCerts && legacyCerts.map(renderCertShowWithUsername)}
+          {legacyCerts &&
+            legacyCerts
+              .filter(({ show }) => show)
+              .map(cert => (
+                <CertLink cert={cert} key={cert.title} username={username} />
+              ))}
           <Spacer size={2} />
         </div>
       ) : null}

--- a/client/src/components/profile/components/Certifications.tsx
+++ b/client/src/components/profile/components/Certifications.tsx
@@ -57,8 +57,7 @@ function renderCertShow(username: string, cert: ICert): React.ReactNode {
             className='btn btn-lg btn-primary btn-block'
             to={`/certification/${username}/${cert.certSlug}`}
           >
-            View{' '}
-            {t(`certs:certNames.${cert.title.replace(' Certification', '')}`)}
+            View {t(`certs:certNames.${cert.certSlug}`)}
           </Link>
         </Col>
       </Row>

--- a/client/src/components/profile/components/Certifications.tsx
+++ b/client/src/components/profile/components/Certifications.tsx
@@ -9,7 +9,7 @@ import { ButtonSpacer, FullWidthRow, Link, Spacer } from '../../helpers';
 import './certifications.css';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const mapStateToProps = (state: any, props: ICertificationProps) =>
+const mapStateToProps = (state: any, props: CertificationProps) =>
   createSelector(
     certificatesByNameSelector(props.username),
     ({
@@ -18,7 +18,7 @@ const mapStateToProps = (state: any, props: ICertificationProps) =>
       currentCerts,
       legacyCerts
     }: Pick<
-      ICertificationProps,
+      CertificationProps,
       'hasModernCert' | 'hasLegacyCert' | 'currentCerts' | 'legacyCerts'
     >) => ({
       hasModernCert,
@@ -31,23 +31,23 @@ const mapStateToProps = (state: any, props: ICertificationProps) =>
     // @ts-ignore
   )(state, props);
 
-interface ICert {
+interface Cert {
   show: boolean;
   title: string;
   certSlug: string;
 }
 
-interface ICertificationProps {
-  currentCerts?: ICert[];
+interface CertificationProps {
+  currentCerts?: Cert[];
   hasLegacyCert?: boolean;
   hasModernCert?: boolean;
-  legacyCerts?: ICert[];
+  legacyCerts?: Cert[];
   username: string;
 }
 
 interface CertLinkProps {
   username: string;
-  cert: ICert;
+  cert: Cert;
 }
 
 function CertLink({ username, cert }: CertLinkProps): JSX.Element {
@@ -75,7 +75,7 @@ function Certificates({
   hasLegacyCert,
   hasModernCert,
   username
-}: ICertificationProps): JSX.Element {
+}: CertificationProps): JSX.Element {
   const { t } = useTranslation();
   return (
     <FullWidthRow className='certifications'>

--- a/client/src/components/profile/components/Certifications.tsx
+++ b/client/src/components/profile/components/Certifications.tsx
@@ -47,6 +47,8 @@ interface ICertificationProps {
 }
 
 function renderCertShow(username: string, cert: ICert): React.ReactNode {
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const { t } = useTranslation();
   return cert.show ? (
     <Fragment key={cert.title}>
       <Row>
@@ -55,7 +57,8 @@ function renderCertShow(username: string, cert: ICert): React.ReactNode {
             className='btn btn-lg btn-primary btn-block'
             to={`/certification/${username}/${cert.certSlug}`}
           >
-            View {cert.title}
+            View{' '}
+            {t(`certs:certNames.${cert.title.replace(' Certification', '')}`)}
           </Link>
         </Col>
       </Row>

--- a/client/src/components/profile/components/TimeLine.tsx
+++ b/client/src/components/profile/components/TimeLine.tsx
@@ -163,7 +163,10 @@ class TimelineInner extends Component<TimelineInnerProps, TimeLineInnerState> {
     }
   }
 
-  renderCompletion(completed: SortedTimeline): JSX.Element {
+  renderCompletion(
+    completed: SortedTimeline,
+    t: TFunction<'translation'>
+  ): JSX.Element {
     const { idToNameMap, username } = this.props;
     const { id, challengeFiles, githubLink, solution } = completed;
     const completedDate = new Date(completed.completedDate);
@@ -177,11 +180,18 @@ class TimelineInner extends Component<TimelineInnerProps, TimeLineInnerState> {
               className='timeline-cert-link'
               to={`/certification/${username}/${certPath as string}`}
             >
-              {challengeTitle}
+              {t(
+                `certs:certNames.${(challengeTitle as string).replace(
+                  ' Certification',
+                  ''
+                )}`
+              )}
               <CertificationIcon />
             </Link>
           ) : (
-            <Link to={challengePath as string}>{challengeTitle}</Link>
+            <Link to={challengePath as string}>
+              {t(`certs:projectNames.${challengeTitle as string}`)}
+            </Link>
           )}
         </td>
         <td>
@@ -277,7 +287,7 @@ class TimelineInner extends Component<TimelineInnerProps, TimeLineInnerState> {
             <tbody>
               {sortedTimeline
                 .slice(startIndex, endIndex)
-                .map(this.renderCompletion)}
+                .map(el => this.renderCompletion(el, t))}
             </tbody>
           </Table>
         )}

--- a/client/src/components/profile/components/TimeLine.tsx
+++ b/client/src/components/profile/components/TimeLine.tsx
@@ -19,6 +19,7 @@ import {
   getPathFromID,
   getTitleFromId
 } from '../../../../../utils';
+import { dasherize } from '../../../../../utils/slugs';
 import CertificationIcon from '../../../assets/icons/certification-icon';
 import { ChallengeFiles } from '../../../redux/prop-types';
 import { maybeUrlRE } from '../../../utils';
@@ -172,6 +173,7 @@ class TimelineInner extends Component<TimelineInnerProps, TimeLineInnerState> {
     const completedDate = new Date(completed.completedDate);
     // @ts-expect-error idToNameMap is not a <string, string> Map...
     const { challengeTitle, challengePath, certPath } = idToNameMap.get(id);
+    console.table(idToNameMap.get(id));
     return (
       <tr className='timeline-row' key={id}>
         <td>
@@ -180,17 +182,12 @@ class TimelineInner extends Component<TimelineInnerProps, TimeLineInnerState> {
               className='timeline-cert-link'
               to={`/certification/${username}/${certPath as string}`}
             >
-              {t(
-                `certs:certNames.${(challengeTitle as string).replace(
-                  ' Certification',
-                  ''
-                )}`
-              )}
+              {t(`certs:certNames.${certPath as string}`)}
               <CertificationIcon />
             </Link>
           ) : (
             <Link to={challengePath as string}>
-              {t(`certs:projectNames.${challengeTitle as string}`)}
+              {t(`certs:projectNames.${dasherize(challengeTitle as string)}`)}
             </Link>
           )}
         </td>

--- a/client/src/components/profile/components/TimeLine.tsx
+++ b/client/src/components/profile/components/TimeLine.tsx
@@ -19,7 +19,6 @@ import {
   getPathFromID,
   getTitleFromId
 } from '../../../../../utils';
-import { dasherize } from '../../../../../utils/slugs';
 import CertificationIcon from '../../../assets/icons/certification-icon';
 import { ChallengeFiles } from '../../../redux/prop-types';
 import { maybeUrlRE } from '../../../utils';
@@ -172,7 +171,7 @@ class TimelineInner extends Component<TimelineInnerProps, TimeLineInnerState> {
     const { id, challengeFiles, githubLink, solution } = completed;
     const completedDate = new Date(completed.completedDate);
     // @ts-expect-error idToNameMap is not a <string, string> Map...
-    const { challengeTitle, challengePath, certPath } = idToNameMap.get(id);
+    const { challengePath, certPath } = idToNameMap.get(id);
     console.table(idToNameMap.get(id));
     return (
       <tr className='timeline-row' key={id}>
@@ -187,7 +186,11 @@ class TimelineInner extends Component<TimelineInnerProps, TimeLineInnerState> {
             </Link>
           ) : (
             <Link to={challengePath as string}>
-              {t(`certs:projectNames.${dasherize(challengeTitle as string)}`)}
+              {t(
+                `certs:projectNames.${
+                  (challengePath as string).split('/').reverse()[0]
+                }`
+              )}
             </Link>
           )}
         </td>

--- a/client/src/components/settings/Certification.js
+++ b/client/src/components/settings/Certification.js
@@ -11,7 +11,6 @@ import React, { Component } from 'react';
 import { withTranslation } from 'react-i18next';
 import { createSelector } from 'reselect';
 
-import { dasherize } from '../../../../utils/slugs';
 import {
   projectMap,
   legacyProjectMap
@@ -294,7 +293,9 @@ export class CertificationSettings extends Component {
       .map(({ link, title, id }) => (
         <tr className='project-row' key={id}>
           <td className='project-title col-sm-8'>
-            <Link to={link}>{t(`certs:projectNames.${dasherize(title)}`)}</Link>
+            <Link to={link}>
+              {t(`certs:projectNames.${link.split('/').reverse()[0]}`)}
+            </Link>
           </td>
           <td className='project-solution col-sm-4'>
             {this.getProjectSolution(id, title)}

--- a/client/src/components/settings/Certification.js
+++ b/client/src/components/settings/Certification.js
@@ -255,7 +255,7 @@ export class CertificationSettings extends Component {
       <FullWidthRow key={certName}>
         <Spacer />
         <h3 className='text-center' id={`cert-${certSlug}`}>
-          {certName}
+          {t(`certs:certNames.${certName}`)}
         </h3>
         <Table>
           <thead>
@@ -293,7 +293,7 @@ export class CertificationSettings extends Component {
       .map(({ link, title, id }) => (
         <tr className='project-row' key={id}>
           <td className='project-title col-sm-8'>
-            <Link to={link}>{title}</Link>
+            <Link to={link}>{t(`certs:projectNames.${title}`)}</Link>
           </td>
           <td className='project-solution col-sm-4'>
             {this.getProjectSolution(id, title)}
@@ -371,7 +371,7 @@ export class CertificationSettings extends Component {
             })}
           </p>
           <ul>
-            <li>Responsive Web Design</li>
+            <li>{t(`certs:certNames.${'Responsive Web Design'}`)}</li>
             <li>JavaScript Algorithms and Data Structures</li>
             <li>Front End Development Libraries</li>
             <li>Data Visualization</li>

--- a/client/src/components/settings/Certification.js
+++ b/client/src/components/settings/Certification.js
@@ -11,6 +11,7 @@ import React, { Component } from 'react';
 import { withTranslation } from 'react-i18next';
 import { createSelector } from 'reselect';
 
+import { dasherize } from '../../../../utils/slugs';
 import {
   projectMap,
   legacyProjectMap
@@ -255,7 +256,7 @@ export class CertificationSettings extends Component {
       <FullWidthRow key={certName}>
         <Spacer />
         <h3 className='text-center' id={`cert-${certSlug}`}>
-          {t(`certs:certNames.${certName}`)}
+          {t(`certs:certNames.${certSlug}`)}
         </h3>
         <Table>
           <thead>
@@ -293,7 +294,7 @@ export class CertificationSettings extends Component {
       .map(({ link, title, id }) => (
         <tr className='project-row' key={id}>
           <td className='project-title col-sm-8'>
-            <Link to={link}>{t(`certs:projectNames.${title}`)}</Link>
+            <Link to={link}>{t(`certs:projectNames.${dasherize(title)}`)}</Link>
           </td>
           <td className='project-solution col-sm-4'>
             {this.getProjectSolution(id, title)}
@@ -371,7 +372,7 @@ export class CertificationSettings extends Component {
             })}
           </p>
           <ul>
-            <li>{t(`certs:certNames.${'Responsive Web Design'}`)}</li>
+            <li>{t(`certs:certNames.${'responsive-web-design'}`)}</li>
             <li>JavaScript Algorithms and Data Structures</li>
             <li>Front End Development Libraries</li>
             <li>Data Visualization</li>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This is a spike on #40998 - looking at the approach of making project and cert names translatable through an `i18n` config.

Many of the names come from maps in the code base that aren't easily translatable, which is why I took an approach here.