### PR TITLE
Removed an unnecessary word in "Learn HTML by Building a Cat Photo App" - Step 36

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/step-036.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/step-036.md
@@ -7,7 +7,7 @@ dashedName: step-36
 
 # --description--
 
-The `input` element offers you several ways to collect data from a web form. Like anchor (`a`) elements, `input` elements are <dfn>self-closing</dfn> and do not need closing tags.
+The `input` element allows you several ways to collect data from a web form. Like anchor (`a`) elements, `input` elements are <dfn>self-closing</dfn> and do not need closing tags.
 
 Nest an `input` element in the `form` element.
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/step-036.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/step-036.md
@@ -7,7 +7,7 @@ dashedName: step-36
 
 # --description--
 
-The `input` element is allows you several ways to collect data from a web form. Like anchor (`a`) elements, `input` elements are <dfn>self-closing</dfn> and do not need closing tags.
+The `input` element offers you several ways to collect data from a web form. Like anchor (`a`) elements, `input` elements are <dfn>self-closing</dfn> and do not need closing tags.
 
 Nest an `input` element in the `form` element.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #44618

#### Affected page
(https://www.freecodecamp.org/learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-36)

<!-- Feel free to add any additional description of changes below this line -->

The challenge description contains an unnecessary word:
The input element **~~is allows~~** you several ways to collect data from a web form. 

### The correct way can be:
**Proposal 1**: The input element **offers** you several ways to collect data from a web form. 