### PR TITLE
feat: show project preview

### DIFF
--- a/client/gatsby-node.js
+++ b/client/gatsby-node.js
@@ -101,6 +101,7 @@ exports.createPages = function createPages({ graphql, actions, reporter }) {
                 superBlock
                 superOrder
                 template
+                usesMultifileEditor
               }
             }
           }

--- a/client/gatsby-node.js
+++ b/client/gatsby-node.js
@@ -87,6 +87,13 @@ exports.createPages = function createPages({ graphql, actions, reporter }) {
                   src
                 }
                 challengeOrder
+                challengeFiles {
+                  name
+                  ext
+                  contents
+                  head
+                  tail
+                }
                 solutions {
                   contents
                   ext

--- a/client/gatsby-node.js
+++ b/client/gatsby-node.js
@@ -87,6 +87,10 @@ exports.createPages = function createPages({ graphql, actions, reporter }) {
                   src
                 }
                 challengeOrder
+                solutions {
+                  contents
+                  ext
+                }
                 superBlock
                 superOrder
                 template

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -63,7 +63,7 @@
     "submit-and-go": "Submit and go to next challenge",
     "go-to-next": "Go to next challenge",
     "ask-later": "Ask me later",
-    "hide-project-preview": "Get started"
+    "start-coding": "Start coding!"
   },
   "landing": {
     "big-heading-1": "Learn to code — for free.",

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -290,7 +290,7 @@
     },
     "help-translate": "We are still translating the following certifications.",
     "help-translate-link": "Help us translate.",
-    "project-preview-title": "Complete project demo."
+    "project-preview-title": "Here's a preview of what you will build"
   },
   "donate": {
     "title": "Support our nonprofit",

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -62,7 +62,8 @@
     "verify-email": "Verify Email",
     "submit-and-go": "Submit and go to next challenge",
     "go-to-next": "Go to next challenge",
-    "ask-later": "Ask me later"
+    "ask-later": "Ask me later",
+    "hide-project-preview": "Get started"
   },
   "landing": {
     "big-heading-1": "Learn to code — for free.",
@@ -288,7 +289,8 @@
       "preview": "Preview"
     },
     "help-translate": "We are still translating the following certifications.",
-    "help-translate-link": "Help us translate."
+    "help-translate-link": "Help us translate.",
+    "project-preview-title": "Complete project demo."
   },
   "donate": {
     "title": "Support our nonprofit",

--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -105,7 +105,7 @@ export type MarkdownRemark = {
 
 type Question = { text: string; answers: string[]; solution: number };
 type Fields = { slug: string; blockName: string; tests: Test[] };
-type Required = {
+export type Required = {
   link: string;
   raw: boolean;
   src: string;

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -96,7 +96,7 @@ interface ShowClassicProps {
   output: string[];
   pageContext: {
     challengeMeta: ChallengeMeta;
-    projectPreview: PreviewConfig & { isFirstChallengeInBlock: boolean };
+    projectPreview: PreviewConfig & { showProjectPreview: boolean };
   };
   t: TFunction;
   tests: Test[];
@@ -255,13 +255,13 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
       },
       pageContext: {
         challengeMeta,
-        projectPreview: { isFirstChallengeInBlock }
+        projectPreview: { showProjectPreview }
       }
     } = this.props;
     initConsole('');
     createFiles(challengeFiles ?? []);
     initTests(tests);
-    if (isFirstChallengeInBlock) openModal('projectPreview');
+    if (showProjectPreview) openModal('projectPreview');
     updateChallengeMeta({
       ...challengeMeta,
       title,

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -28,6 +28,9 @@ import CompletionModal from '../components/completion-modal';
 import HelpModal from '../components/help-modal';
 import Output from '../components/output';
 import Preview from '../components/preview';
+import ProjectPreviewModal, {
+  PreviewConfig
+} from '../components/project-preview-modal';
 import SidePanel from '../components/side-panel';
 import VideoModal from '../components/video-modal';
 import {
@@ -41,7 +44,10 @@ import {
   initConsole,
   initTests,
   isChallengeCompletedSelector,
-  updateChallengeMeta
+  previewMounted,
+  updateChallengeMeta,
+  openModal,
+  setEditorFocusability
 } from '../redux';
 import { getGuideUrl } from '../utils';
 import MultifileEditor from './MultifileEditor';
@@ -68,7 +74,10 @@ const mapDispatchToProps = (dispatch: Dispatch) =>
       updateChallengeMeta,
       challengeMounted,
       executeChallenge,
-      cancelTests
+      cancelTests,
+      previewMounted,
+      openModal,
+      setEditorFocusability
     },
     dispatch
   );
@@ -87,10 +96,13 @@ interface ShowClassicProps {
   output: string[];
   pageContext: {
     challengeMeta: ChallengeMeta;
+    projectPreview: PreviewConfig & { isFirstChallengeInBlock: boolean };
   };
   t: TFunction;
   tests: Test[];
   updateChallengeMeta: (arg0: ChallengeMeta) => void;
+  openModal: (modal: string) => void;
+  setEditorFocusability: (canFocus: boolean) => void;
 }
 
 interface ShowClassicState {
@@ -231,6 +243,7 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
       initConsole,
       initTests,
       updateChallengeMeta,
+      openModal,
       data: {
         challengeNode: {
           challengeFiles,
@@ -240,11 +253,15 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
           helpCategory
         }
       },
-      pageContext: { challengeMeta }
+      pageContext: {
+        challengeMeta,
+        projectPreview: { isFirstChallengeInBlock }
+      }
     } = this.props;
     initConsole('');
     createFiles(challengeFiles ?? []);
     initTests(tests);
+    if (isFirstChallengeInBlock) openModal('projectPreview');
     updateChallengeMeta({
       ...challengeMeta,
       title,
@@ -359,7 +376,11 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
 
   renderPreview() {
     return (
-      <Preview className='full-height' disableIframe={this.state.resizing} />
+      <Preview
+        className='full-height'
+        disableIframe={this.state.resizing}
+        previewMounted={previewMounted}
+      />
     );
   }
 
@@ -384,7 +405,8 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
     const {
       executeChallenge,
       pageContext: {
-        challengeMeta: { nextChallengePath, prevChallengePath }
+        challengeMeta: { nextChallengePath, prevChallengePath },
+        projectPreview
       },
       challengeFiles,
       t
@@ -444,6 +466,7 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
           <HelpModal />
           <VideoModal videoUrl={this.getVideoUrl()} />
           <ResetModal />
+          <ProjectPreviewModal previewConfig={projectPreview} />
         </LearnLayout>
       </Hotkeys>
     );
@@ -457,9 +480,6 @@ export default connect(
   mapDispatchToProps
 )(withTranslation()(ShowClassic));
 
-// TODO: handle jsx (not sure why it doesn't get an editableRegion) EDIT:
-// probably because the dummy challenge didn't include it, so Gatsby couldn't
-// infer it.
 export const query = graphql`
   query ClassicChallenge($slug: String!) {
     challengeNode(fields: { slug: { eq: $slug } }) {

--- a/client/src/templates/Challenges/components/preview.css
+++ b/client/src/templates/Challenges/components/preview.css
@@ -1,6 +1,7 @@
 .challenge-preview,
 .challenge-preview-frame {
   height: 100%;
+  min-height: 70vh;
   width: 100%;
   padding: 0;
   margin: 0;

--- a/client/src/templates/Challenges/components/preview.tsx
+++ b/client/src/templates/Challenges/components/preview.tsx
@@ -1,30 +1,23 @@
 import React, { useState, useEffect } from 'react';
-import { withTranslation } from 'react-i18next';
-import { connect } from 'react-redux';
-import { bindActionCreators, Dispatch } from 'redux';
+import { useTranslation } from 'react-i18next';
 
-import { previewMounted } from '../redux';
+import { mainPreviewId } from '../utils/frame';
 
 import './preview.css';
-
-const mainId = 'fcc-main-frame';
-
-const mapDispatchToProps = (dispatch: Dispatch) =>
-  bindActionCreators(
-    {
-      previewMounted
-    },
-    dispatch
-  );
 
 interface PreviewProps {
   className?: string;
   disableIframe?: boolean;
   previewMounted: () => void;
-  t: (text: string) => string;
+  previewId?: string;
 }
 
-function Preview({ disableIframe, previewMounted, t }: PreviewProps) {
+function Preview({
+  disableIframe,
+  previewMounted,
+  previewId
+}: PreviewProps): JSX.Element {
+  const { t } = useTranslation();
   const [iframeStatus, setIframeStatus] = useState<boolean | undefined>(false);
   const iframeToggle = iframeStatus ? 'disable' : 'enable';
 
@@ -36,11 +29,14 @@ function Preview({ disableIframe, previewMounted, t }: PreviewProps) {
     setIframeStatus(disableIframe);
   }, [disableIframe]);
 
+  // TODO: remove type assertion once frame.js has been migrated.
+  const id: string = previewId ?? (mainPreviewId as string);
+
   return (
     <div className={`notranslate challenge-preview ${iframeToggle}-iframe`}>
       <iframe
         className={'challenge-preview-frame'}
-        id={mainId}
+        id={id}
         title={t('learn.chal-preview')}
       />
     </div>
@@ -49,4 +45,4 @@ function Preview({ disableIframe, previewMounted, t }: PreviewProps) {
 
 Preview.displayName = 'Preview';
 
-export default connect(null, mapDispatchToProps)(withTranslation()(Preview));
+export default Preview;

--- a/client/src/templates/Challenges/components/project-preview-modal.css
+++ b/client/src/templates/Challenges/components/project-preview-modal.css
@@ -1,3 +1,4 @@
-/* .project-preview-modal {
-  min-width: 70%;
-} */
+.project-preview-modal-body {
+  line-height: 0;
+  padding: 0;
+}

--- a/client/src/templates/Challenges/components/project-preview-modal.css
+++ b/client/src/templates/Challenges/components/project-preview-modal.css
@@ -1,0 +1,3 @@
+.project-preview-modal {
+  min-width: 70%;
+}

--- a/client/src/templates/Challenges/components/project-preview-modal.css
+++ b/client/src/templates/Challenges/components/project-preview-modal.css
@@ -1,4 +1,3 @@
-.project-preview-modal-body {
-  line-height: 0;
-  padding: 0;
-}
+/* .project-preview-modal {
+  min-width: 70%;
+} */

--- a/client/src/templates/Challenges/components/project-preview-modal.css
+++ b/client/src/templates/Challenges/components/project-preview-modal.css
@@ -1,3 +1,3 @@
-.project-preview-modal {
+/* .project-preview-modal {
   min-width: 70%;
-}
+} */

--- a/client/src/templates/Challenges/components/project-preview-modal.tsx
+++ b/client/src/templates/Challenges/components/project-preview-modal.tsx
@@ -77,6 +77,8 @@ export function ProjectPreviewModal({
             projectPreviewMounted(previewConfig);
           }}
         />
+      </Modal.Body>
+      <Modal.Footer>
         <Button
           block={true}
           bsSize='lg'
@@ -88,7 +90,7 @@ export function ProjectPreviewModal({
         >
           {t('buttons.hide-project-preview')}
         </Button>
-      </Modal.Body>
+      </Modal.Footer>
     </Modal>
   );
 }

--- a/client/src/templates/Challenges/components/project-preview-modal.tsx
+++ b/client/src/templates/Challenges/components/project-preview-modal.tsx
@@ -1,0 +1,98 @@
+import { Button, Modal } from '@freecodecamp/react-bootstrap';
+import React, { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { connect } from 'react-redux';
+
+import type { ChallengeFile, Required } from '../../../redux/prop-types';
+import {
+  closeModal,
+  setEditorFocusability,
+  isProjectPreviewModalOpenSelector,
+  projectPreviewMounted
+} from '../redux';
+import { projectPreviewId } from '../utils/frame';
+import Preview from './preview';
+
+export interface PreviewConfig {
+  challengeType: boolean;
+  challengeFiles: ChallengeFile[];
+  required: Required;
+  template: string;
+}
+
+interface Props {
+  closeModal: () => void;
+  isOpen: boolean;
+  projectPreviewMounted: (previewConfig: PreviewConfig) => void;
+  previewConfig: PreviewConfig;
+  setEditorFocusability: (focusability: boolean) => void;
+}
+
+const mapStateToProps = (state: unknown) => ({
+  isOpen: isProjectPreviewModalOpenSelector(state) as boolean
+});
+const mapDispatchToProps = {
+  closeModal: () => closeModal('projectPreview'),
+  setEditorFocusability,
+  projectPreviewMounted
+};
+
+export function ProjectPreviewModal({
+  closeModal,
+  isOpen,
+  projectPreviewMounted,
+  previewConfig,
+  setEditorFocusability
+}: Props): JSX.Element {
+  const { t } = useTranslation();
+  useEffect(() => {
+    if (isOpen) setEditorFocusability(false);
+  });
+
+  return (
+    <Modal
+      dialogClassName='project-preview-modal'
+      onHide={() => {
+        closeModal();
+        setEditorFocusability(true);
+      }}
+      show={isOpen}
+    >
+      <Modal.Header
+        className='project-preview-modal-header fcc-modal'
+        closeButton={true}
+      >
+        <Modal.Title className='text-center'>
+          {t('learn.project-preview-title')}
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body className='project-preview-modal-body text-center'>
+        {/* remove type assertion once frame.js has been migrated to TS */}
+        <Preview
+          previewId={projectPreviewId as string}
+          previewMounted={() => {
+            projectPreviewMounted(previewConfig);
+          }}
+        />
+        <Button
+          block={true}
+          bsSize='lg'
+          bsStyle='primary'
+          onClick={() => {
+            closeModal();
+            setEditorFocusability(true);
+          }}
+        >
+          {t('buttons.hide-project-preview')}
+        </Button>
+      </Modal.Body>
+    </Modal>
+  );
+}
+
+ProjectPreviewModal.displayName = 'ProjectPreviewModal';
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ProjectPreviewModal);

--- a/client/src/templates/Challenges/components/project-preview-modal.tsx
+++ b/client/src/templates/Challenges/components/project-preview-modal.tsx
@@ -53,6 +53,7 @@ export function ProjectPreviewModal({
 
   return (
     <Modal
+      bsSize='lg'
       data-cy='project-preview-modal'
       dialogClassName='project-preview-modal'
       onHide={() => {

--- a/client/src/templates/Challenges/components/project-preview-modal.tsx
+++ b/client/src/templates/Challenges/components/project-preview-modal.tsx
@@ -89,7 +89,7 @@ export function ProjectPreviewModal({
             setEditorFocusability(true);
           }}
         >
-          {t('buttons.hide-project-preview')}
+          {t('buttons.start-coding')}
         </Button>
       </Modal.Footer>
     </Modal>

--- a/client/src/templates/Challenges/components/project-preview-modal.tsx
+++ b/client/src/templates/Challenges/components/project-preview-modal.tsx
@@ -34,7 +34,7 @@ const mapStateToProps = (state: unknown) => ({
   isOpen: isProjectPreviewModalOpenSelector(state) as boolean
 });
 const mapDispatchToProps = {
-  closeModal: () => closeModal('projectPreview'),
+  closeModal,
   setEditorFocusability,
   projectPreviewMounted
 };
@@ -57,7 +57,7 @@ export function ProjectPreviewModal({
       data-cy='project-preview-modal'
       dialogClassName='project-preview-modal'
       onHide={() => {
-        closeModal();
+        closeModal('projectPreview');
         setEditorFocusability(true);
       }}
       show={isOpen}
@@ -85,7 +85,7 @@ export function ProjectPreviewModal({
           bsSize='lg'
           bsStyle='primary'
           onClick={() => {
-            closeModal();
+            closeModal('projectPreview');
             setEditorFocusability(true);
           }}
         >

--- a/client/src/templates/Challenges/components/project-preview-modal.tsx
+++ b/client/src/templates/Challenges/components/project-preview-modal.tsx
@@ -23,7 +23,7 @@ export interface PreviewConfig {
 }
 
 interface Props {
-  closeModal: () => void;
+  closeModal: (arg: string) => void;
   isOpen: boolean;
   projectPreviewMounted: (previewConfig: PreviewConfig) => void;
   previewConfig: PreviewConfig;

--- a/client/src/templates/Challenges/components/project-preview-modal.tsx
+++ b/client/src/templates/Challenges/components/project-preview-modal.tsx
@@ -51,6 +51,7 @@ export function ProjectPreviewModal({
 
   return (
     <Modal
+      data-cy='project-preview-modal'
       dialogClassName='project-preview-modal'
       onHide={() => {
         closeModal();

--- a/client/src/templates/Challenges/components/project-preview-modal.tsx
+++ b/client/src/templates/Challenges/components/project-preview-modal.tsx
@@ -13,6 +13,8 @@ import {
 import { projectPreviewId } from '../utils/frame';
 import Preview from './preview';
 
+import './project-preview-modal.css';
+
 export interface PreviewConfig {
   challengeType: boolean;
   challengeFiles: ChallengeFile[];

--- a/client/src/templates/Challenges/rechallenge/builders.js
+++ b/client/src/templates/Challenges/rechallenge/builders.js
@@ -20,7 +20,7 @@ const cssCatch = '\n/*fcc*/\n';
 
 const defaultTemplate = ({ source }) => {
   return `
-  <body id='display-body'style='margin:8px;'>
+  <body id='display-body'>
     <!-- fcc-start-source -->
       ${source}
     <!-- fcc-end-source -->

--- a/client/src/templates/Challenges/rechallenge/builders.js
+++ b/client/src/templates/Challenges/rechallenge/builders.js
@@ -27,16 +27,6 @@ const defaultTemplate = ({ source }) => {
   </body>`;
 };
 
-// for demo/preview modal of a finished project
-const demoTemplate = ({ source }) => {
-  return `
-  <body id='display-body'>
-    <!-- fcc-start-source -->
-      ${source}
-    <!-- fcc-end-source -->
-  </body>`;
-};
-
 const wrapInScript = partial(
   transformContents,
   content => `${htmlCatch}<script>${content}${jsCatch}</script>`
@@ -83,11 +73,9 @@ function wasHtmlFile(challengeFile) {
 export function concatHtml({
   required = [],
   template,
-  challengeFiles = [],
-  useDemoTemplate = false
+  challengeFiles = []
 } = {}) {
-  const templateToUse = useDemoTemplate ? demoTemplate : defaultTemplate;
-  const createBody = template ? _template(template) : templateToUse;
+  const createBody = template ? _template(template) : defaultTemplate;
   const head = required
     .map(({ link, src }) => {
       if (link && src) {

--- a/client/src/templates/Challenges/rechallenge/builders.js
+++ b/client/src/templates/Challenges/rechallenge/builders.js
@@ -27,6 +27,16 @@ const defaultTemplate = ({ source }) => {
   </body>`;
 };
 
+// for demo/preview modal of a finished project
+const demoTemplate = ({ source }) => {
+  return `
+  <body id='display-body'>
+    <!-- fcc-start-source -->
+      ${source}
+    <!-- fcc-end-source -->
+  </body>`;
+};
+
 const wrapInScript = partial(
   transformContents,
   content => `${htmlCatch}<script>${content}${jsCatch}</script>`
@@ -73,9 +83,11 @@ function wasHtmlFile(challengeFile) {
 export function concatHtml({
   required = [],
   template,
-  challengeFiles = []
+  challengeFiles = [],
+  useDemoTemplate = false
 } = {}) {
-  const createBody = template ? _template(template) : defaultTemplate;
+  const templateToUse = useDemoTemplate ? demoTemplate : defaultTemplate;
+  const createBody = template ? _template(template) : templateToUse;
   const head = required
     .map(({ link, src }) => {
       if (link && src) {

--- a/client/src/templates/Challenges/redux/action-types.js
+++ b/client/src/templates/Challenges/redux/action-types.js
@@ -32,6 +32,7 @@ export const actionTypes = createTypes(
     'openModal',
 
     'previewMounted',
+    'projectPreviewMounted',
     'challengeMounted',
     'checkChallenge',
     'executeChallenge',

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -240,8 +240,8 @@ function* previewChallengeSaga({ flushLogs = true } = {}) {
 // TODO: remove everything about proxyLogger here
 function* previewProjectSolutionSaga({ payload }) {
   if (!payload) return;
-  const { isFirstChallengeInBlock, challengeData } = payload;
-  if (!isFirstChallengeInBlock) return;
+  const { showProjectPreview, challengeData } = payload;
+  if (!showProjectPreview) return;
 
   const logProxy = yield channel();
   const proxyLogger = args => logProxy.put(args);

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -244,7 +244,9 @@ function* previewProjectSolutionSaga({ payload }) {
 
   try {
     if (canBuildChallenge(challengeData)) {
-      const buildData = yield buildChallengeData(challengeData);
+      const buildData = yield buildChallengeData(challengeData, {
+        useDemoTemplate: true
+      });
       if (challengeHasPreview(challengeData)) {
         const document = yield getContext('document');
         yield call(updateProjectPreview, buildData, document);

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -244,9 +244,7 @@ function* previewProjectSolutionSaga({ payload }) {
 
   try {
     if (canBuildChallenge(challengeData)) {
-      const buildData = yield buildChallengeData(challengeData, {
-        useDemoTemplate: true
-      });
+      const buildData = yield buildChallengeData(challengeData);
       if (challengeHasPreview(challengeData)) {
         const document = yield getContext('document');
         yield call(updateProjectPreview, buildData, document);

--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -39,7 +39,8 @@ const initialState = {
     completion: false,
     help: false,
     video: false,
-    reset: false
+    reset: false,
+    projectPreview: false
   },
   projectFormValues: {},
   successMessage: 'Happy Coding!'
@@ -114,6 +115,9 @@ export const closeModal = createAction(actionTypes.closeModal);
 export const openModal = createAction(actionTypes.openModal);
 
 export const previewMounted = createAction(actionTypes.previewMounted);
+export const projectPreviewMounted = createAction(
+  actionTypes.projectPreviewMounted
+);
 export const challengeMounted = createAction(actionTypes.challengeMounted);
 export const checkChallenge = createAction(actionTypes.checkChallenge);
 export const executeChallenge = createAction(actionTypes.executeChallenge);
@@ -148,6 +152,8 @@ export const isCompletionModalOpenSelector = state =>
 export const isHelpModalOpenSelector = state => state[ns].modal.help;
 export const isVideoModalOpenSelector = state => state[ns].modal.video;
 export const isResetModalOpenSelector = state => state[ns].modal.reset;
+export const isProjectPreviewModalOpenSelector = state =>
+  state[ns].modal.projectPreview;
 export const isResettingSelector = state => state[ns].isResetting;
 
 export const isBuildEnabledSelector = state => state[ns].isBuildEnabled;

--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -62,21 +62,16 @@ export const sagas = [
 export const createFiles = createAction(
   actionTypes.createFiles,
   challengeFiles =>
-    challengeFiles.reduce((challengeFiles, challengeFile) => {
-      return [
-        ...challengeFiles,
-        {
-          ...createPoly(challengeFile),
-          seed: challengeFile.contents.slice(),
-          editableContents: getLines(
-            challengeFile.contents,
-            challengeFile.editableRegionBoundaries
-          ),
-          seedEditableRegionBoundaries:
-            challengeFile.editableRegionBoundaries.slice()
-        }
-      ];
-    }, [])
+    challengeFiles.map(challengeFile => ({
+      ...createPoly(challengeFile),
+      seed: challengeFile.contents.slice(),
+      editableContents: getLines(
+        challengeFile.contents,
+        challengeFile.editableRegionBoundaries
+      ),
+      seedEditableRegionBoundaries:
+        challengeFile.editableRegionBoundaries.slice()
+    }))
 );
 
 export const createQuestion = createAction(actionTypes.createQuestion);

--- a/client/src/templates/Challenges/utils/build.js
+++ b/client/src/templates/Challenges/utils/build.js
@@ -139,7 +139,7 @@ function getJSTestRunner({ build, sources }, { proxyLogger, removeComments }) {
 
 async function getDOMTestRunner(buildData, { proxyLogger }, document) {
   await new Promise(resolve =>
-    createTestFramer(document, resolve, proxyLogger)(buildData)
+    createTestFramer(document, proxyLogger, resolve)(buildData)
   );
   return (testString, testTimeout) =>
     runTestInTestFrame(document, testString, testTimeout);
@@ -198,29 +198,23 @@ export function buildBackendChallenge({ url }) {
   };
 }
 
-// TODO: use fewer arguments (and no boolean ones!)
-export async function updatePreview(
-  buildData,
-  document,
-  proxyLogger,
-  previewProjectSolution
-) {
-  const { challengeType } = buildData;
-
-  // TODO: no need to await here, nothing is waiting for the preview to be
-  // visible
-  if (challengeType === challengeTypes.html) {
-    if (previewProjectSolution) {
-      await new Promise(resolve =>
-        createProjectPreviewFramer(document, resolve, proxyLogger)(buildData)
-      );
-    } else {
-      await new Promise(resolve =>
-        createMainPreviewFramer(document, resolve, proxyLogger)(buildData)
-      );
-    }
+export function updatePreview(buildData, document, proxyLogger) {
+  if (buildData.challengeType === challengeTypes.html) {
+    createMainPreviewFramer(document, proxyLogger)(buildData);
   } else {
-    throw new Error(`Cannot show preview for challenge type ${challengeType}`);
+    throw new Error(
+      `Cannot show preview for challenge type ${buildData.challengeType}`
+    );
+  }
+}
+
+export function updateProjectPreview(buildData, document) {
+  if (buildData.challengeType === challengeTypes.html) {
+    createProjectPreviewFramer(document)(buildData);
+  } else {
+    throw new Error(
+      `Cannot show preview for challenge type ${buildData.challengeType}`
+    );
   }
 }
 

--- a/client/src/templates/Challenges/utils/build.js
+++ b/client/src/templates/Challenges/utils/build.js
@@ -99,7 +99,6 @@ export async function buildChallenge(challengeData, options) {
   const { challengeType } = challengeData;
   let build = buildFunctions[challengeType];
   if (build) {
-    if (options?.useDemoTemplate) challengeData.useDemoTemplate = true;
     return build(challengeData, options);
   }
   throw new Error(`Cannot build challenge of type ${challengeType}`);
@@ -149,8 +148,7 @@ async function getDOMTestRunner(buildData, { proxyLogger }, document) {
 export function buildDOMChallenge({
   challengeFiles,
   required = [],
-  template = '',
-  useDemoTemplate = false
+  template = ''
 }) {
   const finalRequires = [...globalRequires, ...required, ...frameRunner];
   const loadEnzyme = challengeFiles.some(
@@ -163,12 +161,7 @@ export function buildDOMChallenge({
     .then(checkFilesErrors)
     .then(challengeFiles => ({
       challengeType: challengeTypes.html,
-      build: concatHtml({
-        required: finalRequires,
-        template,
-        challengeFiles,
-        useDemoTemplate
-      }),
+      build: concatHtml({ required: finalRequires, template, challengeFiles }),
       sources: buildSourceMap(challengeFiles),
       loadEnzyme
     }));

--- a/client/src/templates/Challenges/utils/build.js
+++ b/client/src/templates/Challenges/utils/build.js
@@ -9,7 +9,8 @@ import { getTransformers } from '../rechallenge/transformers';
 import {
   createTestFramer,
   runTestInTestFrame,
-  createMainFramer
+  createMainPreviewFramer,
+  createProjectPreviewFramer
 } from './frame';
 import createWorker from './worker-executor';
 
@@ -197,13 +198,27 @@ export function buildBackendChallenge({ url }) {
   };
 }
 
-export async function updatePreview(buildData, document, proxyLogger) {
+// TODO: use fewer arguments (and no boolean ones!)
+export async function updatePreview(
+  buildData,
+  document,
+  proxyLogger,
+  previewProjectSolution
+) {
   const { challengeType } = buildData;
 
+  // TODO: no need to await here, nothing is waiting for the preview to be
+  // visible
   if (challengeType === challengeTypes.html) {
-    await new Promise(resolve =>
-      createMainFramer(document, resolve, proxyLogger)(buildData)
-    );
+    if (previewProjectSolution) {
+      await new Promise(resolve =>
+        createProjectPreviewFramer(document, resolve, proxyLogger)(buildData)
+      );
+    } else {
+      await new Promise(resolve =>
+        createMainPreviewFramer(document, resolve, proxyLogger)(buildData)
+      );
+    }
   } else {
     throw new Error(`Cannot show preview for challenge type ${challengeType}`);
   }

--- a/client/src/templates/Challenges/utils/build.js
+++ b/client/src/templates/Challenges/utils/build.js
@@ -99,6 +99,7 @@ export async function buildChallenge(challengeData, options) {
   const { challengeType } = challengeData;
   let build = buildFunctions[challengeType];
   if (build) {
+    if (options?.useDemoTemplate) challengeData.useDemoTemplate = true;
     return build(challengeData, options);
   }
   throw new Error(`Cannot build challenge of type ${challengeType}`);
@@ -148,7 +149,8 @@ async function getDOMTestRunner(buildData, { proxyLogger }, document) {
 export function buildDOMChallenge({
   challengeFiles,
   required = [],
-  template = ''
+  template = '',
+  useDemoTemplate = false
 }) {
   const finalRequires = [...globalRequires, ...required, ...frameRunner];
   const loadEnzyme = challengeFiles.some(
@@ -161,7 +163,12 @@ export function buildDOMChallenge({
     .then(checkFilesErrors)
     .then(challengeFiles => ({
       challengeType: challengeTypes.html,
-      build: concatHtml({ required: finalRequires, template, challengeFiles }),
+      build: concatHtml({
+        required: finalRequires,
+        template,
+        challengeFiles,
+        useDemoTemplate
+      }),
       sources: buildSourceMap(challengeFiles),
       loadEnzyme
     }));

--- a/client/src/templates/Challenges/utils/frame.js
+++ b/client/src/templates/Challenges/utils/frame.js
@@ -3,11 +3,11 @@ import { format } from '../../../utils/format';
 
 // we use two different frames to make them all essentially pure functions
 // main iframe is responsible rendering the preview and is where we proxy the
-const mainPreviewId = 'fcc-main-frame';
+export const mainPreviewId = 'fcc-main-frame';
 // the test frame is responsible for running the assert tests
 const testId = 'fcc-test-frame';
 // the project preview frame demos the finished project
-const projectPreviewId = 'fcc-project-preview-frame';
+export const projectPreviewId = 'fcc-project-preview-frame';
 
 // base tag here will force relative links
 // within iframe to point to '' instead of

--- a/client/utils/gatsby/challenge-page-creator.js
+++ b/client/utils/gatsby/challenge-page-creator.js
@@ -1,6 +1,7 @@
 const path = require('path');
+const { createPoly } = require('../../../utils/polyvinyl');
 const { dasherize } = require('../../../utils/slugs');
-
+const { sortChallengeFiles } = require('../../../utils/sort-challengefiles');
 const { viewTypes } = require('../challenge-types');
 
 const backend = path.resolve(
@@ -57,7 +58,7 @@ function getTemplateComponent(challengeType) {
 }
 
 exports.createChallengePages = function (createPage) {
-  return function ({ node }, index, allChallenges) {
+  return function ({ node: challenge }, index, allChallengeEdges) {
     const {
       superBlock,
       block,
@@ -65,17 +66,11 @@ exports.createChallengePages = function (createPage) {
       required = [],
       template,
       challengeType,
-      id,
-      challengeOrder
-    } = node;
+      id
+    } = challenge;
     // TODO: challengeType === 7 and isPrivate are the same, right? If so, we
     // should remove one of them.
 
-    const challengesInBlock = allChallenges.filter(
-      ({ node }) => node.block === block
-    );
-    const allSolutionsToLastChallenge =
-      challengesInBlock[challengesInBlock.length - 1].node.solutions;
     createPage({
       path: slug,
       component: getTemplateComponent(challengeType),
@@ -85,17 +80,55 @@ exports.createChallengePages = function (createPage) {
           block,
           template,
           required,
-          nextChallengePath: getNextChallengePath(node, index, allChallenges),
-          prevChallengePath: getPrevChallengePath(node, index, allChallenges),
-          id,
-          isFirstChallengeInBlock: challengeOrder === 0,
-          solutionToLastChallenge: allSolutionsToLastChallenge[0]
+          nextChallengePath: getNextChallengePath(
+            challenge,
+            index,
+            allChallengeEdges
+          ),
+          prevChallengePath: getPrevChallengePath(
+            challenge,
+            index,
+            allChallengeEdges
+          ),
+          id
         },
+        projectPreview: getProjectPreviewConfig(challenge, allChallengeEdges),
         slug
       }
     });
   };
 };
+
+function getProjectPreviewConfig(challenge, allChallengeEdges) {
+  const { block, challengeOrder } = challenge;
+
+  const challengesInBlock = allChallengeEdges
+    .filter(({ node }) => node.block === block)
+    .map(({ node }) => node);
+  const lastChallenge = challengesInBlock[challengesInBlock.length - 1];
+  const solutionToLastChallenge = sortChallengeFiles(
+    lastChallenge.solutions[0] ?? []
+  );
+  const lastChallengeFiles = sortChallengeFiles(
+    lastChallenge.challengeFiles ?? []
+  );
+  const projectPreviewChallengeFiles = lastChallengeFiles.map((file, id) =>
+    createPoly({
+      ...file,
+      contents: solutionToLastChallenge[id]?.contents ?? file.contents
+    })
+  );
+
+  return {
+    isFirstChallengeInBlock: challengeOrder === 0,
+    challengeData: {
+      challengeType: lastChallenge.challengeType,
+      challengeFiles: projectPreviewChallengeFiles,
+      required: lastChallenge.required,
+      template: lastChallenge.template
+    }
+  };
+}
 
 exports.createBlockIntroPages = function (createPage) {
   return function (edge) {

--- a/client/utils/gatsby/challenge-page-creator.js
+++ b/client/utils/gatsby/challenge-page-creator.js
@@ -100,7 +100,7 @@ exports.createChallengePages = function (createPage) {
 };
 
 function getProjectPreviewConfig(challenge, allChallengeEdges) {
-  const { block, challengeOrder } = challenge;
+  const { block, challengeOrder, usesMultifileEditor } = challenge;
 
   const challengesInBlock = allChallengeEdges
     .filter(({ node }) => node.block === block)
@@ -120,7 +120,7 @@ function getProjectPreviewConfig(challenge, allChallengeEdges) {
   );
 
   return {
-    isFirstChallengeInBlock: challengeOrder === 0,
+    showProjectPreview: challengeOrder === 0 && usesMultifileEditor,
     challengeData: {
       challengeType: lastChallenge.challengeType,
       challengeFiles: projectPreviewChallengeFiles,

--- a/client/utils/gatsby/challenge-page-creator.js
+++ b/client/utils/gatsby/challenge-page-creator.js
@@ -57,7 +57,7 @@ function getTemplateComponent(challengeType) {
 }
 
 exports.createChallengePages = function (createPage) {
-  return function ({ node }, index, thisArray) {
+  return function ({ node }, index, allChallenges) {
     const {
       superBlock,
       block,
@@ -65,11 +65,17 @@ exports.createChallengePages = function (createPage) {
       required = [],
       template,
       challengeType,
-      id
+      id,
+      challengeOrder
     } = node;
     // TODO: challengeType === 7 and isPrivate are the same, right? If so, we
     // should remove one of them.
 
+    const challengesInBlock = allChallenges.filter(
+      ({ node }) => node.block === block
+    );
+    const allSolutionsToLastChallenge =
+      challengesInBlock[challengesInBlock.length - 1].node.solutions;
     createPage({
       path: slug,
       component: getTemplateComponent(challengeType),
@@ -79,9 +85,11 @@ exports.createChallengePages = function (createPage) {
           block,
           template,
           required,
-          nextChallengePath: getNextChallengePath(node, index, thisArray),
-          prevChallengePath: getPrevChallengePath(node, index, thisArray),
-          id
+          nextChallengePath: getNextChallengePath(node, index, allChallenges),
+          prevChallengePath: getPrevChallengePath(node, index, allChallenges),
+          id,
+          isFirstChallengeInBlock: challengeOrder === 0,
+          solutionToLastChallenge: allSolutionsToLastChallenge[0]
         },
         slug
       }

--- a/cypress/integration/learn/challenges/project-preview.js
+++ b/cypress/integration/learn/challenges/project-preview.js
@@ -20,21 +20,20 @@ const legacyFirstChallengeUrls = [
 
 describe('project preview', () => {
   if (Cypress.env('SHOW_UPCOMING_CHANGES') === 'true') {
-    // it('should appear on the first challenges of each practice project', () => {
-    //   practiceProjectUrls.forEach(url => {
-    //     cy.visit(url + 'part-1');
-    //     cy.contains('Complete project demo.');
-    //     cy.get('[data-cy="project-preview-modal"]').should('be.focused');
-    //   });
-    // });
+    it('should appear on the first challenges of each practice project', () => {
+      practiceProjectUrls.forEach(url => {
+        cy.visit(url + 'part-1');
+        cy.contains('Complete project demo.');
+        cy.get('[data-cy="project-preview-modal"]').should('be.focused');
+      });
+    });
 
-    // Tests for the absence of an element are tricky, if, as the case here, the
-    // element is not rendered initially. So, instead, we test for a side effect
-    // of not showing the modal: an editor is allowed to get focus.
+    // Tests for the absence of an element are tricky, if, as is the case here,
+    // the element is not rendered straight away. So, instead, we test for a
+    // side effect of not showing the modal: an editor is allowed to get focus.
     it('should NOT appear on the second challenges of each practice project', () => {
       practiceProjectUrls.forEach(url => {
         cy.visit(url + 'part-2');
-        // if no modals are showing, then the editor should have focus:
         cy.focused()
           .parents()
           .should('have.class', 'react-monaco-editor-container');

--- a/cypress/integration/learn/challenges/project-preview.js
+++ b/cypress/integration/learn/challenges/project-preview.js
@@ -1,0 +1,54 @@
+const practiceProjectUrls = [
+  '/learn/responsive-web-design/css-variables-skyline/',
+  '/learn/responsive-web-design/basic-html-cat-photo-app/',
+  '/learn/responsive-web-design/basic-css-cafe-menu/',
+  '/learn/responsive-web-design/css-picasso-painting/',
+  '/learn/responsive-web-design/css-box-model/',
+  '/learn/responsive-web-design/css-piano/',
+  '/learn/responsive-web-design/registration-form/',
+  '/learn/responsive-web-design/accessibility-quiz/'
+];
+
+const legacyFirstChallengeUrls = [
+  '/learn/responsive-web-design/basic-html-and-html5/say-hello-to-html-elements',
+  '/learn/responsive-web-design/basic-css/change-the-color-of-text',
+  '/learn/responsive-web-design/applied-visual-design/create-visual-balance-using-the-text-align-property',
+  '/learn/responsive-web-design/applied-accessibility/add-a-text-alternative-to-images-for-visually-impaired-accessibility',
+  '/learn/responsive-web-design/css-flexbox/use-display-flex-to-position-two-boxes',
+  '/learn/responsive-web-design/css-grid/create-your-first-css-grid'
+];
+
+describe('project preview', () => {
+  if (Cypress.env('SHOW_UPCOMING_CHANGES') === 'true') {
+    // it('should appear on the first challenges of each practice project', () => {
+    //   practiceProjectUrls.forEach(url => {
+    //     cy.visit(url + 'part-1');
+    //     cy.contains('Complete project demo.');
+    //     cy.get('[data-cy="project-preview-modal"]').should('be.focused');
+    //   });
+    // });
+
+    // Tests for the absence of an element are tricky, if, as the case here, the
+    // element is not rendered initially. So, instead, we test for a side effect
+    // of not showing the modal: an editor is allowed to get focus.
+    it('should NOT appear on the second challenges of each practice project', () => {
+      practiceProjectUrls.forEach(url => {
+        cy.visit(url + 'part-2');
+        // if no modals are showing, then the editor should have focus:
+        cy.focused()
+          .parents()
+          .should('have.class', 'react-monaco-editor-container');
+      });
+    });
+  }
+
+  it('should NOT appear on the first challenges of legacy blocks', () => {
+    legacyFirstChallengeUrls.forEach(url => {
+      cy.visit(url);
+      // if no modals are showing, then the editor should have focus:
+      cy.focused()
+        .parents()
+        .should('have.class', 'react-monaco-editor-container');
+    });
+  });
+});

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -14,11 +14,19 @@
 
 const { execSync } = require('child_process');
 const { existsSync } = require('fs');
+require('dotenv').config();
 
 module.exports = (on, config) => {
+  // `on` is used to hook into various events Cypress emits
+  // `config` is the resolved Cypress config
+  config.env = config.env || {};
   on('before:run', () => {
     if (!existsSync('../../config/curriculum.json')) {
       execSync('npm run build:curriculum');
     }
   });
+
+  // Allows us to test the new curriculum before it's released:
+  config.env.SHOW_UPCOMING_CHANGES = process.env.SHOW_UPCOMING_CHANGES;
+  return config;
 };


### PR DESCRIPTION
Shows a modal which previews the solution to the final step of a practice project.

Not all practice projects _have_ solutions, yet, and so the modal doesn't appear for registration-form.  Once they all do we should lock that down with a test.

@ahmadabdolsaheb if you've got a chance, could you look at smartening up the Modal?  It... works, but it's not pretty.

@raisedadead since this is an upcoming feature, I disabled the tests with `SHOW_UPCOMING_CHANGES` so we can run them locally when we want and then in CI when we're ready.  Does that seem reasonable?