### PR TITLE
docs: update guidlines for reporting security issues

### DIFF
--- a/HoF.md
+++ b/HoF.md
@@ -1,7 +1,0 @@
-# Responsible Disclosure
-
-We appreciate any responsible disclosure of vulnerabilities that might impact the integrity of our platforms and users. While we do not offer any bounties or swags at the moment, we are grateful to these awesome people for helping us keep the platform safe for everyone:
-
-- Mehul Mohan from [codedamn](https://codedamn.com) ([@mehulmpt](https://twitter.com/mehulmpt)) - [Vulnerability Fix](https://github.com/freeCodeCamp/freeCodeCamp/blob/bb5a9e815313f1f7c91338e171bfe5acb8f3e346/client/src/components/Flash/index.js)
-- Peter Samir https://www.linkedin.com/in/peter-samir/
-  > ### Thank you for your contributions :pray:

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ If you're confident it's a new bug and have confirmed that someone else is facin
 
 If you think you have found a vulnerability, _please report responsibly_. Don't create GitHub issues for security issues. Instead, please send an email to `security@freecodecamp.org` and we'll look into it immediately.
 
-We appreciate any responsible disclosure of vulnerabilities that might impact the integrity of our platforms and users. While we do not offer any bounties or swags at the moment, we'll be happy to list your name in our [Hall of Fame](HoF.md) for security researchers.
+We appreciate any responsible disclosure of vulnerabilities that might impact the integrity of our platforms and users. While we do not offer any bounties or swags at the moment, we'll be happy to list your name in our [Hall of Fame](https://contribute.freecodecamp.org/#/security-hall-of-fame) for security researchers.
 
 ### Contributing
 
@@ -178,7 +178,7 @@ The freeCodeCamp.org community is possible thanks to thousands of kind volunteer
 
 ### Platform, Build, and Deployment Status
 
-The general platform status for all our applications is available at [`status.freecodecamp.org`](https://status.freecodecamp.org). The build and deployment status for the code is available in [our DevOps Guide](/docs/devops.md).
+The general platform status for all our applications is available at [`status.freecodecamp.org`](https://status.freecodecamp.org). The build and deployment status for the code is available in [our DevOps Guide](https://contribute.freecodecamp.org/#/devops).
 
 ### License
 

--- a/docs/security-hall-of-fame.md
+++ b/docs/security-hall-of-fame.md
@@ -1,0 +1,12 @@
+# Responsible Disclosure - Hall of Fame
+
+We appreciate any responsible disclosure of vulnerabilities that might impact the integrity of our platforms and users.
+
+While we do not offer any bounties or swags at the moment, we are grateful to these awesome people for helping us keep the platform safe for everyone:
+
+- Mehul Mohan from [codedamn](https://codedamn.com) ([@mehulmpt](https://twitter.com/mehulmpt)) - [Vulnerability Fix](https://github.com/freeCodeCamp/freeCodeCamp/blob/bb5a9e815313f1f7c91338e171bfe5acb8f3e346/client/src/components/Flash/index.js)
+- Peter Samir https://www.linkedin.com/in/peter-samir/
+
+  > ### Thank you for your contributions :pray:
+
+If you are interested in contributing to the security of our platform, please read our [security policy outlined here](https://contribute.freecodecamp.org/#/security).

--- a/docs/security.md
+++ b/docs/security.md
@@ -14,6 +14,8 @@ This document outlines our security policy for the codebase, and how to report v
 
 If you think you have found a vulnerability, _please report responsibly_. Don't create GitHub issues for security issues. Instead, please send an email to `security@freecodecamp.org` and we'll look into it immediately.
 
-We appreciate any responsible disclosure of vulnerabilities that might impact the integrity of our platforms and users. While we do not offer any bounties or swags at the moment, we'll be happy to list your name in our [Hall of Fame](HoF.md) list.
+We appreciate any responsible disclosure of vulnerabilities that might impact the integrity of our platforms and users.
+
+While we do not offer any bounties or swags at the moment, we'll be happy to list your name in our [Hall of Fame](https://contribute.freecodecamp.org/#/security-hall-of-fame) list, provided the reports are not low-effort for example: using tools & online utilities to report SFP configurations, or SSL Server tests, etc. We consider those in the category of ["beg bounties"](https://www.troyhunt.com/beg-bounties/).
 
 Ensure that you are using the **latest**, **stable** and **updated** version of the Operating System and Web Browser available to you on your machine.


### PR DESCRIPTION
This update adds some quick notes about "beg bounties" and restructures the files a bit for use with both the contribute site and GitHub. We can deliberate on adding/removing things for example about guidelines about other platforms in a separate PR.
