### PR TITLE
fix: make beta go to RWD superblock instead of learn

### DIFF
--- a/client/src/templates/Introduction/components/legacy-links.tsx
+++ b/client/src/templates/Introduction/components/legacy-links.tsx
@@ -16,7 +16,7 @@ function LegacyLinks({ superBlock }: LegacyLinksProps): JSX.Element {
         <Alert bsStyle='info'>
           <p>
             {t('intro:misc-text.viewing-upcoming-change')}{' '}
-            <Link sameTab={false} to={`/learn/`}>
+            <Link sameTab={false} to={`/learn/responsive-web-design`}>
               {t('intro:misc-text.go-back-to-learn')}
             </Link>
           </p>


### PR DESCRIPTION
Not sure if we want this one, maybe there was a reason it's this way - so feel free to deny the change. But, the link to "The stable version of the challenges" goes to /learn. This makes it go to the current (soon-to-be legacy) superblock - which feels more appropriate. Pretty minor.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
