### PR TITLE
feat: enable japanese docs

### DIFF
--- a/.github/workflows/crowdin-i18n-docs.download.yml
+++ b/.github/workflows/crowdin-i18n-docs.download.yml
@@ -162,6 +162,40 @@ jobs:
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID_DOCS }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_CAMPERBOT_SERVICE_TOKEN }}
 
+      ##### Download Japanese #####
+      - name: Crowdin Download Japanese Translations
+        uses: crowdin/github-action@master
+        # options: https://github.com/crowdin/github-action/blob/master/action.yml
+        with:
+          # uploads
+          upload_sources: false
+          upload_translations: false
+          auto_approve_imported: false
+          import_eq_suggestions: false
+
+          # downloads
+          download_translations: true
+          download_language: ja
+          skip_untranslated_files: false
+          export_only_approved: true
+
+          push_translations: false
+
+          # pull-request
+          create_pull_request: false
+
+          # global options
+          config: './config/crowdin/docs/crowdin.yml'
+          base_url: ${{ secrets.CROWDIN_BASE_URL_FCC }}
+
+          # Uncomment below to debug
+          # dryrun_action: true
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.CROWDIN_CAMPERBOT_PAT }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID_DOCS }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_CAMPERBOT_SERVICE_TOKEN }}
+
       # Create Commit
       - name: Commit Changes
         env:

--- a/docs/_translations.md
+++ b/docs/_translations.md
@@ -11,6 +11,7 @@
 - [Chinese](/i18n/chinese/index.md)
 - [English](/index.md)
 - [Español](/i18n/espanol/index.md)
+- [Japanese](/i18n/japanese/index.md)
 - [Portuguese](/i18n/portuguese/index.md)
 - [Italian](/i18n/italian/index.md)
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
The Japanese translation team have completed translating the "How to Translate Files" document. This PR adds Japanese to the docs download and the translation menu. 