### PR TITLE
feat: locale specific help posts

### DIFF
--- a/client/i18n/locales/chinese-traditional/links.json
+++ b/client/i18n/locales/chinese-traditional/links.json
@@ -18,6 +18,11 @@
   "nav": {
     "forum": "https://chinese.freecodecamp.org/forum/",
     "news": "https://chinese.freecodecamp.org/news/"
+  },
+  "help": {
+    "HTML-CSS": "front-end",
+    "JavaScript": "front-end",
+    "Python": "curriculum",
+    "Relational Databases": "curriculum"
   }
-  
 }

--- a/client/i18n/locales/chinese/links.json
+++ b/client/i18n/locales/chinese/links.json
@@ -18,6 +18,11 @@
   "nav": {
     "forum": "https://chinese.freecodecamp.org/forum/",
     "news": "https://chinese.freecodecamp.org/news/"
+  },
+  "help": {
+    "HTML-CSS": "front-end",
+    "JavaScript": "front-end",
+    "Python": "curriculum",
+    "Relational Databases": "curriculum"
   }
-  
 }

--- a/client/i18n/locales/english/links.json
+++ b/client/i18n/locales/english/links.json
@@ -18,5 +18,11 @@
   "nav": {
     "forum": "https://forum.freecodecamp.org/",
     "news": "https://freecodecamp.org/news/"
+  },
+  "help": {
+    "HTML-CSS": "HTML-CSS",
+    "JavaScript": "JavaScript",
+    "Python": "Python",
+    "Relational Databases": "Relational Databases"
   }
 }

--- a/client/i18n/locales/espanol/links.json
+++ b/client/i18n/locales/espanol/links.json
@@ -18,5 +18,11 @@
   "nav": {
     "forum": "https://forum.freecodecamp.org/c/espanol/",
     "news": "https://freecodecamp.org/espanol/news/"
+  },
+  "help": {
+    "HTML-CSS": "Espanol/HTML-CSS",
+    "JavaScript": "Espanol/JavaScript",
+    "Python": "Espanol/Python",
+    "Relational Databases": "Espanol/Relational Databases"
   }
 }

--- a/client/i18n/locales/italian/links.json
+++ b/client/i18n/locales/italian/links.json
@@ -18,5 +18,11 @@
   "nav": {
     "forum": "https://forum.freecodecamp.org/c/italiano/",
     "news": "https://freecodecamp.org/italian/news/"
+  },
+  "help": {
+    "HTML-CSS": "Italiano/HTML-CSS",
+    "JavaScript": "Italiano/JavaScript",
+    "Python": "Italiano/Python",
+    "Relational Databases": "Italiano/Relational Databases"
   }
 }

--- a/client/i18n/locales/portuguese/links.json
+++ b/client/i18n/locales/portuguese/links.json
@@ -18,5 +18,11 @@
   "nav": {
     "forum": "https://forum.freecodecamp.org/c/portugues/",
     "news": "https://freecodecamp.org/portuguese/news/"
+  },
+  "help": {
+    "HTML-CSS": "Portugues/HTML-CSS",
+    "JavaScript": "Portugues/JavaScript",
+    "Python": "Portugues/Python",
+    "Relational Databases": "Portugues/Relational Databases"
   }
 }

--- a/client/src/templates/Challenges/redux/create-question-epic.js
+++ b/client/src/templates/Challenges/redux/create-question-epic.js
@@ -81,7 +81,9 @@ function createQuestionEpic(action$, state$, { window }) {
         )}\n${i18next.t('forum-help.add-code-three')}\n\n\`\`\`\n${endingText}`
       );
 
-      const category = window.encodeURIComponent(helpCategory || 'Help');
+      const category = window.encodeURIComponent(
+        i18next.t('links:help.' + helpCategory || 'Help')
+      );
 
       const studentCode = window.encodeURIComponent(textMessage);
       const altStudentCode = window.encodeURIComponent(altTextMessage);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #41015 (the translation of the forum post content was implemented a while ago)

<!-- Feel free to add any additional description of changes below this line -->
This PR adds to the `links.json` files to allow us to translate the `helpCategory` into locale-specific categories. Campers on the spanish version of the site, now, will be able to ask for help in the Espanol JavaScript category instead of the English.