### PR TITLE
fix: keyboard accessibility on curriculum map

### DIFF
--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -307,11 +307,32 @@ fieldset[disabled] .btn-primary.focus {
   margin-left: 5px;
 }
 
-.link-btn:hover,
-.link-btn.btn-lg:hover svg {
+.link-btn:active {
+  background-color: var(--quaternary-background);
+}
+
+.link-btn:focus,
+.link-btn.btn-lg:focus svg {
   fill: var(--quaternary-background);
   background-color: var(--secondary-color);
+  border-color: var(--gray-45);
   color: var(--secondary-background);
+}
+
+.link-btn:focus:not(:focus-visible),
+.link-btn.btn-lg:focus:not(:focus-visible) svg {
+  background-color: var(--quaternary-background);
+  border-color: var(--secondary-color);
+  color: var(--secondary-color);
+  fill: var(--primary-color);
+}
+
+.link-btn:hover,
+.link-btn.btn-lg:hover svg {
+  fill: var(--quaternary-background) !important;
+  background-color: var(--secondary-color) !important;
+  border-color: var(--secondary-color) !important;
+  color: var(--secondary-background) !important;
 }
 
 .link-btn.btn-lg svg,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This one has been bothering me for a while :slightly_smiling_face: The keyboard focus outline for the big gray box links in the curriculum map are problematic. With chrome I can barely see a 1px thin outline embedded within the black border. But with firefox I cannot even see that, it's as if there is no outline at all. I've noticed that with most of the other interactive elements, the focus indicator is basically the same as the hover state. I have done the same thing here, reversing the colors for the focus indicator so that they match the hover state with the exception that the focus indicator has a slightly lighter border (to allow for a slight change if the user hovers over a link that currently has focus).
