### PR TITLE
fix(curriculum): strip comments from code when testing

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/compare-scopes-of-the-var-and-let-keywords.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/compare-scopes-of-the-var-and-let-keywords.md
@@ -85,15 +85,14 @@ This exercise is designed to illustrate the difference between how `var` and `le
 `var` should not exist in code.
 
 ```js
-(getUserInput) => assert(!getUserInput('index').match(/var/g));
+(getUserInput) => assert(!code.match(/var/g));
 ```
 
 The variable `i` declared in the `if` statement should equal the string `block scope`.
 
 ```js
 (getUserInput) =>
-  assert(
-    getUserInput('index').match(/(i\s*=\s*).*\s*.*\s*.*\1('|")block\s*scope\2/g)
+  assert(code.match(/(i\s*=\s*).*\s*.*\s*.*\1('|")block\s*scope\2/g)
   );
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/compare-scopes-of-the-var-and-let-keywords.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/compare-scopes-of-the-var-and-let-keywords.md
@@ -91,8 +91,7 @@ This exercise is designed to illustrate the difference between how `var` and `le
 The variable `i` declared in the `if` statement should equal the string `block scope`.
 
 ```js
-  assert(code.match(/(i\s*=\s*).*\s*.*\s*.*\1('|")block\s*scope\2/g)
-  );
+assert(code.match(/(i\s*=\s*).*\s*.*\s*.*\1('|")block\s*scope\2/g));
 ```
 
 `checkScope()` should return the string `function scope`

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/compare-scopes-of-the-var-and-let-keywords.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/compare-scopes-of-the-var-and-let-keywords.md
@@ -85,7 +85,7 @@ This exercise is designed to illustrate the difference between how `var` and `le
 `var` should not exist in code.
 
 ```js
-(getUserInput) => assert(!code.match(/var/g));
+assert(!code.match(/var/g));
 ```
 
 The variable `i` declared in the `if` statement should equal the string `block scope`.

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/compare-scopes-of-the-var-and-let-keywords.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/compare-scopes-of-the-var-and-let-keywords.md
@@ -91,7 +91,6 @@ This exercise is designed to illustrate the difference between how `var` and `le
 The variable `i` declared in the `if` statement should equal the string `block scope`.
 
 ```js
-(getUserInput) =>
   assert(code.match(/(i\s*=\s*).*\s*.*\s*.*\1('|")block\s*scope\2/g)
   );
 ```


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #43578

<!-- Feel free to add any additional description of changes below this line -->
Fixes the Issue: Adding a comment causes a valid answer to be wrong in ES6 Challenge > Compare Scopes of the var and let keywords, by using the code variable instead of (getUserInput('index')). This ensures that any code inside comment tags does not affect the validation.
Successful test results on local instance attached.

![Screenshot-after-fix](https://user-images.githubusercontent.com/83444996/135142583-0c3b6c4a-b8ea-4b3a-b820-2c7005157476.png)

