### PR TITLE
chore: fix + test curriculum order

### DIFF
--- a/api-server/src/server/boot/challenge.js
+++ b/api-server/src/server/boot/challenge.js
@@ -153,7 +153,7 @@ export function buildChallengeUrl(challenge) {
 export function getFirstChallenge(allChallenges) {
   const first = allChallenges.find(
     ({ challengeOrder, superOrder, order }) =>
-      challengeOrder === 0 && superOrder === 1 && order === 0
+      challengeOrder === 0 && superOrder === 0 && order === 0
   );
 
   return first ? buildChallengeUrl(first) : '/learn';

--- a/api-server/src/server/boot_tests/fixtures.js
+++ b/api-server/src/server/boot_tests/fixtures.js
@@ -163,11 +163,6 @@ export const matchUserIdQuery = {
   where: { id: mockUser.id }
 };
 
-export const firstChallengeQuery = {
-  // first challenge of the first block of the first superBlock
-  where: { challengeOrder: 0, superOrder: 1, order: 0 }
-};
-
 export const fullStackChallenges = [
   {
     completedDate: 1585210952511,

--- a/api-server/src/server/boot_tests/fixtures.js
+++ b/api-server/src/server/boot_tests/fixtures.js
@@ -17,7 +17,7 @@ export const mockFirstChallenge = {
   superBlock: 'the',
   dashedName: 'challenge',
   challengeOrder: 0,
-  superOrder: 1,
+  superOrder: 0,
   order: 0
 };
 

--- a/client/src/components/Map/index.tsx
+++ b/client/src/components/Map/index.tsx
@@ -146,7 +146,7 @@ export function Map({
     query SuperBlockNodes {
       allChallengeNode(
         sort: { fields: [superOrder] }
-        filter: { order: { eq: 1 }, challengeOrder: { eq: 1 } }
+        filter: { order: { eq: 0 }, challengeOrder: { eq: 0 } }
       ) {
         nodes {
           superBlock

--- a/client/src/components/Map/index.tsx
+++ b/client/src/components/Map/index.tsx
@@ -138,7 +138,7 @@ export function Map({
   currentSuperBlock = null
 }: MapProps): React.ReactElement {
   /*
-   * this query gets the first challenge from each block and the second block
+   * this query gets the first challenge from each block and the first block
    * from each superblock, leaving you with one challenge from each
    * superblock
    */
@@ -146,7 +146,7 @@ export function Map({
     query SuperBlockNodes {
       allChallengeNode(
         sort: { fields: [superOrder] }
-        filter: { order: { eq: 2 }, challengeOrder: { eq: 1 } }
+        filter: { order: { eq: 1 }, challengeOrder: { eq: 1 } }
       ) {
         nodes {
           superBlock

--- a/curriculum/challenges/_meta/advanced-node-and-express/meta.json
+++ b/curriculum/challenges/_meta/advanced-node-and-express/meta.json
@@ -2,12 +2,12 @@
   "name": "Advanced Node and Express",
   "isUpcomingChange": false,
   "dashedName": "advanced-node-and-express",
-  "order": 2,
+  "order": 1,
   "time": "5 hours",
   "template": "",
   "required": [],
   "superBlock": "quality-assurance",
-  "superOrder": 7,
+  "superOrder": 6,
   "challengeOrder": [
     [
       "5895f700f9fc0f352b528e63",

--- a/curriculum/challenges/_meta/algorithms/meta.json
+++ b/curriculum/challenges/_meta/algorithms/meta.json
@@ -2,12 +2,12 @@
   "name": "Algorithms",
   "isUpcomingChange": false,
   "dashedName": "algorithms",
-  "order": 1,
+  "order": 0,
   "time": "",
   "template": "",
   "required": [],
   "superBlock": "coding-interview-prep",
-  "superOrder": 12,
+  "superOrder": 11,
   "challengeOrder": [
     [
       "a3f503de51cf954ede28891d",

--- a/curriculum/challenges/_meta/applied-accessibility/meta.json
+++ b/curriculum/challenges/_meta/applied-accessibility/meta.json
@@ -7,7 +7,7 @@
   "template": "",
   "required": [],
   "superBlock": "responsive-web-design",
-  "superOrder": 1,
+  "superOrder": 0,
   "challengeOrder": [
     [
       "587d774c367417b2b2512a9c",

--- a/curriculum/challenges/_meta/applied-visual-design/meta.json
+++ b/curriculum/challenges/_meta/applied-visual-design/meta.json
@@ -7,7 +7,7 @@
   "template": "",
   "required": [],
   "superBlock": "responsive-web-design",
-  "superOrder": 1,
+  "superOrder": 0,
   "challengeOrder": [
     [
       "587d7791367417b2b2512ab3",

--- a/curriculum/challenges/_meta/back-end-development-and-apis-certification/meta.json
+++ b/curriculum/challenges/_meta/back-end-development-and-apis-certification/meta.json
@@ -2,7 +2,7 @@
   "name": "Back End Development and APIs Certification",
   "isUpcomingChange": false,
   "dashedName": "back-end-development-and-apis-certification",
-  "order": 6,
+  "order": 5,
   "time": "",
   "template": "",
   "required": [],

--- a/curriculum/challenges/_meta/back-end-development-and-apis-certification/meta.json
+++ b/curriculum/challenges/_meta/back-end-development-and-apis-certification/meta.json
@@ -7,7 +7,6 @@
   "template": "",
   "required": [],
   "superBlock": "certifications",
-  "superOrder": 0,
   "challengeOrder": [
     [
       "561add10cb82ac38a17523bc",

--- a/curriculum/challenges/_meta/back-end-development-and-apis-projects/meta.json
+++ b/curriculum/challenges/_meta/back-end-development-and-apis-projects/meta.json
@@ -2,10 +2,10 @@
   "name": "Back End Development and APIs Projects",
   "isUpcomingChange": false,
   "dashedName": "back-end-development-and-apis-projects",
-  "order": 4,
+  "order": 3,
   "time": "150 hours",
   "superBlock": "back-end-development-and-apis",
-  "superOrder": 6,
+  "superOrder": 5,
   "challengeOrder": [
     [
       "bd7158d8c443edefaeb5bdef",

--- a/curriculum/challenges/_meta/basic-algorithm-scripting/meta.json
+++ b/curriculum/challenges/_meta/basic-algorithm-scripting/meta.json
@@ -2,12 +2,12 @@
   "name": "Basic Algorithm Scripting",
   "isUpcomingChange": false,
   "dashedName": "basic-algorithm-scripting",
-  "order": 6,
+  "order": 5,
   "time": "50 hours",
   "template": "",
   "required": [],
   "superBlock": "javascript-algorithms-and-data-structures",
-  "superOrder": 2,
+  "superOrder": 1,
   "challengeOrder": [
     [
       "56533eb9ac21ba0edf2244b3",

--- a/curriculum/challenges/_meta/basic-css/meta.json
+++ b/curriculum/challenges/_meta/basic-css/meta.json
@@ -7,7 +7,7 @@
   "template": "",
   "required": [],
   "superBlock": "responsive-web-design",
-  "superOrder": 1,
+  "superOrder": 0,
   "challengeOrder": [
     [
       "bad87fee1348bd9aedf08803",

--- a/curriculum/challenges/_meta/basic-data-structures/meta.json
+++ b/curriculum/challenges/_meta/basic-data-structures/meta.json
@@ -2,12 +2,12 @@
   "name": "Basic Data Structures",
   "isUpcomingChange": false,
   "dashedName": "basic-data-structures",
-  "order": 5,
+  "order": 4,
   "time": "1 hour",
   "template": "",
   "required": [],
   "superBlock": "javascript-algorithms-and-data-structures",
-  "superOrder": 2,
+  "superOrder": 1,
   "challengeOrder": [
     [
       "587d7b7e367417b2b2512b20",

--- a/curriculum/challenges/_meta/basic-html-and-html5/meta.json
+++ b/curriculum/challenges/_meta/basic-html-and-html5/meta.json
@@ -7,7 +7,7 @@
   "template": "",
   "required": [],
   "superBlock": "responsive-web-design",
-  "superOrder": 1,
+  "superOrder": 0,
   "challengeOrder": [
     [
       "bd7123c8c441eddfaeb5bdef",

--- a/curriculum/challenges/_meta/basic-javascript-rpg-game/meta.json
+++ b/curriculum/challenges/_meta/basic-javascript-rpg-game/meta.json
@@ -3,12 +3,12 @@
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "basic-javascript-rpg-game",
-  "order": 11,
+  "order": 10,
   "time": "2 hours",
   "template": "",
   "required": [],
   "superBlock": "javascript-algorithms-and-data-structures",
-  "superOrder": 2,
+  "superOrder": 1,
   "isBeta": true,
   "challengeOrder": [
     [

--- a/curriculum/challenges/_meta/basic-javascript/meta.json
+++ b/curriculum/challenges/_meta/basic-javascript/meta.json
@@ -2,12 +2,12 @@
   "name": "Basic JavaScript",
   "isUpcomingChange": false,
   "dashedName": "basic-javascript",
-  "order": 1,
+  "order": 0,
   "time": "10 hours",
   "template": "",
   "required": [],
   "superBlock": "javascript-algorithms-and-data-structures",
-  "superOrder": 2,
+  "superOrder": 1,
   "challengeOrder": [
     [
       "bd7123c9c441eddfaeb4bdef",

--- a/curriculum/challenges/_meta/basic-node-and-express/meta.json
+++ b/curriculum/challenges/_meta/basic-node-and-express/meta.json
@@ -2,10 +2,10 @@
   "name": "Basic Node and Express",
   "isUpcomingChange": false,
   "dashedName": "basic-node-and-express",
-  "order": 2,
+  "order": 1,
   "time": "5 hours",
   "superBlock": "back-end-development-and-apis",
-  "superOrder": 6,
+  "superOrder": 5,
   "challengeOrder": [
     [
       "587d7fb0367417b2b2512bed",

--- a/curriculum/challenges/_meta/bootstrap/meta.json
+++ b/curriculum/challenges/_meta/bootstrap/meta.json
@@ -2,7 +2,7 @@
   "name": "Bootstrap",
   "isUpcomingChange": false,
   "dashedName": "bootstrap",
-  "order": 1,
+  "order": 0,
   "time": "5 hours",
   "template": "",
   "required": [
@@ -11,7 +11,7 @@
     }
   ],
   "superBlock": "front-end-development-libraries",
-  "superOrder": 3,
+  "superOrder": 2,
   "challengeOrder": [
     [
       "bad87fee1348bd9acde08712",

--- a/curriculum/challenges/_meta/bootstrap/meta.json
+++ b/curriculum/challenges/_meta/bootstrap/meta.json
@@ -2,7 +2,7 @@
   "name": "Bootstrap",
   "isUpcomingChange": false,
   "dashedName": "bootstrap",
-  "order": 2,
+  "order": 1,
   "time": "5 hours",
   "template": "",
   "required": [

--- a/curriculum/challenges/_meta/css-flexbox/meta.json
+++ b/curriculum/challenges/_meta/css-flexbox/meta.json
@@ -7,7 +7,7 @@
   "template": "",
   "required": [],
   "superBlock": "responsive-web-design",
-  "superOrder": 1,
+  "superOrder": 0,
   "challengeOrder": [
     [
       "587d78ab367417b2b2512af0",

--- a/curriculum/challenges/_meta/css-grid/meta.json
+++ b/curriculum/challenges/_meta/css-grid/meta.json
@@ -7,7 +7,7 @@
   "template": "",
   "required": [],
   "superBlock": "responsive-web-design",
-  "superOrder": 1,
+  "superOrder": 0,
   "challengeOrder": [
     [
       "5a858944d96184f06fd60d61",

--- a/curriculum/challenges/_meta/d3-dashboard/meta.json
+++ b/curriculum/challenges/_meta/d3-dashboard/meta.json
@@ -3,7 +3,7 @@
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "d3-dashboard",
-  "order": 4,
+  "order": 3,
   "time": "5 hours",
   "template": "",
   "required": [
@@ -12,7 +12,7 @@
     }
   ],
   "superBlock": "data-visualization",
-  "superOrder": 4,
+  "superOrder": 3,
   "challengeOrder": [
     [
       "5d8a4cfbe6b6180ed9a1c9de",

--- a/curriculum/challenges/_meta/data-analysis-with-python-certification/meta.json
+++ b/curriculum/challenges/_meta/data-analysis-with-python-certification/meta.json
@@ -7,7 +7,6 @@
   "template": "",
   "required": [],
   "superBlock": "certifications",
-  "superOrder": 0,
   "challengeOrder": [
     [
       "5e46fc95ac417301a38fb934",

--- a/curriculum/challenges/_meta/data-analysis-with-python-certification/meta.json
+++ b/curriculum/challenges/_meta/data-analysis-with-python-certification/meta.json
@@ -2,7 +2,7 @@
   "name": "Data Analysis with Python Certification",
   "isUpcomingChange": false,
   "dashedName": "data-analysis-with-python-v7-certification",
-  "order": 9,
+  "order": 8,
   "time": "",
   "template": "",
   "required": [],

--- a/curriculum/challenges/_meta/data-analysis-with-python-course/meta.json
+++ b/curriculum/challenges/_meta/data-analysis-with-python-course/meta.json
@@ -2,12 +2,12 @@
   "name": "Data Analysis with Python Course",
   "isUpcomingChange": false,
   "dashedName": "data-analysis-with-python-course",
-  "order": 1,
+  "order": 0,
   "time": "15 hours",
   "template": "",
   "required": [],
   "superBlock": "data-analysis-with-python",
-  "superOrder": 9,
+  "superOrder": 8,
   "challengeOrder": [
     [
       "5e9a093a74c4063ca6f7c14c",

--- a/curriculum/challenges/_meta/data-analysis-with-python-projects/meta.json
+++ b/curriculum/challenges/_meta/data-analysis-with-python-projects/meta.json
@@ -2,10 +2,10 @@
   "name": "Data Analysis with Python Projects",
   "isUpcomingChange": false,
   "dashedName": "data-analysis-with-python-projects",
-  "order": 3,
+  "order": 2,
   "time": "150 hours",
   "superBlock": "data-analysis-with-python",
-  "superOrder": 9,
+  "superOrder": 8,
   "challengeOrder": [
     [
       "5e46f7e5ac417301a38fb928",

--- a/curriculum/challenges/_meta/data-structures/meta.json
+++ b/curriculum/challenges/_meta/data-structures/meta.json
@@ -2,12 +2,12 @@
   "name": "Data Structures",
   "isUpcomingChange": false,
   "dashedName": "data-structures",
-  "order": 2,
+  "order": 1,
   "time": "",
   "template": "",
   "required": [],
   "superBlock": "coding-interview-prep",
-  "superOrder": 12,
+  "superOrder": 11,
   "challengeOrder": [
     [
       "587d8253367417b2b2512c6a",

--- a/curriculum/challenges/_meta/data-visualization-certification/meta.json
+++ b/curriculum/challenges/_meta/data-visualization-certification/meta.json
@@ -2,7 +2,7 @@
   "name": "Data Visualization Certification",
   "isUpcomingChange": false,
   "dashedName": "data-visualization-certification",
-  "order": 4,
+  "order": 3,
   "time": "",
   "template": "",
   "required": [],

--- a/curriculum/challenges/_meta/data-visualization-certification/meta.json
+++ b/curriculum/challenges/_meta/data-visualization-certification/meta.json
@@ -7,7 +7,6 @@
   "template": "",
   "required": [],
   "superBlock": "certifications",
-  "superOrder": 0,
   "challengeOrder": [
     [
       "5a553ca864b52e1d8bceea14",

--- a/curriculum/challenges/_meta/data-visualization-projects/meta.json
+++ b/curriculum/challenges/_meta/data-visualization-projects/meta.json
@@ -2,12 +2,12 @@
   "name": "Data Visualization Projects",
   "isUpcomingChange": false,
   "dashedName": "data-visualization-projects",
-  "order": 3,
+  "order": 2,
   "time": "150 hours",
   "template": "",
   "required": [],
   "superBlock": "data-visualization",
-  "superOrder": 4,
+  "superOrder": 3,
   "challengeOrder": [
     [
       "bd7168d8c242eddfaeb5bd13",

--- a/curriculum/challenges/_meta/data-visualization-with-d3/meta.json
+++ b/curriculum/challenges/_meta/data-visualization-with-d3/meta.json
@@ -2,7 +2,7 @@
   "name": "Data Visualization with D3",
   "isUpcomingChange": false,
   "dashedName": "data-visualization-with-d3",
-  "order": 1,
+  "order": 0,
   "time": "5 hours",
   "template": "",
   "required": [
@@ -11,7 +11,7 @@
     }
   ],
   "superBlock": "data-visualization",
-  "superOrder": 4,
+  "superOrder": 3,
   "challengeOrder": [
     ["587d7fa6367417b2b2512bc2", "Add Document Elements with D3"],
     ["587d7fa6367417b2b2512bc3", "Select a Group of Elements with D3"],

--- a/curriculum/challenges/_meta/debugging/meta.json
+++ b/curriculum/challenges/_meta/debugging/meta.json
@@ -2,12 +2,12 @@
   "name": "Debugging",
   "isUpcomingChange": false,
   "dashedName": "debugging",
-  "order": 4,
+  "order": 3,
   "time": "1 hour",
   "template": "",
   "required": [],
   "superBlock": "javascript-algorithms-and-data-structures",
-  "superOrder": 2,
+  "superOrder": 1,
   "challengeOrder": [
     [
       "587d7b83367417b2b2512b33",

--- a/curriculum/challenges/_meta/es6/meta.json
+++ b/curriculum/challenges/_meta/es6/meta.json
@@ -2,12 +2,12 @@
   "name": "ES6",
   "isUpcomingChange": false,
   "dashedName": "es6",
-  "order": 2,
+  "order": 1,
   "time": "5 hours",
   "template": "",
   "required": [],
   "superBlock": "javascript-algorithms-and-data-structures",
-  "superOrder": 2,
+  "superOrder": 1,
   "challengeOrder": [
     [
       "587d7b87367417b2b2512b40",

--- a/curriculum/challenges/_meta/front-end-development-libraries-certification/meta.json
+++ b/curriculum/challenges/_meta/front-end-development-libraries-certification/meta.json
@@ -2,7 +2,7 @@
   "name": "Front End Development Libraries Certification",
   "isUpcomingChange": false,
   "dashedName": "front-end-development-libraries-certification",
-  "order": 3,
+  "order": 2,
   "time": "",
   "template": "",
   "required": [],

--- a/curriculum/challenges/_meta/front-end-development-libraries-certification/meta.json
+++ b/curriculum/challenges/_meta/front-end-development-libraries-certification/meta.json
@@ -7,7 +7,6 @@
   "template": "",
   "required": [],
   "superBlock": "certifications",
-  "superOrder": 0,
   "challengeOrder": [
     [
       "561acd10cb82ac38a17513bc",

--- a/curriculum/challenges/_meta/front-end-development-libraries-projects/meta.json
+++ b/curriculum/challenges/_meta/front-end-development-libraries-projects/meta.json
@@ -2,7 +2,7 @@
   "name": "Front End Development Libraries Projects",
   "isUpcomingChange": false,
   "dashedName": "front-end-development-libraries-projects",
-  "order": 8,
+  "order": 7,
   "time": "150 hours",
   "template": "",
   "required": [],

--- a/curriculum/challenges/_meta/front-end-development-libraries-projects/meta.json
+++ b/curriculum/challenges/_meta/front-end-development-libraries-projects/meta.json
@@ -2,12 +2,12 @@
   "name": "Front End Development Libraries Projects",
   "isUpcomingChange": false,
   "dashedName": "front-end-development-libraries-projects",
-  "order": 7,
+  "order": 6,
   "time": "150 hours",
   "template": "",
   "required": [],
   "superBlock": "front-end-development-libraries",
-  "superOrder": 3,
+  "superOrder": 2,
   "challengeOrder": [
     [
       "bd7158d8c442eddfaeb5bd13",

--- a/curriculum/challenges/_meta/functional-programming-spreadsheet/meta.json
+++ b/curriculum/challenges/_meta/functional-programming-spreadsheet/meta.json
@@ -3,12 +3,12 @@
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "functional-programming-spreadsheet",
-  "order": 13,
+  "order": 12,
   "time": "2 hours",
   "template": "",
   "required": [],
   "superBlock": "javascript-algorithms-and-data-structures",
-  "superOrder": 2,
+  "superOrder": 1,
   "isBeta": true,
   "challengeOrder": [
     [

--- a/curriculum/challenges/_meta/functional-programming/meta.json
+++ b/curriculum/challenges/_meta/functional-programming/meta.json
@@ -2,12 +2,12 @@
   "name": "Functional Programming",
   "isUpcomingChange": false,
   "dashedName": "functional-programming",
-  "order": 8,
+  "order": 7,
   "time": "5 hours",
   "template": "",
   "required": [],
   "superBlock": "javascript-algorithms-and-data-structures",
-  "superOrder": 2,
+  "superOrder": 1,
   "challengeOrder": [
     [
       "587d7b8d367417b2b2512b5b",

--- a/curriculum/challenges/_meta/how-neural-networks-work/meta.json
+++ b/curriculum/challenges/_meta/how-neural-networks-work/meta.json
@@ -2,12 +2,12 @@
   "name": "How Neural Networks Work",
   "isUpcomingChange": false,
   "dashedName": "how-neural-networks-work",
-  "order": 2,
+  "order": 1,
   "time": "10 hours",
   "template": "",
   "required": [],
   "superBlock": "machine-learning-with-python",
-  "superOrder": 11,
+  "superOrder": 10,
   "challengeOrder": [
     [
       "5e9a0e9ef99a403d019610ca",

--- a/curriculum/challenges/_meta/information-security-certification/meta.json
+++ b/curriculum/challenges/_meta/information-security-certification/meta.json
@@ -2,7 +2,7 @@
   "name": "Information Security Certification",
   "isUpcomingChange": false,
   "dashedName": "information-security-v7-certification",
-  "order": 10,
+  "order": 9,
   "time": "",
   "template": "",
   "required": [],

--- a/curriculum/challenges/_meta/information-security-certification/meta.json
+++ b/curriculum/challenges/_meta/information-security-certification/meta.json
@@ -7,7 +7,6 @@
   "template": "",
   "required": [],
   "superBlock": "certifications",
-  "superOrder": 0,
   "challengeOrder": [
     [
       "5e6021435ac9d0ecd8b94b00",

--- a/curriculum/challenges/_meta/information-security-projects/meta.json
+++ b/curriculum/challenges/_meta/information-security-projects/meta.json
@@ -2,12 +2,12 @@
   "name": "Information Security Projects",
   "isUpcomingChange": false,
   "dashedName": "information-security-projects",
-  "order": 3,
+  "order": 2,
   "time": "150 hours",
   "template": "",
   "required": [],
   "superBlock": "information-security",
-  "superOrder": 10,
+  "superOrder": 9,
   "challengeOrder": [
     [
       "587d824a367417b2b2512c44",

--- a/curriculum/challenges/_meta/information-security-with-helmetjs/meta.json
+++ b/curriculum/challenges/_meta/information-security-with-helmetjs/meta.json
@@ -2,12 +2,12 @@
   "name": "Information Security with HelmetJS",
   "isUpcomingChange": false,
   "dashedName": "information-security-with-helmetjs",
-  "order": 1,
+  "order": 0,
   "time": "5 hours",
   "template": "",
   "required": [],
   "superBlock": "information-security",
-  "superOrder": 10,
+  "superOrder": 9,
   "challengeOrder": [
     [
       "587d8247367417b2b2512c36",

--- a/curriculum/challenges/_meta/intermediate-algorithm-scripting/meta.json
+++ b/curriculum/challenges/_meta/intermediate-algorithm-scripting/meta.json
@@ -2,12 +2,12 @@
   "name": "Intermediate Algorithm Scripting",
   "isUpcomingChange": false,
   "dashedName": "intermediate-algorithm-scripting",
-  "order": 9,
+  "order": 8,
   "time": "50 hours",
   "template": "",
   "required": [],
   "superBlock": "javascript-algorithms-and-data-structures",
-  "superOrder": 2,
+  "superOrder": 1,
   "challengeOrder": [
     [
       "a3566b1109230028080c9345",

--- a/curriculum/challenges/_meta/intermediate-javascript-calorie-counter/meta.json
+++ b/curriculum/challenges/_meta/intermediate-javascript-calorie-counter/meta.json
@@ -3,12 +3,12 @@
   "isUpcomingChange": true,
   "usesMultifileEditor": true,
   "dashedName": "intermediate-javascript-calorie-counter",
-  "order": 12,
+  "order": 11,
   "time": "2 hours",
   "template": "",
   "required": [],
   "superBlock": "javascript-algorithms-and-data-structures",
-  "superOrder": 2,
+  "superOrder": 1,
   "challengeOrder": [
     [
       "5ddb965c65d27e1512d44d9a",

--- a/curriculum/challenges/_meta/javascript-algorithms-and-data-structures-certification/meta.json
+++ b/curriculum/challenges/_meta/javascript-algorithms-and-data-structures-certification/meta.json
@@ -2,7 +2,7 @@
   "name": "JavaScript Algorithms and Data Structures Certification",
   "isUpcomingChange": false,
   "dashedName": "javascript-algorithms-and-data-structures-certification",
-  "order": 2,
+  "order": 1,
   "time": "",
   "template": "",
   "required": [],

--- a/curriculum/challenges/_meta/javascript-algorithms-and-data-structures-certification/meta.json
+++ b/curriculum/challenges/_meta/javascript-algorithms-and-data-structures-certification/meta.json
@@ -7,7 +7,6 @@
   "template": "",
   "required": [],
   "superBlock": "certifications",
-  "superOrder": 0,
   "challengeOrder": [
     [
       "561abd10cb81ac38a17513bc",

--- a/curriculum/challenges/_meta/javascript-algorithms-and-data-structures-projects/meta.json
+++ b/curriculum/challenges/_meta/javascript-algorithms-and-data-structures-projects/meta.json
@@ -2,12 +2,12 @@
   "name": "JavaScript Algorithms and Data Structures Projects",
   "isUpcomingChange": false,
   "dashedName": "javascript-algorithms-and-data-structures-projects",
-  "order": 10,
+  "order": 9,
   "time": "50 hours",
   "template": "",
   "required": [],
   "superBlock": "javascript-algorithms-and-data-structures",
-  "superOrder": 2,
+  "superOrder": 1,
   "challengeOrder": [
     [
       "aaa48de84e1ecc7c742e1124",

--- a/curriculum/challenges/_meta/jquery/meta.json
+++ b/curriculum/challenges/_meta/jquery/meta.json
@@ -2,7 +2,7 @@
   "name": "jQuery",
   "isUpcomingChange": false,
   "dashedName": "jquery",
-  "order": 2,
+  "order": 1,
   "time": "3 hours",
   "template": "",
   "required": [
@@ -11,7 +11,7 @@
     }
   ],
   "superBlock": "front-end-development-libraries",
-  "superOrder": 3,
+  "superOrder": 2,
   "challengeOrder": [
     [
       "bad87fee1348bd9acdd08826",

--- a/curriculum/challenges/_meta/jquery/meta.json
+++ b/curriculum/challenges/_meta/jquery/meta.json
@@ -2,7 +2,7 @@
   "name": "jQuery",
   "isUpcomingChange": false,
   "dashedName": "jquery",
-  "order": 3,
+  "order": 2,
   "time": "3 hours",
   "template": "",
   "required": [

--- a/curriculum/challenges/_meta/json-apis-and-ajax/meta.json
+++ b/curriculum/challenges/_meta/json-apis-and-ajax/meta.json
@@ -2,7 +2,7 @@
   "name": "JSON APIs and AJAX",
   "isUpcomingChange": false,
   "dashedName": "json-apis-and-ajax",
-  "order": 2,
+  "order": 1,
   "time": "2 hours",
   "template": "",
   "required": [
@@ -11,7 +11,7 @@
     }
   ],
   "superBlock": "data-visualization",
-  "superOrder": 4,
+  "superOrder": 3,
   "challengeOrder": [
     [
       "587d7fad367417b2b2512be1",

--- a/curriculum/challenges/_meta/learn-accessibility-by-building-a-quiz/meta.json
+++ b/curriculum/challenges/_meta/learn-accessibility-by-building-a-quiz/meta.json
@@ -8,7 +8,7 @@
   "template": "",
   "required": [],
   "superBlock": "responsive-web-design",
-  "superOrder": 1,
+  "superOrder": 0,
   "isBeta": true,
   "challengeOrder": [
     [

--- a/curriculum/challenges/_meta/learn-basic-css-by-building-a-cafe-menu/meta.json
+++ b/curriculum/challenges/_meta/learn-basic-css-by-building-a-cafe-menu/meta.json
@@ -8,7 +8,7 @@
   "template": "",
   "required": [],
   "superBlock": "responsive-web-design",
-  "superOrder": 1,
+  "superOrder": 0,
   "isBeta": true,
   "challengeOrder": [
     [

--- a/curriculum/challenges/_meta/learn-css-animation-by-building-a-ferris-wheel/meta.json
+++ b/curriculum/challenges/_meta/learn-css-animation-by-building-a-ferris-wheel/meta.json
@@ -7,7 +7,7 @@
   "template": "",
   "required": [],
   "superBlock": "responsive-web-design",
-  "superOrder": 1,
+  "superOrder": 0,
   "isBeta": true,
   "challengeOrder": [
     [

--- a/curriculum/challenges/_meta/learn-css-flexbox-by-building-a-photo-gallery/meta.json
+++ b/curriculum/challenges/_meta/learn-css-flexbox-by-building-a-photo-gallery/meta.json
@@ -7,7 +7,7 @@
   "template": "",
   "required": [],
   "superBlock": "responsive-web-design",
-  "superOrder": 1,
+  "superOrder": 0,
   "isBeta": true,
   "challengeOrder": [
     [

--- a/curriculum/challenges/_meta/learn-css-grid-by-building-a-magazine/meta.json
+++ b/curriculum/challenges/_meta/learn-css-grid-by-building-a-magazine/meta.json
@@ -7,7 +7,7 @@
   "template": "",
   "required": [],
   "superBlock": "responsive-web-design",
-  "superOrder": 1,
+  "superOrder": 0,
   "isBeta": true,
   "challengeOrder": [
     [

--- a/curriculum/challenges/_meta/learn-css-variables-by-building-a-city-skyline/meta.json
+++ b/curriculum/challenges/_meta/learn-css-variables-by-building-a-city-skyline/meta.json
@@ -8,7 +8,7 @@
   "template": "",
   "required": [],
   "superBlock": "responsive-web-design",
-  "superOrder": 1,
+  "superOrder": 0,
   "challengeOrder": [
     [
       "5d822fd413a79914d39e98c9",

--- a/curriculum/challenges/_meta/learn-html-by-building-a-cat-photo-app/meta.json
+++ b/curriculum/challenges/_meta/learn-html-by-building-a-cat-photo-app/meta.json
@@ -8,7 +8,7 @@
   "template": "",
   "required": [],
   "superBlock": "responsive-web-design",
-  "superOrder": 1,
+  "superOrder": 0,
   "isBeta": true,
   "challengeOrder": [
     [

--- a/curriculum/challenges/_meta/learn-html-forms-by-building-a-registration-form/meta.json
+++ b/curriculum/challenges/_meta/learn-html-forms-by-building-a-registration-form/meta.json
@@ -7,7 +7,7 @@
   "template": "",
   "required": [],
   "superBlock": "responsive-web-design",
-  "superOrder": 1,
+  "superOrder": 0,
   "isBeta": true,
   "challengeOrder": [
     [

--- a/curriculum/challenges/_meta/learn-intermediate-css-by-building-a-picasso-painting/meta.json
+++ b/curriculum/challenges/_meta/learn-intermediate-css-by-building-a-picasso-painting/meta.json
@@ -8,7 +8,7 @@
   "template": "",
   "required": [],
   "superBlock": "responsive-web-design",
-  "superOrder": 1,
+  "superOrder": 0,
   "isBeta": true,
   "challengeOrder": [
     [

--- a/curriculum/challenges/_meta/learn-relational-databases/meta.json
+++ b/curriculum/challenges/_meta/learn-relational-databases/meta.json
@@ -2,7 +2,7 @@
   "name": "Learn Relational Databases",
   "isUpcomingChange": true,
   "dashedName": "learn-relational-databases",
-  "order": 2,
+  "order": 1,
   "time": "",
   "template": "",
   "required": [],

--- a/curriculum/challenges/_meta/learn-relational-databases/meta.json
+++ b/curriculum/challenges/_meta/learn-relational-databases/meta.json
@@ -2,12 +2,12 @@
   "name": "Learn Relational Databases",
   "isUpcomingChange": true,
   "dashedName": "learn-relational-databases",
-  "order": 1,
+  "order": 0,
   "time": "",
   "template": "",
   "required": [],
   "superBlock": "relational-databases",
-  "superOrder": 5,
+  "superOrder": 4,
   "challengeOrder": [
     [
       "5ea8adfab628f68d805bfc5e",

--- a/curriculum/challenges/_meta/learn-responsive-web-design-by-building-a-piano/meta.json
+++ b/curriculum/challenges/_meta/learn-responsive-web-design-by-building-a-piano/meta.json
@@ -8,7 +8,7 @@
   "template": "",
   "required": [],
   "superBlock": "responsive-web-design",
-  "superOrder": 1,
+  "superOrder": 0,
   "isBeta": true,
   "challengeOrder": [
     [

--- a/curriculum/challenges/_meta/learn-the-css-box-model-by-building-a-rothko-painting/meta.json
+++ b/curriculum/challenges/_meta/learn-the-css-box-model-by-building-a-rothko-painting/meta.json
@@ -8,7 +8,7 @@
   "template": "",
   "required": [],
   "superBlock": "responsive-web-design",
-  "superOrder": 1,
+  "superOrder": 0,
   "isBeta": true,
   "challengeOrder": [
     [

--- a/curriculum/challenges/_meta/learn-typography-by-building-a-nutrition-label/meta.json
+++ b/curriculum/challenges/_meta/learn-typography-by-building-a-nutrition-label/meta.json
@@ -7,7 +7,7 @@
   "template": "",
   "required": [],
   "superBlock": "responsive-web-design",
-  "superOrder": 1,
+  "superOrder": 0,
   "isBeta": true,
   "challengeOrder": [
     [

--- a/curriculum/challenges/_meta/legacy-back-end-certification/meta.json
+++ b/curriculum/challenges/_meta/legacy-back-end-certification/meta.json
@@ -2,7 +2,7 @@
   "name": "Legacy Back End Certification",
   "isUpcomingChange": false,
   "dashedName": "legacy-back-end-certification",
-  "order": 13,
+  "order": 12,
   "time": "",
   "template": "",
   "required": [],

--- a/curriculum/challenges/_meta/legacy-back-end-certification/meta.json
+++ b/curriculum/challenges/_meta/legacy-back-end-certification/meta.json
@@ -7,7 +7,6 @@
   "template": "",
   "required": [],
   "superBlock": "certifications",
-  "superOrder": 0,
   "challengeOrder": [
     [
       "660add10cb82ac38a17513be",

--- a/curriculum/challenges/_meta/legacy-back-end-certification/meta.json
+++ b/curriculum/challenges/_meta/legacy-back-end-certification/meta.json
@@ -2,12 +2,12 @@
   "name": "Legacy Back End Certification",
   "isUpcomingChange": false,
   "dashedName": "legacy-back-end-certification",
-  "order": 1,
+  "order": 13,
   "time": "",
   "template": "",
   "required": [],
   "superBlock": "certifications",
-  "superOrder": 12,
+  "superOrder": 0,
   "challengeOrder": [
     [
       "660add10cb82ac38a17513be",

--- a/curriculum/challenges/_meta/legacy-data-visualization-certification/meta.json
+++ b/curriculum/challenges/_meta/legacy-data-visualization-certification/meta.json
@@ -2,12 +2,12 @@
   "name": "Legacy Data Visualization Certification",
   "isUpcomingChange": false,
   "dashedName": "legacy-data-visualization-certification",
-  "order": 1,
+  "order": 14,
   "time": "",
   "template": "",
   "required": [],
   "superBlock": "certifications",
-  "superOrder": 12,
+  "superOrder": 0,
   "challengeOrder": [
     [
       "561add10cb82ac39a17513bc",

--- a/curriculum/challenges/_meta/legacy-data-visualization-certification/meta.json
+++ b/curriculum/challenges/_meta/legacy-data-visualization-certification/meta.json
@@ -2,7 +2,7 @@
   "name": "Legacy Data Visualization Certification",
   "isUpcomingChange": false,
   "dashedName": "legacy-data-visualization-certification",
-  "order": 14,
+  "order": 13,
   "time": "",
   "template": "",
   "required": [],

--- a/curriculum/challenges/_meta/legacy-data-visualization-certification/meta.json
+++ b/curriculum/challenges/_meta/legacy-data-visualization-certification/meta.json
@@ -7,7 +7,6 @@
   "template": "",
   "required": [],
   "superBlock": "certifications",
-  "superOrder": 0,
   "challengeOrder": [
     [
       "561add10cb82ac39a17513bc",

--- a/curriculum/challenges/_meta/legacy-front-end-certification/meta.json
+++ b/curriculum/challenges/_meta/legacy-front-end-certification/meta.json
@@ -2,7 +2,7 @@
   "name": "Legacy Front End Certification",
   "isUpcomingChange": false,
   "dashedName": "legacy-front-end-certification",
-  "order": 12,
+  "order": 11,
   "time": "",
   "template": "",
   "required": [],

--- a/curriculum/challenges/_meta/legacy-front-end-certification/meta.json
+++ b/curriculum/challenges/_meta/legacy-front-end-certification/meta.json
@@ -7,7 +7,6 @@
   "template": "",
   "required": [],
   "superBlock": "certifications",
-  "superOrder": 0,
   "challengeOrder": [
     [
       "561add10cb82ac38a17513be",

--- a/curriculum/challenges/_meta/legacy-front-end-certification/meta.json
+++ b/curriculum/challenges/_meta/legacy-front-end-certification/meta.json
@@ -2,12 +2,12 @@
   "name": "Legacy Front End Certification",
   "isUpcomingChange": false,
   "dashedName": "legacy-front-end-certification",
-  "order": 1,
+  "order": 12,
   "time": "",
   "template": "",
   "required": [],
   "superBlock": "certifications",
-  "superOrder": 12,
+  "superOrder": 0,
   "challengeOrder": [
     [
       "561add10cb82ac38a17513be",

--- a/curriculum/challenges/_meta/legacy-full-stack-certification/meta.json
+++ b/curriculum/challenges/_meta/legacy-full-stack-certification/meta.json
@@ -2,12 +2,12 @@
   "name": "Legacy Full Stack Certification",
   "isUpcomingChange": false,
   "dashedName": "full-stack-certification",
-  "order": 5,
+  "order": 16,
   "time": "",
   "template": "",
   "required": [],
   "superBlock": "certifications",
-  "superOrder": 12,
+  "superOrder": 0,
   "challengeOrder": [
     [
       "561add10cb82ac38a17213bd",

--- a/curriculum/challenges/_meta/legacy-full-stack-certification/meta.json
+++ b/curriculum/challenges/_meta/legacy-full-stack-certification/meta.json
@@ -7,7 +7,6 @@
   "template": "",
   "required": [],
   "superBlock": "certifications",
-  "superOrder": 0,
   "challengeOrder": [
     [
       "561add10cb82ac38a17213bd",

--- a/curriculum/challenges/_meta/legacy-full-stack-certification/meta.json
+++ b/curriculum/challenges/_meta/legacy-full-stack-certification/meta.json
@@ -2,7 +2,7 @@
   "name": "Legacy Full Stack Certification",
   "isUpcomingChange": false,
   "dashedName": "full-stack-certification",
-  "order": 16,
+  "order": 15,
   "time": "",
   "template": "",
   "required": [],

--- a/curriculum/challenges/_meta/legacy-information-security-and-quality-assurance-certification/meta.json
+++ b/curriculum/challenges/_meta/legacy-information-security-and-quality-assurance-certification/meta.json
@@ -2,12 +2,12 @@
   "name": "Legacy Information Security and Quality Assurance Certification",
   "isUpcomingChange": false,
   "dashedName": "information-security-and-quality-assurance-certification",
-  "order": 1,
+  "order": 15,
   "time": "",
   "template": "",
   "required": [],
   "superBlock": "certifications",
-  "superOrder": 12,
+  "superOrder": 0,
   "challengeOrder": [
     [
       "561add10cb82ac38a17213bc",

--- a/curriculum/challenges/_meta/legacy-information-security-and-quality-assurance-certification/meta.json
+++ b/curriculum/challenges/_meta/legacy-information-security-and-quality-assurance-certification/meta.json
@@ -2,7 +2,7 @@
   "name": "Legacy Information Security and Quality Assurance Certification",
   "isUpcomingChange": false,
   "dashedName": "information-security-and-quality-assurance-certification",
-  "order": 15,
+  "order": 14,
   "time": "",
   "template": "",
   "required": [],

--- a/curriculum/challenges/_meta/legacy-information-security-and-quality-assurance-certification/meta.json
+++ b/curriculum/challenges/_meta/legacy-information-security-and-quality-assurance-certification/meta.json
@@ -7,7 +7,6 @@
   "template": "",
   "required": [],
   "superBlock": "certifications",
-  "superOrder": 0,
   "challengeOrder": [
     [
       "561add10cb82ac38a17213bc",

--- a/curriculum/challenges/_meta/machine-learning-with-python-certification/meta.json
+++ b/curriculum/challenges/_meta/machine-learning-with-python-certification/meta.json
@@ -7,7 +7,6 @@
   "template": "",
   "required": [],
   "superBlock": "certifications",
-  "superOrder": 0,
   "challengeOrder": [
     [
       "5e46fc95ac417301a38fb935",

--- a/curriculum/challenges/_meta/machine-learning-with-python-certification/meta.json
+++ b/curriculum/challenges/_meta/machine-learning-with-python-certification/meta.json
@@ -2,7 +2,7 @@
   "name": "Machine Learning with Python Certification",
   "isUpcomingChange": false,
   "dashedName": "machine-learning-with-python-v7-certification",
-  "order": 11,
+  "order": 10,
   "time": "",
   "template": "",
   "required": [],

--- a/curriculum/challenges/_meta/machine-learning-with-python-projects/meta.json
+++ b/curriculum/challenges/_meta/machine-learning-with-python-projects/meta.json
@@ -2,10 +2,10 @@
   "name": "Machine Learning with Python Projects",
   "isUpcomingChange": false,
   "dashedName": "machine-learning-with-python-projects",
-  "order": 3,
+  "order": 2,
   "time": "150 hours",
   "superBlock": "machine-learning-with-python",
-  "superOrder": 11,
+  "superOrder": 10,
   "challengeOrder": [
     [
       "5e46f8d6ac417301a38fb92d",

--- a/curriculum/challenges/_meta/managing-packages-with-npm/meta.json
+++ b/curriculum/challenges/_meta/managing-packages-with-npm/meta.json
@@ -2,10 +2,10 @@
   "name": "Managing Packages with npm",
   "isUpcomingChange": false,
   "dashedName": "managing-packages-with-npm",
-  "order": 1,
+  "order": 0,
   "time": "5 hours",
   "superBlock": "back-end-development-and-apis",
-  "superOrder": 6,
+  "superOrder": 5,
   "challengeOrder": [
     [
       "587d7fb3367417b2b2512bfb",

--- a/curriculum/challenges/_meta/mongodb-and-mongoose/meta.json
+++ b/curriculum/challenges/_meta/mongodb-and-mongoose/meta.json
@@ -2,10 +2,10 @@
   "name": "MongoDB and Mongoose",
   "isUpcomingChange": false,
   "dashedName": "mongodb-and-mongoose",
-  "order": 3,
+  "order": 2,
   "time": "5 hours",
   "superBlock": "back-end-development-and-apis",
-  "superOrder": 6,
+  "superOrder": 5,
   "challengeOrder": [
     [
       "587d7fb6367417b2b2512c06",

--- a/curriculum/challenges/_meta/numpy/meta.json
+++ b/curriculum/challenges/_meta/numpy/meta.json
@@ -2,12 +2,12 @@
   "name": "Numpy",
   "isUpcomingChange": false,
   "dashedName": "numpy",
-  "order": 2,
+  "order": 1,
   "time": "5 hours",
   "template": "",
   "required": [],
   "superBlock": "data-analysis-with-python",
-  "superOrder": 9,
+  "superOrder": 8,
   "challengeOrder": [
     [
       "5e9a0a8e09c5df3cc3600ed2",

--- a/curriculum/challenges/_meta/object-oriented-programming/meta.json
+++ b/curriculum/challenges/_meta/object-oriented-programming/meta.json
@@ -2,12 +2,12 @@
   "name": "Object Oriented Programming",
   "isUpcomingChange": false,
   "dashedName": "object-oriented-programming",
-  "order": 7,
+  "order": 6,
   "time": "5 hours",
   "template": "",
   "required": [],
   "superBlock": "javascript-algorithms-and-data-structures",
-  "superOrder": 2,
+  "superOrder": 1,
   "challengeOrder": [
     [
       "587d7dac367417b2b2512b73",

--- a/curriculum/challenges/_meta/project-euler/meta.json
+++ b/curriculum/challenges/_meta/project-euler/meta.json
@@ -2,7 +2,7 @@
   "name": "Project Euler",
   "isUpcomingChange": false,
   "dashedName": "project-euler",
-  "order": 6,
+  "order": 5,
   "time": "",
   "template": "",
   "required": [],

--- a/curriculum/challenges/_meta/project-euler/meta.json
+++ b/curriculum/challenges/_meta/project-euler/meta.json
@@ -2,12 +2,12 @@
   "name": "Project Euler",
   "isUpcomingChange": false,
   "dashedName": "project-euler",
-  "order": 5,
+  "order": 4,
   "time": "",
   "template": "",
   "required": [],
   "superBlock": "coding-interview-prep",
-  "superOrder": 12,
+  "superOrder": 11,
   "challengeOrder": [
     [
       "5900f36e1000cf542c50fe80",

--- a/curriculum/challenges/_meta/python-for-everybody/meta.json
+++ b/curriculum/challenges/_meta/python-for-everybody/meta.json
@@ -2,10 +2,10 @@
   "name": "Python for Everybody",
   "isUpcomingChange": false,
   "dashedName": "python-for-everybody",
-  "order": 1,
+  "order": 0,
   "time": "15 hours",
   "superBlock": "scientific-computing-with-python",
-  "superOrder": 8,
+  "superOrder": 7,
   "challengeOrder": [
     [
       "5e6a54a558d3af90110a60a0",

--- a/curriculum/challenges/_meta/python-for-penetration-testing/meta.json
+++ b/curriculum/challenges/_meta/python-for-penetration-testing/meta.json
@@ -2,12 +2,12 @@
   "name": "Python for Penetration Testing",
   "isUpcomingChange": false,
   "dashedName": "python-for-penetration-testing",
-  "order": 2,
+  "order": 1,
   "time": "5 hours",
   "template": "",
   "required": [],
   "superBlock": "information-security",
-  "superOrder": 10,
+  "superOrder": 9,
   "challengeOrder": [
     [
       "5ea9997bbec2e9bc47e94dae",

--- a/curriculum/challenges/_meta/quality-assurance-and-testing-with-chai/meta.json
+++ b/curriculum/challenges/_meta/quality-assurance-and-testing-with-chai/meta.json
@@ -2,12 +2,12 @@
   "name": "Quality Assurance and Testing with Chai",
   "isUpcomingChange": false,
   "dashedName": "quality-assurance-and-testing-with-chai",
-  "order": 1,
+  "order": 0,
   "time": "5 hours",
   "template": "",
   "required": [],
   "superBlock": "quality-assurance",
-  "superOrder": 7,
+  "superOrder": 6,
   "challengeOrder": [
     [
       "587d824a367417b2b2512c46",

--- a/curriculum/challenges/_meta/quality-assurance-certification/meta.json
+++ b/curriculum/challenges/_meta/quality-assurance-certification/meta.json
@@ -7,7 +7,6 @@
   "template": "",
   "required": [],
   "superBlock": "certifications",
-  "superOrder": 0,
   "challengeOrder": [
     [
       "5e611829481575a52dc59c0e",

--- a/curriculum/challenges/_meta/quality-assurance-certification/meta.json
+++ b/curriculum/challenges/_meta/quality-assurance-certification/meta.json
@@ -2,7 +2,7 @@
   "name": "Quality Assurance Certification",
   "isUpcomingChange": false,
   "dashedName": "quality-assurance-v7-certification",
-  "order": 7,
+  "order": 6,
   "time": "",
   "template": "",
   "required": [],

--- a/curriculum/challenges/_meta/quality-assurance-projects/meta.json
+++ b/curriculum/challenges/_meta/quality-assurance-projects/meta.json
@@ -2,12 +2,12 @@
   "name": "Quality Assurance Projects",
   "isUpcomingChange": false,
   "dashedName": "quality-assurance-projects",
-  "order": 3,
+  "order": 2,
   "time": "150 hours",
   "template": "",
   "required": [],
   "superBlock": "quality-assurance",
-  "superOrder": 7,
+  "superOrder": 6,
   "challengeOrder": [
     [
       "587d8249367417b2b2512c41",

--- a/curriculum/challenges/_meta/react-and-redux/meta.json
+++ b/curriculum/challenges/_meta/react-and-redux/meta.json
@@ -2,7 +2,7 @@
   "name": "React and Redux",
   "isUpcomingChange": false,
   "dashedName": "react-and-redux",
-  "order": 6,
+  "order": 5,
   "time": "5 hours",
   "template": "<body><div id='root'></div>${ source || '' }</body>",
   "required": [
@@ -20,7 +20,7 @@
     }
   ],
   "superBlock": "front-end-development-libraries",
-  "superOrder": 3,
+  "superOrder": 2,
   "challengeOrder": [
     [
       "5a24c314108439a4d4036141",

--- a/curriculum/challenges/_meta/react-and-redux/meta.json
+++ b/curriculum/challenges/_meta/react-and-redux/meta.json
@@ -2,7 +2,7 @@
   "name": "React and Redux",
   "isUpcomingChange": false,
   "dashedName": "react-and-redux",
-  "order": 7,
+  "order": 6,
   "time": "5 hours",
   "template": "<body><div id='root'></div>${ source || '' }</body>",
   "required": [

--- a/curriculum/challenges/_meta/react/meta.json
+++ b/curriculum/challenges/_meta/react/meta.json
@@ -2,7 +2,7 @@
   "name": "React",
   "isUpcomingChange": false,
   "dashedName": "react",
-  "order": 5,
+  "order": 4,
   "time": "5 hours",
   "template": "<body><div id='root'></div><div id='challenge-node'></div>${ source || '' }</body>",
   "required": [

--- a/curriculum/challenges/_meta/react/meta.json
+++ b/curriculum/challenges/_meta/react/meta.json
@@ -2,7 +2,7 @@
   "name": "React",
   "isUpcomingChange": false,
   "dashedName": "react",
-  "order": 4,
+  "order": 3,
   "time": "5 hours",
   "template": "<body><div id='root'></div><div id='challenge-node'></div>${ source || '' }</body>",
   "required": [
@@ -14,7 +14,7 @@
     }
   ],
   "superBlock": "front-end-development-libraries",
-  "superOrder": 3,
+  "superOrder": 2,
   "challengeOrder": [
     [
       "587d7dbc367417b2b2512bb1",

--- a/curriculum/challenges/_meta/redux/meta.json
+++ b/curriculum/challenges/_meta/redux/meta.json
@@ -2,7 +2,7 @@
   "name": "Redux",
   "isUpcomingChange": false,
   "dashedName": "redux",
-  "order": 5,
+  "order": 4,
   "time": "5 hours",
   "template": "",
   "required": [
@@ -14,7 +14,7 @@
     }
   ],
   "superBlock": "front-end-development-libraries",
-  "superOrder": 3,
+  "superOrder": 2,
   "challengeOrder": [
     [
       "5a24c314108439a4d403614b",

--- a/curriculum/challenges/_meta/redux/meta.json
+++ b/curriculum/challenges/_meta/redux/meta.json
@@ -2,7 +2,7 @@
   "name": "Redux",
   "isUpcomingChange": false,
   "dashedName": "redux",
-  "order": 6,
+  "order": 5,
   "time": "5 hours",
   "template": "",
   "required": [

--- a/curriculum/challenges/_meta/regular-expressions/meta.json
+++ b/curriculum/challenges/_meta/regular-expressions/meta.json
@@ -2,12 +2,12 @@
   "name": "Regular Expressions",
   "isUpcomingChange": false,
   "dashedName": "regular-expressions",
-  "order": 3,
+  "order": 2,
   "time": "5 hours",
   "template": "",
   "required": [],
   "superBlock": "javascript-algorithms-and-data-structures",
-  "superOrder": 2,
+  "superOrder": 1,
   "challengeOrder": [
     [
       "587d7db3367417b2b2512b8e",

--- a/curriculum/challenges/_meta/relational-databases-certification/meta.json
+++ b/curriculum/challenges/_meta/relational-databases-certification/meta.json
@@ -2,7 +2,7 @@
   "name": "Relational Databases Certification",
   "isUpcomingChange": true,
   "dashedName": "relational-databases-v8-certification",
-  "order": 5,
+  "order": 4,
   "time": "",
   "template": "",
   "required": [],

--- a/curriculum/challenges/_meta/relational-databases-certification/meta.json
+++ b/curriculum/challenges/_meta/relational-databases-certification/meta.json
@@ -7,7 +7,6 @@
   "template": "",
   "required": [],
   "superBlock": "certifications",
-  "superOrder": 0,
   "challengeOrder": [
     [
       "606243f50267e718b1e755f4",

--- a/curriculum/challenges/_meta/responsive-web-design-certification/meta.json
+++ b/curriculum/challenges/_meta/responsive-web-design-certification/meta.json
@@ -2,7 +2,7 @@
   "name": "Responsive Web Design Certification",
   "isUpcomingChange": false,
   "dashedName": "responsive-web-design-certification",
-  "order": 1,
+  "order": 0,
   "time": "",
   "template": "",
   "required": [],

--- a/curriculum/challenges/_meta/responsive-web-design-certification/meta.json
+++ b/curriculum/challenges/_meta/responsive-web-design-certification/meta.json
@@ -7,7 +7,6 @@
   "template": "",
   "required": [],
   "superBlock": "certifications",
-  "superOrder": 0,
   "challengeOrder": [
     [
       "561add10cb82ac38a17513bc",

--- a/curriculum/challenges/_meta/responsive-web-design-principles/meta.json
+++ b/curriculum/challenges/_meta/responsive-web-design-principles/meta.json
@@ -7,7 +7,7 @@
   "template": "",
   "required": [],
   "superBlock": "responsive-web-design",
-  "superOrder": 1,
+  "superOrder": 0,
   "challengeOrder": [
     [
       "587d78b0367417b2b2512b08",

--- a/curriculum/challenges/_meta/responsive-web-design-projects/meta.json
+++ b/curriculum/challenges/_meta/responsive-web-design-projects/meta.json
@@ -7,7 +7,7 @@
   "template": "",
   "required": [],
   "superBlock": "responsive-web-design",
-  "superOrder": 1,
+  "superOrder": 0,
   "challengeOrder": [
     [
       "bd7158d8c442eddfaeb5bd18",

--- a/curriculum/challenges/_meta/rosetta-code/meta.json
+++ b/curriculum/challenges/_meta/rosetta-code/meta.json
@@ -2,12 +2,12 @@
   "name": "Rosetta Code",
   "isUpcomingChange": false,
   "dashedName": "rosetta-code",
-  "order": 4,
+  "order": 3,
   "time": "",
   "template": "",
   "required": [],
   "superBlock": "coding-interview-prep",
-  "superOrder": 12,
+  "superOrder": 11,
   "challengeOrder": [
     [
       "594810f028c0303b75339acb",

--- a/curriculum/challenges/_meta/rosetta-code/meta.json
+++ b/curriculum/challenges/_meta/rosetta-code/meta.json
@@ -2,7 +2,7 @@
   "name": "Rosetta Code",
   "isUpcomingChange": false,
   "dashedName": "rosetta-code",
-  "order": 5,
+  "order": 4,
   "time": "",
   "template": "",
   "required": [],

--- a/curriculum/challenges/_meta/sass/meta.json
+++ b/curriculum/challenges/_meta/sass/meta.json
@@ -2,7 +2,7 @@
   "name": "Sass",
   "isUpcomingChange": false,
   "dashedName": "sass",
-  "order": 4,
+  "order": 3,
   "time": "5 hours",
   "template": "",
   "required": [],

--- a/curriculum/challenges/_meta/sass/meta.json
+++ b/curriculum/challenges/_meta/sass/meta.json
@@ -2,12 +2,12 @@
   "name": "Sass",
   "isUpcomingChange": false,
   "dashedName": "sass",
-  "order": 3,
+  "order": 2,
   "time": "5 hours",
   "template": "",
   "required": [],
   "superBlock": "front-end-development-libraries",
-  "superOrder": 3,
+  "superOrder": 2,
   "challengeOrder": [
     [
       "587d7dbd367417b2b2512bb4",

--- a/curriculum/challenges/_meta/scientific-computing-with-python-certification/meta.json
+++ b/curriculum/challenges/_meta/scientific-computing-with-python-certification/meta.json
@@ -2,7 +2,7 @@
   "name": "Scientific Computing with Python Certification",
   "isUpcomingChange": false,
   "dashedName": "scientific-computing-with-python-v7-certification",
-  "order": 8,
+  "order": 7,
   "time": "",
   "template": "",
   "required": [],

--- a/curriculum/challenges/_meta/scientific-computing-with-python-certification/meta.json
+++ b/curriculum/challenges/_meta/scientific-computing-with-python-certification/meta.json
@@ -7,7 +7,6 @@
   "template": "",
   "required": [],
   "superBlock": "certifications",
-  "superOrder": 0,
   "challengeOrder": [
     [
       "5e44431b903586ffb414c951",

--- a/curriculum/challenges/_meta/scientific-computing-with-python-projects/meta.json
+++ b/curriculum/challenges/_meta/scientific-computing-with-python-projects/meta.json
@@ -2,10 +2,10 @@
   "name": "Scientific Computing with Python Projects",
   "isUpcomingChange": false,
   "dashedName": "scientific-computing-with-python-projects",
-  "order": 2,
+  "order": 1,
   "time": "150 hours",
   "superBlock": "scientific-computing-with-python",
-  "superOrder": 8,
+  "superOrder": 7,
   "challengeOrder": [
     [
       "5e44412c903586ffb414c94c",

--- a/curriculum/challenges/_meta/take-home-projects/meta.json
+++ b/curriculum/challenges/_meta/take-home-projects/meta.json
@@ -2,12 +2,12 @@
   "name": "Take Home Projects",
   "isUpcomingChange": false,
   "dashedName": "take-home-projects",
-  "order": 3,
+  "order": 2,
   "time": "",
   "template": "",
   "required": [],
   "superBlock": "coding-interview-prep",
-  "superOrder": 12,
+  "superOrder": 11,
   "challengeOrder": [
     [
       "bd7158d8c442eddfaeb5bd10",

--- a/curriculum/challenges/_meta/take-home-projects/meta.json
+++ b/curriculum/challenges/_meta/take-home-projects/meta.json
@@ -2,7 +2,7 @@
   "name": "Take Home Projects",
   "isUpcomingChange": false,
   "dashedName": "take-home-projects",
-  "order": 4,
+  "order": 3,
   "time": "",
   "template": "",
   "required": [],

--- a/curriculum/challenges/_meta/tensorflow/meta.json
+++ b/curriculum/challenges/_meta/tensorflow/meta.json
@@ -2,10 +2,10 @@
   "name": "TensorFlow",
   "isUpcomingChange": false,
   "dashedName": "tensorflow",
-  "order": 1,
+  "order": 0,
   "time": "15 hours",
   "superBlock": "machine-learning-with-python",
-  "superOrder": 11,
+  "superOrder": 10,
   "challengeOrder": [
     [
       "5e8f2f13c4cdbe86b5c72d87",

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -256,13 +256,8 @@ function populateTestsForLang({ lang, challenges, meta }) {
      * when we are working on the new project-based curriculum for
      * a superblock (because keeping those challenges in order is
      * tricky and needs cleaning up before deploying).
-     * TODO: determine approach for new certifications being upcoming changes,
-     * thereby breaking the tests.
      */
-    const superBlocksUnderDevelopment = [
-      'certifications',
-      'responsive-web-design'
-    ];
+    const superBlocksUnderDevelopment = ['responsive-web-design'];
     const superBlocks = new Set([
       ...Object.values(meta)
         .map(el => el.superBlock)
@@ -270,7 +265,11 @@ function populateTestsForLang({ lang, challenges, meta }) {
     ]);
     superBlocks.forEach(superBlock => {
       const filteredMeta = Object.values(meta)
-        .filter(el => el.superBlock === superBlock)
+        /**
+         * Exclude any meta which doesn't have a superOrder, as these shouldn't
+         * appear on the learn map and thus don't need to be validated.
+         */
+        .filter(el => el.superBlock === superBlock && el.superOrder)
         .sort((a, b) => a.order - b.order);
       if (!filteredMeta.length) {
         return;

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -196,21 +196,14 @@ async function setup() {
   }
 
   const meta = {};
-  const fullMeta = {};
   for (const challenge of challenges) {
     const dashedBlockName = challenge.block;
     if (!meta[dashedBlockName]) {
-      meta[dashedBlockName] = (
-        await getMetaForBlock(dashedBlockName)
-      ).challengeOrder;
-    }
-    if (!fullMeta[dashedBlockName]) {
-      fullMeta[dashedBlockName] = await getMetaForBlock(dashedBlockName);
+      meta[dashedBlockName] = await getMetaForBlock(dashedBlockName);
     }
   }
   return {
     meta,
-    fullMeta,
     challenges,
     lang
   };
@@ -253,7 +246,7 @@ async function getChallenges(lang) {
   return sortChallenges(challenges);
 }
 
-function populateTestsForLang({ lang, challenges, meta, fullMeta }) {
+function populateTestsForLang({ lang, challenges, meta }) {
   const mongoIds = new MongoIds();
   const challengeTitles = new ChallengeTitles();
   const validateChallenge = challengeSchemaValidator();
@@ -271,12 +264,12 @@ function populateTestsForLang({ lang, challenges, meta, fullMeta }) {
       'responsive-web-design'
     ];
     const superBlocks = new Set([
-      ...Object.values(fullMeta)
+      ...Object.values(meta)
         .map(el => el.superBlock)
         .filter(el => !superBlocksUnderDevelopment.includes(el))
     ]);
     superBlocks.forEach(superBlock => {
-      const filteredMeta = Object.values(fullMeta)
+      const filteredMeta = Object.values(meta)
         .filter(el => el.superBlock === superBlock)
         .sort((a, b) => a.order - b.order);
       if (!filteredMeta.length) {
@@ -306,7 +299,7 @@ function populateTestsForLang({ lang, challenges, meta, fullMeta }) {
           // Note: the title in meta.json are purely for human readability and
           // do not include translations, so we do not validate against them.
           it('Matches an ID in meta.json', function () {
-            const index = meta[dashedBlockName].findIndex(
+            const index = meta[dashedBlockName].challengeOrder.findIndex(
               arr => arr[0] === challenge.id
             );
 

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -269,7 +269,10 @@ function populateTestsForLang({ lang, challenges, meta }) {
          * Exclude any meta which doesn't have a superOrder, as these shouldn't
          * appear on the learn map and thus don't need to be validated.
          */
-        .filter(el => el.superBlock === superBlock && el.superOrder)
+        .filter(
+          el =>
+            el.superBlock === superBlock && typeof el.superOrder !== 'undefined'
+        )
         .sort((a, b) => a.order - b.order);
       if (!filteredMeta.length) {
         return;
@@ -283,7 +286,7 @@ function populateTestsForLang({ lang, challenges, meta }) {
       });
       filteredMeta.forEach((meta, index) => {
         it(`${meta.superBlock} ${meta.name} must be in order`, function () {
-          assert.equal(meta.order, index + 1);
+          assert.equal(meta.order, index);
         });
       });
     });

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -259,11 +259,17 @@ function populateTestsForLang({ lang, challenges, meta, fullMeta }) {
   const validateChallenge = challengeSchemaValidator();
 
   describe('Assert meta order', function () {
-    // This array can be used to skip a superblock - we'll use this
-    // when we are working on the new project-based curriculum for
-    // a superblock (because keeping those challenges in order is
-    // tricky and needs cleaning up before deploying).
-    const superBlocksUnderDevelopment = ['responsive-web-design'];
+    /** This array can be used to skip a superblock - we'll use this
+     * when we are working on the new project-based curriculum for
+     * a superblock (because keeping those challenges in order is
+     * tricky and needs cleaning up before deploying).
+     * TODO: determine approach for new certifications being upcoming changes,
+     * thereby breaking the tests.
+     */
+    const superBlocksUnderDevelopment = [
+      'certifications',
+      'responsive-web-design'
+    ];
     const superBlocks = new Set([
       ...Object.values(fullMeta)
         .map(el => el.superBlock)


### PR DESCRIPTION
<!-- Please note that low quality PRs and PRs that do not follow our contributing guidelines will be marked as invalid for Hacktoberfest. -->

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Revisiting the conversation in #43407, this pull adds tests that assert the block order for each superblock is 1-indexed and does not skip numbers.

There's a config array within the tests for temporarily disabling the checks on a given superblock, to avoid headaches when working on the project based curriculum for a given superblock.

Needed to handle this to resolve some issues with #44183 where superblocks don't render because of discrepancies in the block orders.