### PR TITLE
fix: handle uppercase and missing user verification

### DIFF
--- a/api-server/src/common/models/user.js
+++ b/api-server/src/common/models/user.js
@@ -55,7 +55,7 @@ function destroyAll(id, Model) {
   return Observable.fromNodeCallback(Model.destroyAll, Model)({ userId: id });
 }
 
-function ensureLowerCaseString(maybeString) {
+export function ensureLowerCaseString(maybeString) {
   return (maybeString && maybeString.toLowerCase()) || '';
 }
 

--- a/api-server/src/server/boot/certificate.js
+++ b/api-server/src/server/boot/certificate.js
@@ -548,10 +548,17 @@ function createVerifyCanClaim(certTypeIds, app) {
         .flatMap(challenge => {
           const certName = certTypeTitleMap[certType];
           const { tests = [] } = challenge;
-          const { isHonest = false, completedChallenges } = user;
-          const isProjectsCompleted = canClaim(tests, completedChallenges);
           let result = 'incomplete-requirements';
           let status = false;
+          if (!user) {
+            return Observable.just({
+              type: 'success',
+              message: { status, result },
+              variables: { name: certName }
+            });
+          }
+          const { isHonest, completedChallenges } = user;
+          const isProjectsCompleted = canClaim(tests, completedChallenges);
 
           if (isHonest && isProjectsCompleted) {
             status = true;

--- a/api-server/src/server/boot/certificate.js
+++ b/api-server/src/server/boot/certificate.js
@@ -548,7 +548,7 @@ function createVerifyCanClaim(certTypeIds, app) {
         .flatMap(challenge => {
           const certName = certTypeTitleMap[certType];
           const { tests = [] } = challenge;
-          const { isHonest, completedChallenges } = user;
+          const { isHonest = false, completedChallenges } = user;
           const isProjectsCompleted = canClaim(tests, completedChallenges);
           let result = 'incomplete-requirements';
           let status = false;

--- a/api-server/src/server/boot/certificate.js
+++ b/api-server/src/server/boot/certificate.js
@@ -20,6 +20,7 @@ import { reportError } from '../middlewares/sentry-error-handler.js';
 import { getChallenges } from '../utils/get-curriculum';
 import { ifNoUser401 } from '../utils/middleware';
 import { observeQuery } from '../utils/rx';
+import { ensureLowerCaseString } from '../../common/models/user';
 
 const {
   legacyFrontEndChallengeId,
@@ -523,7 +524,7 @@ function createVerifyCanClaim(certTypeIds, app) {
     let certType = superBlockCertTypeMap[superBlock];
     log(certType);
 
-    return findUserByUsername$(username, {
+    return findUserByUsername$(ensureLowerCaseString(username), {
       isFrontEndCert: true,
       isBackEndCert: true,
       isFullStackCert: true,
@@ -544,19 +545,33 @@ function createVerifyCanClaim(certTypeIds, app) {
       isHonest: true,
       completedChallenges: true
     }).subscribe(user => {
+      if (!user) {
+        return res.status(404).json({
+          message: {
+            type: 'info',
+            message: 'flash.username-not-found',
+            variables: { username }
+          }
+        });
+      }
+
+      if (!certTypeIds[certType]) {
+        return res.status(404).json({
+          message: {
+            type: 'info',
+            // TODO: create a specific 'flash.cert-not-found' message
+            message: 'flash.could-not-find'
+          }
+        });
+      }
+
       return Observable.of(certTypeIds[certType])
         .flatMap(challenge => {
           const certName = certTypeTitleMap[certType];
           const { tests = [] } = challenge;
           let result = 'incomplete-requirements';
           let status = false;
-          if (!user) {
-            return Observable.just({
-              type: 'success',
-              message: { status, result },
-              variables: { name: certName }
-            });
-          }
+
           const { isHonest, completedChallenges } = user;
           const isProjectsCompleted = canClaim(tests, completedChallenges);
 

--- a/client/src/templates/Introduction/components/cert-challenge.tsx
+++ b/client/src/templates/Introduction/components/cert-challenge.tsx
@@ -91,12 +91,22 @@ const CertChallenge = ({
       void (async () => {
         try {
           const data = await getVerifyCanClaimCert(username, superBlock);
-          const { status, result } = data?.response?.message;
-          setCanClaimCert(status);
-          setCertVerificationMessage(result);
-          setVerificationComplete(true);
+          if (data?.message) {
+            setCanClaimCert(false);
+            createFlashMessage(data.message);
+          } else {
+            const { status, result } = data?.response?.message;
+            setCanClaimCert(status);
+            setCertVerificationMessage(result);
+          }
         } catch (e) {
-          // TODO: How do we handle errors...?
+          console.error(e);
+          createFlashMessage({
+            type: 'danger',
+            message: FlashMessages.ReallyWeird
+          });
+        } finally {
+          setVerificationComplete(true);
         }
       })();
     }

--- a/client/src/utils/ajax.ts
+++ b/client/src/utils/ajax.ts
@@ -1,5 +1,6 @@
 import cookies from 'browser-cookies';
 import envData from '../../../config/env.json';
+import { FlashMessageArg } from '../components/Flash/redux';
 
 import type {
   ChallengeFile,
@@ -172,6 +173,7 @@ export interface GetVerifyCanClaimCert {
   };
   isCertMap: ClaimedCertifications;
   completedChallenges: CompletedChallenge[];
+  message?: FlashMessageArg;
 }
 
 export function getVerifyCanClaimCert(


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
This should be a hot-fix for instances where `isHonest` isn't set in the database. We'll need to investigate why it isn't being set, but this will ideally resolve the Sentry error.