### PR TITLE
fix(a11y): add h1 heading to classic challenges

### DIFF
--- a/client/src/templates/Challenges/components/__snapshots__/challenge-title.test.tsx.snap
+++ b/client/src/templates/Challenges/components/__snapshots__/challenge-title.test.tsx.snap
@@ -39,9 +39,9 @@ exports[`<ChallengeTitle/> renders correctly 1`] = `
     <div
       className="title-text"
     >
-      <b>
+      <h1>
         title text
-      </b>
+      </h1>
       <svg
         aria-label="icons.passed"
         height="50"

--- a/client/src/templates/Challenges/components/challenge-title.css
+++ b/client/src/templates/Challenges/components/challenge-title.css
@@ -91,6 +91,13 @@
   padding: 0px 3px;
 }
 
+.title-text h1 {
+  font-size: inherit;
+  line-height: 1.42857143;
+  margin: 0;
+  display: inline;
+}
+
 .title-translation-cta {
   display: flex;
   flex-direction: row;

--- a/client/src/templates/Challenges/components/challenge-title.tsx
+++ b/client/src/templates/Challenges/components/challenge-title.tsx
@@ -39,7 +39,7 @@ function ChallengeTitle({
       {showBreadCrumbs && <BreadCrumb block={block} superBlock={superBlock} />}
       <div className='challenge-title'>
         <div className='title-text'>
-          <b>{children}</b>
+          <h1>{children}</h1>
           {isCompleted ? (
             <GreenPass
               style={{ height: '15px', width: '15px', marginLeft: '7px' }}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Accessibility best practices recommend that every page have an h1 heading near the top of the page. The classic challenges currently have no headings at all. It's a no-brainer to turn the bold title into an h1.