### PR TITLE
fix: validating innerText and attributes remain unchanged

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/check-radio-buttons-and-checkboxes-by-default.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/check-radio-buttons-and-checkboxes-by-default.md
@@ -29,10 +29,26 @@ Your first radio button on your form should be checked by default.
 assert($('input[type="radio"]').prop('checked'));
 ```
 
+Radio input's attributes and text should be unchanged.
+
+```js
+assert.equal(document.querySelector('label[for="indoor"]')?.innerText?.trim(), 'Indoor');
+assert(document.getElementById("indoor").name == 'indoor-outdoor');
+assert(document.getElementById("indoor").value == 'indoor');
+```
+
 Your first checkbox on your form should be checked by default.
 
 ```js
 assert($('input[type="checkbox"]').prop('checked'));
+```
+
+Check input's attributes and text should be unchanged.
+
+```js
+assert.equal(document.querySelector('label[for="loving"]')?.innerText?.trim(), 'Loving');
+assert(document.getElementById("loving").name == 'personality');
+assert(document.getElementById("loving").value == 'loving');
 ```
 
 # --seed--


### PR DESCRIPTION
Page: https://www.freecodecamp.org/learn/responsive-web-design/basic-html-and-html5/check-radio-buttons-and-checkboxes-by-default
Users are able to pass the task with sloppy html (i.e "checked> value='indoor'>")
My fix validates that:
- no attributes of the radio & check input tag have been changed or removed. 
- innerText of the label is unchanged
Fixes #43750

Checklist:

 

- [x] I have read freeCodeCamp's contribution guidelines.
 

- [x] My pull request has a descriptive title (not a vague title like Update index.md)

 

- [x] My pull request targets the main branch of freeCodeCamp.

- [x]  I have tested these changes either locally on my machine, or GitPod.

Closes #43750