### PR TITLE
fix(curriculum): update challenge to heading tags instead of headers …

### DIFF
--- a/curriculum/challenges/_meta/applied-visual-design/meta.json
+++ b/curriculum/challenges/_meta/applied-visual-design/meta.json
@@ -47,7 +47,7 @@
     ],
     [
       "587d781b367417b2b2512abd",
-      "Adjust the Size of a Header Versus a Paragraph Tag"
+      "Adjust the Size of a Heading Element Versus a Paragraph Element"
     ],
     [
       "587d781b367417b2b2512abe",

--- a/curriculum/challenges/chinese-traditional/01-responsive-web-design/applied-visual-design/adjust-the-size-of-a-heading-element-versus-a-paragraph-element.md
+++ b/curriculum/challenges/chinese-traditional/01-responsive-web-design/applied-visual-design/adjust-the-size-of-a-heading-element-versus-a-paragraph-element.md
@@ -1,23 +1,23 @@
 ---
 id: 587d781b367417b2b2512abd
-title: Regolare la dimensione di un'intestazione rispetto a quella di un paragrafo
+title: 調整標題與段落的大小
 challengeType: 0
 videoUrl: 'https://scrimba.com/c/c3bRPTz'
 forumTopicId: 301037
-dashedName: adjust-the-size-of-a-header-versus-a-paragraph-tag
+dashedName: adjust-the-size-of-a-heading-element-versus-a-paragraph-element
 ---
 
 # --description--
 
-La dimensione del carattere dei tag di intestazione (da `h1` a `h6`) dovrebbe essere generalmente più grande della dimensione del carattere dei tag di paragrafo. Questo rende più facile per l'utente capire visivamente il layout e il livello di importanza di ogni elemento della pagina. Si utilizza la proprietà `font-size` per regolare la dimensione del testo in un elemento.
+標題標籤的字體大小（從 `h1` 到 `h6`）一般應該大於段落標籤的字體大小。 這使用戶更容易在視覺上了解頁面上所有內容的佈局和重要程度。 你可以使用 `font-size` 屬性來設置元素內文字的大小。
 
 # --instructions--
 
-Per rendere l'intestazione significativamente più grande del paragrafo, porta `font-size` del tag `h4` a 27 pixel.
+把 `h4` 標籤的 `font-size` 的屬性值改成 27px，讓標題更醒目。
 
 # --hints--
 
-Il tuo codice dovrebbe aggiungere una proprietà `font-size` all'elemento `h4`, impostata a 27 pixel.
+應給 `h4` 元素添加一個 `font-size` 屬性並將屬性值設置爲 27px。
 
 ```js
 assert($('h4').css('font-size') == '27px');

--- a/curriculum/challenges/chinese/01-responsive-web-design/applied-visual-design/adjust-the-size-of-a-heading-element-versus-a-paragraph-element.md
+++ b/curriculum/challenges/chinese/01-responsive-web-design/applied-visual-design/adjust-the-size-of-a-heading-element-versus-a-paragraph-element.md
@@ -1,23 +1,23 @@
 ---
 id: 587d781b367417b2b2512abd
-title: Ajusta el tamaño de un título contra una etiqueta de párrafo
+title: 调整标题与段落的大小
 challengeType: 0
 videoUrl: 'https://scrimba.com/c/c3bRPTz'
 forumTopicId: 301037
-dashedName: adjust-the-size-of-a-header-versus-a-paragraph-tag
+dashedName: adjust-the-size-of-a-heading-element-versus-a-paragraph-element
 ---
 
 # --description--
 
-El tamaño de fuente de las etiquetas de encabezado (`h1` a `h6`) generalmente debería ser mayor que el tamaño de fuente de las etiquetas de párrafos. Esto hace que sea más sencillo para que el usuario entienda visualmente el diseño y el nivel de importancia de cada elemento en la página. Utiliza la propiedad `font-size` para ajustar el tamaño del texto en un elemento.
+标题标签的字体大小（从 `h1` 到 `h6`）一般应该大于段落标签的字体大小。 这使用户更容易在视觉上了解页面上所有内容的布局和重要程度。 你可以使用 `font-size` 属性来设置元素内文字的大小。
 
 # --instructions--
 
-Para que el encabezado sea significativamente más grande que el párrafo, cambia la etiqueta `font-size` de la etiqueta `h4` a 27 píxeles.
+把 `h4` 标签的 `font-size` 的属性值改成 27px，让标题更醒目。
 
 # --hints--
 
-Tu código debe agregar una propiedad `font-size` al elemento `h4` y establecerlo en 27 píxeles.
+应给 `h4` 元素添加一个 `font-size` 属性并将属性值设置为 27px。
 
 ```js
 assert($('h4').css('font-size') == '27px');

--- a/curriculum/challenges/english/01-responsive-web-design/applied-accessibility/use-headings-to-show-hierarchical-relationships-of-content.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-accessibility/use-headings-to-show-hierarchical-relationships-of-content.md
@@ -17,7 +17,7 @@ If you were writing a paper with an introduction, a body, and a conclusion, it w
 
 Headings with equal (or higher) rank start new implied sections, headings with lower rank start subsections of the previous one.
 
-As an example, a page with an `h2` element followed by several subsections labeled with `h4` tags would confuse a screen reader user. With six choices, it's tempting to use a tag because it looks better in a browser, but you can use CSS to edit the relative sizing.
+As an example, a page with an `h2` element followed by several subsections labeled with `h4` elements would confuse a screen reader user. With six choices, it's tempting to use a tag because it looks better in a browser, but you can use CSS to edit the relative sizing.
 
 One final point, each page should always have one (and only one) `h1` element, which is the main subject of your content. This and the other headings are used in part by search engines to understand the topic of the page.
 
@@ -27,7 +27,7 @@ Camper Cat wants a page on his site dedicated to becoming a ninja. Help him fix 
 
 # --hints--
 
-Your code should have 6 `h3` tags.
+Your code should have 6 `h3` elements.
 
 ```js
 assert($('h3').length === 6);
@@ -39,7 +39,7 @@ Your code should have 6 `h3` closing tags.
 assert((code.match(/\/h3/g) || []).length === 6);
 ```
 
-Your code should not have any `h5` tags.
+Your code should not have any `h5` elements.
 
 ```js
 assert($('h5').length === 0);

--- a/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/adjust-the-size-of-a-heading-element-versus-a-paragraph-element.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-visual-design/adjust-the-size-of-a-heading-element-versus-a-paragraph-element.md
@@ -1,19 +1,19 @@
 ---
 id: 587d781b367417b2b2512abd
-title: Adjust the Size of a Header Versus a Paragraph Tag
+title: Adjust the Size of a Heading Element Versus a Paragraph Element
 challengeType: 0
 videoUrl: 'https://scrimba.com/c/c3bRPTz'
 forumTopicId: 301037
-dashedName: adjust-the-size-of-a-header-versus-a-paragraph-tag
+dashedName: adjust-the-size-of-a-heading-element-versus-a-paragraph-element
 ---
 
 # --description--
 
-The font size of header tags (`h1` through `h6`) should generally be larger than the font size of paragraph tags. This makes it easier for the user to visually understand the layout and level of importance of everything on the page. You use the `font-size` property to adjust the size of the text in an element.
+The font size of heading elements (`h1` through `h6`) should generally be larger than the font size of paragraph tags. This makes it easier for the user to visually understand the layout and level of importance of everything on the page. You use the `font-size` property to adjust the size of the text in an element.
 
 # --instructions--
 
-To make the heading significantly larger than the paragraph, change the `font-size` of the `h4` tag to 27 pixels.
+To make the heading significantly larger than the paragraph, change the `font-size` of the `h4` element to 27 pixels.
 
 # --hints--
 
@@ -116,3 +116,4 @@ assert($('h4').css('font-size') == '27px');
   </div>
 </div>
 ```
+

--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/link-to-internal-sections-of-a-page-with-anchor-elements.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/link-to-internal-sections-of-a-page-with-anchor-elements.md
@@ -21,7 +21,7 @@ Below is an example of an internal anchor link and its target element:
 <h2 id="contacts-header">Contacts</h2>
 ```
 
-When users click the `Contacts` link, they'll be taken to the section of the webpage with the **Contacts** header element.
+When users click the `Contacts` link, they'll be taken to the section of the webpage with the **Contacts** heading element.
 
 # --instructions--
 

--- a/curriculum/challenges/english/03-front-end-development-libraries/front-end-development-libraries-projects/build-a-markdown-previewer.md
+++ b/curriculum/challenges/english/03-front-end-development-libraries/front-end-development-libraries-projects/build-a-markdown-previewer.md
@@ -22,7 +22,7 @@ You can use any mix of HTML, JavaScript, CSS, Bootstrap, SASS, React, Redux, and
 
 **User Story #4:** When I enter GitHub flavored markdown into the `#editor` element, the text is rendered as HTML in the `#preview` element as I type (HINT: You don't need to parse Markdown yourself - you can import the Marked library for this: <https://cdnjs.com/libraries/marked>).
 
-**User Story #5:** When my markdown previewer first loads, the default text in the `#editor` field should contain valid markdown that represents at least one of each of the following elements: a header (H1 size), a sub header (H2 size), a link, inline code, a code block, a list item, a blockquote, an image, and bolded text.
+**User Story #5:** When my markdown previewer first loads, the default text in the `#editor` field should contain valid markdown that represents at least one of each of the following elements: a heading element (H1 size), a sub heading element (H2 size), a link, inline code, a code block, a list item, a blockquote, an image, and bolded text.
 
 **User Story #6:** When my markdown previewer first loads, the default markdown in the `#editor` field should be rendered as HTML in the `#preview` element.
 

--- a/curriculum/challenges/english/03-front-end-development-libraries/react/compose-react-components.md
+++ b/curriculum/challenges/english/03-front-end-development-libraries/react/compose-react-components.md
@@ -14,7 +14,7 @@ As the challenges continue to use more complex compositions with React component
 
 In the code editor, the `TypesOfFood` component is already rendering a component called `Vegetables`. Also, there is the `Fruits` component from the last challenge.
 
-Nest two components inside of `Fruits` — first `NonCitrus`, and then `Citrus`. Both of these components are provided for you behind the scenes. Next, nest the `Fruits` class component into the `TypesOfFood` component, below the `h1` header and above `Vegetables`. The result should be a series of nested components, which uses two different component types.
+Nest two components inside of `Fruits` — first `NonCitrus`, and then `Citrus`. Both of these components are provided for you behind the scenes. Next, nest the `Fruits` class component into the `TypesOfFood` component, below the `h1` heading element and above `Vegetables`. The result should be a series of nested components, which uses two different component types.
 
 # --hints--
 

--- a/curriculum/challenges/english/03-front-end-development-libraries/react/create-a-controlled-form.md
+++ b/curriculum/challenges/english/03-front-end-development-libraries/react/create-a-controlled-form.md
@@ -109,7 +109,7 @@ assert(
 );
 ```
 
-The `h1` header should render the value of the `submit` field from the component's state.
+The `h1` heading element should render the value of the `submit` field from the component's state.
 
 ```js
 (() => {

--- a/curriculum/challenges/english/03-front-end-development-libraries/react/create-a-react-component.md
+++ b/curriculum/challenges/english/03-front-end-development-libraries/react/create-a-react-component.md
@@ -38,7 +38,7 @@ The React component should return a `div` element.
 assert(Enzyme.shallow(React.createElement(MyComponent)).type() === 'div');
 ```
 
-The returned `div` should render an `h1` header within it.
+The returned `div` should render an `h1` heading element within it.
 
 ```js
 assert(
@@ -48,7 +48,7 @@ assert(
 );
 ```
 
-The `h1` header should contain the string `Hello React!`.
+The `h1` heading element should contain the string `Hello React!`.
 
 ```js
 assert(

--- a/curriculum/challenges/english/03-front-end-development-libraries/react/render-state-in-the-user-interface-another-way.md
+++ b/curriculum/challenges/english/03-front-end-development-libraries/react/render-state-in-the-user-interface-another-way.md
@@ -27,7 +27,7 @@ assert(
 );
 ```
 
-`MyComponent` should render an `h1` header enclosed in a single `div`.
+`MyComponent` should render an `h1` heading element enclosed in a single `div`.
 
 ```js
 assert(
@@ -44,7 +44,7 @@ The rendered `h1` tag should include a reference to `{name}`.
   assert(/<h1>\n*\s*\{\s*name\s*\}\s*\n*<\/h1>/.test(getUserInput('index')));
 ```
 
-The rendered `h1` header should contain text rendered from the component's state.
+The rendered `h1` heading element should contain text rendered from the component's state.
 
 ```js
 async () => {

--- a/curriculum/challenges/english/03-front-end-development-libraries/react/render-state-in-the-user-interface.md
+++ b/curriculum/challenges/english/03-front-end-development-libraries/react/render-state-in-the-user-interface.md
@@ -33,7 +33,7 @@ assert(
 );
 ```
 
-`MyComponent` should render an `h1` header enclosed in a single `div`.
+`MyComponent` should render an `h1` heading element enclosed in a single `div`.
 
 ```js
 assert(
@@ -43,7 +43,7 @@ assert(
 );
 ```
 
-The rendered `h1` header should only contain text rendered from the component's state.
+The rendered `h1` heading element should only contain text rendered from the component's state.
 
 ```js
 async () => {

--- a/curriculum/challenges/english/03-front-end-development-libraries/react/set-state-with-this.setstate.md
+++ b/curriculum/challenges/english/03-front-end-development-libraries/react/set-state-with-this.setstate.md
@@ -35,13 +35,13 @@ assert(
 );
 ```
 
-`MyComponent` should render an `h1` header.
+`MyComponent` should render an `h1` heading element.
 
 ```js
 assert(Enzyme.mount(React.createElement(MyComponent)).find('h1').length === 1);
 ```
 
-The rendered `h1` header should contain text rendered from the component's state.
+The rendered `h1` heading element should contain text rendered from the component's state.
 
 ```js
 async () => {

--- a/curriculum/challenges/espanol/01-responsive-web-design/applied-visual-design/adjust-the-size-of-a-heading-element-versus-a-paragraph-element.md
+++ b/curriculum/challenges/espanol/01-responsive-web-design/applied-visual-design/adjust-the-size-of-a-heading-element-versus-a-paragraph-element.md
@@ -1,23 +1,23 @@
 ---
 id: 587d781b367417b2b2512abd
-title: 调整标题与段落的大小
+title: Ajusta el tamaño de un título contra una etiqueta de párrafo
 challengeType: 0
 videoUrl: 'https://scrimba.com/c/c3bRPTz'
 forumTopicId: 301037
-dashedName: adjust-the-size-of-a-header-versus-a-paragraph-tag
+dashedName: adjust-the-size-of-a-heading-element-versus-a-paragraph-element
 ---
 
 # --description--
 
-标题标签的字体大小（从 `h1` 到 `h6`）一般应该大于段落标签的字体大小。 这使用户更容易在视觉上了解页面上所有内容的布局和重要程度。 你可以使用 `font-size` 属性来设置元素内文字的大小。
+El tamaño de fuente de las etiquetas de encabezado (`h1` a `h6`) generalmente debería ser mayor que el tamaño de fuente de las etiquetas de párrafos. Esto hace que sea más sencillo para que el usuario entienda visualmente el diseño y el nivel de importancia de cada elemento en la página. Utiliza la propiedad `font-size` para ajustar el tamaño del texto en un elemento.
 
 # --instructions--
 
-把 `h4` 标签的 `font-size` 的属性值改成 27px，让标题更醒目。
+Para que el encabezado sea significativamente más grande que el párrafo, cambia la etiqueta `font-size` de la etiqueta `h4` a 27 píxeles.
 
 # --hints--
 
-应给 `h4` 元素添加一个 `font-size` 属性并将属性值设置为 27px。
+Tu código debe agregar una propiedad `font-size` al elemento `h4` y establecerlo en 27 píxeles.
 
 ```js
 assert($('h4').css('font-size') == '27px');

--- a/curriculum/challenges/espanol/05-back-end-development-and-apis/basic-node-and-express/meet-the-node-console.md
+++ b/curriculum/challenges/espanol/05-back-end-development-and-apis/basic-node-and-express/meet-the-node-console.md
@@ -1,6 +1,6 @@
 ---
 id: 587d7fb0367417b2b2512bed
-title: Meet the Node console
+title: Bienvenido a la consola de Node
 challengeType: 2
 forumTopicId: 301515
 dashedName: meet-the-node-console
@@ -8,29 +8,27 @@ dashedName: meet-the-node-console
 
 # --description--
 
-Working on these challenges will involve you writing your code using one of the following methods:
+Trabajar en estos desafíos implica escribir tu código usando uno de los siguientes métodos:
 
-- Clone [this GitHub repo](https://github.com/freeCodeCamp/boilerplate-express/) and complete these challenges locally.
-- Use [our Replit starter project](https://replit.com/github/freeCodeCamp/boilerplate-express) to complete these challenges.
-- Use a site builder of your choice to complete the project. Be sure to incorporate all the files from our GitHub repo.
+- Clona [este repositorio de GitHub](https://github.com/freeCodeCamp/boilerplate-express/) y completa estos desafíos localmente.
+- Usa [nuestro proyecto inicial de Replit](https://replit.com/github/freeCodeCamp/boilerplate-express) para completar estos desafíos.
+- Utiliza un constructor de sitios de tu elección para completar el proyecto. Asegúrate de incorporar todos los archivos de nuestro repositorio de GitHub.
 
-When you are done, make sure a working demo of your project is hosted somewhere public. Then submit the URL to it in the `Solution Link` field.
+Cuando hayas terminado, asegúrate de que un demo funcional de tu proyecto esté alojado en algún lugar público. A continuación, envía la URL en el campo `Solution Link`.
 
-During the development process, it is important to be able to check what’s going on in your code.
+Durante el proceso de desarrollo, es importante poder comprobar lo que está pasando en tu código.
 
-Node is just a JavaScript environment. Like client side JavaScript, you can use the console to display useful debug information. On your local machine, you would see console output in a terminal. On Replit, a terminal is open in the right pane by default.
+Node es sólo un entorno JavaScript. Al igual que JavaScript en el lado del cliente, puedes usar la consola para mostrar información útil de depuración. En tu máquina local, verías la salida de la consola en una terminal. En Replit, una terminal está abierta por defecto en el panel derecho.
 
-We recommend to keep the terminal open while working at these challenges. By reading the output in the terminal, you can see any errors that may occur.
+Recomendamos mantener la terminal abierta mientras trabajamos en estos desafíos. Al leer la salida en la terminal, puedes ver cualquier error que pueda ocurrir.
 
 # --instructions--
 
-If you have not already done so, please read the instructions in [the introduction](/learn/back-end-development-and-apis/basic-node-and-express/) and start a new project on Repl.it using [this link](https://repl.it/github/freeCodeCamp/boilerplate-express).
-
-Modify the `myApp.js` file to log "Hello World" to the console.
+Modifica el archivo `myApp.js` para escribir "Hello World" en la consola.
 
 # --hints--
 
-`"Hello World"` should be in the console
+`"Hello World"` debe estar en la consola
 
 ```js
 (getUserInput) =>

--- a/curriculum/challenges/espanol/05-back-end-development-and-apis/managing-packages-with-npm/use-the-tilde-character-to-always-use-the-latest-patch-version-of-a-dependency.md
+++ b/curriculum/challenges/espanol/05-back-end-development-and-apis/managing-packages-with-npm/use-the-tilde-character-to-always-use-the-latest-patch-version-of-a-dependency.md
@@ -1,6 +1,6 @@
 ---
 id: 587d7fb5367417b2b2512c02
-title: Use the Tilde-Character to Always Use the Latest Patch Version of a Dependency
+title: Usa el carácter tilde para usar la última versión del parche de una dependencia
 challengeType: 2
 forumTopicId: 301532
 dashedName: use-the-tilde-character-to-always-use-the-latest-patch-version-of-a-dependency
@@ -8,9 +8,9 @@ dashedName: use-the-tilde-character-to-always-use-the-latest-patch-version-of-a-
 
 # --description--
 
-In the last challenge, you told npm to only include a specific version of a package. That’s a useful way to freeze your dependencies if you need to make sure that different parts of your project stay compatible with each other. But in most use cases, you don’t want to miss bug fixes since they often include important security patches and (hopefully) don’t break things in doing so.
+En el último desafío, le dijiste a npm que sólo incluyera una versión específica de un paquete. Es una forma útil de congelar tus dependencias si necesitas asegurarte de que las diferentes partes de tu proyecto permanezcan compatibles entre sí. Pero en la mayoría de los casos, no querrás perderte las correcciones de errores, ya que a menudo incluyen importantes parches de seguridad y (con suerte) no rompen cosas al hacerlo.
 
-To allow an npm dependency to update to the latest PATCH version, you can prefix the dependency’s version with the tilde (`~`) character. Here's an example of how to allow updates to any 1.3.x version.
+Para permitir que una dependencia de npm se actualice a la última versión de PATCH, puedes prefijar la versión de la dependencia con el carácter tilde (`~`). Aquí hay un ejemplo de cómo permitir actualizaciones a cualquier versión 1.3.x.
 
 ```json
 "package": "~1.3.8"
@@ -18,15 +18,15 @@ To allow an npm dependency to update to the latest PATCH version, you can prefix
 
 # --instructions--
 
-In the package.json file, your current rule for how npm may upgrade moment is to use a specific version (2.10.2). But now, you want to allow the latest 2.10.x version.
+En el archivo package.json, su regla actual para que npm pueda actualizar la dependencia "moment" es usar una versión específica (2.10.2). Pero ahora, quieres permitir la última versión 2.10.x.
 
-Use the tilde (`~`) character to prefix the version of moment in your dependencies, and allow npm to update it to any new PATCH release.
+Usa el tilde (`~`) para anteponer la versión de moment en tus dependencias y permitir a npm actualizarlo a cualquier nueva versión PATCH.
 
-**Note:** The version numbers themselves should not be changed.
+**Nota:** Los números de versión no deben ser cambiados.
 
 # --hints--
 
-"dependencies" should include "moment"
+"dependencies" debe incluir "moment"
 
 ```js
 (getUserInput) =>
@@ -45,7 +45,7 @@ Use the tilde (`~`) character to prefix the version of moment in your dependenci
   );
 ```
 
-"moment" version should match "~2.10.2"
+la versión de "moment" debe coincidir con "~2.10.2"
 
 ```js
 (getUserInput) =>

--- a/curriculum/challenges/italian/01-responsive-web-design/applied-visual-design/adjust-the-size-of-a-heading-element-versus-a-paragraph-element.md
+++ b/curriculum/challenges/italian/01-responsive-web-design/applied-visual-design/adjust-the-size-of-a-heading-element-versus-a-paragraph-element.md
@@ -1,23 +1,23 @@
 ---
 id: 587d781b367417b2b2512abd
-title: Contrastar o tamanho de um título com o de um parágrafo
+title: Regolare la dimensione di un'intestazione rispetto a quella di un paragrafo
 challengeType: 0
 videoUrl: 'https://scrimba.com/c/c3bRPTz'
 forumTopicId: 301037
-dashedName: adjust-the-size-of-a-header-versus-a-paragraph-tag
+dashedName: adjust-the-size-of-a-heading-element-versus-a-paragraph-element
 ---
 
 # --description--
 
-O tamanho da tipografia das tags de títulos (`h1` a `h6`) geralmente deve ser maior do que o tamanho da tipografia das tags de parágrafo. Isso torna mais fácil para o usuário entender visualmente o layout e o nível de importância de tudo na página. Você pode usar a propriedade `font-size` para ajustar o tamanho do texto de um elemento.
+La dimensione del carattere dei tag di intestazione (da `h1` a `h6`) dovrebbe essere generalmente più grande della dimensione del carattere dei tag di paragrafo. Questo rende più facile per l'utente capire visivamente il layout e il livello di importanza di ogni elemento della pagina. Si utilizza la proprietà `font-size` per regolare la dimensione del testo in un elemento.
 
 # --instructions--
 
-Para tornar o título significativamente maior do que o parágrafo, altere a propriedade `font-size` da tag `h4` para 27 pixels.
+Per rendere l'intestazione significativamente più grande del paragrafo, porta `font-size` del tag `h4` a 27 pixel.
 
 # --hints--
 
-Adicione ao elemento `h4` a propriedade `font-size` com o valor de 27 pixels.
+Il tuo codice dovrebbe aggiungere una proprietà `font-size` all'elemento `h4`, impostata a 27 pixel.
 
 ```js
 assert($('h4').css('font-size') == '27px');

--- a/curriculum/challenges/portuguese/01-responsive-web-design/applied-visual-design/adjust-the-size-of-a-heading-element-versus-a-paragraph-element.md
+++ b/curriculum/challenges/portuguese/01-responsive-web-design/applied-visual-design/adjust-the-size-of-a-heading-element-versus-a-paragraph-element.md
@@ -1,23 +1,23 @@
 ---
 id: 587d781b367417b2b2512abd
-title: 調整標題與段落的大小
+title: Contrastar o tamanho de um título com o de um parágrafo
 challengeType: 0
 videoUrl: 'https://scrimba.com/c/c3bRPTz'
 forumTopicId: 301037
-dashedName: adjust-the-size-of-a-header-versus-a-paragraph-tag
+dashedName: adjust-the-size-of-a-heading-element-versus-a-paragraph-element
 ---
 
 # --description--
 
-標題標籤的字體大小（從 `h1` 到 `h6`）一般應該大於段落標籤的字體大小。 這使用戶更容易在視覺上了解頁面上所有內容的佈局和重要程度。 你可以使用 `font-size` 屬性來設置元素內文字的大小。
+O tamanho da tipografia das tags de títulos (`h1` a `h6`) geralmente deve ser maior do que o tamanho da tipografia das tags de parágrafo. Isso torna mais fácil para o usuário entender visualmente o layout e o nível de importância de tudo na página. Você pode usar a propriedade `font-size` para ajustar o tamanho do texto de um elemento.
 
 # --instructions--
 
-把 `h4` 標籤的 `font-size` 的屬性值改成 27px，讓標題更醒目。
+Para tornar o título significativamente maior do que o parágrafo, altere a propriedade `font-size` da tag `h4` para 27 pixels.
 
 # --hints--
 
-應給 `h4` 元素添加一個 `font-size` 屬性並將屬性值設置爲 27px。
+Adicione ao elemento `h4` a propriedade `font-size` com o valor de 27 pixels.
 
 ```js
 assert($('h4').css('font-size') == '27px');

--- a/cypress/integration/learn/redirects/heading-challenge.js
+++ b/cypress/integration/learn/redirects/heading-challenge.js
@@ -1,0 +1,13 @@
+describe('Header to heading element redirect', () => {
+  const basePath = '/learn/responsive-web-design/applied-visual-design';
+
+  it(`should redirect from ${basePath}/adjust-the-size-of-a-header-versus-a-paragraph-tag to ${basePath}/adjust-the-size-of-a-heading-element-versus-a-paragraph-element`, () => {
+    cy.visit(`${basePath}/adjust-the-size-of-a-header-versus-a-paragraph-tag`);
+
+    cy.location().should(loc => {
+      expect(loc.pathname).to.eq(
+        `${basePath}/adjust-the-size-of-a-heading-element-versus-a-paragraph-element`
+      );
+    });
+  });
+});

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -6,7 +6,7 @@ Read our ["How to Contribute to Open Source Guide"](https://github.com/freeCodeC
 
 Yes - You can contribute to any of the 30+ languages we have enabled on our translation platform.
 
-We have user-contributed translations live in Chinese (中文) and Spanish (Español). We intend to localize freeCodeCamp into several major world languages. You can read all about this in our [announcement here](https://www.freecodecamp.org/news/world-language-translation-effort).
+We have user-contributed translations live in some languages. We intend to localize freeCodeCamp into several major world languages. You can read all about this in our [announcement here](https://www.freecodecamp.org/news/world-language-translation-effort).
 
 If you are interested in contributing to translations please makes sure you [read this guide](how-to-translate-files.md) first.
 

--- a/docs/i18n/chinese/_sidebar.md
+++ b/docs/i18n/chinese/_sidebar.md
@@ -1,26 +1,26 @@
 - **准备开始**
   - [介绍](index.md "为 freeCodeCamp.org 社区贡献")
   - [常见问题](FAQ.md)
-- **代码贡献**
-  - [如何在本地系统中设置 freeCodeCamp 的编码环境](how-to-setup-freecodecamp-locally.md)
-  - [代码库最佳实践](codebase-best-practices.md)
-  - [拉取请求](how-to-open-a-pull-request.md)
-  - [参与编程挑战贡献](how-to-work-on-coding-challenges.md)
-  - [参与视频挑战贡献](how-to-help-with-video-challenges.md)
-  - [参与专栏贡献](how-to-work-on-the-news-theme.md)
-  - [参与文档贡献](how-to-work-on-the-docs-theme.md)
-  - [参与练习项目贡献](how-to-work-on-practice-projects.md)
-- **翻译贡献**
-  - [参与翻译](how-to-translate-files.md)
-  - [参与校对](how-to-proofread-files.md)
-- **Resources**
-  - [在 Windows 上运行 freeCodeCamp（WSL）](how-to-setup-wsl.md)
-  - [添加 Cypress 测试](how-to-add-cypress-tests.md)
-  - [在本地运行客户端 web app](how-to-work-on-localized-client-webapp.md)
-  - [本地接收电子邮件](how-to-catch-outgoing-emails-locally.md)
-  - [测试本地翻译](how-to-test-translations-locally.md)
-  - [了解文件结构课程](curriculum-file-structure.md)
-  - [Work on tutorials w/ CodeRoad](how-to-work-on-tutorials-that-use-coderoad.md)
+- **Translation Contribution**
+  - [Work on translating resources](how-to-translate-files.md)
+  - [Work on proofreading translations](how-to-proofread-files.md)
+- **Code Contribution**
+  - [Set up freeCodeCamp locally](how-to-setup-freecodecamp-locally.md)
+  - [Follow coding best practices](codebase-best-practices.md)
+  - [Open a pull request](how-to-open-a-pull-request.md)
+  - [Work on coding challenges](how-to-work-on-coding-challenges.md)
+  - [Work on practice projects](how-to-work-on-practice-projects.md)
+  - [Work on tutorials with CodeRoad](how-to-work-on-tutorials-that-use-coderoad.md)
+  - [Work on localized client web app](how-to-work-on-localized-client-webapp.md)
+  - [Work on Cypress tests](how-to-add-cypress-tests.md)
+  - [Work on video challenges](how-to-help-with-video-challenges.md)
+  - [Work on the news theme](how-to-work-on-the-news-theme.md)
+  - [Work on the docs theme](how-to-work-on-the-docs-theme.md)
+- **Additional Guides**
+  - [Test translations locally](how-to-test-translations-locally.md)
+  - [Understand the curriculum file structure](curriculum-file-structure.md)
+  - [Debug outgoing emails locally](how-to-catch-outgoing-emails-locally.md)
+  - [Set up freeCodeCamp on Windows (WSL)](how-to-setup-wsl.md)
 
 ---
 

--- a/docs/i18n/espanol/_sidebar.md
+++ b/docs/i18n/espanol/_sidebar.md
@@ -1,26 +1,26 @@
 - **Comenzando**
   - [Introducción](index.md "Contribuye a la comunidad freeCodeCamp.org")
   - [Preguntas más frecuentes](FAQ.md)
-- **Contribución de Código**
-  - [Configurar freeCodeCamp localmente](how-to-setup-freecodecamp-locally.md)
-  - [Las mejores prácticas de la base de código](codebase-best-practices.md)
-  - [Abre un pull request](how-to-open-a-pull-request.md)
-  - [Trabaja en los desafíos de codificación](how-to-work-on-coding-challenges.md)
-  - [Trabaja en los desafíos de video](how-to-help-with-video-challenges.md)
-  - [Trabaja en el tema de noticias](how-to-work-on-the-news-theme.md)
-  - [Trabaja en el tema de documentaciones](how-to-work-on-the-docs-theme.md)
-  - [Trabaja en proyectos de práctica](how-to-work-on-practice-projects.md)
-- **Contribución a Traducción**
-  - [Trabaja en la traducción de recursos](how-to-translate-files.md)
-  - [Trabaja en la revisión de traducciones](how-to-proofread-files.md)
-- **Recursos**
-  - [Configura freeCodeCamp en Windows (WSL)](how-to-setup-wsl.md)
-  - [Agregar pruebas de Cypress](how-to-add-cypress-tests.md)
-  - [Trabaja en la aplicación web de cliente localizada](how-to-work-on-localized-client-webapp.md)
-  - [Captura correos electrónicos salientes localmente](how-to-catch-outgoing-emails-locally.md)
-  - [Prueba traducciones localmente](how-to-test-translations-locally.md)
-  - [Entiende la estructura del archivo del curriculum](curriculum-file-structure.md)
-  - [Trabaja en tutoriales con CodeRoad](how-to-work-on-tutorials-that-use-coderoad.md)
+- **Translation Contribution**
+  - [Work on translating resources](how-to-translate-files.md)
+  - [Work on proofreading translations](how-to-proofread-files.md)
+- **Code Contribution**
+  - [Set up freeCodeCamp locally](how-to-setup-freecodecamp-locally.md)
+  - [Follow coding best practices](codebase-best-practices.md)
+  - [Open a pull request](how-to-open-a-pull-request.md)
+  - [Work on coding challenges](how-to-work-on-coding-challenges.md)
+  - [Work on practice projects](how-to-work-on-practice-projects.md)
+  - [Work on tutorials with CodeRoad](how-to-work-on-tutorials-that-use-coderoad.md)
+  - [Work on localized client web app](how-to-work-on-localized-client-webapp.md)
+  - [Work on Cypress tests](how-to-add-cypress-tests.md)
+  - [Work on video challenges](how-to-help-with-video-challenges.md)
+  - [Work on the news theme](how-to-work-on-the-news-theme.md)
+  - [Work on the docs theme](how-to-work-on-the-docs-theme.md)
+- **Additional Guides**
+  - [Test translations locally](how-to-test-translations-locally.md)
+  - [Understand the curriculum file structure](curriculum-file-structure.md)
+  - [Debug outgoing emails locally](how-to-catch-outgoing-emails-locally.md)
+  - [Set up freeCodeCamp on Windows (WSL)](how-to-setup-wsl.md)
 
 ---
 

--- a/docs/i18n/italian/_sidebar.md
+++ b/docs/i18n/italian/_sidebar.md
@@ -1,26 +1,26 @@
 - **Per iniziare**
   - [Introduzione](index.md "Contribuire alla comunità freeCodeCamp.org")
   - [Domande frequenti](FAQ.md)
-- **Contribuire al codice**
-  - [Imposta freeCodeCamp localmente](how-to-setup-freecodecamp-locally.md)
-  - [Buone pratiche per il codebase](codebase-best-practices.md)
-  - [Aprire una pull request](how-to-open-a-pull-request.md)
-  - [Lavorare sulle sfide di programmazione](how-to-work-on-coding-challenges.md)
-  - [Lavorare sulle sfide video](how-to-help-with-video-challenges.md)
-  - [Lavorare sul tema delle news](how-to-work-on-the-news-theme.md)
-  - [Lavorare sul tema della documentazione](how-to-work-on-the-docs-theme.md)
-  - [Lavorare sui progetti di pratica](how-to-work-on-practice-projects.md)
-- **Contribuire alla traduzione**
-  - [Lavorare a tradurre le risorse](how-to-translate-files.md)
-  - [Lavorare a correggere le risorse](how-to-proofread-files.md)
-- **Resources**
-  - [Settare freeCodeCamp su Windows (WSL)](how-to-setup-wsl.md)
-  - [Aggiungere test Cypress](how-to-add-cypress-tests.md)
-  - [Lavorare sulla app web in locale](how-to-work-on-localized-client-webapp.md)
-  - [Intercettare email in uscita localmente](how-to-catch-outgoing-emails-locally.md)
-  - [Testare traduzioni in locale](how-to-test-translations-locally.md)
-  - [Capire la struttura dei file del curriculum](curriculum-file-structure.md)
-  - [Work on tutorials w/ CodeRoad](how-to-work-on-tutorials-that-use-coderoad.md)
+- **Translation Contribution**
+  - [Work on translating resources](how-to-translate-files.md)
+  - [Work on proofreading translations](how-to-proofread-files.md)
+- **Code Contribution**
+  - [Set up freeCodeCamp locally](how-to-setup-freecodecamp-locally.md)
+  - [Follow coding best practices](codebase-best-practices.md)
+  - [Open a pull request](how-to-open-a-pull-request.md)
+  - [Work on coding challenges](how-to-work-on-coding-challenges.md)
+  - [Work on practice projects](how-to-work-on-practice-projects.md)
+  - [Work on tutorials with CodeRoad](how-to-work-on-tutorials-that-use-coderoad.md)
+  - [Work on localized client web app](how-to-work-on-localized-client-webapp.md)
+  - [Work on Cypress tests](how-to-add-cypress-tests.md)
+  - [Work on video challenges](how-to-help-with-video-challenges.md)
+  - [Work on the news theme](how-to-work-on-the-news-theme.md)
+  - [Work on the docs theme](how-to-work-on-the-docs-theme.md)
+- **Additional Guides**
+  - [Test translations locally](how-to-test-translations-locally.md)
+  - [Understand the curriculum file structure](curriculum-file-structure.md)
+  - [Debug outgoing emails locally](how-to-catch-outgoing-emails-locally.md)
+  - [Set up freeCodeCamp on Windows (WSL)](how-to-setup-wsl.md)
 
 ---
 

--- a/docs/i18n/japanese/_sidebar.md
+++ b/docs/i18n/japanese/_sidebar.md
@@ -1,26 +1,26 @@
 - **はじめに**
   - [イントロダクション](index.md "freeCodeCamp.org コミュニティに貢献する")
   - [よくある質問](FAQ.md)
-- **コードのコントリビューション**
-  - [freeCodeCamp をローカルでセットアップする](how-to-setup-freecodecamp-locally.md)
-  - [Codebase best practices](codebase-best-practices.md)
+- **Translation Contribution**
+  - [Work on translating resources](how-to-translate-files.md)
+  - [Work on proofreading translations](how-to-proofread-files.md)
+- **Code Contribution**
+  - [Set up freeCodeCamp locally](how-to-setup-freecodecamp-locally.md)
+  - [Follow coding best practices](codebase-best-practices.md)
   - [Open a pull request](how-to-open-a-pull-request.md)
   - [Work on coding challenges](how-to-work-on-coding-challenges.md)
+  - [Work on practice projects](how-to-work-on-practice-projects.md)
+  - [Work on tutorials with CodeRoad](how-to-work-on-tutorials-that-use-coderoad.md)
+  - [Work on localized client web app](how-to-work-on-localized-client-webapp.md)
+  - [Work on Cypress tests](how-to-add-cypress-tests.md)
   - [Work on video challenges](how-to-help-with-video-challenges.md)
   - [Work on the news theme](how-to-work-on-the-news-theme.md)
   - [Work on the docs theme](how-to-work-on-the-docs-theme.md)
-  - [Work on practice projects](how-to-work-on-practice-projects.md)
-- **翻訳のコントリビューション**
-  - [リソースを翻訳する](how-to-translate-files.md)
-  - [翻訳を校正する](how-to-proofread-files.md)
-- **Resources**
-  - [Set up freeCodeCamp on Windows (WSL)](how-to-setup-wsl.md)
-  - [Add Cypress tests](how-to-add-cypress-tests.md)
-  - [Work on localized client web app](how-to-work-on-localized-client-webapp.md)
-  - [Catch outgoing emails locally](how-to-catch-outgoing-emails-locally.md)
+- **Additional Guides**
   - [Test translations locally](how-to-test-translations-locally.md)
   - [Understand the curriculum file structure](curriculum-file-structure.md)
-  - [Work on tutorials w/ CodeRoad](how-to-work-on-tutorials-that-use-coderoad.md)
+  - [Debug outgoing emails locally](how-to-catch-outgoing-emails-locally.md)
+  - [Set up freeCodeCamp on Windows (WSL)](how-to-setup-wsl.md)
 
 ---
 

--- a/docs/i18n/portuguese/_sidebar.md
+++ b/docs/i18n/portuguese/_sidebar.md
@@ -1,26 +1,26 @@
 - **Primeiros passos**
   - [Introdução](index.md "Contribua para a comunidade do freeCodeCamp.org")
   - [Perguntas frequentes](FAQ.md)
-- **Contribuição de código**
-  - [Configure o freeCodeCamp localmente](how-to-setup-freecodecamp-locally.md)
-  - [Práticas recomendadas da base de código](codebase-best-practices.md)
-  - [Abra um pull request](how-to-open-a-pull-request.md)
-  - [Trabalhe em desafios de programação](how-to-work-on-coding-challenges.md)
-  - [Trabalhe nos desafios em vídeo](how-to-help-with-video-challenges.md)
-  - [Trabalhe no tema de notícias](how-to-work-on-the-news-theme.md)
-  - [Trabalhe no tema de documentação](how-to-work-on-the-docs-theme.md)
-  - [Trabalhe em projetos práticos](how-to-work-on-practice-projects.md)
-- **Contribuição de tradução**
-  - [Ajude na tradução de recursos](how-to-translate-files.md)
-  - [Ajude na revisão de traduções](how-to-proofread-files.md)
-- **Recursos**
-  - [Configure freeCodeCamp no Windows (WSL)](how-to-setup-wsl.md)
-  - [Adicione testes no Cypress](how-to-add-cypress-tests.md)
-  - [Ajude na tradução da aplicação web](how-to-work-on-localized-client-webapp.md)
-  - [Capture e-mails enviados localmente](how-to-catch-outgoing-emails-locally.md)
-  - [Teste traduções localmente](how-to-test-translations-locally.md)
-  - [Compreenda a estrutura do arquivo do currículo](curriculum-file-structure.md)
-  - [Trabalhe nos tutoriais com o CodeRoad](how-to-work-on-tutorials-that-use-coderoad.md)
+- **Translation Contribution**
+  - [Work on translating resources](how-to-translate-files.md)
+  - [Work on proofreading translations](how-to-proofread-files.md)
+- **Code Contribution**
+  - [Set up freeCodeCamp locally](how-to-setup-freecodecamp-locally.md)
+  - [Follow coding best practices](codebase-best-practices.md)
+  - [Open a pull request](how-to-open-a-pull-request.md)
+  - [Work on coding challenges](how-to-work-on-coding-challenges.md)
+  - [Work on practice projects](how-to-work-on-practice-projects.md)
+  - [Work on tutorials with CodeRoad](how-to-work-on-tutorials-that-use-coderoad.md)
+  - [Work on localized client web app](how-to-work-on-localized-client-webapp.md)
+  - [Work on Cypress tests](how-to-add-cypress-tests.md)
+  - [Work on video challenges](how-to-help-with-video-challenges.md)
+  - [Work on the news theme](how-to-work-on-the-news-theme.md)
+  - [Work on the docs theme](how-to-work-on-the-docs-theme.md)
+- **Additional Guides**
+  - [Test translations locally](how-to-test-translations-locally.md)
+  - [Understand the curriculum file structure](curriculum-file-structure.md)
+  - [Debug outgoing emails locally](how-to-catch-outgoing-emails-locally.md)
+  - [Set up freeCodeCamp on Windows (WSL)](how-to-setup-wsl.md)
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,15 +3,13 @@ The [freeCodeCamp.org](https://freecodecamp.org) community is possible thanks to
 > [!NOTE]
 > Before you proceed, please take a quick 2 minutes to read our [Code of Conduct](https://www.freecodecamp.org/code-of-conduct). We strictly enforce it across our community so that contributing to freeCodeCamp.org is a safe, inclusive experience for everyone.
 
-Happy contributing.
-
-You are welcome to:
-
-- Create, update and fix bugs in our [curriculum](#curriculum).
-- Help us fix bugs in freeCodeCamp.org's [learning platform](#learning-platform).
-- [Help us translate](#translations) freeCodeCamp.org to world languages.
+You are welcome to create, update and fix bugs in our [curriculum](#curriculum), help us fix bugs in freeCodeCamp.org's [learning platform](#learning-platform), or [help us translate](#translations) freeCodeCamp.org to world languages.
 
 We answer the most common questions about contributing [in our contributor FAQ](FAQ.md).
+
+Happy contributing.
+
+---
 
 ## Curriculum
 
@@ -23,7 +21,9 @@ You can help expand and improve the curriculum. You can also update project user
 
 ## Translations
 
-We are localizing freeCodeCamp.org to major world languages. Some of the certifications are already live in [Chinese (中文)](https://chinese.freecodecamp.org/learn) and [Spanish (Español)](https://www.freecodecamp.org/espanol/learn/). We encourage you to read the [announcement here](https://www.freecodecamp.org/news/world-language-translation-effort) and share it your friends to get them excited about this.
+We are localizing freeCodeCamp.org to major world languages.
+
+Certifications are already live in some major world languages like [Chinese (中文)](https://chinese.freecodecamp.org/learn), [Spanish (Español)](https://www.freecodecamp.org/espanol/learn/), [Italian (Italiano)](https://www.freecodecamp.org/espanol/learn/), [Portuguese (Português)](https://www.freecodecamp.org/espanol/learn/). We encourage you to read the [announcement here](https://www.freecodecamp.org/news/world-language-translation-effort) and share it with your friends to get them excited about this.
 
 **If you're interested in translating, here's [how to translate freeCodeCamp's resources](how-to-translate-files.md).**
 
@@ -31,13 +31,7 @@ We are localizing freeCodeCamp.org to major world languages. Some of the certifi
 
 Our learning platform runs on a modern JavaScript stack. It has various components, tools, and libraries. These include Node.js, MongoDB, OAuth 2.0, React, Gatsby, Webpack, and more.
 
-Broadly, we use
-
-- a Node.js based API server
-- a set of React-based client applications
-- and testing scripts to evaluate camper-submitted curriculum projects.
-
-If you want to productively contribute to the learning platform, we recommend some familiarity with these tools.
+Broadly, we have a Node.js based API server, a set of React-based client applications, testing scripts to evaluate camper-submitted curriculum projects, and more. If you want to productively contribute to the learning platform, we recommend some familiarity with these tools.
 
 If you want to help us improve our codebase...
 


### PR DESCRIPTION
…(#43429)

* header changed to heading tag

* fix: Exercise about heading tags <h1> ... <h6>, accidentally refers to header tags

* fix: changed header to heading on pages affected

* Update curriculum/challenges/_meta/applied-visual-design/meta.json

Co-authored-by: Ilenia <nethleen@gmail.com>

* Update curriculum/challenges/english/01-responsive-web-design/applied-accessibility/use-headings-to-show-hierarchical-relationships-of-content.md

Co-authored-by: Shaun Hamilton <shauhami020@gmail.com>

* Update curriculum/challenges/english/01-responsive-web-design/applied-accessibility/use-headings-to-show-hierarchical-relationships-of-content.md

Co-authored-by: Shaun Hamilton <shauhami020@gmail.com>

* Update curriculum/challenges/english/01-responsive-web-design/applied-accessibility/use-headings-to-show-hierarchical-relationships-of-content.md

Co-authored-by: Shaun Hamilton <shauhami020@gmail.com>

* Update curriculum/challenges/english/01-responsive-web-design/applied-accessibility/use-headings-to-show-hierarchical-relationships-of-content.md

Co-authored-by: Shaun Hamilton <shauhami020@gmail.com>

* Update curriculum/challenges/english/01-responsive-web-design/applied-accessibility/use-headings-to-show-hierarchical-relationships-of-content.md

Co-authored-by: Shaun Hamilton <shauhami020@gmail.com>

* Update curriculum/challenges/english/01-responsive-web-design/basic-html-cat-photo-app/part-002.md

Co-authored-by: Shaun Hamilton <shauhami020@gmail.com>

* Update curriculum/challenges/english/01-responsive-web-design/applied-visual-design/adjust-the-size-of-a-header-versus-a-paragraph-tag.md

Co-authored-by: gikf <60067306+gikf@users.noreply.github.com>

* Update curriculum/challenges/english/01-responsive-web-design/applied-visual-design/adjust-the-size-of-a-header-versus-a-paragraph-tag.md

Co-authored-by: gikf <60067306+gikf@users.noreply.github.com>

* file renamed

* dashed-name changed for all languages

* made changes in all the challenges

* file title changed

* added cypress test

* cypress test added

* Update cypress/integration/learn/redirects/heading-challenge.js

Co-authored-by: Kristofer Koishigawa <scissorsneedfoodtoo@gmail.com>

Co-authored-by: Ilenia <nethleen@gmail.com>
Co-authored-by: Shaun Hamilton <shauhami020@gmail.com>
Co-authored-by: gikf <60067306+gikf@users.noreply.github.com>
Co-authored-by: Kristofer Koishigawa <scissorsneedfoodtoo@gmail.com>

<!-- Please note that low quality PRs and PRs that do not follow our contributing guidelines will be marked as invalid for Hacktoberfest. -->

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
