### PR TITLE
fix: keep hints while user edits code

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -607,36 +607,46 @@ const Editor = (props: EditorProps): JSX.Element => {
 
   // TODO: DRY this and the update function
   function initializeEditableRegion(
-    stickiness: number,
-    target: editor.ITextModel,
-    range: IRange
+    range: IRange,
+    modelContext: {
+      monaco: typeof monacoEditor;
+      model: editor.ITextModel;
+    }
   ) {
+    const { monaco, model } = modelContext;
     const lineDecoration = {
       range,
       options: {
         isWholeLine: true,
         linesDecorationsClassName: 'myEditableLineDecoration',
-        stickiness
+        stickiness:
+          monaco.editor.TrackedRangeStickiness.AlwaysGrowsWhenTypingAtEdges
       }
     };
-    return target.deltaDecorations([], [lineDecoration]);
+    return model.deltaDecorations([], [lineDecoration]);
   }
 
   function updateEditableRegion(
-    stickiness: number,
-    target: editor.ITextModel,
     range: IRange,
-    oldIds: string[] = []
+    modelContext: {
+      monaco: typeof monacoEditor;
+      model: editor.ITextModel;
+    }
   ) {
+    const { monaco, model } = modelContext;
     const lineDecoration = {
       range,
       options: {
         isWholeLine: true,
         linesDecorationsClassName: 'myEditableLineDecoration',
-        stickiness
+        stickiness:
+          monaco.editor.TrackedRangeStickiness.AlwaysGrowsWhenTypingAtEdges
       }
     };
-    return target.deltaDecorations(oldIds, [lineDecoration]);
+    return model.deltaDecorations(
+      [dataRef.current.insideEditDecId],
+      [lineDecoration]
+    );
   }
 
   function getDescriptionZoneTop() {
@@ -723,11 +733,10 @@ const Editor = (props: EditorProps): JSX.Element => {
       editableRegion[1] - 1
     ]);
 
-    dataRef.current.insideEditDecId = initializeEditableRegion(
-      monaco.editor.TrackedRangeStickiness.AlwaysGrowsWhenTypingAtEdges,
-      model,
-      editableRange
-    )[0];
+    dataRef.current.insideEditDecId = initializeEditableRegion(editableRange, {
+      monaco,
+      model
+    })[0];
   }
 
   function addWidgetsToRegions(editor: editor.IStandaloneCodeEditor) {
@@ -794,10 +803,8 @@ const Editor = (props: EditorProps): JSX.Element => {
         const coveringRange = getLinesCoveringEditableRegion();
         if (coveringRange) {
           dataRef.current.insideEditDecId = updateEditableRegion(
-            monaco.editor.TrackedRangeStickiness.AlwaysGrowsWhenTypingAtEdges,
-            model,
             coveringRange,
-            [dataRef.current.insideEditDecId]
+            { monaco, model }
           )[0];
         }
       };

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -558,7 +558,7 @@ const Editor = (props: EditorProps): JSX.Element => {
 
     // Resetting margin decorations
     const range = model?.getDecorationRange(insideEditDecId);
-    if (range && model) {
+    if (range) {
       updateEditableRegion(range, { model });
     }
   }
@@ -624,14 +624,14 @@ const Editor = (props: EditorProps): JSX.Element => {
   function updateEditableRegion(
     range: IRange,
     modelContext: {
-      model: editor.ITextModel;
+      model?: editor.ITextModel;
     },
     options: editor.IModelDecorationOptions = {}
   ) {
     const { model } = modelContext;
     const { insideEditDecId } = dataRef.current;
 
-    const oldOptions = model.getDecorationOptions(insideEditDecId);
+    const oldOptions = model?.getDecorationOptions(insideEditDecId);
     const lineDecoration = {
       range,
       options: {
@@ -639,7 +639,7 @@ const Editor = (props: EditorProps): JSX.Element => {
         ...options
       }
     };
-    return model.deltaDecorations([insideEditDecId], [lineDecoration]);
+    model?.deltaDecorations([insideEditDecId], [lineDecoration]);
   }
 
   function getDescriptionZoneTop() {
@@ -789,16 +789,13 @@ const Editor = (props: EditorProps): JSX.Element => {
   function addContentChangeListener() {
     const { model } = dataRef.current;
     const monaco = monacoRef.current;
-    if (!model || !monaco) return;
+    if (!monaco) return;
 
-    model.onDidChangeContent(() => {
+    model?.onDidChangeContent(() => {
       const redecorateEditableRegion = () => {
         const coveringRange = getLinesCoveringEditableRegion();
         if (coveringRange) {
-          dataRef.current.insideEditDecId = updateEditableRegion(
-            coveringRange,
-            { model }
-          )[0];
+          updateEditableRegion(coveringRange, { model });
         }
       };
 
@@ -918,7 +915,7 @@ const Editor = (props: EditorProps): JSX.Element => {
         }
 
         const range = model?.getDecorationRange(insideEditDecId);
-        if (range && model) {
+        if (range) {
           updateEditableRegion(
             range,
             { model },

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -861,33 +861,36 @@ const Editor = (props: EditorProps): JSX.Element => {
         updateDescriptionZone();
         updateOutputZone();
         showEditableRegion(editor);
-      }
-      // resetting test output
-      // TODO: DRY this - createOutputNode doesn't also need to set this up.
-      const testButton = document.getElementById('test-button');
-      if (testButton) {
-        testButton.innerHTML = 'Check Your Code (Ctrl + Enter)';
-        testButton.onclick = () => {
-          props.executeChallenge();
-        };
-      }
-      const testStatus = document.getElementById('test-status');
-      if (testStatus) {
-        testStatus.innerHTML = '';
-      }
-      const testOutput = document.getElementById('test-output');
-      if (testOutput) {
-        testOutput.innerHTML = '';
-      }
-      // resetting margin decorations
-      // TODO: this should be done via the decorator api, not by manipulating
-      // the DOM
-      const editableRegionDecorators = document.getElementsByClassName(
-        'myEditableLineDecoration'
-      );
-      if (editableRegionDecorators.length > 0) {
-        for (const i of editableRegionDecorators) {
-          i.classList.remove('tests-passed');
+
+        // Resetting test output widget. This only happens when the step is
+        // restarted, so users that want to try different solutions will need to
+        // restart the step.
+        const testButton = document.getElementById('test-button');
+        if (testButton) {
+          testButton.innerHTML = 'Check Your Code (Ctrl + Enter)';
+          testButton.onclick = () => {
+            props.executeChallenge();
+          };
+        }
+        const testStatus = document.getElementById('test-status');
+        if (testStatus) {
+          testStatus.innerHTML = '';
+        }
+        const testOutput = document.getElementById('test-output');
+        if (testOutput) {
+          testOutput.innerHTML = '';
+        }
+
+        // Resetting margin decorations
+        // TODO: this should be done via the decorator api, not by manipulating
+        // the DOM
+        const editableRegionDecorators = document.getElementsByClassName(
+          'myEditableLineDecoration'
+        );
+        if (editableRegionDecorators.length > 0) {
+          for (const i of editableRegionDecorators) {
+            i.classList.remove('tests-passed');
+          }
         }
       }
     }

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -538,6 +538,36 @@ const Editor = (props: EditorProps): JSX.Element => {
     return outputNode;
   }
 
+  function resetOutputNode() {
+    const testButton = document.getElementById('test-button');
+    if (testButton) {
+      testButton.innerHTML = 'Check Your Code (Ctrl + Enter)';
+      testButton.onclick = () => {
+        props.executeChallenge();
+      };
+    }
+    const testStatus = document.getElementById('test-status');
+    if (testStatus) {
+      testStatus.innerHTML = '';
+    }
+    const testOutput = document.getElementById('test-output');
+    if (testOutput) {
+      testOutput.innerHTML = '';
+    }
+
+    // Resetting margin decorations
+    // TODO: this should be done via the decorator api, not by manipulating
+    // the DOM
+    const editableRegionDecorators = document.getElementsByClassName(
+      'myEditableLineDecoration'
+    );
+    if (editableRegionDecorators.length > 0) {
+      for (const i of editableRegionDecorators) {
+        i.classList.remove('tests-passed');
+      }
+    }
+  }
+
   function focusOnHotkeys() {
     const currContainerRef = props.containerRef.current;
     if (currContainerRef) {
@@ -862,36 +892,9 @@ const Editor = (props: EditorProps): JSX.Element => {
         updateOutputZone();
         showEditableRegion(editor);
 
-        // Resetting test output widget. This only happens when the step is
-        // restarted, so users that want to try different solutions will need to
-        // restart the step.
-        const testButton = document.getElementById('test-button');
-        if (testButton) {
-          testButton.innerHTML = 'Check Your Code (Ctrl + Enter)';
-          testButton.onclick = () => {
-            props.executeChallenge();
-          };
-        }
-        const testStatus = document.getElementById('test-status');
-        if (testStatus) {
-          testStatus.innerHTML = '';
-        }
-        const testOutput = document.getElementById('test-output');
-        if (testOutput) {
-          testOutput.innerHTML = '';
-        }
-
-        // Resetting margin decorations
-        // TODO: this should be done via the decorator api, not by manipulating
-        // the DOM
-        const editableRegionDecorators = document.getElementsByClassName(
-          'myEditableLineDecoration'
-        );
-        if (editableRegionDecorators.length > 0) {
-          for (const i of editableRegionDecorators) {
-            i.classList.remove('tests-passed');
-          }
-        }
+        // Since the outputNode is only reset when the step is restarted, users
+        // that want to try different solutions will need to do that.
+        resetOutputNode();
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
- fix: only reset hints and test button on restart
- refactor: move output node reset into own function
- refactor: reorganise init/update editable region args
- fix: control when line decorations update
- refactor: clean up updateEditableRegion

Closes: https://github.com/freeCodeCamp/freeCodeCamp/issues/44050