### PR TITLE
chore: enable portuguese certs

### DIFF
--- a/config/i18n/all-langs.ts
+++ b/config/i18n/all-langs.ts
@@ -89,7 +89,9 @@ export const auditedCerts = {
     SuperBlocks.SciCompPy,
     SuperBlocks.DataAnalysisPy,
     SuperBlocks.InfoSec,
-    SuperBlocks.MachineLearningPy
+    SuperBlocks.MachineLearningPy,
+    SuperBlocks.CodingInterviewPrep,
+    SuperBlocks.RelationalDb
   ]
 };
 


### PR DESCRIPTION
<!-- Please note that low quality PRs and PRs that do not follow our contributing guidelines will be marked as invalid for Hacktoberfest. -->

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

The Portuguese curriculum + learn UI are both at 100%! This enables the final two certifications (though I think the RDB cert is still hidden by `SHOW_UPCOMING_CHANGES`?)