### PR TITLE
fix(curriculum): improve regex

### DIFF
--- a/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/set-up-passport.md
+++ b/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/set-up-passport.md
@@ -111,7 +111,7 @@ Session and session secret should be correctly set up.
     (data) => {
       assert.match(
         data,
-        /secret:( |)process\.env(\.SESSION_SECRET|\[(?<q>"|')SESSION_SECRET\k<q>\])/g,
+        /secret ?: ?process\.env(\.SESSION_SECRET|\[(?<q>"|')SESSION_SECRET\k<q>\])/g,
         'Your express app should have express-session set up with your secret as process.env.SESSION_SECRET'
       );
     },

--- a/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/set-up-passport.md
+++ b/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/set-up-passport.md
@@ -111,7 +111,7 @@ Session and session secret should be correctly set up.
     (data) => {
       assert.match(
         data,
-        /secret ?: ?process\.env(\.SESSION_SECRET|\[(?<q>"|')SESSION_SECRET\k<q>\])/g,
+        /secret *: *process\.env(\.SESSION_SECRET|\[(?<q>"|')SESSION_SECRET\k<q>\])/g,
         'Your express app should have express-session set up with your secret as process.env.SESSION_SECRET'
       );
     },


### PR DESCRIPTION
<!-- Please note that low quality PRs and PRs that do not follow our contributing guidelines will be marked as invalid for Hacktoberfest. -->

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #44400

<!-- Feel free to add any additional description of changes below this line -->

Modified the regex to accept either zero or one space on either side of the colon in "secret: process.env.SESSION_SECRET"

