### PR TITLE
Traduction improves and details

### DIFF
--- a/curriculum/challenges/espanol/02-javascript-algorithms-and-data-structures/functional-programming/add-elements-to-the-end-of-an-array-using-concat-instead-of-push.md
+++ b/curriculum/challenges/espanol/02-javascript-algorithms-and-data-structures/functional-programming/add-elements-to-the-end-of-an-array-using-concat-instead-of-push.md
@@ -1,6 +1,6 @@
 ---
 id: 587d7da9367417b2b2512b67
-title: Agrega elementos al final de un arreglo utilizando concat en lugar de push
+title: Agrega elementos al final de un array utilizando concat en lugar de push
 challengeType: 1
 forumTopicId: 301226
 dashedName: add-elements-to-the-end-of-an-array-using-concat-instead-of-push
@@ -10,7 +10,7 @@ dashedName: add-elements-to-the-end-of-an-array-using-concat-instead-of-push
 
 La programación funcional consiste en crear y utilizar funciones no mutantes.
 
-El último desafío introdujo el método `concat` como una forma de combinar arreglos en uno nuevo sin mutar los arreglos originales. Compara `concat` con el método `push`. `push` añade un elemento al final del arreglo desde el que se llama, lo cual muta ese arreglo. Aquí hay un ejemplo:
+El último desafío introdujo el método `concat` como una forma de combinar arrays en uno nuevo sin mutar los arrays originales. Compara `concat` con el método `push`. `push` añade un elemento al final del array desde el que se llama, lo cual muta ese array. Aquí hay un ejemplo:
 
 ```js
 var arr = [1, 2, 3];
@@ -19,11 +19,11 @@ arr.push([4, 5, 6]);
 
 `arr` tendría un valor modificado de `[1, 2, 3, [4, 5, 6]]`, que no encaja con el paradigma de la programación funcional.
 
-`concat` ofrece una forma de añadir nuevos elementos al final de un arreglo, sin provocar ningún efecto de mutación.
+`concat` ofrece una forma de añadir nuevos elementos al final de un array, sin provocar ningún efecto de mutación.
 
 # --instructions--
 
-Cambia la función `nonMutatingPush` para que use `concat` para añadir `newItem` al final de `original` en lugar de `push`. La función debe devolver un arreglo.
+Cambia la función `nonMutatingPush` para que use `concat` para añadir `newItem` al final de `original` en lugar de `push`. La función debe devolver un array.
 
 # --hints--
 
@@ -39,13 +39,13 @@ El código no debe utilizar el método `push`.
 assert(!code.match(/\.?[\s\S]*?push/g));
 ```
 
-El arreglo `first` no debe modificarse.
+El array `first` no debe modificarse.
 
 ```js
 assert(JSON.stringify(first) === JSON.stringify([1, 2, 3]));
 ```
 
-El arreglo `second` no debe modificarse.
+El array `second` no debe modificarse.
 
 ```js
 assert(JSON.stringify(second) === JSON.stringify([4, 5]));
@@ -66,10 +66,10 @@ assert(
 
 ```js
 function nonMutatingPush(original, newItem) {
-  // Only change code below this line
+  // Sólo modifica el código bajo esta línea
   return original.push(newItem);
 
-  // Only change code above this line
+  // Sólo modifica el código sobre esta línea
 }
 var first = [1, 2, 3];
 var second = [4, 5];


### PR DESCRIPTION
Change "arreglo" and "arreglos" by "array" and "arrays" that are used in spanish language when there is programming context. Also, translate seed contents' js comments.

<!-- Please note that low quality PRs and PRs that do not follow our contributing guidelines will be marked as invalid for Hacktoberfest. -->

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
