### PR TITLE
fix(curriculum): added test using a tree that is not a binary search tree

### DIFF
--- a/curriculum/challenges/english/10-coding-interview-prep/data-structures/check-if-binary-search-tree.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/data-structures/check-if-binary-search-tree.md
@@ -39,6 +39,24 @@ assert(
 );
 ```
 
+`isBinarySearchTree()` should return false when checked with a tree that is not a binary search tree.
+
+```js
+assert(
+  (function () {
+    var test = false;
+    if (typeof BinarySearchTree !== 'undefined') {
+      test = new BinarySearchTree();
+    } else {
+      return false;
+    }
+    test.push(1);
+    test.root.left = new Node(1);
+    return isBinarySearchTree(test) == false;
+  })()
+);
+```
+
 # --seed--
 
 ## --after-user-code--
@@ -114,7 +132,7 @@ function isBinarySearchTree(tree) {
     function checkTree(node) {
       if (node.left != null) {
         const left = node.left;
-        if (left.value > node.value) {
+        if (left.value >= node.value) {
           isBST = false;
         } else {
           checkTree(left);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->



<!-- Feel free to add any additional description of changes below this line -->

The challenge description states that the value of a left child node in a binary search tree should be less than the parent node value. The current solution does not set `isBST` to false if the `left.value === node.value`. I fixed this.

To test that the solution fails if there is a left node value that is equal to its parent value, I added another test with a tree where one node's left value is equal to its parent node value. 

This PR is not targeted to close a specific open issue.
