### PR TITLE
fix: remove whilespace in hall-of-fame

### DIFF
--- a/HoF.md
+++ b/HoF.md
@@ -4,4 +4,4 @@ We appreciate any responsible disclosure of vulnerabilities that might impact th
 
 - Mehul Mohan from [codedamn](https://codedamn.com) ([@mehulmpt](https://twitter.com/mehulmpt)) - [Vulnerability Fix](https://github.com/freeCodeCamp/freeCodeCamp/blob/bb5a9e815313f1f7c91338e171bfe5acb8f3e346/client/src/components/Flash/index.js)
 - Peter Samir https://www.linkedin.com/in/peter-samir/
-  > ### Thank you for your contributions :pray:
+> ### Thank you for your contributions :pray:


### PR DESCRIPTION
My first open source contributions.
I just got rid of the extra whitespace, that way the document looks better.

<!-- Please note that low quality PRs and PRs that do not follow our contributing guidelines will be marked as invalid for Hacktoberfest. -->

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
