### PR TITLE
fix(client):make menu bar disappear after user chooses item from it on landing page

### DIFF
--- a/client/src/components/Header/components/universal-nav.tsx
+++ b/client/src/components/Header/components/universal-nav.tsx
@@ -37,7 +37,7 @@ export const UniversalNav = ({
 
   const search =
     typeof window !== `undefined` && isLanding(window.location.pathname) ? (
-      <SearchBarOptimized />
+      <SearchBarOptimized innerRef={searchBarRef} />
     ) : (
       <SearchBar innerRef={searchBarRef} />
     );

--- a/client/src/components/Header/index.tsx
+++ b/client/src/components/Header/index.tsx
@@ -44,6 +44,12 @@ export class Header extends React.Component<
       this.state.displayMenu &&
       this.menuButtonRef.current &&
       !this.menuButtonRef.current.contains(event.target) &&
+      // here we are making this check
+      // to know if the user is using the search bar or not
+      // and if he does we won't invoke the function
+      // becasue if we don't do this check
+      // clicking on the search bar will close the menu bar in small screens
+      // including the search bar itself as it was moved to the menu bar in small screens
       this.searchBarRef.current &&
       !this.searchBarRef.current.contains(event.target)
     ) {

--- a/client/src/components/Header/index.tsx
+++ b/client/src/components/Header/index.tsx
@@ -43,9 +43,7 @@ export class Header extends React.Component<
     if (
       this.state.displayMenu &&
       this.menuButtonRef.current &&
-      !this.menuButtonRef.current.contains(event.target) &&
-      this.searchBarRef.current &&
-      !this.searchBarRef.current.contains(event.target)
+      !this.menuButtonRef.current.contains(event.target)
     ) {
       this.toggleDisplayMenu();
     }

--- a/client/src/components/Header/index.tsx
+++ b/client/src/components/Header/index.tsx
@@ -26,6 +26,7 @@ export class Header extends React.Component<
       displayMenu: false
     };
     this.menuButtonRef = React.createRef();
+    this.searchBarRef = React.createRef();
     this.handleClickOutside = this.handleClickOutside.bind(this);
     this.toggleDisplayMenu = this.toggleDisplayMenu.bind(this);
   }

--- a/client/src/components/Header/index.tsx
+++ b/client/src/components/Header/index.tsx
@@ -43,7 +43,9 @@ export class Header extends React.Component<
     if (
       this.state.displayMenu &&
       this.menuButtonRef.current &&
-      !this.menuButtonRef.current.contains(event.target)
+      !this.menuButtonRef.current.contains(event.target) &&
+      this.searchBarRef.current &&
+      !this.searchBarRef.current.contains(event.target)
     ) {
       this.toggleDisplayMenu();
     }

--- a/client/src/components/Header/index.tsx
+++ b/client/src/components/Header/index.tsx
@@ -44,12 +44,8 @@ export class Header extends React.Component<
       this.state.displayMenu &&
       this.menuButtonRef.current &&
       !this.menuButtonRef.current.contains(event.target) &&
-      // here we are making this check
-      // to know if the user is using the search bar or not
-      // and if he does we won't invoke the function
-      // becasue if we don't do this check
-      // clicking on the search bar will close the menu bar in small screens
-      // including the search bar itself as it was moved to the menu bar in small screens
+      // since the search bar is part of the menu on small screens, clicks on
+      // the search bar should not toggle the menu
       this.searchBarRef.current &&
       !this.searchBarRef.current.contains(event.target)
     ) {

--- a/client/src/components/Header/index.tsx
+++ b/client/src/components/Header/index.tsx
@@ -26,7 +26,6 @@ export class Header extends React.Component<
       displayMenu: false
     };
     this.menuButtonRef = React.createRef();
-    this.searchBarRef = React.createRef();
     this.handleClickOutside = this.handleClickOutside.bind(this);
     this.toggleDisplayMenu = this.toggleDisplayMenu.bind(this);
   }

--- a/client/src/components/search/searchBar/search-bar-optimized.tsx
+++ b/client/src/components/search/searchBar/search-bar-optimized.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import Magnifier from '../../../assets/icons/Magnifier';
 import { searchPageUrl } from '../../../utils/algolia-locale-setup';
 
-type innerRefPrototype = {
+type Props = {
   innerRef?: React.RefObject<HTMLDivElement>;
 };
 

--- a/client/src/components/search/searchBar/search-bar-optimized.tsx
+++ b/client/src/components/search/searchBar/search-bar-optimized.tsx
@@ -3,7 +3,11 @@ import { useTranslation } from 'react-i18next';
 import Magnifier from '../../../assets/icons/Magnifier';
 import { searchPageUrl } from '../../../utils/algolia-locale-setup';
 
-const SearchBarOptimized = (): JSX.Element => {
+type innerRefPrototype = {
+  innerRef?: React.RefObject<HTMLDivElement>;
+};
+
+const SearchBarOptimized = ({ innerRef }: innerRefPrototype): JSX.Element => {
   const { t } = useTranslation();
   const placeholder = t('search.placeholder');
   const searchUrl = searchPageUrl;
@@ -18,7 +22,7 @@ const SearchBarOptimized = (): JSX.Element => {
   };
 
   return (
-    <div className='fcc_searchBar' data-testid='fcc_searchBar'>
+    <div className='fcc_searchBar' data-testid='fcc_searchBar' ref={innerRef}>
       <div className='fcc_search_wrapper'>
         <div className='ais-SearchBox' data-cy='ais-SearchBox'>
           <form

--- a/client/src/components/search/searchBar/search-bar-optimized.tsx
+++ b/client/src/components/search/searchBar/search-bar-optimized.tsx
@@ -7,7 +7,7 @@ type Props = {
   innerRef?: React.RefObject<HTMLDivElement>;
 };
 
-const SearchBarOptimized = ({ innerRef }: innerRefPrototype): JSX.Element => {
+const SearchBarOptimized = ({ innerRef }: Props): JSX.Element => {
   const { t } = useTranslation();
   const placeholder = t('search.placeholder');
   const searchUrl = searchPageUrl;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #43448

I found out that what was causing this problem is that React for some reason doesn't create a ref for the search bar on the first render(still digging on why it does so), so when the function handleClickOutside is triggered the menu bar doesn't close because it has a condition that says close it only if there is a seearchBarRef.current.
What I did here is that I removed the searchBarRef from the logic, I understand this might not be the best solution, I am just opening a discussion here to find out the importance of the searchBarRef in the codebase logic and then try to find a better solution.
