### PR TITLE
fix(tools): correct files -> challengeFiles

### DIFF
--- a/tools/challenge-helper-scripts/utils.js
+++ b/tools/challenge-helper-scripts/utils.js
@@ -113,7 +113,7 @@ const reorderSteps = () => {
 };
 
 const getChallengeSeeds = challengeFilePath => {
-  return parseMDSync(challengeFilePath).files;
+  return parseMDSync(challengeFilePath).challengeFiles;
 };
 
 module.exports = {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

We (I) changed `files -> challengeFiles`, but did not change one location in the curriculum helper script. So, running `npm run create-next-step` does not add the `challengeFiles`