### PR TITLE
feat: add note about campfire mode

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -99,7 +99,7 @@
     "private-name": "Your name will not appear on your certifications, if this is set to private.",
     "claim-legacy": "Once you've earned the following freeCodeCamp certifications, you'll be able to claim the {{cert}}:",
     "for": "Account Settings for {{username}}",
-    "sound-mode": "Campfire Mode adds the pleasant sound of an acoustic guitar throughout the website. You'll get musical feedback when you type in the editor, complete challenges, claim certifications, and more.",
+    "sound-mode": "This adds the pleasant sound of acoustic guitar throughout the website. You'll get musical feedback as you type in the editor, complete challenges, claim certifications, and more.",
     "username": {
       "contains invalid characters": "Username \"{{username}}\" contains invalid characters",
       "is too short": "Username \"{{username}}\" is too short",

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -99,6 +99,7 @@
     "private-name": "Your name will not appear on your certifications, if this is set to private.",
     "claim-legacy": "Once you've earned the following freeCodeCamp certifications, you'll be able to claim the {{cert}}:",
     "for": "Account Settings for {{username}}",
+    "sound-mode": "Campfire Mode adds the pleasant sound of an acoustic guitar throughout the website. You'll get musical feedback when you type in the editor, complete challenges, claim certifications, and more.",
     "username": {
       "contains invalid characters": "Username \"{{username}}\" contains invalid characters",
       "is too short": "Username \"{{username}}\" is too short",

--- a/client/src/components/settings/sound.tsx
+++ b/client/src/components/settings/sound.tsx
@@ -19,6 +19,7 @@ export default function SoundSettings({
     <Form inline={true} onSubmit={(e: React.FormEvent) => e.preventDefault()}>
       <ToggleSetting
         action={t('settings.labels.sound-mode')}
+        explain={t('settings.sound-mode')}
         flag={sound}
         flagName='sound'
         offLabel={t('buttons.off')}


### PR DESCRIPTION
<!-- Please note that low quality PRs and PRs that do not follow our contributing guidelines will be marked as invalid for Hacktoberfest. -->

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to the discussion in #44040, this adds a note to the settings page explaining what Campfire Mode actually *does*.

![image](https://user-images.githubusercontent.com/63889819/140180671-894a7df4-100b-41be-8e9c-68e5560dae97.png)

It's a wee bit long, but descriptive (and borrows the verbiage from the Summit news article).

<!-- Feel free to add any additional description of changes below this line -->
