### PR TITLE
fix(a11y): remove tab role from buttons in beta rwd challenges

### DIFF
--- a/client/src/templates/Challenges/classic/action-row.tsx
+++ b/client/src/templates/Challenges/classic/action-row.tsx
@@ -48,7 +48,6 @@ const ActionRow = ({
             onClick={() => togglePane('showConsole')}
           >
             {t('learn.editor-tabs.console')}{' '}
-            <span className='sr-only'>display</span>
           </button>
           {hasNotes && (
             <button
@@ -57,7 +56,6 @@ const ActionRow = ({
               onClick={() => togglePane('showNotes')}
             >
               {t('learn.editor-tabs.notes')}{' '}
-              <span className='sr-only'>display</span>
             </button>
           )}
           <button
@@ -66,7 +64,6 @@ const ActionRow = ({
             onClick={() => togglePane('showPreview')}
           >
             {t('learn.editor-tabs.preview')}{' '}
-            <span className='sr-only'>display</span>
           </button>
         </div>
       </div>

--- a/client/src/templates/Challenges/classic/action-row.tsx
+++ b/client/src/templates/Challenges/classic/action-row.tsx
@@ -38,36 +38,35 @@ const ActionRow = ({
       </div>
       <div className='tabs-row'>
         <EditorTabs />
-        <button
-          className='restart-step-tab'
-          onClick={resetChallenge}
-          role='tab'
-        >
+        <button className='restart-step-tab' onClick={resetChallenge}>
           {t('learn.editor-tabs.restart-step')}
         </button>
         <div className='panel-display-tabs'>
           <button
+            aria-expanded={showConsole ? 'true' : 'false'}
             className={showConsole ? 'active-tab' : ''}
             onClick={() => togglePane('showConsole')}
-            role='tab'
           >
-            {t('learn.editor-tabs.console')}
+            {t('learn.editor-tabs.console')}{' '}
+            <span className='sr-only'>display</span>
           </button>
           {hasNotes && (
             <button
+              aria-expanded={showNotes ? 'true' : 'false'}
               className={showNotes ? 'active-tab' : ''}
               onClick={() => togglePane('showNotes')}
-              role='tab'
             >
-              {t('learn.editor-tabs.notes')}
+              {t('learn.editor-tabs.notes')}{' '}
+              <span className='sr-only'>display</span>
             </button>
           )}
           <button
+            aria-expanded={showPreview ? 'true' : 'false'}
             className={showPreview ? 'active-tab' : ''}
             onClick={() => togglePane('showPreview')}
-            role='tab'
           >
-            {t('learn.editor-tabs.preview')}
+            {t('learn.editor-tabs.preview')}{' '}
+            <span className='sr-only'>display</span>
           </button>
         </div>
       </div>

--- a/client/src/templates/Challenges/classic/action-row.tsx
+++ b/client/src/templates/Challenges/classic/action-row.tsx
@@ -47,7 +47,7 @@ const ActionRow = ({
             className={showConsole ? 'active-tab' : ''}
             onClick={() => togglePane('showConsole')}
           >
-            {t('learn.editor-tabs.console')}{' '}
+            {t('learn.editor-tabs.console')}
           </button>
           {hasNotes && (
             <button
@@ -55,7 +55,7 @@ const ActionRow = ({
               className={showNotes ? 'active-tab' : ''}
               onClick={() => togglePane('showNotes')}
             >
-              {t('learn.editor-tabs.notes')}{' '}
+              {t('learn.editor-tabs.notes')}
             </button>
           )}
           <button
@@ -63,7 +63,7 @@ const ActionRow = ({
             className={showPreview ? 'active-tab' : ''}
             onClick={() => togglePane('showPreview')}
           >
-            {t('learn.editor-tabs.preview')}{' '}
+            {t('learn.editor-tabs.preview')}
           </button>
         </div>
       </div>

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -88,7 +88,7 @@ button.monaco-editor-tab:hover {
   border-bottom: 2px solid var(--primary-background);
 }
 
-.monaco-editor-tab[role='tab'][aria-selected='true'] {
+.monaco-editor-tab[aria-expanded='true'] {
   border-color: var(--secondary-color);
   background-color: var(--secondary-color);
   color: var(--secondary-background);

--- a/client/src/templates/Challenges/classic/editor-tabs.tsx
+++ b/client/src/templates/Challenges/classic/editor-tabs.tsx
@@ -42,13 +42,13 @@ class EditorTabs extends Component<EditorTabsProps> {
         {sortChallengeFiles(challengeFiles).map(
           (challengeFile: ChallengeFile) => (
             <button
-              aria-selected={visibleEditors[challengeFile.fileKey]}
+              aria-expanded={visibleEditors[challengeFile.fileKey] ?? 'false'}
               className='monaco-editor-tab'
               key={challengeFile.fileKey}
               onClick={() => toggleVisibleEditor(challengeFile.fileKey)}
-              role='tab'
             >
-              {`${challengeFile.name}.${challengeFile.ext}`}
+              {`${challengeFile.name}.${challengeFile.ext}`}{' '}
+              <span className='sr-only'>editor</span>
             </button>
           )
         )}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes on my machine.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
In the Beta RWD step challenges, there are five buttons across the top that all have a role set to `tab`. This is not a proper use of the tab role as these buttons are not acting as tabs in a tablist but rather are simple disclosure buttons. Furthermore, an element with a role of tab must be a child of an element with the role of `tablist`, and they must control a corresponding element with the role of `tabpanel`, which is not the case here.

In accordance with accepted best practices for disclosure buttons, I have added the `aria-expanded` attribute to them.