### PR TITLE
fix(curriculum): Fix a typo in "Problem 141: Investigating progressive numbers, n, which are also square"

### DIFF
--- a/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-141-investigating-progressive-numbers-n-which-are-also-square.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-141-investigating-progressive-numbers-n-which-are-also-square.md
@@ -16,7 +16,7 @@ We will call such numbers, $n$, progressive.
 
 Some progressive numbers, such as 9 and 10404 = ${102}^2$, also happen to be perfect squares. The sum of all progressive perfect squares below one hundred thousand is 124657.
 
-Find the sum of all progressive perfect squares below one trillion (${101}^2$).
+Find the sum of all progressive perfect squares below one trillion (${10}^{12}$).
 
 # --hints--
 


### PR DESCRIPTION
<!-- Please note that low quality PRs and PRs that do not follow our contributing guidelines will be marked as invalid for Hacktoberfest. -->

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I was translating this file and noticed that this sentence is a little bit weird.

I checked the [original question](https://projecteuler.net/problem=141) and found there is a typo.

<!-- Feel free to add any additional description of changes below this line -->
