### PR TITLE
Changing documentation links for i18n ease

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -8,7 +8,7 @@ Yes - You can contribute to any of the 30+ languages we have enabled on our tran
 
 We have the user contributed translations live in Chinese (中文) and Spanish (Español). We intend to localize freeCodeCamp into several major world languages. You can read all about this in our [announcement here](https://www.freecodecamp.org/news/world-language-translation-effort).
 
-If you are interested in contributing to translations please makes sure you [read this guide](/how-to-translate-files) first.
+If you are interested in contributing to translations please makes sure you [read this guide](how-to-translate-files.md) first.
 
 ### How can I report a new bug?
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,3 @@
 ## Our contributing docs are available here: <https://contribute.freecodecamp.org>.
 
-Looking to edit these docs? Read [this document](https://contribute.freecodecamp.org/#/how-to-work-on-the-docs-theme) first.
+Looking to edit these docs? Read [this document](how-to-work-on-the-docs-theme.md) first.

--- a/docs/codebase-best-practices.md
+++ b/docs/codebase-best-practices.md
@@ -2,7 +2,7 @@
 
 ## General JavaScript
 
-In most cases, our [linter](how-to-setup-freecodecamp-locally?id=follow-these-steps-to-get-your-development-environment-ready) will warn of any formatting which goes against this codebase's preferred practice.
+In most cases, our [linter](how-to-setup-freecodecamp-locally.md#follow-these-steps-to-get-your-development-environment-ready) will warn of any formatting which goes against this codebase's preferred practice.
 
 It is encouraged to use functional components over class-based components.
 

--- a/docs/how-to-open-a-pull-request.md
+++ b/docs/how-to-open-a-pull-request.md
@@ -81,7 +81,7 @@ Our moderators will now take a look and leave you feedback. Please be patient wi
 And as always, feel free to ask questions on the ['Contributors' category on our forum](https://forum.freecodecamp.org/c/contributors) or [the contributors chat room](https://chat.freecodecamp.org/channel/contributors).
 
 > [!TIP]
-> If you are to be contributing more pull requests, we recommend you read the [making changes and syncing](how-to-setup-freecodecamp-locally.md?id=making-changes-locally) guidelines to avoid having to delete your fork.
+> If you are to be contributing more pull requests, we recommend you read the [making changes and syncing](how-to-setup-freecodecamp-locally.md#making-changes-locally) guidelines to avoid having to delete your fork.
 
 ## Conflicts on a pull request
 

--- a/docs/how-to-open-a-pull-request.md
+++ b/docs/how-to-open-a-pull-request.md
@@ -70,7 +70,7 @@ Some examples of good PRs titles would be:
 
    - This is very important when making changes that are not just edits to text content like documentation or a challenge description. Examples of changes that need local testing include JavaScript, CSS, or HTML which could change the functionality or layout of a page.
 
-   - If your PR affects the behaviour of a page it should be accompanied by corresponding [Cypress integration tests](/how-to-add-cypress-tests).
+   - If your PR affects the behaviour of a page it should be accompanied by corresponding [Cypress integration tests](how-to-add-cypress-tests.md).
 
 ## Feedback on pull requests
 
@@ -81,7 +81,7 @@ Our moderators will now take a look and leave you feedback. Please be patient wi
 And as always, feel free to ask questions on the ['Contributors' category on our forum](https://forum.freecodecamp.org/c/contributors) or [the contributors chat room](https://chat.freecodecamp.org/channel/contributors).
 
 > [!TIP]
-> If you are to be contributing more pull requests, we recommend you read the [making changes and syncing](https://contribute.freecodecamp.org/#/how-to-setup-freecodecamp-locally?id=making-changes-locally) guidelines to avoid having to delete your fork.
+> If you are to be contributing more pull requests, we recommend you read the [how-to-setup-freecodecamp-locally.md#making-changes-locally) guidelines to avoid having to delete your fork.
 
 ## Conflicts on a pull request
 

--- a/docs/how-to-open-a-pull-request.md
+++ b/docs/how-to-open-a-pull-request.md
@@ -81,7 +81,7 @@ Our moderators will now take a look and leave you feedback. Please be patient wi
 And as always, feel free to ask questions on the ['Contributors' category on our forum](https://forum.freecodecamp.org/c/contributors) or [the contributors chat room](https://chat.freecodecamp.org/channel/contributors).
 
 > [!TIP]
-> If you are to be contributing more pull requests, we recommend you read the [how-to-setup-freecodecamp-locally.md?id=making-changes-locally) guidelines to avoid having to delete your fork.
+> If you are to be contributing more pull requests, we recommend you read the [making changes and syncing](how-to-setup-freecodecamp-locally.md?id=making-changes-locally) guidelines to avoid having to delete your fork.
 
 ## Conflicts on a pull request
 

--- a/docs/how-to-open-a-pull-request.md
+++ b/docs/how-to-open-a-pull-request.md
@@ -81,7 +81,7 @@ Our moderators will now take a look and leave you feedback. Please be patient wi
 And as always, feel free to ask questions on the ['Contributors' category on our forum](https://forum.freecodecamp.org/c/contributors) or [the contributors chat room](https://chat.freecodecamp.org/channel/contributors).
 
 > [!TIP]
-> If you are to be contributing more pull requests, we recommend you read the [how-to-setup-freecodecamp-locally.md#making-changes-locally) guidelines to avoid having to delete your fork.
+> If you are to be contributing more pull requests, we recommend you read the [how-to-setup-freecodecamp-locally.md?id=making-changes-locally) guidelines to avoid having to delete your fork.
 
 ## Conflicts on a pull request
 

--- a/docs/how-to-open-a-pull-request.md
+++ b/docs/how-to-open-a-pull-request.md
@@ -3,7 +3,7 @@
 A pull request (PR) enables you to send changes from your fork on GitHub to freeCodeCamp.org's main repository. Once you are done making changes to the code, you can follow these guidelines to open a PR.
 
 > [!NOTE]
-> Your PR should be in English. See [here](https://contribute.freecodecamp.org/#/index?id=translations) for how to contribute translations.
+> Your PR should be in English. See [here](index.md#translations) for how to contribute translations.
 
 ## Prepare a good PR title
 

--- a/docs/how-to-proofread-files.md
+++ b/docs/how-to-proofread-files.md
@@ -15,7 +15,7 @@ You should see the list of projects you have been granted access to. Select the 
 You should now see the list of available files. Choose your file by selecting the `Proofread` button on the right of that file, then choosing `Proofreading` from the drop-down menu that appears.
 
 > [!NOTE]
-> If you are in this workspace view, but want to work on [translating a file](./how-to-translate-files.md) instead of proofreading, you may select `Crowdsourcing` from the dropdown menu instead.
+> If you are in this workspace view, but want to work on [translating a file](how-to-translate-files.md) instead of proofreading, you may select `Crowdsourcing` from the dropdown menu instead.
 
 ## Proofread Translations
 

--- a/docs/how-to-setup-freecodecamp-locally.md
+++ b/docs/how-to-setup-freecodecamp-locally.md
@@ -15,7 +15,7 @@ Start by installing the prerequisite software for your operating system.
 
 We primarily support development on Linux and Unix-based systems. Our staff and community contributors regularly work with the codebase using tools installed on Ubuntu and macOS.
 
-We also support Windows 10 via WSL2, which you can prepare by [reading this guide](/how-to-setup-wsl).
+We also support Windows 10 via WSL2, which you can prepare by [reading this guide](how-to-setup-wsl.md).
 
 Some community members also develop on Windows 10 natively with Git for Windows (Git Bash), and other tools installed on Windows. We do not have official support for such a setup at this time, we recommend using WSL2 instead.
 

--- a/docs/how-to-setup-wsl.md
+++ b/docs/how-to-setup-wsl.md
@@ -7,7 +7,7 @@
 >
 > **Docker Desktop for Windows**: See respective requirements for [Windows 10 Pro](https://docs.docker.com/docker-for-windows/install/#system-requirements) and [Windows 10 Home](https://docs.docker.com/docker-for-windows/install-windows-home/#system-requirements)
 
-This guide covers some common steps with the setup of WSL2. Once some of the common issues with WSL2 are addressed, you should be able to follow [this local setup guide](https://contribute.freecodecamp.org/#/how-to-setup-freecodecamp-locally) to work with freeCodeCamp on Windows running a WSL distro like Ubuntu.
+This guide covers some common steps with the setup of WSL2. Once some of the common issues with WSL2 are addressed, you should be able to follow [this local setup guide](how-to-setup-freecodecamp-locally.md) to work with freeCodeCamp on Windows running a WSL distro like Ubuntu.
 
 ## Enable WSL
 
@@ -120,7 +120,7 @@ npm install -g npm@latest
 
 ## Set up freeCodeCamp locally
 
-Now that you have installed the pre-requisites, follow [our local setup guide](https://contribute.freecodecamp.org/#/how-to-setup-freecodecamp-locally) to clone, install and setup freeCodeCamp locally on your machine.
+Now that you have installed the pre-requisites, follow [our local setup guide](how-to-setup-freecodecamp-locally.md) to clone, install and setup freeCodeCamp locally on your machine.
 
 > [!WARNING]
 >

--- a/docs/how-to-work-on-coding-challenges.md
+++ b/docs/how-to-work-on-coding-challenges.md
@@ -477,7 +477,7 @@ You are also able to test one challenge individually by performing the following
    npm run test -- -g challenge-title-goes-here
    ```
 
-Once you have verified that each challenge you've worked on passes the tests, [please create a pull request](https://github.com/freeCodeCamp/freeCodeCamp/blob/main/docs/how-to-open-a-pull-request.md).
+Once you have verified that each challenge you've worked on passes the tests, [please create a pull request](how-to-open-a-pull-request.md).
 
 > [!TIP]
 > You can set the environment variable `LOCALE` in the `.env` to the language of the challenge(s) you need to test.

--- a/docs/how-to-work-on-localized-client-webapp.md
+++ b/docs/how-to-work-on-localized-client-webapp.md
@@ -2,14 +2,14 @@
 
 The react based client web app that powers our learning platform is built using Gatsby. It is translated into various world languages using [react-i18next](https://react.i18next.com/) and [i18next](https://www.i18next.com/).
 
-You can learn more about setting up the client application locally for development by following [our local setup guide here](/how-to-setup-freecodecamp-locally). By default the application is available only in English.
+You can learn more about setting up the client application locally for development by following [our local setup guide here](how-to-setup-freecodecamp-locally.md). By default the application is available only in English.
 
 Once you have setup the project locally you should be able to follow this documentation to run the client in the language of your choice from the list of available languages.
 
 This could be helpful when you are working on a feature that specifically targets something that involves localization, and requires you to validate for instance a button's label in a different language.
 
 > [!TIP]
-> You do not need to follow this document for translating freeCodeCamp's curriculum or contributing documentation. Read [this guide here](./how-to-translate-files.md) instead.
+> You do not need to follow this document for translating freeCodeCamp's curriculum or contributing documentation. Read [this guide here](how-to-translate-files.md) instead.
 
 Let's understand how the i18n frameworks and tooling work.
 
@@ -68,7 +68,7 @@ Some of these files are translated on our translation platform (Crowdin), some a
 
 - The `intro.json` file contains the key-value pairs for the introduction text on the certification pages.
 
-  If you want to add/update translations for the keys please [read this guide here](/how-to-translate-files.md).
+  If you want to add/update translations for the keys please [read this guide here](how-to-translate-files.md).
 
 **Files NOT translated on our translations platform:**
 

--- a/docs/how-to-work-on-practice-projects.md
+++ b/docs/how-to-work-on-practice-projects.md
@@ -12,7 +12,7 @@ If you want to create new steps, the following tools simplify that process.
 
 A one-off script that will automatically add the next step based on the last step numbered as `part-xxx.md` where `xxx` represents the 3-digit step number of the last step. The challenge seed code will use the previous step's challenge seed code with the editable region markers (ERMs) removed.
 
-**Note:** This script also runs [reorder-steps](how-to-work-on-practice-projects#reorder-steps).
+**Note:** This script also runs [reorder-steps](#reorder-steps).
 
 ### How to run script:
 
@@ -27,7 +27,7 @@ npm run create-next-step
 
 A one-off script that automatically adds a specified number of steps at a specific starting step number. The challenge seed code for all steps created will be empty.
 
-**Note:** This script also runs [reorder-steps](how-to-work-on-practice-projects#reorder-steps).
+**Note:** This script also runs [reorder-steps](#reorder-steps).
 
 ### How to run script:
 
@@ -42,7 +42,7 @@ npm run create-empty-steps start=X num=Y # where X is the starting step number a
 
 A one-off script that automatically adds a new step between two existing consecutive steps. The challenge seed code will use the existing starting step's challenge seed code with the editable region markers (ERMs) removed.
 
-**Note:** This script also runs [reorder-steps](how-to-work-on-practice-projects#reorder-steps).
+**Note:** This script also runs [reorder-steps](#reorder-steps).
 
 ### How to run script:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ You are welcome to:
 - Help us fix bugs in freeCodeCamp.org's [learning platform](#learning-platform).
 - [Help us translate](#translations) freeCodeCamp.org to world languages.
 
-We answer the most common questions about contributing [in our contributor FAQ](/FAQ.md).
+We answer the most common questions about contributing [in our contributor FAQ](FAQ.md).
 
 ## Curriculum
 

--- a/docs/moderator-handbook.md
+++ b/docs/moderator-handbook.md
@@ -20,7 +20,7 @@ freeCodeCamp is an inclusive community, and we need to keep it that way.
 We have a single code of conduct that governs our entire community. The fewer the rules, the easier they are to remember. You can read those rules and commit them to memory [here](https://code-of-conduct.freecodecamp.org).
 
 > [!NOTE]
-> As a moderator we would add you to one or more teams on GitHub, our community forum(s) & chat servers. If you are missing access on a platform that you would like to moderate please [reach out to a staff member](/FAQ?id=additional-assistance).
+> As a moderator we would add you to one or more teams on GitHub, our community forum(s) & chat servers. If you are missing access on a platform that you would like to moderate please [reach out to a staff member](FAQ.md#additional-assistance).
 
 ## Moderating GitHub
 
@@ -41,7 +41,7 @@ You can help us organize and triage the issue reports by applying labels from [t
 
 Please pay special attention to the labels `"help wanted"` and `"first timers only"`. These are to be added to threads that you think can be opened up to potential contributors for making a pull request.
 
-A `"first timer only"` label should be applied to a trivial issue (ex. a typo fix) and should include additional information. You can use this [reply template](/moderator-handbook?id=first-timer-only-issues) for triage.
+A `"first timer only"` label should be applied to a trivial issue (ex. a typo fix) and should include additional information. You can use this [reply template](moderator-handbook.md#first-timer-only-issues) for triage.
 
 #### Closing Stale, Outdated, Inactive Issues and Pull Requests
 
@@ -52,7 +52,7 @@ A `"first timer only"` label should be applied to a trivial issue (ex. a typo fi
 - If the contributor asks for additional assistance or even time, the above can be relaxed and revisited after a response is given. In any case, the mods should use their best judgment to resolve the outstanding PR's status.
 
 > [!TIP]
-> We recommend you use this list of standard [reply templates](https://contribute.freecodecamp.org/#/moderator-handbook?id=reply-templates) while triaging issues.
+> We recommend you use this list of standard [reply templates](moderator-handbook.md#reply-templates) while triaging issues.
 
 ### Moderating Pull Requests
 
@@ -66,7 +66,7 @@ Pull Requests (PRs) are how contributors submit changes to freeCodeCamp's reposi
 
    You can also review these right on GitHub and decide whether to merge them. We need to be a bit more careful about these because millions of people will encounter this text as they work through the freeCodeCamp curriculum. Does the pull request make the text more clear without making it much longer? Are the edits relevant and not overly pedantic? Remember that our goal is for challenges to be as clear and as short as possible. They aren't the place for obscure details. Contributors may try to add links to resources to the challenges.
 
-   You can close invalid pull requests and reply to them with these [reply templates](https://contribute.freecodecamp.org/#/moderator-handbook?id=closing-invalid-pull-requests).
+   You can close invalid pull requests and reply to them with these [reply templates](moderator-handbook.md#closing-invalid-pull-requests).
 
    If the change looks good, please ensure to leave an approval with a "LGTM" comment. Once a pull request gets at least two approvals (including yours) from the moderators or the dev-team, you can go ahead and merge it.
 
@@ -78,7 +78,7 @@ Pull Requests (PRs) are how contributors submit changes to freeCodeCamp's reposi
 
    Some contributors may try to add additional tests to cover pedantic corner-cases. We need to be careful to not make the challenge too complicated. These challenges and their tests should be as simple and intuitive as possible. Aside from the algorithm challenges and interview prep section, learners should be able to solve each challenge within about 2 minutes.
 
-   You can close invalid pull requests and reply to them with these [reply templates](https://contribute.freecodecamp.org/#/moderator-handbook?id=closing-invalid-pull-requests).
+   You can close invalid pull requests and reply to them with these [reply templates](moderator-handbook.md#closing-invalid-pull-requests).
 
    If the change looks good, please ensure to leave an approval with a "LGTM" comment. Once a pull request gets at least two approvals (including yours) from the moderators or the dev-team, you can go ahead and merge it.
 
@@ -145,7 +145,7 @@ Often, a pull request will be low effort. You can usually tell this immediately 
 
 There are also situations where the contributor is trying to add a link to their website, include a library they created, or have a frivolous edit that doesn't help anyone but themselves.
 
-You can close invalid pull requests and reply to them with these [reply templates](https://contribute.freecodecamp.org/#/moderator-handbook?id=closing-invalid-pull-requests).
+You can close invalid pull requests and reply to them with these [reply templates](moderator-handbook.md#closing-invalid-pull-requests).
 
 #### Other guidelines for Moderators on GitHub
 
@@ -393,7 +393,7 @@ Once you resolve these issues, we will be able to review your PR and merge it. �
 
 ---
 
-Feel free to reference the [contributing guidelines](https://contribute.freecodecamp.org/#/how-to-work-on-coding-challenges?id=testing-challenges) for instructions on running the CI build locally. ✅
+Feel free to reference the [contributing guidelines](how-to-work-on-coding-challenges.md#testing-challenges) for instructions on running the CI build locally. ✅
 ```
 
 ### Syncing Fork


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I have opened this pull request, because many links between translated documentation pages link back to the English version.
The few that worked had a relative link to an other md file, so I went through the links to other documentation pages and changed them to be a relative link to an other md file. So translators don't need to translate the links themselves to have this working.
In this way I imagine that crowdin will create the files with those links, and then docsify convert them automatically to links to other pages in the same language/folder. The links to specific sections will still have to be fixed by translators, as the id depends on the header content.

I think I found them all but I can be wrong.