### PR TITLE
fix(a11y): use appropriate aria-label for fCC logo depending on its use

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -458,7 +458,6 @@
   },
   "aria": {
     "fcc-curriculum": "freeCodeCamp Curriculum",
-    "fcc-logo": "freeCodeCamp Logo",
     "answer": "Answer",
     "linkedin": "Link to {{username}}'s LinkedIn",
     "github": "Link to {{username}}'s GitHub",

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -458,6 +458,7 @@
   },
   "aria": {
     "fcc-curriculum": "freeCodeCamp Curriculum",
+    "fcc-logo": "freeCodeCamp Logo",
     "answer": "Answer",
     "linkedin": "Link to {{username}}'s LinkedIn",
     "github": "Link to {{username}}'s GitHub",

--- a/client/src/assets/icons/FreeCodeCamp-logo.tsx
+++ b/client/src/assets/icons/FreeCodeCamp-logo.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-function FreeCodeCampLogo(): JSX.Element {
+type FreeCodeCampLogoProps = {
+  ariaLabel: string;
+};
+
+function FreeCodeCampLogo({ ariaLabel }: FreeCodeCampLogoProps): JSX.Element {
   const { t } = useTranslation();
 
   return (
     <svg
-      aria-label={t('aria.fcc-curriculum')}
+      aria-label={t(ariaLabel)}
       height={24}
       version='1.1'
       viewBox='0 0 210 24'

--- a/client/src/assets/icons/FreeCodeCamp-logo.tsx
+++ b/client/src/assets/icons/FreeCodeCamp-logo.tsx
@@ -1,22 +1,17 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 
-type FreeCodeCampLogoProps = {
-  ariaLabel: string;
-};
-
-function FreeCodeCampLogo({ ariaLabel }: FreeCodeCampLogoProps): JSX.Element {
-  const { t } = useTranslation();
-
+function FreeCodeCampLogo(
+  props: JSX.IntrinsicAttributes & React.SVGProps<SVGSVGElement>
+): JSX.Element {
   return (
     <svg
-      aria-label={t(ariaLabel)}
       height={24}
       version='1.1'
       viewBox='0 0 210 24'
       width={210}
       xmlns='http://www.w3.org/2000/svg'
       xmlnsXlink='http://www.w3.org/1999/xlink'
+      {...props}
     >
       <defs>
         <path

--- a/client/src/client-only-routes/show-certification.tsx
+++ b/client/src/client-only-routes/show-certification.tsx
@@ -322,7 +322,7 @@ const ShowCertification = (props: ShowCertificationProps): JSX.Element => {
         <header>
           <Col md={5} sm={12}>
             <div className='logo'>
-              <FreeCodeCampLogo />
+              <FreeCodeCampLogo ariaLabel='aria.fcc-logo' />
             </div>
           </Col>
           <Col md={7} sm={12}>

--- a/client/src/client-only-routes/show-certification.tsx
+++ b/client/src/client-only-routes/show-certification.tsx
@@ -322,7 +322,7 @@ const ShowCertification = (props: ShowCertificationProps): JSX.Element => {
         <header>
           <Col md={5} sm={12}>
             <div className='logo'>
-              <FreeCodeCampLogo ariaLabel='aria.fcc-logo' />
+              <FreeCodeCampLogo aria-hidden='true' />
             </div>
           </Col>
           <Col md={7} sm={12}>

--- a/client/src/components/Header/components/nav-logo.tsx
+++ b/client/src/components/Header/components/nav-logo.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import FreeCodeCampLogo from '../../../assets/icons/FreeCodeCamp-logo';
 
 const NavLogo = (): JSX.Element => {
-  return <FreeCodeCampLogo ariaLabel='aria.fcc-curriculum' />;
+  const { t } = useTranslation();
+  return <FreeCodeCampLogo aria-label={t('aria.fcc-curriculum')} />;
 };
 
 NavLogo.displayName = 'NavLogo';

--- a/client/src/components/Header/components/nav-logo.tsx
+++ b/client/src/components/Header/components/nav-logo.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import FreeCodeCampLogo from '../../../assets/icons/FreeCodeCamp-logo';
 
 const NavLogo = (): JSX.Element => {
-  return <FreeCodeCampLogo />;
+  return <FreeCodeCampLogo ariaLabel='aria.fcc-curriculum' />;
 };
 
 NavLogo.displayName = 'NavLogo';


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #45095

<!-- Feel free to add any additional description of changes below this line -->
`FreeCodeCampLogo` component is used on 2 different places, in the main navigation bar (as a link to the curriculum) and in certificates (as a pure logo).
Use "freeCodeCamp Curriculum" for `aria-label` in navigation bar, but "freeCodeCamp Logo" in certificates.
![curriculum](https://user-images.githubusercontent.com/25644062/154852613-9b8f1c4e-c09d-4ab1-b4f5-f5b6713d0c6c.png)

![logo](https://user-images.githubusercontent.com/25644062/154852635-e1f221ee-beb2-4576-94f2-03427e44b7c2.png)

