### PR TITLE
fix(curriculum): typos in Beta Colored Markers section

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/step-022.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/step-022.md
@@ -7,7 +7,7 @@ dashedName: step-22
 
 # --description--
 
-A function is a piece of code that can take an input and perform a specific action. The CSS `rgb` function accepts a values, or <dfn>arguments</dfn>, for red, green, and blue, and produces a color:
+A function is a piece of code that can take an input and perform a specific action. The CSS `rgb` function accepts values, or <dfn>arguments</dfn>, for red, green, and blue, and produces a color:
 
 ```css
 rgb(red, green, blue);

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/step-080.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/step-080.md
@@ -7,7 +7,7 @@ dashedName: step-80
 
 # --description--
 
-Borders have several styles to choose from. You can make your border a solid line, but can also go with a dashed or dotted line if you prefer. Solid border lines are probably the most common.
+Borders have several styles to choose from. You can make your border a solid line, but you can also use a dashed or dotted line if you prefer. Solid border lines are probably the most common.
 
 In the `.sleeve` CSS rule, add the `border-left-style` property with the value `solid`.
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/step-088.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/step-088.md
@@ -15,7 +15,7 @@ box-shadow: offsetX offsetY blurRadius color;
 
 If a `blurRadius` value isn't included, it defaults to `0` and produces sharp edges. The higher the value of `blurRadius`, the greater the blurring effect is.
 
-In the `.green` CSS rule, add the `box-shadow` property with the values `5px` for `offsetX`, `5px` for `offsetY`, `5px`, for `blurRadius`, and `green` for `color`.
+In the `.green` CSS rule, add the `box-shadow` property with the values `5px` for `offsetX`, `5px` for `offsetY`, `5px` for `blurRadius`, and `green` for `color`.
 
 # --hints--
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/step-089.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/step-089.md
@@ -17,7 +17,7 @@ Like `blurRadius`, `spreadRadius` defaults to `0` if it isn't included.
 
 Practice by adding a 5 pixel shadow directly around the blue marker.
 
-In the `.blue` CSS rule, add the `box-shadow` property with the values `0` for `offsetX`, `0` for `offsetY`, `0`, for `blurRadius`, `5px` for `spreadRadius`, and `blue` for `color`.
+In the `.blue` CSS rule, add the `box-shadow` property with the values `0` for `offsetX`, `0` for `offsetY`, `0` for `blurRadius`, `5px` for `spreadRadius`, and `blue` for `color`.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!-- Feel free to add any additional description of changes below this line -->

Step 22 Remove word: removed "a" from before the word "values"
Step 80 Add word & change words: added "you" before "can also go with" in the second sentence and replaced "go with" to "use"
Step 88 Remove character: removed the comma after 5px for the blur radius
Step 89 Remove character: removed the comma after 0 for the blur radius