### PR TITLE
fix(curriculum): typos in BETA  City Skyline section

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-variables-by-building-a-city-skyline/step-022.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-variables-by-building-a-city-skyline/step-022.md
@@ -7,7 +7,7 @@ dashedName: step-22
 
 # --description--
 
-Create a new variable by the other one called `--building-color2` and give it a value of `#66cc99`. Then set it as the `background-color` of `.bb2`.
+Create a new variable below the other one called `--building-color2` and give it a value of `#66cc99`. Then set it as the `background-color` of `.bb2`.
 
 # --hints--
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-variables-by-building-a-city-skyline/step-024.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-variables-by-building-a-city-skyline/step-024.md
@@ -7,7 +7,7 @@ dashedName: step-24
 
 # --description--
 
-Create a new variable by the other ones named `--building-color3` and give it a value of `#cc6699`. Then use it as the `background-color` of the `.bb3` class and give it a fallback value of `pink`.
+Create a new variable below the other ones named `--building-color3` and give it a value of `#cc6699`. Then use it as the `background-color` of the `.bb3` class and give it a fallback value of `pink`.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!-- Feel free to add any additional description of changes below this line -->

Steps 22 & 24:  Changed the word `by` to `below` in the phrases `by the other one` for Step 22 and `by the other ones` for Step 24.
