### PR TITLE
fix(curriculum): add test to ensure the innerText of labels doesnt change

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/check-radio-buttons-and-checkboxes-by-default.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/check-radio-buttons-and-checkboxes-by-default.md
@@ -35,6 +35,18 @@ Your first checkbox on your form should be checked by default.
 assert($('input[type="checkbox"]').prop('checked'));
 ```
 
+You should not change the inner text of the `Indoor` label.
+
+```js
+assert.equal(document.querySelector('label[for="indoor"]')?.innerText?.trim(), 'Indoor');
+```
+
+You should not change the inner text of the `Loving` label.
+
+```js
+assert.equal(document.querySelector('label[for="loving"]')?.innerText?.trim(), 'Loving');
+```
+
 # --seed--
 
 ## --seed-contents--


### PR DESCRIPTION
For the check-radio-buttons-and-checkboxes-by-default exercise,
campers are able to pass the exercise if the checked attribute is
written in an incorrect syntax. This PR checks the innerText of the
elements which are being added the 'checked' attribute and ensures that
their value doesn't change.
Fixes #43750

<!-- Please note that low quality PRs and PRs that do not follow our contributing guidelines will be marked as invalid for Hacktoberfest. -->

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #43750

<!-- Feel free to add any additional description of changes below this line -->
