### PR TITLE
fix: button width and text not matching

### DIFF
--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -27,9 +27,10 @@ body {
 
 .btn-cta-big {
   max-height: 100%;
-  font-size: 1.3rem;
+  font-size: 1.5rem;
   white-space: normal;
   width: 100%;
+  max-width: 500px;
   padding: 5px;
   margin: 0 auto;
 }
@@ -98,7 +99,7 @@ p {
   background-color: var(--selection-color);
 }
 
-@media (max-width: 1000px) {
+@media (max-width: 500px) {
   .big-heading {
     font-size: 1.5rem !important;
   }
@@ -117,7 +118,7 @@ p {
   }
 }
 
-@media (min-width: 1000px) {
+@media (max-width: 1199px) {
   .btn-cta-big {
     font-size: 1.3rem;
   }

--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -27,10 +27,9 @@ body {
 
 .btn-cta-big {
   max-height: 100%;
-  font-size: 1.5rem;
+  font-size: 1.3rem;
   white-space: normal;
   width: 100%;
-  max-width: 500px;
   padding: 5px;
   margin: 0 auto;
 }
@@ -99,7 +98,7 @@ p {
   background-color: var(--selection-color);
 }
 
-@media (max-width: 500px) {
+@media (max-width: 1000px) {
   .big-heading {
     font-size: 1.5rem !important;
   }
@@ -118,7 +117,7 @@ p {
   }
 }
 
-@media (max-width: 1199px) {
+@media (min-width: 1000px) {
   .btn-cta-big {
     font-size: 1.3rem;
   }

--- a/client/src/templates/Challenges/components/completion-modal.css
+++ b/client/src/templates/Challenges/components/completion-modal.css
@@ -35,6 +35,11 @@
   animation: success-icon-animation 150ms linear 100ms forwards;
 }
 
+.challenge-success-modal .btn-cta-big {
+  max-width: 100%;
+  font-size: 1.3rem;
+}
+
 @keyframes success-icon-animation {
   100% {
     opacity: 1;
@@ -97,7 +102,10 @@
   .challenge-success-modal .btn-lg {
     font-size: 1rem;
   }
-
+  .challenge-success-modal .btn-cta-big {
+    max-width: 100%;
+    font-size: 1rem;
+  }
   .completion-modal-body {
     min-height: 340px;
   }

--- a/client/src/templates/Challenges/components/completion-modal.css
+++ b/client/src/templates/Challenges/components/completion-modal.css
@@ -95,7 +95,7 @@
 
 @media screen and (max-width: 991px) {
   .challenge-success-modal .btn-lg {
-    font-size: 16px;
+    font-size: 1rem;
   }
 
   .completion-modal-body {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #43357

<!-- Feel free to add any additional description of changes below this line -->
Button's width and text should now be the same as other buttons on the modal and should be responsive.
