### PR TITLE
fix: ensure index.html is always first in source map

### DIFF
--- a/client/src/templates/Challenges/utils/build.js
+++ b/client/src/templates/Challenges/utils/build.js
@@ -44,7 +44,15 @@ const composeFunctions = (...fns) =>
 
 function buildSourceMap(challengeFiles) {
   // TODO: rename sources.index to sources.contents.
-  const source = challengeFiles.reduce(
+  // Make sure index.html is always first
+  let fixedChallengeFiles = challengeFiles;
+  if (
+    challengeFiles.length === 2 &&
+    challengeFiles[1].fileKey === 'indexhtml'
+  ) {
+    fixedChallengeFiles = [...challengeFiles].reverse();
+  }
+  const source = fixedChallengeFiles.reduce(
     (sources, challengeFile) => {
       sources.index += challengeFile.source || challengeFile.contents;
       sources.editableContents += challengeFile.editableContents || '';

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-animation-by-building-a-ferris-wheel/step-001.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-animation-by-building-a-ferris-wheel/step-001.md
@@ -51,10 +51,10 @@ Your `html` element should have a closing tag.
 assert(code.match(/<\/html\s*>/));
 ```
 
-Your `html` element should be below the `DOCTYPE` declaration.
+Your `DOCTYPE` declaration should be at the beginning of your HTML
 
 ```js
-assert(code.match(/\s*<!DOCTYPE\s+html\s*>(\r?\n)+<\s*html\s*>/gi));
+assert(__helpers.removeHtmlComments(code).match(/^\s*<!DOCTYPE\s+html\s*>/i));
 ```
 
 You should have an opening `head` tag.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This PR sets us up to finish [issue 44626](https://github.com/freeCodeCamp/freeCodeCamp/issues/44626) by ensuring that the HTML in index.html will always be processed first when building the source map. The `index` property on the source map contains a string that combines index.html and styles.css (which is then used for the assert tests in each step). Currently the order is determined by which file was edited last, with the the most recently edited file being placed **last** in the combined string. This is causing an issue when checking for proper placement of the DOCTYPE declaration. The user edits index.html to add the DOCTYPE, which places it after styles.css in the `index` string. By default, if styles.css does not have any content then the system adds `/*fcc*/` to styles.css, which then comes before the DOCTYPE declaration in the `index` string, adding extra complexity when checking that DOCTYPE is the first element in index.html.

Furthermore, while this DOCTYPE check is usually done during the first step in the course and the user has not been instructed to add anything to styles.css, they technically are able to, and this fix would allow the test to ignore anything they add there as well as anything adding in styles.css would come after the HTML in index.html.

I have also included a modified DOCTYPE test for the Ferris Wheel course so you can see what the new assert would look like and test it for yourselves. I will wait for this fix to be merged before fixing the other courses just in case this isn't approved or changes have been made that might affect how we do the tests.
