### PR TITLE
feat(actions): autoclose workflow

### DIFF
--- a/.github/workflows/autoclose.yml
+++ b/.github/workflows/autoclose.yml
@@ -1,0 +1,41 @@
+name: Autoclose
+on:
+  pull_request_target:
+    branches:
+      - "main"
+    paths:
+      - ".gitignore"
+
+jobs:
+  autoclose:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v5
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const files = await github.rest.pulls.listFiles({
+              owner: context.payload.repository.owner.login,
+              repo: context.payload.repository.name,
+              pull_number: context.payload.pull_request.number,
+            });
+            if (
+              files.data.length === 1 &&
+              files.data[0].filename === ".gitignore" &&
+              files.data[0].patch ===
+                "@@ -63,7 +63,6 @@ $RECYCLE.BIN/\n # Icon must end with two \\r\n Icon\n \n-\n # Thumbnails\n ._*\n "
+            ) {
+              core.setFailed("Invalid PR detected.");
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: "Thank you for opening this pull request.\n\nThis is a standard message notifying you that we've reviewed your pull request and have decided not to merge it. We would welcome future pull requests from you.\n\nThank you and happy coding.",
+              });
+              await github.rest.pulls.update({
+                owner: context.payload.repository.owner.login,
+                repo: context.payload.repository.name,
+                pull_number: context.payload.pull_request.number,
+                state: "closed"
+              });
+            }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
In preparation for Hacktoberfest (and because some folks have asked for this...)

This new action will automatically close any PR where the only change is removing the extra new line in the `.gitignore`. This is a common thing we see.

The workflow will:
- [Autoclose PRs that only remove the extra newline](https://github.com/nhcarrigan/actions-testing/pull/42)
- [Run on, but not close, PRs that change the `.gitignore` in other ways](https://github.com/nhcarrigan/actions-testing/pull/43)
- [Not run on PRs that do not touch the `.gitignore`](https://github.com/nhcarrigan/actions-testing/pull/44)
- [Run on, but not close, PRs that touch multiple files including the `.gitignore`](https://github.com/nhcarrigan/actions-testing/pull/45)