### PR TITLE
feat: reduce request payload for non-js projects

### DIFF
--- a/client/src/templates/Challenges/redux/completion-epic.js
+++ b/client/src/templates/Challenges/redux/completion-epic.js
@@ -66,8 +66,7 @@ function submitModern(type, state) {
       const challengeFiles = challengeFilesSelector(state);
       const { username } = userSelector(state);
       const challengeInfo = {
-        id,
-        files: undefined
+        id
       };
       // Only send files to server, if it is a JS project
       if (block === 'javascript-algorithms-and-data-structures-projects') {

--- a/client/src/templates/Challenges/redux/completion-epic.js
+++ b/client/src/templates/Challenges/redux/completion-epic.js
@@ -62,16 +62,20 @@ function submitModern(type, state) {
     }
 
     if (type === actionTypes.submitChallenge) {
-      const { id } = challengeMetaSelector(state);
+      const { id, block } = challengeMetaSelector(state);
       const challengeFiles = challengeFilesSelector(state);
       const { username } = userSelector(state);
       const challengeInfo = {
         id,
-        files: challengeFiles.reduce(
+        files: undefined
+      };
+      // Only send files to server, if it is a JS project
+      if (block === 'javascript-algorithms-and-data-structures-projects') {
+        challengeInfo.files = challengeFiles.reduce(
           (acc, { fileKey, ...curr }) => [...acc, { ...curr, key: fileKey }],
           []
-        )
-      };
+        );
+      }
       const update = {
         endpoint: '/modern-challenge-completed',
         payload: challengeInfo


### PR DESCRIPTION


<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This change reduces the request body to just an `id`, for `/modern-challenge-completed` submissions. The server already omits the `files` content, using similar logic. So, I thought it best just not to send it anyway.

- `files` is only sent if submission is for a JSAlgo Certification Project

I noticed this while reviewing other issues, and thought it strange. So, I changed it 🤷‍♂️ 

I realise this will need to change again, when we implement internal submissions for RWD.