### PR TITLE
fix(curriculum): added test for depth first search challenge

### DIFF
--- a/curriculum/challenges/english/10-coding-interview-prep/data-structures/depth-first-search.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/data-structures/depth-first-search.md
@@ -49,6 +49,23 @@ assert.sameMembers(
 );
 ```
 
+The input graph `[[0, 1, 0, 0], [1, 0, 1, 0], [0, 1, 0, 1], [0, 0, 1, 0]]` with a start node of `3` should return an array with `3`, `2`, `1`, and `0`.
+
+```js
+assert.sameMembers(
+  (function () {
+    var graph = [
+      [0, 1, 0, 0],
+      [1, 0, 1, 0],
+      [0, 1, 0, 1],
+      [0, 0, 1, 0]
+    ];
+    return dfs(graph, 3);
+  })(),
+  [3, 2, 1, 0]
+);
+```
+
 The input graph `[[0, 1, 0, 0], [1, 0, 1, 0], [0, 1, 0, 1], [0, 0, 1, 0]]` with a start node of `1` should return an array with four elements.
 
 ```js


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->

This PR is not targeted to close a specific open issue.

The [solution in the freeCodeCamp forum](https://forum.freecodecamp.org/t/freecodecamp-challenge-guide-depth-first-search/301640) and the [solution in the GitHub repo](https://github.com/freeCodeCamp/freeCodeCamp/blob/main/curriculum/challenges/english/10-coding-interview-prep/data-structures/depth-first-search.md) give different answers when using the example adjacency matrix graph and root node, given in the starter code, as inputs. Both pass the tests. The forum solution output is not correct.

<br/>
<br/>

| Input  | Forum solution output | GitHub repo solution output |
| :------------- | ------------- | ------------- |
| dfs(exDFSGraph, 3);  | [ 3, 2, 1 ]  | [ 3, 2, 1, 0 ] |

<br/>
<br/>

I added another test for this case. 
