### PR TITLE
fix(client): SASS - show error messages instead of timeout

### DIFF
--- a/client/src/templates/Challenges/utils/build.js
+++ b/client/src/templates/Challenges/utils/build.js
@@ -84,7 +84,6 @@ export function canBuildChallenge(challengeData) {
 export async function buildChallenge(challengeData, options) {
   const { challengeType } = challengeData;
   let build = buildFunctions[challengeType];
-
   if (build) {
     return build(challengeData, options);
   }

--- a/client/src/templates/Challenges/utils/build.js
+++ b/client/src/templates/Challenges/utils/build.js
@@ -84,6 +84,7 @@ export function canBuildChallenge(challengeData) {
 export async function buildChallenge(challengeData, options) {
   const { challengeType } = challengeData;
   let build = buildFunctions[challengeType];
+
   if (build) {
     return build(challengeData, options);
   }


### PR DESCRIPTION
<!-- Please note that low quality PRs and PRs that do not follow our contributing guidelines will be marked as invalid for Hacktoberfest. -->

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #39432

<!-- Feel free to add any additional description of changes below this line -->
I don't know if this totally closes #39432. I was just fixing the issue the last comment in the issue had pointed out which was
that it wasn't displaying a better error message than the timeout default error in the console. 

I also found out that the main cause for the timeout is happening in execute-challenge-saga.js inside of the previewChallengeSage function. I noticed that getting rid of the delay did help significantly but then was updating the console consistently and from my understanding is not the desired effect. 

I just wanted to point out that's where the timeout is originating from and not sure if the this issue was being held open because of the error message needed to be handled better or if there still needs to be a fix for this. 