### PR TITLE
fix: Type Json and PNG file.

### DIFF
--- a/.eslintrc-base.json
+++ b/.eslintrc-base.json
@@ -56,10 +56,7 @@
     "import/no-unresolved": [
       2,
       {
-        "commonjs": true,
-        "ignore": [
-          ".json"
-        ]
+        "commonjs": true
       }
     ],
     "import/order": [

--- a/.eslintrc-base.json
+++ b/.eslintrc-base.json
@@ -2,14 +2,33 @@
   "rules": {
     "max-len": [
       "error",
-      { "code": 80, "ignoreUrls": true, "ignoreTemplateLiterals": true }
+      {
+        "code": 80,
+        "ignoreUrls": true,
+        "ignoreTemplateLiterals": true
+      }
     ],
     "block-scoped-var": 0,
-    "brace-style": [2, "1tbs", { "allowSingleLine": true }],
+    "brace-style": [
+      2,
+      "1tbs",
+      {
+        "allowSingleLine": true
+      }
+    ],
     "camelcase": 2,
     "comma-dangle": 2,
-    "comma-spacing": [2, { "before": false, "after": true }],
-    "comma-style": [2, "last"],
+    "comma-spacing": [
+      2,
+      {
+        "before": false,
+        "after": true
+      }
+    ],
+    "comma-style": [
+      2,
+      "last"
+    ],
     "complexity": 0,
     "consistent-return": 2,
     "consistent-this": 0,
@@ -25,19 +44,48 @@
     "handle-callback-err": 2,
     "import/default": 2,
     "import/export": 2,
-    "import/extensions": [0, "always"],
+    "import/extensions": [
+      0,
+      "always"
+    ],
     "import/first": 2,
     "import/named": 2,
     "import/namespace": 2,
     "import/newline-after-import": 2,
     "import/no-duplicates": 2,
-    "import/no-unresolved": [2, { "commonjs": true }],
-    "import/order": [2, { "alphabetize": { "order": "asc" } }],
+    "import/no-unresolved": [
+      2,
+      {
+        "commonjs": true,
+        "ignore": [
+          ".json"
+        ]
+      }
+    ],
+    "import/order": [
+      2,
+      {
+        "alphabetize": {
+          "order": "asc"
+        }
+      }
+    ],
     "import/unambiguous": 2,
     "import/no-anonymous-default-export": 2,
-    "jsx-quotes": [2, "prefer-single"],
-    "key-spacing": [2, { "beforeColon": false, "afterColon": true }],
-    "keyword-spacing": [2],
+    "jsx-quotes": [
+      2,
+      "prefer-single"
+    ],
+    "key-spacing": [
+      2,
+      {
+        "beforeColon": false,
+        "afterColon": true
+      }
+    ],
+    "keyword-spacing": [
+      2
+    ],
     "max-depth": 0,
     "max-nested-callbacks": 0,
     "max-params": 0,
@@ -86,7 +134,12 @@
     "no-mixed-spaces-and-tabs": 2,
     "no-multi-spaces": 2,
     "no-multi-str": 2,
-    "no-multiple-empty-lines": [2, { "max": 2 }],
+    "no-multiple-empty-lines": [
+      2,
+      {
+        "max": 2
+      }
+    ],
     "no-nested-ternary": 2,
     "no-new": 2,
     "no-new-func": 2,
@@ -125,31 +178,62 @@
     "no-use-before-define": 0,
     "no-useless-rename": 2,
     "no-void": 0,
-    "no-warning-comments": [2, { "terms": ["fixme"], "location": "start" }],
+    "no-warning-comments": [
+      2,
+      {
+        "terms": [
+          "fixme"
+        ],
+        "location": "start"
+      }
+    ],
     "no-with": 2,
     "one-var": 0,
     "operator-assignment": 0,
     "padded-blocks": 0,
     "prefer-object-spread/prefer-object-spread": 2,
     "prettier/prettier": "error",
-    "quote-props": [2, "as-needed"],
-    "quotes": [2, "single", "avoid-escape"],
+    "quote-props": [
+      2,
+      "as-needed"
+    ],
+    "quotes": [
+      2,
+      "single",
+      "avoid-escape"
+    ],
     "radix": 2,
     "react/display-name": 2,
-    "react/jsx-boolean-value": [2, "always"],
+    "react/jsx-boolean-value": [
+      2,
+      "always"
+    ],
     "react/jsx-closing-bracket-location": [
       2,
-      { "selfClosing": "line-aligned", "nonEmpty": "props-aligned" }
+      {
+        "selfClosing": "line-aligned",
+        "nonEmpty": "props-aligned"
+      }
     ],
     "react/jsx-no-undef": 2,
-    "react/jsx-sort-props": [2, { "ignoreCase": true }],
+    "react/jsx-sort-props": [
+      2,
+      {
+        "ignoreCase": true
+      }
+    ],
     "react/jsx-uses-react": 2,
     "react/jsx-uses-vars": 2,
     "react/jsx-wrap-multilines": 2,
     "react/jsx-fragments": 2,
     "react/no-did-mount-set-state": 2,
     "react/no-did-update-set-state": 2,
-    "react/no-multi-comp": [2, { "ignoreStateless": true }],
+    "react/no-multi-comp": [
+      2,
+      {
+        "ignoreStateless": true
+      }
+    ],
     "react/no-unescaped-entities": 0,
     "react/no-unknown-property": 2,
     "react/prop-types": 2,
@@ -158,22 +242,54 @@
     "react/sort-prop-types": 2,
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "error",
-    "semi": [2, "always"],
-    "semi-spacing": [2, { "before": false, "after": true }],
+    "semi": [
+      2,
+      "always"
+    ],
+    "semi-spacing": [
+      2,
+      {
+        "before": false,
+        "after": true
+      }
+    ],
     "sort-vars": 0,
-    "space-before-blocks": [2, "always"],
-    "space-before-function-paren": [2, "never"],
+    "space-before-blocks": [
+      2,
+      "always"
+    ],
+    "space-before-function-paren": [
+      2,
+      "never"
+    ],
     "space-in-brackets": 0,
     "space-in-parens": 0,
     "space-infix-ops": 2,
-    "space-unary-ops": [2, { "words": true, "nonwords": false }],
-    "spaced-comment": [2, "always", { "exceptions": ["-"] }],
+    "space-unary-ops": [
+      2,
+      {
+        "words": true,
+        "nonwords": false
+      }
+    ],
+    "spaced-comment": [
+      2,
+      "always",
+      {
+        "exceptions": [
+          "-"
+        ]
+      }
+    ],
     "strict": 0,
     "use-isnan": 2,
     "valid-jsdoc": 0,
     "valid-typeof": 2,
     "vars-on-top": 0,
-    "wrap-iife": [2, "any"],
+    "wrap-iife": [
+      2,
+      "any"
+    ],
     "wrap-regex": 2,
     "yoda": 0
   }

--- a/client/src/components/landing/components/Testimonials.tsx
+++ b/client/src/components/landing/components/Testimonials.tsx
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import React from 'react';
 
 import { Trans, useTranslation } from 'react-i18next';
@@ -7,11 +6,7 @@ import sarahImg from '../../../assets/images/landing/Sarah.png';
 import shawnImg from '../../../assets/images/landing/Shawn.png';
 import { ImageLoader } from '../../helpers';
 
-const propTypes = {
-  page: PropTypes.string
-};
-
-const Testimonials = () => {
+const Testimonials = (): JSX.Element => {
   const { t } = useTranslation();
 
   return (
@@ -106,5 +101,5 @@ const Testimonials = () => {
 };
 
 Testimonials.displayName = 'Testimonals';
-Testimonials.propTypes = propTypes;
+
 export default Testimonials;

--- a/client/src/declarations.d.ts
+++ b/client/src/declarations.d.ts
@@ -9,6 +9,16 @@ declare module '*.svg' {
   const content: string;
   export default content;
 }
+
+declare module '*.json' {
+  const value: string;
+  export default value;
+}
+
+declare module '*.png' {
+  const content: string;
+  export default content;
+}
 declare namespace NodeJS {
   interface Global {
     MathJax: {

--- a/client/src/declarations.d.ts
+++ b/client/src/declarations.d.ts
@@ -15,10 +15,10 @@ declare module '*.json' {
   export default value;
 }
 
-declare module '*.png' {
-  const content: string;
-  export default content;
-}
+// declare module '*.png' {
+//   const content: string;
+//   export default content;
+// }
 declare namespace NodeJS {
   interface Global {
     MathJax: {

--- a/client/src/templates/Challenges/rechallenge/transformers.js
+++ b/client/src/templates/Challenges/rechallenge/transformers.js
@@ -11,8 +11,6 @@ import {
   stubTrue
 } from 'lodash-es';
 
-// the config files are created during the build, but not before linting
-// eslint-disable-next-line import/no-unresolved
 import sassData from '../../../../../config/client/sass-compile.json';
 import {
   transformContents,

--- a/client/src/templates/Challenges/utils/build.js
+++ b/client/src/templates/Challenges/utils/build.js
@@ -1,7 +1,4 @@
-// the config files are created during the build, but not before linting
-// eslint-disable-next-line import/no-unresolved
 import frameRunnerData from '../../../../../config/client/frame-runner.json';
-// eslint-disable-next-line import/no-unresolved
 import testEvaluatorData from '../../../../../config/client/test-evaluator.json';
 import { challengeTypes } from '../../../../utils/challenge-types';
 import { cssToHtml, jsToHtml, concatHtml } from '../rechallenge/builders.js';

--- a/client/utils/tags.tsx
+++ b/client/utils/tags.tsx
@@ -2,6 +2,7 @@ import { withPrefix } from 'gatsby';
 import i18next from 'i18next';
 import psl from 'psl';
 import React from 'react';
+
 import env from '../../config/env.json';
 
 const { homeLocation } = env;

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -34,11 +34,8 @@ const {
   default: createWorker
 } = require('../../client/src/templates/Challenges/utils/worker-executor');
 const { challengeTypes } = require('../../client/utils/challenge-types');
-// the config files are created during the build, but not before linting
-/* eslint-disable import/no-unresolved */
 const testEvaluator =
   require('../../config/client/test-evaluator.json').filename;
-/* eslint-enable import/no-unresolved */
 
 const { getLines } = require('../../utils/get-lines');
 const { isAuditedCert } = require('../../utils/is-audited');

--- a/package.json
+++ b/package.json
@@ -91,8 +91,8 @@
   },
   "lint-staged": {
     "*.css": "prettier --write",
-    "*.(js|ts|tsx)": "eslint --max-warnings 0 --cache --fix",
-    "./curriculum/challenges/**/*.md": "node ./tools/scripts/lint/index.js"
+    "./curriculum/challenges/**/*.md": "node ./tools/scripts/lint/index.js",
+    "*.(js|ts|tsx)": "eslint --max-warnings 0 --cache --fix"
   },
   "dependencies": {
     "dotenv": "10.0.0",

--- a/tools/crowdin/actions/convert-chinese/index.js
+++ b/tools/crowdin/actions/convert-chinese/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-unresolved */
 const path = require('path');
 const fs = require('fs-extra');
 const opencc = require('node-opencc');

--- a/tools/crowdin/actions/hide-specific-string/index.js
+++ b/tools/crowdin/actions/hide-specific-string/index.js
@@ -2,7 +2,6 @@ require('dotenv').config({ path: `${__dirname}/../../.env` });
 const core = require('@actions/core');
 const { getFiles } = require('../../utils/files');
 const { getStrings, changeHiddenStatus } = require('../../utils/strings');
-// eslint-disable-next-line import/no-unresolved
 
 const filename = core.getInput('filename');
 const stringContent = core.getInput('string-content');

--- a/tools/crowdin/actions/pr-creator/index.js
+++ b/tools/crowdin/actions/pr-creator/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-unresolved */
 /* eslint-disable camelcase */
 const core = require('@actions/core');
 const githubRoot = require('@actions/github');


### PR DESCRIPTION
<!-- Please note that low quality PRs and PRs that do not follow our contributing guidelines will be marked as invalid for Hacktoberfest. -->

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
While on navigating and refactoring some code realized that there was bo types for .json and  .png files that caused the refactor of the landing page to be harder with a bunch of error.
There was also the same issue for the json files that can be seen [here](https://github.com/freeCodeCamp/freeCodeCamp/blob/main/client/src/templates/Challenges/utils/build.js#L2).

This PR solves that and allows to remove those disable across the codebase and the use the json and png files in a safer and easier way.
