### PR TITLE
fix(curriculum): move img tag to editable region

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-grid-by-building-a-magazine/step-024.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-grid-by-building-a-magazine/step-024.md
@@ -206,7 +206,7 @@ assert(document.querySelectorAll('.image-wrapper img')?.[2]?.getAttribute('heigh
           />
           <blockquote class="image-quote"></blockquote>
 --fcc-editable-region--
-<img />
+          <img />
 --fcc-editable-region--
         </aside>
       </section>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-grid-by-building-a-magazine/step-024.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-grid-by-building-a-magazine/step-024.md
@@ -205,9 +205,8 @@ assert(document.querySelectorAll('.image-wrapper img')?.[2]?.getAttribute('heigh
             height="400"
           />
           <blockquote class="image-quote"></blockquote>
-          <img />
 --fcc-editable-region--
-
+<img />
 --fcc-editable-region--
         </aside>
       </section>


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #44796

<!-- Feel free to add any additional description of changes below this line -->

The HTML tag `<img />` was moved from the HTML source code into the `fcc-editable-region` to make the lesson be more in line with previous lessons. Plus, the user would have had to remove ` />` from the tag and add it to the editor to pass the lesson.
