### PR TITLE
feat: Allow display username with uppercase characters

### DIFF
--- a/api-server/src/common/models/user.js
+++ b/api-server/src/common/models/user.js
@@ -108,12 +108,13 @@ function isTheSame(val1, val2) {
 
 function getAboutProfile({
   username,
+  usernameDisplay,
   githubProfile: github,
   progressTimestamps = [],
   bio
 }) {
   return {
-    username,
+    username: usernameDisplay || username,
     github,
     browniePoints: progressTimestamps.length,
     bio
@@ -127,7 +128,8 @@ function nextTick(fn) {
 const getRandomNumber = () => Math.random();
 
 function populateRequiredFields(user) {
-  user.username = user.username.trim().toLowerCase();
+  user.usernameDisplay = user.username.trim();
+  user.username = user.usernameDisplay.toLowerCase();
   user.email =
     typeof user.email === 'string'
       ? user.email.trim().toLowerCase()
@@ -722,42 +724,6 @@ export default function initializeUser(User) {
         Your privacy settings have been updated.
       `
     );
-  };
-
-  User.prototype.updateMyUsername = function updateMyUsername(newUsername) {
-    return Observable.defer(() => {
-      const isOwnUsername = isTheSame(newUsername, this.username);
-      if (isOwnUsername) {
-        return Observable.of(dedent`
-          ${newUsername} is already associated with this account.
-          `);
-      }
-      return Observable.fromPromise(User.doesExist(newUsername));
-    }).flatMap(boolOrMessage => {
-      if (typeof boolOrMessage === 'string') {
-        return Observable.of(boolOrMessage);
-      }
-      if (boolOrMessage) {
-        return Observable.of(dedent`
-        ${newUsername} is already associated with a different account.
-        `);
-      }
-
-      const usernameUpdate = new Promise((resolve, reject) =>
-        this.updateAttribute('username', newUsername, err => {
-          if (err) {
-            return reject(err);
-          }
-          return resolve();
-        })
-      );
-
-      return Observable.fromPromise(usernameUpdate).map(
-        () => dedent`
-        Your username has been updated successfully.
-        `
-      );
-    });
   };
 
   function prepUserForPublish(user, profileUI) {

--- a/api-server/src/common/models/user.json
+++ b/api-server/src/common/models/user.json
@@ -74,6 +74,9 @@
       },
       "require": true
     },
+    "usernameDisplay": {
+      "type": "string"
+    },
     "about": {
       "type": "string",
       "default": ""
@@ -276,9 +279,7 @@
       "default": {}
     },
     "donationEmails": {
-      "type": [
-        "string"
-      ]
+      "type": ["string"]
     },
     "isDonating": {
       "type": "boolean",

--- a/api-server/src/server/boot/settings.js
+++ b/api-server/src/server/boot/settings.js
@@ -195,7 +195,8 @@ function createUpdateMyUsername(app) {
       });
     }
 
-    const exists = await User.doesExist(username);
+    const exists =
+      username === user.username ? false : await User.doesExist(username);
 
     if (exists) {
       return res.json({

--- a/api-server/src/server/boot/settings.js
+++ b/api-server/src/server/boot/settings.js
@@ -173,11 +173,14 @@ function updateMyAbout(req, res, next) {
 function createUpdateMyUsername(app) {
   const { User } = app.models;
   return async function updateMyUsername(req, res, next) {
-    const {
-      user,
-      body: { username }
-    } = req;
-    if (username === user.username) {
+    const { user, body } = req;
+    const usernameDisplay = body.username.trim();
+    const username = usernameDisplay.toLowerCase();
+    if (
+      username === user.username &&
+      user.usernameDisplay &&
+      usernameDisplay === user.usernameDisplay
+    ) {
       return res.json({
         type: 'info',
         message: 'flash.username-used'
@@ -201,7 +204,7 @@ function createUpdateMyUsername(app) {
       });
     }
 
-    return user.updateAttribute('username', username, err => {
+    return user.updateAttributes({ username, usernameDisplay }, err => {
       if (err) {
         res.status(500).json(standardErrorMessage);
         return next(err);
@@ -210,7 +213,7 @@ function createUpdateMyUsername(app) {
       return res.status(200).json({
         type: 'success',
         message: `flash.username-updated`,
-        variables: { username: username }
+        variables: { username: usernameDisplay }
       });
     });
   };

--- a/api-server/src/server/boot/user.js
+++ b/api-server/src/server/boot/user.js
@@ -76,6 +76,7 @@ function createReadSessionUser(app) {
           user: {
             [user.username]: {
               ...pick(user, userPropsForSession),
+              username: user.usernameDisplay || user.username,
               isEmailVerified: !!user.emailVerified,
               isGithub: !!user.githubProfile,
               isLinkedIn: !!user.linkedin,

--- a/client/src/components/settings/username.tsx
+++ b/client/src/components/settings/username.tsx
@@ -131,7 +131,9 @@ class UsernameSettings extends Component<UsernameProps, UsernameState> {
         submitClicked: false
       },
       () =>
-        this.state.isFormPristine || this.state.characterValidation.error
+        this.state.isFormPristine ||
+        this.state.characterValidation.error ||
+        username.toLowerCase().trim() === newValue.toLowerCase().trim()
           ? null
           : validateUsername(this.state.formValue)
     );

--- a/cypress/integration/settings/username-change.js
+++ b/cypress/integration/settings/username-change.js
@@ -148,6 +148,19 @@ describe('Username input field', () => {
     cy.resetUsername();
   });
 
+  it('Should change username with uppercase characters if `Save` button is clicked', () => {
+    cy.get('@usernameInput')
+      .clear({ force: true })
+      .type('Quincy', { force: true });
+
+    cy.contains('Username is available');
+
+    cy.get('@usernameForm').contains('Save').click({ force: true });
+    cy.contains('Account Settings for Quincy').should('be.visible');
+
+    cy.resetUsername();
+  });
+
   it('Should show flash message showing username has been updated', () => {
     cy.get('@usernameInput')
       .clear({ force: true })
@@ -194,23 +207,5 @@ describe('Username input field', () => {
     cy.contains('Account Settings for symbol').should('be.visible');
 
     cy.resetUsername();
-  });
-  it('Should show warning if username includes uppercase characters', () => {
-    cy.get('@usernameInput')
-      .clear({ force: true })
-      .type('QuincyLarson', { force: true });
-
-    cy.contains('Username "QuincyLarson" must be lowercase')
-      .should('be.visible')
-      .should('have.attr', 'role', 'alert')
-      .should('have.class', 'alert alert-danger');
-  });
-
-  it('Should not be able to click the `Save` button if username includes uppercase characters', () => {
-    cy.get('@usernameInput')
-      .clear({ force: true })
-      .type('QuincyLarson', { force: true });
-
-    cy.get('@usernameForm').contains('Save').should('be.disabled');
   });
 });

--- a/utils/validate.js
+++ b/utils/validate.js
@@ -8,20 +8,16 @@ const usernameIsHttpStatusCode = {
   valid: false,
   error: 'is a reserved error code'
 };
-const usernameUpperCase = { valid: false, error: 'must be lowercase' };
 
 const isNumeric = num => !isNaN(num);
 const validCharsRE = /^[a-zA-Z0-9\-_+]*$/;
 const isHttpStatusCode = str =>
   isNumeric(str) && parseInt(str, 10) >= 100 && parseInt(str, 10) <= 599;
-const isUsernameLowercase = str => {
-  return str === str.toLowerCase();
-};
+
 const isValidUsername = str => {
   if (!validCharsRE.test(str)) return invalidCharError;
   if (str.length < 3) return usernameTooShort;
   if (isHttpStatusCode(str)) return usernameIsHttpStatusCode;
-  if (!isUsernameLowercase(str)) return usernameUpperCase;
   return validationSuccess;
 };
 
@@ -29,10 +25,8 @@ module.exports = {
   isNumeric,
   isHttpStatusCode,
   isValidUsername,
-  isUsernameLowercase,
   validationSuccess,
   usernameTooShort,
   usernameIsHttpStatusCode,
-  invalidCharError,
-  usernameUpperCase
+  invalidCharError
 };

--- a/utils/validate.test.js
+++ b/utils/validate.test.js
@@ -3,8 +3,7 @@ const {
   usernameTooShort,
   validationSuccess,
   usernameIsHttpStatusCode,
-  invalidCharError,
-  usernameUpperCase
+  invalidCharError
 } = require('./validate');
 
 function inRange(num, range) {
@@ -37,9 +36,6 @@ describe('isValidUsername', () => {
     expect(isValidUsername('a-b')).toStrictEqual(validationSuccess);
     expect(isValidUsername('a_b')).toStrictEqual(validationSuccess);
   });
-  it('rejects uppercase characters', () => {
-    expect(isValidUsername('Quincy')).toStrictEqual(usernameUpperCase);
-  });
 
   it('rejects all other ASCII characters', () => {
     const allowedCharactersList = ['-', '_', '+'];
@@ -54,7 +50,7 @@ describe('isValidUsername', () => {
       let expected = invalidCharError;
       if (allowedCharactersList.includes(char)) expected = validationSuccess;
       if (inRange(code, numbers)) expected = validationSuccess;
-      if (inRange(code, upperCase)) expected = usernameUpperCase;
+      if (inRange(code, upperCase)) expected = validationSuccess;
       if (inRange(code, lowerCase)) expected = validationSuccess;
       expect(isValidUsername(base + char)).toStrictEqual(expected);
     }


### PR DESCRIPTION
<!-- Please note that low quality PRs and PRs that do not follow our contributing guidelines will be marked as invalid for Hacktoberfest. -->

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #35525

<!-- Feel free to add any additional description of changes below this line -->

- Allows users to save *UpperCasedUserName* in `usernameDisplay` field, while the lowercased version is stored in `username`
- Allows users to update lowercase version to uppercased version of the same username
- Removes  `User.prototype.updateMyUsername` that is not used anywhere
