### PR TITLE
fix(curriculum): remove redundant part of description

### DIFF
--- a/curriculum/challenges/english/03-front-end-development-libraries/bootstrap/call-out-optional-actions-with-btn-info.md
+++ b/curriculum/challenges/english/03-front-end-development-libraries/bootstrap/call-out-optional-actions-with-btn-info.md
@@ -10,7 +10,7 @@ dashedName: call-out-optional-actions-with-btn-info
 
 Bootstrap comes with several pre-defined colors for buttons. The `btn-info` class is used to call attention to optional actions that the user can take.
 
-Create a new block-level Bootstrap button below your `Like` button with the text `Info`, and add Bootstrap's `btn-info` and `btn-block` classes to it.
+Create a new block-level Bootstrap button below your `Like` button with the text `Info`, and add Bootstrap's `btn-info` class to it.
 
 Note that these buttons still need the `btn` and `btn-block` classes.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->
<!-- Feel free to add any additional description of changes below this line -->

This fix removes a redund class that was added twice on the same exercice description.

I checked previous and following exercices to make sure the fix is according to what is generally done.
