### PR TITLE
fix(a11y): add title attribute to iframes

### DIFF
--- a/client/src/templates/Challenges/utils/build.js
+++ b/client/src/templates/Challenges/utils/build.js
@@ -208,7 +208,13 @@ export function updateProjectPreview(buildData, document) {
     buildData.challengeType === challengeTypes.html ||
     buildData.challengeType === challengeTypes.multiFileCertProject
   ) {
-    createProjectPreviewFramer(document)(buildData);
+    // Give iframe a title attribute for accessibility using the preview
+    // document's <title>.
+    const titleMatch = buildData?.sources?.index?.match(
+      /<title>(.*?)<\/title>/
+    );
+    const frameTitle = titleMatch ? titleMatch[1] + ' preview' : 'preview';
+    createProjectPreviewFramer(document, frameTitle)(buildData);
   } else {
     throw new Error(
       `Cannot show preview for challenge type ${buildData.challengeType}`

--- a/client/src/templates/Challenges/utils/frame.js
+++ b/client/src/templates/Challenges/utils/frame.js
@@ -61,9 +61,12 @@ export const runTestInTestFrame = async function (document, test, timeout) {
   ]);
 };
 
-const createFrame = (document, id) => ctx => {
+const createFrame = (document, id, title) => ctx => {
   const frame = document.createElement('iframe');
   frame.id = id;
+  if (typeof title === 'string') {
+    frame.title = title;
+  }
   return {
     ...ctx,
     element: frame
@@ -182,17 +185,38 @@ const writeContentToFrame = ctx => {
 };
 
 export const createMainPreviewFramer = (document, proxyLogger) =>
-  createFramer(document, mainPreviewId, initMainFrame, proxyLogger);
+  createFramer(
+    document,
+    mainPreviewId,
+    initMainFrame,
+    proxyLogger,
+    undefined,
+    'previewer'
+  );
 
 export const createProjectPreviewFramer = document =>
-  createFramer(document, projectPreviewId, initPreviewFrame);
+  createFramer(
+    document,
+    projectPreviewId,
+    initPreviewFrame,
+    undefined,
+    undefined,
+    'project preview'
+  );
 
 export const createTestFramer = (document, proxyLogger, frameReady) =>
   createFramer(document, testId, initTestFrame, proxyLogger, frameReady);
 
-const createFramer = (document, id, init, proxyLogger, frameReady) =>
+const createFramer = (
+  document,
+  id,
+  init,
+  proxyLogger,
+  frameReady,
+  frameTitle
+) =>
   flow(
-    createFrame(document, id),
+    createFrame(document, id, frameTitle),
     mountFrame(document, id),
     buildProxyConsole(proxyLogger),
     writeContentToFrame,

--- a/client/src/templates/Challenges/utils/frame.js
+++ b/client/src/templates/Challenges/utils/frame.js
@@ -194,14 +194,14 @@ export const createMainPreviewFramer = (document, proxyLogger) =>
     'previewer'
   );
 
-export const createProjectPreviewFramer = document =>
+export const createProjectPreviewFramer = (document, frameTitle) =>
   createFramer(
     document,
     projectPreviewId,
     initPreviewFrame,
     undefined,
     undefined,
-    'project preview'
+    frameTitle
   );
 
 export const createTestFramer = (document, proxyLogger, frameReady) =>

--- a/client/src/templates/Challenges/utils/frame.js
+++ b/client/src/templates/Challenges/utils/frame.js
@@ -191,7 +191,7 @@ export const createMainPreviewFramer = (document, proxyLogger) =>
     initMainFrame,
     proxyLogger,
     undefined,
-    'previewer'
+    'preview'
   );
 
 export const createProjectPreviewFramer = (document, frameTitle) =>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally on my machine.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Accessibility best practices suggest that every iframe should have a tittle attribute describing the content it contains. There are two iframes accessible to the user: the `challenge-preview-frame` which shows the user the results of their code and the `fcc-project-preview-frame` which shows a preview of the project to be built in the RWD Beta certification courses.

For the latter I have pulled the text from the `<title>` of the preview document to create a custom title attribute for the iframe (title + 'preview'). 

For the challenge preview iframe I have given it the title of 'preview' so that it matches the Preview tab name.