### PR TITLE
fix(flash-message) Centered text of flash-message

### DIFF
--- a/client/src/components/Flash/flash.css
+++ b/client/src/components/Flash/flash.css
@@ -1,7 +1,5 @@
 .flash-message {
-  display: flex;
-  justify-content: space-around;
-  flex-direction: row-reverse;
+  text-align: center;
   margin-bottom: 0px;
   padding-top: 3px;
   padding-bottom: 3px;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #44835

<!-- Feel free to add any additional description of changes below this line -->
Centered text of flash-message in the alert bar and moved close button to right in the alert bar. Verified for both updating preference (dark mode on/off) and trying to claim a certificate without completing the necessary steps. 