### PR TITLE
chore: update root lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5254,9 +5254,9 @@
       "integrity": "sha512-afmTuJrylUU/0OtqzaRkbyYFFNgCF73Bvel/sw90pvGrWIZ+vyoIJqA6eMSoA6+nb443kTmulmBtC9NerXboNg=="
     },
     "node_modules/@rollup/plugin-babel": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.0.tgz",
-      "integrity": "sha512-9uIC8HZOnVLrLHxayq/PTzw+uS25E14KPUBh5ktF+18Mjo5yK0ToMMx6epY0uEgkjwJw0aBW4x2horYXh8juWw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
+      "integrity": "sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==",
       "dev": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.10.4",
@@ -45367,9 +45367,9 @@
       "integrity": "sha1-8z/pz7Urv9UgqhgyO8ZdsRCht2w="
     },
     "node_modules/rollup": {
-      "version": "2.67.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.67.3.tgz",
-      "integrity": "sha512-G/x1vUwbGtP6O5ZM8/sWr8+p7YfZhI18pPqMRtMYMWSbHjKZ/ajHGiM+GWNTlWyOR0EHIdT8LHU+Z4ciIZ1oBw==",
+      "version": "2.68.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.68.0.tgz",
+      "integrity": "sha512-XrMKOYK7oQcTio4wyTz466mucnd8LzkiZLozZ4Rz0zQD+HeX4nUK4B8GrTX/2EvN2/vBF/i2WnaXboPxo0JylA==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -53147,7 +53147,7 @@
       "devDependencies": {
         "@babel/core": "7.17.5",
         "@babel/preset-env": "7.16.11",
-        "@rollup/plugin-babel": "5.3.0",
+        "@rollup/plugin-babel": "5.3.1",
         "@rollup/plugin-commonjs": "19.0.2",
         "@rollup/plugin-node-resolve": "13.1.3",
         "@rollup/plugin-typescript": "8.3.0",
@@ -53170,7 +53170,7 @@
         "postcss": "8.4.6",
         "postcss-import": "14.0.2",
         "rimraf": "3.0.2",
-        "rollup": "2.67.3",
+        "rollup": "2.68.0",
         "rollup-plugin-postcss": "4.0.2",
         "rollup-plugin-terser": "7.0.2",
         "tailwindcss": "3.0.23"
@@ -56045,7 +56045,7 @@
         "@babel/core": "7.17.5",
         "@babel/preset-env": "7.16.11",
         "@babel/preset-typescript": "7.16.7",
-        "@rollup/plugin-babel": "5.3.0",
+        "@rollup/plugin-babel": "5.3.1",
         "@rollup/plugin-commonjs": "19.0.2",
         "@rollup/plugin-node-resolve": "13.1.3",
         "@rollup/plugin-typescript": "8.3.0",
@@ -56070,7 +56070,7 @@
         "react": "16.14.0",
         "react-dom": "16.14.0",
         "rimraf": "3.0.2",
-        "rollup": "2.67.3",
+        "rollup": "2.68.0",
         "rollup-plugin-postcss": "4.0.2",
         "rollup-plugin-terser": "7.0.2",
         "tailwindcss": "3.0.23",
@@ -57877,9 +57877,9 @@
       "integrity": "sha512-afmTuJrylUU/0OtqzaRkbyYFFNgCF73Bvel/sw90pvGrWIZ+vyoIJqA6eMSoA6+nb443kTmulmBtC9NerXboNg=="
     },
     "@rollup/plugin-babel": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.0.tgz",
-      "integrity": "sha512-9uIC8HZOnVLrLHxayq/PTzw+uS25E14KPUBh5ktF+18Mjo5yK0ToMMx6epY0uEgkjwJw0aBW4x2horYXh8juWw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
+      "integrity": "sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.10.4",
@@ -88783,9 +88783,9 @@
       "integrity": "sha1-8z/pz7Urv9UgqhgyO8ZdsRCht2w="
     },
     "rollup": {
-      "version": "2.67.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.67.3.tgz",
-      "integrity": "sha512-G/x1vUwbGtP6O5ZM8/sWr8+p7YfZhI18pPqMRtMYMWSbHjKZ/ajHGiM+GWNTlWyOR0EHIdT8LHU+Z4ciIZ1oBw==",
+      "version": "2.68.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.68.0.tgz",
+      "integrity": "sha512-XrMKOYK7oQcTio4wyTz466mucnd8LzkiZLozZ4Rz0zQD+HeX4nUK4B8GrTX/2EvN2/vBF/i2WnaXboPxo0JylA==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"


### PR DESCRIPTION
This updates the botched lockfile update that seems to happen from time to time. In this case the offending commit seems to be 2f4cee8e36483c6df62c82872051f9a0b7c4b393
