### PR TITLE
feat: update editable region behaviour

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -238,7 +238,7 @@ const Editor = (props: EditorProps): JSX.Element => {
     suggestOnTriggerCharacters: false
   };
 
-  const getEditableRegion = () => {
+  const getEditableRegionFromRedux = () => {
     const { challengeFiles, fileKey } = props;
     const edRegBounds = challengeFiles?.find(
       challengeFile => challengeFile.fileKey === fileKey
@@ -266,7 +266,7 @@ const Editor = (props: EditorProps): JSX.Element => {
         modeMap[challengeFile?.ext ?? 'html']
       );
     data.model = model;
-    const editableRegion = getEditableRegion();
+    const editableRegion = getEditableRegionFromRedux();
 
     if (editableRegion.length === 2) decorateForbiddenRanges(editableRegion);
 
@@ -373,7 +373,7 @@ const Editor = (props: EditorProps): JSX.Element => {
     });
     editor.onDidFocusEditorWidget(() => props.setEditorFocusability(true));
 
-    const editableBoundaries = getEditableRegion();
+    const editableBoundaries = getEditableRegionFromRedux();
 
     if (editableBoundaries.length === 2) {
       const createWidget = (
@@ -1006,7 +1006,7 @@ const Editor = (props: EditorProps): JSX.Element => {
   }, [props.challengeFiles]);
   useEffect(() => {
     const { output, tests } = props;
-    const editableRegion = getEditableRegion();
+    const editableRegion = getEditableRegionFromRedux();
     if (editableRegion.length === 2) {
       const challengeComplete = tests.every(test => test.pass && !test.err);
       const chellengeHasErrors = tests.some(test => test.err);

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -448,7 +448,7 @@ const Editor = (props: EditorProps): JSX.Element => {
     // position of the overlayWidget (i.e. trigger it via onComputedHeight). If
     // not the editor may report the wrong value for position of the lines.
     const viewZone = {
-      afterLineNumber: getLineAfterDescriptionZone() - 1,
+      afterLineNumber: getLineBeforeEditableRegion(),
       heightInPx: domNode.offsetHeight,
       domNode: document.createElement('div'),
       onComputedHeight: () =>
@@ -479,7 +479,7 @@ const Editor = (props: EditorProps): JSX.Element => {
     // position of the overlayWidget (i.e. trigger it via onComputedHeight). If
     // not the editor may report the wrong value for position of the lines.
     const viewZone = {
-      afterLineNumber: getLineAfterEditableRegion() - 1,
+      afterLineNumber: getLastLineOfEditableRegion(),
       heightInPx: outputNode.offsetHeight,
       domNode: document.createElement('div'),
       onComputedHeight: () =>
@@ -667,21 +667,14 @@ const Editor = (props: EditorProps): JSX.Element => {
     return `${data.outputZoneTop}px`;
   }
 
-  // It's not possible to directly access the current view zone so we track
-  // the region it should cover instead.
-  function getLineAfterDescriptionZone() {
-    const range = data.model?.getDecorationRange(data.startEditDecId);
-    // if the first decoration is missing, this implies the region reaches the
-    // start of the editor.
-    return range ? range.endLineNumber + 1 : 1;
+  function getLineBeforeEditableRegion() {
+    const range = data.model?.getDecorationRange(data.insideEditDecId);
+    return range ? range.startLineNumber - 1 : 1;
   }
 
-  function getLineAfterEditableRegion() {
-    // TODO: handle the case that the editable region reaches the bottom of the
-    // editor
-    return (
-      data.model?.getDecorationRange(data.endEditDecId)?.startLineNumber ?? 1
-    );
+  function getLastLineOfEditableRegion() {
+    const range = data.model?.getDecorationRange(data.insideEditDecId);
+    return range ? range.endLineNumber : 1;
   }
 
   const translateRange = (range: IRange, lineDelta: number) => {


### PR DESCRIPTION
- refactor: remove ambiguity about editable region
- fix: make jaws follow the highlighted region
- fix: update the jaws on all content changes
- feat: make editable region 'absorb' text

![NewEditorBehaviour](https://user-images.githubusercontent.com/15801806/134379727-a4a9137a-08de-492e-aa1b-b86e108e7833.gif)
