### PR TITLE
fix: throw better error when JS parse fails

### DIFF
--- a/curriculum/test/utils/extract-js-comments.js
+++ b/curriculum/test/utils/extract-js-comments.js
@@ -9,7 +9,7 @@ function extractComments(js) {
   try {
     parser.parse(js, { onComment: comments, ecmaVersion: 2020 });
   } catch {
-    throw Error(`extract-js-comments could not parse the code below, this challenge have invalid syntax:
+    throw Error(`extract-js-comments could not parse the code below, this challenge has invalid syntax:
 
 ${js}
 `);

--- a/curriculum/test/utils/extract-js-comments.js
+++ b/curriculum/test/utils/extract-js-comments.js
@@ -6,8 +6,14 @@ const parser = acorn.Parser;
 function extractComments(js) {
   let comments = [];
   const file = { data: {} };
-  parser.parse(js, { onComment: comments, ecmaVersion: 2020 });
+  try {
+    parser.parse(js, { onComment: comments, ecmaVersion: 2020 });
+  } catch {
+    throw Error(`extract-js-comments could not parse the code below, this challenge have invalid syntax:
 
+${js}
+`);
+  }
   comments
     .map(({ value }) => value.trim())
     .forEach(comment => commentToData(file, comment));

--- a/curriculum/test/utils/extract-js-comments.test.js
+++ b/curriculum/test/utils/extract-js-comments.test.js
@@ -13,6 +13,8 @@ var y = '// single line comment';
 
 `;
 
+const someInvalidJS = `const isChange;`;
+
 describe('extractJSComments', () => {
   it('should return an object with comment keys and count values', () => {
     const commentCounts = {
@@ -20,5 +22,14 @@ describe('extractJSComments', () => {
       'a multiline comment': 1
     };
     expect(extractJSComments(someJS)).toEqual(commentCounts);
+  });
+
+  it('should throw an informative error if the JS is invalid', () => {
+    expect(() => extractJSComments(someInvalidJS)).toThrow(
+      `extract-js-comments could not parse the code below, this challenge have invalid syntax:
+
+${someInvalidJS}
+`
+    );
   });
 });

--- a/curriculum/test/utils/extract-js-comments.test.js
+++ b/curriculum/test/utils/extract-js-comments.test.js
@@ -26,7 +26,7 @@ describe('extractJSComments', () => {
 
   it('should throw an informative error if the JS is invalid', () => {
     expect(() => extractJSComments(someInvalidJS)).toThrow(
-      `extract-js-comments could not parse the code below, this challenge have invalid syntax:
+      `extract-js-comments could not parse the code below, this challenge has invalid syntax:
 
 ${someInvalidJS}
 `


### PR DESCRIPTION
This should help debugging challenges with invalid syntax.

Ref: https://github.com/freeCodeCamp/freeCodeCamp/pull/44031