### PR TITLE
fix(learn, i18n): fix help tags to create help post in Japanese subforum

### DIFF
--- a/client/i18n/locales/japanese/links.json
+++ b/client/i18n/locales/japanese/links.json
@@ -23,9 +23,9 @@
     "news": "https://www.freecodecamp.org/japanese/news/"
   },
   "help": {
-    "HTML-CSS": "HTML-CSS",
-    "JavaScript": "JavaScript",
-    "Python": "Python",
-    "Relational Databases": "Relational Databases"
+    "HTML-CSS": "Japanese/HTML-CSS",
+    "JavaScript": "Japanese/JavaScript",
+    "Python": "Japanese/Python",
+    "Relational Databases": "Japanese/Relational Databases"
   }
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
I updated the "help" tags in links.json so that the "Ask for Help" button creates a help post under Japanese subforum.

![image](https://user-images.githubusercontent.com/25644062/151620337-31606049-661d-42b6-aa98-fa8df6790cbd.png)
