### PR TITLE
fix: unhide this string

### DIFF
--- a/.github/workflows/crowdin-i18n-curriculum-upload.yml
+++ b/.github/workflows/crowdin-i18n-curriculum-upload.yml
@@ -71,3 +71,13 @@ jobs:
           CROWDIN_API_URL: 'https://freecodecamp.crowdin.com/api/v2/'
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID_CURRICULUM }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_CAMPERBOT_SERVICE_TOKEN }}
+
+      - name: Unhide Title of Use && For a More Concise Conditional
+        uses: ./tools/crowdin/actions/unhide-specific-string
+        with:
+          filename: 'react/use--for-a-more-concise-conditional.md'
+          string-content: 'Use &amp;&amp; for a More Concise Conditional'
+        env:
+          CROWDIN_API_URL: 'https://freecodecamp.crowdin.com/api/v2/'
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID_CURRICULUM }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_CAMPERBOT_SERVICE_TOKEN }}

--- a/tools/crowdin/actions/unhide-specific-string/action.yml
+++ b/tools/crowdin/actions/unhide-specific-string/action.yml
@@ -1,0 +1,12 @@
+name: 'Unhide Specific String'
+description: "Updates a specific string to be not hidden"
+runs:
+  using: 'node12'
+  main: './index.js'
+inputs:
+  filename:
+    description: 'name of file with specific string to hide'
+    required: true
+  string-content:
+    description: 'text content of string to unhide'
+    required: true

--- a/tools/crowdin/actions/unhide-specific-string/index.js
+++ b/tools/crowdin/actions/unhide-specific-string/index.js
@@ -1,0 +1,34 @@
+require('dotenv').config({ path: `${__dirname}/../../.env` });
+const core = require('@actions/core');
+const { getFiles } = require('../../utils/files');
+const { getStrings, changeHiddenStatus } = require('../../utils/strings');
+// eslint-disable-next-line import/no-unresolved
+
+const filename = core.getInput('filename');
+const stringContent = core.getInput('string-content');
+
+const hideString = async (projectId, fileName, string) => {
+  const fileResponse = await getFiles(projectId);
+  const targetFile = fileResponse.find(el => el.path.endsWith(filename));
+  if (!targetFile) {
+    core.setFailed(`${fileName} was not found.`);
+    return;
+  }
+
+  const stringResponse = await getStrings({
+    projectId,
+    fileId: targetFile.fileId
+  });
+
+  const targetString = stringResponse.find(el => el.data.text === string);
+  if (!targetString) {
+    core.setFailed(`${string} was not found.`);
+    return;
+  }
+
+  await changeHiddenStatus(projectId, targetString.data.id, false);
+  console.log('string unhidden!');
+};
+
+const projectId = process.env.CROWDIN_PROJECT_ID;
+hideString(projectId, filename, stringContent);

--- a/tools/crowdin/actions/unhide-specific-string/index.js
+++ b/tools/crowdin/actions/unhide-specific-string/index.js
@@ -2,7 +2,6 @@ require('dotenv').config({ path: `${__dirname}/../../.env` });
 const core = require('@actions/core');
 const { getFiles } = require('../../utils/files');
 const { getStrings, changeHiddenStatus } = require('../../utils/strings');
-// eslint-disable-next-line import/no-unresolved
 
 const filename = core.getInput('filename');
 const stringContent = core.getInput('string-content');


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #42656 

<!-- Feel free to add any additional description of changes below this line -->
Okay, I'm not sure why this string is being hidden in the workflow, but since it's a one-off case I went ahead and added a step to go back and unhide it.

This will allow us to unhide other individual strings in the future, if needed.