### PR TITLE
feat(client): language dropdown in the side menu is now a drop down

### DIFF
--- a/client/src/components/Header/Header.test.tsx
+++ b/client/src/components/Header/Header.test.tsx
@@ -8,6 +8,10 @@ import { create, ReactTestRendererJSON } from 'react-test-renderer';
 import ShallowRenderer from 'react-test-renderer/shallow';
 
 import envData from '../../../../config/env.json';
+import {
+  availableLangs,
+  langDisplayNames
+} from '../../../../config/i18n/all-langs';
 import AuthOrProfile from './components/auth-or-profile';
 import { NavLinks } from './components/nav-links';
 import { UniversalNav } from './components/universal-nav';
@@ -63,7 +67,9 @@ describe('<NavLinks />', () => {
         hasCurriculumNavItem(view) &&
         hasForumNavItem(view) &&
         hasNewsNavItem(view) &&
-        hasRadioNavItem(view)
+        hasRadioNavItem(view) &&
+        hasLanguageHeader(view) &&
+        hasLanguageDropdown(view)
     ).toBeTruthy();
   });
 
@@ -123,7 +129,37 @@ describe('<NavLinks />', () => {
         hasForumNavItem(view) &&
         hasNewsNavItem(view) &&
         hasRadioNavItem(view) &&
-        hasSignOutNavItem(view)
+        hasSignOutNavItem(view) &&
+        hasLanguageHeader(view) &&
+        hasLanguageDropdown(view)
+    ).toBeTruthy();
+  });
+
+  it('has expected available languages in the language dropdown', () => {
+    const defaultLanguage = 'en';
+    const landingPageProps = {
+      fetchState: {
+        pending: false
+      },
+      user: {
+        isDonating: true,
+        username: 'moT01',
+        theme: 'default'
+      },
+      i18n: {
+        language: defaultLanguage
+      },
+      t: t,
+      toggleNightMode: (theme: string) => theme
+    };
+    const utils = ShallowRenderer.createRenderer();
+    utils.render(<NavLinks {...landingPageProps} />);
+    const view = utils.getRenderOutput();
+    expect(
+      hasLanguageHeader(view) &&
+        hasLanguageDropdown(view) &&
+        hasDefaultLanguageInLanguageDropdown(view, defaultLanguage) &&
+        hasAllAvailableLanguagesInDropdown(view)
     ).toBeTruthy();
   });
 });
@@ -205,6 +241,7 @@ const navigationLinks = (component: JSX.Element, key: string) => {
   );
   return target.props;
 };
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const profileNavItem = (component: any) => component.children[0];
 
@@ -265,6 +302,40 @@ const hasRadioNavItem = (component: JSX.Element) => {
   return (
     children[0].props.children === 'buttons.radio' &&
     to === 'https://coderadio.freecodecamp.org'
+  );
+};
+
+const hasLanguageHeader = (component: JSX.Element) => {
+  const { children } = navigationLinks(component, 'lang-header');
+  return children === 'footer.language';
+};
+
+const hasLanguageDropdown = (component: JSX.Element) => {
+  const { children } = navigationLinks(component, 'language-dropdown');
+  return children.type === 'select';
+};
+
+const hasDefaultLanguageInLanguageDropdown = (
+  component: JSX.Element,
+  defaultLanguage: string
+) => {
+  const { children } = navigationLinks(component, 'language-dropdown');
+
+  return children.props.value === defaultLanguage;
+};
+
+const hasAllAvailableLanguagesInDropdown = (component: JSX.Element) => {
+  const { children }: { children: JSX.Element } = navigationLinks(
+    component,
+    'language-dropdown'
+  );
+  console.log('children', children.props.children);
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+  return children.props.children.every(
+    ({ props }: { props: { value: string; children: string } }) =>
+      availableLangs.client.includes(props.value) &&
+      (langDisplayNames as Record<string, string>)[props.value] ===
+        props.children
   );
 };
 

--- a/client/src/components/Header/Header.test.tsx
+++ b/client/src/components/Header/Header.test.tsx
@@ -329,7 +329,6 @@ const hasAllAvailableLanguagesInDropdown = (component: JSX.Element) => {
     component,
     'language-dropdown'
   );
-  console.log('children', children.props.children);
   // eslint-disable-next-line @typescript-eslint/no-unsafe-call
   return children.props.children.every(
     ({ props }: { props: { value: string; children: string } }) =>

--- a/client/src/components/Header/Header.test.tsx
+++ b/client/src/components/Header/Header.test.tsx
@@ -16,7 +16,7 @@ import AuthOrProfile from './components/auth-or-profile';
 import { NavLinks } from './components/nav-links';
 import { UniversalNav } from './components/universal-nav';
 
-const { apiLocation } = envData;
+const { apiLocation, clientLocale } = envData;
 
 jest.mock('../../analytics');
 
@@ -136,7 +136,6 @@ describe('<NavLinks />', () => {
   });
 
   it('has expected available languages in the language dropdown', () => {
-    const defaultLanguage = 'en';
     const landingPageProps = {
       fetchState: {
         pending: false
@@ -147,7 +146,7 @@ describe('<NavLinks />', () => {
         theme: 'default'
       },
       i18n: {
-        language: defaultLanguage
+        language: 'en'
       },
       t: t,
       toggleNightMode: (theme: string) => theme
@@ -158,8 +157,34 @@ describe('<NavLinks />', () => {
     expect(
       hasLanguageHeader(view) &&
         hasLanguageDropdown(view) &&
-        hasDefaultLanguageInLanguageDropdown(view, defaultLanguage) &&
         hasAllAvailableLanguagesInDropdown(view)
+    ).toBeTruthy();
+  });
+
+  it('has default language selected in language dropdown based on client config', () => {
+    const landingPageProps = {
+      fetchState: {
+        pending: false
+      },
+      user: {
+        isDonating: true,
+        username: 'moT01',
+        theme: 'default'
+      },
+      i18n: {
+        language: 'en'
+      },
+      t: t,
+      toggleNightMode: (theme: string) => theme
+    };
+    const utils = ShallowRenderer.createRenderer();
+    utils.render(<NavLinks {...landingPageProps} />);
+    const view = utils.getRenderOutput();
+    expect(
+      hasLanguageHeader(view) &&
+        hasLanguageDropdown(view) &&
+        hasAllAvailableLanguagesInDropdown(view) &&
+        hasDefaultLanguageInLanguageDropdown(view, clientLocale)
     ).toBeTruthy();
   });
 });
@@ -320,7 +345,6 @@ const hasDefaultLanguageInLanguageDropdown = (
   defaultLanguage: string
 ) => {
   const { children } = navigationLinks(component, 'language-dropdown');
-
   return children.props.value === defaultLanguage;
 };
 

--- a/client/src/components/Header/components/nav-links.tsx
+++ b/client/src/components/Header/components/nav-links.tsx
@@ -16,7 +16,6 @@ import {
   faExternalLinkAlt
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { navigate } from 'gatsby';
 import React, { Component, Fragment } from 'react';
 import { TFunction, withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -25,6 +24,7 @@ import {
   availableLangs,
   langDisplayNames
 } from '../../../../../config/i18n/all-langs';
+import { hardGoTo as navigate } from '../../../redux';
 import { updateUserFlag } from '../../../redux/settings';
 import createLanguageRedirect from '../../create-language-redirect';
 import { Link } from '../../helpers';
@@ -41,9 +41,11 @@ export interface NavLinksProps {
   toggleDisplayMenu?: React.MouseEventHandler<HTMLButtonElement>;
   toggleNightMode: (x: any) => any;
   user?: Record<string, unknown>;
+  navigate?: (location: string) => void;
 }
 
 const mapDispatchToProps = {
+  navigate,
   toggleNightMode: (theme: unknown) => updateUserFlag({ theme })
 };
 
@@ -62,15 +64,15 @@ export class NavLinks extends Component<NavLinksProps, {}> {
   handleLanguageChange = (
     event: React.ChangeEvent<HTMLSelectElement>
   ): void => {
-    this.props.toggleDisplayMenu();
-    void navigate({
-      to: createLanguageRedirect({
-        clientLocale,
-        lang: event.target.value
-      })
+    const { toggleDisplayMenu, navigate } = this.props;
+    toggleDisplayMenu();
+
+    const path = createLanguageRedirect({
+      clientLocale,
+      lang: event.target.value
     });
 
-    return;
+    return navigate(path);
   };
 
   render() {
@@ -84,6 +86,7 @@ export class NavLinks extends Component<NavLinksProps, {}> {
     }: NavLinksProps = this.props;
 
     const { pending } = fetchState;
+
     return pending ? (
       <div className='nav-skeleton' />
     ) : (
@@ -186,6 +189,7 @@ export class NavLinks extends Component<NavLinksProps, {}> {
         <div className='nav-link nav-link-header' key='lang-header'>
           {t('footer.language')}
         </div>
+
         <div className='nav-link' key='language-dropdown'>
           <select
             className='nav-link-lang-dropdown'

--- a/client/src/components/Header/components/nav-links.tsx
+++ b/client/src/components/Header/components/nav-links.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/no-onchange */
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
@@ -9,20 +10,19 @@
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
 // @ts-nocheck
 import {
-  faCheck,
   faCheckSquare,
   faHeart,
   faSquare,
   faExternalLinkAlt
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { navigate } from 'gatsby';
 import React, { Component, Fragment } from 'react';
 import { TFunction, withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import envData from '../../../../../config/env.json';
 import {
   availableLangs,
-  i18nextCodes,
   langDisplayNames
 } from '../../../../../config/i18n/all-langs';
 import { updateUserFlag } from '../../../redux/settings';
@@ -49,9 +49,29 @@ const mapDispatchToProps = {
 
 export class NavLinks extends Component<NavLinksProps, {}> {
   static displayName: string;
+
+  constructor(props: NavLinksProps) {
+    super(props);
+    this.handleLanguageChange = this.handleLanguageChange.bind(this);
+  }
+
   toggleTheme(currentTheme = 'default', toggleNightMode: any) {
     toggleNightMode(currentTheme === 'night' ? 'default' : 'night');
   }
+
+  handleLanguageChange = (
+    event: React.ChangeEvent<HTMLSelectElement>
+  ): void => {
+    this.props.toggleDisplayMenu();
+    void navigate({
+      to: createLanguageRedirect({
+        clientLocale,
+        lang: event.target.value
+      })
+    });
+
+    return;
+  };
 
   render() {
     const {
@@ -59,7 +79,6 @@ export class NavLinks extends Component<NavLinksProps, {}> {
       i18n,
       fetchState,
       t,
-      toggleDisplayMenu,
       toggleNightMode,
       user: { isDonating = false, username, theme }
     }: NavLinksProps = this.props;
@@ -167,32 +186,19 @@ export class NavLinks extends Component<NavLinksProps, {}> {
         <div className='nav-link nav-link-header' key='lang-header'>
           {t('footer.language')}
         </div>
-        {locales.map(lang =>
-          // current lang is a button that closes the menu
-          i18n.language === i18nextCodes[lang] ? (
-            <button
-              className='nav-link nav-link-lang nav-link-flex'
-              key={'lang-' + lang}
-              onClick={toggleDisplayMenu}
-            >
-              <span>{langDisplayNames[lang]}</span>
-              <FontAwesomeIcon icon={faCheck} />
-            </button>
-          ) : (
-            <Link
-              className='nav-link nav-link-lang nav-link-flex'
-              external={true}
-              // Todo: should treat other lang client application links as external??
-              key={'lang-' + lang}
-              to={createLanguageRedirect({
-                clientLocale,
-                lang
-              })}
-            >
-              {langDisplayNames[lang]}
-            </Link>
-          )
-        )}
+        <div className='nav-link' key='language-dropdown'>
+          <select
+            className='nav-link-lang-dropdown'
+            onChange={this.handleLanguageChange}
+            value={i18n.language as string}
+          >
+            {locales.map(lang => (
+              <option key={'lang-' + lang} value={lang}>
+                {langDisplayNames[lang]}
+              </option>
+            ))}
+          </select>
+        </div>
         {username && (
           <Fragment key='signout-frag'>
             <hr className='nav-line-2' />

--- a/client/src/components/Header/components/nav-links.tsx
+++ b/client/src/components/Header/components/nav-links.tsx
@@ -78,7 +78,6 @@ export class NavLinks extends Component<NavLinksProps, {}> {
   render() {
     const {
       displayMenu,
-      i18n,
       fetchState,
       t,
       toggleNightMode,
@@ -194,7 +193,7 @@ export class NavLinks extends Component<NavLinksProps, {}> {
           <select
             className='nav-link-lang-dropdown'
             onChange={this.handleLanguageChange}
-            value={i18n.language as string}
+            value={clientLocale}
           >
             {locales.map(lang => (
               <option key={'lang-' + lang} value={lang}>

--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -102,8 +102,8 @@
   color: var(--gray-00);
   background-color: var(--gray-90);
   opacity: 1;
-  white-space: nowrap;
-  height: var(--header-height);
+  white-space: normal;
+  min-height: var(--header-height);
   width: 100%;
   align-items: center;
   border: none;
@@ -135,8 +135,21 @@
   height: auto !important;
 }
 
-.nav-link-lang {
-  padding-left: 30px;
+.nav-link:hover .nav-link-lang-dropdown,
+.nav-link:active .nav-link-lang-dropdown {
+  background-color: var(--gray-00);
+  color: var(--gray-90);
+  cursor: pointer;
+}
+
+.nav-link-lang-dropdown {
+  color: var(--gray-00);
+  background-color: var(--gray-90);
+  width: 100%;
+  border: none;
+}
+.nav-link-lang-dropdown:focus {
+  outline: none;
 }
 
 .nav-link-flex {

--- a/client/src/components/Header/index.tsx
+++ b/client/src/components/Header/index.tsx
@@ -45,7 +45,8 @@ export class Header extends React.Component<
       this.menuButtonRef.current &&
       !this.menuButtonRef.current.contains(event.target) &&
       this.searchBarRef.current &&
-      !this.searchBarRef.current.contains(event.target)
+      !this.searchBarRef.current.contains(event.target) &&
+      !(event.target instanceof HTMLSelectElement)
     ) {
       this.toggleDisplayMenu();
     }


### PR DESCRIPTION
As suggested in #42951  I have made the following changes:
1. Make text wrap in the navigation menu items.
2. Added language dropdown menu in place of the language selection.
3. Prevent language dropdown menu from closing when selecting a language until after a language is selected.

<!-- Please note that low quality PRs and PRs that do not follow our contributing guidelines will be marked as invalid for Hacktoberfest. -->

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #42951

<!-- Feel free to add any additional description of changes below this line -->

Screenshots:
1. Text wrap
![image](https://user-images.githubusercontent.com/6754603/136035856-fe59d10f-57e7-4ffb-924a-b728d885c782.png)
2. Language Dropdown
![image](https://user-images.githubusercontent.com/6754603/136050771-70e55029-849e-4793-8779-a2410b6f7d71.png)
![image](https://user-images.githubusercontent.com/6754603/136050905-5a79fa94-5789-4fd6-8f49-a4f04619e872.png)

