### PR TITLE
fix: ignore package-lock

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,4 @@ curriculum/challenges/**/*
 config/**/*.json
 client/i18n/**/*.json
 docs/i18n
+**/package-lock.json


### PR DESCRIPTION
<!-- Please note that low quality PRs and PRs that do not follow our contributing guidelines will be marked as invalid for Hacktoberfest. -->

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
This is a temporary workaround for the lerna/renovate/npm8 issue by telling prettier to ignore the `package-lock.json` files which will unblock Renovate's PRs (hopefully).