### PR TITLE
feat: add curriculum feature flag

### DIFF
--- a/config/read-env.js
+++ b/config/read-env.js
@@ -31,7 +31,8 @@ const {
   PAYPAL_CLIENT_ID: paypalClientId,
   PATREON_CLIENT_ID: patreonClientId,
   DEPLOYMENT_ENV: deploymentEnv,
-  SHOW_UPCOMING_CHANGES: showUpcomingChanges
+  SHOW_UPCOMING_CHANGES: showUpcomingChanges,
+  SHOW_NEW_CURRICULUM: showNewCurriculum
 } = process.env;
 
 const locations = {
@@ -70,5 +71,6 @@ module.exports = Object.assign(locations, {
     !patreonClientId || patreonClientId === 'id_from_patreon_dashboard'
       ? null
       : patreonClientId,
-  showUpcomingChanges: showUpcomingChanges === 'true'
+  showUpcomingChanges: showUpcomingChanges === 'true',
+  showNewCurriculum: showNewCurriculum === 'true'
 });

--- a/sample.env
+++ b/sample.env
@@ -57,6 +57,7 @@ CURRICULUM_LOCALE=english
 
 # Show or hide WIP in progress challenges
 SHOW_UPCOMING_CHANGES=false
+SHOW_NEW_CURRICULUM=false
 
 # Application paths
 HOME_LOCATION=http://localhost:8000

--- a/tools/scripts/build/ensure-env.ts
+++ b/tools/scripts/build/ensure-env.ts
@@ -49,7 +49,8 @@ if (FREECODECAMP_NODE_ENV !== 'development') {
     'showLocaleDropdownMenu',
     'deploymentEnv',
     'environment',
-    'showUpcomingChanges'
+    'showUpcomingChanges',
+    'showNewCurriculum'
   ];
   const searchKeys = ['algoliaAppId', 'algoliaAPIKey'];
   const donationKeys = ['stripePublicKey', 'paypalClientId', 'patreonClientId'];
@@ -112,13 +113,18 @@ if (FREECODECAMP_NODE_ENV !== 'development') {
   checkClientLocale();
   checkCurriculumLocale();
   if (fs.existsSync(`${globalConfigPath}/env.json`)) {
-    // eslint-disable-next-line
-    const { showUpcomingChanges } = require(`${globalConfigPath}/env.json`);
-    if (env['showUpcomingChanges'] !== showUpcomingChanges) {
+    /* eslint-disable @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-assignment */
+    const {
+      showNewCurriculum,
+      showUpcomingChanges
+    } = require(`${globalConfigPath}/env.json`);
+    /* eslint-enable @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-assignment */
+    if (
+      env['showUpcomingChanges'] !== showUpcomingChanges ||
+      env['showNewCurriculum'] !== showNewCurriculum
+    ) {
       /* eslint-enable @typescript-eslint/no-unsafe-member-access */
-      console.log(
-        'SHOW_UPCOMING_CHANGES value has changed, cleaning client cache.'
-      );
+      console.log('Feature flags have been changed, cleaning client cache.');
       const child = spawn('npm', ['run', 'clean:client']);
       child.stdout.setEncoding('utf8');
       child.stdout.on('data', function (data) {


### PR DESCRIPTION
<!-- Please note that low quality PRs and PRs that do not follow our contributing guidelines will be marked as invalid for Hacktoberfest. -->

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

After discussion with @ojeytonwilliams, we decided to extract this from #44183 into it's own PR.

This PR adds an env value that can be used as a feature-flag to gate the new curriculum. Currently this feature flag does absolutely nothing, but will be integrated into the above PR to allow us to control the deployment of the new curriculum - The goal here is to be able to display the new curriculum on English, but not on i18n deployments until we begin translating.