### PR TITLE
fix: handle the sorting of transformed files

### DIFF
--- a/client/gatsby-node.js
+++ b/client/gatsby-node.js
@@ -95,10 +95,12 @@ exports.createPages = function createPages({ graphql, actions, reporter }) {
                     contents
                     head
                     tail
+                    history
                   }
                   solutions {
                     contents
                     ext
+                    history
                   }
                   superBlock
                   superOrder

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -271,7 +271,6 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
       }
     } = this.props;
     initConsole('');
-    console.log('props', this.props);
     createFiles(challengeFiles ?? []);
     initTests(tests);
     if (showProjectPreview) openModal('projectPreview');

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -271,6 +271,7 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
       }
     } = this.props;
     initConsole('');
+    console.log('props', this.props);
     createFiles(challengeFiles ?? []);
     initTests(tests);
     if (showProjectPreview) openModal('projectPreview');
@@ -547,6 +548,7 @@ export const query = graphql`
           head
           tail
           editableRegionBoundaries
+          history
         }
       }
     }

--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -2,7 +2,6 @@ import { isEmpty } from 'lodash-es';
 import { createAction, handleActions } from 'redux-actions';
 
 import { getLines } from '../../../../../utils/get-lines';
-import { createPoly } from '../../../../../utils/polyvinyl';
 import { challengeTypes } from '../../../../utils/challenge-types';
 import { completedChallengesSelector } from '../../../redux';
 import { getTargetEditor } from '../utils/getTargetEditor';
@@ -58,12 +57,11 @@ export const sagas = [
   ...createCurrentChallengeSaga(actionTypes)
 ];
 
-// TODO: can createPoly handle editable region, rather than separating it?
 export const createFiles = createAction(
   actionTypes.createFiles,
   challengeFiles =>
     challengeFiles.map(challengeFile => ({
-      ...createPoly(challengeFile),
+      ...challengeFile,
       seed: challengeFile.contents.slice(),
       editableContents: getLines(
         challengeFile.contents,

--- a/client/utils/gatsby/challenge-page-creator.js
+++ b/client/utils/gatsby/challenge-page-creator.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const { createPoly } = require('../../../utils/polyvinyl');
 const { dasherize } = require('../../../utils/slugs');
 const { sortChallengeFiles } = require('../../../utils/sort-challengefiles');
 const { challengeTypes, viewTypes } = require('../challenge-types');
@@ -115,12 +114,10 @@ function getProjectPreviewConfig(challenge, allChallengeEdges) {
   const lastChallengeFiles = sortChallengeFiles(
     lastChallenge.challengeFiles ?? []
   );
-  const projectPreviewChallengeFiles = lastChallengeFiles.map((file, id) =>
-    createPoly({
-      ...file,
-      contents: solutionToLastChallenge[id]?.contents ?? file.contents
-    })
-  );
+  const projectPreviewChallengeFiles = lastChallengeFiles.map((file, id) => ({
+    ...file,
+    contents: solutionToLastChallenge[id]?.contents ?? file.contents
+  }));
 
   return {
     showProjectPreview:

--- a/curriculum/getChallenges.js
+++ b/curriculum/getChallenges.js
@@ -337,19 +337,15 @@ ${getFullPath('english')}
   challenge.translationPending =
     lang !== 'english' && !isAuditedCert(lang, superBlock);
   challenge.usesMultifileEditor = !!usesMultifileEditor;
-
-  return prepareChallenge(challenge);
-}
-
-// gets the challenge ready for sourcing into Gatsby
-function prepareChallenge(challenge) {
   if (challenge.challengeFiles) {
-    challenge.challengeFiles = filesToPolys(challenge.challengeFiles);
+    // The client expects the challengeFiles to be an array of polyvinyls
+    challenge.challengeFiles = challengeFilesToPolys(challenge.challengeFiles);
   }
+
   return challenge;
 }
 
-function filesToPolys(files) {
+function challengeFilesToPolys(files) {
   return files.reduce((challengeFiles, challengeFile) => {
     return [
       ...challengeFiles,
@@ -384,4 +380,4 @@ function getBlockNameFromPath(filePath) {
 exports.hasEnglishSource = hasEnglishSource;
 exports.parseTranslation = parseTranslation;
 exports.createChallenge = createChallenge;
-exports.filesToPolys = filesToPolys;
+exports.challengeFilesToPolys = challengeFilesToPolys;

--- a/curriculum/getChallenges.js
+++ b/curriculum/getChallenges.js
@@ -341,6 +341,11 @@ ${getFullPath('english')}
     // The client expects the challengeFiles to be an array of polyvinyls
     challenge.challengeFiles = challengeFilesToPolys(challenge.challengeFiles);
   }
+  if (challenge.solutions) {
+    // The test runner needs the solutions to be an array of polyvinyls so it
+    // can sort them correctly.
+    challenge.solutions = challengeFilesToPolys(challenge.solutions);
+  }
 
   return challenge;
 }
@@ -380,4 +385,3 @@ function getBlockNameFromPath(filePath) {
 exports.hasEnglishSource = hasEnglishSource;
 exports.parseTranslation = parseTranslation;
 exports.createChallenge = createChallenge;
-exports.challengeFilesToPolys = challengeFilesToPolys;

--- a/curriculum/getChallenges.js
+++ b/curriculum/getChallenges.js
@@ -341,7 +341,7 @@ ${getFullPath('english')}
     // The client expects the challengeFiles to be an array of polyvinyls
     challenge.challengeFiles = challengeFilesToPolys(challenge.challengeFiles);
   }
-  if (challenge.solutions) {
+  if (challenge.solutions?.length) {
     // The test runner needs the solutions to be arrays of polyvinyls so it
     // can sort them correctly.
     challenge.solutions = challenge.solutions.map(challengeFilesToPolys);

--- a/curriculum/getChallenges.js
+++ b/curriculum/getChallenges.js
@@ -342,9 +342,9 @@ ${getFullPath('english')}
     challenge.challengeFiles = challengeFilesToPolys(challenge.challengeFiles);
   }
   if (challenge.solutions) {
-    // The test runner needs the solutions to be an array of polyvinyls so it
+    // The test runner needs the solutions to be arrays of polyvinyls so it
     // can sort them correctly.
-    challenge.solutions = challengeFilesToPolys(challenge.solutions);
+    challenge.solutions = challenge.solutions.map(challengeFilesToPolys);
   }
 
   return challenge;

--- a/curriculum/getChallenges.js
+++ b/curriculum/getChallenges.js
@@ -344,20 +344,21 @@ ${getFullPath('english')}
 // gets the challenge ready for sourcing into Gatsby
 function prepareChallenge(challenge) {
   if (challenge.challengeFiles) {
-    challenge.challengeFiles = challenge.challengeFiles.reduce(
-      (challengeFiles, challengeFile) => {
-        return [
-          ...challengeFiles,
-          {
-            ...createPoly(challengeFile),
-            seed: challengeFile.contents.slice(0)
-          }
-        ];
-      },
-      []
-    );
+    challenge.challengeFiles = filesToPolys(challenge.challengeFiles);
   }
   return challenge;
+}
+
+function filesToPolys(files) {
+  return files.reduce((challengeFiles, challengeFile) => {
+    return [
+      ...challengeFiles,
+      {
+        ...createPoly(challengeFile),
+        seed: challengeFile.contents.slice(0)
+      }
+    ];
+  }, []);
 }
 
 async function hasEnglishSource(basePath, translationPath) {
@@ -383,3 +384,4 @@ function getBlockNameFromPath(filePath) {
 exports.hasEnglishSource = hasEnglishSource;
 exports.parseTranslation = parseTranslation;
 exports.createChallenge = createChallenge;
+exports.filesToPolys = filesToPolys;

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -48,7 +48,7 @@ const {
   getChallengesForLang,
   getMetaForBlock,
   getTranslatableComments,
-  filesToPolys
+  challengeFilesToPolys
 } = require('../getChallenges');
 const { challengeSchemaValidator } = require('../schema/challengeSchema');
 const { testedLang, getSuperOrder } = require('../utils');
@@ -529,7 +529,7 @@ ${inspect(commentMap)}
           // sortChallengeFiles relies on the history, which doesn't exist
           // before we make them into polyVinyls.
           const solutionsAsArrays = solutions
-            .map(filesToPolys)
+            .map(challengeFilesToPolys)
             .map(sortChallengeFiles);
 
           const filteredSolutions = solutionsAsArrays.filter(solution => {

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -47,8 +47,7 @@ const { sortChallengeFiles } = require('../../utils/sort-challengefiles');
 const {
   getChallengesForLang,
   getMetaForBlock,
-  getTranslatableComments,
-  challengeFilesToPolys
+  getTranslatableComments
 } = require('../getChallenges');
 const { challengeSchemaValidator } = require('../schema/challengeSchema');
 const { testedLang, getSuperOrder } = require('../utils');
@@ -526,13 +525,9 @@ ${inspect(commentMap)}
           // TODO: the no-solution filtering is a little convoluted:
           const noSolution = new RegExp('// solution required');
 
-          // sortChallengeFiles relies on the history, which doesn't exist
-          // before we make them into polyVinyls.
-          const solutionsAsArrays = solutions
-            .map(challengeFilesToPolys)
-            .map(sortChallengeFiles);
+          const sortedSolutions = solutions.map(sortChallengeFiles);
 
-          const filteredSolutions = solutionsAsArrays.filter(solution => {
+          const filteredSolutions = sortedSolutions.filter(solution => {
             return !isEmpty(
               solution.filter(
                 challengeFile => !noSolution.test(challengeFile.contents)

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -43,7 +43,6 @@ const testEvaluator =
 const { getLines } = require('../../utils/get-lines');
 const { isAuditedCert } = require('../../utils/is-audited');
 
-const { sortChallengeFiles } = require('../../utils/sort-challengefiles');
 const {
   getChallengesForLang,
   getMetaForBlock,
@@ -525,9 +524,7 @@ ${inspect(commentMap)}
           // TODO: the no-solution filtering is a little convoluted:
           const noSolution = new RegExp('// solution required');
 
-          const sortedSolutions = solutions.map(sortChallengeFiles);
-
-          const filteredSolutions = sortedSolutions.filter(solution => {
+          const filteredSolutions = solutions.filter(solution => {
             return !isEmpty(
               solution.filter(
                 challengeFile => !noSolution.test(challengeFile.contents)

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -47,7 +47,8 @@ const { sortChallengeFiles } = require('../../utils/sort-challengefiles');
 const {
   getChallengesForLang,
   getMetaForBlock,
-  getTranslatableComments
+  getTranslatableComments,
+  filesToPolys
 } = require('../getChallenges');
 const { challengeSchemaValidator } = require('../schema/challengeSchema');
 const { testedLang, getSuperOrder } = require('../utils');
@@ -525,7 +526,11 @@ ${inspect(commentMap)}
           // TODO: the no-solution filtering is a little convoluted:
           const noSolution = new RegExp('// solution required');
 
-          const solutionsAsArrays = solutions.map(sortChallengeFiles);
+          // sortChallengeFiles relies on the history, which doesn't exist
+          // before we make them into polyVinyls.
+          const solutionsAsArrays = solutions
+            .map(filesToPolys)
+            .map(sortChallengeFiles);
 
           const filteredSolutions = solutionsAsArrays.filter(solution => {
             return !isEmpty(

--- a/utils/sort-challengefiles.js
+++ b/utils/sort-challengefiles.js
@@ -1,16 +1,14 @@
 exports.sortChallengeFiles = function sortChallengeFiles(challengeFiles) {
   const xs = challengeFiles.slice();
-  // TODO: refactor this to use an ext array ['html', 'js', 'css'] and loop over
-  // that.
   xs.sort((a, b) => {
-    if (a.ext === 'html') return -1;
-    if (b.ext === 'html') return 1;
-    if (a.ext === 'css') return -1;
-    if (b.ext === 'css') return 1;
-    if (a.ext === 'jsx') return -1;
-    if (b.ext === 'jsx') return 1;
-    if (a.ext === 'js') return -1;
-    if (b.ext === 'js') return 1;
+    if (a.history[0] === 'index.html') return -1;
+    if (b.history[0] === 'index.html') return 1;
+    if (a.history[0] === 'styles.css') return -1;
+    if (b.history[0] === 'styles.css') return 1;
+    if (a.history[0] === 'index.jsx') return -1;
+    if (b.history[0] === 'index.jsx') return 1;
+    if (a.history[0] === 'script.js') return -1;
+    if (b.history[0] === 'script.js') return 1;
     return 0;
   });
   return xs;


### PR DESCRIPTION
We can't use the ext property, since that is transformed, but the history is maintained.

This PR should be merged before https://github.com/freeCodeCamp/freeCodeCamp/pull/44720