### PR TITLE
docs: fix links within docs to point to respective language page

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -102,7 +102,7 @@ moderators' team. Open source work is voluntary work and our time is limited.
 We acknowledge that this is probably true in your case as well. So we emphasize
 being **consistent** rather than engaging in the community 24/7.
 
-Take a look at our [Moderator Handbook](https://contribute.freecodecamp.org/#/moderator-handbook)
+Take a look at our [Moderator Handbook](moderator-handbook.md)
 for a more exhaustive list of other responsibilities and expectations we have
 of our moderators.
 

--- a/docs/security-hall-of-fame.md
+++ b/docs/security-hall-of-fame.md
@@ -1,6 +1,6 @@
 # Responsible Disclosure - Hall of Fame
 
-We appreciate any responsible disclosure of vulnerabilities that might impact the integrity of our platforms and users. If you are interested in contributing to the security of our platform, please read our [security policy outlined here](https://contribute.freecodecamp.org/#/security).
+We appreciate any responsible disclosure of vulnerabilities that might impact the integrity of our platforms and users. If you are interested in contributing to the security of our platform, please read our [security policy outlined here](security.md).
 
 While we do not offer any bounties or swags at the moment, we are grateful to these awesome people for helping us keep the platform safe for everyone:
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -12,7 +12,7 @@ We appreciate any responsible disclosure of vulnerabilities that might impact th
 
 Once you report a vulnerability, we will look into it and make sure that it is not a false positive. We will get back to you if we need to clarify any details. You can submit separate reports for each issue you find.
 
-While we do not offer any bounties or swags at the moment, we'll be happy to list your name in our [Hall of Fame](https://contribute.freecodecamp.org/#/security-hall-of-fame) list, provided the reports are not low-effort.
+While we do not offer any bounties or swags at the moment, we'll be happy to list your name in our [Hall of Fame](security-hall-of-fame.md) list, provided the reports are not low-effort.
 
 We consider using tools & online utilities to report issues with SPF & DKIM configs, or SSL Server tests, etc. in the category of ["beg bounties"](https://www.troyhunt.com/beg-bounties/) and are unable to respond to these reports.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
There are some links pointing to another page within docs. If they specify the entire URL, it will always point to English page.
This PR changes them to specify only the file name, so that they will take you to the page in respective language.

Note: The files other than English should be updated through Crowdin.