### PR TITLE
feat: create mobile curriculum data on build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,6 +201,7 @@ api-server/lib/*
 curriculum/dist
 curriculum/build
 client/static/_redirects
+client/static/mobile
 
 ### UI Components ###
 tools/ui-components/dist

--- a/tools/scripts/build/build-curriculum.js
+++ b/tools/scripts/build/build-curriculum.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 
 const { getChallengesForLang } = require('../../../curriculum/getChallenges');
+const { buildMobileCurriculum } = require('./build-mobile-curriculum');
 
 const globalConfigPath = path.resolve(__dirname, '../../../config');
 
@@ -9,4 +10,7 @@ const globalConfigPath = path.resolve(__dirname, '../../../config');
 // across all languages.
 getChallengesForLang('english')
   .then(JSON.stringify)
-  .then(x => fs.writeFileSync(`${globalConfigPath}/curriculum.json`, x));
+  .then(json => {
+    fs.writeFileSync(`${globalConfigPath}/curriculum.json`, json);
+    buildMobileCurriculum(json);
+  });

--- a/tools/scripts/build/build-curriculum.js
+++ b/tools/scripts/build/build-curriculum.js
@@ -9,8 +9,11 @@ const globalConfigPath = path.resolve(__dirname, '../../../config');
 // We are defaulting to English because the ids for the challenges are same
 // across all languages.
 getChallengesForLang('english')
+  .then(result => {
+    buildMobileCurriculum(result);
+    return result;
+  })
   .then(JSON.stringify)
   .then(json => {
     fs.writeFileSync(`${globalConfigPath}/curriculum.json`, json);
-    buildMobileCurriculum(json);
   });

--- a/tools/scripts/build/build-mobile-curriculum.js
+++ b/tools/scripts/build/build-mobile-curriculum.js
@@ -4,12 +4,8 @@ const path = require('path');
 exports.buildMobileCurriculum = function buildMobileCurriculum(json) {
   const mobileStaticPath = path.resolve(__dirname, '../../../client/static');
 
-  if (!fs.existsSync(`${mobileStaticPath}/mobile`)) {
-    fs.mkdirSync(`${mobileStaticPath}/mobile`);
-    writeAndParseCurriculumJson(json);
-  } else {
-    writeAndParseCurriculumJson(json);
-  }
+  fs.mkdirSync(`${mobileStaticPath}/mobile`, { recursive: true });
+  writeAndParseCurriculumJson(json);
 
   function writeAndParseCurriculumJson(curriculum) {
     const superBlockKeys = Object.keys(curriculum).filter(

--- a/tools/scripts/build/build-mobile-curriculum.js
+++ b/tools/scripts/build/build-mobile-curriculum.js
@@ -14,30 +14,28 @@ exports.buildMobileCurriculum = function buildMobileCurriculum(json) {
   function writeAndParseCurriculumJson(curriculum) {
     curriculum = JSON.parse(curriculum);
 
-    const superBlockKeys = Object.keys(curriculum).slice(1);
+    const superBlockKeys = Object.keys(curriculum).filter(
+      key => key !== '00-certifications'
+    );
 
-    const superBlockObj = { superblocks: superBlockKeys };
-
-    writeToFile('availableSuperblocks', superBlockObj);
-
-    let superBlocks = {};
+    writeToFile('availableSuperblocks', { superblocks: superBlockKeys });
 
     for (let i = 0; i < superBlockKeys.length; i++) {
+      const superBlock = {};
       const blockNames = Object.keys(curriculum[superBlockKeys[i]].blocks);
 
       if (blockNames.length === 0) continue;
 
-      superBlocks[superBlockKeys[i]] = {};
-      superBlocks[superBlockKeys[i]]['blocks'] = {};
+      superBlock[superBlockKeys[i]] = {};
+      superBlock[superBlockKeys[i]]['blocks'] = {};
 
       for (let j = 0; j < blockNames.length; j++) {
-        superBlocks[superBlockKeys[i]]['blocks'][blockNames[j]] = {};
-        superBlocks[superBlockKeys[i]]['blocks'][blockNames[j]]['challenges'] =
+        superBlock[superBlockKeys[i]]['blocks'][blockNames[j]] = {};
+        superBlock[superBlockKeys[i]]['blocks'][blockNames[j]]['challenges'] =
           curriculum[superBlockKeys[i]]['blocks'][blockNames[j]]['meta'];
       }
 
-      writeToFile(superBlockKeys[i], superBlocks);
-      superBlocks = {};
+      writeToFile(superBlockKeys[i], superBlock);
     }
   }
 

--- a/tools/scripts/build/build-mobile-curriculum.js
+++ b/tools/scripts/build/build-mobile-curriculum.js
@@ -5,9 +5,7 @@ exports.buildMobileCurriculum = function buildMobileCurriculum(json) {
   const mobileStaticPath = path.resolve(__dirname, '../../../client/static');
 
   if (!fs.existsSync(`${mobileStaticPath}/mobile`)) {
-    fs.mkdir(`${mobileStaticPath}/mobile`, err => {
-      return err;
-    });
+    fs.mkdirSync(`${mobileStaticPath}/mobile`)
     writeJson(json);
   } else {
     writeJson(json);
@@ -16,9 +14,9 @@ exports.buildMobileCurriculum = function buildMobileCurriculum(json) {
   function writeJson(curriculum) {
     curriculum = JSON.parse(curriculum);
 
-    const superBlocks = Object.keys(curriculum);
+    const superBlocksAndCertifications = Object.keys(curriculum);
 
-    const superBlockObj = { superblocks: superBlocks.slice(1) };
+    const superBlockObj = { superblocks: superBlocksAndCertifications.slice(1) };
 
     writeToFile('availableSuperblocks', superBlockObj);
 
@@ -45,9 +43,9 @@ exports.buildMobileCurriculum = function buildMobileCurriculum(json) {
     }
   }
 
-  function writeToFile(superblock, json) {
+  function writeToFile(filename, json) {
     fs.writeFileSync(
-      `${mobileStaticPath}/mobile/${superblock}.json`,
+      `${mobileStaticPath}/mobile/${filename}.json`,
       JSON.stringify(json, null, 2)
     );
   }

--- a/tools/scripts/build/build-mobile-curriculum.js
+++ b/tools/scripts/build/build-mobile-curriculum.js
@@ -1,0 +1,53 @@
+const fs = require('fs');
+const path = require('path');
+
+exports.buildMobileCurriculum = function buildMobileCurriculum(json) {
+  const mobileStaticPath = path.resolve(__dirname, '../../../client/static');
+
+  if (!fs.existsSync(`${mobileStaticPath}/mobile`)) {
+    fs.mkdir(`${mobileStaticPath}/mobile`, err => {
+      return err;
+    });
+    writeJson(json);
+  } else {
+    writeJson(json);
+  }
+
+  function writeJson(curriculum) {
+    curriculum = JSON.parse(curriculum);
+
+    const superBlocks = Object.keys(curriculum);
+
+    let blockNames = {};
+
+    for (let i = 0; i < superBlocks.length; i++) {
+      // blockGroup = object parent without key-name
+
+      const blockGroup = Object.keys(curriculum[superBlocks[i]].blocks);
+
+      if (blockGroup.length === 0) continue;
+
+      blockNames[superBlocks[i]] = {};
+
+      for (let j = 0; j < blockGroup.length; j++) {
+        blockNames[superBlocks[i]][blockGroup[j]] = {};
+        blockNames[superBlocks[i]][blockGroup[j]]['challenges'] =
+          curriculum[superBlocks[i]]['blocks'][blockGroup[j]]['meta'];
+      }
+    }
+
+    // remove certification object
+
+    for (var i in blockNames) {
+      delete blockNames[i];
+      break;
+    }
+
+    const parsedJson = { superblocks: blockNames };
+
+    fs.writeFileSync(
+      `${mobileStaticPath}/mobile/curriculum-mobile.json`,
+      JSON.stringify(parsedJson)
+    );
+  }
+};

--- a/tools/scripts/build/build-mobile-curriculum.js
+++ b/tools/scripts/build/build-mobile-curriculum.js
@@ -20,26 +20,26 @@ exports.buildMobileCurriculum = function buildMobileCurriculum(json) {
 
     writeToFile('availableSuperblocks', superBlockObj);
 
-    let blockNames = {};
+    let blocks = {};
 
     for (let i = 0; i < superBlocks.length; i++) {
-      // blockGroup = object parent without key-name
+      // blockNames = object parent without key-name
 
-      const blockGroup = Object.keys(curriculum[superBlocks[i]].blocks);
+      const blockNames = Object.keys(curriculum[superBlocks[i]].blocks);
 
-      if (blockGroup.length === 0) continue;
+      if (blockNames.length === 0) continue;
 
-      blockNames[superBlocks[i]] = {};
-      blockNames[superBlocks[i]]['blocks'] = {};
+      blocks[superBlocks[i]] = {};
+      blocks[superBlocks[i]]['blocks'] = {};
 
-      for (let j = 0; j < blockGroup.length; j++) {
-        blockNames[superBlocks[i]]['blocks'][blockGroup[j]] = {};
-        blockNames[superBlocks[i]]['blocks'][blockGroup[j]]['challenges'] =
-          curriculum[superBlocks[i]]['blocks'][blockGroup[j]]['meta'];
+      for (let j = 0; j < blockNames.length; j++) {
+        blocks[superBlocks[i]]['blocks'][blockNames[j]] = {};
+        blocks[superBlocks[i]]['blocks'][blockNames[j]]['challenges'] =
+          curriculum[superBlocks[i]]['blocks'][blockNames[j]]['meta'];
       }
 
-      writeToFile(superBlocks[i], blockNames);
-      blockNames = {};
+      writeToFile(superBlocks[i], blocks);
+      blocks = {};
     }
   }
 

--- a/tools/scripts/build/build-mobile-curriculum.js
+++ b/tools/scripts/build/build-mobile-curriculum.js
@@ -5,18 +5,18 @@ exports.buildMobileCurriculum = function buildMobileCurriculum(json) {
   const mobileStaticPath = path.resolve(__dirname, '../../../client/static');
 
   if (!fs.existsSync(`${mobileStaticPath}/mobile`)) {
-    fs.mkdirSync(`${mobileStaticPath}/mobile`)
-    writeJson(json);
+    fs.mkdirSync(`${mobileStaticPath}/mobile`);
+    writeAndParseCurriculumJson(json);
   } else {
-    writeJson(json);
+    writeAndParseCurriculumJson(json);
   }
 
-  function writeJson(curriculum) {
+  function writeAndParseCurriculumJson(curriculum) {
     curriculum = JSON.parse(curriculum);
 
-    const superBlocksAndCertifications = Object.keys(curriculum);
+    const superBlocks = Object.keys(curriculum).slice(1);
 
-    const superBlockObj = { superblocks: superBlocksAndCertifications.slice(1) };
+    const superBlockObj = { superblocks: superBlocks };
 
     writeToFile('availableSuperblocks', superBlockObj);
 

--- a/tools/scripts/build/build-mobile-curriculum.js
+++ b/tools/scripts/build/build-mobile-curriculum.js
@@ -12,8 +12,6 @@ exports.buildMobileCurriculum = function buildMobileCurriculum(json) {
   }
 
   function writeAndParseCurriculumJson(curriculum) {
-    curriculum = JSON.parse(curriculum);
-
     const superBlockKeys = Object.keys(curriculum).filter(
       key => key !== '00-certifications'
     );

--- a/tools/scripts/build/build-mobile-curriculum.js
+++ b/tools/scripts/build/build-mobile-curriculum.js
@@ -14,32 +14,30 @@ exports.buildMobileCurriculum = function buildMobileCurriculum(json) {
   function writeAndParseCurriculumJson(curriculum) {
     curriculum = JSON.parse(curriculum);
 
-    const superBlocks = Object.keys(curriculum).slice(1);
+    const superBlockKeys = Object.keys(curriculum).slice(1);
 
-    const superBlockObj = { superblocks: superBlocks };
+    const superBlockObj = { superblocks: superBlockKeys };
 
     writeToFile('availableSuperblocks', superBlockObj);
 
-    let blocks = {};
+    let superBlocks = {};
 
-    for (let i = 0; i < superBlocks.length; i++) {
-      // blockNames = object parent without key-name
-
-      const blockNames = Object.keys(curriculum[superBlocks[i]].blocks);
+    for (let i = 0; i < superBlockKeys.length; i++) {
+      const blockNames = Object.keys(curriculum[superBlockKeys[i]].blocks);
 
       if (blockNames.length === 0) continue;
 
-      blocks[superBlocks[i]] = {};
-      blocks[superBlocks[i]]['blocks'] = {};
+      superBlocks[superBlockKeys[i]] = {};
+      superBlocks[superBlockKeys[i]]['blocks'] = {};
 
       for (let j = 0; j < blockNames.length; j++) {
-        blocks[superBlocks[i]]['blocks'][blockNames[j]] = {};
-        blocks[superBlocks[i]]['blocks'][blockNames[j]]['challenges'] =
-          curriculum[superBlocks[i]]['blocks'][blockNames[j]]['meta'];
+        superBlocks[superBlockKeys[i]]['blocks'][blockNames[j]] = {};
+        superBlocks[superBlockKeys[i]]['blocks'][blockNames[j]]['challenges'] =
+          curriculum[superBlockKeys[i]]['blocks'][blockNames[j]]['meta'];
       }
 
-      writeToFile(superBlocks[i], blocks);
-      blocks = {};
+      writeToFile(superBlockKeys[i], superBlocks);
+      superBlocks = {};
     }
   }
 

--- a/tools/scripts/build/build-mobile-curriculum.js
+++ b/tools/scripts/build/build-mobile-curriculum.js
@@ -48,7 +48,7 @@ exports.buildMobileCurriculum = function buildMobileCurriculum(json) {
   function writeToFile(superblock, json) {
     fs.writeFileSync(
       `${mobileStaticPath}/mobile/${superblock}.json`,
-      JSON.stringify(json)
+      JSON.stringify(json, null, 2)
     );
   }
 };

--- a/tools/scripts/build/build-mobile-curriculum.js
+++ b/tools/scripts/build/build-mobile-curriculum.js
@@ -28,10 +28,11 @@ exports.buildMobileCurriculum = function buildMobileCurriculum(json) {
       if (blockGroup.length === 0) continue;
 
       blockNames[superBlocks[i]] = {};
+      blockNames[superBlocks[i]]['blocks'] = {};
 
       for (let j = 0; j < blockGroup.length; j++) {
-        blockNames[superBlocks[i]][blockGroup[j]] = {};
-        blockNames[superBlocks[i]][blockGroup[j]]['challenges'] =
+        blockNames[superBlocks[i]]['blocks'][blockGroup[j]] = {};
+        blockNames[superBlocks[i]]['blocks'][blockGroup[j]]['challenges'] =
           curriculum[superBlocks[i]]['blocks'][blockGroup[j]]['meta'];
       }
     }

--- a/tools/scripts/build/build-mobile-curriculum.js
+++ b/tools/scripts/build/build-mobile-curriculum.js
@@ -18,6 +18,10 @@ exports.buildMobileCurriculum = function buildMobileCurriculum(json) {
 
     const superBlocks = Object.keys(curriculum);
 
+    const superBlockObj = { superblocks: superBlocks.slice(1) };
+
+    writeToFile('availableSuperblocks', superBlockObj);
+
     let blockNames = {};
 
     for (let i = 0; i < superBlocks.length; i++) {
@@ -35,20 +39,16 @@ exports.buildMobileCurriculum = function buildMobileCurriculum(json) {
         blockNames[superBlocks[i]]['blocks'][blockGroup[j]]['challenges'] =
           curriculum[superBlocks[i]]['blocks'][blockGroup[j]]['meta'];
       }
+
+      writeToFile(superBlocks[i], blockNames);
+      blockNames = {};
     }
+  }
 
-    // remove certification object
-
-    for (var i in blockNames) {
-      delete blockNames[i];
-      break;
-    }
-
-    const parsedJson = { superblocks: blockNames };
-
+  function writeToFile(superblock, json) {
     fs.writeFileSync(
-      `${mobileStaticPath}/mobile/curriculum-mobile.json`,
-      JSON.stringify(parsedJson)
+      `${mobileStaticPath}/mobile/${superblock}.json`,
+      JSON.stringify(json)
     );
   }
 };


### PR DESCRIPTION
As discussed with Oliver it would be useful to statically generate curriculum data for the mobile client on build.

If we want to make learn natively available in the mobile client, this is the first step. 
