### PR TITLE
test: wait longer for login to complete

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -35,7 +35,7 @@
 Cypress.Commands.add('login', () => {
   cy.visit('/');
   cy.contains("Get started (it's free)").click();
-  cy.location().should(loc => {
+  cy.location({ timeout: 10000 }).should(loc => {
     // I'm not 100% sure why logins get redirected to /learn/ via 301 in
     // development, but not in production, but they do. Hence to make it easier
     // work on tests, we'll just allow for both.


### PR DESCRIPTION
Hopefully this is long enough. If it isn't, we'll need to find out why login takes so long.

Ref: https://github.com/freeCodeCamp/freeCodeCamp/runs/4382148089?check_suite_focus=true#step:11:939