### PR TITLE
fix(a11y): FCC logo link

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -448,7 +448,7 @@
     "magnifier": "magnifier"
   },
   "aria": {
-    "fcc-curriculum":"freeCodeCamp Curriculum",
+    "fcc-curriculum": "freeCodeCamp Curriculum",
     "answer": "Answer",
     "linkedin": "Link to {{username}}'s LinkedIn",
     "github": "Link to {{username}}'s GitHub",

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -448,7 +448,7 @@
     "magnifier": "magnifier"
   },
   "aria": {
-    "fcc-logo": "freeCodeCamp Logo",
+    "fcc-curriculum":"freeCodeCamp Curriculum",
     "answer": "Answer",
     "linkedin": "Link to {{username}}'s LinkedIn",
     "github": "Link to {{username}}'s GitHub",

--- a/client/src/assets/icons/FreeCodeCamp-logo.tsx
+++ b/client/src/assets/icons/FreeCodeCamp-logo.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 function FreeCodeCampLogo(): JSX.Element {
   return (
     <svg
-      aria-label='freeCodeCamp'
+      aria-label='freeCodeCamp.org'
       height={24}
       version='1.1'
       viewBox='0 0 210 24'

--- a/client/src/assets/icons/FreeCodeCamp-logo.tsx
+++ b/client/src/assets/icons/FreeCodeCamp-logo.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 function FreeCodeCampLogo(): JSX.Element {
+  const { t } = useTranslation();
+
   return (
     <svg
-      aria-label='freeCodeCamp.org'
+      aria-label={t('aria.fcc-curriculum')}
       height={24}
       version='1.1'
       viewBox='0 0 210 24'

--- a/client/src/assets/icons/FreeCodeCamp-logo.tsx
+++ b/client/src/assets/icons/FreeCodeCamp-logo.tsx
@@ -1,14 +1,10 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 
 function FreeCodeCampLogo(): JSX.Element {
-  const { t } = useTranslation();
-
   return (
     <svg
-      aria-label={t('aria.fcc-logo')}
+      aria-label='freeCodeCamp'
       height={24}
-      role='math'
       version='1.1'
       viewBox='0 0 210 24'
       width={210}

--- a/client/src/components/Header/components/universal-nav.tsx
+++ b/client/src/components/Header/components/universal-nav.tsx
@@ -57,7 +57,6 @@ export const UniversalNav = ({
       <div className='universal-nav-middle'>
         <Link id='universal-nav-logo' to='/learn'>
           <NavLogo />
-          <span className='sr-only'>freeCodeCamp.org</span>
         </Link>
       </div>
       <div className='universal-nav-right main-nav'>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either on my machine.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
There are two issues with the FCC logo link at the top of every page. First, the svg has a label of "freeCodeCamp Logo" and the link itself has sr-only text of "freeCodeCamp.org", so screen reader users will hear "freeCodeCamp Logo freeCodeCamp.org link" which is unnecessary duplication. Second, the label for the svg should not refer to itself as a "logo". Since this svg is being used as the link text it should only include the text needed for the link to describe where it is pointing to. In this case, the link is pointing to freeCodeCamp.org, not a logo of freeCodeCamp.org.

Hence, the link does not need any extra sr-only text since it can use the svg's label as the link text, and that label should just be "freeCodeCamp.org".