### PR TITLE
fix: actually lint staged files on commit

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -5,14 +5,18 @@ const cli = new ESLint();
 // if a lot of files are changed, it's faster to run prettier/eslint on the
 // whole project than to run them on each file separately
 module.exports = {
-  '*.(js|ts|tsx)': files =>
-    files.length > 10
+  '*.(js|ts|tsx)': async files => {
+    const ignoredIds = await Promise.all(
+      files.map(file => cli.isPathIgnored(file))
+    );
+    const lintableFiles = files.filter((_, i) => !ignoredIds[i]);
+    return files.length > 10
       ? ['eslint --max-warnings=0 --cache --fix .', 'prettier --write .']
       : [
-          'eslint --max-warnings=0 --cache --fix ' +
-            files.filter(file => !cli.isPathIgnored(file)).join(' '),
+          'eslint --max-warnings=0 --cache --fix ' + lintableFiles.join(' '),
           ...files.map(filename => `prettier --write '${filename}'`)
-        ],
+        ];
+  },
   '*.!(js|ts|tsx)': files =>
     files.length > 10
       ? 'prettier --write .'


### PR DESCRIPTION
I noticed a bunch of PRs had lint errors and so I took a look at lint-staged.  It's been ignoring everything for a few weeks, but, with this, it should start doing its job again.