### PR TITLE
fix: reset regex.lastIndex when tests use test method

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/find-one-or-more-criminals-in-a-hunt.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/find-one-or-more-criminals-in-a-hunt.md
@@ -69,12 +69,14 @@ assert(
 Your regex should not match any criminals in the empty string `""`
 
 ```js
+reCriminals.lastIndex = 0;
 assert(!reCriminals.test(''));
 ```
 
 Your regex should not match any criminals in the string `P1P2P3`
 
 ```js
+reCriminals.lastIndex = 0;
 assert(!reCriminals.test('P1P2P3'));
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/ignore-case-while-matching.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/ignore-case-while-matching.md
@@ -23,60 +23,70 @@ Write a regex `fccRegex` to match `freeCodeCamp`, no matter its case. Your regex
 Your regex should match the string `freeCodeCamp`
 
 ```js
+fccRegex.lastIndex = 0; 
 assert(fccRegex.test('freeCodeCamp'));
 ```
 
 Your regex should match the string `FreeCodeCamp`
 
 ```js
+fccRegex.lastIndex = 0;
 assert(fccRegex.test('FreeCodeCamp'));
 ```
 
 Your regex should match the string `FreecodeCamp`
 
 ```js
+fccRegex.lastIndex = 0;
 assert(fccRegex.test('FreecodeCamp'));
 ```
 
 Your regex should match the string `FreeCodecamp`
 
 ```js
+fccRegex.lastIndex = 0;
 assert(fccRegex.test('FreeCodecamp'));
 ```
 
 Your regex should not match the string `Free Code Camp`
 
 ```js
+fccRegex.lastIndex = 0;
 assert(!fccRegex.test('Free Code Camp'));
 ```
 
 Your regex should match the string `FreeCOdeCamp`
 
 ```js
+fccRegex.lastIndex = 0;
 assert(fccRegex.test('FreeCOdeCamp'));
 ```
 
 Your regex should not match the string `FCC`
 
 ```js
+fccRegex.lastIndex = 0;
 assert(!fccRegex.test('FCC'));
 ```
 
 Your regex should match the string `FrEeCoDeCamp`
 
 ```js
+fccRegex.lastIndex = 0;
 assert(fccRegex.test('FrEeCoDeCamp'));
 ```
 
 Your regex should match the string `FrEeCodECamp`
 
 ```js
+fccRegex.lastIndex = 0;
 assert(fccRegex.test('FrEeCodECamp'));
 ```
 
 Your regex should match the string `FReeCodeCAmp`
 
 ```js
+fccRegex.lastIndex = 0;
 assert(fccRegex.test('FReeCodeCAmp'));
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-a-literal-string-with-different-possibilities.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-a-literal-string-with-different-possibilities.md
@@ -25,42 +25,49 @@ Complete the regex `petRegex` to match the pets `dog`, `cat`, `bird`, or `fish`.
 Your regex `petRegex` should return `true` for the string `John has a pet dog.`
 
 ```js
+petRegex.lastIndex = 0;
 assert(petRegex.test('John has a pet dog.'));
 ```
 
 Your regex `petRegex` should return `false` for the string `Emma has a pet rock.`
 
 ```js
+petRegex.lastIndex = 0;
 assert(!petRegex.test('Emma has a pet rock.'));
 ```
 
 Your regex `petRegex` should return `true` for the string `Emma has a pet bird.`
 
 ```js
+petRegex.lastIndex = 0;
 assert(petRegex.test('Emma has a pet bird.'));
 ```
 
 Your regex `petRegex` should return `true` for the string `Liz has a pet cat.`
 
 ```js
+petRegex.lastIndex = 0;
 assert(petRegex.test('Liz has a pet cat.'));
 ```
 
 Your regex `petRegex` should return `false` for the string `Kara has a pet dolphin.`
 
 ```js
+petRegex.lastIndex = 0;
 assert(!petRegex.test('Kara has a pet dolphin.'));
 ```
 
 Your regex `petRegex` should return `true` for the string `Alice has a pet fish.`
 
 ```js
+petRegex.lastIndex = 0;
 assert(petRegex.test('Alice has a pet fish.'));
 ```
 
 Your regex `petRegex` should return `false` for the string `Jimmy has a pet computer.`
 
 ```js
+petRegex.lastIndex = 0;
 assert(!petRegex.test('Jimmy has a pet computer.'));
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-beginning-string-patterns.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-beginning-string-patterns.md
@@ -43,12 +43,14 @@ assert(calRegex.flags == '');
 Your regex should match the string `Cal` at the beginning of the string.
 
 ```js
+calRegex.lastIndex = 0;
 assert(calRegex.test('Cal and Ricky both like racing.'));
 ```
 
 Your regex should not match the string `Cal` in the middle of a string.
 
 ```js
+calRegex.lastIndex = 0;
 assert(!calRegex.test('Ricky and Cal both like racing.'));
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-ending-string-patterns.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-ending-string-patterns.md
@@ -43,7 +43,7 @@ assert(lastRegex.flags == '');
 You should match `caboose` at the end of the string `The last car on a train is the caboose`
 
 ```js
-latRegex.lastIndex = 0;
+lastRegex.lastIndex = 0;
 assert(lastRegex.test('The last car on a train is the caboose'));
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-ending-string-patterns.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-ending-string-patterns.md
@@ -43,6 +43,7 @@ assert(lastRegex.flags == '');
 You should match `caboose` at the end of the string `The last car on a train is the caboose`
 
 ```js
+latRegex.lastIndex = 0;
 assert(lastRegex.test('The last car on a train is the caboose'));
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-literal-strings.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/match-literal-strings.md
@@ -38,12 +38,14 @@ Complete the regex `waldoRegex` to find `"Waldo"` in the string `waldoIsHiding` 
 Your regex `waldoRegex` should find the string `Waldo`
 
 ```js
+waldoRegex.lastIndex = 0;
 assert(waldoRegex.test(waldoIsHiding));
 ```
 
 Your regex `waldoRegex` should not search for anything else.
 
 ```js
+waldoRegex.lastIndex = 0;
 assert(!waldoRegex.test('Somewhere is hiding in this text.'));
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/positive-and-negative-lookahead.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/positive-and-negative-lookahead.md
@@ -52,48 +52,56 @@ assert(pwRegex.source.match(/\(\?=.*?\)\(\?=.*?\)/) !== null);
 Your regex should not match the string `astronaut`
 
 ```js
+pwRegex.lastIndex = 0;
 assert(!pwRegex.test('astronaut'));
 ```
 
 Your regex should not match the string `banan1`
 
 ```js
+pwRegex.lastIndex = 0;
 assert(!pwRegex.test('banan1'));
 ```
 
 Your regex should match the string `bana12`
 
 ```js
+pwRegex.lastIndex = 0;
 assert(pwRegex.test('bana12'));
 ```
 
 Your regex should match the string `abc123`
 
 ```js
+pwRegex.lastIndex = 0;
 assert(pwRegex.test('abc123'));
 ```
 
 Your regex should not match the string `12345`
 
 ```js
+pwRegex.lastIndex = 0;
 assert(!pwRegex.test('12345'));
 ```
 
 Your regex should match the string `8pass99`
 
 ```js
+pwRegex.lastIndex = 0;
 assert(pwRegex.test('8pass99'));
 ```
 
 Your regex should not match the string `1a2bcde`
 
 ```js
+pwRegex.lastIndex = 0;
 assert(!pwRegex.test('1a2bcde'));
 ```
 
 Your regex should match the string `astr1on11aut`
 
 ```js
+pwRegex.lastIndex = 0;
 assert(pwRegex.test('astr1on11aut'));
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/restrict-possible-usernames.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/restrict-possible-usernames.md
@@ -29,78 +29,91 @@ Change the regex `userCheck` to fit the constraints listed above.
 Your regex should match the string `JACK`
 
 ```js
+userCheck.lastIndex = 0;
 assert(userCheck.test('JACK'));
 ```
 
 Your regex should not match the string `J`
 
 ```js
+userCheck.lastIndex = 0;
 assert(!userCheck.test('J'));
 ```
 
 Your regex should match the string `Jo`
 
 ```js
+userCheck.lastIndex = 0;
 assert(userCheck.test('Jo'));
 ```
 
 Your regex should match the string `Oceans11`
 
 ```js
+userCheck.lastIndex = 0;
 assert(userCheck.test('Oceans11'));
 ```
 
 Your regex should match the string `RegexGuru`
 
 ```js
+userCheck.lastIndex = 0;
 assert(userCheck.test('RegexGuru'));
 ```
 
 Your regex should not match the string `007`
 
 ```js
+userCheck.lastIndex = 0;
 assert(!userCheck.test('007'));
 ```
 
 Your regex should not match the string `9`
 
 ```js
+userCheck.lastIndex = 0;
 assert(!userCheck.test('9'));
 ```
 
 Your regex should not match the string `A1`
 
 ```js
+userCheck.lastIndex = 0;
 assert(!userCheck.test('A1'));
 ```
 
 Your regex should not match the string `BadUs3rnam3`
 
 ```js
+userCheck.lastIndex = 0;
 assert(!userCheck.test('BadUs3rnam3'));
 ```
 
 Your regex should match the string `Z97`
 
 ```js
+userCheck.lastIndex = 0;
 assert(userCheck.test('Z97'));
 ```
 
 Your regex should not match the string `c57bT3`
 
 ```js
+userCheck.lastIndex = 0;
 assert(!userCheck.test('c57bT3'));
 ```
 
 Your regex should match the string `AB1`
 
 ```js
+userCheck.lastIndex = 0;
 assert(userCheck.test('AB1'));
 ```
 
 Your regex should not match the string `J%4`
 
 ```js
+userCheck.lastIndex = 0;
 assert(!userCheck.test('J%4'))
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/reuse-patterns-using-capture-groups.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/reuse-patterns-using-capture-groups.md
@@ -52,12 +52,14 @@ assert(reRegex.source.match(/\\1|\\2/g).length >= 2);
 Your regex should match the string `42 42 42`.
 
 ```js
+reRegex.lastIndex = 0;
 assert(reRegex.test('42 42 42'));
 ```
 
 Your regex should match the string `100 100 100`.
 
 ```js
+reRegex.lastIndex = 0;
 assert(reRegex.test('100 100 100'));
 ```
 
@@ -76,18 +78,21 @@ assert.equal('42 42'.match(reRegex.source), null);
 Your regex should not match the string `101 102 103`.
 
 ```js
+reRegex.lastIndex = 0;
 assert(!reRegex.test('101 102 103'));
 ```
 
 Your regex should not match the string `1 2 3`.
 
 ```js
+reRegex.lastIndex = 0;
 assert(!reRegex.test('1 2 3'));
 ```
 
 Your regex should match the string `10 10 10`.
 
 ```js
+reRegex.lastIndex = 0;
 assert(reRegex.test('10 10 10'));
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/specify-only-the-lower-number-of-matches.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/specify-only-the-lower-number-of-matches.md
@@ -41,12 +41,14 @@ assert(haRegex.source.match(/{.*?}/).length > 0);
 Your regex should not match the string `Hazzah`
 
 ```js
+haRegex.lastIndex = 0;
 assert(!haRegex.test('Hazzah'));
 ```
 
 Your regex should not match the string `Hazzzah`
 
 ```js
+haRegex.lastIndex = 0;
 assert(!haRegex.test('Hazzzah'));
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/specify-upper-and-lower-number-of-matches.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/specify-upper-and-lower-number-of-matches.md
@@ -39,6 +39,7 @@ assert(ohRegex.source.match(/{.*?}/).length > 0);
 Your regex should not match the string `Ohh no`
 
 ```js
+ohRegex.lastIndex = 0;
 assert(!ohRegex.test('Ohh no'));
 ```
 
@@ -69,6 +70,7 @@ assert('Ohhhhhh no'.match(ohRegex)[0].length === 10);
 Your regex should not match the string `Ohhhhhhh no`
 
 ```js
+ohRegex.lastIndex = 0;
 assert(!ohRegex.test('Ohhhhhhh no'));
 ```
 


### PR DESCRIPTION
<!-- Please note that low quality PRs and PRs that do not follow our contributing guidelines will be marked as invalid for Hacktoberfest. -->

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related #43516 
Closes #40211

<!-- Feel free to add any additional description of changes below this line -->

There were already various challenge with the line `regex.lastIndex = 0` so I didn't need to do that much work.
But if this was the issue, after this the challenge test can again be run in the same envirtonment instead of resetting the environment after each test