### PR TITLE
feat: enable reset in multifile editor

### DIFF
--- a/client/src/templates/Challenges/classic/DesktopLayout.js
+++ b/client/src/templates/Challenges/classic/DesktopLayout.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { ReflexContainer, ReflexSplitter, ReflexElement } from 'react-reflex';
 import envData from '../../../../../config/env.json';
-import { toSortedArray } from '../../../../../utils/sort-files';
+import { sortChallengeFiles } from '../../../../../utils/sort-challengefiles';
 import EditorTabs from './EditorTabs';
 import ActionRow from './action-row.tsx';
 
@@ -57,7 +57,7 @@ class DesktopLayout extends Component {
 
   getChallengeFile() {
     const { challengeFiles } = this.props;
-    return first(toSortedArray(challengeFiles));
+    return first(sortChallengeFiles(challengeFiles));
   }
 
   render() {

--- a/client/src/templates/Challenges/classic/EditorTabs.js
+++ b/client/src/templates/Challenges/classic/EditorTabs.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 
-import { toSortedArray } from '../../../../../utils/sort-files';
+import { sortChallengeFiles } from '../../../../../utils/sort-challengefiles';
 import {
   toggleVisibleEditor,
   visibleEditorsSelector,
@@ -39,7 +39,7 @@ class EditorTabs extends Component {
     const { challengeFiles, toggleVisibleEditor, visibleEditors } = this.props;
     return (
       <div className='monaco-editor-tabs'>
-        {toSortedArray(challengeFiles).map(challengeFile => (
+        {sortChallengeFiles(challengeFiles).map(challengeFile => (
           <button
             aria-selected={visibleEditors[challengeFile.fileKey]}
             className='monaco-editor-tab'

--- a/client/src/templates/Challenges/classic/action-row.tsx
+++ b/client/src/templates/Challenges/classic/action-row.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import BreadCrumb from '../components/bread-crumb';
+import { resetChallenge } from '../redux';
 import EditorTabs from './EditorTabs';
 
 interface ActionRowProps {
@@ -9,18 +11,21 @@ interface ActionRowProps {
   showPreview: boolean;
   superBlock: string;
   switchDisplayTab: (displayTab: string) => void;
+  resetChallenge: () => void;
 }
+
+const mapDispatchToProps = {
+  resetChallenge
+};
 
 const ActionRow = ({
   switchDisplayTab,
   showPreview,
   showConsole,
   superBlock,
-  block
+  block,
+  resetChallenge
 }: ActionRowProps): JSX.Element => {
-  const restartStep = () => {
-    console.log('restart');
-  };
   return (
     <div className='action-row'>
       <div className='breadcrumbs-demo'>
@@ -30,7 +35,7 @@ const ActionRow = ({
         <EditorTabs />
         <button
           className='restart-step-tab'
-          onClick={() => restartStep()}
+          onClick={resetChallenge}
           role='tab'
         >
           Restart Step
@@ -57,4 +62,5 @@ const ActionRow = ({
 };
 
 ActionRow.displayName = 'ActionRow';
-export default ActionRow;
+
+export default connect(null, mapDispatchToProps)(ActionRow);

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -444,7 +444,7 @@ const Editor = (props: EditorProps): JSX.Element => {
         editableRegion[1] - 1
       ]);
 
-      data.insideEditDecId = highlightEditableLines(
+      data.insideEditDecId = initializeEditableRegion(
         monaco.editor.TrackedRangeStickiness.AlwaysGrowsWhenTypingAtEdges,
         model,
         editableRange
@@ -509,7 +509,7 @@ const Editor = (props: EditorProps): JSX.Element => {
         const redecorateEditableRegion = () => {
           const coveringRange = getLinesCoveringEditableRegion();
           if (coveringRange) {
-            data.insideEditDecId = highlightEditableLines(
+            data.insideEditDecId = updateEditableRegion(
               monaco.editor.TrackedRangeStickiness.AlwaysGrowsWhenTypingAtEdges,
               model,
               coveringRange,
@@ -849,7 +849,25 @@ const Editor = (props: EditorProps): JSX.Element => {
     return target.deltaDecorations(oldIds, [lineDecoration]);
   }
 
-  function highlightEditableLines(
+  // TODO: DRY this and the update function
+  function initializeEditableRegion(
+    stickiness: number,
+    target: editor.ITextModel,
+    range: IRange
+  ) {
+    const lineDecoration = {
+      range,
+      options: {
+        isWholeLine: true,
+        linesDecorationsClassName: 'myEditableLineDecoration',
+        className: 'do-not-edit',
+        stickiness
+      }
+    };
+    return target.deltaDecorations([], [lineDecoration]);
+  }
+
+  function updateEditableRegion(
     stickiness: number,
     target: editor.ITextModel,
     range: IRange,

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -461,12 +461,6 @@ const Editor = (props: EditorProps): JSX.Element => {
           model,
           forbiddenRange
         )[0];
-
-        highlightText(
-          monaco.editor.TrackedRangeStickiness.GrowsOnlyWhenTypingBefore,
-          model,
-          forbiddenRange
-        );
       }
 
       const forbiddenRange = positionsToRange(model, forbiddenRegions[1]);
@@ -477,12 +471,6 @@ const Editor = (props: EditorProps): JSX.Element => {
         model,
         forbiddenRange
       )[0];
-
-      highlightText(
-        monaco.editor.TrackedRangeStickiness.GrowsOnlyWhenTypingAfter,
-        model,
-        forbiddenRange
-      );
     }
 
     // TODO this listener needs to be replaced on reset.
@@ -883,23 +871,6 @@ const Editor = (props: EditorProps): JSX.Element => {
       }
     };
     return target.deltaDecorations(oldIds, [lineDecoration]);
-  }
-
-  function highlightText(
-    stickiness: number,
-    target: editor.ITextModel,
-    range: IRange,
-    oldIds: string[] = []
-  ) {
-    const inlineDecoration = {
-      range,
-      options: {
-        inlineClassName: 'myInlineDecoration',
-        stickiness
-      }
-    };
-
-    return target.deltaDecorations(oldIds, [inlineDecoration]);
   }
 
   function getDescriptionZoneTop() {

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -290,12 +290,7 @@ const Editor = (props: EditorProps): JSX.Element => {
     editorRef.current = editor;
     data.editor = editor;
 
-    const editableRegionBoundaries = getEditableRegionFromRedux();
-
-    if (editableRegionBoundaries.length === 2) {
-      initializeRegions(editableRegionBoundaries);
-      addContentChangeListener();
-    }
+    initializeProjectFeatures();
 
     const storedAccessibilityMode = () => {
       const accessibility = store.get('accessibilityMode') as boolean;
@@ -373,298 +368,6 @@ const Editor = (props: EditorProps): JSX.Element => {
       }
     });
     editor.onDidFocusEditorWidget(() => props.setEditorFocusability(true));
-
-    if (editableRegionBoundaries.length === 2) {
-      const createWidget = (
-        id: string,
-        domNode: HTMLDivElement,
-        getTop: () => string
-      ) => {
-        const getId = () => id;
-        const getDomNode = () => domNode;
-        const getPosition = () => {
-          domNode.style.width = `${editor.getLayoutInfo().contentWidth}px`;
-          domNode.style.top = getTop();
-
-          // must return null, so that Monaco knows the widget will position
-          // itself.
-          return null;
-        };
-        return {
-          getId,
-          getDomNode,
-          getPosition
-        };
-      };
-
-      const descriptionNode = createDescription(editor);
-
-      const outputNode = createOutputNode(editor);
-
-      const descriptionWidget = createWidget(
-        'description.widget',
-        descriptionNode,
-        getDescriptionZoneTop
-      );
-      data.descriptionWidget = descriptionWidget;
-      const outputWidget = createWidget(
-        'output.widget',
-        outputNode,
-        getOutputZoneTop
-      );
-      data.outputWidget = outputWidget;
-
-      editor.addOverlayWidget(descriptionWidget);
-
-      // TODO: order of insertion into the DOM probably matters, revisit once
-      // the tabs have been fixed!
-
-      editor.addOverlayWidget(outputWidget);
-
-      editor.changeViewZones(descriptionZoneCallback);
-      editor.changeViewZones(outputZoneCallback);
-
-      editor.onDidScrollChange(() => {
-        editor.layoutOverlayWidget(descriptionWidget);
-        editor.layoutOverlayWidget(outputWidget);
-      });
-      showEditableRegion();
-    }
-
-    function initializeRegions(editableRegion: number[]) {
-      const { model } = data;
-      if (!model) return;
-      const forbiddenRegions: [number, number][] = [
-        [0, editableRegion[0]],
-        [editableRegion[1], model.getLineCount()]
-      ];
-
-      const editableRange = positionsToRange(model, [
-        editableRegion[0] + 1,
-        editableRegion[1] - 1
-      ]);
-
-      data.insideEditDecId = initializeEditableRegion(
-        monaco.editor.TrackedRangeStickiness.AlwaysGrowsWhenTypingAtEdges,
-        model,
-        editableRange
-      )[0];
-
-      // if the forbidden range includes the top of the editor
-      // we simply don't add those decorations
-      if (forbiddenRegions[0][1] > 0) {
-        const forbiddenRange = positionsToRange(model, forbiddenRegions[0]);
-        // the first range should expand at the top
-        // TODO: Unsure what this should be - returns an array, so I added [0] @ojeytonwilliams
-        data.startEditDecId = initializeForbiddenRegion(
-          monaco.editor.TrackedRangeStickiness.GrowsOnlyWhenTypingBefore,
-          model,
-          forbiddenRange
-        )[0];
-      }
-
-      const forbiddenRange = positionsToRange(model, forbiddenRegions[1]);
-      // TODO: handle the case the region covers the bottom of the editor
-      // the second range should expand at the bottom
-      data.endEditDecId = initializeForbiddenRegion(
-        monaco.editor.TrackedRangeStickiness.GrowsOnlyWhenTypingAfter,
-        model,
-        forbiddenRange
-      )[0];
-    }
-
-    // TODO this listener needs to be replaced on reset.
-    function addContentChangeListener() {
-      const { model } = data;
-      if (!model) return;
-
-      model.onDidChangeContent(e => {
-        // TODO: it would be nice if undoing could remove the warning, but
-        // it's probably too hard to track. i.e. if they make two warned edits
-        // and then ctrl + z twice, it would realise they've removed their
-        // edits. However, what if they made a warned edit, then a normal
-        // edit, then a warned one.  Could it track that they need to make 3
-        // undos?
-        const deletedLine = getDeletedLine(e);
-
-        const deletedRange = {
-          startLineNumber: deletedLine,
-          endLineNumber: deletedLine,
-          startColumn: 1,
-          endColumn: 1
-        };
-
-        const redecorateEditableRegion = () => {
-          const coveringRange = getLinesCoveringEditableRegion();
-          if (coveringRange) {
-            data.insideEditDecId = updateEditableRegion(
-              monaco.editor.TrackedRangeStickiness.AlwaysGrowsWhenTypingAtEdges,
-              model,
-              coveringRange,
-              [data.insideEditDecId]
-            )[0];
-          }
-        };
-
-        redecorateEditableRegion();
-
-        if (e.isUndoing) {
-          // TODO: can we be more targeted? Only update when they could get out of
-          // sync
-          updateDescriptionZone();
-          updateOutputZone();
-          return;
-        }
-
-        const warnUser = (id: string) => {
-          const range = model.getDecorationRange(id);
-          if (range) {
-            const coveringRange = toStartOfLine(range);
-            e.changes.forEach(({ range }) => {
-              if (
-                monaco.Range.areIntersectingOrTouching(coveringRange, range)
-              ) {
-                console.log('OVERLAP!');
-              }
-            });
-          }
-        };
-
-        // TODO: can this be removed along with the rest of the forbidden region
-        // decorators?
-        const preventOverlap = (
-          id: string,
-          stickiness: number,
-          updateRegion: typeof updateForbiddenRegion
-        ) => {
-          // Even though the decoration covers the whole line, it has a
-          // startColumn that moves.  toStartOfLine ensures that the
-          // comparison detects if any change has occurred on that line
-          // NOTE: any change in the decoration has already happened by this point
-          // so this covers the *new* decoration range.
-          const range = model.getDecorationRange(id);
-          if (!range) {
-            return id;
-          }
-          const coveringRange = toStartOfLine(range);
-          const oldStartOfRange = translateRange(
-            coveringRange.collapseToStart(),
-            1
-          );
-          const newCoveringRange = coveringRange.setStartPosition(
-            oldStartOfRange?.startLineNumber ?? 1,
-            1
-          );
-
-          // TODO: this triggers both when you delete the first line of the
-          // decoration AND the second. To see this, consider a region on line 5
-          // If you delete 5, then the new start is 4 and the computed start is 5
-          // so they match.
-          // If you delete 6, then the start of the region stays at 5, so the
-          // computed start is 6 and they still match.
-          // Is there a way to tell these cases apart?
-          // This means that if you delete the second line it actually removes the
-          // grey background from the first line.
-          if (oldStartOfRange) {
-            const touchingDeleted = monaco.Range.areIntersectingOrTouching(
-              deletedRange,
-              oldStartOfRange
-            );
-
-            if (touchingDeleted) {
-              // TODO: if they undo this should be reversed
-              const decorations = updateRegion(
-                stickiness,
-                model,
-                newCoveringRange,
-                [id]
-              );
-
-              updateOutputZone();
-              return decorations[0];
-            } else {
-              return id;
-            }
-          }
-          return id;
-        };
-
-        // we only need to handle the special case of the second region being
-        // pulled up, the first region already behaves correctly.
-
-        data.endEditDecId = preventOverlap(
-          data.endEditDecId,
-          monaco.editor.TrackedRangeStickiness.GrowsOnlyWhenTypingBefore,
-          updateForbiddenRegion
-        );
-
-        // If the content has changed, the zones may need moving. Rather than
-        // working out if they have to for a particular content changed, we simply
-        // ask monaco to update regardless.
-        updateDescriptionZone();
-        updateOutputZone();
-
-        if (data.startEditDecId) {
-          warnUser(data.startEditDecId);
-        }
-        if (data.endEditDecId) {
-          warnUser(data.endEditDecId);
-        }
-      });
-      // The deleted line is always considered to be the one that has moved up.
-      // - if the user deletes at the end of line 5, line 6 is deleted and
-      // - if the user backspaces at the start of line 6, line 6 is deleted
-      // TODO: handle multiple simultaneous changes (multicursors do this)
-      function getDeletedLine(event: editor.IModelContentChangedEvent) {
-        const isDeleted =
-          event.changes[0].text === '' &&
-          event.changes[0].range.endColumn === 1;
-        return isDeleted ? event.changes[0].range.endLineNumber : 0;
-      }
-    }
-
-    // creates a range covering all the lines in 'positions'
-    // NOTE: positions is an array of [startLine, endLine]
-    function positionsToRange(
-      model: editor.ITextModel,
-      [start, end]: [number, number]
-    ) {
-      // convert to [startLine, startColumn, endLine, endColumn]
-      const range = new monaco.Range(start, 1, end, 1);
-
-      // Protect against ranges that extend outside the editor
-      const startLineNumber = Math.max(1, range.startLineNumber);
-      const endLineNumber = Math.min(model.getLineCount(), range.endLineNumber);
-      const endColumnText = model.getLineContent(endLineNumber);
-      // NOTE: the end column is incremented by 2 so that the dangerous range
-      // extends far enough to capture new text added to the end.
-      // NOTE: according to the spec, it should only need to be +1, but in
-      // practice that's not enough.
-      return range
-        .setStartPosition(startLineNumber, 1)
-        .setEndPosition(range.endLineNumber, endColumnText.length + 2);
-    }
-
-    function showEditableRegion() {
-      // TODO: The heuristic has been commented out for now because the cursor
-      // position is not saved at the moment, so it's redundant. I'm leaving it
-      // here for now, in case we decide to save it in future.
-      // this is a heuristic: if the cursor is at the start of the page, chances
-      // are the user has not edited yet. If so, move to the start of the editable
-      // region.
-      // if (
-      //  isEqual({ ..._editor.getPosition() }, { lineNumber: 1, column: 1 })
-      // ) {
-      editor.setPosition({
-        lineNumber: editableRegionBoundaries[0] + 1,
-        column: 1
-      });
-      editor.revealLinesInCenter(
-        editableRegionBoundaries[0],
-        editableRegionBoundaries[1]
-      );
-      // }
-    }
   };
 
   const descriptionZoneCallback = (
@@ -937,10 +640,317 @@ const Editor = (props: EditorProps): JSX.Element => {
     }
   };
 
+  function initializeProjectFeatures() {
+    const editableRegionBoundaries = getEditableRegionFromRedux();
+    const editor = data.editor;
+    if (editableRegionBoundaries.length === 2 && editor) {
+      initializeRegions(editableRegionBoundaries);
+      addWidgetsToRegions(editor);
+      addContentChangeListener();
+    }
+  }
+
+  function initializeRegions(editableRegion: number[]) {
+    const { model } = data;
+    const monaco = monacoRef.current;
+    if (!model || !monaco) return;
+    const forbiddenRegions: [number, number][] = [
+      [0, editableRegion[0]],
+      [editableRegion[1], model.getLineCount()]
+    ];
+
+    const editableRange = positionsToRange(monaco, model, [
+      editableRegion[0] + 1,
+      editableRegion[1] - 1
+    ]);
+
+    data.insideEditDecId = initializeEditableRegion(
+      monaco.editor.TrackedRangeStickiness.AlwaysGrowsWhenTypingAtEdges,
+      model,
+      editableRange
+    )[0];
+
+    // if the forbidden range includes the top of the editor
+    // we simply don't add those decorations
+    if (forbiddenRegions[0][1] > 0) {
+      const forbiddenRange = positionsToRange(
+        monaco,
+        model,
+        forbiddenRegions[0]
+      );
+      // the first range should expand at the top
+      // TODO: Unsure what this should be - returns an array, so I added [0] @ojeytonwilliams
+      data.startEditDecId = initializeForbiddenRegion(
+        monaco.editor.TrackedRangeStickiness.GrowsOnlyWhenTypingBefore,
+        model,
+        forbiddenRange
+      )[0];
+    }
+
+    const forbiddenRange = positionsToRange(monaco, model, forbiddenRegions[1]);
+    // TODO: handle the case the region covers the bottom of the editor
+    // the second range should expand at the bottom
+    data.endEditDecId = initializeForbiddenRegion(
+      monaco.editor.TrackedRangeStickiness.GrowsOnlyWhenTypingAfter,
+      model,
+      forbiddenRange
+    )[0];
+  }
+
+  function addWidgetsToRegions(editor: editor.IStandaloneCodeEditor) {
+    const createWidget = (
+      id: string,
+      domNode: HTMLDivElement,
+      getTop: () => string
+    ) => {
+      const getId = () => id;
+      const getDomNode = () => domNode;
+      const getPosition = () => {
+        domNode.style.width = `${editor.getLayoutInfo().contentWidth}px`;
+        domNode.style.top = getTop();
+
+        // must return null, so that Monaco knows the widget will position
+        // itself.
+        return null;
+      };
+      return {
+        getId,
+        getDomNode,
+        getPosition
+      };
+    };
+
+    const descriptionNode = createDescription(editor);
+
+    const outputNode = createOutputNode(editor);
+
+    if (!data.descriptionWidget) {
+      data.descriptionWidget = createWidget(
+        'description.widget',
+        descriptionNode,
+        getDescriptionZoneTop
+      );
+      editor.addOverlayWidget(data.descriptionWidget);
+      editor.changeViewZones(descriptionZoneCallback);
+    }
+    if (!data.outputWidget) {
+      data.outputWidget = createWidget(
+        'output.widget',
+        outputNode,
+        getOutputZoneTop
+      );
+      editor.addOverlayWidget(data.outputWidget);
+      editor.changeViewZones(outputZoneCallback);
+    }
+
+    editor.onDidScrollChange(() => {
+      if (data.descriptionWidget)
+        editor.layoutOverlayWidget(data.descriptionWidget);
+      if (data.outputWidget) editor.layoutOverlayWidget(data.outputWidget);
+    });
+    showEditableRegion(editor);
+  }
+
+  // TODO this listener needs to be replaced on reset.
+  function addContentChangeListener() {
+    const { model } = data;
+    const monaco = monacoRef.current;
+    if (!model || !monaco) return;
+
+    model.onDidChangeContent(e => {
+      // TODO: it would be nice if undoing could remove the warning, but
+      // it's probably too hard to track. i.e. if they make two warned edits
+      // and then ctrl + z twice, it would realise they've removed their
+      // edits. However, what if they made a warned edit, then a normal
+      // edit, then a warned one.  Could it track that they need to make 3
+      // undos?
+      const deletedLine = getDeletedLine(e);
+
+      const deletedRange = {
+        startLineNumber: deletedLine,
+        endLineNumber: deletedLine,
+        startColumn: 1,
+        endColumn: 1
+      };
+
+      const redecorateEditableRegion = () => {
+        const coveringRange = getLinesCoveringEditableRegion();
+        if (coveringRange) {
+          data.insideEditDecId = updateEditableRegion(
+            monaco.editor.TrackedRangeStickiness.AlwaysGrowsWhenTypingAtEdges,
+            model,
+            coveringRange,
+            [data.insideEditDecId]
+          )[0];
+        }
+      };
+
+      redecorateEditableRegion();
+
+      if (e.isUndoing) {
+        // TODO: can we be more targeted? Only update when they could get out of
+        // sync
+        updateDescriptionZone();
+        updateOutputZone();
+        return;
+      }
+
+      const warnUser = (id: string) => {
+        const range = model.getDecorationRange(id);
+        if (range) {
+          const coveringRange = toStartOfLine(range);
+          e.changes.forEach(({ range }) => {
+            if (monaco.Range.areIntersectingOrTouching(coveringRange, range)) {
+              console.log('OVERLAP!');
+            }
+          });
+        }
+      };
+
+      // TODO: can this be removed along with the rest of the forbidden region
+      // decorators?
+      const preventOverlap = (
+        id: string,
+        stickiness: number,
+        updateRegion: typeof updateForbiddenRegion
+      ) => {
+        // Even though the decoration covers the whole line, it has a
+        // startColumn that moves.  toStartOfLine ensures that the
+        // comparison detects if any change has occurred on that line
+        // NOTE: any change in the decoration has already happened by this point
+        // so this covers the *new* decoration range.
+        const range = model.getDecorationRange(id);
+        if (!range) {
+          return id;
+        }
+        const coveringRange = toStartOfLine(range);
+        const oldStartOfRange = translateRange(
+          coveringRange.collapseToStart(),
+          1
+        );
+        const newCoveringRange = coveringRange.setStartPosition(
+          oldStartOfRange?.startLineNumber ?? 1,
+          1
+        );
+
+        // TODO: this triggers both when you delete the first line of the
+        // decoration AND the second. To see this, consider a region on line 5
+        // If you delete 5, then the new start is 4 and the computed start is 5
+        // so they match.
+        // If you delete 6, then the start of the region stays at 5, so the
+        // computed start is 6 and they still match.
+        // Is there a way to tell these cases apart?
+        // This means that if you delete the second line it actually removes the
+        // grey background from the first line.
+        if (oldStartOfRange) {
+          const touchingDeleted = monaco.Range.areIntersectingOrTouching(
+            deletedRange,
+            oldStartOfRange
+          );
+
+          if (touchingDeleted) {
+            // TODO: if they undo this should be reversed
+            const decorations = updateRegion(
+              stickiness,
+              model,
+              newCoveringRange,
+              [id]
+            );
+
+            updateOutputZone();
+            return decorations[0];
+          } else {
+            return id;
+          }
+        }
+        return id;
+      };
+
+      // we only need to handle the special case of the second region being
+      // pulled up, the first region already behaves correctly.
+
+      data.endEditDecId = preventOverlap(
+        data.endEditDecId,
+        monaco.editor.TrackedRangeStickiness.GrowsOnlyWhenTypingBefore,
+        updateForbiddenRegion
+      );
+
+      // If the content has changed, the zones may need moving. Rather than
+      // working out if they have to for a particular content changed, we simply
+      // ask monaco to update regardless.
+      updateDescriptionZone();
+      updateOutputZone();
+
+      if (data.startEditDecId) {
+        warnUser(data.startEditDecId);
+      }
+      if (data.endEditDecId) {
+        warnUser(data.endEditDecId);
+      }
+    });
+    // The deleted line is always considered to be the one that has moved up.
+    // - if the user deletes at the end of line 5, line 6 is deleted and
+    // - if the user backspaces at the start of line 6, line 6 is deleted
+    // TODO: handle multiple simultaneous changes (multicursors do this)
+    function getDeletedLine(event: editor.IModelContentChangedEvent) {
+      const isDeleted =
+        event.changes[0].text === '' && event.changes[0].range.endColumn === 1;
+      return isDeleted ? event.changes[0].range.endLineNumber : 0;
+    }
+  }
+
+  function showEditableRegion(editor: editor.IStandaloneCodeEditor) {
+    const editableRegionBoundaries = getEditableRegionFromRedux();
+    // TODO: The heuristic has been commented out for now because the cursor
+    // position is not saved at the moment, so it's redundant. I'm leaving it
+    // here for now, in case we decide to save it in future.
+    // this is a heuristic: if the cursor is at the start of the page, chances
+    // are the user has not edited yet. If so, move to the start of the editable
+    // region.
+    // if (
+    //  isEqual({ ..._editor.getPosition() }, { lineNumber: 1, column: 1 })
+    // ) {
+    editor.setPosition({
+      lineNumber: editableRegionBoundaries[0] + 1,
+      column: 1
+    });
+    editor.revealLinesInCenter(
+      editableRegionBoundaries[0],
+      editableRegionBoundaries[1]
+    );
+    // }
+  }
+
+  // creates a range covering all the lines in 'positions'
+  // NOTE: positions is an array of [startLine, endLine]
+  function positionsToRange(
+    monaco: typeof monacoEditor,
+    model: editor.ITextModel,
+    [start, end]: [number, number]
+  ) {
+    // convert to [startLine, startColumn, endLine, endColumn]
+    const range = new monaco.Range(start, 1, end, 1);
+
+    // Protect against ranges that extend outside the editor
+    const startLineNumber = Math.max(1, range.startLineNumber);
+    const endLineNumber = Math.min(model.getLineCount(), range.endLineNumber);
+    const endColumnText = model.getLineContent(endLineNumber);
+    // NOTE: the end column is incremented by 2 so that the dangerous range
+    // extends far enough to capture new text added to the end.
+    // NOTE: according to the spec, it should only need to be +1, but in
+    // practice that's not enough.
+    return range
+      .setStartPosition(startLineNumber, 1)
+      .setEndPosition(range.endLineNumber, endColumnText.length + 2);
+  }
+
   useEffect(() => {
     // If a challenge is reset, it needs to communicate that change to the
     // editor.
     updateEditorValues();
+    initializeProjectFeatures();
+    updateDescriptionZone();
+    updateOutputZone();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.challengeFiles]);
   useEffect(() => {

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -954,11 +954,18 @@ const Editor = (props: EditorProps): JSX.Element => {
   useEffect(() => {
     // If a challenge is reset, it needs to communicate that change to the
     // editor.
+    const { editor } = data;
+
     const hasChangedContents = updateEditorValues();
     if (hasChangedContents && isProject()) {
       initializeProjectFeatures();
       updateDescriptionZone();
       updateOutputZone();
+    }
+
+    editor?.focus();
+    if (isProject() && editor) {
+      showEditableRegion(editor);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.challengeFiles]);

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -830,7 +830,6 @@ const Editor = (props: EditorProps): JSX.Element => {
       options: {
         isWholeLine: true,
         linesDecorationsClassName: 'myLineDecoration',
-        className: 'do-not-edit',
         stickiness
       }
     };
@@ -848,7 +847,6 @@ const Editor = (props: EditorProps): JSX.Element => {
       options: {
         isWholeLine: true,
         linesDecorationsClassName: 'myLineDecoration',
-        className: 'do-not-edit',
         stickiness
       }
     };
@@ -866,7 +864,6 @@ const Editor = (props: EditorProps): JSX.Element => {
       options: {
         isWholeLine: true,
         linesDecorationsClassName: 'myEditableLineDecoration',
-        className: 'do-not-edit',
         stickiness
       }
     };
@@ -884,7 +881,6 @@ const Editor = (props: EditorProps): JSX.Element => {
       options: {
         isWholeLine: true,
         linesDecorationsClassName: 'myEditableLineDecoration',
-        className: 'do-not-edit',
         stickiness
       }
     };

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -290,7 +290,10 @@ const Editor = (props: EditorProps): JSX.Element => {
     editorRef.current = editor;
     data.editor = editor;
 
-    initializeProjectFeatures();
+    if (isProject()) {
+      initializeProjectFeatures();
+      addContentChangeListener();
+    }
 
     const storedAccessibilityMode = () => {
       const accessibility = store.get('accessibilityMode') as boolean;
@@ -641,13 +644,16 @@ const Editor = (props: EditorProps): JSX.Element => {
   };
 
   function initializeProjectFeatures() {
-    const editableRegionBoundaries = getEditableRegionFromRedux();
     const editor = data.editor;
-    if (editableRegionBoundaries.length === 2 && editor) {
-      initializeRegions(editableRegionBoundaries);
+    if (editor) {
+      initializeRegions(getEditableRegionFromRedux());
       addWidgetsToRegions(editor);
-      addContentChangeListener();
     }
+  }
+
+  function isProject() {
+    const editableRegionBoundaries = getEditableRegionFromRedux();
+    return editableRegionBoundaries.length === 2;
   }
 
   function initializeRegions(editableRegion: number[]) {
@@ -751,7 +757,6 @@ const Editor = (props: EditorProps): JSX.Element => {
     showEditableRegion(editor);
   }
 
-  // TODO this listener needs to be replaced on reset.
   function addContentChangeListener() {
     const { model } = data;
     const monaco = monacoRef.current;

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -269,7 +269,6 @@ const Editor = (props: EditorProps): JSX.Element => {
 
   // Updates the model if the contents has changed. This is only necessary for
   // changes coming from outside the editor (such as code resets).
-  // TODO: is this even necessary?
   const updateEditorValues = () => {
     const { challengeFiles, fileKey } = props;
     const { model } = data;

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -278,6 +278,9 @@ const Editor = (props: EditorProps): JSX.Element => {
     )?.contents;
     if (model?.getValue() !== newContents) {
       model?.setValue(newContents ?? '');
+      return true;
+    } else {
+      return false;
     }
   };
 
@@ -951,8 +954,8 @@ const Editor = (props: EditorProps): JSX.Element => {
   useEffect(() => {
     // If a challenge is reset, it needs to communicate that change to the
     // editor.
-    updateEditorValues();
-    if (isProject()) {
+    const hasChangedContents = updateEditorValues();
+    if (hasChangedContents && isProject()) {
       initializeProjectFeatures();
       updateDescriptionZone();
       updateOutputZone();

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -952,9 +952,11 @@ const Editor = (props: EditorProps): JSX.Element => {
     // If a challenge is reset, it needs to communicate that change to the
     // editor.
     updateEditorValues();
-    initializeProjectFeatures();
-    updateDescriptionZone();
-    updateOutputZone();
+    if (isProject()) {
+      initializeProjectFeatures();
+      updateDescriptionZone();
+      updateOutputZone();
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.challengeFiles]);
   useEffect(() => {

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -293,6 +293,7 @@ const Editor = (props: EditorProps): JSX.Element => {
     if (isProject()) {
       initializeProjectFeatures();
       addContentChangeListener();
+      showEditableRegion(editor);
     }
 
     const storedAccessibilityMode = () => {
@@ -754,7 +755,6 @@ const Editor = (props: EditorProps): JSX.Element => {
         editor.layoutOverlayWidget(data.descriptionWidget);
       if (data.outputWidget) editor.layoutOverlayWidget(data.outputWidget);
     });
-    showEditableRegion(editor);
   }
 
   function addContentChangeListener() {

--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -277,22 +277,16 @@ export const reducer = handleActions(
     }),
     [actionTypes.resetChallenge]: state => {
       console.log('before!!', inspect(state.challengeFiles));
-      const challengeFilesReset = [
-        ...state.challengeFiles.reduce(
-          (challengeFiles, challengeFile) => ({
-            ...challengeFiles,
-            ...challengeFile,
-            contents: challengeFile.seed.slice(),
-            editableContents: getLines(
-              challengeFile.seed,
-              challengeFile.seedEditableRegionBoundaries
-            ),
-            editableRegionBoundaries:
-              challengeFile.seedEditableRegionBoundaries.slice()
-          }),
-          {}
-        )
-      ];
+      const challengeFilesReset = state.challengeFiles.map(challengeFile => ({
+        ...challengeFile,
+        contents: challengeFile.seed.slice(),
+        editableContents: getLines(
+          challengeFile.seed,
+          challengeFile.seedEditableRegionBoundaries
+        ),
+        editableRegionBoundaries:
+          challengeFile.seedEditableRegionBoundaries.slice()
+      }));
       console.log('challengeFilesReset', inspect(challengeFilesReset));
       return {
         ...state,

--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -1,4 +1,3 @@
-import { inspect } from 'util';
 import { isEmpty } from 'lodash-es';
 import { createAction, handleActions } from 'redux-actions';
 
@@ -276,7 +275,6 @@ export const reducer = handleActions(
       challengeMeta: { ...payload }
     }),
     [actionTypes.resetChallenge]: state => {
-      console.log('before!!', inspect(state.challengeFiles));
       const challengeFilesReset = state.challengeFiles.map(challengeFile => ({
         ...challengeFile,
         contents: challengeFile.seed.slice(),
@@ -287,10 +285,9 @@ export const reducer = handleActions(
         editableRegionBoundaries:
           challengeFile.seedEditableRegionBoundaries.slice()
       }));
-      console.log('challengeFilesReset', inspect(challengeFilesReset));
       return {
         ...state,
-        // currentTab: 2,
+        currentTab: 2,
         challengeFiles: challengeFilesReset,
         challengeTests: state.challengeTests.map(({ text, testString }) => ({
           text,

--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -216,10 +216,12 @@ export const reducer = handleActions(
       { payload: { fileKey, editorValue, editableRegionBoundaries } }
     ) => {
       const updates = {};
-      if (editableRegionBoundaries)
+      // if a given part of the payload is null, we leave that part of the state
+      // unchanged
+      if (editableRegionBoundaries !== null)
         updates.editableRegionBoundaries = editableRegionBoundaries;
-      if (editorValue) updates.contents = editorValue;
-      if (editableRegionBoundaries && editorValue)
+      if (editorValue !== null) updates.contents = editorValue;
+      if (editableRegionBoundaries !== null && editorValue !== null)
         updates.editableContents = getLines(
           editorValue,
           editableRegionBoundaries

--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -1,3 +1,4 @@
+import { inspect } from 'util';
 import { isEmpty } from 'lodash-es';
 import { createAction, handleActions } from 'redux-actions';
 
@@ -215,15 +216,22 @@ export const reducer = handleActions(
       state,
       { payload: { fileKey, editorValue, editableRegionBoundaries } }
     ) => {
+      const updates = {};
+      if (editableRegionBoundaries)
+        updates.editableRegionBoundaries = editableRegionBoundaries;
+      if (editorValue) updates.contents = editorValue;
+      if (editableRegionBoundaries && editorValue)
+        updates.editableContents = getLines(
+          editorValue,
+          editableRegionBoundaries
+        );
       return {
         ...state,
         challengeFiles: [
           ...state.challengeFiles.filter(x => x.fileKey !== fileKey),
           {
             ...state.challengeFiles.find(x => x.fileKey === fileKey),
-            contents: editorValue,
-            editableContents: getLines(editorValue, editableRegionBoundaries),
-            editableRegionBoundaries
+            ...updates
           }
         ]
       };
@@ -268,6 +276,7 @@ export const reducer = handleActions(
       challengeMeta: { ...payload }
     }),
     [actionTypes.resetChallenge]: state => {
+      console.log('before!!', inspect(state.challengeFiles));
       const challengeFilesReset = [
         ...state.challengeFiles.reduce(
           (challengeFiles, challengeFile) => ({
@@ -278,14 +287,16 @@ export const reducer = handleActions(
               challengeFile.seed,
               challengeFile.seedEditableRegionBoundaries
             ),
-            editableRegionBoundaries: challengeFile.seedEditableRegionBoundaries
+            editableRegionBoundaries:
+              challengeFile.seedEditableRegionBoundaries.slice()
           }),
           {}
         )
       ];
+      console.log('challengeFilesReset', inspect(challengeFilesReset));
       return {
         ...state,
-        currentTab: 2,
+        // currentTab: 2,
         challengeFiles: challengeFilesReset,
         challengeTests: state.challengeTests.map(({ text, testString }) => ({
           text,

--- a/client/src/templates/Challenges/utils/getTargetEditor.js
+++ b/client/src/templates/Challenges/utils/getTargetEditor.js
@@ -1,5 +1,5 @@
 import { isEmpty } from 'lodash-es';
-import { toSortedArray } from '../../../../../utils/sort-files';
+import { sortChallengeFiles } from '../../../../../utils/sort-challengefiles';
 
 export function getTargetEditor(challengeFiles) {
   if (isEmpty(challengeFiles)) return null;
@@ -9,6 +9,6 @@ export function getTargetEditor(challengeFiles) {
     )?.fileKey;
 
     // fallback for when there is no editable region.
-    return targetEditor || toSortedArray(challengeFiles)[0].fileKey;
+    return targetEditor || sortChallengeFiles(challengeFiles)[0].fileKey;
   }
 }

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -43,7 +43,7 @@ const testEvaluator =
 const { getLines } = require('../../utils/get-lines');
 const { isAuditedCert } = require('../../utils/is-audited');
 
-const { toSortedArray } = require('../../utils/sort-files');
+const { sortChallengeFiles } = require('../../utils/sort-challengefiles');
 const {
   getChallengesForLang,
   getMetaForBlock,
@@ -471,7 +471,7 @@ ${inspect(commentMap)}
           // TODO: the no-solution filtering is a little convoluted:
           const noSolution = new RegExp('// solution required');
 
-          const solutionsAsArrays = solutions.map(toSortedArray);
+          const solutionsAsArrays = solutions.map(sortChallengeFiles);
 
           const filteredSolutions = solutionsAsArrays.filter(solution => {
             return !isEmpty(

--- a/utils/sort-challengefiles.js
+++ b/utils/sort-challengefiles.js
@@ -1,4 +1,4 @@
-exports.toSortedArray = function toSortedArray(challengeFiles) {
+exports.sortChallengeFiles = function sortChallengeFiles(challengeFiles) {
   const xs = challengeFiles.slice();
   // TODO: refactor this to use an ext array ['html', 'js', 'css'] and loop over
   // that.

--- a/utils/sort-challengefiles.test.js
+++ b/utils/sort-challengefiles.test.js
@@ -1,21 +1,21 @@
 const { challengeFiles } = require('./__fixtures__/challenges');
-const { toSortedArray } = require('./sort-files');
+const { sortChallengeFiles } = require('./sort-challengefiles');
 
 describe('sort-files', () => {
-  describe('toSortedArray', () => {
+  describe('sortChallengeFiles', () => {
     it('should return an array', () => {
-      const sorted = toSortedArray(challengeFiles);
+      const sorted = sortChallengeFiles(challengeFiles);
       expect(Array.isArray(sorted)).toBe(true);
     });
     it('should not modify the challenges', () => {
-      const sorted = toSortedArray(challengeFiles);
+      const sorted = sortChallengeFiles(challengeFiles);
       const expected = challengeFiles;
       expect(sorted).toEqual(expect.arrayContaining(expected));
       expect(sorted.length).toEqual(expected.length);
     });
 
     it('should sort the objects into html, css, jsx, js order', () => {
-      const sorted = challengeFiles;
+      const sorted = sortChallengeFiles(challengeFiles);
       const sortedKeys = sorted.map(({ fileKey }) => fileKey);
       const expected = ['indexhtml', 'indexcss', 'indexjsx', 'indexjs'];
       expect(sortedKeys).toStrictEqual(expected);

--- a/utils/sort-files.js
+++ b/utils/sort-files.js
@@ -1,5 +1,5 @@
 exports.toSortedArray = function toSortedArray(challengeFiles) {
-  const xs = challengeFiles;
+  const xs = challengeFiles.slice();
   // TODO: refactor this to use an ext array ['html', 'js', 'css'] and loop over
   // that.
   xs.sort((a, b) => {


### PR DESCRIPTION
I also had to refactor quite a bit, just to understand how everything was interacting, hence the large amount of red.

The change in functionality is straightforward, though: now the Restart Step button should work!