### PR TITLE
fix: step-1 on practice projects crashing

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -907,8 +907,8 @@ const Editor = (props: EditorProps): JSX.Element => {
     if (!previewOpen && showProjectPreview) {
       const description = document.getElementsByClassName(
         'description-container'
-      )[0];
-      description.classList.add('description-highlighter');
+      )?.[0];
+      description?.classList.add('description-highlighter');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.previewOpen]);


### PR DESCRIPTION
issue (described in chat):
1) Go to [step-1](https://www.freecodecamp.dev/learn/2022/responsive-web-design/learn-css-transforms-by-building-a-penguin/step-1) of any practice project
2) Close and open the index.html file
3) Crash

A couple quick tests, this appears to fix it.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
