### PR TITLE
fix: footer showing up on new RWD challenges

### DIFF
--- a/client/src/utils/path-parsers.test.ts
+++ b/client/src/utils/path-parsers.test.ts
@@ -7,11 +7,23 @@ const pathnames = {
     challenge:
       '/learn/responsive-web-design/basic-html-and-html5/say-hello-to-html-elements'
   },
+  englishWithYear: {
+    landing: '/',
+    superBlock: '/learn/2022/responsive-web-design',
+    challenge:
+      '/learn/2022/responsive-web-design/basic-html-and-html5/say-hello-to-html-elements'
+  },
   espanol: {
     landing: '/espanol',
     superBlock: '/espanol/learn/responsive-web-design',
     challenge:
       '/espanol/learn/responsive-web-design/basic-html-and-html5/say-hello-to-html-elements'
+  },
+  espanolWithYear: {
+    landing: '/espanol',
+    superBlock: '/espanol/learn/2022/responsive-web-design',
+    challenge:
+      '/espanol/learn/2022/responsive-web-design/basic-html-and-html5/say-hello-to-html-elements'
   }
 };
 
@@ -37,6 +49,12 @@ describe('isLanding', () => {
   it('returns false for English challenge pathname', () => {
     expect(isLanding(pathnames.english.challenge)).toBe(false);
   });
+  it('returns false for English with year challenge pathname', () => {
+    expect(isLanding(pathnames.englishWithYear.challenge)).toBe(false);
+  });
+  it('returns false for Espanol with year challenge pathname', () => {
+    expect(isLanding(pathnames.espanolWithYear.challenge)).toBe(false);
+  });
 });
 
 describe('isChallenge', () => {
@@ -60,5 +78,11 @@ describe('isChallenge', () => {
   });
   it('returns true for English challenge pathname', () => {
     expect(isChallenge(pathnames.english.challenge)).toBe(true);
+  });
+  it('returns true for English with year challenge pathname', () => {
+    expect(isChallenge(pathnames.englishWithYear.challenge)).toBe(true);
+  });
+  it('returns true for Espanol with year challenge pathname', () => {
+    expect(isChallenge(pathnames.espanolWithYear.challenge)).toBe(true);
   });
 });

--- a/client/src/utils/path-parsers.ts
+++ b/client/src/utils/path-parsers.ts
@@ -7,8 +7,14 @@ const splitPath = (pathname: string): string[] =>
 export const isChallenge = (pathname: string): boolean => {
   const pathArray = splitPath(pathname);
   return (
-    (pathArray.length === 4 && pathArray[0]) === 'learn' ||
-    (pathArray.length === 5 && pathArray[1]) === 'learn'
+    // learn/<superBlock>/<block>/<challenge>
+    (pathArray.length === 4 && pathArray[0] === 'learn') ||
+    // learn/<year>/<superBlock>/<block>/<challenge>
+    (pathArray.length === 5 && pathArray[0] === 'learn') ||
+    // <i18n>/learn/<superBlock>/<block>/<challenge>
+    (pathArray.length === 5 && pathArray[1] === 'learn') ||
+    // <i18n>/learn/<year>/<superBlock>/<block>/<challenge>
+    (pathArray.length === 6 && pathArray[1] === 'learn')
   );
 };
 


### PR DESCRIPTION
The footer is showing up on new challenges. See [challenge](https://www.freecodecamp.dev/learn/2022/responsive-web-design/learn-typography-by-building-a-nutrition-label/step-15). This should fix it.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
