### PR TITLE
fix(curriculum): made `Timestamp Microservice` project tests sort of "timezone aware"

### DIFF
--- a/curriculum/challenges/english/05-back-end-development-and-apis/back-end-development-and-apis-projects/timestamp-microservice.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/back-end-development-and-apis-projects/timestamp-microservice.md
@@ -16,6 +16,8 @@ Build a full stack JavaScript app that is functionally similar to this: <https:/
 
 When you are done, make sure a working demo of your project is hosted somewhere public. Then submit the URL to it in the `Solution Link` field. Optionally, also submit a link to your project's source code in the `GitHub Link` field.
 
+**Note:** Time zones conversion is not a purpose of this project, so assume all sent valid dates will be parsed with `new Date()` as GMT dates. 
+
 # --hints--
 
 You should provide your own project, not the example URL.
@@ -85,7 +87,7 @@ Your project can handle dates that can be successfully parsed by `new Date(date_
 
 ```js
 (getUserInput) =>
-  $.get(getUserInput('url') + '/api/05 October 2011').then(
+  $.get(getUserInput('url') + '/api/05 October 2011, GMT').then(
     (data) => {
       assert(
         data.unix === 1317772800000 &&


### PR DESCRIPTION
<!-- Please note that low quality PRs and PRs that do not follow our contributing guidelines will be marked as invalid for Hacktoberfest. -->

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #43049

Dates like `2011-07-05` are [parsed as UTC dates](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse#date_time_string_format), so such test cases are not a problem. Non-standard dates like `05 October 2011` are [treated as local dates](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse#fall-back_to_implementation-specific_date_formats) and to make the tests pass it is needed to 1) make sort of timezone conversion logic (which is not a purpose of this project, I believe) or 2) change camper's PC timezone (I saw someone reported this on forums). 

A better solution is just add explicit `GMT` timezone for non-standard dates.
