### PR TITLE
feat: make renovate group all monaco packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,7 @@
     },
     {
       "groupName": "Monaco Editor",
-      "matchPackageNames": ["monaco-editor", "monaco-editor-webpack-plugin"]
+      "matchPackageNames": ["monaco-editor", "monaco-editor-webpack-plugin", "react-monaco-editor"]
     },
     {
       "matchPackageNames": ["normalize-url"],


### PR DESCRIPTION
react-monaco-editor depends on specific monaco-editor versions, so this
makes sure they're all updated in the same renovate PR

Closes https://github.com/freeCodeCamp/freeCodeCamp/pull/43641