### PR TITLE
feat: editor page title rework

### DIFF
--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -263,12 +263,9 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
 
   getChallenge = () => this.props.data.challengeNode;
 
-  getBlockNameTitle() {
-    const {
-      fields: { blockName },
-      title
-    } = this.getChallenge();
-    return `${blockName}: ${title}`;
+  getBlockNameTitle(t: TFunction) {
+    const { block, superBlock, title } = this.getChallenge();
+    return `${t(`intro:${superBlock}.blocks.${block}.title`)}: ${title}`;
   }
 
   getVideoUrl = () => this.getChallenge().videoUrl;
@@ -385,7 +382,8 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
       pageContext: {
         challengeMeta: { nextChallengePath, prevChallengePath }
       },
-      challengeFiles
+      challengeFiles,
+      t
     } = this.props;
 
     return (
@@ -399,7 +397,7 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
         usesMultifileEditor={usesMultifileEditor}
       >
         <LearnLayout>
-          <Helmet title={`${this.getBlockNameTitle()} | freeCodeCamp.org`} />
+          <Helmet title={`${this.getBlockNameTitle(t)} | freeCodeCamp.org`} />
           <Media maxWidth={MAX_MOBILE_WIDTH}>
             <MobileLayout
               editor={this.renderEditor()}

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -385,8 +385,7 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
       pageContext: {
         challengeMeta: { nextChallengePath, prevChallengePath }
       },
-      challengeFiles,
-      t
+      challengeFiles
     } = this.props;
 
     return (
@@ -400,11 +399,7 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
         usesMultifileEditor={usesMultifileEditor}
       >
         <LearnLayout>
-          <Helmet
-            title={`${t(
-              'learn.learn'
-            )} ${this.getBlockNameTitle()} | freeCodeCamp.org`}
-          />
+          <Helmet title={`${this.getBlockNameTitle()} | freeCodeCamp.org`} />
           <Media maxWidth={MAX_MOBILE_WIDTH}>
             <MobileLayout
               editor={this.renderEditor()}

--- a/client/src/templates/Challenges/projects/backend/Show.tsx
+++ b/client/src/templates/Challenges/projects/backend/Show.tsx
@@ -203,7 +203,9 @@ class BackEnd extends Component<BackEndProps> {
       updateSolutionFormValues
     } = this.props;
 
-    const blockNameTitle = `${blockName} - ${title}`;
+    const blockNameTitle = `${t(
+      `intro:${superBlock}.blocks.${block}.title`
+    )} - ${title}`;
 
     return (
       <Hotkeys

--- a/client/src/templates/Challenges/projects/frontend/Show.tsx
+++ b/client/src/templates/Challenges/projects/frontend/Show.tsx
@@ -149,7 +149,9 @@ class Project extends Component<ProjectProps> {
       updateSolutionFormValues
     } = this.props;
 
-    const blockNameTitle = `${blockName} - ${title}`;
+    const blockNameTitle = `${t(
+      `intro:${superBlock}.blocks.${block}.title`
+    )} - ${title}`;
 
     return (
       <Hotkeys

--- a/client/src/templates/Challenges/video/Show.tsx
+++ b/client/src/templates/Challenges/video/Show.tsx
@@ -189,7 +189,9 @@ class ShowVideo extends Component<ShowVideoProps, ShowVideoState> {
       isChallengeCompleted
     } = this.props;
 
-    const blockNameTitle = `${blockName} - ${title}`;
+    const blockNameTitle = `${t(
+      `intro:${superBlock}.blocks.${block}.title`
+    )} - ${title}`;
     return (
       <Hotkeys
         executeChallenge={() => {

--- a/cypress/integration/learn/challenges/backend.js
+++ b/cypress/integration/learn/challenges/backend.js
@@ -19,7 +19,7 @@ describe('Backend challenge', function () {
 
     cy.title().should(
       'eq',
-      'Managing Packages with Npm - How to Use package.json, the Core of Any' +
+      'Managing Packages with NPM - How to Use package.json, the Core of Any' +
         ' Node.js Project or npm Package | Learn | freeCodeCamp.org'
     );
   });

--- a/cypress/integration/learn/challenges/output.js
+++ b/cypress/integration/learn/challenges/output.js
@@ -27,8 +27,7 @@ describe('Classic challenge', function () {
   it('renders the default output text', () => {
     cy.title().should(
       'eq',
-      'Learn Basic HTML and HTML5: Say Hello to HTML Elements |' +
-        ' freeCodeCamp.org'
+      'Basic HTML and HTML5: Say Hello to HTML Elements |' + ' freeCodeCamp.org'
     );
     cy.get(selectors.defaultOutput).contains(defaultOutput);
   });

--- a/cypress/integration/legacy/redirects/challenges.js
+++ b/cypress/integration/legacy/redirects/challenges.js
@@ -43,7 +43,7 @@ describe('challenges/superblock/block/challenge redirect', function () {
     cy.title().should(
       'eq',
       // eslint-disable-next-line max-len
-      'Learn Basic HTML and HTML5: Say Hello to HTML Elements | freeCodeCamp.org'
+      'Basic HTML and HTML5: Say Hello to HTML Elements | freeCodeCamp.org'
     );
     cy.location().should(loc => {
       expect(loc.pathname).to.eq(locations.learnChallenge);


### PR DESCRIPTION
<!-- Please note that low quality PRs and PRs that do not follow our contributing guidelines will be marked as invalid for Hacktoberfest. -->

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
This removes the `learn` text from the title of the page when viewing a challenge.

While this made sense for the current naming convention, it breaks with the new `Learn X by Building Y` convention.