### PR TITLE
fix : Added tests for curriculum order

### DIFF
--- a/curriculum/challenges/_meta/legacy-back-end-certification/meta.json
+++ b/curriculum/challenges/_meta/legacy-back-end-certification/meta.json
@@ -2,12 +2,12 @@
   "name": "Legacy Back End Certification",
   "isUpcomingChange": false,
   "dashedName": "legacy-back-end-certification",
-  "order": 1,
+  "order": 13,
   "time": "",
   "template": "",
   "required": [],
   "superBlock": "certifications",
-  "superOrder": 12,
+  "superOrder": 0,
   "challengeOrder": [
     [
       "660add10cb82ac38a17513be",

--- a/curriculum/challenges/_meta/legacy-data-visualization-certification/meta.json
+++ b/curriculum/challenges/_meta/legacy-data-visualization-certification/meta.json
@@ -2,12 +2,12 @@
   "name": "Legacy Data Visualization Certification",
   "isUpcomingChange": false,
   "dashedName": "legacy-data-visualization-certification",
-  "order": 1,
+  "order": 14,
   "time": "",
   "template": "",
   "required": [],
   "superBlock": "certifications",
-  "superOrder": 12,
+  "superOrder": 0,
   "challengeOrder": [
     [
       "561add10cb82ac39a17513bc",

--- a/curriculum/challenges/_meta/legacy-front-end-certification/meta.json
+++ b/curriculum/challenges/_meta/legacy-front-end-certification/meta.json
@@ -2,12 +2,12 @@
   "name": "Legacy Front End Certification",
   "isUpcomingChange": false,
   "dashedName": "legacy-front-end-certification",
-  "order": 1,
+  "order": 15,
   "time": "",
   "template": "",
   "required": [],
   "superBlock": "certifications",
-  "superOrder": 12,
+  "superOrder": 0,
   "challengeOrder": [
     [
       "561add10cb82ac38a17513be",

--- a/curriculum/challenges/_meta/legacy-full-stack-certification/meta.json
+++ b/curriculum/challenges/_meta/legacy-full-stack-certification/meta.json
@@ -2,12 +2,12 @@
   "name": "Legacy Full Stack Certification",
   "isUpcomingChange": false,
   "dashedName": "full-stack-certification",
-  "order": 5,
+  "order": 16,
   "time": "",
   "template": "",
   "required": [],
   "superBlock": "certifications",
-  "superOrder": 12,
+  "superOrder": 0,
   "challengeOrder": [
     [
       "561add10cb82ac38a17213bd",

--- a/curriculum/challenges/_meta/legacy-information-security-and-quality-assurance-certification/meta.json
+++ b/curriculum/challenges/_meta/legacy-information-security-and-quality-assurance-certification/meta.json
@@ -2,12 +2,12 @@
   "name": "Legacy Information Security and Quality Assurance Certification",
   "isUpcomingChange": false,
   "dashedName": "information-security-and-quality-assurance-certification",
-  "order": 1,
+  "order": 17,
   "time": "",
   "template": "",
   "required": [],
   "superBlock": "certifications",
-  "superOrder": 12,
+  "superOrder": 0,
   "challengeOrder": [
     [
       "561add10cb82ac38a17213bc",

--- a/curriculum/test/test-curriculum-order.js
+++ b/curriculum/test/test-curriculum-order.js
@@ -95,7 +95,7 @@ describe('curriculumOrder', function () {
       });
     });
 
-    it('order numbers are expected to be contiguos for each superBlock', function () {
+    it('order numbers are expected to be contiguous for each superBlock', function () {
       Object.keys(superBlocks).forEach(key => {
         const orders = Object.keys(superBlocks[key]).map(toNumber);
         orders.sort((a, b) => a < b);
@@ -103,7 +103,7 @@ describe('curriculumOrder', function () {
         // expect(orders).to.deep.equal([...Array(orders.length).keys()]);
         for (let i = 1; i < orders.length; i++) {
           if (orders[i] !== orders[i - 1] + 1) {
-            console.warn(`orders for ${key} are not contiguos`);
+            console.warn(`orders for ${key} are not contiguous`);
             break;
           }
         }

--- a/curriculum/test/test-curriculum-order.js
+++ b/curriculum/test/test-curriculum-order.js
@@ -1,0 +1,131 @@
+const fs = require('fs');
+const path = require('path');
+const chai = require('chai');
+const { toNumber } = require('lodash');
+
+const expect = chai.expect;
+
+/**
+ * Reading the meta.json from all the directories in _meta
+ * Metadata is stored in-memory to perform all the tests
+ */
+const _meta = path.join(__dirname, '..', 'challenges/_meta');
+const metaDirs = fs.readdirSync(_meta);
+const metaData = {};
+metaDirs.forEach(dir => {
+  const metaPath = path.join(_meta, dir, 'meta.json');
+  metaData[dir] = JSON.parse(fs.readFileSync(metaPath));
+});
+
+/**
+ * The test suite to test the whole curriculum order
+ */
+describe('curriculumOrder', function () {
+  /**
+   * Checks to verify that all the superBlocks are unique and each superBlock has a unique superOrder
+   */
+  describe('superBlock and superOrder', function () {
+    it('each superBlock and corresponding superOrder must be unique', function () {
+      const superBlockOrder = {};
+      const superOrderBlock = {};
+
+      Object.values(metaData).forEach(block => {
+        const superBlock = block.superBlock;
+        const superOrder = block.superOrder;
+
+        // Check that there exists a unique superOrder for each superBlock
+        if (superBlock in superBlockOrder) {
+          expect(
+            superOrder,
+            `Inside ${block.dashedName}, superOrder of ${superBlock} does not match the superOrder in other blocks.`
+          ).to.equal(superBlockOrder[superBlock]);
+        } else {
+          superBlockOrder[superBlock] = superOrder;
+        }
+
+        // Check that there exists a unique superBlock for each superOrder
+        if (superOrder in superOrderBlock) {
+          expect(
+            superBlock,
+            `Inside ${block.dashedName}, superOrder (i.e. ${superOrder}) is assigned to another superBlock (i.e. ${superOrderBlock[superOrder]}).`
+          ).to.equal(superOrderBlock[superOrder]);
+        } else {
+          superOrderBlock[superOrder] = superBlock;
+        }
+      });
+    });
+  });
+
+  /**
+   * Checks to verify that the order numbers are unique for each block inside a superBlock
+   */
+  describe('block and order', function () {
+    // superBlocks = { superBlock : { order : block } }
+    const superBlocks = {};
+
+    it('order numbers should be unique for each challenge inside a superBlock', function () {
+      Object.values(metaData).forEach(block => {
+        const superBlock = block.superBlock;
+        const order = block.order;
+
+        if (superBlock in superBlocks) {
+          if (order in superBlocks[superBlock]) {
+            expect(
+              superBlocks[superBlock][order],
+              `Inside ${block.dashedName}, order (i.e. ${order}) is assigned to another block (i.e. ${superBlocks[superBlock][order]}).`
+            ).to.equal(block.dashedName);
+          } else {
+            superBlocks[superBlock][order] = block.dashedName;
+          }
+        } else {
+          superBlocks[superBlock] = {};
+          superBlocks[superBlock][order] = block.dashedName;
+        }
+      });
+    });
+
+    it('order numbers are expected to start at 1 in each superBlock', function () {
+      Object.keys(superBlocks).forEach(key => {
+        const orders = Object.keys(superBlocks[key]).map(toNumber);
+        orders.sort((a, b) => a < b);
+
+        // expect(orders[0], `orders for ${key} do not start at 1.`).to.equal(1);
+        if (orders[0] !== 1)
+          console.warn(`orders for ${key} do not start at 1.`);
+      });
+    });
+
+    it('order numbers are expected to be contiguos for each superBlock', function () {
+      Object.keys(superBlocks).forEach(key => {
+        const orders = Object.keys(superBlocks[key]).map(toNumber);
+        orders.sort((a, b) => a < b);
+
+        // expect(orders).to.deep.equal([...Array(orders.length).keys()]);
+        for (let i = 1; i < orders.length; i++) {
+          if (orders[i] !== orders[i - 1] + 1) {
+            console.warn(`orders for ${key} are not contiguos`);
+            break;
+          }
+        }
+      });
+    });
+  });
+
+  /**
+   * Checks whether the challenge IDs are unique inside each block
+   * TODO: Add checks to verify that the chllenges corresponding to the challenge ID's exist
+   */
+  describe('challenge IDs', function () {
+    it('challenge IDs must be unique inside a block', function () {
+      Object.values(metaData).forEach(block => {
+        const challenges = block.challengeOrder.map(arr => arr[0]);
+        challenges.forEach((id, i) => {
+          expect(
+            challenges.indexOf(id),
+            `challenge ID's for ${block.dashedName} are not unique`
+          ).to.equal(i);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #43407

<!-- Feel free to add any additional description of changes below this line -->

**Added tests for curriculum order.** 
- Checks for unique superBlock and superOrder
- Checks for unique order numbers for each block in a superBlock
- Console Warning if the order numbers do not start at 1 or are not contiguous
- Checks for unique challenge IDs inside each block

Also modified the order numbers and superOrder for legacy certification blocks.