### PR TITLE
fix: stop using .night to control theme

### DIFF
--- a/client/src/redux/night-mode-saga.js
+++ b/client/src/redux/night-mode-saga.js
@@ -5,15 +5,11 @@ import store from 'store';
 
 const themeKey = 'fcc-theme';
 const defaultTheme = 'default';
-const nightTheme = 'night';
 
 export function setTheme(currentTheme = defaultTheme, theme) {
   if (currentTheme !== theme) {
     store.set(themeKey, theme);
   }
-  const html = document.getElementById('__fcc-html');
-  html.classList.remove(theme === nightTheme ? defaultTheme : nightTheme);
-  html.classList.add(theme);
 }
 
 function* updateLocalThemeSaga({ payload: { user, theme } }) {

--- a/client/src/templates/Challenges/components/help-modal.css
+++ b/client/src/templates/Challenges/components/help-modal.css
@@ -3,7 +3,3 @@
     font-size: 16px;
   }
 }
-
-.night .help-modal-header .close {
-  color: #fff;
-}


### PR DESCRIPTION
.light-palette and .dark-palette should be enough, so there's no need to attach the default or night classes to the html element.  Also, the close cross renders fine without that bit of css.
