### PR TITLE
fix: remove unused dispatch imports from multifile editor

### DIFF
--- a/client/src/templates/Challenges/classic/MultifileEditor.js
+++ b/client/src/templates/Challenges/classic/MultifileEditor.js
@@ -7,11 +7,7 @@ import { isDonationModalOpenSelector, userSelector } from '../../../redux';
 import {
   canFocusEditorSelector,
   consoleOutputSelector,
-  executeChallenge,
-  saveEditorContent,
-  setEditorFocusability,
-  visibleEditorsSelector,
-  updateFile
+  visibleEditorsSelector
 } from '../redux';
 import { getTargetEditor } from '../utils/getTargetEditor';
 import './editor.css';
@@ -26,7 +22,6 @@ const propTypes = {
   description: PropTypes.string,
   dimensions: PropTypes.object,
   editorRef: PropTypes.any.isRequired,
-  executeChallenge: PropTypes.func.isRequired,
   ext: PropTypes.string,
   fileKey: PropTypes.string,
   initialEditorContent: PropTypes.string,
@@ -37,11 +32,8 @@ const propTypes = {
     onStopResize: PropTypes.func,
     onResize: PropTypes.func
   }),
-  saveEditorContent: PropTypes.func.isRequired,
-  setEditorFocusability: PropTypes.func,
   theme: PropTypes.string,
   title: PropTypes.string,
-  updateFile: PropTypes.func.isRequired,
   usesMultifileEditor: PropTypes.bool,
   visibleEditors: PropTypes.shape({
     scriptjs: PropTypes.bool,
@@ -64,13 +56,6 @@ const mapStateToProps = createSelector(
     theme
   })
 );
-
-const mapDispatchToProps = {
-  executeChallenge,
-  saveEditorContent,
-  setEditorFocusability,
-  updateFile
-};
 
 const MultifileEditor = props => {
   const {
@@ -159,4 +144,4 @@ const MultifileEditor = props => {
 MultifileEditor.displayName = 'MultifileEditor';
 MultifileEditor.propTypes = propTypes;
 
-export default connect(mapStateToProps, mapDispatchToProps)(MultifileEditor);
+export default connect(mapStateToProps)(MultifileEditor);


### PR DESCRIPTION
These weren't being used in this component

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
