### PR TITLE
Fix doctype regex in various RWD beta challenges

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/step-001.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/step-001.md
@@ -52,7 +52,7 @@ assert(code.match(/<\/html\s*>/gi));
 Your `html` element should be below the `DOCTYPE` declaration.
 
 ```js
-assert(code.match(/(?<!<html\s*>)<!DOCTYPE\s+html\s*>/gi));
+assert(code.match(/\s*<!DOCTYPE\s+html\s*>(\r?\n)+<\s*html\s*>/gi));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-flexbox-by-building-a-photo-gallery/step-001.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-flexbox-by-building-a-photo-gallery/step-001.md
@@ -50,7 +50,7 @@ assert(code.match(/<\/html\s*>/));
 Your `html` element should be below the `DOCTYPE` declaration.
 
 ```js
-assert(code.match(/(?<!<html\s*>)<!DOCTYPE\s+html\s*>/gi));
+assert(code.match(/\s*<!DOCTYPE\s+html\s*>(\r?\n)+<\s*html\s*>/gi));
 ```
 
 You should have an opening `head` tag.

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-grid-by-building-a-magazine/step-001.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-grid-by-building-a-magazine/step-001.md
@@ -52,7 +52,7 @@ assert(code.match(/<\/html\s*>/));
 Your `html` element should be below the `DOCTYPE` declaration.
 
 ```js
-assert(code.match(/(?<!<html\s*>)<!DOCTYPE\s+html\s*>/gi));
+assert(code.match(/\s*<!DOCTYPE\s+html\s*>(\r?\n)+<\s*html\s*>/gi));
 ```
 
 You should have an opening `head` tag.

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-variables-by-building-a-city-skyline/step-002.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-variables-by-building-a-city-skyline/step-002.md
@@ -14,7 +14,7 @@ Add opening and closing `html` tags below the `DOCTYPE` so you have a place to s
 Your `html` element should be below the `DOCTYPE` declaration.
 
 ```js
-assert(code.match(/(?<!<html\s*>)<!DOCTYPE\s+html\s*>/gi));
+assert(code.match(/\s*<!DOCTYPE\s+html\s*>(\r?\n)+<\s*html\s*>/gi));
 ```
 
 Your `html` element should have an opening tag.

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/step-002.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/step-002.md
@@ -14,7 +14,7 @@ Add opening and closing `html` tags below the `DOCTYPE` so you have a place to s
 Your `html` element should be below the `DOCTYPE` declaration.
 
 ```js
-assert(code.match(/(?<!<html\s*>)<!DOCTYPE\s+html\s*>/gi));
+assert(code.match(/\s*<!DOCTYPE\s+html\s*>(\r?\n)+<\s*html\s*>/gi));
 ```
 
 Your `html` element should have an opening tag.

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-intermediate-css-by-building-a-picasso-painting/step-001.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-intermediate-css-by-building-a-picasso-painting/step-001.md
@@ -38,7 +38,7 @@ assert(code.match(/html\s*>/gi));
 Your `html` element should be below the `DOCTYPE` declaration.
 
 ```js
-assert(code.match(/(?<!<html\s*>)<!DOCTYPE\s+html\s*>/gi));
+assert(code.match(/\s*<!DOCTYPE\s+html\s*>(\r?\n)+<\s*html\s*>/gi));
 ```
 
 Your `html` element should have an opening tag.

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-responsive-web-design-by-building-a-piano/step-001.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-responsive-web-design-by-building-a-piano/step-001.md
@@ -50,7 +50,7 @@ assert(code.match(/<\/html\s*>/));
 Your `html` element should be below the `DOCTYPE` declaration.
 
 ```js
-assert(code.match(/(?<!<html\s*>)<!DOCTYPE\s+html\s*>/gi));
+assert(code.match(/\s*<!DOCTYPE\s+html\s*>(\r?\n)+<\s*html\s*>/gi));
 ```
 
 You should have an opening `head` tag.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod. **tested in GitPod on Safari

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #44626

<!-- Feel free to add any additional description of changes below this line -->
Used @bbsmooth's regex/code `assert(code.match(/\s*<!DOCTYPE\s+html\s*>(\r?\n)+<\s*html\s*>/gi));` and updated the pages in RWD beta that contained the code for `Your `html` element should be below the `DOCTYPE` declaration.`

Pages changed: 
Build a Set of Colored Markers - Step 1
Build a Photo Gallery - Step 1
Build a Magazine - Step 1
Build a City Skyline - Step 2
Build a Registration Form - Step 2
Build a Picasso Painting - Step 1
Build a Piano - Step 1

Camper Cafe Menu and Cat Photo App dont have this specific check but have similar instruction wording to the other Challenges. Is this intentionally omitted? Should this check be included?