### PR TITLE
fix(docs): reorder the sidebar in order of relevance

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -10,7 +10,7 @@
   - [Open a pull request](how-to-open-a-pull-request.md)
   - [Work on coding challenges](how-to-work-on-coding-challenges.md)
   - [Work on practice projects](how-to-work-on-practice-projects.md)
-  - [Work on tutorials w/ CodeRoad](how-to-work-on-tutorials-that-use-coderoad.md)
+  - [Work on tutorials with CodeRoad](how-to-work-on-tutorials-that-use-coderoad.md)
   - [Work on localized client web app](how-to-work-on-localized-client-webapp.md)
   - [Work on Cypress tests](how-to-add-cypress-tests.md)
   - [Work on video challenges](how-to-help-with-video-challenges.md)

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,26 +1,26 @@
 - **Getting Started**
   - [Introduction](index.md 'Contribute to the freeCodeCamp.org Community')
   - [Frequently Asked Questions](FAQ.md)
-- **Code Contribution**
-  - [Set up freeCodeCamp locally](how-to-setup-freecodecamp-locally.md)
-  - [Codebase best practices](codebase-best-practices.md)
-  - [Open a pull request](how-to-open-a-pull-request.md)
-  - [Work on coding challenges](how-to-work-on-coding-challenges.md)
-  - [Work on video challenges](how-to-help-with-video-challenges.md)
-  - [Work on the news theme](how-to-work-on-the-news-theme.md)
-  - [Work on the docs theme](how-to-work-on-the-docs-theme.md)
-  - [Work on practice projects](how-to-work-on-practice-projects.md)
 - **Translation Contribution**
   - [Work on translating resources](how-to-translate-files.md)
   - [Work on proofreading translations](how-to-proofread-files.md)
-- **Resources**
-  - [Set up freeCodeCamp on Windows (WSL)](how-to-setup-wsl.md)
-  - [Add Cypress tests](how-to-add-cypress-tests.md)
+- **Code Contribution**
+  - [Set up freeCodeCamp locally](how-to-setup-freecodecamp-locally.md)
+  - [Follow coding best practices](codebase-best-practices.md)
+  - [Open a pull request](how-to-open-a-pull-request.md)
+  - [Work on coding challenges](how-to-work-on-coding-challenges.md)
+  - [Work on practice projects](how-to-work-on-practice-projects.md)
+  - [Work on tutorials w/ CodeRoad](how-to-work-on-tutorials-that-use-coderoad.md)
   - [Work on localized client web app](how-to-work-on-localized-client-webapp.md)
-  - [Catch outgoing emails locally](how-to-catch-outgoing-emails-locally.md)
+  - [Work on Cypress tests](how-to-add-cypress-tests.md)
+  - [Work on video challenges](how-to-help-with-video-challenges.md)
+  - [Work on the news theme](how-to-work-on-the-news-theme.md)
+  - [Work on the docs theme](how-to-work-on-the-docs-theme.md)
+- **Additional Guides**
   - [Test translations locally](how-to-test-translations-locally.md)
   - [Understand the curriculum file structure](curriculum-file-structure.md)
-  - [Work on tutorials w/ CodeRoad](how-to-work-on-tutorials-that-use-coderoad.md)
+  - [Debug outgoing emails locally](how-to-catch-outgoing-emails-locally.md)
+  - [Set up freeCodeCamp on Windows (WSL)](how-to-setup-wsl.md)
 
 ---
 


### PR DESCRIPTION
Moved around the items in the list to be more relevant in the order of the most frequently used to least. Changed the wording to be more friendly here needed.


<!-- Please note that low quality PRs and PRs that do not follow our contributing guidelines will be marked as invalid for Hacktoberfest. -->

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
