### PR TITLE
fix(client): remove normalize.css from globals

### DIFF
--- a/client/src/templates/Challenges/rechallenge/builders.js
+++ b/client/src/templates/Challenges/rechallenge/builders.js
@@ -91,7 +91,7 @@ A required file can not have both a src and a link: src = ${src}, link = ${link}
       }
       return '';
     })
-    .reduce((head, element) => head.concat(element));
+    .reduce((head, element) => head.concat(element), []);
 
   const indexHtml = findIndexHtml(challengeFiles);
 

--- a/client/src/templates/Challenges/utils/build.js
+++ b/client/src/templates/Challenges/utils/build.js
@@ -23,14 +23,6 @@ const frameRunner = [
   }
 ];
 
-const globalRequires = [
-  {
-    link:
-      'https://cdnjs.cloudflare.com/' +
-      'ajax/libs/normalize/4.2.0/normalize.min.css'
-  }
-];
-
 const applyFunction = fn =>
   async function (file) {
     try {
@@ -142,7 +134,7 @@ export function buildDOMChallenge(
   { challengeFiles, required = [], template = '' },
   { usesTestRunner } = { usesTestRunner: false }
 ) {
-  const finalRequires = [...globalRequires, ...required];
+  const finalRequires = [...required];
   if (usesTestRunner) finalRequires.push(...frameRunner);
 
   const loadEnzyme = challengeFiles.some(

--- a/curriculum/challenges/english/04-data-visualization/d3-dashboard/step-137.md
+++ b/curriculum/challenges/english/04-data-visualization/d3-dashboard/step-137.md
@@ -25,12 +25,7 @@ After this, you will be able to use `data[index]` to get that item in the array.
 test-text
 
 ```js
-const script = $('.dashboard').siblings('script')[1].innerHTML;
-assert(
-  /var index = data.findIndex\(function \(d\) \{\s*return (year === d\.year|d.year === year);\s*\}\);/g.test(
-    script
-  )
-);
+assert.match(code,/const index = data.findIndex\(\(?d\)? => (year === d\.year|d.year === year)\s*\)/g);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/04-data-visualization/d3-dashboard/step-139.md
+++ b/curriculum/challenges/english/04-data-visualization/d3-dashboard/step-139.md
@@ -20,12 +20,9 @@ So now, when you hover a label, the function will be called with the year that i
 test-text
 
 ```js
-const script = $('.dashboard').siblings('script')[1].innerHTML;
-assert(
-  /\.on\(('|"|`)mouseover\1, function \(d\) \{\s*return drawDashboard\(d\);\s*\}\)/g.test(
-    script
-  )
-);
+assert.match(code,
+  /\.on\('mouseover', d => drawDashboard\(d\)\)/g
+  );
 ```
 
 # --seed--

--- a/curriculum/challenges/english/04-data-visualization/d3-dashboard/step-140.md
+++ b/curriculum/challenges/english/04-data-visualization/d3-dashboard/step-140.md
@@ -16,8 +16,7 @@ Go back to the top of the function and use `d3.select` to select the `.dashboard
 test-text
 
 ```js
-const script = $('.dashboard').siblings('script')[1].innerHTML;
-assert(/d3\.select\(('|"|`)\.dashboard\1\)\.html\(('|"|`)\2\)/g.test(script));
+assert.match(code, /d3\.select\(('|"|`)\.dashboard\1\)\.html\(('|"|`)\2\)/g);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/04-data-visualization/d3-dashboard/step-142.md
+++ b/curriculum/challenges/english/04-data-visualization/d3-dashboard/step-142.md
@@ -14,11 +14,8 @@ Create another `mouseover` event for when you hover one of the `twitter-circles`
 test-text
 
 ```js
-const script = $('.dashboard').siblings('script')[1].innerHTML;
-assert(
-  /\.on\(('|"|`)mouseover\1, function \(d\) \{\s*return drawDashboard\(d\.year\);\s*\}\)/g.test(
-    script
-  )
+assert.match(code, 
+  /\.on\('mouseover', d => drawDashboard\(d\.year\)\)/
 );
 ```
 

--- a/curriculum/challenges/english/04-data-visualization/d3-dashboard/step-144.md
+++ b/curriculum/challenges/english/04-data-visualization/d3-dashboard/step-144.md
@@ -16,11 +16,10 @@ After that, you will be able hover any of the circles or year labels to get the 
 test-text
 
 ```js
-const script = $('.dashboard').siblings('script')[1].innerHTML;
-assert(
-  script.match(
-    /\.on\(('|"|`)mouseover\1, function \(d\) \{\s*return drawDashboard\(d\.year\);\s*\}\)/g
-  ).length === 3
+assert.equal(
+  code.match(
+    /\.on\('mouseover', d => drawDashboard\(d\.year\)\)/g
+  )?.length, 3
 );
 ```
 


### PR DESCRIPTION
<!-- Please note that low quality PRs and PRs that do not follow our contributing guidelines will be marked as invalid for Hacktoberfest. -->

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This removes `normalize.css`. I checked a few projects/lessons, and see no detrimental side affects, but, I did not check in Safari so... 🤷‍♂️ 

The main thing this fixes is lessons like `registration-form/part-008`, where before, there was no visual change, but now there is.