### PR TITLE
fix(config): add a bolder warning when missing .env

### DIFF
--- a/config/read-env.js
+++ b/config/read-env.js
@@ -4,12 +4,16 @@ const envPath = path.resolve(__dirname, '../.env');
 const { error } = require('dotenv').config({ path: envPath });
 
 if (error) {
-  if (process.env.FREECODECAMP_NODE_ENV === 'development') {
-    console.warn('.env not found, please copy sample.env to .env');
-  } else {
-    console.warn(`.env not found. If env vars are not being set another way,
-this could be a problem.`);
-  }
+  console.warn(`
+  ----------------------------------------------------
+  Warning: .env file not found.
+  ----------------------------------------------------
+  Please copy sample.env to .env
+
+  You can ignore this warning if using a different way
+  to setup this environment.
+  ----------------------------------------------------
+  `);
 }
 
 const {


### PR DESCRIPTION
This adds a more noticeable warning in the build logs and consolidates the missing .env file warning

Ex: I am not using the .env file locally and would prefer to see this message appearing consistently while building prod builds which I set up with system environment variables.
