### PR TITLE
fix(curriculum): check only values set via style tag 

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/set-the-font-size-for-multiple-heading-elements.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/set-the-font-size-for-multiple-heading-elements.md
@@ -29,38 +29,43 @@ The `font-size` property is used to specify how large the text is in a given ele
 Your code should set the `font-size` property for the `h1` tag to 68 pixels.
 
 ```js
-assert($('h1').css('font-size') == '68px');
+ const fontSizeOfh1 = new __helpers.CSSHelp(document).getStyle('h1')?.getPropertyValue('font-size');
+ assert(fontSizeOfh1 === '68px');
 ```
 
 Your code should set the `font-size` property for the `h2` tag to 52 pixels.
 
 ```js
-assert($('h2').css('font-size') == '52px');
+ const fontSizeOfh2 = new __helpers.CSSHelp(document).getStyle('h2')?.getPropertyValue('font-size');
+ assert(fontSizeOfh2 === '52px');
 ```
 
 Your code should set the `font-size` property for the `h3` tag to 40 pixels.
 
 ```js
-assert($('h3').css('font-size') == '40px');
+ const fontSizeOfh3 = new __helpers.CSSHelp(document).getStyle('h3')?.getPropertyValue('font-size');
+ assert(fontSizeOfh3 === '40px');
 ```
 
 Your code should set the `font-size` property for the `h4` tag to 32 pixels.
 
 ```js
-assert($('h4').css('font-size') == '32px');
+ const fontSizeOfh4 = new __helpers.CSSHelp(document).getStyle('h4')?.getPropertyValue('font-size');
+ assert(fontSizeOfh4 === '32px');
 ```
 
 Your code should set the `font-size` property for the `h5` tag to 21 pixels.
 
 ```js
-assert($('h5').css('font-size') == '21px');
+ const fontSizeOfh5 = new __helpers.CSSHelp(document).getStyle('h5')?.getPropertyValue('font-size');
+ assert(fontSizeOfh5 === '21px');
 ```
 
 Your code should set the `font-size` property for the `h6` tag to 14 pixels.
 
 ```js
-const regex = /h6\s*\{\s*font-size\s*:\s*14px\s*(;\s*\}|\})/i;
-assert.strictEqual(true, regex.test(code));
+ const fontSizeOfh6 = new __helpers.CSSHelp(document).getStyle('h6')?.getPropertyValue('font-size');
+ assert(fontSizeOfh6 === '14px');
 ```
 
 # --seed--


### PR DESCRIPTION
**Details**: Incorrect answer passes test for Set the font-size for Multiple Heading Elements challenge

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #43264

<!-- Feel free to add any additional description of changes below this line -->
```
<style>
<h1 style="font-size: 68px">This is h1 text</h1>
<h2 style="font-size: 52px">This is h2 text</h2>
<h3 style="font-size: 40px">This is h3 text</h3>
<h4 style="font-size: 32px">This is h4 text</h4>
<h5 style="font-size: 21px">This is h5 text</h5>
h6 {
  font-size:14px;
}
</style>
<h1 style="font-size: 68px">This is h1 text</h1>
<h2 style="font-size: 52px">This is h2 text</h2>
<h3 style="font-size: 40px">This is h3 text</h3>
<h4 style="font-size: 32px">This is h4 text</h4>
<h5 style="font-size: 21px">This is h5 text</h5>
<h6 style="font-size: 14px">This is h6 text</h6>
```
issue: All of those headings in the style tags are supposed to be in the correct css format.
But it looks like the test will just accept one of them in the correct format.
The challenge is supposed to focus on just the style tags. Not inline-styles.

I think only this correct answer should be accepted.
```
<style>
  h1 {
    font-size: 68px;
  }

  h2 {
    font-size: 52px
  }

  h3 {
    font-size: 40px;
  }

  h4 {
    font-size: 32px;
  }

  h5 {
    font-size: 21px;
  }

  h6 {
    font-size: 14px;
  }
</style>
<h1>This is h1 text</h1>
<h2>This is h2 text</h2>
<h3>This is h3 text</h3>
<h4>This is h4 text</h4>
<h5>This is h5 text</h5>
<h6>This is h6 text</h6>

```
**Affected page**
https://www.freecodecamp.org/learn/responsive-web-design/applied-visual-design/set-the-font-size-for-multiple-heading-elements

**Solution:** Used CSSHelp Component so that the test only check the values of the stylesheet and ignore inline-styles.