### PR TITLE
fix: hide file tabs on legacy challenges

### DIFF
--- a/client/src/templates/Challenges/classic/desktop-layout.tsx
+++ b/client/src/templates/Challenges/classic/desktop-layout.tsx
@@ -9,7 +9,6 @@ import {
   ResizeProps
 } from '../../../redux/prop-types';
 import ActionRow from './action-row';
-import EditorTabs from './editor-tabs';
 
 const { showUpcomingChanges } = envData;
 
@@ -33,7 +32,6 @@ interface DesktopLayoutProps {
   resizeProps: ResizeProps;
   superBlock: string;
   testOutput: ReactElement;
-  usesMultifileEditor: boolean;
 }
 
 const reflexProps = {
@@ -78,8 +76,7 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
     layoutState,
     preview,
     hasEditableBoundaries,
-    superBlock,
-    usesMultifileEditor
+    superBlock
   } = props;
 
   const challengeFile = getChallengeFile();
@@ -90,12 +87,6 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
   const displayConsole = projectBasedChallenge ? showConsole : true;
   const { codePane, editorPane, instructionPane, previewPane, testsPane } =
     layoutState;
-
-  const displayEditorTabs =
-    challengeFile &&
-    showUpcomingChanges &&
-    !hasEditableBoundaries &&
-    usesMultifileEditor;
 
   return (
     <div className='desktop-layout'>
@@ -120,7 +111,6 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
         )}
 
         <ReflexElement flex={editorPane.flex} {...resizeProps}>
-          {displayEditorTabs && <EditorTabs />}
           {challengeFile && (
             <ReflexContainer
               key={challengeFile.fileKey}

--- a/client/src/templates/Challenges/classic/desktop-layout.tsx
+++ b/client/src/templates/Challenges/classic/desktop-layout.tsx
@@ -33,6 +33,7 @@ interface DesktopLayoutProps {
   resizeProps: ResizeProps;
   superBlock: string;
   testOutput: ReactElement;
+  usesMultifileEditor: boolean;
 }
 
 const reflexProps = {
@@ -77,17 +78,24 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
     layoutState,
     preview,
     hasEditableBoundaries,
-    superBlock
+    superBlock,
+    usesMultifileEditor
   } = props;
 
   const challengeFile = getChallengeFile();
   const projectBasedChallenge = showUpcomingChanges && hasEditableBoundaries;
-  const isPreviewDisplayable = projectBasedChallenge
+  const displayPreview = projectBasedChallenge
     ? showPreview && hasPreview
     : hasPreview;
-  const isConsoleDisplayable = projectBasedChallenge ? showConsole : true;
+  const displayConsole = projectBasedChallenge ? showConsole : true;
   const { codePane, editorPane, instructionPane, previewPane, testsPane } =
     layoutState;
+
+  const displayEditorTabs =
+    challengeFile &&
+    showUpcomingChanges &&
+    !hasEditableBoundaries &&
+    usesMultifileEditor;
 
   return (
     <div className='desktop-layout'>
@@ -112,9 +120,7 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
         )}
 
         <ReflexElement flex={editorPane.flex} {...resizeProps}>
-          {challengeFile && showUpcomingChanges && !hasEditableBoundaries && (
-            <EditorTabs />
-          )}
+          {displayEditorTabs && <EditorTabs />}
           {challengeFile && (
             <ReflexContainer
               key={challengeFile.fileKey}
@@ -127,10 +133,10 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
               >
                 {editor}
               </ReflexElement>
-              {isConsoleDisplayable && (
+              {displayConsole && (
                 <ReflexSplitter propagate={true} {...resizeProps} />
               )}
-              {isConsoleDisplayable && (
+              {displayConsole && (
                 <ReflexElement
                   flex={testsPane.flex}
                   {...reflexProps}
@@ -142,10 +148,8 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
             </ReflexContainer>
           )}
         </ReflexElement>
-        {isPreviewDisplayable && (
-          <ReflexSplitter propagate={true} {...resizeProps} />
-        )}
-        {isPreviewDisplayable && (
+        {displayPreview && <ReflexSplitter propagate={true} {...resizeProps} />}
+        {displayPreview && (
           <ReflexElement flex={previewPane.flex} {...resizeProps}>
             {preview}
           </ReflexElement>

--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -59,9 +59,8 @@ class MobileLayout extends Component<MobileLayoutProps> {
       unmountOnExit: true
     };
 
-    // This is not the same logic as the desktop version since the mobile
-    // version does not have an ActionRow, but does need a way to switch between
-    // the different tabs.
+    // Unlike the desktop layout the mobile version does not have an ActionRow,
+    // but still needs a way to switch between the different tabs.
     const displayEditorTabs = showUpcomingChanges && usesMultifileEditor;
 
     return (

--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -33,6 +33,7 @@ interface MobileLayoutProps {
   preview: JSX.Element;
   testOutput: JSX.Element;
   videoUrl: string;
+  usesMultifileEditor: boolean;
 }
 class MobileLayout extends Component<MobileLayoutProps> {
   static displayName: string;
@@ -49,13 +50,19 @@ class MobileLayout extends Component<MobileLayoutProps> {
       hasPreview,
       preview,
       guideUrl,
-      videoUrl
+      videoUrl,
+      usesMultifileEditor
     } = this.props;
 
     const editorTabPaneProps = {
       mountOnEnter: true,
       unmountOnExit: true
     };
+
+    // This is not the same logic as the desktop version since the mobile
+    // version does not have an ActionRow, but does need a way to switch between
+    // the different tabs.
+    const displayEditorTabs = showUpcomingChanges && usesMultifileEditor;
 
     return (
       <>
@@ -73,7 +80,7 @@ class MobileLayout extends Component<MobileLayoutProps> {
             title={i18next.t('learn.editor-tabs.code')}
             {...editorTabPaneProps}
           >
-            {showUpcomingChanges && <EditorTabs />}
+            {displayEditorTabs && <EditorTabs />}
             {editor}
           </TabPane>
           <TabPane

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -431,6 +431,7 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
               })}
               preview={this.renderPreview()}
               testOutput={this.renderTestOutput()}
+              usesMultifileEditor={usesMultifileEditor}
               videoUrl={this.getVideoUrl()}
             />
           </Media>

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -449,6 +449,7 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
               resizeProps={this.resizeProps}
               superBlock={superBlock}
               testOutput={this.renderTestOutput()}
+              usesMultifileEditor={usesMultifileEditor}
             />
           </Media>
           <CompletionModal

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -450,7 +450,6 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
               resizeProps={this.resizeProps}
               superBlock={superBlock}
               testOutput={this.renderTestOutput()}
-              usesMultifileEditor={usesMultifileEditor}
             />
           </Media>
           <CompletionModal

--- a/curriculum/challenges/_meta/learn-css-animation-by-building-a-ferris-wheel/meta.json
+++ b/curriculum/challenges/_meta/learn-css-animation-by-building-a-ferris-wheel/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Learn CSS Animation by Building a Ferris Wheel",
   "isUpcomingChange": true,
+  "usesMultifileEditor": true,
   "dashedName": "learn-css-animation-by-building-a-ferris-wheel",
   "order": 15,
   "time": "5 hours",

--- a/curriculum/challenges/_meta/learn-css-flexbox-by-building-a-photo-gallery/meta.json
+++ b/curriculum/challenges/_meta/learn-css-flexbox-by-building-a-photo-gallery/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Learn CSS Flexbox by Building a Photo Gallery",
   "isUpcomingChange": true,
+  "usesMultifileEditor": true,
   "dashedName": "learn-css-flexbox-by-building-a-photo-gallery",
   "order": 20,
   "time": "5 hours",

--- a/curriculum/challenges/_meta/learn-css-grid-by-building-a-magazine/meta.json
+++ b/curriculum/challenges/_meta/learn-css-grid-by-building-a-magazine/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Learn CSS Grid by Building a Magazine",
   "isUpcomingChange": true,
+  "usesMultifileEditor": true,
   "dashedName": "learn-css-grid-by-building-a-magazine",
   "order": 16,
   "time": "5 hours",

--- a/curriculum/challenges/_meta/learn-html-forms-by-building-a-registration-form/meta.json
+++ b/curriculum/challenges/_meta/learn-html-forms-by-building-a-registration-form/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Learn HTML Forms by Building a Registration Form",
   "isUpcomingChange": true,
+  "usesMultifileEditor": true,
   "dashedName": "learn-html-forms-by-building-a-registration-form",
   "order": 23,
   "time": "5 hours",

--- a/curriculum/challenges/_meta/learn-typography-by-building-a-nutrition-label/meta.json
+++ b/curriculum/challenges/_meta/learn-typography-by-building-a-nutrition-label/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Learn Typography by Building a Nutrition Label",
   "isUpcomingChange": true,
+  "usesMultifileEditor": true,
   "dashedName": "learn-typography-by-building-a-nutrition-label",
   "order": 25,
   "time": "5 hours",


### PR DESCRIPTION
This is based off https://github.com/freeCodeCamp/freeCodeCamp/pull/43967, hence the pile of commits.

With SHOW_UPCOMING_CHANGES true:

Before:

Desktop
![image](https://user-images.githubusercontent.com/15801806/143570732-15b3ebb1-fb86-440a-9df2-b26a43e5c1e1.png)

Mobile
![image](https://user-images.githubusercontent.com/15801806/143570576-fa41a731-45ce-48cd-8571-8e57ad6b997b.png)

After: 

Desktop
![image](https://user-images.githubusercontent.com/15801806/143569090-ada9f197-d525-496b-b306-b6ff8c580fb8.png)
Mobile
![image](https://user-images.githubusercontent.com/15801806/143569320-a4b25423-f8cc-47a2-8d6d-5f8ccabe3567.png)
