### PR TITLE
feat: add tailwind theme support

### DIFF
--- a/tools/ui-components/src/button.css
+++ b/tools/ui-components/src/button.css
@@ -3,21 +3,11 @@
 .storybook-button {
   font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-weight: 700;
-  border: 0;
-  border-radius: 3em;
   cursor: pointer;
   display: inline-block;
   line-height: 1;
 }
-.storybook-button--primary {
-  color: white;
-  background-color: #1ea7fd;
-}
-.storybook-button--secondary {
-  color: #333;
-  background-color: transparent;
-  box-shadow: rgba(0, 0, 0, 0.15) 0px 0px 0px 1px inset;
-}
+
 .storybook-button--small {
   font-size: 12px;
   padding: 10px 16px;
@@ -31,6 +21,9 @@
   padding: 12px 24px;
 }
 
-.fcc-style {
-  @apply bg-fccSecondary;
+.button-default-style {
+  @apply bg-default-background-quaternary;
+  @apply border-default-foreground-secondary;
+  @apply text-default-foreground-secondary;
+  @apply border-2;
 }

--- a/tools/ui-components/src/button.stories.tsx
+++ b/tools/ui-components/src/button.stories.tsx
@@ -7,11 +7,27 @@ const story = {
   title: 'Example/Button',
   component: Button,
   argTypes: {
-    backgroundColor: { control: 'color' }
+    theme: {
+      options: ['dark', 'light'],
+      control: { type: 'radio' },
+      defaultValue: 'light'
+    }
   }
 };
 
-const Template: Story<ButtonProps> = args => <Button {...args} />;
+const Template: Story<ButtonProps> = args => {
+  return (
+    <div
+      className={`flex h-screen justify-center items-center ${
+        args.theme === 'dark'
+          ? 'dark bg-dark-theme-background'
+          : 'light bg-light-theme-background'
+      }`}
+    >
+      <Button {...args} />
+    </div>
+  );
+};
 
 export const Primary = Template.bind({});
 Primary.args = {

--- a/tools/ui-components/src/button.tsx
+++ b/tools/ui-components/src/button.tsx
@@ -9,7 +9,6 @@ import './button.css';
 export const Button: React.FC<ButtonProps> = ({
   primary,
   size = 'medium',
-  backgroundColor,
   label,
   ...props
 }: ButtonProps) => {
@@ -22,9 +21,8 @@ export const Button: React.FC<ButtonProps> = ({
         'storybook-button',
         `storybook-button--${size}`,
         mode,
-        'fcc-style'
+        'button-default-style'
       ].join(' ')}
-      style={{ backgroundColor }}
       type='button'
       {...props}
     >

--- a/tools/ui-components/src/button.types.ts
+++ b/tools/ui-components/src/button.types.ts
@@ -3,8 +3,8 @@ type ButtonSize = 'small' | 'medium' | 'large';
 export interface ButtonProps {
   primary?: boolean;
   size?: ButtonSize;
-  backgroundColor?: string;
   label: string;
   customKey?: string;
   onClick: () => void;
+  theme?: 'light' | 'dark';
 }

--- a/tools/ui-components/src/colors.css
+++ b/tools/ui-components/src/colors.css
@@ -33,37 +33,25 @@
   --red90: #850000;
 }
 
-:export {
-  --gray00: var(--gray00);
-  --gray05: var(--gray05);
-  --gray10: var(--gray10);
-  --gray15: var(--gray15);
-  --gray45: var(--gray45);
-  --gray75: var(--gray75);
-  --gray80: var(--gray80);
-  --gray85: var(--gray85);
-  --gray90: var(--gray90);
+html,
+div.light {
+  --default-foreground-primary: var(--gray90);
+  --default-foreground-secondary: var(--gray85);
+  --default-foreground-tertiary: var(--gray80);
+  --default-foreground-quaternary: var(--gray75);
+  --default-background-primary: var(--gray00);
+  --default-background-secondary: var(--gray05);
+  --default-background-tertiary: var(--gray10);
+  --default-background-quaternary: var(--gray15);
+}
 
-  --purple10: var(--purple10);
-  --purple50: var(--purple50);
-  --purple90: var(--purple90);
-
-  --yellow10: var(--yellow10);
-  --yellow20: var(--yellow20);
-  --yellow50: var(--yellow50);
-  --yellow90: var(--yellow90);
-
-  --blue10: var(--blue10);
-  --blue20: var(--blue20);
-  --blue30: var(--blue30);
-  --blue50: var(--blue50);
-  --blue90: var(--blue90);
-
-  --green10: var(--green10);
-  --green90: var(--green90);
-
-  --red10: var(--red10);
-  --red20: var(--red20);
-  --red80: var(--red80);
-  --red90: var(--red90);
+html.dark,
+div.dark {
+  --default-foreground-primary: var(--gray00);
+  --default-foreground-secondary: var(--gray05);
+  --default-foreground-quaternary: var(--gray15);
+  --default-background-primary: var(--gray90);
+  --default-background-secondary: var(--gray85);
+  --default-background-tertiary: var(--gray80);
+  --default-background-quaternary: var(--gray75);
 }

--- a/tools/ui-components/tailwind.config.js
+++ b/tools/ui-components/tailwind.config.js
@@ -1,9 +1,20 @@
 module.exports = {
   purge: ['./src/**/*.html', './src/**/*.js'],
-  darkMode: false,
+  darkMode: 'class',
   theme: {
-    colors: {
-      fccSecondary: 'var(--green90)'
+    extend: {
+      colors: {
+        'dark-theme-background': 'var(--gray90)',
+        'light-theme-background': 'var(--gray00)',
+        'default-foreground-primary': 'var(--default-foreground-primary)',
+        'default-foreground-secondary': 'var(--default-foreground-secondary)',
+        'default-foreground-tertiary': 'var(--default-foreground-tertiary)',
+        'default-foreground-quaternary': 'var(--default-foreground-quaternary)',
+        'default-background-primary': 'var(--default-background-primary)',
+        'default-background-secondary': 'var(--default-background-secondary)',
+        'default-background-tertiary': 'var(--default-background-tertiary)',
+        'default-background-quaternary': 'var(--default-background-quaternary)'
+      }
     }
   },
   variants: {

--- a/tools/ui-components/tailwind.config.js
+++ b/tools/ui-components/tailwind.config.js
@@ -2,19 +2,17 @@ module.exports = {
   purge: ['./src/**/*.html', './src/**/*.js'],
   darkMode: 'class',
   theme: {
-    extend: {
-      colors: {
-        'dark-theme-background': 'var(--gray90)',
-        'light-theme-background': 'var(--gray00)',
-        'default-foreground-primary': 'var(--default-foreground-primary)',
-        'default-foreground-secondary': 'var(--default-foreground-secondary)',
-        'default-foreground-tertiary': 'var(--default-foreground-tertiary)',
-        'default-foreground-quaternary': 'var(--default-foreground-quaternary)',
-        'default-background-primary': 'var(--default-background-primary)',
-        'default-background-secondary': 'var(--default-background-secondary)',
-        'default-background-tertiary': 'var(--default-background-tertiary)',
-        'default-background-quaternary': 'var(--default-background-quaternary)'
-      }
+    colors: {
+      'dark-theme-background': 'var(--gray90)',
+      'light-theme-background': 'var(--gray00)',
+      'default-foreground-primary': 'var(--default-foreground-primary)',
+      'default-foreground-secondary': 'var(--default-foreground-secondary)',
+      'default-foreground-tertiary': 'var(--default-foreground-tertiary)',
+      'default-foreground-quaternary': 'var(--default-foreground-quaternary)',
+      'default-background-primary': 'var(--default-background-primary)',
+      'default-background-secondary': 'var(--default-background-secondary)',
+      'default-background-tertiary': 'var(--default-background-tertiary)',
+      'default-background-quaternary': 'var(--default-background-quaternary)'
     }
   },
   variants: {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #42186

<!-- Feel free to add any additional description of changes below this line -->
This pull request adds theme support as described in #42186 by setting a list of colors variables that change based on the class of the html element.

<img width="1440" alt="Screen Shot 2021-09-29 at 3 42 15 PM" src="https://user-images.githubusercontent.com/4591597/135278629-4af58c97-5b4d-4388-b482-1507dfcbe80c.png">

Note: Since color variables change based on the class of the HTML, I added a small hack and wrapped components in a div whose classes changes based on the theme argument. Once we find a better way to add theme controls, we could remove the wrapper.

