### PR TITLE
fix(tools): autoclose syntax error

### DIFF
--- a/.github/workflows/autoclose.yml
+++ b/.github/workflows/autoclose.yml
@@ -15,7 +15,7 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const patches = [
-              "@@ -63,7 +63,6 @@ $RECYCLE.BIN/\n # Icon must end with two \\r\n Icon\n \n-\n # Thumbnails\n ._*\n "
+              "@@ -63,7 +63,6 @@ $RECYCLE.BIN/\n # Icon must end with two \\r\n Icon\n \n-\n # Thumbnails\n ._*\n ",
               "@@ -63,7 +63,6 @@ $RECYCLE.BIN/\n # Icon must end with two \\r\n Icon\n \n-\n # Thumbnails\n ._*\n \n@@ -165,7 +164,6 @@ config/curriculum.json\n config/i18n/all-langs.js\n config/certification-settings.js\n \n-\n ### vim ###\n # Swap\n [._]*.s[a-v][a-z]",
               "@@ -165,7 +165,6 @@ config/curriculum.json\n config/i18n/all-langs.js\n config/certification-settings.js\n \n-\n ### vim ###\n # Swap\n [._]*.s[a-v][a-z]"
             ];


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

---

- Fixes syntax error in the autoclose workflow.
- Tested on fork on the test branch (after adding test branch to the workflow branches) - https://github.com/gikf/freeCodeCamp/pull/116
