### PR TITLE
fix(i18n): include period in translatable string

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -217,7 +217,7 @@
     "tax-exempt-status": "freeCodeCamp is a donor-supported tax-exempt 501(c)(3) nonprofit organization (United States Federal Tax Identification Number: 82-0779546)",
     "mission-statement": "Our mission: to help people learn to code for free. We accomplish this by creating thousands of videos, articles, and interactive coding lessons - all freely available to the public. We also have thousands of freeCodeCamp study groups around the world.",
     "donation-initiatives": "Donations to freeCodeCamp go toward our education initiatives, and help pay for servers, services, and staff.",
-    "donate-text": "You can <0>make a tax-deductible donation here</0>.",
+    "donate-text": "You can <1>make a tax-deductible donation here</1>.",
     "trending-guides": "Trending Guides",
     "our-nonprofit": "Our Nonprofit",
     "links": {

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -218,7 +218,7 @@
     "mission-statement": "Our mission: to help people learn to code for free. We accomplish this by creating thousands of videos, articles, and interactive coding lessons - all freely available to the public. We also have thousands of freeCodeCamp study groups around the world.",
     "donation-initiatives": "Donations to freeCodeCamp go toward our education initiatives, and help pay for servers, services, and staff.",
     "donate-text": "You can",
-    "donate-link": "make a tax-deductible donation here",
+    "donate-link": "make a tax-deductible donation here.",
     "trending-guides": "Trending Guides",
     "our-nonprofit": "Our Nonprofit",
     "links": {

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -217,8 +217,7 @@
     "tax-exempt-status": "freeCodeCamp is a donor-supported tax-exempt 501(c)(3) nonprofit organization (United States Federal Tax Identification Number: 82-0779546)",
     "mission-statement": "Our mission: to help people learn to code for free. We accomplish this by creating thousands of videos, articles, and interactive coding lessons - all freely available to the public. We also have thousands of freeCodeCamp study groups around the world.",
     "donation-initiatives": "Donations to freeCodeCamp go toward our education initiatives, and help pay for servers, services, and staff.",
-    "donate-text": "You can",
-    "donate-link": "make a tax-deductible donation here.",
+    "donate-text": "You can <0>make a tax-deductible donation here</0>.",
     "trending-guides": "Trending Guides",
     "our-nonprofit": "Our Nonprofit",
     "links": {

--- a/client/src/components/Footer/__snapshots__/footer.test.tsx.snap
+++ b/client/src/components/Footer/__snapshots__/footer.test.tsx.snap
@@ -25,14 +25,14 @@ exports[`<Footer /> matches snapshot 1`] = `
         <p
           className="footer-donation"
         >
-          footer.donate-text
-           
+          You can
           <a
             className="inline"
             href="/donate"
           >
-            footer.donate-link
+            make a tax-deductible donation here
           </a>
+          .
         </p>
       </div>
       <div

--- a/client/src/components/Footer/__snapshots__/footer.test.tsx.snap
+++ b/client/src/components/Footer/__snapshots__/footer.test.tsx.snap
@@ -33,7 +33,6 @@ exports[`<Footer /> matches snapshot 1`] = `
           >
             footer.donate-link
           </a>
-          .
         </p>
       </div>
       <div

--- a/client/src/components/Footer/index.tsx
+++ b/client/src/components/Footer/index.tsx
@@ -19,7 +19,6 @@ function Footer(): JSX.Element {
               <Link className='inline' to='/donate'>
                 {t('footer.donate-link')}
               </Link>
-              .
             </p>
           </div>
           <div className='trending-guides'>

--- a/client/src/components/Footer/index.tsx
+++ b/client/src/components/Footer/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import Link from '../helpers/link';
 import './footer.css';
 
@@ -15,10 +15,9 @@ function Footer(): JSX.Element {
             <p>{t('footer.mission-statement')}</p>
             <p>{t('footer.donation-initiatives')}</p>
             <p className='footer-donation'>
-              {t('footer.donate-text')}{' '}
-              <Link className='inline' to='/donate'>
-                {t('footer.donate-link')}
-              </Link>
+              <Trans i18nKey='footer.donate-text'>
+                <Link className='inline' to='/donate' />
+              </Trans>
             </p>
           </div>
           <div className='trending-guides'>

--- a/client/src/components/Footer/index.tsx
+++ b/client/src/components/Footer/index.tsx
@@ -16,7 +16,11 @@ function Footer(): JSX.Element {
             <p>{t('footer.donation-initiatives')}</p>
             <p className='footer-donation'>
               <Trans i18nKey='footer.donate-text'>
-                <Link className='inline' to='/donate' />
+                You can
+                <Link className='inline' to='/donate'>
+                  make a tax-deductible donation here
+                </Link>
+                .
               </Trans>
             </p>
           </div>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

The string "You can make a tax-deductible donation here." in the footer doesn't include `.` in the translatable string. But in Japanese, we end a sentence with `。` instead of `.`

We need to include `.` in the translatable string to display it properly in the languages with different ending characters.

We had a similar problem in news-theme too. Refer to: https://github.com/freeCodeCamp/news-theme/pull/198#issuecomment-955352234