### PR TITLE
fix(curriculum): fixed test for binary search tree challenge

### DIFF
--- a/curriculum/challenges/english/10-coding-interview-prep/data-structures/delete-a-node-with-one-child-in-a-binary-search-tree.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/data-structures/delete-a-node-with-one-child-in-a-binary-search-tree.md
@@ -128,14 +128,15 @@ assert(
     if (typeof test.remove !== 'function') {
       return false;
     }
-    test.add(-1);
+    test.add(1);
+    test.add(4);
     test.add(3);
-    test.add(7);
-    test.add(16);
-    test.remove(16);
-    test.remove(7);
+    test.add(2);
+    test.add(6);
+    test.add(8);
+    test.remove(6);
     test.remove(3);
-    return test.inorder().join('') == '-1';
+    return test.inorder().join('') == '1248';
   })()
 );
 ```


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR is not targeted to close a specific open issue.

<!-- Feel free to add any additional description of changes below this line -->
The test: `The remove method should remove nodes with one child` for the *Delete a Node with One Child in a Binary Search Tree challenge* does not check if a node with one child is removed. It checks if leaf nodes are removed, which is already checked in another test. I changed the test so that it checks if nodes with one child are removed.

