### PR TITLE
fix: sideways checkmarks on blocks

### DIFF
--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -208,7 +208,7 @@ button.map-title {
   stroke: var(--color-quaternary);
 }
 
-.open > .map-title svg:first-child {
+.open > .map-title > svg:first-child {
   transform: rotate(90deg);
 }
 


### PR DESCRIPTION
issue - the checkmark is sideways when block is expanded:

![Screen Shot 2021-12-23 at 8 43 14 AM](https://user-images.githubusercontent.com/20648924/147260315-22a07c45-131a-4dd3-9999-3d05594918b8.png)


<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
