### PR TITLE
fix(curriculum): added whitespace after MathJax tag

### DIFF
--- a/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-331-cross-flips.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-331-cross-flips.md
@@ -18,7 +18,7 @@ It can be proven that 3 is the minimal number of turns to finish this game.
 
 The bottom left disk on the $N×N$ board has coordinates (0, 0); the bottom right disk has coordinates ($N - 1$,$0$) and the top left disk has coordinates ($0$,$N - 1$).
 
-Let $C_N$ be the following configuration of a board with $N × N$disks: A disk at ($x$, $y$) satisfying $N - 1 \le \sqrt{x^2 + y^2} \lt N$, shows its black side; otherwise, it shows its white side. $C_5$ is shown above.
+Let $C_N$ be the following configuration of a board with $N × N$ disks: A disk at ($x$, $y$) satisfying $N - 1 \le \sqrt{x^2 + y^2} \lt N$, shows its black side; otherwise, it shows its white side. $C_5$ is shown above.
 
 Let $T(N)$ be the minimal number of turns to finish a game starting from configuration $C_N$ or 0 if configuration $C_N$ is unsolvable. We have shown that $T(5) = 3$. You are also given that $T(10) = 29$ and $T(1\\,000) = 395\\,253$.
 


### PR DESCRIPTION
<!-- Please note that low quality PRs and PRs that do not follow our contributing guidelines will be marked as invalid for Hacktoberfest. -->

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #44303

<!-- Feel free to add any additional description of changes below this line -->

Added space after closing MathJax tag and before "disks."

Please let me know if this fix is acceptable. Appreciate the opportunity to contribute.

<img width="1015" alt="Screen Shot 2021-11-27 at 4 10 33 PM" src="https://user-images.githubusercontent.com/52871164/143722049-58c7f595-d8cd-4cc4-85e5-de34a746a452.png">

