### PR TITLE
fix(curriculum): consts must be initialized

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-variables.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-variables.md
@@ -108,7 +108,7 @@ const testObj = {
 };
 
 // Only change code below this line
-const playerNumber;       // Change this line
+const playerNumber = 42;  // Change this line
 const player = testObj;   // Change this line
 ```
 


### PR DESCRIPTION
This should allow crowdin syncing to continue Ref: https://github.com/freeCodeCamp/freeCodeCamp/pull/44021

I considered fixing extract-js-comments.js, but it's not trivial since we need to be able to parse JS to remove comments.  I'll create a follow-up PR to improve the error, since the current reporting is pretty cryptic.