### PR TITLE
fix: adjust patreon night colors

### DIFF
--- a/client/src/components/Donation/Donation.css
+++ b/client/src/components/Donation/Donation.css
@@ -451,6 +451,19 @@ a.patreon-button:hover {
   background-color: #e13d47;
 }
 
+.dark-palette a.patreon-button {
+  background-color: white;
+}
+
+.dark-palette a.patreon-button svg {
+  fill: #ff424d;
+}
+.dark-palette a.patreon-button:active,
+.dark-palette a.patreon-button:active:focus,
+.dark-palette a.patreon-button:hover {
+  background-color: #efefef;
+}
+
 .hide {
   display: none;
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

This pr adds night colors to the Patreon button.
<img width="602" alt="Screen Shot 2021-11-23 at 4 46 11 PM" src="https://user-images.githubusercontent.com/4591597/143035789-7d62c98e-ba31-4087-8891-6d715c272958.png">
.
<img width="586" alt="Screen Shot 2021-11-23 at 4 46 19 PM" src="https://user-images.githubusercontent.com/4591597/143035780-0d84805b-5b30-412f-892a-57a6d124d224.png">

<!-- Feel free to add any additional description of changes below this line -->