### PR TITLE
feat: highlight editable region

### DIFF
--- a/client/src/templates/Challenges/classic/editor.css
+++ b/client/src/templates/Challenges/classic/editor.css
@@ -67,3 +67,8 @@
 .myEditableLineDecoration.tests-passed {
   background-color: #4caf50;
 }
+
+.editable-region {
+  background-color: var(--primary-background);
+  z-index: -1;
+}

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -143,7 +143,10 @@ const modeMap = {
 };
 
 let monacoThemesDefined = false;
-const defineMonacoThemes = (monaco: typeof monacoEditor) => {
+const defineMonacoThemes = (
+  monaco: typeof monacoEditor,
+  options: { usesMultifileEditor: boolean }
+) => {
   if (monacoThemesDefined) {
     return;
   }
@@ -169,7 +172,7 @@ const defineMonacoThemes = (monaco: typeof monacoEditor) => {
     inherit: true,
     // TODO: Use actual color from style-guide
     colors: {
-      'editor.background': '#fff'
+      'editor.background': options.usesMultifileEditor ? '#eee' : '#fff'
     },
     rules: [{ token: 'identifier.js', foreground: darkBlueColor }]
   });
@@ -259,10 +262,11 @@ const Editor = (props: EditorProps): JSX.Element => {
   };
 
   const editorWillMount = (monaco: typeof monacoEditor) => {
-    const { challengeFiles, fileKey } = props;
+    const { challengeFiles, fileKey, usesMultifileEditor } = props;
+    console.log('editorWillMount', props);
 
     monacoRef.current = monaco;
-    defineMonacoThemes(monaco);
+    defineMonacoThemes(monaco, { usesMultifileEditor });
     // If a model is not provided, then the editor 'owns' the model it creates
     // and will dispose of that model if it is replaced. Since we intend to
     // swap and reuse models, we have to create our own models to prevent
@@ -613,6 +617,7 @@ const Editor = (props: EditorProps): JSX.Element => {
       range,
       options: {
         isWholeLine: true,
+        className: 'editable-region',
         linesDecorationsClassName: 'myEditableLineDecoration',
         stickiness:
           monaco.editor.TrackedRangeStickiness.AlwaysGrowsWhenTypingAtEdges

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -65,7 +65,6 @@ interface EditorProps {
   initialExt: string;
   initTests: (tests: Test[]) => void;
   initialTests: Test[];
-  isProjectStep: boolean;
   isResetting: boolean;
   output: string[];
   resizeProps: ResizePropsType;

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -262,7 +262,6 @@ const Editor = (props: EditorProps): JSX.Element => {
 
   const editorWillMount = (monaco: typeof monacoEditor) => {
     const { challengeFiles, fileKey, usesMultifileEditor } = props;
-    console.log('editorWillMount', props);
 
     monacoRef.current = monaco;
     defineMonacoThemes(monaco, { usesMultifileEditor });


### PR DESCRIPTION
This gives the editable region a lighter background than the rest of the editor.  Hopefully this will draw the user's eye to the right part of the page.

Before:

![BeforeDay](https://user-images.githubusercontent.com/15801806/140335766-fb0320d9-bd7b-4158-95d1-0954f99e3de7.png)
![BeforeNight](https://user-images.githubusercontent.com/15801806/140335779-173ed232-29fb-4bf2-889d-48c699420692.png)

and after:

![AfterDay](https://user-images.githubusercontent.com/15801806/140335842-d955ecfb-0920-4e71-9832-2b115c159ee2.png)
![AfterNight](https://user-images.githubusercontent.com/15801806/140335859-0b6fef28-f985-49be-b583-02a0d676cd44.png)


