### PR TITLE
fix(client): include labels in editor tabs buttons

### DIFF
--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -357,7 +357,6 @@ export type ChallengeFile = {
   name: string;
   editableRegionBoundaries: number[];
   usesMultifileEditor: boolean;
-  path: string;
   error: null | string;
   head: string;
   tail: string;

--- a/client/src/templates/Challenges/classic/editor-tabs.tsx
+++ b/client/src/templates/Challenges/classic/editor-tabs.tsx
@@ -48,7 +48,7 @@ class EditorTabs extends Component<EditorTabsProps> {
               onClick={() => toggleVisibleEditor(challengeFile.fileKey)}
               role='tab'
             >
-              {challengeFile.path}
+              {`${challengeFile.name}.${challengeFile.ext}`}
             </button>
           )
         )}


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

---

- Brings back labels in editor tabs buttons.
- Removes unused property from the type.
- Before ![image](https://user-images.githubusercontent.com/60067306/151050587-7e9190dc-9602-4344-981f-452d258f24be.png)
- After ![image](https://user-images.githubusercontent.com/60067306/151050591-67667a26-e5ce-4652-a315-01571f462d69.png)
