### PR TITLE
fix(a11y): remove complementary role from instructions panel

### DIFF
--- a/client/src/templates/Challenges/components/side-panel.tsx
+++ b/client/src/templates/Challenges/components/side-panel.tsx
@@ -70,7 +70,6 @@ export function SidePanel({
     <div
       className='instructions-panel'
       ref={instructionsPanelRef}
-      role='complementary'
       tabIndex={-1}
     >
       {challengeTitle}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
The instructions-panel div in the classic challenges has a role of `complementary` set on it which turns it into a landmark. I've been searching all day and I have found nothing that is dependent upon that role being there. Perhaps, as @ShaunSHamilton has suggested in the #contributor chat channel, this is a holdover from a past incarnation of FCC and was just never removed.

Regardless, the instructions are certainly not "complementary" content, they are the main content for the challenge, and thus this role should be removed. One less unnecessary (and inaccurate) landmark for screen reader users to deal with.