### PR TITLE
fix: only include frame-runner when running tests

### DIFF
--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -86,7 +86,8 @@ export function* executeChallengeSaga({ payload }) {
     const protect = isLoopProtected(challengeMeta);
     const buildData = yield buildChallengeData(challengeData, {
       preview: false,
-      protect
+      protect,
+      usesTestRunner: true
     });
     const document = yield getContext('document');
     const testRunner = yield call(

--- a/client/src/templates/Challenges/utils/build.js
+++ b/client/src/templates/Challenges/utils/build.js
@@ -145,12 +145,13 @@ async function getDOMTestRunner(buildData, { proxyLogger }, document) {
     runTestInTestFrame(document, testString, testTimeout);
 }
 
-export function buildDOMChallenge({
-  challengeFiles,
-  required = [],
-  template = ''
-}) {
-  const finalRequires = [...globalRequires, ...required, ...frameRunner];
+export function buildDOMChallenge(
+  { challengeFiles, required = [], template = '' },
+  { usesTestRunner }
+) {
+  const finalRequires = [...globalRequires, ...required];
+  if (usesTestRunner) finalRequires.push(...frameRunner);
+
   const loadEnzyme = challengeFiles.some(
     challengeFile => challengeFile.ext === 'jsx'
   );

--- a/client/src/templates/Challenges/utils/build.js
+++ b/client/src/templates/Challenges/utils/build.js
@@ -147,7 +147,7 @@ async function getDOMTestRunner(buildData, { proxyLogger }, document) {
 
 export function buildDOMChallenge(
   { challengeFiles, required = [], template = '' },
-  { usesTestRunner }
+  { usesTestRunner } = { usesTestRunner: false }
 ) {
   const finalRequires = [...globalRequires, ...required];
   if (usesTestRunner) finalRequires.push(...frameRunner);

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -529,11 +529,14 @@ async function createTestRunner(
     challengeFile.editableContents = solutionFile.editableContents;
   });
 
-  const { build, sources, loadEnzyme } = await buildChallenge({
-    challengeFiles,
-    required,
-    template
-  });
+  const { build, sources, loadEnzyme } = await buildChallenge(
+    {
+      challengeFiles,
+      required,
+      template
+    },
+    { usesTestRunner: true }
+  );
 
   const code = {
     contents: sources.index,


### PR DESCRIPTION
frame-runner is only used by tests, so we can defer loading it until they are run.
