### PR TITLE
fix: move ActionRow outside the ReflexContainer

### DIFF
--- a/client/src/components/layouts/learn.css
+++ b/client/src/components/layouts/learn.css
@@ -1,4 +1,6 @@
 #learn-app-wrapper .desktop-layout {
+  display: flex;
+  flex-direction: column;
   height: calc(
     100vh - var(--header-height, 0px) - var(--flash-message-height, 0px)
   );

--- a/client/src/templates/Challenges/classic/DesktopLayout.js
+++ b/client/src/templates/Challenges/classic/DesktopLayout.js
@@ -87,7 +87,7 @@ class DesktopLayout extends Component {
       layoutState;
 
     return (
-      <ReflexContainer className='desktop-layout' orientation='horizontal'>
+      <>
         {projectBasedChallenge && (
           <ActionRow
             block={block}
@@ -96,73 +96,75 @@ class DesktopLayout extends Component {
             superBlock={superBlock}
           />
         )}
-        <ReflexElement flex={8} {...reflexProps} {...resizeProps}>
-          <ReflexContainer orientation='vertical'>
-            {!projectBasedChallenge && (
+        <ReflexContainer className='desktop-layout' orientation='horizontal'>
+          <ReflexElement flex={8} {...reflexProps} {...resizeProps}>
+            <ReflexContainer orientation='vertical'>
+              {!projectBasedChallenge && (
+                <ReflexElement
+                  flex={instructionPane.flex}
+                  name='instructionPane'
+                  {...resizeProps}
+                >
+                  {instructions}
+                </ReflexElement>
+              )}
+              {!projectBasedChallenge && (
+                <ReflexSplitter propagate={true} {...resizeProps} />
+              )}
+
               <ReflexElement
-                flex={instructionPane.flex}
-                name='instructionPane'
+                flex={editorPane.flex}
+                name='editorPane'
                 {...resizeProps}
               >
-                {instructions}
-              </ReflexElement>
-            )}
-            {!projectBasedChallenge && (
-              <ReflexSplitter propagate={true} {...resizeProps} />
-            )}
-
-            <ReflexElement
-              flex={editorPane.flex}
-              name='editorPane'
-              {...resizeProps}
-            >
-              {challengeFile &&
-                showUpcomingChanges &&
-                !hasEditableBoundries && <EditorTabs />}
-              {challengeFile && (
-                <ReflexContainer
-                  key={challengeFile.fileKey}
-                  orientation='horizontal'
-                >
-                  <ReflexElement
-                    flex={codePane.flex}
-                    name='codePane'
-                    {...reflexProps}
-                    {...resizeProps}
+                {challengeFile &&
+                  showUpcomingChanges &&
+                  !hasEditableBoundries && <EditorTabs />}
+                {challengeFile && (
+                  <ReflexContainer
+                    key={challengeFile.fileKey}
+                    orientation='horizontal'
                   >
-                    {editor}
-                  </ReflexElement>
-                  {isConsoleDisplayable && (
-                    <ReflexSplitter propagate={true} {...resizeProps} />
-                  )}
-                  {isConsoleDisplayable && (
                     <ReflexElement
-                      flex={testsPane.flex}
-                      name='testsPane'
+                      flex={codePane.flex}
+                      name='codePane'
                       {...reflexProps}
                       {...resizeProps}
                     >
-                      {testOutput}
+                      {editor}
                     </ReflexElement>
-                  )}
-                </ReflexContainer>
-              )}
-            </ReflexElement>
-            {isPreviewDisplayable && (
-              <ReflexSplitter propagate={true} {...resizeProps} />
-            )}
-            {isPreviewDisplayable && (
-              <ReflexElement
-                flex={previewPane.flex}
-                name='previewPane'
-                {...resizeProps}
-              >
-                {preview}
+                    {isConsoleDisplayable && (
+                      <ReflexSplitter propagate={true} {...resizeProps} />
+                    )}
+                    {isConsoleDisplayable && (
+                      <ReflexElement
+                        flex={testsPane.flex}
+                        name='testsPane'
+                        {...reflexProps}
+                        {...resizeProps}
+                      >
+                        {testOutput}
+                      </ReflexElement>
+                    )}
+                  </ReflexContainer>
+                )}
               </ReflexElement>
-            )}
-          </ReflexContainer>
-        </ReflexElement>
-      </ReflexContainer>
+              {isPreviewDisplayable && (
+                <ReflexSplitter propagate={true} {...resizeProps} />
+              )}
+              {isPreviewDisplayable && (
+                <ReflexElement
+                  flex={previewPane.flex}
+                  name='previewPane'
+                  {...resizeProps}
+                >
+                  {preview}
+                </ReflexElement>
+              )}
+            </ReflexContainer>
+          </ReflexElement>
+        </ReflexContainer>
+      </>
     );
   }
 }

--- a/client/src/templates/Challenges/classic/DesktopLayout.js
+++ b/client/src/templates/Challenges/classic/DesktopLayout.js
@@ -36,9 +36,7 @@ const propTypes = {
 };
 
 const reflexProps = {
-  propagateDimensions: true,
-  renderOnResize: true,
-  renderOnResizeRate: 20
+  propagateDimensions: true
 };
 
 class DesktopLayout extends Component {

--- a/client/src/templates/Challenges/classic/DesktopLayout.js
+++ b/client/src/templates/Challenges/classic/DesktopLayout.js
@@ -87,7 +87,7 @@ class DesktopLayout extends Component {
       layoutState;
 
     return (
-      <>
+      <div className='desktop-layout'>
         {projectBasedChallenge && (
           <ActionRow
             block={block}
@@ -96,75 +96,71 @@ class DesktopLayout extends Component {
             superBlock={superBlock}
           />
         )}
-        <ReflexContainer className='desktop-layout' orientation='horizontal'>
-          <ReflexElement flex={8} {...reflexProps} {...resizeProps}>
-            <ReflexContainer orientation='vertical'>
-              {!projectBasedChallenge && (
-                <ReflexElement
-                  flex={instructionPane.flex}
-                  name='instructionPane'
-                  {...resizeProps}
-                >
-                  {instructions}
-                </ReflexElement>
-              )}
-              {!projectBasedChallenge && (
-                <ReflexSplitter propagate={true} {...resizeProps} />
-              )}
+        <ReflexContainer orientation='vertical'>
+          {!projectBasedChallenge && (
+            <ReflexElement
+              flex={instructionPane.flex}
+              name='instructionPane'
+              {...resizeProps}
+            >
+              {instructions}
+            </ReflexElement>
+          )}
+          {!projectBasedChallenge && (
+            <ReflexSplitter propagate={true} {...resizeProps} />
+          )}
 
-              <ReflexElement
-                flex={editorPane.flex}
-                name='editorPane'
-                {...resizeProps}
+          <ReflexElement
+            flex={editorPane.flex}
+            name='editorPane'
+            {...resizeProps}
+          >
+            {challengeFile && showUpcomingChanges && !hasEditableBoundries && (
+              <EditorTabs />
+            )}
+            {challengeFile && (
+              <ReflexContainer
+                key={challengeFile.fileKey}
+                orientation='horizontal'
               >
-                {challengeFile &&
-                  showUpcomingChanges &&
-                  !hasEditableBoundries && <EditorTabs />}
-                {challengeFile && (
-                  <ReflexContainer
-                    key={challengeFile.fileKey}
-                    orientation='horizontal'
-                  >
-                    <ReflexElement
-                      flex={codePane.flex}
-                      name='codePane'
-                      {...reflexProps}
-                      {...resizeProps}
-                    >
-                      {editor}
-                    </ReflexElement>
-                    {isConsoleDisplayable && (
-                      <ReflexSplitter propagate={true} {...resizeProps} />
-                    )}
-                    {isConsoleDisplayable && (
-                      <ReflexElement
-                        flex={testsPane.flex}
-                        name='testsPane'
-                        {...reflexProps}
-                        {...resizeProps}
-                      >
-                        {testOutput}
-                      </ReflexElement>
-                    )}
-                  </ReflexContainer>
-                )}
-              </ReflexElement>
-              {isPreviewDisplayable && (
-                <ReflexSplitter propagate={true} {...resizeProps} />
-              )}
-              {isPreviewDisplayable && (
                 <ReflexElement
-                  flex={previewPane.flex}
-                  name='previewPane'
+                  flex={codePane.flex}
+                  name='codePane'
+                  {...reflexProps}
                   {...resizeProps}
                 >
-                  {preview}
+                  {editor}
                 </ReflexElement>
-              )}
-            </ReflexContainer>
+                {isConsoleDisplayable && (
+                  <ReflexSplitter propagate={true} {...resizeProps} />
+                )}
+                {isConsoleDisplayable && (
+                  <ReflexElement
+                    flex={testsPane.flex}
+                    name='testsPane'
+                    {...reflexProps}
+                    {...resizeProps}
+                  >
+                    {testOutput}
+                  </ReflexElement>
+                )}
+              </ReflexContainer>
+            )}
           </ReflexElement>
+          {isPreviewDisplayable && (
+            <ReflexSplitter propagate={true} {...resizeProps} />
+          )}
+          {isPreviewDisplayable && (
+            <ReflexElement
+              flex={previewPane.flex}
+              name='previewPane'
+              {...resizeProps}
+            >
+              {preview}
+            </ReflexElement>
+          )}
         </ReflexContainer>
-      </>
+      </div>
     );
   }
 }

--- a/client/src/templates/Challenges/classic/MultifileEditor.js
+++ b/client/src/templates/Challenges/classic/MultifileEditor.js
@@ -98,9 +98,7 @@ class MultifileEditor extends Component {
     // editors.map(props => <EditorWrapper ...props>).join(<ReflexSplitter>)
     // ...probably! As long as we can put keys in the right places.
     const reflexProps = {
-      propagateDimensions: true,
-      renderOnResize: true,
-      renderOnResizeRate: 20
+      propagateDimensions: true
     };
 
     let splitterJSXRight, splitterHTMLRight, splitterCSSRight;


### PR DESCRIPTION
It does not need to be resizable.

There's a lot of diff noise, but the only change is that the ActionRow has been pulled out of the ReflexContainer.