### PR TITLE
fix(curriculum): test removing non-existing element from empty and non-empty tree

### DIFF
--- a/curriculum/challenges/english/10-coding-interview-prep/data-structures/delete-a-leaf-node-in-a-binary-search-tree.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/data-structures/delete-a-leaf-node-in-a-binary-search-tree.md
@@ -46,6 +46,25 @@ assert(
 );
 ```
 
+Trying to remove an element from an empty tree should return `null`.
+
+```js
+assert(
+  (function () {
+    var test = false;
+    if (typeof BinarySearchTree !== 'undefined') {
+      test = new BinarySearchTree();
+    } else {
+      return false;
+    }
+    if (typeof test.remove !== 'function') {
+      return false;
+    }
+    return test.remove(100) == null;
+  })()
+);
+```
+
 Trying to remove an element that does not exist should return `null`.
 
 ```js

--- a/curriculum/challenges/english/10-coding-interview-prep/data-structures/delete-a-leaf-node-in-a-binary-search-tree.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/data-structures/delete-a-leaf-node-in-a-binary-search-tree.md
@@ -60,6 +60,8 @@ assert(
     if (typeof test.remove !== 'function') {
       return false;
     }
+    test.add(15);
+    test.add(30);
     return test.remove(100) == null;
   })()
 );


### PR DESCRIPTION
- Tests both removing element from empty tree and from non-empty tree without that element.
- Tested against code linked in issue, with and without modification not working right now in production, and own solution.

Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #40411
