### PR TITLE
chore(.env): remove stripe create plans key

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -32,7 +32,6 @@ ALGOLIA_API_KEY=api_key_from_algolia_dashboard
 # ---------------------
 
 # Stripe
-STRIPE_CREATE_PLANS=true
 STRIPE_PUBLIC_KEY=pk_from_stripe_dashboard
 STRIPE_SECRET_KEY=sk_from_stripe_dashboard
 


### PR DESCRIPTION
The values in the sample files should default to false