### PR TITLE
fix: keep challengeFile order on update

### DIFF
--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -232,7 +232,9 @@ export const reducer = handleActions(
       return {
         ...state,
         challengeFiles: state.challengeFiles.map(challengeFile =>
-          challengeFile.fileKey === fileKey ? { ...challengeFile, ...updates } : { ...challengeFile }
+          challengeFile.fileKey === fileKey
+            ? { ...challengeFile, ...updates }
+            : { ...challengeFile }
         )
       };
     },

--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -231,8 +231,8 @@ export const reducer = handleActions(
         );
       return {
         ...state,
-        challengeFiles: state.challengeFiles.map(file =>
-          file.fileKey === fileKey ? { ...file, ...updates } : { ...file }
+        challengeFiles: state.challengeFiles.map(challengeFile =>
+          challengeFile.fileKey === fileKey ? { ...challengeFile, ...updates } : { ...challengeFile }
         )
       };
     },

--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -231,13 +231,9 @@ export const reducer = handleActions(
         );
       return {
         ...state,
-        challengeFiles: [
-          ...state.challengeFiles.filter(x => x.fileKey !== fileKey),
-          {
-            ...state.challengeFiles.find(x => x.fileKey === fileKey),
-            ...updates
-          }
-        ]
+        challengeFiles: state.challengeFiles.map(file =>
+          file.fileKey === fileKey ? { ...file, ...updates } : { ...file }
+        )
       };
     },
     [actionTypes.storedCodeFound]: (state, { payload }) => ({


### PR DESCRIPTION
This is why https://github.com/freeCodeCamp/freeCodeCamp/pull/44720 was necessary. That PR is still good (it's safer to sort the challengeFiles before use).  We *also* should not be re-arranging them each time the user types in a different editor..