### PR TITLE
refactor: stop spreading challenge over the node

### DIFF
--- a/client/plugins/fcc-source-challenges/create-challenge-nodes.js
+++ b/client/plugins/fcc-source-challenges/create-challenge-nodes.js
@@ -1,4 +1,5 @@
 const crypto = require('crypto');
+const { blockNameify } = require('../../../utils/block-nameify');
 
 function createChallengeNode(challenge, reporter) {
   // challengeType 11 is for video challenges (they only have instructions)
@@ -31,6 +32,17 @@ function createChallengeNode(challenge, reporter) {
     type: challenge.challengeType === 7 ? 'CertificateNode' : 'ChallengeNode'
   };
 
+  if (internal.type === 'ChallengeNode') {
+    const { tests = [], block, dashedName, superBlock } = challenge;
+    const slug = `/learn/${superBlock}/${block}/${dashedName}`;
+
+    challenge.fields = {
+      slug,
+      blockName: blockNameify(block),
+      tests
+    };
+  }
+
   return JSON.parse(
     JSON.stringify(
       Object.assign(
@@ -41,7 +53,8 @@ function createChallengeNode(challenge, reporter) {
           internal,
           sourceInstanceName: 'challenge'
         },
-        challenge
+        { challenge },
+        { id: crypto.randomUUID() }
       )
     )
   );

--- a/client/src/__mocks__/challenge-nodes.js
+++ b/client/src/__mocks__/challenge-nodes.js
@@ -1,136 +1,158 @@
 const mockChallengeNodes = [
   {
-    fields: {
-      slug: '/super-block-one/block-a/challenge-one',
-      blockName: 'Block A'
-    },
-    id: 'a',
-    block: 'block-a',
-    title: 'Challenge One',
-    isPrivate: false,
-    superBlock: 'super-block-one',
-    dashedName: 'challenge-one'
+    challenge: {
+      fields: {
+        slug: '/super-block-one/block-a/challenge-one',
+        blockName: 'Block A'
+      },
+      id: 'a',
+      block: 'block-a',
+      title: 'Challenge One',
+      isPrivate: false,
+      superBlock: 'super-block-one',
+      dashedName: 'challenge-one'
+    }
   },
   {
-    fields: {
-      slug: '/super-block-one/block-a/challenge-two',
-      blockName: 'Block A'
-    },
-    id: 'b',
-    block: 'block-a',
-    title: 'Challenge Two',
-    isPrivate: false,
-    superBlock: 'super-block-one',
-    dashedName: 'challenge-two'
+    challenge: {
+      fields: {
+        slug: '/super-block-one/block-a/challenge-two',
+        blockName: 'Block A'
+      },
+      id: 'b',
+      block: 'block-a',
+      title: 'Challenge Two',
+      isPrivate: false,
+      superBlock: 'super-block-one',
+      dashedName: 'challenge-two'
+    }
   },
   {
-    fields: {
-      slug: '/super-block-one/block-b/challenge-one',
-      blockName: 'Block B'
-    },
-    id: 'c',
-    block: 'block-b',
-    title: 'Challenge One',
-    isPrivate: false,
-    superBlock: 'super-block-one',
-    dashedName: 'challenge-one'
+    challenge: {
+      fields: {
+        slug: '/super-block-one/block-b/challenge-one',
+        blockName: 'Block B'
+      },
+      id: 'c',
+      block: 'block-b',
+      title: 'Challenge One',
+      isPrivate: false,
+      superBlock: 'super-block-one',
+      dashedName: 'challenge-one'
+    }
   },
   {
-    fields: {
-      slug: '/super-block-one/block-b/challenge-two',
-      blockName: 'Block B'
-    },
+    challenge: {
+      fields: {
+        slug: '/super-block-one/block-b/challenge-two',
+        blockName: 'Block B'
+      },
 
-    id: 'd',
-    block: 'block-b',
-    title: 'Challenge Two',
-    isPrivate: false,
-    superBlock: 'super-block-one',
-    dashedName: 'challenge-two'
+      id: 'd',
+      block: 'block-b',
+      title: 'Challenge Two',
+      isPrivate: false,
+      superBlock: 'super-block-one',
+      dashedName: 'challenge-two'
+    }
   },
   {
-    fields: {
-      slug: '/super-block-one/block-c/challenge-one',
-      blockName: 'Block C'
-    },
-    id: 'e',
-    block: 'block-c',
-    title: 'Challenge One',
-    isPrivate: true,
-    superBlock: 'super-block-one',
-    dashedName: 'challenge-one'
+    challenge: {
+      fields: {
+        slug: '/super-block-one/block-c/challenge-one',
+        blockName: 'Block C'
+      },
+      id: 'e',
+      block: 'block-c',
+      title: 'Challenge One',
+      isPrivate: true,
+      superBlock: 'super-block-one',
+      dashedName: 'challenge-one'
+    }
   },
   {
-    fields: {
-      slug: '/super-block-two/block-a/challenge-one',
-      blockName: 'Block A'
-    },
-    id: 'f',
-    block: 'block-a',
-    title: 'Challenge One',
-    isPrivate: false,
-    superBlock: 'super-block-two',
-    dashedName: 'challenge-one'
+    challenge: {
+      fields: {
+        slug: '/super-block-two/block-a/challenge-one',
+        blockName: 'Block A'
+      },
+      id: 'f',
+      block: 'block-a',
+      title: 'Challenge One',
+      isPrivate: false,
+      superBlock: 'super-block-two',
+      dashedName: 'challenge-one'
+    }
   },
   {
-    fields: {
-      slug: '/super-block-two/block-a/challenge-two',
-      blockName: 'Block A'
-    },
-    id: 'g',
-    block: 'block-a',
-    title: 'Challenge Two',
-    isPrivate: false,
-    superBlock: 'super-block-two',
-    dashedName: 'challenge-two'
+    challenge: {
+      fields: {
+        slug: '/super-block-two/block-a/challenge-two',
+        blockName: 'Block A'
+      },
+      id: 'g',
+      block: 'block-a',
+      title: 'Challenge Two',
+      isPrivate: false,
+      superBlock: 'super-block-two',
+      dashedName: 'challenge-two'
+    }
   },
   {
-    fields: {
-      slug: '/super-block-two/block-b/challenge-one',
-      blockName: 'Block B'
-    },
-    id: 'h',
-    block: 'block-b',
-    title: 'Challenge One',
-    isPrivate: false,
-    superBlock: 'super-block-two',
-    dashedName: 'challenge-one'
+    challenge: {
+      fields: {
+        slug: '/super-block-two/block-b/challenge-one',
+        blockName: 'Block B'
+      },
+      id: 'h',
+      block: 'block-b',
+      title: 'Challenge One',
+      isPrivate: false,
+      superBlock: 'super-block-two',
+      dashedName: 'challenge-one'
+    }
   },
   {
-    fields: {
-      slug: '/super-block-two/block-b/challenge-two',
-      blockName: 'Block B'
-    },
-    id: 'i',
-    block: 'block-b',
-    title: 'Challenge Two',
-    isPrivate: false,
-    superBlock: 'super-block-two',
-    dashedName: 'challenge-two'
+    challenge: {
+      fields: {
+        slug: '/super-block-two/block-b/challenge-two',
+        blockName: 'Block B'
+      },
+      id: 'i',
+      block: 'block-b',
+      title: 'Challenge Two',
+      isPrivate: false,
+      superBlock: 'super-block-two',
+      dashedName: 'challenge-two'
+    }
   },
   {
-    fields: {
-      slug: '/super-block-three/block-a/challenge-one',
-      blockName: 'Block A'
-    },
-    id: 'j',
-    block: 'block-a',
-    title: 'Challenge One',
-    isPrivate: false,
-    superBlock: 'super-block-three',
-    dashedName: 'challenge-one'
+    challenge: {
+      fields: {
+        slug: '/super-block-three/block-a/challenge-one',
+        blockName: 'Block A'
+      },
+      id: 'j',
+      block: 'block-a',
+      title: 'Challenge One',
+      isPrivate: false,
+      superBlock: 'super-block-three',
+      dashedName: 'challenge-one'
+    }
   },
   {
-    fields: {
-      slug: '/super-block-three/block-c/challenge-two',
-      blockName: 'Block C'
-    },
-    id: 'k',
-    block: 'block-c',
-    title: 'Challenge Two',
-    isPrivate: false,
-    superBlock: 'super-block-three',
-    dashedName: 'challenge-two'
+    challenge: {
+      fields: {
+        slug: '/super-block-three/block-c/challenge-two',
+        blockName: 'Block C'
+      },
+      id: 'k',
+      block: 'block-c',
+      title: 'Challenge Two',
+      isPrivate: false,
+      superBlock: 'super-block-three',
+      dashedName: 'challenge-two'
+    }
   }
 ];
 

--- a/client/src/components/Map/index.tsx
+++ b/client/src/components/Map/index.tsx
@@ -42,19 +42,19 @@ const linkSpacingStyle = {
 
 function renderLandingMap(nodes: ChallengeNode[]) {
   nodes = nodes.filter(
-    node => node.superBlock !== SuperBlocks.CodingInterviewPrep
+    ({ challenge }) => challenge.superBlock !== SuperBlocks.CodingInterviewPrep
   );
   return (
     <ul data-test-label='certifications'>
-      {nodes.map((node, i) => (
+      {nodes.map(({ challenge }, i) => (
         <li key={i}>
           <Link
             className='btn link-btn btn-lg'
-            to={`/learn/${node.superBlock}/`}
+            to={`/learn/${challenge.superBlock}/`}
           >
             <div style={linkSpacingStyle}>
-              {generateIconComponent(node.superBlock, 'map-icon')}
-              {i18next.t(`intro:${node.superBlock}.title`)}
+              {generateIconComponent(challenge.superBlock, 'map-icon')}
+              {i18next.t(`intro:${challenge.superBlock}.title`)}
             </div>
             <LinkButton />
           </Link>
@@ -68,18 +68,20 @@ function renderLearnMap(
   nodes: ChallengeNode[],
   currentSuperBlock: MapProps['currentSuperBlock']
 ) {
-  nodes = nodes.filter(node => node.superBlock !== currentSuperBlock);
+  nodes = nodes.filter(
+    ({ challenge }) => challenge.superBlock !== currentSuperBlock
+  );
   return curriculumLocale === 'english' ? (
     <ul data-test-label='learn-curriculum-map'>
-      {nodes.map((node, i) => (
+      {nodes.map(({ challenge }, i) => (
         <li key={i}>
           <Link
             className='btn link-btn btn-lg'
-            to={`/learn/${node.superBlock}/`}
+            to={`/learn/${challenge.superBlock}/`}
           >
             <div style={linkSpacingStyle}>
-              {generateIconComponent(node.superBlock, 'map-icon')}
-              {createSuperBlockTitle(node.superBlock)}
+              {generateIconComponent(challenge.superBlock, 'map-icon')}
+              {createSuperBlockTitle(challenge.superBlock)}
             </div>
           </Link>
         </li>
@@ -88,16 +90,18 @@ function renderLearnMap(
   ) : (
     <ul data-test-label='learn-curriculum-map'>
       {nodes
-        .filter(node => isAuditedCert(curriculumLocale, node.superBlock))
-        .map((node, i) => (
+        .filter(({ challenge }) =>
+          isAuditedCert(curriculumLocale, challenge.superBlock)
+        )
+        .map(({ challenge }, i) => (
           <li key={i}>
             <Link
               className='btn link-btn btn-lg'
-              to={`/learn/${node.superBlock}/`}
+              to={`/learn/${challenge.superBlock}/`}
             >
               <div style={linkSpacingStyle}>
-                {generateIconComponent(node.superBlock, 'map-icon')}
-                {createSuperBlockTitle(node.superBlock)}
+                {generateIconComponent(challenge.superBlock, 'map-icon')}
+                {createSuperBlockTitle(challenge.superBlock)}
               </div>
             </Link>
           </li>
@@ -115,16 +119,19 @@ function renderLearnMap(
         <Spacer />
       </div>
       {nodes
-        .filter(node => !isAuditedCert(curriculumLocale, node.superBlock))
-        .map((node, i) => (
+        .filter(
+          ({ challenge }) =>
+            !isAuditedCert(curriculumLocale, challenge.superBlock)
+        )
+        .map(({ challenge }, i) => (
           <li key={i}>
             <Link
               className='btn link-btn btn-lg'
-              to={`/learn/${node.superBlock}/`}
+              to={`/learn/${challenge.superBlock}/`}
             >
               <div style={linkSpacingStyle}>
-                {generateIconComponent(node.superBlock, 'map-icon')}
-                {createSuperBlockTitle(node.superBlock)}
+                {generateIconComponent(challenge.superBlock, 'map-icon')}
+                {createSuperBlockTitle(challenge.superBlock)}
               </div>
             </Link>
           </li>
@@ -145,12 +152,14 @@ export function Map({
   const data: MapData = useStaticQuery(graphql`
     query SuperBlockNodes {
       allChallengeNode(
-        sort: { fields: [superOrder] }
-        filter: { order: { eq: 0 }, challengeOrder: { eq: 0 } }
+        sort: { fields: [challenge___superOrder] }
+        filter: { challenge: { order: { eq: 0 }, challengeOrder: { eq: 0 } } }
       ) {
         nodes {
-          superBlock
-          dashedName
+          challenge {
+            superBlock
+            dashedName
+          }
         }
       }
     }

--- a/client/src/components/profile/components/TimeLine.tsx
+++ b/client/src/components/profile/components/TimeLine.tsx
@@ -269,11 +269,13 @@ function useIdToNameMap(): Map<string, string> {
       allChallengeNode {
         edges {
           node {
-            fields {
-              slug
+            challenge {
+              fields {
+                slug
+              }
+              id
+              title
             }
-            id
-            title
           }
         }
       }
@@ -289,12 +291,14 @@ function useIdToNameMap(): Map<string, string> {
   edges.forEach(
     ({
       node: {
-        // @ts-expect-error Graphql needs typing
-        id,
-        // @ts-expect-error Graphql needs typing
-        title,
-        // @ts-expect-error Graphql needs typing
-        fields: { slug }
+        challenge: {
+          // @ts-expect-error Graphql needs typing
+          id,
+          // @ts-expect-error Graphql needs typing
+          title,
+          // @ts-expect-error Graphql needs typing
+          fields: { slug }
+        }
       }
     }) => {
       idToNameMap.set(id, { challengeTitle: title, challengePath: slug });

--- a/client/src/components/profile/components/time-line.test.tsx
+++ b/client/src/components/profile/components/time-line.test.tsx
@@ -12,29 +12,35 @@ beforeEach(() => {
       edges: [
         {
           node: {
-            fields: {
-              slug: ''
-            },
-            id: '5e46f802ac417301a38fb92b',
-            title: 'Page View Time Series Visualizer'
+            challenge: {
+              fields: {
+                slug: ''
+              },
+              id: '5e46f802ac417301a38fb92b',
+              title: 'Page View Time Series Visualizer'
+            }
           }
         },
         {
           node: {
-            fields: {
-              slug: ''
-            },
-            id: '5e4f5c4b570f7e3a4949899f',
-            title: 'Sea Level Predictor'
+            challenge: {
+              fields: {
+                slug: ''
+              },
+              id: '5e4f5c4b570f7e3a4949899f',
+              title: 'Sea Level Predictor'
+            }
           }
         },
         {
           node: {
-            fields: {
-              slug: ''
-            },
-            id: '5e46f7f8ac417301a38fb92a',
-            title: 'Medical Data Visualizer'
+            challenge: {
+              fields: {
+                slug: ''
+              },
+              id: '5e46f7f8ac417301a38fb92a',
+              title: 'Medical Data Visualizer'
+            }
           }
         }
       ]

--- a/client/src/pages/learn.tsx
+++ b/client/src/pages/learn.tsx
@@ -53,7 +53,9 @@ interface LearnPageProps {
   user: User;
   data: {
     challengeNode: {
-      fields: Slug;
+      challenge: {
+        fields: Slug;
+      };
     };
   };
   executeGA: (payload: Record<string, unknown>) => void;
@@ -70,7 +72,9 @@ function LearnPage({
   executeGA,
   data: {
     challengeNode: {
-      fields: { slug }
+      challenge: {
+        fields: { slug }
+      }
     }
   }
 }: LearnPageProps) {
@@ -117,9 +121,11 @@ export default connect(mapStateToProps, mapDispatchToProps)(LearnPage);
 
 export const query = graphql`
   query FirstChallenge {
-    challengeNode(order: { eq: 0 }, challengeOrder: { eq: 0 }) {
-      fields {
-        slug
+    challengeNode(challenge: { order: { eq: 0 }, challengeOrder: { eq: 0 } }) {
+      challenge {
+        fields {
+          slug
+        }
       }
     }
   }

--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -128,55 +128,57 @@ export interface VideoLocaleIds {
 }
 
 export type ChallengeNode = {
-  block: string;
-  challengeOrder: number;
-  challengeType: number;
-  dashedName: string;
-  description: string;
-  challengeFiles: ChallengeFiles;
-  fields: Fields;
-  forumTopicId: number;
-  guideUrl: string;
-  head: string[];
-  helpCategory: string;
-  id: string;
-  instructions: string;
-  isComingSoon: boolean;
-  internal?: {
-    content: string;
-    contentDigest: string;
+  challenge: {
+    block: string;
+    challengeOrder: number;
+    challengeType: number;
+    dashedName: string;
     description: string;
-    fieldOwners: string[];
-    ignoreType: boolean | null;
-    mediaType: string;
-    owner: string;
-    type: string;
+    challengeFiles: ChallengeFiles;
+    fields: Fields;
+    forumTopicId: number;
+    guideUrl: string;
+    head: string[];
+    helpCategory: string;
+    id: string;
+    instructions: string;
+    isComingSoon: boolean;
+    internal?: {
+      content: string;
+      contentDigest: string;
+      description: string;
+      fieldOwners: string[];
+      ignoreType: boolean | null;
+      mediaType: string;
+      owner: string;
+      type: string;
+    };
+    notes: string;
+    removeComments: boolean;
+    isLocked: boolean;
+    isPrivate: boolean;
+    order: number;
+    question: Question;
+    required: Required[];
+    solutions: {
+      [T in FileKey]: FileKeyChallenge;
+    };
+    sourceInstanceName: string;
+    superOrder: number;
+    superBlock: SuperBlocks;
+    tail: string[];
+    template: string;
+    tests: Test[];
+    time: string;
+    title: string;
+    translationPending: boolean;
+    url: string;
+    usesMultifileEditor: boolean;
+    videoId: string;
+    videoLocaleIds?: VideoLocaleIds;
+    bilibiliIds?: BilibiliIds;
+    videoUrl: string;
   };
-  notes: string;
-  removeComments: boolean;
-  isLocked: boolean;
-  isPrivate: boolean;
-  order: number;
-  question: Question;
-  required: Required[];
-  solutions: {
-    [T in FileKey]: FileKeyChallenge;
-  };
-  sourceInstanceName: string;
-  superOrder: number;
-  superBlock: SuperBlocks;
-  tail: string[];
-  template: string;
-  tests: Test[];
-  time: string;
-  title: string;
-  translationPending: boolean;
-  url: string;
-  usesMultifileEditor: boolean;
-  videoId: string;
-  videoLocaleIds?: VideoLocaleIds;
-  bilibiliIds?: BilibiliIds;
-  videoUrl: string;
 };
 
 export type AllChallengeNode = {

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -212,7 +212,9 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
   componentDidMount() {
     const {
       data: {
-        challengeNode: { title }
+        challengeNode: {
+          challenge: { title }
+        }
       }
     } = this.props;
     this.initializeComponent(title);
@@ -222,16 +224,20 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
     const {
       data: {
         challengeNode: {
-          title: prevTitle,
-          fields: { tests: prevTests }
+          challenge: {
+            title: prevTitle,
+            fields: { tests: prevTests }
+          }
         }
       }
     } = prevProps;
     const {
       data: {
         challengeNode: {
-          title: currentTitle,
-          fields: { tests: currTests }
+          challenge: {
+            title: currentTitle,
+            fields: { tests: currTests }
+          }
         }
       }
     } = this.props;
@@ -250,11 +256,13 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
       openModal,
       data: {
         challengeNode: {
-          challengeFiles,
-          fields: { tests },
-          challengeType,
-          removeComments,
-          helpCategory
+          challenge: {
+            challengeFiles,
+            fields: { tests },
+            challengeType,
+            removeComments,
+            helpCategory
+          }
         }
       },
       pageContext: {
@@ -282,7 +290,7 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
     cancelTests();
   }
 
-  getChallenge = () => this.props.data.challengeNode;
+  getChallenge = () => this.props.data.challengeNode.challenge;
 
   getBlockNameTitle(t: TFunction) {
     const { block, superBlock, title } = this.getChallenge();
@@ -337,8 +345,10 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
       challengeFiles,
       data: {
         challengeNode: {
-          fields: { tests },
-          usesMultifileEditor
+          challenge: {
+            fields: { tests },
+            usesMultifileEditor
+          }
         }
       }
     } = this.props;
@@ -489,40 +499,42 @@ export default connect(
 
 export const query = graphql`
   query ClassicChallenge($slug: String!) {
-    challengeNode(fields: { slug: { eq: $slug } }) {
-      block
-      title
-      description
-      instructions
-      notes
-      removeComments
-      challengeType
-      helpCategory
-      videoUrl
-      superBlock
-      translationPending
-      forumTopicId
-      fields {
-        blockName
-        slug
-        tests {
-          text
-          testString
+    challengeNode(challenge: { fields: { slug: { eq: $slug } } }) {
+      challenge {
+        block
+        title
+        description
+        instructions
+        notes
+        removeComments
+        challengeType
+        helpCategory
+        videoUrl
+        superBlock
+        translationPending
+        forumTopicId
+        fields {
+          blockName
+          slug
+          tests {
+            text
+            testString
+          }
         }
-      }
-      required {
-        link
-        src
-      }
-      usesMultifileEditor
-      challengeFiles {
-        fileKey
-        ext
-        name
-        contents
-        head
-        tail
-        editableRegionBoundaries
+        required {
+          link
+          src
+        }
+        usesMultifileEditor
+        challengeFiles {
+          fileKey
+          ext
+          name
+          contents
+          head
+          tail
+          editableRegionBoundaries
+        }
       }
     }
   }

--- a/client/src/templates/Challenges/codeally/show.tsx
+++ b/client/src/templates/Challenges/codeally/show.tsx
@@ -49,7 +49,9 @@ class ShowCodeAlly extends Component<ShowCodeAllyProps> {
     const {
       updateChallengeMeta,
       data: {
-        challengeNode: { challengeType, title }
+        challengeNode: {
+          challenge: { challengeType, title }
+        }
       },
       pageContext: { challengeMeta }
     } = this.props;
@@ -60,9 +62,11 @@ class ShowCodeAlly extends Component<ShowCodeAllyProps> {
     const {
       data: {
         challengeNode: {
-          title,
-          fields: { blockName },
-          url
+          challenge: {
+            title,
+            fields: { blockName },
+            url
+          }
         }
       },
       webhookToken = null
@@ -94,12 +98,14 @@ export default connect(mapStateToProps, mapDispatchToProps)(ShowCodeAlly);
 // GraphQL
 export const query = graphql`
   query CodeAllyChallenge($slug: String!) {
-    challengeNode(fields: { slug: { eq: $slug } }) {
-      title
-      challengeType
-      url
-      fields {
-        blockName
+    challengeNode(challenge: { fields: { slug: { eq: $slug } } }) {
+      challenge {
+        title
+        challengeType
+        url
+        fields {
+          blockName
+        }
       }
     }
   }

--- a/client/src/templates/Challenges/components/completion-modal.tsx
+++ b/client/src/templates/Challenges/components/completion-modal.tsx
@@ -280,13 +280,23 @@ const useCurrentBlockIds = (blockName: string) => {
     allChallengeNode: { edges }
   }: { allChallengeNode: AllChallengeNode } = useStaticQuery(graphql`
     query getCurrentBlockNodes {
-      allChallengeNode(sort: { fields: [superOrder, order, challengeOrder] }) {
+      allChallengeNode(
+        sort: {
+          fields: [
+            challenge___superOrder
+            challenge___order
+            challenge___challengeOrder
+          ]
+        }
+      ) {
         edges {
           node {
-            fields {
-              blockName
+            challenge {
+              fields {
+                blockName
+              }
+              id
             }
-            id
           }
         }
       }
@@ -294,9 +304,9 @@ const useCurrentBlockIds = (blockName: string) => {
   `);
 
   const currentBlockIds = edges
-    .filter(edge => edge.node.fields.blockName === blockName)
+    .filter(edge => edge.node.challenge.fields.blockName === blockName)
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    .map(edge => edge.node.id);
+    .map(edge => edge.node.challenge.id);
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return currentBlockIds;
 };

--- a/client/src/templates/Challenges/projects/backend/Show.tsx
+++ b/client/src/templates/Challenges/projects/backend/Show.tsx
@@ -123,16 +123,20 @@ class BackEnd extends Component<BackEndProps> {
     const {
       data: {
         challengeNode: {
-          title: prevTitle,
-          fields: { tests: prevTests }
+          challenge: {
+            title: prevTitle,
+            fields: { tests: prevTests }
+          }
         }
       }
     } = prevProps;
     const {
       data: {
         challengeNode: {
-          title: currentTitle,
-          fields: { tests: currTests }
+          challenge: {
+            title: currentTitle,
+            fields: { tests: currTests }
+          }
         }
       }
     } = this.props;
@@ -149,10 +153,12 @@ class BackEnd extends Component<BackEndProps> {
       updateChallengeMeta,
       data: {
         challengeNode: {
-          fields: { tests },
-          title,
-          challengeType,
-          helpCategory
+          challenge: {
+            fields: { tests },
+            title,
+            challengeType,
+            helpCategory
+          }
         }
       },
       pageContext: { challengeMeta }
@@ -182,15 +188,17 @@ class BackEnd extends Component<BackEndProps> {
     const {
       data: {
         challengeNode: {
-          fields: { blockName },
-          challengeType,
-          forumTopicId,
-          title,
-          description,
-          instructions,
-          translationPending,
-          superBlock,
-          block
+          challenge: {
+            fields: { blockName },
+            challengeType,
+            forumTopicId,
+            title,
+            description,
+            instructions,
+            translationPending,
+            superBlock,
+            block
+          }
         }
       },
       isChallengeCompleted,
@@ -278,22 +286,24 @@ export default connect(
 
 export const query = graphql`
   query BackendChallenge($slug: String!) {
-    challengeNode(fields: { slug: { eq: $slug } }) {
-      forumTopicId
-      title
-      description
-      instructions
-      challengeType
-      helpCategory
-      superBlock
-      block
-      translationPending
-      fields {
-        blockName
-        slug
-        tests {
-          text
-          testString
+    challengeNode(challenge: { fields: { slug: { eq: $slug } } }) {
+      challenge {
+        forumTopicId
+        title
+        description
+        instructions
+        challengeType
+        helpCategory
+        superBlock
+        block
+        translationPending
+        fields {
+          blockName
+          slug
+          tests {
+            text
+            testString
+          }
         }
       }
     }

--- a/client/src/templates/Challenges/projects/frontend/Show.tsx
+++ b/client/src/templates/Challenges/projects/frontend/Show.tsx
@@ -76,7 +76,9 @@ class Project extends Component<ProjectProps> {
     const {
       challengeMounted,
       data: {
-        challengeNode: { title, challengeType, helpCategory }
+        challengeNode: {
+          challenge: { title, challengeType, helpCategory }
+        }
       },
       pageContext: { challengeMeta },
       updateChallengeMeta
@@ -94,13 +96,17 @@ class Project extends Component<ProjectProps> {
   componentDidUpdate(prevProps: ProjectProps): void {
     const {
       data: {
-        challengeNode: { title: prevTitle }
+        challengeNode: {
+          challenge: { title: prevTitle }
+        }
       }
     } = prevProps;
     const {
       challengeMounted,
       data: {
-        challengeNode: { title: currentTitle, challengeType, helpCategory }
+        challengeNode: {
+          challenge: { title: currentTitle, challengeType, helpCategory }
+        }
       },
       pageContext: { challengeMeta },
       updateChallengeMeta
@@ -130,15 +136,17 @@ class Project extends Component<ProjectProps> {
     const {
       data: {
         challengeNode: {
-          challengeType,
-          fields: { blockName },
-          forumTopicId,
-          title,
-          description,
-          instructions,
-          superBlock,
-          block,
-          translationPending
+          challenge: {
+            challengeType,
+            fields: { blockName },
+            forumTopicId,
+            title,
+            description,
+            instructions,
+            superBlock,
+            block,
+            translationPending
+          }
         }
       },
       isChallengeCompleted,
@@ -215,19 +223,21 @@ export default connect(
 
 export const query = graphql`
   query ProjectChallenge($slug: String!) {
-    challengeNode(fields: { slug: { eq: $slug } }) {
-      forumTopicId
-      title
-      description
-      instructions
-      challengeType
-      helpCategory
-      superBlock
-      block
-      translationPending
-      fields {
-        blockName
-        slug
+    challengeNode(challenge: { fields: { slug: { eq: $slug } } }) {
+      challenge {
+        forumTopicId
+        title
+        description
+        instructions
+        challengeType
+        helpCategory
+        superBlock
+        block
+        translationPending
+        fields {
+          blockName
+          slug
+        }
       }
     }
   }

--- a/client/src/templates/Challenges/video/Show.tsx
+++ b/client/src/templates/Challenges/video/Show.tsx
@@ -97,7 +97,9 @@ class ShowVideo extends Component<ShowVideoProps, ShowVideoState> {
     const {
       challengeMounted,
       data: {
-        challengeNode: { title, challengeType, helpCategory }
+        challengeNode: {
+          challenge: { title, challengeType, helpCategory }
+        }
       },
       pageContext: { challengeMeta },
       updateChallengeMeta
@@ -115,13 +117,17 @@ class ShowVideo extends Component<ShowVideoProps, ShowVideoState> {
   componentDidUpdate(prevProps: ShowVideoProps): void {
     const {
       data: {
-        challengeNode: { title: prevTitle }
+        challengeNode: {
+          challenge: { title: prevTitle }
+        }
       }
     } = prevProps;
     const {
       challengeMounted,
       data: {
-        challengeNode: { title: currentTitle, challengeType, helpCategory }
+        challengeNode: {
+          challenge: { title: currentTitle, challengeType, helpCategory }
+        }
       },
       pageContext: { challengeMeta },
       updateChallengeMeta
@@ -169,16 +175,18 @@ class ShowVideo extends Component<ShowVideoProps, ShowVideoState> {
     const {
       data: {
         challengeNode: {
-          fields: { blockName },
-          title,
-          description,
-          superBlock,
-          block,
-          translationPending,
-          videoId,
-          videoLocaleIds,
-          bilibiliIds,
-          question: { text, answers, solution }
+          challenge: {
+            fields: { blockName },
+            title,
+            description,
+            superBlock,
+            block,
+            translationPending,
+            videoId,
+            videoLocaleIds,
+            bilibiliIds,
+            question: { text, answers, solution }
+          }
         }
       },
       openCompletionModal,
@@ -313,34 +321,36 @@ export default connect(
 
 export const query = graphql`
   query VideoChallenge($slug: String!) {
-    challengeNode(fields: { slug: { eq: $slug } }) {
-      videoId
-      videoLocaleIds {
-        espanol
-        italian
-        portuguese
+    challengeNode(challenge: { fields: { slug: { eq: $slug } } }) {
+      challenge {
+        videoId
+        videoLocaleIds {
+          espanol
+          italian
+          portuguese
+        }
+        bilibiliIds {
+          aid
+          bvid
+          cid
+        }
+        title
+        description
+        challengeType
+        helpCategory
+        superBlock
+        block
+        fields {
+          blockName
+          slug
+        }
+        question {
+          text
+          answers
+          solution
+        }
+        translationPending
       }
-      bilibiliIds {
-        aid
-        bvid
-        cid
-      }
-      title
-      description
-      challengeType
-      helpCategory
-      superBlock
-      block
-      fields {
-        blockName
-        slug
-      }
-      question {
-        text
-        answers
-        solution
-      }
-      translationPending
     }
   }
 `;

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -101,7 +101,7 @@ export class Block extends Component<BlockProps> {
     } = this.props;
 
     let completedCount = 0;
-    const challengesWithCompleted = challenges.map(challenge => {
+    const challengesWithCompleted = challenges.map(({ challenge }) => {
       const { id } = challenge;
       const isCompleted = completedChallengeIds.some(
         (completedChallengeId: string) => completedChallengeId === id
@@ -112,7 +112,7 @@ export class Block extends Component<BlockProps> {
       return { ...challenge, isCompleted };
     });
 
-    const isProjectBlock = challenges.some(challenge => {
+    const isProjectBlock = challenges.some(({ challenge }) => {
       const isJsProject =
         challenge.order === 10 && challenge.challengeType === 5;
 

--- a/client/src/templates/Introduction/intro.tsx
+++ b/client/src/templates/Introduction/intro.tsx
@@ -21,7 +21,7 @@ function renderMenuItems({
   edges?: Array<{ node: ChallengeNode }>;
 }) {
   return edges
-    .map(({ node }) => node)
+    .map(({ node: { challenge } }) => challenge)
     .map(({ title, fields: { slug } }) => (
       <Link key={'intro-' + slug} to={slug}>
         <ListGroupItem>{title}</ListGroupItem>
@@ -42,7 +42,8 @@ function IntroductionPage({
     html,
     frontmatter: { block }
   } = markdownRemark;
-  const firstLesson = allChallengeNode && allChallengeNode.edges[0].node;
+  const firstLesson =
+    allChallengeNode && allChallengeNode.edges[0].node.challenge;
   const firstLessonPath = firstLesson
     ? firstLesson.fields.slug
     : '/strange-place';
@@ -97,15 +98,23 @@ export const query = graphql`
       html
     }
     allChallengeNode(
-      filter: { block: { eq: $block } }
-      sort: { fields: [superOrder, order, challengeOrder] }
+      filter: { challenge: { block: { eq: $block } } }
+      sort: {
+        fields: [
+          challenge___superOrder
+          challenge___order
+          challenge___challengeOrder
+        ]
+      }
     ) {
       edges {
         node {
-          fields {
-            slug
+          challenge {
+            fields {
+              slug
+            }
+            title
           }
-          title
         }
       }
     }

--- a/client/src/templates/Introduction/super-block-intro.tsx
+++ b/client/src/templates/Introduction/super-block-intro.tsx
@@ -141,15 +141,15 @@ const SuperBlockIntroductionPage = (props: SuperBlockProp) => {
     if (isSignedIn) {
       // see if currentChallenge is in this superBlock
       const currentChallengeEdge = edges.find(
-        edge => edge.node.id === currentChallengeId
+        edge => edge.node.challenge.id === currentChallengeId
       );
 
       return currentChallengeEdge
-        ? currentChallengeEdge.node.block
-        : edge.node.block;
+        ? currentChallengeEdge.node.challenge.block
+        : edge.node.challenge.block;
     }
 
-    return edge.node.block;
+    return edge.node.challenge.block;
   };
 
   const initializeExpandedState = () => {
@@ -173,7 +173,9 @@ const SuperBlockIntroductionPage = (props: SuperBlockProp) => {
   } = props;
 
   const nodesForSuperBlock = edges.map(({ node }) => node);
-  const blockDashedNames = uniq(nodesForSuperBlock.map(({ block }) => block));
+  const blockDashedNames = uniq(
+    nodesForSuperBlock.map(({ challenge: { block } }) => block)
+  );
   const i18nSuperBlock = t(`intro:${superBlock}.title`);
   const i18nTitle =
     superBlock === SuperBlocks.CodingInterviewPrep
@@ -206,7 +208,7 @@ const SuperBlockIntroductionPage = (props: SuperBlockProp) => {
                   <Block
                     blockDashedName={blockDashedName}
                     challenges={nodesForSuperBlock.filter(
-                      node => node.block === blockDashedName
+                      node => node.challenge.block === blockDashedName
                     )}
                     superBlock={superBlock}
                   />
@@ -263,22 +265,30 @@ export const query = graphql`
       }
     }
     allChallengeNode(
-      sort: { fields: [superOrder, order, challengeOrder] }
-      filter: { superBlock: { eq: $superBlock } }
+      sort: {
+        fields: [
+          challenge___superOrder
+          challenge___order
+          challenge___challengeOrder
+        ]
+      }
+      filter: { challenge: { superBlock: { eq: $superBlock } } }
     ) {
       edges {
         node {
-          fields {
-            slug
-            blockName
+          challenge {
+            fields {
+              slug
+              blockName
+            }
+            id
+            block
+            challengeType
+            title
+            order
+            superBlock
+            dashedName
           }
-          id
-          block
-          challengeType
-          title
-          order
-          superBlock
-          dashedName
         }
       }
     }

--- a/client/utils/gatsby/challenge-page-creator.js
+++ b/client/utils/gatsby/challenge-page-creator.js
@@ -45,12 +45,12 @@ const views = {
 
 function getNextChallengePath(_node, index, nodeArray) {
   const next = nodeArray[index + 1];
-  return next ? next.node.fields.slug : '/learn';
+  return next ? next.node.challenge.fields.slug : '/learn';
 }
 
 function getPrevChallengePath(_node, index, nodeArray) {
   const prev = nodeArray[index - 1];
-  return prev ? prev.node.fields.slug : '/learn';
+  return prev ? prev.node.challenge.fields.slug : '/learn';
 }
 
 function getTemplateComponent(challengeType) {
@@ -58,7 +58,7 @@ function getTemplateComponent(challengeType) {
 }
 
 exports.createChallengePages = function (createPage) {
-  return function ({ node: challenge }, index, allChallengeEdges) {
+  return function ({ node: { challenge } }, index, allChallengeEdges) {
     const {
       superBlock,
       block,
@@ -103,8 +103,8 @@ function getProjectPreviewConfig(challenge, allChallengeEdges) {
   const { block, challengeOrder, usesMultifileEditor } = challenge;
 
   const challengesInBlock = allChallengeEdges
-    .filter(({ node }) => node.block === block)
-    .map(({ node }) => node);
+    .filter(({ node: { challenge } }) => challenge.block === block)
+    .map(({ node: { challenge } }) => challenge);
   const lastChallenge = challengesInBlock[challengesInBlock.length - 1];
   const solutionToLastChallenge = sortChallengeFiles(
     lastChallenge.solutions[0] ?? []


### PR DESCRIPTION
Instead of creating a Gatsby node with id of challenge.id, we create a
single node field that has all the challenge data.

While this makes the GraphQL queries more verbose, it means we're free
to create multiple nodes with the same challenge.id.

I think this is a smarter approach than https://github.com/freeCodeCamp/freeCodeCamp/pull/44418 which was my first attempt at this.