### PR TITLE
fix: make new editor more accessible

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -491,7 +491,6 @@ const Editor = (props: EditorProps): JSX.Element => {
     // The z-index needs increasing as ViewZones default to below the lines.
     domNode.style.zIndex = '10';
 
-    domNode.setAttribute('aria-hidden', 'true');
     domNode.style.left = `${editor.getLayoutInfo().contentLeft}px`;
     domNode.style.width = `${editor.getLayoutInfo().contentWidth}px`;
 
@@ -526,8 +525,6 @@ const Editor = (props: EditorProps): JSX.Element => {
     // TODO: does it?
     // The z-index needs increasing as ViewZones default to below the lines.
     outputNode.style.zIndex = '10';
-
-    outputNode.setAttribute('aria-hidden', 'true');
 
     outputNode.style.left = `${editor.getLayoutInfo().contentLeft}px`;
     outputNode.style.width = `${editor.getLayoutInfo().contentWidth}px`;


### PR DESCRIPTION
This makes the instructions and run tests button accessible in the new editor. I played around with a few ideas. This seemed like the simplest solution for now. Pretty tricky to figure out the best way to go about this - I'm open to suggestions.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
