### PR TITLE
fix(tools): 👷 update CodeSee workflow to now work with PRs from forks

### DIFF
--- a/.github/workflows/codesee-arch-diagram.yml
+++ b/.github/workflows/codesee-arch-diagram.yml
@@ -2,21 +2,23 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 name: CodeSee Map
 
 jobs:
   test_map_action:
-    if: ${{ github.actor != 'renovate[bot]' && github.actor != 'camperbot' }}
     runs-on: ubuntu-latest
-    name: Run map action on action code
+    continue-on-error: true
+    name: Run CodeSee Map Analysis
     steps:
       - name: checkout
         id: checkout
         uses: actions/checkout@v2
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
 
       # codesee-detect-languages has an output with id languages.
@@ -54,10 +56,26 @@ jobs:
 
       # CodeSee Maps Rust support uses a static binary so there's no setup step required.
 
-      - name: run
-        id: run
+      - name: Generate Map
+        id: generate-map
         uses: Codesee-io/codesee-map-action@latest
         with:
+          step: map
+          github_ref: ${{ github.ref }}
+          languages: ${{ steps.detect-languages.outputs.languages }}
+
+      - name: Upload Map
+        id: upload-map
+        uses: Codesee-io/codesee-map-action@latest
+        with:
+          step: mapUpload
           api_token: ${{ secrets.CODESEE_ARCH_DIAG_API_TOKEN }}
           github_ref: ${{ github.ref }}
-          support_typescript: true
+      
+      - name: Insights
+        id: insights
+        uses: Codesee-io/codesee-map-action@latest
+        with:
+          step: insights
+          api_token: ${{ secrets.CODESEE_ARCH_DIAG_API_TOKEN }}
+          github_ref: ${{ github.ref }}

--- a/.github/workflows/codesee-arch-diagram.yml
+++ b/.github/workflows/codesee-arch-diagram.yml
@@ -72,7 +72,7 @@ jobs:
           step: mapUpload
           api_token: ${{ secrets.CODESEE_ARCH_DIAG_API_TOKEN }}
           github_ref: ${{ github.ref }}
-      
+
       - name: Insights
         id: insights
         uses: Codesee-io/codesee-map-action@latest

--- a/.github/workflows/codesee-arch-diagram.yml
+++ b/.github/workflows/codesee-arch-diagram.yml
@@ -10,6 +10,7 @@ name: CodeSee Map
 jobs:
   test_map_action:
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'renovate[bot]' && github.actor != 'camperbot' }}
     continue-on-error: true
     name: Run CodeSee Map Analysis
     steps:


### PR DESCRIPTION
This change updates the CodeSee Architecture Diagram workflow to enable PR diagrams from forks.

<!-- Please note that low quality PRs and PRs that do not follow our contributing guidelines will be marked as invalid for Hacktoberfest. -->

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!-- Feel free to add any additional description of changes below this line -->

*Since it's a github workflow change, I wasn't able to specifically test it locally, but this a template workflow with the primary branch updated to match your project.*