### PR TITLE
feat(storybook): add theme toggle

### DIFF
--- a/tools/ui-components/.storybook/preview.js
+++ b/tools/ui-components/.storybook/preview.js
@@ -5,5 +5,39 @@ export const parameters = {
       color: /(background|color)$/i,
       date: /Date$/
     }
+  },
+  backgrounds: {
+    values: [
+      {
+        name: 'light',
+        value: '#ffffff'
+      },
+      {
+        name: 'dark',
+        value: '#0a0a23'
+      }
+    ]
   }
 };
+
+export const decorators = [renderTheme];
+
+/**
+ * Gets matching theme name for currently selected background and provides it
+ * to the story.
+ */
+function renderTheme(Story, context) {
+  const selectedBackgroundValue = context.globals.backgrounds?.value;
+  const selectedBackgroundName = parameters.backgrounds.values.find(
+    bg => bg.value === selectedBackgroundValue
+  )?.name;
+
+  // There can be no background selected, prevent "undefined" className
+  const className = selectedBackgroundName || '';
+
+  return (
+    <div className={className}>
+      <Story />
+    </div>
+  );
+}

--- a/tools/ui-components/src/button.stories.tsx
+++ b/tools/ui-components/src/button.stories.tsx
@@ -5,28 +5,11 @@ import { ButtonProps } from './button.types';
 
 const story = {
   title: 'Example/Button',
-  component: Button,
-  argTypes: {
-    theme: {
-      options: ['dark', 'light'],
-      control: { type: 'radio' },
-      defaultValue: 'light'
-    }
-  }
+  component: Button
 };
 
 const Template: Story<ButtonProps> = args => {
-  return (
-    <div
-      className={`flex h-screen justify-center items-center ${
-        args.theme === 'dark'
-          ? 'dark bg-dark-theme-background'
-          : 'light bg-light-theme-background'
-      }`}
-    >
-      <Button {...args} />
-    </div>
-  );
+  return <Button {...args} />;
 };
 
 export const Primary = Template.bind({});

--- a/tools/ui-components/src/button.types.ts
+++ b/tools/ui-components/src/button.types.ts
@@ -6,5 +6,4 @@ export interface ButtonProps {
   label: string;
   customKey?: string;
   onClick: () => void;
-  theme?: 'light' | 'dark';
 }

--- a/tools/ui-components/src/global.css
+++ b/tools/ui-components/src/global.css
@@ -1,4 +1,4 @@
 @import 'tailwindcss/base';
 @import 'tailwindcss/components';
 @import 'tailwindcss/utilities';
-@import './colors';
+@import './colors.css';


### PR DESCRIPTION
<!-- Please note that low quality PRs and PRs that do not follow our contributing guidelines will be marked as invalid for Hacktoberfest. -->

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

**Description**
This PR provides a slightly improved theme toggle functionality.

- It works out of the box for all stories - there is no need to wrap an individual story in some kind of provider.
- Theme can be toggled from the toolbar, as opposed to selecting it from the props
- The functionality is build on the top of built-in [Backgrounds addon](https://storybook.js.org/docs/react/essentials/backgrounds)

**Old**
![old](https://user-images.githubusercontent.com/58401630/142761457-90597e8b-9cf3-446f-8103-97a32c372a7b.png)

**New**
![new](https://user-images.githubusercontent.com/58401630/142761459-3fb7ee21-4d1d-4a84-82b9-994e1c86fcb9.png)

**Full preview**

https://user-images.githubusercontent.com/58401630/142761717-8dbd93c6-9e88-4227-a2b4-c09827cb712a.mov

cc: @ahmadabdolsaheb 