### PR TITLE
feat(tools): test jQuery is defined

### DIFF
--- a/cypress/integration/learn/challenges/output.js
+++ b/cypress/integration/learn/challenges/output.js
@@ -8,7 +8,10 @@ const selectors = {
 const locations = {
   index:
     '/learn/responsive-web-design/basic-html-and-html5/' +
-    'say-hello-to-html-elements'
+    'say-hello-to-html-elements',
+  jQuery:
+    '/learn/front-end-development-libraries/jquery/' +
+    'target-html-elements-with-selectors-using-jquery'
 };
 
 const defaultOutput = `
@@ -57,5 +60,26 @@ describe('Classic challenge', function () {
           .contains(runningOutput)
           .contains(finishedOutput);
       });
+  });
+});
+
+describe('jQuery challenge', function () {
+  before(() => {
+    cy.visit(locations.jQuery);
+  });
+
+  it('renders the default output text', () => {
+    cy.title().should(
+      'eq',
+      'jQuery: Target HTML Elements with Selectors Using jQuery | freeCodeCamp.org'
+    );
+    cy.get(selectors.defaultOutput).contains(defaultOutput);
+  });
+
+  it('should not show a reference error', () => {
+    cy.get(selectors.defaultOutput).should(
+      'not.contain',
+      'ReferenceError: $ is not defined'
+    );
   });
 });

--- a/cypress/integration/learn/challenges/output.js
+++ b/cypress/integration/learn/challenges/output.js
@@ -77,6 +77,7 @@ describe('jQuery challenge', function () {
   });
 
   it('should not show a reference error', () => {
+    cy.wait(5000);
     cy.get(selectors.defaultOutput).should(
       'not.contain',
       'ReferenceError: $ is not defined'


### PR DESCRIPTION
<!-- Please note that low quality PRs and PRs that do not follow our contributing guidelines will be marked as invalid for Hacktoberfest. -->

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Adds a test for the second jQuery challenge to assert that the console displays the default text and does not display a reference error for `$`.