### PR TITLE
refactor(tools): Alert component

### DIFF
--- a/tools/ui-components/.storybook/preview.js
+++ b/tools/ui-components/.storybook/preview.js
@@ -1,5 +1,4 @@
 export const parameters = {
-  actions: { argTypesRegex: '^on[A-Z].*' },
   controls: {
     matchers: {
       color: /(background|color)$/i,

--- a/tools/ui-components/src/alert/alert.stories.tsx
+++ b/tools/ui-components/src/alert/alert.stories.tsx
@@ -14,49 +14,65 @@ const story = {
 
 const Template: Story<AlertProps> = args => <Alert {...args} />;
 
-export const Basic = Template.bind({});
-Basic.args = {
+export const Success = Template.bind({});
+Success.args = {
   children: 'Hello, Alert!',
-  className: '',
+  variant: 'success'
+};
+
+export const Info = Template.bind({});
+Info.args = {
+  children: 'Hello, Alert!',
+  variant: 'info'
+};
+
+export const Warning = Template.bind({});
+Warning.args = {
+  children: 'Hello, Alert!',
+  variant: 'warning'
+};
+
+export const Danger = Template.bind({});
+Danger.args = {
+  children: 'Hello, Alert!',
+  variant: 'danger'
+};
+
+export const LongText = Template.bind({});
+LongText.args = {
+  variant: 'success',
+  children:
+    'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Amet animi commodi cumque dicta ducimus eum iure, maiores mollitia, odit porro quas quod rerum soluta sunt tempora unde, vel voluptas voluptates.'
+};
+
+export const WithHeadingAndParagraphs = Template.bind({});
+WithHeadingAndParagraphs.args = {
+  variant: 'info',
+  children: (
+    <>
+      <h4>
+        <strong>Some Heading Text</strong>
+      </h4>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Amet animi
+        commodi cumque dicta ducimus eum iure, maiores mollitia, odit porro quas
+        quod rerum soluta sunt tempora unde, vel voluptas voluptates.
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Amet animi
+        commodi cumque dicta ducimus eum iure, maiores mollitia, odit porro quas
+        quod rerum soluta sunt tempora unde, vel voluptas voluptates.
+      </p>
+    </>
+  )
+};
+
+export const Dismissable = Template.bind({});
+Dismissable.args = {
+  children: 'Hello, Alert!',
   variant: 'success',
   dismissLabel: 'Close alert',
   onDismiss: () => console.log('Close alert!')
 };
-
-export const LongText = (): JSX.Element => (
-  <Alert variant='success'>
-    Lorem ipsum dolor sit amet, consectetur adipisicing elit. Amet animi commodi
-    cumque dicta ducimus eum iure, maiores mollitia, odit porro quas quod rerum
-    soluta sunt tempora unde, vel voluptas voluptates.
-  </Alert>
-);
-
-export const WithHeadingAndParagraphs = (): JSX.Element => (
-  <Alert variant='info'>
-    <h4>
-      <strong>Some Heading Text</strong>
-    </h4>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipisicing elit. Amet animi
-      commodi cumque dicta ducimus eum iure, maiores mollitia, odit porro quas
-      quod rerum soluta sunt tempora unde, vel voluptas voluptates.
-    </p>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipisicing elit. Amet animi
-      commodi cumque dicta ducimus eum iure, maiores mollitia, odit porro quas
-      quod rerum soluta sunt tempora unde, vel voluptas voluptates.
-    </p>
-  </Alert>
-);
-
-export const WithCloseButton = (): JSX.Element => (
-  <Alert onDismiss={() => console.log('Alert closed')} variant='success'>
-    Hello, Alert!
-  </Alert>
-);
-
-export const WithoutCloseButton = (): JSX.Element => (
-  <Alert variant='success'>Hello, Alert without close button!</Alert>
-);
 
 export default story;

--- a/tools/ui-components/src/alert/alert.tsx
+++ b/tools/ui-components/src/alert/alert.tsx
@@ -32,22 +32,17 @@ export function Alert({
   const variantClass = variantClasses[variant];
 
   const classes = [
-    'relative p-4 mb-6 border border-transparent break-words',
+    'flex items-start p-4 mb-6 border border-transparent break-words',
     variantClass,
-    isDismissable ? 'pr-10' : '',
     className
   ].join(' ');
 
   return (
     <div className={classes} role='alert'>
+      <div className='grow'>{children}</div>
       {isDismissable && (
-        <CloseButton
-          className='absolute right-4'
-          label={dismissLabel}
-          onClick={onDismiss}
-        />
+        <CloseButton label={dismissLabel} onClick={onDismiss} />
       )}
-      {children}
     </div>
   );
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

This PR: 
- Swaps the order of the alert message and the close button. At the moment the close button is rendered first in the DOM. This is not an issue for sighted users, but for non-sighted users, screen readers will announce it before the alert message, which might be confusing for them.
- Refactors the Storybook page of the Alert component. I reckon it would be easier to follow the changes with the code, so I will explain the changes and the motivation in the comments.
- Removes a default Storybook config that automatically injects an action to each `on*` prop. This is part of the storybook refactoring, I will elaborate in the comments.

The changes were split into separate commits to help make it easier to review.

## Screenshots

### Storybook improvements

| | Before | After |
| --- | --- | --- |
| Component examples | <img width="227" alt="Screen Shot 2022-02-04 at 18 25 01" src="https://user-images.githubusercontent.com/25715018/152521123-1509fd0d-05c5-4d1d-9fb3-6463befa5584.png"> | <img width="230" alt="Screen Shot 2022-02-04 at 17 49 38" src="https://user-images.githubusercontent.com/25715018/152517729-67771597-293c-46ae-a2c7-641d11cc6f3e.png"> |
| Code snippet | <img width="1040" alt="Screen Shot 2022-02-04 at 18 23 40" src="https://user-images.githubusercontent.com/25715018/152520995-8f7366b6-4ca7-4fac-9358-3ac3ca3c2c47.png"> | <img width="1035" alt="Screen Shot 2022-02-04 at 18 24 04" src="https://user-images.githubusercontent.com/25715018/152521033-11d41af5-a8db-4ffe-ace7-07e53de7a69c.png"> |