### PR TITLE
fix(client): make language dropdown as wide as the nav

### DIFF
--- a/client/src/components/Header/components/nav-links.tsx
+++ b/client/src/components/Header/components/nav-links.tsx
@@ -189,7 +189,7 @@ export class NavLinks extends Component<NavLinksProps, {}> {
           {t('footer.language')}
         </div>
 
-        <div className='nav-link' key='language-dropdown'>
+        <div className='nav-link dropdown-nav-link' key='language-dropdown'>
           <select
             className='nav-link-lang-dropdown'
             onChange={this.handleLanguageChange}

--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -109,6 +109,16 @@
   border: none;
 }
 
+.dropdown-nav-link {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.dropdown-nav-link:hover .nav-link-lang-dropdown,
+.dropdown-nav-link:active .nav-link-lang-dropdown {
+  background-image: url('data:image/svg+xml;charset=UTF-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2212%22%20height%3D%2212%22%20viewBox%3D%220%200%2012%2012%22%3E%3Ctitle%3Edown-arrow%3C%2Ftitle%3E%3Cg%20fill%3D%22%23000000%22%3E%3Cpath%20d%3D%22M10.293%2C3.293%2C6%2C7.586%2C1.707%2C3.293A1%2C1%2C0%2C0%2C0%2C.293%2C4.707l5%2C5a1%2C1%2C0%2C0%2C0%2C1.414%2C0l5-5a1%2C1%2C0%2C1%2C0-1.414-1.414Z%22%20fill%3D%22%23000000%22%3E%3C%2Fpath%3E%3C%2Fg%3E%3C%2Fsvg%3E');
+}
+
 .nav-link:hover,
 .nav-link:active {
   color: var(--theme-color);
@@ -143,11 +153,21 @@
 }
 
 .nav-link-lang-dropdown {
+  padding: 0 15px;
   color: var(--gray-00);
   background-color: var(--gray-90);
   width: 100%;
   border: none;
+  position: relative;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-image: url('data:image/svg+xml;charset=UTF-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2212%22%20height%3D%2212%22%20viewBox%3D%220%200%2012%2012%22%3E%3Ctitle%3Edown-arrow%3C%2Ftitle%3E%3Cg%20fill%3D%22%23ffffff%22%3E%3Cpath%20d%3D%22M10.293%2C3.293%2C6%2C7.586%2C1.707%2C3.293A1%2C1%2C0%2C0%2C0%2C.293%2C4.707l5%2C5a1%2C1%2C0%2C0%2C0%2C1.414%2C0l5-5a1%2C1%2C0%2C1%2C0-1.414-1.414Z%22%20fill%3D%22%23ffffff%22%3E%3C%2Fpath%3E%3C%2Fg%3E%3C%2Fsvg%3E');
+  background-size: 10px;
+  background-position: calc(100% - 15px) center;
+  background-repeat: no-repeat;
 }
+
 .nav-link-lang-dropdown:focus {
   outline: none;
 }


### PR DESCRIPTION
- The language dropdown is made as wide as the containing element.
- Tested in Chrome, Firefox, Edge, Safari and  Chrome(Android).

Before: 


![Screenshot from 2021-10-25 00-44-58](https://user-images.githubusercontent.com/61292452/138609317-2f6aa4e7-8756-41e3-9ba7-fe119de89c1c.png)


After : 


![Screenshot from 2021-10-25 00-51-04](https://user-images.githubusercontent.com/61292452/138609432-00c0ad13-9cf1-4b1f-8b8b-dcdd67cbee16.png)



<!-- Please note that low quality PRs and PRs that do not follow our contributing guidelines will be marked as invalid for Hacktoberfest. -->

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #43990

<!-- Feel free to add any additional description of changes below this line -->
