### PR TITLE
fix(tools): add missing colors to the Color storybook page

### DIFF
--- a/tools/ui-components/src/colors.css
+++ b/tools/ui-components/src/colors.css
@@ -61,7 +61,6 @@
 
   --yellow05: var(--yellow05);
   --yellow10: var(--yellow10);
-  --yellow20: var(--yellow20);
   --yellow40: var(--yellow40);
   --yellow45: var(--yellow45);
   --yellow50: var(--yellow50);
@@ -84,7 +83,6 @@
   --red05: var(--red05);
   --red10: var(--red10);
   --red15: var(--red15);
-  --red20: var(--red20);
   --red30: var(--red30);
   --red70: var(--red70);
   --red80: var(--red80);

--- a/tools/ui-components/src/colors.css
+++ b/tools/ui-components/src/colors.css
@@ -59,22 +59,34 @@
   --purple50: var(--purple50);
   --purple90: var(--purple90);
 
+  --yellow05: var(--yellow05);
   --yellow10: var(--yellow10);
   --yellow20: var(--yellow20);
+  --yellow40: var(--yellow40);
+  --yellow45: var(--yellow45);
   --yellow50: var(--yellow50);
+  --yellow70: var(--yellow70);
   --yellow90: var(--yellow90);
 
+  --blue05: var(--blue05);
   --blue10: var(--blue10);
-  --blue20: var(--blue20);
   --blue30: var(--blue30);
   --blue50: var(--blue50);
+  --blue70: var(--blue70);
   --blue90: var(--blue90);
 
+  --green05: var(--green05);
   --green10: var(--green10);
+  --green40: var(--green40);
+  --green70: var(--green70);
   --green90: var(--green90);
 
+  --red05: var(--red05);
   --red10: var(--red10);
+  --red15: var(--red15);
   --red20: var(--red20);
+  --red30: var(--red30);
+  --red70: var(--red70);
   --red80: var(--red80);
   --red90: var(--red90);
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

https://github.com/freeCodeCamp/freeCodeCamp/pull/44970 exported color variables from the `colors.css` file in order to have them displayed on the Color storybook page. However, some new colors were missing from the export.

This PR is to complete the color list.

## To test

Run `npm run storybook` and check the Color story.

## Screenshot

| Before | After |
| --- | --- |
| <img width="979" alt="Screen Shot 2022-02-04 at 22 32 20" src="https://user-images.githubusercontent.com/25715018/152557166-ac4f2770-2940-41ec-9807-21f4aba63eb5.png"> | <img width="856" alt="Screen Shot 2022-02-04 at 22 29 51" src="https://user-images.githubusercontent.com/25715018/152557187-7bf04abe-77fd-4b77-a2ed-985e93ffcd37.png"> |
