### PR TITLE
fix(curriculum): fix casing of Dense keyword in quiz

### DIFF
--- a/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/natural-language-processing-with-rnns-sentimental-analysis.md
+++ b/curriculum/challenges/english/11-machine-learning-with-python/tensorflow/natural-language-processing-with-rnns-sentimental-analysis.md
@@ -20,7 +20,7 @@ Fill in the blanks below to create the model for the RNN:
 model = __A__.keras.Sequential([
     __A__.keras.layers.__B__(88584, 32),
     __A__.keras.layers.__C__(32),
-    __A__.keras.layers.DENSE(1, activation='sigmoid')
+    __A__.keras.layers.Dense(1, activation='sigmoid')
 ])
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

## Issue:
In the quiz the code below, it is written as : `__A__.keras.layers.DENSE(1, activation='sigmoid')`
But as far as I checked, Python is case sensitive and the correct code should be `Dense` instead.

## Affected page:
https://www.freecodecamp.org/learn/machine-learning-with-python/tensorflow/natural-language-processing-with-rnns-sentiment-analysis

![quiz](https://user-images.githubusercontent.com/25644062/149621185-fc149220-8df3-4d95-a37d-337069d40b53.png)

## References:
You can check the behavior with the Colab notebook provided for this video:
https://colab.research.google.com/drive/1ysEKrw_LE2jMndo1snrZUh5w87LQsCxk?usp=sharing

Keras API Reference: 
https://keras.io/api/layers/core_layers/dense/