### PR TITLE
fix:  Account deletion redirects too quickly

### DIFF
--- a/client/src/redux/settings/danger-zone-saga.js
+++ b/client/src/redux/settings/danger-zone-saga.js
@@ -7,15 +7,26 @@ import { postResetProgress, postDeleteAccount } from '../../utils/ajax';
 import { actionTypes as appTypes } from '../action-types';
 import { deleteAccountError, resetProgressError } from './';
 
+// Dealy funtion
+function wait(ms) {
+  var start = new Date().getTime();
+  var end = start;
+  while (end < start + ms) {
+    end = new Date().getTime();
+  }
+}
+
 function* deleteAccountSaga() {
   try {
     yield call(postDeleteAccount);
     yield put(
       createFlashMessage({
         type: 'info',
-        message: 'flash.account-deleted'
+        message: 'Your account has been successfully deleted'
       })
     );
+    // add delay of 3 seconds
+    wait(3000);
     // remove current user information from application state
     yield put(resetUserData());
     yield call(navigate, '/');
@@ -30,9 +41,11 @@ function* resetProgressSaga() {
     yield put(
       createFlashMessage({
         type: 'info',
-        message: 'flash.progress-reset'
+        message: 'Your progress has been reset'
       })
     );
+    // add delay of 3 seconds
+    wait(3000);
     // refresh current user data in application state
     yield put(fetchUser());
     // wait for the refresh to complete

--- a/client/src/redux/settings/danger-zone-saga.js
+++ b/client/src/redux/settings/danger-zone-saga.js
@@ -22,7 +22,7 @@ function* deleteAccountSaga() {
     yield put(
       createFlashMessage({
         type: 'info',
-        message: 'Your account has been successfully deleted'
+        message: 'flash.account-deleted'
       })
     );
     // add delay of 3 seconds
@@ -41,7 +41,7 @@ function* resetProgressSaga() {
     yield put(
       createFlashMessage({
         type: 'info',
-        message: 'Your progress has been reset'
+        message: 'flash.progress-reset'
       })
     );
     // add delay of 3 seconds


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #39508

Added Time Delay function which will display account deletion message upto 3 seconds before redirecting.


