### PR TITLE
fix: block name in block intro pages

### DIFF
--- a/client/src/pages/learn/responsive-web-design/learn-accessibility-by-building-a-quiz/index.md
+++ b/client/src/pages/learn/responsive-web-design/learn-accessibility-by-building-a-quiz/index.md
@@ -1,10 +1,10 @@
 ---
-title: Introduction to the Learn Accessibility by Building a Quiz
-block: learn-accessibility-by-building-a-quiz
+title: Introduction to the Learn Accessibility by Building a Quiz Project
+block: Learn Accessibility by Building a Quiz
 superBlock: Responsive Web Design
 isBeta: true
 ---
 
-## Introduction to the Learn Accessibility by Building a Quiz
+## Introduction to the Learn Accessibility by Building a Quiz Project
 
 This is a test for the new project-based curriculum.

--- a/client/src/pages/learn/responsive-web-design/learn-basic-css-by-building-a-cafe-menu/index.md
+++ b/client/src/pages/learn/responsive-web-design/learn-basic-css-by-building-a-cafe-menu/index.md
@@ -1,10 +1,10 @@
 ---
-title: Introduction to the Learn Basic CSS by Building a Cafe Menu
+title: Introduction to the Learn Basic CSS by Building a Cafe Menu Project
 block: Learn Basic CSS by Building a Cafe Menu
 superBlock: Responsive Web Design
 isBeta: true
 ---
 
-## Introduction to the Learn Basic CSS by Building a Cafe Menu
+## Introduction to the Learn Basic CSS by Building a Cafe Menu Project
 
 This is a test for the new project-based curriculum.

--- a/client/src/pages/learn/responsive-web-design/learn-css-animation-by-building-a-ferris-wheel/index.md
+++ b/client/src/pages/learn/responsive-web-design/learn-css-animation-by-building-a-ferris-wheel/index.md
@@ -1,10 +1,10 @@
 ---
-title: Introduction to the Learn CSS Animation by Building a Ferris Wheel
-block: learn-css-animation-by-building-a-ferris-wheel
+title: Introduction to the Learn CSS Animation by Building a Ferris Wheel Project
+block: Learn CSS Animation by Building a Ferris Wheel
 superBlock: Responsive Web Design
 isBeta: true
 ---
 
-## Introduction to the Learn CSS Animation by Building a Ferris Wheel
+## Introduction to the Learn CSS Animation by Building a Ferris Wheel Project
 
 This is a test for the new project-based curriculum.

--- a/client/src/pages/learn/responsive-web-design/learn-css-flexbox-by-building-a-photo-gallery/index.md
+++ b/client/src/pages/learn/responsive-web-design/learn-css-flexbox-by-building-a-photo-gallery/index.md
@@ -1,10 +1,10 @@
 ---
-title: Introduction to the Learn CSS Flexbox by Building a Photo Gallery
-block: learn-css-flexbox-by-building-a-photo-gallery
+title: Introduction to the Learn CSS Flexbox by Building a Photo Gallery Project
+block: Learn CSS Flexbox by Building a Photo Gallery
 superBlock: Responsive Web Design
 isBeta: true
 ---
 
-## Introduction to the Learn CSS Flexbox by Building a Photo Gallery
+## Introduction to the Learn CSS Flexbox by Building a Photo Gallery Project
 
 This is a test for the new project-based curriculum.

--- a/client/src/pages/learn/responsive-web-design/learn-css-grid-by-building-a-magazine/index.md
+++ b/client/src/pages/learn/responsive-web-design/learn-css-grid-by-building-a-magazine/index.md
@@ -1,10 +1,10 @@
 ---
-title: Introduction to the Learn CSS Grid by Building a Magazine
-block: learn-css-grid-by-building-a-magazine
+title: Introduction to the Learn CSS Grid by Building a Magazine Project
+block: Learn CSS Grid by Building a Magazine
 superBlock: Responsive Web Design
 isBeta: true
 ---
 
-## Introduction to the Learn CSS Grid by Building a Magazine
+## Introduction to the Learn CSS Grid by Building a Magazine Project
 
 This is a test for the new project-based curriculum.

--- a/client/src/pages/learn/responsive-web-design/learn-css-variables-by-building-a-city-skyline/index.md
+++ b/client/src/pages/learn/responsive-web-design/learn-css-variables-by-building-a-city-skyline/index.md
@@ -1,9 +1,9 @@
 ---
-title: Introduction to the Learn CSS Variables by Building a City Skyline
-block: learn-css-variables-by-building-a-city-skyline
+title: Introduction to the Learn CSS Variables by Building a City Skyline Project
+block: Learn CSS Variables by Building a City Skyline
 superBlock: Responsive Web Design
 ---
 
-## Introduction to the Learn CSS Variables by Building a City Skyline
+## Introduction to the Learn CSS Variables by Building a City Skyline Project
 
 <dfn>Learn CSS Variables by Building a City Skyline</dfn> Placeholder Introduction.

--- a/client/src/pages/learn/responsive-web-design/learn-html-by-building-a-cat-photo-app/index.md
+++ b/client/src/pages/learn/responsive-web-design/learn-html-by-building-a-cat-photo-app/index.md
@@ -1,10 +1,10 @@
 ---
-title: Introduction to the Learn HTML by Building a Cat Photo App
+title: Introduction to the Learn HTML by Building a Cat Photo App Project
 block: Learn HTML by Building a Cat Photo App
 superBlock: Responsive Web Design
 isBeta: true
 ---
 
-## Introduction to the Learn HTML by Building a Cat Photo App
+## Introduction to the Learn HTML by Building a Cat Photo App Project
 
 This is a test for the new project-based curriculum.

--- a/client/src/pages/learn/responsive-web-design/learn-html-forms-by-building-a-registration-form/index.md
+++ b/client/src/pages/learn/responsive-web-design/learn-html-forms-by-building-a-registration-form/index.md
@@ -1,10 +1,10 @@
 ---
-title: Introduction to the Registration Form
-block: Registration Form
+title: Introduction to the Learn HTML Forms by Building a Registration Form Project
+block: Learn HTML Forms by Building a Registration Form
 superBlock: Responsive Web Design
 isBeta: true
 ---
 
-## Introduction to the Registration Form
+## Introduction to the Registration Form Project
 
 This is a test for the new project-based curriculum.

--- a/client/src/pages/learn/responsive-web-design/learn-intermediate-css-by-building-a-picasso-painting/index.md
+++ b/client/src/pages/learn/responsive-web-design/learn-intermediate-css-by-building-a-picasso-painting/index.md
@@ -1,10 +1,10 @@
 ---
-title: Introduction to the Learn Intermediate CSS by Building a Picasso Painting
-block: learn-intermediate-css-by-building-a-picasso-painting
+title: Introduction to the Learn Intermediate CSS by Building a Picasso Painting Project
+block: Learn Intermediate CSS by Building a Picasso Painting
 superBlock: Responsive Web Design
 isBeta: true
 ---
 
-## Introduction to the Learn Intermediate CSS by Building a Picasso Painting
+## Introduction to the Learn Intermediate CSS by Building a Picasso Painting Project
 
 This is a test for the new project-based curriculum.

--- a/client/src/pages/learn/responsive-web-design/learn-responsive-web-design-by-building-a-piano/index.md
+++ b/client/src/pages/learn/responsive-web-design/learn-responsive-web-design-by-building-a-piano/index.md
@@ -1,10 +1,10 @@
 ---
-title: Introduction to the Learn Responsive Web Design by Building a Piano
-block: learn-responsive-web-design-by-building-a-piano
+title: Introduction to the Learn Responsive Web Design by Building a Piano Project
+block: Learn Responsive Web Design by Building a Piano
 superBlock: Responsive Web Design
 isBeta: true
 ---
 
-## Introduction to the Learn Responsive Web Design by Building a Piano
+## Introduction to the Learn Responsive Web Design by Building a Piano Project
 
 This is a test for the new project-based curriculum.

--- a/client/src/pages/learn/responsive-web-design/learn-the-css-box-model-by-building-a-rothko-painting/index.md
+++ b/client/src/pages/learn/responsive-web-design/learn-the-css-box-model-by-building-a-rothko-painting/index.md
@@ -1,10 +1,10 @@
 ---
-title: Introduction to the Learn the CSS Box Model by Building a Rothko Painting
-block: learn-the-css-box-model-by-building-a-rothko-painting
+title: Introduction to the Learn the CSS Box Model by Building a Rothko Painting Project
+block: Learn the CSS Box Model by Building a Rothko Painting
 superBlock: Responsive Web Design
 isBeta: true
 ---
 
-## Introduction to the Learn the CSS Box Model by Building a Rothko Painting
+## Introduction to the Learn the CSS Box Model by Building a Rothko Painting Project
 
 This is a test for the new project-based curriculum.

--- a/client/src/pages/learn/responsive-web-design/learn-typography-by-building-a-nutrition-label/index.md
+++ b/client/src/pages/learn/responsive-web-design/learn-typography-by-building-a-nutrition-label/index.md
@@ -1,10 +1,10 @@
 ---
-title: Introduction to the Learn Typography by Building a Nutrition Label
-block: learn-typography-by-building-a-nutrition-label
+title: Introduction to the Learn Typography by Building a Nutrition Label Project
+block: Learn Typography by Building a Nutrition Label
 superBlock: Responsive Web Design
 isBeta: true
 ---
 
-## Introduction to the Learn Typography by Building a Nutrition Label
+## Introduction to the Learn Typography by Building a Nutrition Label Project
 
 This is a test for the new project-based curriculum.


### PR DESCRIPTION
When merging some of the last few PR's that renamed the RWD practice projects, I noticed some of the block names in the block intro pages were using the dashed version. They should use the undashed version to work. They're the hidden pages for each block. I also added the word 'Project' at the end of the intro titles, since I think it made more sense.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
