### PR TITLE
fix(client): use https for CodeAlly frame

### DIFF
--- a/client/src/templates/Challenges/codeally/show.tsx
+++ b/client/src/templates/Challenges/codeally/show.tsx
@@ -63,7 +63,7 @@ class ShowCodeAlly extends Component<ShowCodeAllyProps> {
           className='codeally-frame'
           // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
           sandbox='allow-modals allow-forms allow-popups allow-scripts allow-same-origin'
-          src={`http://codeally.io/embed/?repoUrl=${url}`}
+          src={`https://codeally.io/embed/?repoUrl=${url}`}
           title='Editor'
         />
       </LearnLayout>


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

---
- Changes CodeAlly frame url to use https. When trying to open, one of the Relational Databases project from curriculum, ie. on GitPod, which uses https, it ends up with the mixed content error.