### PR TITLE
fix: only jump to editable region on reset

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -969,7 +969,7 @@ const Editor = (props: EditorProps): JSX.Element => {
 
     editor?.focus();
     if (isProjectStep() && editor) {
-      showEditableRegion(editor);
+      if (hasChangedContents) showEditableRegion(editor);
 
       // resetting test output
       // TODO: DRY this - createOutputNode doesn't also need to set this up.


### PR DESCRIPTION
If the code has changed without the user typing (e.g. they've pushed
the restart button), then we jump them back to the editable region.
Otherwise (e.g. they've typed in the editor) we reset the display, but
do not move the editor.
