### PR TITLE
Revert "fix: only include frame-runner when running tests (#44337)"

### DIFF
--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -86,8 +86,7 @@ export function* executeChallengeSaga({ payload }) {
     const protect = isLoopProtected(challengeMeta);
     const buildData = yield buildChallengeData(challengeData, {
       preview: false,
-      protect,
-      usesTestRunner: true
+      protect
     });
     const document = yield getContext('document');
     const testRunner = yield call(

--- a/client/src/templates/Challenges/utils/build.js
+++ b/client/src/templates/Challenges/utils/build.js
@@ -130,13 +130,12 @@ async function getDOMTestRunner(buildData, { proxyLogger }, document) {
     runTestInTestFrame(document, testString, testTimeout);
 }
 
-export function buildDOMChallenge(
-  { challengeFiles, required = [], template = '' },
-  { usesTestRunner } = { usesTestRunner: false }
-) {
-  const finalRequires = [...required];
-  if (usesTestRunner) finalRequires.push(...frameRunner);
-
+export function buildDOMChallenge({
+  challengeFiles,
+  required = [],
+  template = ''
+}) {
+  const finalRequires = [...required, ...frameRunner];
   const loadEnzyme = challengeFiles.some(
     challengeFile => challengeFile.ext === 'jsx'
   );

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -570,14 +570,11 @@ async function createTestRunner(
     challengeFile.editableContents = solutionFile.editableContents;
   });
 
-  const { build, sources, loadEnzyme } = await buildChallenge(
-    {
-      challengeFiles,
-      required,
-      template
-    },
-    { usesTestRunner: true }
-  );
+  const { build, sources, loadEnzyme } = await buildChallenge({
+    challengeFiles,
+    required,
+    template
+  });
 
   const code = {
     contents: sources.index,


### PR DESCRIPTION
This reverts commit a23a47750b869cbb31c0f1a17869b7c89b705b90.

<!-- Please note that low quality PRs and PRs that do not follow our contributing guidelines will be marked as invalid for Hacktoberfest. -->

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This reverts the optimisation to the preview pane - because the frame-runner mounts jQuery to the `window` object, not including it causes jQuery challenges to break in the preview.