### PR TITLE
fix: removed one extra blank line (inconsistency)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,7 +63,6 @@ $RECYCLE.BIN/
 # Icon must end with two \r
 Icon
 
-
 # Thumbnails
 ._*
 


### PR DESCRIPTION
Removed one extra blank line between the 'Icon' and 'Thumbnails' Sections. At lines 64-65-66.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [ x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
