### PR TITLE
fix(curriculum): remove extra "\" from description

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/step-004.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/step-004.md
@@ -9,7 +9,7 @@ dashedName: step-4
 
 Commenting allows you to leave messages without affecting the browser display. It also allows you to make code inactive. A comment in HTML starts with `<!--`, contains any number of lines of text, and ends with `-->`. For example, the comment `<!-- TODO: Remove h1 -->` contains the text `TODO: Remove h1`.
 
-Add a comment above the `p` element with the text `TODO: Add link to cat photos`. \\
+Add a comment above the `p` element with the text `TODO: Add link to cat photos`.
 
 # --hints--
 


### PR DESCRIPTION
Noticed an extra "\\" in the text file on cat photo step description on beta course 

https://www.freecodecamp.org/learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-4

before 

<img width="715" alt="Screen Shot 2021-12-29 at 4 42 04 PM" src="https://user-images.githubusercontent.com/5950956/147708635-3be01a31-f597-458e-b9c2-60681e4be57c.png">

after (removed excess "\\")

<img width="725" alt="Screen Shot 2021-12-29 at 5 10 55 PM" src="https://user-images.githubusercontent.com/5950956/147709774-d4950552-7b08-479d-8ded-a3920ce93f73.png">

To test: 

- I updated the `.env` variable of `SHOW_NEW_CURRICULUM=true`

Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod. 
