### PR TITLE
fix: rename superblock to use /2022/

### DIFF
--- a/client/i18n/locales/english/intro.json
+++ b/client/i18n/locales/english/intro.json
@@ -66,7 +66,7 @@
       }
     }
   },
-  "responsive-web-design-22": {
+  "2022/responsive-web-design": {
     "title": "Responsive Web Design",
     "intro": [
       "In this Responsive Web Design Certification, you'll learn the languages that developers use to build webpages: HTML (Hypertext Markup Language) for content, and CSS (Cascading Style Sheets) for design.",

--- a/client/src/pages/learn/2022/responsive-web-design/index.md
+++ b/client/src/pages/learn/2022/responsive-web-design/index.md
@@ -1,6 +1,6 @@
 ---
 title: Responsive Web Design
-superBlock: responsive-web-design-22
+superBlock: 2022/responsive-web-design
 certification: responsive-web-design
 ---
 

--- a/client/src/resources/cert-and-project-map.ts
+++ b/client/src/resources/cert-and-project-map.ts
@@ -5,7 +5,7 @@ const { showNewCurriculum } = envData;
 
 const responsiveWebBase =
   '/learn/responsive-web-design/responsive-web-design-projects';
-const responsiveWeb22Base = '/learn/responsive-web-design-22';
+const responsiveWeb22Base = '/learn/2022/responsive-web-design';
 const jsAlgoBase =
   '/learn/javascript-algorithms-and-data-structures/' +
   'javascript-algorithms-and-data-structures-projects';

--- a/client/utils/build-challenges.js
+++ b/client/utils/build-challenges.js
@@ -6,7 +6,6 @@ const envData = require('../../config/env.json');
 const {
   getChallengesForLang,
   createChallenge,
-  createCertification,
   challengesDir,
   getChallengesDirForLang
 } = require('../../curriculum/getChallenges');
@@ -26,11 +25,14 @@ exports.replaceChallengeNode = () => {
       `../../curriculum/challenges/_meta/${blockName}/meta.json`
     );
     delete require.cache[require.resolve(metaPath)];
-    const isCert = path.extname(filePath) === '.yml';
     const meta = require(metaPath);
-    return isCert
-      ? await createCertification(challengesDir, filePath, curriculumLocale)
-      : await createChallenge(challengesDir, filePath, curriculumLocale, meta);
+    // TODO: reimplement hot-reloading of certifications
+    return await createChallenge(
+      challengesDir,
+      filePath,
+      curriculumLocale,
+      meta
+    );
   };
 };
 

--- a/config/certification-settings.ts
+++ b/config/certification-settings.ts
@@ -117,7 +117,7 @@ export const superBlockCertTypeMap = {
 
   // post-modern
   // TODO: use enum
-  'responsive-web-design-22': certTypes.respWebDesign
+  '2022/responsive-web-design': certTypes.respWebDesign
 };
 
 export const certTypeIdMap = {

--- a/curriculum/challenges/_meta/build-a-personal-portfolio-webpage-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-personal-portfolio-webpage-project/meta.json
@@ -5,7 +5,7 @@
   "time": "30 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design-22",
+  "superBlock": "2022/responsive-web-design",
   "challengeOrder": [
     [
       "bd7158d8c242eddfaeb5bd13",

--- a/curriculum/challenges/_meta/build-a-personal-portfolio-webpage-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-personal-portfolio-webpage-project/meta.json
@@ -5,7 +5,7 @@
   "time": "30 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design",
+  "superBlock": "responsive-web-design-22",
   "challengeOrder": [
     [
       "bd7158d8c242eddfaeb5bd13",

--- a/curriculum/challenges/_meta/build-a-product-landing-page-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-product-landing-page-project/meta.json
@@ -5,7 +5,7 @@
   "time": "30 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design-22",
+  "superBlock": "2022/responsive-web-design",
   "challengeOrder": [
     [
       "587d78af367417b2b2512b04",

--- a/curriculum/challenges/_meta/build-a-product-landing-page-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-product-landing-page-project/meta.json
@@ -5,7 +5,7 @@
   "time": "30 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design",
+  "superBlock": "responsive-web-design-22",
   "challengeOrder": [
     [
       "587d78af367417b2b2512b04",

--- a/curriculum/challenges/_meta/build-a-survey-form-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-survey-form-project/meta.json
@@ -5,7 +5,7 @@
   "time": "30 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design",
+  "superBlock": "responsive-web-design-22",
   "challengeOrder": [
     [
       "587d78af367417b2b2512b03",

--- a/curriculum/challenges/_meta/build-a-survey-form-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-survey-form-project/meta.json
@@ -5,7 +5,7 @@
   "time": "30 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design-22",
+  "superBlock": "2022/responsive-web-design",
   "challengeOrder": [
     [
       "587d78af367417b2b2512b03",

--- a/curriculum/challenges/_meta/build-a-technical-documentation-page-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-technical-documentation-page-project/meta.json
@@ -5,7 +5,7 @@
   "time": "30 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design",
+  "superBlock": "responsive-web-design-22",
   "challengeOrder": [
     [
       "587d78b0367417b2b2512b05",

--- a/curriculum/challenges/_meta/build-a-technical-documentation-page-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-technical-documentation-page-project/meta.json
@@ -5,7 +5,7 @@
   "time": "30 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design-22",
+  "superBlock": "2022/responsive-web-design",
   "challengeOrder": [
     [
       "587d78b0367417b2b2512b05",

--- a/curriculum/challenges/_meta/build-a-tribute-page-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-tribute-page-project/meta.json
@@ -5,7 +5,7 @@
   "time": "30 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design",
+  "superBlock": "responsive-web-design-22",
   "challengeOrder": [
     [
       "bd7158d8c442eddfaeb5bd18",

--- a/curriculum/challenges/_meta/build-a-tribute-page-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-tribute-page-project/meta.json
@@ -5,7 +5,7 @@
   "time": "30 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design-22",
+  "superBlock": "2022/responsive-web-design",
   "challengeOrder": [
     [
       "bd7158d8c442eddfaeb5bd18",

--- a/curriculum/challenges/_meta/learn-accessibility-by-building-a-quiz/meta.json
+++ b/curriculum/challenges/_meta/learn-accessibility-by-building-a-quiz/meta.json
@@ -8,7 +8,7 @@
   "time": "5 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design-22",
+  "superBlock": "2022/responsive-web-design",
   "challengeOrder": [
     [
       "614ccc21ea91ef1736b9b578",

--- a/curriculum/challenges/_meta/learn-accessibility-by-building-a-quiz/meta.json
+++ b/curriculum/challenges/_meta/learn-accessibility-by-building-a-quiz/meta.json
@@ -8,7 +8,7 @@
   "time": "5 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design",
+  "superBlock": "responsive-web-design-22",
   "challengeOrder": [
     [
       "614ccc21ea91ef1736b9b578",

--- a/curriculum/challenges/_meta/learn-basic-css-by-building-a-cafe-menu/meta.json
+++ b/curriculum/challenges/_meta/learn-basic-css-by-building-a-cafe-menu/meta.json
@@ -8,7 +8,7 @@
   "time": "5 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design-22",
+  "superBlock": "2022/responsive-web-design",
   "isBeta": true,
   "challengeOrder": [
     [

--- a/curriculum/challenges/_meta/learn-basic-css-by-building-a-cafe-menu/meta.json
+++ b/curriculum/challenges/_meta/learn-basic-css-by-building-a-cafe-menu/meta.json
@@ -8,7 +8,7 @@
   "time": "5 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design",
+  "superBlock": "responsive-web-design-22",
   "isBeta": true,
   "challengeOrder": [
     [

--- a/curriculum/challenges/_meta/learn-css-animation-by-building-a-ferris-wheel/meta.json
+++ b/curriculum/challenges/_meta/learn-css-animation-by-building-a-ferris-wheel/meta.json
@@ -8,7 +8,7 @@
   "time": "5 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design",
+  "superBlock": "responsive-web-design-22",
   "challengeOrder": [
     [
       "6140c7e645d8e905819f1dd4",

--- a/curriculum/challenges/_meta/learn-css-animation-by-building-a-ferris-wheel/meta.json
+++ b/curriculum/challenges/_meta/learn-css-animation-by-building-a-ferris-wheel/meta.json
@@ -8,7 +8,7 @@
   "time": "5 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design-22",
+  "superBlock": "2022/responsive-web-design",
   "challengeOrder": [
     [
       "6140c7e645d8e905819f1dd4",

--- a/curriculum/challenges/_meta/learn-css-flexbox-by-building-a-photo-gallery/meta.json
+++ b/curriculum/challenges/_meta/learn-css-flexbox-by-building-a-photo-gallery/meta.json
@@ -8,7 +8,7 @@
   "time": "5 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design",
+  "superBlock": "responsive-web-design-22",
   "challengeOrder": [
     [
       "61537485c4f2a624f18d7794",

--- a/curriculum/challenges/_meta/learn-css-flexbox-by-building-a-photo-gallery/meta.json
+++ b/curriculum/challenges/_meta/learn-css-flexbox-by-building-a-photo-gallery/meta.json
@@ -8,7 +8,7 @@
   "time": "5 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design-22",
+  "superBlock": "2022/responsive-web-design",
   "challengeOrder": [
     [
       "61537485c4f2a624f18d7794",

--- a/curriculum/challenges/_meta/learn-css-grid-by-building-a-magazine/meta.json
+++ b/curriculum/challenges/_meta/learn-css-grid-by-building-a-magazine/meta.json
@@ -8,7 +8,7 @@
   "time": "5 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design-22",
+  "superBlock": "2022/responsive-web-design",
   "challengeOrder": [
     [
       "61437d575fb98f57fa8f7f36",

--- a/curriculum/challenges/_meta/learn-css-grid-by-building-a-magazine/meta.json
+++ b/curriculum/challenges/_meta/learn-css-grid-by-building-a-magazine/meta.json
@@ -8,7 +8,7 @@
   "time": "5 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design",
+  "superBlock": "responsive-web-design-22",
   "challengeOrder": [
     [
       "61437d575fb98f57fa8f7f36",

--- a/curriculum/challenges/_meta/learn-css-transforms-by-building-a-penguin/meta.json
+++ b/curriculum/challenges/_meta/learn-css-transforms-by-building-a-penguin/meta.json
@@ -8,7 +8,7 @@
   "time": "5 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design",
+  "superBlock": "responsive-web-design-22",
   "challengeOrder": [
     [
       "619665c9abd72906f3ad30f9",

--- a/curriculum/challenges/_meta/learn-css-transforms-by-building-a-penguin/meta.json
+++ b/curriculum/challenges/_meta/learn-css-transforms-by-building-a-penguin/meta.json
@@ -8,7 +8,7 @@
   "time": "5 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design-22",
+  "superBlock": "2022/responsive-web-design",
   "challengeOrder": [
     [
       "619665c9abd72906f3ad30f9",

--- a/curriculum/challenges/_meta/learn-css-variables-by-building-a-city-skyline/meta.json
+++ b/curriculum/challenges/_meta/learn-css-variables-by-building-a-city-skyline/meta.json
@@ -8,7 +8,7 @@
   "time": "5 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design-22",
+  "superBlock": "2022/responsive-web-design",
   "challengeOrder": [
     [
       "5d822fd413a79914d39e98c9",

--- a/curriculum/challenges/_meta/learn-css-variables-by-building-a-city-skyline/meta.json
+++ b/curriculum/challenges/_meta/learn-css-variables-by-building-a-city-skyline/meta.json
@@ -8,7 +8,7 @@
   "time": "5 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design",
+  "superBlock": "responsive-web-design-22",
   "challengeOrder": [
     [
       "5d822fd413a79914d39e98c9",

--- a/curriculum/challenges/_meta/learn-html-by-building-a-cat-photo-app/meta.json
+++ b/curriculum/challenges/_meta/learn-html-by-building-a-cat-photo-app/meta.json
@@ -8,7 +8,7 @@
   "time": "5 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design-22",
+  "superBlock": "2022/responsive-web-design",
   "challengeOrder": [
     [
       "5dc174fcf86c76b9248c6eb2",

--- a/curriculum/challenges/_meta/learn-html-by-building-a-cat-photo-app/meta.json
+++ b/curriculum/challenges/_meta/learn-html-by-building-a-cat-photo-app/meta.json
@@ -8,7 +8,7 @@
   "time": "5 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design",
+  "superBlock": "responsive-web-design-22",
   "challengeOrder": [
     [
       "5dc174fcf86c76b9248c6eb2",

--- a/curriculum/challenges/_meta/learn-html-forms-by-building-a-registration-form/meta.json
+++ b/curriculum/challenges/_meta/learn-html-forms-by-building-a-registration-form/meta.json
@@ -8,7 +8,7 @@
   "time": "5 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design-22",
+  "superBlock": "2022/responsive-web-design",
   "challengeOrder": [
     [
       "60eebd07ea685b0e777b5583",

--- a/curriculum/challenges/_meta/learn-html-forms-by-building-a-registration-form/meta.json
+++ b/curriculum/challenges/_meta/learn-html-forms-by-building-a-registration-form/meta.json
@@ -8,7 +8,7 @@
   "time": "5 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design",
+  "superBlock": "responsive-web-design-22",
   "challengeOrder": [
     [
       "60eebd07ea685b0e777b5583",

--- a/curriculum/challenges/_meta/learn-intermediate-css-by-building-a-picasso-painting/meta.json
+++ b/curriculum/challenges/_meta/learn-intermediate-css-by-building-a-picasso-painting/meta.json
@@ -8,7 +8,7 @@
   "time": "5 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design",
+  "superBlock": "responsive-web-design-22",
   "challengeOrder": [
     [
       "60b69a66b6ddb80858c51578",

--- a/curriculum/challenges/_meta/learn-intermediate-css-by-building-a-picasso-painting/meta.json
+++ b/curriculum/challenges/_meta/learn-intermediate-css-by-building-a-picasso-painting/meta.json
@@ -8,7 +8,7 @@
   "time": "5 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design-22",
+  "superBlock": "2022/responsive-web-design",
   "challengeOrder": [
     [
       "60b69a66b6ddb80858c51578",

--- a/curriculum/challenges/_meta/learn-more-about-css-pseudo-selectors-by-building-a-balance-sheet/meta.json
+++ b/curriculum/challenges/_meta/learn-more-about-css-pseudo-selectors-by-building-a-balance-sheet/meta.json
@@ -8,7 +8,7 @@
   "time": "5 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design",
+  "superBlock": "responsive-web-design-22",
   "challengeOrder": [
     [
       "6193d8081ec2531581ea7b98",

--- a/curriculum/challenges/_meta/learn-more-about-css-pseudo-selectors-by-building-a-balance-sheet/meta.json
+++ b/curriculum/challenges/_meta/learn-more-about-css-pseudo-selectors-by-building-a-balance-sheet/meta.json
@@ -8,7 +8,7 @@
   "time": "5 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design-22",
+  "superBlock": "2022/responsive-web-design",
   "challengeOrder": [
     [
       "6193d8081ec2531581ea7b98",

--- a/curriculum/challenges/_meta/learn-responsive-web-design-by-building-a-piano/meta.json
+++ b/curriculum/challenges/_meta/learn-responsive-web-design-by-building-a-piano/meta.json
@@ -8,7 +8,7 @@
   "time": "5 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design",
+  "superBlock": "responsive-web-design-22",
   "challengeOrder": [
     [
       "612e6afc009b450a437940a1",

--- a/curriculum/challenges/_meta/learn-responsive-web-design-by-building-a-piano/meta.json
+++ b/curriculum/challenges/_meta/learn-responsive-web-design-by-building-a-piano/meta.json
@@ -8,7 +8,7 @@
   "time": "5 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design-22",
+  "superBlock": "2022/responsive-web-design",
   "challengeOrder": [
     [
       "612e6afc009b450a437940a1",

--- a/curriculum/challenges/_meta/learn-the-css-box-model-by-building-a-rothko-painting/meta.json
+++ b/curriculum/challenges/_meta/learn-the-css-box-model-by-building-a-rothko-painting/meta.json
@@ -8,7 +8,7 @@
   "time": "5 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design",
+  "superBlock": "responsive-web-design-22",
   "challengeOrder": [
     [
       "60a3e3396c7b40068ad6996a",

--- a/curriculum/challenges/_meta/learn-the-css-box-model-by-building-a-rothko-painting/meta.json
+++ b/curriculum/challenges/_meta/learn-the-css-box-model-by-building-a-rothko-painting/meta.json
@@ -8,7 +8,7 @@
   "time": "5 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design-22",
+  "superBlock": "2022/responsive-web-design",
   "challengeOrder": [
     [
       "60a3e3396c7b40068ad6996a",

--- a/curriculum/challenges/_meta/learn-typography-by-building-a-nutrition-label/meta.json
+++ b/curriculum/challenges/_meta/learn-typography-by-building-a-nutrition-label/meta.json
@@ -8,7 +8,7 @@
   "time": "5 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design-22",
+  "superBlock": "2022/responsive-web-design",
   "challengeOrder": [
     [
       "615f2abbe7d18d49a1e0e1c8",

--- a/curriculum/challenges/_meta/learn-typography-by-building-a-nutrition-label/meta.json
+++ b/curriculum/challenges/_meta/learn-typography-by-building-a-nutrition-label/meta.json
@@ -8,7 +8,7 @@
   "time": "5 hours",
   "template": "",
   "required": [],
-  "superBlock": "responsive-web-design",
+  "superBlock": "responsive-web-design-22",
   "challengeOrder": [
     [
       "615f2abbe7d18d49a1e0e1c8",

--- a/curriculum/getChallenges.js
+++ b/curriculum/getChallenges.js
@@ -383,4 +383,3 @@ function getBlockNameFromPath(filePath) {
 exports.hasEnglishSource = hasEnglishSource;
 exports.parseTranslation = parseTranslation;
 exports.createChallenge = createChallenge;
-exports.createCertification = createCertification;

--- a/curriculum/getChallenges.js
+++ b/curriculum/getChallenges.js
@@ -254,15 +254,16 @@ async function parseTranslation(transPath, dict, lang, parse = parseMD) {
     : translatedChal;
 }
 
+// eslint-disable-next-line no-unused-vars
 async function createCertification(basePath, filePath, lang) {
   function getFullPath(pathLang) {
     return path.resolve(__dirname, basePath, pathLang, filePath);
   }
-  const { name: superBlock } = superBlockInfoFromPath(filePath);
-  const useEnglish = lang === 'english' || !isAuditedCert(lang, superBlock);
-  return useEnglish
-    ? parseCert(getFullPath('english'))
-    : parseCert(getFullPath(lang));
+  // TODO: restart using isAudited() once we can determine a) the superBlocks
+  // (plural) a certification belongs to and b) get that info from the parsed
+  // certification, rather than the path. ASSUMING that this is used by the
+  // client.  If not, delete this comment and the lang param.
+  return parseCert(getFullPath('english'));
 }
 
 async function createChallenge(basePath, filePath, lang, maybeMeta) {

--- a/curriculum/getChallenges.js
+++ b/curriculum/getChallenges.js
@@ -159,7 +159,7 @@ exports.getChallengesForLang = async function getChallengesForLang(lang) {
   const curriculum = await walk(
     root,
     {},
-    { type: 'directories', depth: 1 },
+    { type: 'directories', depth: 0 },
     buildSuperBlocks
   );
   const cb = (file, curriculum) => buildChallenges(file, curriculum, lang);
@@ -172,57 +172,55 @@ exports.getChallengesForLang = async function getChallengesForLang(lang) {
   );
 };
 
-async function buildBlocks({ basename: blockName }, curriculum, superBlock) {
-  // TODO: this is a hack to avoid fetching the meta for the certifications.
-  // Instead, the certifications should be moved from the challenges directory
-  // and handled separately.
-  if (superBlock === 'certifications') {
-    curriculum[superBlock].blocks[blockName] = { challenges: [] };
-    return;
-  }
+async function buildBlocks({ basename: blockName }, curriculum, baseDir) {
   const metaPath = path.resolve(
     __dirname,
     `./challenges/_meta/${blockName}/meta.json`
   );
-  const blockMeta = require(metaPath);
-  const { isUpcomingChange } = blockMeta;
-  if (typeof isUpcomingChange !== 'boolean') {
-    throw Error(
-      `meta file at ${metaPath} is missing 'isUpcomingChange', it must be 'true' or 'false'`
-    );
-  }
+  let blockMeta;
+  try {
+    blockMeta = require(metaPath);
+    const { isUpcomingChange } = blockMeta;
+    if (typeof isUpcomingChange !== 'boolean') {
+      throw Error(
+        `meta file at ${metaPath} is missing 'isUpcomingChange', it must be 'true' or 'false'`
+      );
+    }
 
-  if (!isUpcomingChange || showUpcomingChanges) {
-    // add the block to the superBlock
-    const blockInfo = { meta: blockMeta, challenges: [] };
-    curriculum[superBlock].blocks[blockName] = blockInfo;
+    if (!isUpcomingChange || showUpcomingChanges) {
+      // add the block to the superBlock
+      const blockInfo = { meta: blockMeta, challenges: [] };
+      curriculum[baseDir].blocks[blockName] = blockInfo;
+    }
+  } catch (e) {
+    curriculum['00-certifications'].blocks[blockName] = { challenges: [] };
   }
 }
 
 async function buildSuperBlocks({ path, fullPath }, curriculum) {
-  const { order, name: superBlock } = superBlockInfo(path);
-  curriculum[superBlock] = { superBlock, order, blocks: {} };
+  const baseDir = getBaseDir(path);
+  curriculum[baseDir] = { blocks: {} };
 
-  const cb = (file, curriculum) => buildBlocks(file, curriculum, superBlock);
+  const cb = (file, curriculum) => buildBlocks(file, curriculum, baseDir);
   return walk(fullPath, curriculum, { depth: 1, type: 'directories' }, cb);
 }
 
 async function buildChallenges({ path: filePath }, curriculum, lang) {
   // path is relative to getChallengesDirForLang(lang)
   const block = getBlockNameFromPath(filePath);
-  const { name: superBlock } = superBlockInfoFromPath(filePath);
+  const baseDir = getBaseDir(filePath);
   let challengeBlock;
 
   // TODO: this try block and process exit can all go once errors terminate the
   // tests correctly.
   try {
-    challengeBlock = curriculum[superBlock].blocks[block];
+    challengeBlock = curriculum[baseDir].blocks[block];
     if (!challengeBlock) {
       // this should only happen when a isUpcomingChange block is skipped
       return;
     }
   } catch (e) {
-    console.log(`failed to create superBlock ${superBlock}`);
+    console.log(`failed to create superBlock from ${baseDir}`);
     // eslint-disable-next-line no-process-exit
     process.exit(1);
   }
@@ -232,7 +230,7 @@ async function buildChallenges({ path: filePath }, curriculum, lang) {
   // of the new curriculum when we don't want it.
   if (
     process.env.SHOW_NEW_CURRICULUM !== 'true' &&
-    superBlock === 'responsive-web-design-22'
+    meta?.superBlock === 'responsive-web-design-22'
   ) {
     return;
   }
@@ -280,7 +278,7 @@ async function createChallenge(basePath, filePath, lang, maybeMeta) {
     );
     meta = require(metaPath);
   }
-  const { name: superBlock } = superBlockInfoFromPath(filePath);
+  const { superBlock } = meta;
   if (!curriculumLangs.includes(lang))
     throw Error(`${lang} is not a accepted language.
   Trying to parse ${filePath}`);
@@ -372,22 +370,9 @@ async function hasEnglishSource(basePath, translationPath) {
     .catch(() => false);
 }
 
-function superBlockInfoFromPath(filePath) {
-  const [maybeSuper] = filePath.split(path.sep);
-  return superBlockInfo(maybeSuper);
-}
-
-function superBlockInfo(fileName) {
-  const [maybeOrder, ...superBlock] = fileName.split('-');
-  let order = parseInt(maybeOrder, 10);
-  if (isNaN(order)) {
-    return { order: 0, name: fileName };
-  } else {
-    return {
-      order: order,
-      name: superBlock.join('-')
-    };
-  }
+function getBaseDir(filePath) {
+  const [baseDir] = filePath.split(path.sep);
+  return [baseDir];
 }
 
 function getBlockNameFromPath(filePath) {

--- a/curriculum/getChallenges.js
+++ b/curriculum/getChallenges.js
@@ -372,7 +372,7 @@ async function hasEnglishSource(basePath, translationPath) {
 
 function getBaseDir(filePath) {
   const [baseDir] = filePath.split(path.sep);
-  return [baseDir];
+  return baseDir;
 }
 
 function getBlockNameFromPath(filePath) {

--- a/curriculum/getChallenges.js
+++ b/curriculum/getChallenges.js
@@ -230,7 +230,7 @@ async function buildChallenges({ path: filePath }, curriculum, lang) {
   // of the new curriculum when we don't want it.
   if (
     process.env.SHOW_NEW_CURRICULUM !== 'true' &&
-    meta?.superBlock === 'responsive-web-design-22'
+    meta?.superBlock === '2022/responsive-web-design'
   ) {
     return;
   }
@@ -323,7 +323,7 @@ ${getFullPath('english')}
    field to track which certification this belongs to. */
   // TODO: generalize this to all superBlocks
   challenge.certification =
-    superBlock === 'responsive-web-design-22'
+    superBlock === '2022/responsive-web-design'
       ? 'responsive-web-design'
       : superBlock;
   challenge.superBlock = superBlock;

--- a/curriculum/utils.js
+++ b/curriculum/utils.js
@@ -36,7 +36,7 @@ const superBlockToOrder = {
 };
 
 const superBlockToNewOrder = {
-  'responsive-web-design-22': 0,
+  '2022/responsive-web-design': 0,
   'javascript-algorithms-and-data-structures': 1,
   'front-end-development-libraries': 2,
   'data-visualization': 3,

--- a/curriculum/utils.test.js
+++ b/curriculum/utils.test.js
@@ -38,7 +38,7 @@ describe('getSuperOrder', () => {
   it('returns a different order if passed the option showNewCurriculum: true', () => {
     expect.assertions(13);
     expect(
-      getSuperOrder('responsive-web-design-22', { showNewCurriculum: true })
+      getSuperOrder('2022/responsive-web-design', { showNewCurriculum: true })
     ).toBe(0);
     expect(
       getSuperOrder('javascript-algorithms-and-data-structures', {

--- a/cypress/integration/learn/challenges/projects.js
+++ b/cypress/integration/learn/challenges/projects.js
@@ -63,10 +63,12 @@ describe('project submission', () => {
     { browser: 'electron' },
     () => {
       cy.fixture('../../config/curriculum.json').then(curriculum => {
-        const { challenges, meta } =
-          curriculum['02-javascript-algorithms-and-data-structures'].blocks[
-            'javascript-algorithms-and-data-structures-projects'
-          ];
+        const targetBlock =
+          'javascript-algorithms-and-data-structures-projects';
+        const javaScriptSuperBlock = Object.values(curriculum).filter(
+          ({ blocks }) => blocks[targetBlock]
+        )[0];
+        const { challenges, meta } = javaScriptSuperBlock.blocks[targetBlock];
 
         const projectTitles = meta.challengeOrder.map(([, title]) => title);
         const projectsInOrder = projectTitles.map(projectTitle => {

--- a/cypress/integration/learn/challenges/projects.js
+++ b/cypress/integration/learn/challenges/projects.js
@@ -64,7 +64,7 @@ describe('project submission', () => {
     () => {
       cy.fixture('../../config/curriculum.json').then(curriculum => {
         const { challenges, meta } =
-          curriculum[SuperBlocks.JsAlgoDataStruct].blocks[
+          curriculum['02-javascript-algorithms-and-data-structures'].blocks[
             'javascript-algorithms-and-data-structures-projects'
           ];
 


### PR DESCRIPTION
I was going to just let us use the `superBlock` property (rather than the directory), but once I'd done that, I figured I might as well rename the slug while I'm at it.

As for the directory name: 14-responsive-web-design-22, we don't need the 22 any more.  I didn't rename that here, but it's just a organisational convenience now, so it can be whatever we like.

I've not done anything about the blocks, just superblocks.  But I think this is a step in the right direction.