### PR TITLE
fix: remove pretest for test:full-output

### DIFF
--- a/curriculum/package.json
+++ b/curriculum/package.json
@@ -26,7 +26,6 @@
     "lint": "gulp lint",
     "reorder-steps": "cross-env CALLING_DIR=$INIT_CWD node ../tools/challenge-helper-scripts/reorder-steps",
     "test": "mocha --delay --exit  --reporter progress --bail",
-    "pretest:full-output": "npm run pretest",
     "test:full-output": "cross-env FULL_OUTPUT=true mocha --delay --reporter progress"
   },
   "devDependencies": {


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Trying to run `npm run test-curriculum-full-output` from main directory, or `npm run test:full-output` from `curriculum/` triggers the `pretest:full-output` with `npm run pretest`. Because `pretest` script was removed from `curriculum/package.json` this ends up with error.