### PR TITLE
fix(UI): prevent dup navigation on account delete

### DIFF
--- a/client/src/client-only-routes/show-settings.test.tsx
+++ b/client/src/client-only-routes/show-settings.test.tsx
@@ -23,11 +23,11 @@ describe('<ShowSettings />', () => {
     );
   });
 
-  it('redirects to sign in page when user is not logged in', () => {
+  it('redirects to learn page when user is not logged in', () => {
     const shallow = new ShallowRenderer();
     shallow.render(<ShowSettings {...loggedOutProps} />);
     expect(navigate).toHaveBeenCalledTimes(1);
-    expect(navigate).toHaveBeenCalledWith(`${apiLocation}/signin`);
+    expect(navigate).toHaveBeenCalledWith('/learn');
     const result = shallow.getRenderOutput();
     // Renders Loader rather than ShowSettings
     expect(result.type.displayName).toBe('Loader');

--- a/client/src/client-only-routes/show-settings.tsx
+++ b/client/src/client-only-routes/show-settings.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 
-import envData from '../../../config/env.json';
 import { createFlashMessage } from '../components/Flash/redux';
 import { Loader, Spacer } from '../components/helpers';
 import Certification from '../components/settings/Certification';
@@ -24,8 +23,6 @@ import {
 } from '../redux';
 import { UserType } from '../redux/prop-types';
 import { submitNewAbout, updateUserFlag, verifyCert } from '../redux/settings';
-
-const { apiLocation } = envData;
 
 // TODO: update types for actions
 interface IShowSettingsProps {
@@ -124,7 +121,7 @@ export function ShowSettings(props: IShowSettingsProps): JSX.Element {
   }
 
   if (!isSignedIn) {
-    if (!wasSignedIn.current) navigate(`${apiLocation}/signin`);
+    if (!wasSignedIn.current) navigate('/learn');
     return <Loader fullScreen={true} />;
   }
 

--- a/client/src/client-only-routes/show-settings.tsx
+++ b/client/src/client-only-routes/show-settings.tsx
@@ -1,5 +1,5 @@
 import { Grid } from '@freecodecamp/react-bootstrap';
-import React from 'react';
+import React, { useRef } from 'react';
 import Helmet from 'react-helmet';
 import { useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -117,13 +117,14 @@ export function ShowSettings(props: IShowSettingsProps): JSX.Element {
     updateIsHonest,
     verifyCert
   } = props;
+  const wasSignedIn = useRef(isSignedIn);
 
   if (showLoading) {
     return <Loader fullScreen={true} />;
   }
 
   if (!isSignedIn) {
-    navigate(`${apiLocation}/signin`);
+    if (!wasSignedIn.current) navigate(`${apiLocation}/signin`);
     return <Loader fullScreen={true} />;
   }
 

--- a/client/src/redux/settings/danger-zone-saga.js
+++ b/client/src/redux/settings/danger-zone-saga.js
@@ -18,7 +18,7 @@ function* deleteAccountSaga() {
     );
     // remove current user information from application state
     yield put(resetUserData());
-    yield call(navigate, '/');
+    yield call(navigate, '/learn');
   } catch (e) {
     yield put(deleteAccountError(e));
   }


### PR DESCRIPTION
<!-- Please note that low quality PRs and PRs that do not follow our contributing guidelines will be marked as invalid for Hacktoberfest. -->

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #39508

<!-- Feel free to add any additional description of changes below this line -->

As I understand the issue happens because `deleteAccountSaga` navigates user to `/`, while the component `ShowSettings` rerenders and subsequently triggers the navigation to `/signin` as `isSignedIn` is no longer true. A less intrusive fix is to track if `isSignedIn` changes from true to false, and prevent navigation if that is the case. 

`isSignedIn` only goes from `true` to `false` for account delete. Signing out is a get request to server which redirects to some other page.