### PR TITLE
test(curriculum): Add sudoku solver test cases

### DIFF
--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/sudoku-solver.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/sudoku-solver.md
@@ -129,17 +129,21 @@ If the puzzle submitted to `/api/solve` is greater or less than 81 characters, t
 
 ```js
 async (getUserInput) => {
-  const input =
-    '9..5.1.85.4....2432......1...69.83.9.....6.62.71...9......1945....4.37.4.3..6..';
+  const inputs = [
+    '..9..5.1.85.4....2432......1...69.83.9.....6.62.71...9......1945....4.37.4.3..6.',
+    '..9..5.1.85.4....2432......1...69.83.9.....6.62.71...9......1945....4.37.4.3..6...'
+  ];
   const output = 'Expected puzzle to be 81 characters long';
-  const data = await fetch(getUserInput('url') + '/api/solve', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ puzzle: input })
-  });
-  const parsed = await data.json();
-  assert.property(parsed, 'error');
-  assert.equal(parsed.error, output);
+  for (const input of inputs) {
+    const data = await fetch(getUserInput('url') + '/api/solve', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ puzzle: input })
+    });
+    const parsed = await data.json();
+    assert.property(parsed, 'error');
+    assert.equal(parsed.error, output);
+  }
 };
 ```
 
@@ -246,19 +250,23 @@ If the puzzle submitted to `/api/check` is greater or less than 81 characters, t
 
 ```js
 async (getUserInput) => {
-  const input =
-    '9..5.1.85.4....2432......1...69.83.9.....6.62.71...9......1945....4.37.4.3..6..';
+  const inputs = [
+    '..9..5.1.85.4....2432......1...69.83.9.....6.62.71...9......1945....4.37.4.3..6.',
+    '..9..5.1.85.4....2432......1...69.83.9.....6.62.71...9......1945....4.37.4.3..6...'
+  ];
   const coordinate = 'A1';
   const value = '1';
   const output = 'Expected puzzle to be 81 characters long';
-  const data = await fetch(getUserInput('url') + '/api/check', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ puzzle: input, coordinate, value })
-  });
-  const parsed = await data.json();
-  assert.property(parsed, 'error');
-  assert.equal(parsed.error, output);
+  for (const input of inputs) {
+    const data = await fetch(getUserInput('url') + '/api/check', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ puzzle: input, coordinate, value })
+    });
+    const parsed = await data.json();
+    assert.property(parsed, 'error');
+    assert.equal(parsed.error, output);
+  }
 };
 ```
 
@@ -266,17 +274,31 @@ If the object submitted to `/api/check` is missing `puzzle`, `coordinate` or `va
 
 ```js
 async (getUserInput) => {
-  const input =
-    '..9..5.1.85.4....2432......1...69.83.9.....6.62.71...9......1945....4.37.4.3..6..';
-  const output = 'Required field(s) missing';
-  const data = await fetch(getUserInput('url') + '/api/check', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ puzzle: input })
-  });
-  const parsed = await data.json();
-  assert.property(parsed, 'error');
-  assert.equal(parsed.error, output);
+  const inputs = [
+    {
+      puzzle: '..9..5.1.85.4....2432......1...69.83.9.....6.62.71...9......1945....4.37.4.3..6..',
+      value: '1',
+    },
+    {
+      puzzle: '..9..5.1.85.4....2432......1...69.83.9.....6.62.71...9......1945....4.37.4.3..6..',
+      coordinate: 'A1',
+    },
+    {
+      coordinate: 'A1',
+      value: '1'
+    }
+  ];
+  for (const input of inputs) {
+    const output = 'Required field(s) missing';
+    const data = await fetch(getUserInput('url') + '/api/check', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input)
+    });
+    const parsed = await data.json();
+    assert.property(parsed, 'error');
+    assert.equal(parsed.error, output);
+  }
 };
 ```
 
@@ -287,16 +309,18 @@ async (getUserInput) => {
   const input =
     '..9..5.1.85.4....2432......1...69.83.9.....6.62.71...9......1945....4.37.4.3..6..';
   const output = 'Invalid coordinate';
-  const coordinate = 'XZ18';
+  const coordinates = ['A0', 'A10', 'J1', 'A', '1', 'XZ18'];
   const value = '7';
-  const data = await fetch(getUserInput('url') + '/api/check', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ puzzle: input, coordinate, value })
-  });
-  const parsed = await data.json();
-  assert.property(parsed, 'error');
-  assert.equal(parsed.error, output);
+  for (const coordinate of coordinates) {
+    const data = await fetch(getUserInput('url') + '/api/check', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ puzzle: input, coordinate, value })
+    });
+    const parsed = await data.json();
+    assert.property(parsed, 'error');
+    assert.equal(parsed.error, output);
+  }
 };
 ```
 
@@ -308,15 +332,17 @@ async (getUserInput) => {
     '..9..5.1.85.4....2432......1...69.83.9.....6.62.71...9......1945....4.37.4.3..6..';
   const output = 'Invalid value';
   const coordinate = 'A1';
-  const value = 'X';
-  const data = await fetch(getUserInput('url') + '/api/check', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ puzzle: input, coordinate, value })
-  });
-  const parsed = await data.json();
-  assert.property(parsed, 'error');
-  assert.equal(parsed.error, output);
+  const values = ['0', '10', 'A'];
+  for (const value of values) {
+    const data = await fetch(getUserInput('url') + '/api/check', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ puzzle: input, coordinate, value })
+    });
+    const parsed = await data.json();
+    assert.property(parsed, 'error');
+    assert.equal(parsed.error, output);
+  }
 };
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!-- Feel free to add any additional description of changes below this line -->

Expands on the tests for the Sudoku Solver challenge. 
* Solve a puzzle with incorrect length: POST request to /api/solve
  * Test 80 and 82 character length puzzles to avoid off-by-one errors
* Check a puzzle placement with incorrect length: POST request to /api/check
  * Test 80 and 82 character length puzzles to avoid off-by-one errors
* Check a puzzle placement with missing required fields: POST request to /api/check
  * Separate test cases for missing the puzzle, coordinate, and value
  * Previously there was only one test case that had the puzzle but not coordinate or value 
* Check a puzzle placement with invalid placement coordinate: POST request to /api/check
  * Additional test cases against likely errors
* Check a puzzle placement with invalid placement value: POST request to /api/check
  * Additional test cases against likely errors including '0' as in [demo-projects#152](https://github.com/freeCodeCamp/demo-projects/pull/152)
