### PR TITLE
fix(client): update links with pt-BR translations

### DIFF
--- a/client/i18n/locales/portuguese/links.json
+++ b/client/i18n/locales/portuguese/links.json
@@ -2,12 +2,12 @@
   "help-translate-link-url": "https://contribute.freecodecamp.org/#/i18n/portuguese/how-to-translate-files",
   "top-contributors": "https://www.freecodecamp.org/news/freecodecamp-top-contributors/",
   "footer": {
-    "about-url": "https://www.freecodecamp.org/news/about/",
+    "about-url": "https://www.freecodecamp.org/portuguese/news/sobre-o-freecodecamp-perguntas-frequentes/",
     "shop-url": "https://www.freecodecamp.org/shop/",
-    "support-url": "https://www.freecodecamp.org/news/support/",
+    "support-url": "https://www.freecodecamp.org/portuguese/news/perguntas-frequentes-sobre-suporte-tecnico-faq-do-freecodecamp/",
     "sponsors-url": "https://www.freecodecamp.org/news/sponsors/",
-    "honesty-url": "https://www.freecodecamp.org/news/academic-honesty-policy/",
-    "coc-url": "https://www.freecodecamp.org/news/code-of-conduct/",
+    "honesty-url": "https://www.freecodecamp.org/portuguese/news/politica-de-honestidade-academica-do-freecodecamp/",
+    "coc-url": "https://www.freecodecamp.org/portuguese/news/codigo-de-conduta-do-freecodecamp/",
     "privacy-url": "https://www.freecodecamp.org/news/privacy-policy/",
     "tos-url": "https://www.freecodecamp.org/news/terms-of-service/",
     "copyright-url": "https://www.freecodecamp.org/news/copyright-policy/"


### PR DESCRIPTION
<!-- Please note that low quality PRs and PRs that do not follow our contributing guidelines will be marked as invalid for Hacktoberfest. -->

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!-- Feel free to add any additional description of changes below this line -->
Some of the articles on the footer already have Portuguese translations. This changes the links for them.
