### PR TITLE
fix(ui): Fix crash when viewing an invalid certificate 

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -462,7 +462,8 @@
     "no-account": "No {{website}} account associated",
     "unlink-success": "You've successfully unlinked your {{website}}",
     "provide-username": "Check if you have provided a username and a report",
-    "report-sent": "A report was sent to the team with {{email}} in copy"
+    "report-sent": "A report was sent to the team with {{email}} in copy",
+    "certificate-missing": "The certification you tried to view does not exist"
   },
   "validation": {
     "max-characters": "There is a maximum limit of 288 characters, you have {{charsLeft}} left",

--- a/client/src/client-only-routes/show-certification.tsx
+++ b/client/src/client-only-routes/show-certification.tsx
@@ -27,6 +27,7 @@ import {
 } from '../redux';
 import { UserType } from '../redux/prop-types';
 import { certMap } from '../resources/cert-and-project-map';
+import certificateMissingMessage from '../utils/certificate-missing-message';
 import reallyWeirdErrorMessage from '../utils/really-weird-error-message';
 import standardErrorMessage from '../utils/standard-error-message';
 
@@ -205,7 +206,7 @@ const ShowCertification = (props: IShowCertificationProps): JSX.Element => {
   } = props;
 
   if (!isValidCert) {
-    createFlashMessage(standardErrorMessage);
+    createFlashMessage(certificateMissingMessage);
     return <RedirectHome />;
   }
 

--- a/client/src/redux/index.js
+++ b/client/src/redux/index.js
@@ -226,8 +226,9 @@ export const shouldRequestDonationSelector = state => {
 
 export const userByNameSelector = username => state => {
   const { user } = state[ns];
-  // TODO: Why return a string or empty objet literal?
-  return username in user ? user[username] : {};
+  // do not initalize  empty object literal to prevent
+  // components from re-rendering unnecessarily
+  return user[username];
 };
 
 export const certificatesByNameSelector = username => state => {

--- a/client/src/redux/index.js
+++ b/client/src/redux/index.js
@@ -226,9 +226,9 @@ export const shouldRequestDonationSelector = state => {
 
 export const userByNameSelector = username => state => {
   const { user } = state[ns];
-  // do not initalize  empty object literal to prevent
-  // components from re-rendering unnecessarily
-  return user[username];
+  // return initial state empty user empty object instead of empty
+  // object litteral to prevent components from re-rendering unnecessarily
+  return user[username] ?? initialState.user;
 };
 
 export const certificatesByNameSelector = username => state => {

--- a/client/src/utils/certificate-missing-message.ts
+++ b/client/src/utils/certificate-missing-message.ts
@@ -1,0 +1,6 @@
+const certificateMissingErrorMessage = {
+  type: 'danger',
+  message: 'flash.certificate-missing'
+};
+
+export default certificateMissingErrorMessage;


### PR DESCRIPTION
<!-- Please note that low quality PRs and PRs that do not follow our contributing guidelines will be marked as invalid for Hacktoberfest. -->

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #43224

<!-- Feel free to add any additional description of changes below this line -->

This issue is caused by how the `userByNameSelector` **always creates an empty object** if the username is not present in the `user` redux state:
```
export const userByNameSelector = username => state => {
  const { user } = state[ns];
  // TODO: Why return a string or empty objet literal?
  return username in user ? user?.[username] : {};
};
```
This causes the`ShowCertification` component to re-render because `user` prop is always updated to a new empty object everytime `userByNameSelector` is accessed.
