### PR TITLE
fix: prevent scroll jumping on /settings

### DIFF
--- a/client/src/components/settings/Certification.js
+++ b/client/src/components/settings/Certification.js
@@ -429,9 +429,7 @@ export class CertificationSettings extends Component {
     const { t } = this.props;
     return (
       <ScrollableAnchor id='certification-settings'>
-        {/* it's weird that we repeat the id, but the ScrollableAnchor does not
-        add any elements to the DOM and cannot be used for styling  */}
-        <section id='certification-settings'>
+        <section className='certification-settings'>
           <SectionHeader>{t('settings.headings.certs')}</SectionHeader>
           {certifications.map(certName =>
             this.renderCertifications(certName, projectMap)

--- a/client/src/components/settings/certification.css
+++ b/client/src/components/settings/certification.css
@@ -1,14 +1,14 @@
-#certification-settings .solutions-dropdown,
-#certification-settings .solutions-dropdown .dropdown-menu,
-#certification-settings .solutions-dropdown .dropdown {
+.certification-settings .solutions-dropdown,
+.certification-settings .solutions-dropdown .dropdown-menu,
+.certification-settings .solutions-dropdown .dropdown {
   width: 100%;
 }
 
-#certification-settings tr {
+.certification-settings tr {
   height: 57px;
 }
 
-#certification-settings .project-title > a {
+.certification-settings .project-title > a {
   line-height: 40px;
 }
 


### PR DESCRIPTION
Fixes the bug introduced by https://github.com/freeCodeCamp/freeCodeCamp/pull/44911 

Now, when you scroll past the certification section of /settings, nothing happens.