### PR TITLE
fix(curriculum): allow usage of gray in css

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/step-081.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/step-081.md
@@ -23,7 +23,7 @@ assert(hasAVisited);
 You should set the `color` property to `grey`.
 
 ```js
-const hasColor = new __helpers.CSSHelp(document).getCSSRules().some(x => x.style.color === 'grey');
+const hasColor = new __helpers.CSSHelp(document).getCSSRules().some(x => (x.style.color === 'grey' || x.style.color === 'gray'));
 assert(hasColor);
 ```
 
@@ -31,7 +31,7 @@ Your `a:visited` should have a `color` of `grey`.
 
 ```js
 const aVisitedColor = new __helpers.CSSHelp(document).getStyle('a:visited')?.getPropertyValue('color');
-assert(aVisitedColor === 'grey');
+assert(aVisitedColor === 'grey' || aVisitedColor === 'gray');
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #44628

<!-- Feel free to add any additional description of changes below this line -->

Use || operator to allow for usage of "gray" or "grey" interchangeably in step 81 of "learn-basic-css-by-building-a-cafe-menu" of responsive web design 2022.
