### PR TITLE
fix(curriculum): typos in Accessibility Quiz section

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/step-008.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/step-008.md
@@ -7,7 +7,7 @@ dashedName: step-8
 
 # --description--
 
-A useful property of an _SVG_ (scalable vector graphics) is that is contains a `path` attribute which allows the image to be scaled without affecting the resolution of the resultant image.
+A useful property of an _SVG_ (scalable vector graphics) is that it contains a `path` attribute which allows the image to be scaled without affecting the resolution of the resultant image.
 
 Currently, the `img` is assuming it's default size, which is too large. Correctly, scale the image using it's `id` as a selector, and setting the `width` to `max(100px, 18vw)`.
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/step-017.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/step-017.md
@@ -11,7 +11,7 @@ Typeface plays an important role in the accessibility of a page. Some fonts are 
 
 Change the font for both the `h1` and `h2` elements to `Verdana`, and use another sans-serif _web safe_ font as a fallback.
 
-Also, add a `border-bottom` of `4px solid #dfdfe2` to `h2` elements, to make the sections distinct.
+Also, add a `border-bottom` of `4px solid #dfdfe2` to `h2` elements to make the sections distinct.
 
 # --hints--
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/step-019.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/step-019.md
@@ -7,7 +7,7 @@ dashedName: step-19
 
 # --description--
 
-Filling out the content of the quiz, below the `#student-info`, add three `div` elements with a `class` of `info`.
+Filling out the content of the quiz, below `#student-info`, add three `div` elements with a `class` of `info`.
 
 Then, within each `div` nest one `label` element, and one `input` element.
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/step-020.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/step-020.md
@@ -9,7 +9,7 @@ dashedName: step-20
 
 It is important to link each `input` to the corresponding `label` element. This provides assistive technology users with a visual reference to the input.
 
-This is done, by giving the `label` a `for` attribute, which contains the `id` of the `input`.
+This is done by giving the `label` a `for` attribute, which contains the `id` of the `input`.
 
 This section will take a student's name, email address, and date of birth. Give the `label` elements appropriate `for` attributes, as well as text content. Then, link the `input` elements to the corresponding `label` elements.
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/step-028.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/step-028.md
@@ -9,7 +9,7 @@ dashedName: step-28
 
 Give each `fieldset` an adaquate `name` attribute. Then, give both unordered lists a `class` of `answers-list`.
 
-Finally, use the `legend` to caption the content of the `fieldset`, by placing a true/false question as the text content.
+Finally, use the `legend` to caption the content of the `fieldset` by placing a true/false question as the text content.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!-- Feel free to add any additional description of changes below this line -->

Step 8  Changed `is` to `it`
Step 17 Removed comma in the last sentence
Step 19 Removed the word `the` though I could have added the word `element` after `#student-info` as an alternate edit
Step 20 Removed commas after `This is done`
Step 28 Removed comma in the last sentence
