### PR TITLE
fix(tools): apply invalid label

### DIFF
--- a/.github/workflows/autoclose.yml
+++ b/.github/workflows/autoclose.yml
@@ -38,4 +38,10 @@ jobs:
                 pull_number: context.payload.pull_request.number,
                 state: "closed"
               });
+              await github.rest.issues.addLabels({
+                owner: context.payload.repository.owner.login,
+                repo: context.payload.repository.name,
+                issue_number: context.issue.number,
+                labels: ["invalid"]
+              });
             }


### PR DESCRIPTION
<!-- Please note that low quality PRs and PRs that do not follow our contributing guidelines will be marked as invalid for Hacktoberfest. -->

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Add a step to automatically apply the `invalid` label to those .gitignore PRs.