### PR TITLE
fix(client): prevent unusual commas in iframe

### DIFF
--- a/client/src/templates/Challenges/rechallenge/builders.js
+++ b/client/src/templates/Challenges/rechallenge/builders.js
@@ -80,8 +80,8 @@ export function concatHtml({
     .map(({ link, src }) => {
       if (link && src) {
         throw new Error(`
-A required file can not have both a src and a link: src = ${src}, link = ${link}
-`);
+		A required file can not have both a src and a link: src = ${src}, link = ${link}
+		`);
       }
       if (src) {
         return `<script src='${src}' type='text/javascript'></script>`;
@@ -91,7 +91,7 @@ A required file can not have both a src and a link: src = ${src}, link = ${link}
       }
       return '';
     })
-    .reduce((head, element) => head.concat(element), []);
+    .join('\n');
 
   const indexHtml = findIndexHtml(challengeFiles);
 

--- a/client/src/templates/Challenges/rechallenge/builders.js
+++ b/client/src/templates/Challenges/rechallenge/builders.js
@@ -80,8 +80,8 @@ export function concatHtml({
     .map(({ link, src }) => {
       if (link && src) {
         throw new Error(`
-		A required file can not have both a src and a link: src = ${src}, link = ${link}
-		`);
+A required file can not have both a src and a link: src = ${src}, link = ${link}
+`);
       }
       if (src) {
         return `<script src='${src}' type='text/javascript'></script>`;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #44449

---

The `reduce` method was causing 2 of the 3 scripts that were required to be placed into the body rather than the head. By swapping it out for the `join` method, all 3 of the scripts now are in the head which has also fixed the erroneous commas in the output. 

The reason this was only occurring on specific challenges was that only a limited number of challenges require external scripts in their `meta.json` files.
