### PR TITLE
fix(api-server): npm run build on Windows

### DIFF
--- a/api-server/package.json
+++ b/api-server/package.json
@@ -20,7 +20,7 @@
   "main": "none",
   "scripts": {
     "babel-dev-server": "babel-node --inspect=0.0.0.0 ./src/server/index.js",
-    "build": "babel src --out-dir lib --ignore 'node_modules /**/*','/**/*.test.js' --copy-files --no-copy-ignored",
+    "build": "babel src --out-dir lib --ignore '/**/*.test.js' --copy-files --no-copy-ignored",
     "develop": "cross-env DEBUG=fcc* node src/development-start.js",
     "start": "cross-env DEBUG=fcc* node lib/production-start.js"
   },


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This fixes the issue with running `npm run build`  on windows. Suggested by Oliver.

<!-- Feel free to add any additional description of changes below this line -->
