### PR TITLE
chore: tree shaking - unused / redundant code

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -35,7 +35,7 @@
     "react": {
       "version": "16.4.2",
       "import/ignore": ["\\.json$"],
-      "import/extensions": [".js", ".jsx", ".tsx"]
+      "import/extensions": [".js", ".jsx", ".tsx", ".ts"]
     },
     "import/ignore": ["node_modules"]
   },

--- a/api-server/src/server/component-passport.js
+++ b/api-server/src/server/component-passport.js
@@ -1,8 +1,4 @@
-// eslint-disable-next-line
-import {
-  // prettier ignore
-  PassportConfigurator
-} from '@freecodecamp/loopback-component-passport';
+import { PassportConfigurator } from '@freecodecamp/loopback-component-passport';
 import dedent from 'dedent';
 import passport from 'passport';
 

--- a/api-server/src/server/utils/get-curriculum.js
+++ b/api-server/src/server/utils/get-curriculum.js
@@ -6,6 +6,7 @@ import { flatten } from 'lodash';
 // via the user object, then we should *not* store this so it can be garbage
 // collected.
 
+// eslint-disable-next-line import/no-unresolved
 import curriculum from '../../../../config/curriculum.json';
 
 export function getChallenges() {

--- a/client/src/components/Footer/index.tsx
+++ b/client/src/components/Footer/index.tsx
@@ -3,18 +3,6 @@ import { useTranslation } from 'react-i18next';
 import Link from '../helpers/link';
 import './footer.css';
 
-type ColHeaderProps = {
-  children: string | React.ReactNode | React.ReactElement;
-};
-
-// TODO: Figure out what ColHeader does: 'ColHeader' is declared but its value is never read.
-// eslint-disable-next-line
-const ColHeader = ({ children, ...other }: ColHeaderProps): JSX.Element => (
-  <div className='col-header' {...other}>
-    {children}
-  </div>
-);
-
 function Footer(): JSX.Element {
   const { t } = useTranslation();
 

--- a/client/src/components/Header/components/auth-or-profile.tsx
+++ b/client/src/components/Header/components/auth-or-profile.tsx
@@ -1,6 +1,4 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 // @ts-nocheck
 import React from 'react';
 import { useTranslation } from 'react-i18next';

--- a/client/src/components/layouts/Default.js
+++ b/client/src/components/layouts/Default.js
@@ -32,11 +32,8 @@ import { flashMessageSelector, removeFlashMessage } from '../Flash/redux';
 import Footer from '../Footer';
 import Header from '../Header';
 import OfflineWarning from '../OfflineWarning';
-// preload common fonts
-// eslint-disable-next-line max-len
-// eslint-disable-next-line max-len
-// eslint-disable-next-line max-len
 
+// preload common fonts
 import './fonts.css';
 import './global.css';
 import './variables.css';

--- a/client/src/pages/search.css
+++ b/client/src/pages/search.css
@@ -1,5 +1,0 @@
-.powered-by-wrapper {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}


### PR DESCRIPTION
<!-- Please note that low quality PRs and PRs that do not follow our contributing guidelines will be marked as invalid for Hacktoberfest. -->

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
There are several esint disable across the app that should be there anymore either because the reason why was introduce is no longer valid or the lint issue should be fixed instead of ignoring.
Some deprecated components that do not use anymore and can/should be removed to keep the codebase clean.
