### PR TITLE
"alt" update in problem-199 "iterative circle packing"

### DIFF
--- a/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-199-iterative-circle-packing.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-199-iterative-circle-packing.md
@@ -10,7 +10,7 @@ dashedName: problem-199-iterative-circle-packing
 
 Three circles of equal radius are placed inside a larger circle such that each pair of circles is tangent to one another and the inner circles do not overlap. There are four uncovered "gaps" which are to be filled iteratively with more tangent circles.
 
-<img class="img-responsive center-block" alt="a diagram of non-overlapping concentric circles" src="https://cdn-media-1.freecodecamp.org/project-euler/199-circles-in-circles.gif" style="background-color: white; padding: 10px;">
+<img class="img-responsive center-block" alt="a diagram of non-overlapping circles" src="https://cdn-media-1.freecodecamp.org/project-euler/199-circles-in-circles.gif" style="background-color: white; padding: 10px;">
 
 At each iteration, a maximally sized circle is placed in each gap, which creates more gaps for the next iteration. After 3 iterations (pictured), there are 108 gaps and the fraction of the area which is not covered by circles is 0.06790342, rounded to eight decimal places.
 


### PR DESCRIPTION
<!-- Please note that low quality PRs and PRs that do not follow our contributing guidelines will be marked as invalid for Hacktoberfest. -->

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #44245 

<!-- Feel free to add any additional description of changes below this line -->

Problem - 199 "Iterative Circle Packing"
Updated the "alt" attribute of the image in the problem statement from "a diagram of non-overlapping concentric circles"  to "a diagram of non-overlapping circles" as those are not concentric circles.
