### PR TITLE
fix: code block newline

### DIFF
--- a/tools/challenge-helper-scripts/helpers/get-step-template.js
+++ b/tools/challenge-helper-scripts/helpers/get-step-template.js
@@ -72,7 +72,6 @@ ${stepDescription}
 Test 1
 
 ${getCodeBlock('js')}
-
 # --seed--` +
     seedChallengeSection +
     seedHeadSection +

--- a/tools/challenge-helper-scripts/helpers/get-step-template.js
+++ b/tools/challenge-helper-scripts/helpers/get-step-template.js
@@ -4,7 +4,7 @@ const { insertErms } = require('./insert-erms');
 function getCodeBlock(label, content) {
   return `\`\`\`${label}
 ${typeof content !== 'undefined' ? content : ''}
-\`\`\``;
+\`\`\`\n`;
 }
 
 // Builds a section

--- a/tools/challenge-helper-scripts/helpers/get-step-template.test.js
+++ b/tools/challenge-helper-scripts/helpers/get-step-template.test.js
@@ -31,7 +31,7 @@ Test 1
 --fcc-editable-region--
 
 --fcc-editable-region--
-\`\`\``;
+\`\`\`\n`;
 
     const props = {
       challengeId: '60d4ebe4801158d1abe1b18f',


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
This has been bugging me for a while. Fixes the challenge step creation tools to properly insert a new line after code blocks.