### PR TITLE
feat: add code highlighting to descriptions in the new editor

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -7,6 +7,7 @@ import type {
   Range as RangeType
   // eslint-disable-next-line import/no-duplicates
 } from 'monaco-editor/esm/vs/editor/editor.api';
+import { highlightAllUnder } from 'prismjs';
 import React, {
   useEffect,
   Suspense,
@@ -450,6 +451,7 @@ const Editor = (props: EditorProps): JSX.Element => {
     descContainer.appendChild(jawHeading);
     descContainer.appendChild(desc);
     desc.innerHTML = description;
+    highlightAllUnder(desc);
     // TODO: the solution is probably just to use an overlay that's forced to
     // follow the decorations.
     // TODO: this is enough for Firefox, but Chrome needs more before the


### PR DESCRIPTION
<!-- Please note that low quality PRs and PRs that do not follow our contributing guidelines will be marked as invalid for Hacktoberfest. -->

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This PR adds Prism highlighting to descriptions in the editor for the new project-based curriculum. It shouldn't affect the editor for older challenges.

Here's a screenshot of an HTML snippet from Part 20 of the new Cat Photo App project after these changes:

![image](https://user-images.githubusercontent.com/2051070/136135866-7901d25f-0293-4a97-ac01-10dcff74bc4b.png)
