### PR TITLE
fix: remove lint translations

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "lint:challenges": "cd ./curriculum && npm run lint",
     "lint:js": "eslint --max-warnings 0 .",
     "lint:ts": "tsc -p client && tsc -p tools/ui-components",
-    "lint:translations": "cd ./client && npm run lint",
     "lint:prettier": "prettier --list-different .",
     "postinstall": "npm run bootstrap",
     "seed": "cross-env DEBUG=fcc:* node ./tools/scripts/seed/seedAuthUser",


### PR DESCRIPTION
<!-- Please note that low quality PRs and PRs that do not follow our contributing guidelines will be marked as invalid for Hacktoberfest. -->

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
As requested by @ojeytonwilliams, this will remove the lint step from the CI that looks at the i18n objects in the client and compares them to the schema.

We tweaked this a while ago to not fail on missing/extraneous keys in the objects, so now the warnings just become noise. Removing the `lint:translations` from the root package.json should prevent it from running in CI, but having the `lint` step available in the *client* package.json should allow us to still run this manually if something needs to be looked in to.