### PR TITLE
docs: add docsify tabs to how-to-setup-freecodecamp-locally.md

### DIFF
--- a/docs/how-to-setup-freecodecamp-locally.md
+++ b/docs/how-to-setup-freecodecamp-locally.md
@@ -175,13 +175,23 @@ The default API keys and environment variables are stored in the file `sample.en
 ```console
 # Create a copy of the "sample.env" and name it ".env".
 # Populate it with the necessary API keys and secrets:
+```
 
-# macOS / Linux
+<!-- tabs:start -->
+
+#### **macOS/Linux**
+
+```console
 cp sample.env .env
+```
 
-# Windows
+#### **Windows**
+
+```console
 copy sample.env .env
 ```
+
+<!-- tabs:end -->
 
 The keys in the `.env` file are _not_ required to be changed to run the app locally. You can leave the default values copied over from `sample.env` as-is.
 
@@ -205,19 +215,25 @@ Before you can run the application locally, you will need to start the MongoDB s
 
 Start the MongoDB server in a separate terminal:
 
-- On macOS & Ubuntu:
+  <!-- tabs:start -->
 
-  ```console
-  mongod
-  ```
+#### **macOS/Linux**
+
+```console
+mongod
+```
+
+#### **Windows**
 
 - On Windows, you must specify the full path to the `mongod` binary
 
-  ```console
-  "C:\Program Files\MongoDB\Server\3.6\bin\mongod"
-  ```
+```console
+"C:\Program Files\MongoDB\Server\3.6\bin\mongod"
+```
 
-  Make sure to replace `3.6` with the version you have installed
+  <!-- tabs:end -->
+
+Make sure to replace `3.6` with the version you have installed
 
 > [!TIP]
 > You can avoid having to start MongoDB every time by installing it as a background service. You can [learn more about it in their documentation for your OS](https://docs.mongodb.com/manual/administration/install-community/)
@@ -533,7 +549,9 @@ git clean -ifdX
 
 If you can't sign in, and instead you see a banner with an error message that it will be reported to freeCodeCamp, please double-check that your local port `3000` is not in use by a different program.
 
-**On Linux / macOS / WSL on Windows - From Terminal:**
+<!-- tabs:start -->
+
+#### **macOS/Linux/WSL on Windows - From Terminal:**
 
 ```console
 netstat -a | grep "3000"
@@ -541,13 +559,17 @@ netstat -a | grep "3000"
 tcp4    0   0    0.0.0.0:3000           DESKTOP      LISTEN
 ```
 
-**On Windows - From Elevated PowerShell:**
+#### **On Windows - From Elevated PowerShell:**
 
 ```powershell
 netstat -ab | Select-String "3000"
 
 TCP    0.0.0.0:3000           DESKTOP      LISTENING
 ```
+
+<!-- tabs:end -->
+
+---
 
 ### Issues installing dependencies
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -149,6 +149,14 @@
           tag: 'remote-markdown-url'
         },
 
+        tabs: {
+          persist: true, // default
+          sync: true, // default
+          theme: 'classic', // default
+          tabComments: true, // default
+          tabHeadings: true // default
+        },
+
         plugins: [
           function (hook, vm) {
             hook.beforeEach(function (markdown) {
@@ -216,8 +224,10 @@
         ]
       };
     </script>
-
-    <script src="https://cdn.jsdelivr.net/npm/docsify/lib/docsify.min.js"></script>
+    <!-- docsify (latest v4.x.x)-->
+    <script src="https://cdn.jsdelivr.net/npm/docsify@4/lib/docsify.min.js"></script>
+    <!-- docsify-tabs (latest v1.x.x) -->
+    <script src="https://cdn.jsdelivr.net/npm/docsify-tabs@1"></script>
 
     <!-- Theme -->
     <!-- <script src="https://cdn.jsdelivr.net/npm/docsify-themeable@0"></script> -->


### PR DESCRIPTION
<!-- Please note that low quality PRs and PRs that do not follow our contributing guidelines will be marked as invalid for Hacktoberfest. -->

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Added tabs to macOS/Linux & Windows commands in the "how-to-setup-freecodecamp-locally.md"
Changes were made to the index.html to facilitate the additional functionality.
Changes were viewed and tested locally on MacOS
