### PR TITLE
fix: strip js comments

### DIFF
--- a/client/src/utils/curriculum-helpers.ts
+++ b/client/src/utils/curriculum-helpers.ts
@@ -50,7 +50,6 @@ function isCalledWithNoArgs(
 const curriculumHelpers = {
   removeHtmlComments,
   removeCssComments,
-  removeJSComments,
   removeWhiteSpace,
   isCalledWithNoArgs,
   CSSHelp

--- a/client/src/utils/curriculum-helpers.ts
+++ b/client/src/utils/curriculum-helpers.ts
@@ -50,6 +50,7 @@ function isCalledWithNoArgs(
 const curriculumHelpers = {
   removeHtmlComments,
   removeCssComments,
+  removeJSComments,
   removeWhiteSpace,
   isCalledWithNoArgs,
   CSSHelp

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/declare-a-read-only-variable-with-the-const-keyword.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/declare-a-read-only-variable-with-the-const-keyword.md
@@ -34,7 +34,7 @@ Change the code so that all variables are declared using `let` or `const`. Use `
 `var` should not exist in your code.
 
 ```js
-(getUserInput) => assert(!getUserInput('index').match(/var/g));
+(getUserInput) => assert(!__helpers.removeJSComments(getUserInput('index')).match(/var/g));
 ```
 
 You should change `fCC` to all uppercase.
@@ -42,7 +42,7 @@ You should change `fCC` to all uppercase.
 ```js
 (getUserInput) => {
   assert(getUserInput('index').match(/(FCC)/));
-  assert(!getUserInput('index').match(/fCC/));
+  assert(!__helpers.removeJSComments(getUserInput('index')).match(/fCC/));
 }
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/declare-a-read-only-variable-with-the-const-keyword.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/declare-a-read-only-variable-with-the-const-keyword.md
@@ -34,16 +34,14 @@ Change the code so that all variables are declared using `let` or `const`. Use `
 `var` should not exist in your code.
 
 ```js
-(getUserInput) => assert(!__helpers.removeJSComments(getUserInput('index')).match(/var/g));
+assert.notMatch(code, /var/g);
 ```
 
 You should change `fCC` to all uppercase.
 
 ```js
-(getUserInput) => {
-  assert(getUserInput('index').match(/(FCC)/));
-  assert(!__helpers.removeJSComments(getUserInput('index')).match(/fCC/));
-}
+assert.match(code, /(FCC)/);
+assert.notMatch(code, /(fCC)/);
 ```
 
 `FCC` should be a constant variable declared with `const`.
@@ -56,14 +54,13 @@ assert.match(code, /const\s+FCC/);
 `fact` should be declared with `let`.
 
 ```js
-(getUserInput) => assert(getUserInput('index').match(/(let fact)/g));
+assert.match(code, /(let\s+fact)/g);
 ```
 
 `console.log` should be changed to print the `FCC` and `fact` variables.
 
 ```js
-(getUserInput) =>
-  assert(getUserInput('index').match(/console\.log\(\s*FCC\s*\,\s*fact\s*\)\s*;?/g));
+assert.match(code, /console\.log\(\s*FCC\s*\,\s*fact\s*\)\s*;?/g);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/explore-differences-between-the-var-and-let-keywords.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/explore-differences-between-the-var-and-let-keywords.md
@@ -42,19 +42,19 @@ Update the code so it only uses the `let` keyword.
 `var` should not exist in the code.
 
 ```js
-(getUserInput) => assert(!__helpers.removeJSComments(getUserInput('index')).match(/var/g));
+assert.notMatch(code, /var/g);
 ```
 
 `catName` should be the string `Oliver`.
 
 ```js
-assert(catName === 'Oliver');
+assert.equal(catName, 'Oliver');
 ```
 
 `catSound` should be the string `Meow!`
 
 ```js
-assert(catSound === 'Meow!');
+assert.equal(catSound, 'Meow!');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/explore-differences-between-the-var-and-let-keywords.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/explore-differences-between-the-var-and-let-keywords.md
@@ -42,7 +42,7 @@ Update the code so it only uses the `let` keyword.
 `var` should not exist in the code.
 
 ```js
-(getUserInput) => assert(!getUserInput('index').match(/var/g));
+(getUserInput) => assert(!__helpers.removeJSComments(getUserInput('index')).match(/var/g));
 ```
 
 `catName` should be the string `Oliver`.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #45127

<!-- Feel free to add any additional description of changes below this line -->

I'm not sure why the `removeJSComments` helper was not being made available, but this PR enables it + fixes the tests in the linked issue.