### PR TITLE
fix: clean tsconfig.buildinfo quietly

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "build:server": "cd ./api-server && npm run build",
     "clean": "npm-run-all clean:build-files clean:client clean:server clean:packages",
     "clean-and-develop": "npm run clean && npm ci && npm run develop",
-    "clean:build-files": "shx rm ./tools/tsconfig.tsbuildinfo",
+    "clean:build-files": "shx rm -f ./tools/tsconfig.tsbuildinfo",
     "clean:client": "cd ./client && npm run clean",
     "clean:curriculum": "shx rm ./config/curriculum.json",
     "clean:gatsby-site": "npm run clean:client",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Without the `-f` this errors out if you happen to have deleted the file and that error prevents the rest of the cleaning.

<!-- Feel free to add any additional description of changes below this line -->
