### PR TITLE
fix: always reset on reset button press

### DIFF
--- a/client/src/templates/Challenges/redux/action-types.js
+++ b/client/src/templates/Challenges/redux/action-types.js
@@ -36,6 +36,7 @@ export const actionTypes = createTypes(
     'checkChallenge',
     'executeChallenge',
     'resetChallenge',
+    'stopResetting',
     'submitChallenge',
 
     'moveToTab',

--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -33,6 +33,7 @@ const initialState = {
   hasCompletedBlock: false,
   isCodeLocked: false,
   isBuildEnabled: true,
+  isResetting: false,
   logsOut: [],
   modal: {
     completion: false,
@@ -117,6 +118,7 @@ export const challengeMounted = createAction(actionTypes.challengeMounted);
 export const checkChallenge = createAction(actionTypes.checkChallenge);
 export const executeChallenge = createAction(actionTypes.executeChallenge);
 export const resetChallenge = createAction(actionTypes.resetChallenge);
+export const stopResetting = createAction(actionTypes.stopResetting);
 export const submitChallenge = createAction(actionTypes.submitChallenge);
 
 export const moveToTab = createAction(actionTypes.moveToTab);
@@ -146,6 +148,7 @@ export const isCompletionModalOpenSelector = state =>
 export const isHelpModalOpenSelector = state => state[ns].modal.help;
 export const isVideoModalOpenSelector = state => state[ns].modal.video;
 export const isResetModalOpenSelector = state => state[ns].modal.reset;
+export const isResettingSelector = state => state[ns].isResetting;
 
 export const isBuildEnabledSelector = state => state[ns].isBuildEnabled;
 export const successMessageSelector = state => state[ns].successMessage;
@@ -295,9 +298,14 @@ export const reducer = handleActions(
           text,
           testString
         })),
-        consoleOut: []
+        consoleOut: [],
+        isResetting: true
       };
     },
+    [actionTypes.stopResetting]: state => ({
+      ...state,
+      isResetting: false
+    }),
     [actionTypes.updateSolutionFormValues]: (state, { payload }) => ({
       ...state,
       projectFormValues: payload


### PR DESCRIPTION
Continuing the PR daisy-chain... This follows up https://github.com/freeCodeCamp/freeCodeCamp/pull/43839 and, again, only the last commit is new.  Once that PR is in, I'll cherry pick this.

The point of these changes is to create a direct link between pressing the reset/restart button and the cleanup that should be triggered in the editors.  This is instead of inferring that a reset must have happened due to changes in the contents.

It also means the code is a bit more readable (`isResetting` is a better description of what's happening than `hasChangedContents`).