### PR TITLE
feat: display multifile projects

### DIFF
--- a/api-server/src/server/boot/challenge.js
+++ b/api-server/src/server/boot/challenge.js
@@ -103,7 +103,7 @@ export function buildUserUpdate(
       )
     };
   } else {
-    completedChallenge = omit(_completedChallenge, ['files']);
+    completedChallenge = omit(_completedChallenge, ['files', 'challengeType']);
   }
   let finalChallenge;
   const updateData = {};
@@ -239,17 +239,22 @@ export function modernChallengeCompleted(req, res, next) {
       const completedDate = Date.now();
       const { id, files, challengeType } = req.body;
 
-      const data = {
+      const completedChallenge = {
         id,
         files,
+        challengeType,
         completedDate
       };
 
       if (challengeType === 14) {
-        data.isManuallyApproved = false;
+        completedChallenge.isManuallyApproved = false;
       }
 
-      const { alreadyCompleted, updateData } = buildUserUpdate(user, id, data);
+      const { alreadyCompleted, updateData } = buildUserUpdate(
+        user,
+        id,
+        completedChallenge
+      );
       const points = alreadyCompleted ? user.points : user.points + 1;
       const updatePromise = new Promise((resolve, reject) =>
         user.updateAttributes(updateData, err => {

--- a/api-server/src/server/boot/challenge.js
+++ b/api-server/src/server/boot/challenge.js
@@ -103,7 +103,7 @@ export function buildUserUpdate(
       )
     };
   } else {
-    completedChallenge = omit(_completedChallenge, ['files', 'challengeType']);
+    completedChallenge = omit(_completedChallenge, ['files']);
   }
   let finalChallenge;
   const updateData = {};
@@ -242,12 +242,20 @@ export function modernChallengeCompleted(req, res, next) {
       const completedChallenge = {
         id,
         files,
-        challengeType,
         completedDate
       };
 
       if (challengeType === 14) {
         completedChallenge.isManuallyApproved = false;
+      }
+
+      // We only need to know the challenge type if it's a project. If it's a
+      // step or normal challenge we can avoid storing in the database.
+      if (
+        jsCertProjectIds.includes(id) ||
+        multiFileCertProjectIds.includes(id)
+      ) {
+        completedChallenge.challengeType = challengeType;
       }
 
       const { alreadyCompleted, updateData } = buildUserUpdate(

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -8,6 +8,7 @@
     "edit": "Edit",
     "show-code": "Show Code",
     "show-solution": "Show Solution",
+    "show-project": "Show Project",
     "frontend": "Front End",
     "backend": "Back End",
     "view": "View",

--- a/client/src/client-only-routes/show-project-links.tsx
+++ b/client/src/client-only-routes/show-project-links.tsx
@@ -67,7 +67,7 @@ const ShowProjectLinks = (props: ShowProjectLinksProps): JSX.Element => {
     }
 
     const { solution, challengeFiles } = completedProject;
-    const showFilesSolution = () =>
+    const showUserCode = () =>
       setSolutionState({
         projectTitle,
         challengeFiles,
@@ -90,7 +90,7 @@ const ShowProjectLinks = (props: ShowProjectLinksProps): JSX.Element => {
         completedChallenge={completedProject}
         dataCy={`${projectTitle} solution`}
         displayContext='certification'
-        showFilesSolution={showFilesSolution}
+        showUserCode={showUserCode}
         showProjectPreview={showProjectPreview}
       ></SolutionDisplayWidget>
     );

--- a/client/src/client-only-routes/show-project-links.tsx
+++ b/client/src/client-only-routes/show-project-links.tsx
@@ -179,7 +179,7 @@ const ShowProjectLinks = (props: ShowProjectLinksProps): JSX.Element => {
         closeText={t('buttons.close')}
         previewTitle={projectTitle}
         showProjectPreview={true}
-      ></ProjectPreviewModal>
+      />
       <Trans i18nKey='certification.project.footnote'>
         If you suspect that any of these projects violate the{' '}
         <a

--- a/client/src/client-only-routes/show-project-links.tsx
+++ b/client/src/client-only-routes/show-project-links.tsx
@@ -12,10 +12,8 @@ import {
 } from '../resources/cert-and-project-map';
 
 import { SolutionDisplayWidget } from '../components/solution-display-widget';
-import ProjectPreviewModal, {
-  ChallengeData
-} from '../templates/Challenges/components/project-preview-modal';
-import { challengeTypes } from '../../utils/challenge-types';
+import ProjectPreviewModal from '../templates/Challenges/components/project-preview-modal';
+
 import { openModal } from '../templates/Challenges/redux';
 
 import '../components/layouts/project-links.css';
@@ -29,15 +27,13 @@ interface ShowProjectLinksProps {
 
 type SolutionState = {
   projectTitle: string;
-  challengeFiles: CompletedChallenge['challengeFiles'];
-  solution: CompletedChallenge['solution'];
+  completedChallenge: CompletedChallenge | null;
   showCode: boolean;
 };
 
 const initSolutionState: SolutionState = {
   projectTitle: '',
-  challengeFiles: [],
-  solution: '',
+  completedChallenge: null,
   showCode: false
 };
 
@@ -66,20 +62,17 @@ const ShowProjectLinks = (props: ShowProjectLinksProps): JSX.Element => {
       return null;
     }
 
-    const { solution, challengeFiles } = completedProject;
     const showUserCode = () =>
       setSolutionState({
         projectTitle,
-        challengeFiles,
-        solution,
+        completedChallenge: completedProject,
         showCode: true
       });
 
     const showProjectPreview = () => {
       setSolutionState({
         projectTitle,
-        challengeFiles,
-        solution,
+        completedChallenge: completedProject,
         showCode: false
       });
       openModal('projectPreview');
@@ -146,13 +139,17 @@ const ShowProjectLinks = (props: ShowProjectLinksProps): JSX.Element => {
     name,
     user: { username }
   } = props;
-  const { challengeFiles, showCode, solution, projectTitle } = solutionState;
-  // TODO: stop hardcoding this
-  const challengeData: ChallengeData = {
-    challengeType: challengeTypes.multiFileCertProject,
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    challengeFiles: challengeFiles?.map(regeneratePathAndHistory) ?? null
-  };
+  const { completedChallenge, showCode, projectTitle } = solutionState;
+
+  const challengeData: CompletedChallenge | null = completedChallenge
+    ? {
+        ...completedChallenge,
+        // // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        challengeFiles:
+          completedChallenge?.challengeFiles?.map(regeneratePathAndHistory) ??
+          null
+      }
+    : null;
 
   return (
     <div>
@@ -166,13 +163,13 @@ const ShowProjectLinks = (props: ShowProjectLinksProps): JSX.Element => {
       <ul>{renderProjectsFor(certName)}</ul>
       <Spacer />
       <ProjectModal
-        challengeFiles={challengeFiles}
+        challengeFiles={completedChallenge?.challengeFiles ?? null}
         handleSolutionModalHide={handleSolutionModalHide}
         isOpen={showCode}
         projectTitle={projectTitle}
         // 'solution' is theoretically never 'null', if it a JsAlgoData cert
         // which is the only time we use the modal
-        solution={solution as undefined | string}
+        solution={completedChallenge?.solution as undefined | string}
       />
       <ProjectPreviewModal
         challengeData={challengeData}

--- a/client/src/client-only-routes/show-project-links.tsx
+++ b/client/src/client-only-routes/show-project-links.tsx
@@ -22,14 +22,14 @@ type SolutionState = {
   projectTitle: string;
   challengeFiles: CompletedChallenge['challengeFiles'];
   solution: CompletedChallenge['solution'];
-  isOpen: boolean;
+  showCode: boolean;
 };
 
 const initSolutionState: SolutionState = {
   projectTitle: '',
   challengeFiles: null,
   solution: '',
-  isOpen: false
+  showCode: false
 };
 
 const ShowProjectLinks = (props: ShowProjectLinksProps): JSX.Element => {
@@ -58,7 +58,7 @@ const ShowProjectLinks = (props: ShowProjectLinksProps): JSX.Element => {
         projectTitle,
         challengeFiles,
         solution,
-        isOpen: true
+        showCode: true
       });
 
     return (
@@ -121,7 +121,7 @@ const ShowProjectLinks = (props: ShowProjectLinksProps): JSX.Element => {
     name,
     user: { username }
   } = props;
-  const { challengeFiles, isOpen, projectTitle, solution } = solutionState;
+  const { challengeFiles, showCode, solution, projectTitle } = solutionState;
   return (
     <div>
       {t(
@@ -133,11 +133,11 @@ const ShowProjectLinks = (props: ShowProjectLinksProps): JSX.Element => {
       <Spacer />
       <ul>{renderProjectsFor(certName)}</ul>
       <Spacer />
-      {isOpen ? (
+      {showCode ? (
         <ProjectModal
           challengeFiles={challengeFiles}
           handleSolutionModalHide={handleSolutionModalHide}
-          isOpen={isOpen}
+          isOpen={showCode}
           projectTitle={projectTitle}
           // 'solution' is theoretically never 'null', if it a JsAlgoData cert
           // which is the only time we use the modal

--- a/client/src/client-only-routes/show-project-links.tsx
+++ b/client/src/client-only-routes/show-project-links.tsx
@@ -4,7 +4,7 @@ import '../components/layouts/project-links.css';
 import { Trans, useTranslation } from 'react-i18next';
 import ProjectModal from '../components/SolutionViewer/ProjectModal';
 import { Spacer, Link } from '../components/helpers';
-import { ChallengeFiles, CompletedChallenge, User } from '../redux/prop-types';
+import { CompletedChallenge, User } from '../redux/prop-types';
 import {
   projectMap,
   legacyProjectMap
@@ -20,7 +20,7 @@ interface ShowProjectLinksProps {
 
 type SolutionState = {
   projectTitle: string;
-  challengeFiles: ChallengeFiles;
+  challengeFiles: CompletedChallenge['challengeFiles'];
   solution: CompletedChallenge['solution'];
   isOpen: boolean;
 };
@@ -46,7 +46,7 @@ const ShowProjectLinks = (props: ShowProjectLinksProps): JSX.Element => {
     const completedProject = find(
       completedChallenges,
       ({ id }) => projectId === id
-    ) as CompletedChallenge;
+    );
 
     if (!completedProject) {
       return null;

--- a/client/src/components/SolutionViewer/ProjectModal.tsx
+++ b/client/src/components/SolutionViewer/ProjectModal.tsx
@@ -27,11 +27,9 @@ const ProjectModal = ({
       onHide={handleSolutionModalHide}
       show={isOpen}
     >
-      <Modal.Header className='this-one?' closeButton={true}>
+      <Modal.Header closeButton={true}>
         <Modal.Title id='solution-viewer-modal-title'>
-          {t('settings.labels.solution-for', {
-            projectTitle: projectTitle
-          })}
+          {t('settings.labels.solution-for', { projectTitle })}
         </Modal.Title>
       </Modal.Header>
       <Modal.Body>

--- a/client/src/components/SolutionViewer/ProjectModal.tsx
+++ b/client/src/components/SolutionViewer/ProjectModal.tsx
@@ -5,7 +5,7 @@ import { CompletedChallenge } from '../../redux/prop-types';
 import SolutionViewer from './SolutionViewer';
 
 type ProjectModalProps = {
-  challengeFiles: CompletedChallenge['challengeFiles'];
+  challengeFiles: CompletedChallenge['challengeFiles'] | null;
   handleSolutionModalHide: () => void;
   isOpen: boolean;
   projectTitle: string;

--- a/client/src/components/SolutionViewer/ProjectModal.tsx
+++ b/client/src/components/SolutionViewer/ProjectModal.tsx
@@ -1,11 +1,11 @@
 import { Button, Modal } from '@freecodecamp/react-bootstrap';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { ChallengeFiles } from '../../redux/prop-types';
+import { CompletedChallenge } from '../../redux/prop-types';
 import SolutionViewer from './SolutionViewer';
 
 type ProjectModalProps = {
-  challengeFiles: ChallengeFiles;
+  challengeFiles: CompletedChallenge['challengeFiles'];
   handleSolutionModalHide: () => void;
   isOpen: boolean;
   projectTitle: string;

--- a/client/src/components/SolutionViewer/SolutionViewer.tsx
+++ b/client/src/components/SolutionViewer/SolutionViewer.tsx
@@ -19,7 +19,7 @@ function SolutionViewer({
           <Panel
             bsStyle='primary'
             className='solution-viewer'
-            key={challengeFile}
+            key={challengeFile.ext}
           >
             <Panel.Heading>{challengeFile.ext.toUpperCase()}</Panel.Heading>
 
@@ -39,16 +39,11 @@ function SolutionViewer({
           </Panel>
         ))
       ) : (
-        <Panel
-          bsStyle='primary'
-          className='solution-viewer'
-          key={solution.slice(0, 10)}
-        >
+        <Panel bsStyle='primary' className='solution-viewer' key='JS'>
           <Panel.Heading>JS</Panel.Heading>
           <Panel.Body>
             <pre>
               <code
-                className='language-markup'
                 dangerouslySetInnerHTML={{
                   __html: Prism.highlight(
                     solution.trim(),

--- a/client/src/components/SolutionViewer/SolutionViewer.tsx
+++ b/client/src/components/SolutionViewer/SolutionViewer.tsx
@@ -1,61 +1,47 @@
 import { Panel } from '@freecodecamp/react-bootstrap';
 import Prism from 'prismjs';
 import React from 'react';
-import { ChallengeFile, ChallengeFiles } from '../../redux/prop-types';
+import { ChallengeFile } from '../../redux/prop-types';
 
-type SolutionViewerProps = {
-  challengeFiles: ChallengeFiles;
+type Props = {
+  challengeFiles: Solution[] | null;
   solution?: string;
 };
+type Solution = Pick<ChallengeFile, 'ext' | 'contents' | 'fileKey'>;
 
-function SolutionViewer({
-  challengeFiles,
-  solution = '// The solution is not available for this project'
-}: SolutionViewerProps): JSX.Element {
+function SolutionViewer({ challengeFiles, solution }: Props) {
+  const isLegacy = !challengeFiles || !challengeFiles.length;
+  const solutions = isLegacy
+    ? [
+        {
+          ext: 'js',
+          contents:
+            solution ?? '// The solution is not available for this project',
+          fileKey: 'script.js'
+        }
+      ]
+    : challengeFiles;
+
   return (
     <>
-      {challengeFiles?.length ? (
-        challengeFiles.map((challengeFile: ChallengeFile) => (
-          <Panel
-            bsStyle='primary'
-            className='solution-viewer'
-            key={challengeFile.ext}
-          >
-            <Panel.Heading>{challengeFile.ext.toUpperCase()}</Panel.Heading>
-
-            <Panel.Body>
-              <pre>
-                <code
-                  dangerouslySetInnerHTML={{
-                    __html: Prism.highlight(
-                      challengeFile.contents.trim(),
-                      Prism.languages[challengeFile.ext],
-                      ''
-                    )
-                  }}
-                />
-              </pre>
-            </Panel.Body>
-          </Panel>
-        ))
-      ) : (
-        <Panel bsStyle='primary' className='solution-viewer' key='JS'>
-          <Panel.Heading>JS</Panel.Heading>
+      {solutions.map(({ fileKey, ext, contents }) => (
+        <Panel bsStyle='primary' className='solution-viewer' key={fileKey}>
+          <Panel.Heading>{ext.toUpperCase()}</Panel.Heading>
           <Panel.Body>
             <pre>
               <code
                 dangerouslySetInnerHTML={{
                   __html: Prism.highlight(
-                    solution.trim(),
-                    Prism.languages.js,
-                    'javascript'
+                    contents.trim(),
+                    Prism.languages[ext],
+                    ext
                   )
                 }}
               />
             </pre>
           </Panel.Body>
         </Panel>
-      )}
+      ))}
     </>
   );
 }

--- a/client/src/components/profile/components/time-line.test.tsx
+++ b/client/src/components/profile/components/time-line.test.tsx
@@ -1,12 +1,17 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
-import { render, screen } from '@testing-library/react';
 import { useStaticQuery } from 'gatsby';
 import React from 'react';
+
+import { render, screen } from '../../../../utils/test-utils';
+import { createStore } from '../../../redux/createStore';
 import TimeLine from './time-line';
 
+jest.mock('react-ga');
+const store = createStore();
+
 beforeEach(() => {
-  // @ts-ignore
+  // @ts-expect-error
   useStaticQuery.mockImplementationOnce(() => ({
     allChallengeNode: {
       edges: [
@@ -50,8 +55,8 @@ beforeEach(() => {
 
 describe('<TimeLine />', () => {
   it('Render button when only solution is present', () => {
-    // @ts-ignore
-    render(<TimeLine {...propsForOnlySolution} />);
+    // @ts-expect-error
+    render(<TimeLine {...propsForOnlySolution} />, store);
     const showViewButton = screen.getByRole('link', { name: 'buttons.view' });
     expect(showViewButton).toHaveAttribute(
       'href',
@@ -60,8 +65,8 @@ describe('<TimeLine />', () => {
   });
 
   it('Render button when both githubLink and solution is present', () => {
-    // @ts-ignore
-    render(<TimeLine {...propsForOnlySolution} />);
+    // @ts-expect-error
+    render(<TimeLine {...propsForOnlySolution} />, store);
 
     const menuItems = screen.getAllByRole('menuitem');
     expect(menuItems).toHaveLength(2);
@@ -76,8 +81,8 @@ describe('<TimeLine />', () => {
   });
 
   it('rendering the correct button when files is present', () => {
-    // @ts-ignore
-    render(<TimeLine {...propsForOnlySolution} />);
+    // @ts-expect-error
+    render(<TimeLine {...propsForOnlySolution} />, store);
 
     const button = screen.getByText('buttons.show-code');
     expect(button).toBeInTheDocument();

--- a/client/src/components/profile/components/time-line.tsx
+++ b/client/src/components/profile/components/time-line.tsx
@@ -126,7 +126,7 @@ function TimelineInner({
     return (
       <SolutionDisplayWidget
         completedChallenge={completedChallenge}
-        showFilesSolution={() => viewSolution(id, solution, challengeFiles)}
+        showUserCode={() => viewSolution(id, solution, challengeFiles)}
         showProjectPreview={() => viewProject(id, solution, challengeFiles)}
         displayContext={'timeline'}
       ></SolutionDisplayWidget>

--- a/client/src/components/profile/components/time-line.tsx
+++ b/client/src/components/profile/components/time-line.tsx
@@ -14,7 +14,7 @@ import {
   getTitleFromId
 } from '../../../../../utils';
 import CertificationIcon from '../../../assets/icons/certification-icon';
-import { ChallengeFiles, CompletedChallenge } from '../../../redux/prop-types';
+import { CompletedChallenge } from '../../../redux/prop-types';
 import { FullWidthRow, Link } from '../../helpers';
 import { SolutionDisplayWidget } from '../../solution-display-widget';
 import TimelinePagination from './timeline-pagination';
@@ -55,17 +55,18 @@ function TimelineInner({
   const [solutionOpen, setSolutionOpen] = useState(false);
   const [pageNo, setPageNo] = useState(1);
   const [solution, setSolution] = useState<string | null>(null);
-  const [challengeFiles, setChallengeFiles] = useState<ChallengeFiles>(null);
+  const [challengeFiles, setChallengeFiles] =
+    useState<CompletedChallenge['challengeFiles']>(null);
 
   function viewSolution(
     id: string,
-    solution_: string | undefined | null,
-    challengeFiles_: ChallengeFiles
+    solution: string | undefined | null,
+    challengeFiles: CompletedChallenge['challengeFiles']
   ): void {
     setSolutionToView(id);
     setSolutionOpen(true);
-    setSolution(solution_ ?? '');
-    setChallengeFiles(challengeFiles_);
+    setSolution(solution ?? '');
+    setChallengeFiles(challengeFiles);
   }
 
   function closeSolution(): void {

--- a/client/src/components/settings/certification.js
+++ b/client/src/components/settings/certification.js
@@ -181,7 +181,7 @@ export class CertificationSettings extends Component {
     }
 
     const { solution, challengeFiles } = completedProject;
-    const showFilesSolution = () =>
+    const showUserCode = () =>
       this.setState({
         solutionViewer: {
           projectTitle,
@@ -208,7 +208,7 @@ export class CertificationSettings extends Component {
       <SolutionDisplayWidget
         completedChallenge={completedProject}
         dataCy={projectTitle}
-        showFilesSolution={showFilesSolution}
+        showUserCode={showUserCode}
         showProjectPreview={showProjectPreview}
         displayContext={'settings'}
       ></SolutionDisplayWidget>

--- a/client/src/components/settings/certification.js
+++ b/client/src/components/settings/certification.js
@@ -193,7 +193,6 @@ export class CertificationSettings extends Component {
     const challengeData = completedProject
       ? {
           ...completedProject,
-
           challengeFiles:
             completedProject?.challengeFiles?.map(regeneratePathAndHistory) ??
             null

--- a/client/src/components/settings/certification.js
+++ b/client/src/components/settings/certification.js
@@ -171,8 +171,7 @@ export class CertificationSettings extends Component {
     }
 
     const { solution, challengeFiles } = completedProject;
-
-    const onClickHandler = () =>
+    const showFilesSolution = () =>
       this.setState({
         solutionViewer: {
           projectTitle,
@@ -186,7 +185,8 @@ export class CertificationSettings extends Component {
       <SolutionDisplayWidget
         completedChallenge={completedProject}
         dataCy={projectTitle}
-        showFilesSolution={onClickHandler}
+        showFilesSolution={showFilesSolution}
+        showProjectPreview={() => {}} // TODO: implement this
         displayContext={'settings'}
       ></SolutionDisplayWidget>
     );

--- a/client/src/components/settings/certification.js
+++ b/client/src/components/settings/certification.js
@@ -361,11 +361,9 @@ export class CertificationSettings extends Component {
   };
 
   render() {
-    const {
-      solutionViewer: { challengeFiles, solution, isOpen, projectTitle }
-    } = this.state;
-
+    const { solutionViewer } = this.state;
     const { t } = this.props;
+
     return (
       <ScrollableAnchor id='certification-settings'>
         <section className='certification-settings'>
@@ -378,16 +376,12 @@ export class CertificationSettings extends Component {
           {legacyCertifications.map(certName =>
             this.renderCertifications(certName, legacyProjectMap)
           )}
-          {isOpen ? (
+          {solutionViewer.isOpen && (
             <ProjectModal
-              challengeFiles={challengeFiles}
+              {...solutionViewer}
               handleSolutionModalHide={this.handleSolutionModalHide}
-              isOpen={isOpen}
-              projectTitle={projectTitle}
-              solution={solution}
-              t={t}
             />
-          ) : null}
+          )}
         </section>
       </ScrollableAnchor>
     );

--- a/client/src/components/settings/certification.js
+++ b/client/src/components/settings/certification.js
@@ -9,7 +9,6 @@ import ScrollableAnchor, { configureAnchors } from 'react-scrollable-anchor';
 import { connect } from 'react-redux';
 
 import { regeneratePathAndHistory } from '../../../../utils/polyvinyl';
-import { challengeTypes } from '../../../utils/challenge-types';
 import ProjectPreviewModal from '../../templates/Challenges/components/project-preview-modal';
 import { openModal } from '../../templates/Challenges/redux';
 import {
@@ -191,14 +190,21 @@ export class CertificationSettings extends Component {
         }
       });
 
+    const challengeData = completedProject
+      ? {
+          ...completedProject,
+
+          challengeFiles:
+            completedProject?.challengeFiles?.map(regeneratePathAndHistory) ??
+            null
+        }
+      : null;
+
     const showProjectPreview = () => {
       this.setState({
         projectViewer: {
           previewTitle: projectTitle,
-          challengeData: {
-            challengeFiles: challengeFiles?.map(regeneratePathAndHistory),
-            challengeType: challengeTypes.multiFileCertProject // TODO: stop hardcoding this
-          }
+          challengeData
         }
       });
       openModal('projectPreview');

--- a/client/src/components/solution-display-widget/index.tsx
+++ b/client/src/components/solution-display-widget/index.tsx
@@ -21,6 +21,7 @@ export function SolutionDisplayWidget({
   showFilesSolution,
   displayContext
 }: Props) {
+  console.log('completedChallenge', completedChallenge);
   const { id, solution, githubLink } = completedChallenge;
   const { t } = useTranslation();
 
@@ -76,6 +77,28 @@ export function SolutionDisplayWidget({
       {t('buttons.show-code')}
     </Button>
   );
+  const ShowMultifileProjectSolution = (
+    <DropdownButton
+      block={true}
+      bsStyle='primary'
+      className='btn-invert'
+      id={`dropdown-for-${id}`}
+      title={t('buttons.view')}
+    >
+      <MenuItem bsStyle='primary' onClick={showFilesSolution}>
+        {t('buttons.show-code')}
+      </MenuItem>
+      <MenuItem
+        bsStyle='primary'
+        href='https://example.com'
+        rel='noopener noreferrer'
+        target='_blank'
+      >
+        {t('buttons.show-project')}
+      </MenuItem>
+    </DropdownButton>
+  );
+
   const ShowProjectAndGithubLinks = (
     <div className='solutions-dropdown'>
       <DropdownButton
@@ -126,12 +149,14 @@ export function SolutionDisplayWidget({
     displayContext === 'certification'
       ? {
           showFilesSolution: ShowFilesSolutionForCertification,
+          showMultifileProjectSolution: ShowMultifileProjectSolution,
           showProjectAndGitHubLinks: ShowProjectAndGithubLinkForCertification,
           showProjectLink: ShowProjectLinkForCertification,
           none: MissingSolutionComponentForCertification
         }
       : {
           showFilesSolution: ShowFilesSolution,
+          showMultifileProjectSolution: ShowMultifileProjectSolution,
           showProjectAndGitHubLinks: ShowProjectAndGithubLinks,
           showProjectLink: ShowProjectLink,
           none: MissingSolutionComponent

--- a/client/src/components/solution-display-widget/index.tsx
+++ b/client/src/components/solution-display-widget/index.tsx
@@ -12,6 +12,7 @@ interface Props {
   completedChallenge: CompletedChallenge;
   dataCy?: string;
   showFilesSolution: () => void;
+  showProjectPreview?: () => void;
   displayContext: 'timeline' | 'settings' | 'certification';
 }
 
@@ -19,6 +20,7 @@ export function SolutionDisplayWidget({
   completedChallenge,
   dataCy,
   showFilesSolution,
+  showProjectPreview,
   displayContext
 }: Props) {
   console.log('completedChallenge', completedChallenge);
@@ -88,12 +90,7 @@ export function SolutionDisplayWidget({
       <MenuItem bsStyle='primary' onClick={showFilesSolution}>
         {t('buttons.show-code')}
       </MenuItem>
-      <MenuItem
-        bsStyle='primary'
-        href='https://example.com'
-        rel='noopener noreferrer'
-        target='_blank'
-      >
+      <MenuItem bsStyle='primary' onClick={showProjectPreview}>
         {t('buttons.show-project')}
       </MenuItem>
     </DropdownButton>

--- a/client/src/components/solution-display-widget/index.tsx
+++ b/client/src/components/solution-display-widget/index.tsx
@@ -11,7 +11,7 @@ import { getSolutionDisplayType } from '../../utils/solution-display-type';
 interface Props {
   completedChallenge: CompletedChallenge;
   dataCy?: string;
-  showFilesSolution: () => void;
+  showUserCode: () => void;
   showProjectPreview?: () => void;
   displayContext: 'timeline' | 'settings' | 'certification';
 }
@@ -19,7 +19,7 @@ interface Props {
 export function SolutionDisplayWidget({
   completedChallenge,
   dataCy,
-  showFilesSolution,
+  showUserCode,
   showProjectPreview,
   displayContext
 }: Props) {
@@ -35,7 +35,7 @@ export function SolutionDisplayWidget({
     <button
       className='project-link-button-override'
       data-cy={dataCy}
-      onClick={showFilesSolution}
+      onClick={showUserCode}
     >
       {t('certification.project.solution')}
     </button>
@@ -64,14 +64,14 @@ export function SolutionDisplayWidget({
   const MissingSolutionComponentForCertification = (
     <>{t('certification.project.no-solution')}</>
   );
-  const ShowFilesSolution = (
+  const ShowUserCode = (
     <Button
       block={true}
       bsStyle='primary'
       className='btn-invert'
       data-cy={dataCy}
       id={`btn-for-${id}`}
-      onClick={showFilesSolution}
+      onClick={showUserCode}
     >
       {t('buttons.show-code')}
     </Button>
@@ -84,7 +84,7 @@ export function SolutionDisplayWidget({
       id={`dropdown-for-${id}`}
       title={t('buttons.view')}
     >
-      <MenuItem bsStyle='primary' onClick={showFilesSolution}>
+      <MenuItem bsStyle='primary' onClick={showUserCode}>
         {t('buttons.show-code')}
       </MenuItem>
       <MenuItem bsStyle='primary' onClick={showProjectPreview}>
@@ -142,14 +142,14 @@ export function SolutionDisplayWidget({
   const displayComponents =
     displayContext === 'certification'
       ? {
-          showFilesSolution: ShowFilesSolutionForCertification,
+          showUserCode: ShowFilesSolutionForCertification,
           showMultifileProjectSolution: ShowMultifileProjectSolution,
           showProjectAndGithubLinks: ShowProjectAndGithubLinkForCertification,
           showProjectLink: ShowProjectLinkForCertification,
           none: MissingSolutionComponentForCertification
         }
       : {
-          showFilesSolution: ShowFilesSolution,
+          showUserCode: ShowUserCode,
           showMultifileProjectSolution: ShowMultifileProjectSolution,
           showProjectAndGithubLinks: ShowProjectAndGithubLinks,
           showProjectLink: ShowProjectLink,

--- a/client/src/components/solution-display-widget/index.tsx
+++ b/client/src/components/solution-display-widget/index.tsx
@@ -26,9 +26,7 @@ export function SolutionDisplayWidget({
   const { id, solution, githubLink } = completedChallenge;
   const { t } = useTranslation();
 
-  const dropdownTitle =
-    displayContext === 'settings' ? 'Show Solutions' : 'View';
-  const projectLinkText =
+  const showOrViewText =
     displayContext === 'settings'
       ? t('buttons.show-solution')
       : t('buttons.view');
@@ -102,7 +100,7 @@ export function SolutionDisplayWidget({
         bsStyle='primary'
         className='btn-invert'
         id={`dropdown-for-${id}`}
-        title={dropdownTitle}
+        title={showOrViewText}
       >
         <MenuItem
           bsStyle='primary'
@@ -133,7 +131,7 @@ export function SolutionDisplayWidget({
       rel='noopener noreferrer'
       target='_blank'
     >
-      {projectLinkText}
+      {showOrViewText}
     </Button>
   );
   const MissingSolutionComponent =

--- a/client/src/components/solution-display-widget/index.tsx
+++ b/client/src/components/solution-display-widget/index.tsx
@@ -146,14 +146,14 @@ export function SolutionDisplayWidget({
       ? {
           showFilesSolution: ShowFilesSolutionForCertification,
           showMultifileProjectSolution: ShowMultifileProjectSolution,
-          showProjectAndGitHubLinks: ShowProjectAndGithubLinkForCertification,
+          showProjectAndGithubLinks: ShowProjectAndGithubLinkForCertification,
           showProjectLink: ShowProjectLinkForCertification,
           none: MissingSolutionComponentForCertification
         }
       : {
           showFilesSolution: ShowFilesSolution,
           showMultifileProjectSolution: ShowMultifileProjectSolution,
-          showProjectAndGitHubLinks: ShowProjectAndGithubLinks,
+          showProjectAndGithubLinks: ShowProjectAndGithubLinks,
           showProjectLink: ShowProjectLink,
           none: MissingSolutionComponent
         };

--- a/client/src/components/solution-display-widget/index.tsx
+++ b/client/src/components/solution-display-widget/index.tsx
@@ -23,7 +23,6 @@ export function SolutionDisplayWidget({
   showProjectPreview,
   displayContext
 }: Props) {
-  console.log('completedChallenge', completedChallenge);
   const { id, solution, githubLink } = completedChallenge;
   const { t } = useTranslation();
 

--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -316,7 +316,9 @@ export type CompletedChallenge = {
   githubLink?: string;
   challengeType?: number;
   completedDate: number;
-  challengeFiles: ChallengeFiles;
+  challengeFiles:
+    | Pick<ChallengeFile, 'contents' | 'ext' | 'fileKey' | 'name'>[]
+    | null;
 };
 
 export type Ext = 'js' | 'html' | 'css' | 'jsx';

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -30,7 +30,7 @@ import Notes from '../components/notes';
 import Output from '../components/output';
 import Preview from '../components/preview';
 import ProjectPreviewModal, {
-  PreviewConfig
+  ChallengeData
 } from '../components/project-preview-modal';
 import SidePanel from '../components/side-panel';
 import VideoModal from '../components/video-modal';
@@ -97,7 +97,10 @@ interface ShowClassicProps {
   output: string[];
   pageContext: {
     challengeMeta: ChallengeMeta;
-    projectPreview: PreviewConfig & { showProjectPreview: boolean };
+    projectPreview: {
+      challengeData: ChallengeData;
+      showProjectPreview: boolean;
+    };
   };
   t: TFunction;
   tests: Test[];
@@ -429,7 +432,7 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
       executeChallenge,
       pageContext: {
         challengeMeta: { nextChallengePath, prevChallengePath },
-        projectPreview
+        projectPreview: { challengeData, showProjectPreview }
       },
       challengeFiles,
       t
@@ -493,7 +496,10 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
           <HelpModal />
           <VideoModal videoUrl={this.getVideoUrl()} />
           <ResetModal />
-          <ProjectPreviewModal previewConfig={projectPreview} />
+          <ProjectPreviewModal
+            challengeData={challengeData}
+            showProjectPreview={showProjectPreview}
+          />
         </LearnLayout>
       </Hotkeys>
     );

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -498,6 +498,8 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
           <ResetModal />
           <ProjectPreviewModal
             challengeData={challengeData}
+            closeText={t('buttons.start-coding')}
+            previewTitle={t('learn.project-preview-title')}
             showProjectPreview={showProjectPreview}
           />
         </LearnLayout>

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -367,7 +367,6 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
       }
     } = this.props;
     const { description, title } = this.getChallenge();
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return (
       challengeFiles && (
         <MultifileEditor

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -16,6 +16,7 @@ import {
   ChallengeFiles,
   ChallengeMeta,
   ChallengeNode,
+  CompletedChallenge,
   ResizeProps,
   Test
 } from '../../../redux/prop-types';
@@ -29,9 +30,7 @@ import HelpModal from '../components/help-modal';
 import Notes from '../components/notes';
 import Output from '../components/output';
 import Preview from '../components/preview';
-import ProjectPreviewModal, {
-  ChallengeData
-} from '../components/project-preview-modal';
+import ProjectPreviewModal from '../components/project-preview-modal';
 import SidePanel from '../components/side-panel';
 import VideoModal from '../components/video-modal';
 import {
@@ -98,7 +97,7 @@ interface ShowClassicProps {
   pageContext: {
     challengeMeta: ChallengeMeta;
     projectPreview: {
-      challengeData: ChallengeData;
+      challengeData: CompletedChallenge;
       showProjectPreview: boolean;
     };
   };

--- a/client/src/templates/Challenges/components/project-preview-modal.tsx
+++ b/client/src/templates/Challenges/components/project-preview-modal.tsx
@@ -14,13 +14,8 @@ import Preview from './preview';
 
 import './project-preview-modal.css';
 
-export interface ChallengeData {
-  challengeType: number;
-  challengeFiles: CompletedChallenge['challengeFiles'] | null;
-}
-
 interface ProjectPreviewMountedPayload {
-  challengeData: ChallengeData;
+  challengeData: CompletedChallenge | null;
   showProjectPreview: boolean;
 }
 
@@ -28,7 +23,7 @@ interface Props {
   closeModal: (arg: string) => void;
   isOpen: boolean;
   projectPreviewMounted: (payload: ProjectPreviewMountedPayload) => void;
-  challengeData: ChallengeData;
+  challengeData: CompletedChallenge | null;
   setEditorFocusability: (focusability: boolean) => void;
   showProjectPreview: boolean;
   previewTitle: string;

--- a/client/src/templates/Challenges/components/project-preview-modal.tsx
+++ b/client/src/templates/Challenges/components/project-preview-modal.tsx
@@ -3,7 +3,7 @@ import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 
-import type { ChallengeFile, Required } from '../../../redux/prop-types';
+import type { CompletedChallenge } from '../../../redux/prop-types';
 import {
   closeModal,
   setEditorFocusability,
@@ -16,10 +16,8 @@ import Preview from './preview';
 import './project-preview-modal.css';
 
 export interface PreviewConfig {
-  challengeType: boolean;
-  challengeFiles: ChallengeFile[];
-  required: Required;
-  template: string;
+  challengeType: number;
+  challengeFiles: CompletedChallenge['challengeFiles'];
 }
 
 interface Props {
@@ -39,7 +37,7 @@ const mapDispatchToProps = {
   projectPreviewMounted
 };
 
-export function ProjectPreviewModal({
+function ProjectPreviewModal({
   closeModal,
   isOpen,
   projectPreviewMounted,

--- a/client/src/templates/Challenges/components/project-preview-modal.tsx
+++ b/client/src/templates/Challenges/components/project-preview-modal.tsx
@@ -1,6 +1,5 @@
 import { Button, Modal } from '@freecodecamp/react-bootstrap';
 import React, { useEffect } from 'react';
-import { useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 
 import type { CompletedChallenge } from '../../../redux/prop-types';
@@ -17,7 +16,7 @@ import './project-preview-modal.css';
 
 export interface ChallengeData {
   challengeType: number;
-  challengeFiles: CompletedChallenge['challengeFiles'];
+  challengeFiles: CompletedChallenge['challengeFiles'] | null;
 }
 
 interface ProjectPreviewMountedPayload {
@@ -32,6 +31,8 @@ interface Props {
   challengeData: ChallengeData;
   setEditorFocusability: (focusability: boolean) => void;
   showProjectPreview: boolean;
+  previewTitle: string;
+  closeText: string;
 }
 
 const mapStateToProps = (state: unknown) => ({
@@ -49,9 +50,10 @@ function ProjectPreviewModal({
   projectPreviewMounted,
   challengeData,
   setEditorFocusability,
-  showProjectPreview
+  showProjectPreview,
+  previewTitle,
+  closeText
 }: Props): JSX.Element {
-  const { t } = useTranslation();
   useEffect(() => {
     if (isOpen) setEditorFocusability(false);
   });
@@ -71,17 +73,15 @@ function ProjectPreviewModal({
         className='project-preview-modal-header fcc-modal'
         closeButton={true}
       >
-        <Modal.Title className='text-center'>
-          {t('learn.project-preview-title')}
-        </Modal.Title>
+        <Modal.Title className='text-center'>{previewTitle}</Modal.Title>
       </Modal.Header>
       <Modal.Body className='project-preview-modal-body text-center'>
         {/* remove type assertion once frame.js has been migrated to TS */}
         <Preview
           previewId={projectPreviewId as string}
-          previewMounted={() => {
-            projectPreviewMounted({ challengeData, showProjectPreview });
-          }}
+          previewMounted={() =>
+            projectPreviewMounted({ challengeData, showProjectPreview })
+          }
         />
       </Modal.Body>
       <Modal.Footer>
@@ -94,7 +94,7 @@ function ProjectPreviewModal({
             setEditorFocusability(true);
           }}
         >
-          {t('buttons.start-coding')}
+          {closeText}
         </Button>
       </Modal.Footer>
     </Modal>

--- a/client/src/templates/Challenges/components/project-preview-modal.tsx
+++ b/client/src/templates/Challenges/components/project-preview-modal.tsx
@@ -15,17 +15,23 @@ import Preview from './preview';
 
 import './project-preview-modal.css';
 
-export interface PreviewConfig {
+export interface ChallengeData {
   challengeType: number;
   challengeFiles: CompletedChallenge['challengeFiles'];
+}
+
+interface ProjectPreviewMountedPayload {
+  challengeData: ChallengeData;
+  showProjectPreview: boolean;
 }
 
 interface Props {
   closeModal: (arg: string) => void;
   isOpen: boolean;
-  projectPreviewMounted: (previewConfig: PreviewConfig) => void;
-  previewConfig: PreviewConfig;
+  projectPreviewMounted: (payload: ProjectPreviewMountedPayload) => void;
+  challengeData: ChallengeData;
   setEditorFocusability: (focusability: boolean) => void;
+  showProjectPreview: boolean;
 }
 
 const mapStateToProps = (state: unknown) => ({
@@ -41,8 +47,9 @@ function ProjectPreviewModal({
   closeModal,
   isOpen,
   projectPreviewMounted,
-  previewConfig,
-  setEditorFocusability
+  challengeData,
+  setEditorFocusability,
+  showProjectPreview
 }: Props): JSX.Element {
   const { t } = useTranslation();
   useEffect(() => {
@@ -73,7 +80,7 @@ function ProjectPreviewModal({
         <Preview
           previewId={projectPreviewId as string}
           previewMounted={() => {
-            projectPreviewMounted(previewConfig);
+            projectPreviewMounted({ challengeData, showProjectPreview });
           }}
         />
       </Modal.Body>

--- a/client/src/templates/Challenges/redux/completion-epic.js
+++ b/client/src/templates/Challenges/redux/completion-epic.js
@@ -35,9 +35,14 @@ function postChallenge(update, username) {
   const saveChallenge = postUpdate$(update).pipe(
     retry(3),
     switchMap(({ points }) => {
+      // TODO: do this all in ajax.ts
       const payloadWithClientProperties = {
         ...omit(update.payload, ['files']),
-        challengeFiles: update.payload.files ?? null
+        challengeFiles:
+          update.payload.files.map(({ key, ...rest }) => ({
+            ...rest,
+            fileKey: key
+          })) ?? null
       };
       return of(
         submitComplete({

--- a/client/src/templates/Challenges/redux/completion-epic.js
+++ b/client/src/templates/Challenges/redux/completion-epic.js
@@ -37,13 +37,16 @@ function postChallenge(update, username) {
     switchMap(({ points }) => {
       // TODO: do this all in ajax.ts
       const payloadWithClientProperties = {
-        ...omit(update.payload, ['files']),
-        challengeFiles:
-          update.payload.files.map(({ key, ...rest }) => ({
+        ...omit(update.payload, ['files'])
+      };
+      if (update.payload.files) {
+        payloadWithClientProperties.challengeFiles = update.payload.files.map(
+          ({ key, ...rest }) => ({
             ...rest,
             fileKey: key
-          })) ?? null
-      };
+          })
+        );
+      }
       return of(
         submitComplete({
           username,

--- a/client/src/utils/__fixtures/completed-challenges.ts
+++ b/client/src/utils/__fixtures/completed-challenges.ts
@@ -27,6 +27,11 @@ export const withChallenges = {
   challengeFiles
 }
 
+export const multifileSolution = {
+  ...withChallenges,
+  challengeType: 14
+}
+
 export const onlyGithubLink = {
   ...baseChallenge,
   githubLink: 'https://some.thing'

--- a/client/src/utils/solution-display-type.test.ts
+++ b/client/src/utils/solution-display-type.test.ts
@@ -29,6 +29,6 @@ describe('getSolutionDisplayType', () => {
     expect(getSolutionDisplayType(invalidGithubLink)).toBe('showProjectLink');
   });
   it('should handle solutions with both links', () => {
-    expect(getSolutionDisplayType(bothLinks)).toBe('showProjectAndGitHubLinks');
+    expect(getSolutionDisplayType(bothLinks)).toBe('showProjectAndGithubLinks');
   });
 });

--- a/client/src/utils/solution-display-type.test.ts
+++ b/client/src/utils/solution-display-type.test.ts
@@ -1,7 +1,8 @@
 import {
   bothLinks,
-  legacySolution,
   invalidGithubLink,
+  legacySolution,
+  multifileSolution,
   onlyGithubLink,
   onlySolution,
   withChallenges
@@ -16,7 +17,11 @@ describe('getSolutionDisplayType', () => {
     expect(getSolutionDisplayType(legacySolution)).toBe('showFilesSolution');
   });
   it('should handle solutions with files', () => {
+    expect.assertions(2);
     expect(getSolutionDisplayType(withChallenges)).toBe('showFilesSolution');
+    expect(getSolutionDisplayType(multifileSolution)).toBe(
+      'showMultifileProjectSolution'
+    );
   });
   it('should handle solutions with a single valid url', () => {
     expect.assertions(2);

--- a/client/src/utils/solution-display-type.test.ts
+++ b/client/src/utils/solution-display-type.test.ts
@@ -14,11 +14,11 @@ describe('getSolutionDisplayType', () => {
     expect(getSolutionDisplayType(onlyGithubLink)).toBe('none');
   });
   it('should handle legacy solutions', () => {
-    expect(getSolutionDisplayType(legacySolution)).toBe('showFilesSolution');
+    expect(getSolutionDisplayType(legacySolution)).toBe('showUserCode');
   });
   it('should handle solutions with files', () => {
     expect.assertions(2);
-    expect(getSolutionDisplayType(withChallenges)).toBe('showFilesSolution');
+    expect(getSolutionDisplayType(withChallenges)).toBe('showUserCode');
     expect(getSolutionDisplayType(multifileSolution)).toBe(
       'showMultifileProjectSolution'
     );

--- a/client/src/utils/solution-display-type.ts
+++ b/client/src/utils/solution-display-type.ts
@@ -16,6 +16,6 @@ export const getSolutionDisplayType = ({
   // Some of the user records still have JavaScript project solutions stored as
   // solution strings
   if (!maybeUrlRE.test(solution)) return 'showFilesSolution';
-  if (maybeUrlRE.test(githubLink ?? '')) return 'showProjectAndGitHubLinks';
+  if (maybeUrlRE.test(githubLink ?? '')) return 'showProjectAndGithubLinks';
   return 'showProjectLink';
 };

--- a/client/src/utils/solution-display-type.ts
+++ b/client/src/utils/solution-display-type.ts
@@ -11,11 +11,11 @@ export const getSolutionDisplayType = ({
   if (challengeFiles?.length)
     return challengeType === challengeTypes.multiFileCertProject
       ? 'showMultifileProjectSolution'
-      : 'showFilesSolution';
+      : 'showUserCode';
   if (!solution) return 'none';
   // Some of the user records still have JavaScript project solutions stored as
   // solution strings
-  if (!maybeUrlRE.test(solution)) return 'showFilesSolution';
+  if (!maybeUrlRE.test(solution)) return 'showUserCode';
   if (maybeUrlRE.test(githubLink ?? '')) return 'showProjectAndGithubLinks';
   return 'showProjectLink';
 };

--- a/client/src/utils/solution-display-type.ts
+++ b/client/src/utils/solution-display-type.ts
@@ -1,12 +1,17 @@
 import type { CompletedChallenge } from '../redux/prop-types';
+import { challengeTypes } from '../../utils/challenge-types';
 import { maybeUrlRE } from '.';
 
 export const getSolutionDisplayType = ({
   solution,
   githubLink,
-  challengeFiles
+  challengeFiles,
+  challengeType
 }: CompletedChallenge) => {
-  if (challengeFiles?.length) return 'showFilesSolution';
+  if (challengeFiles?.length)
+    return challengeType === challengeTypes.multiFileCertProject
+      ? 'showMultifileProjectSolution'
+      : 'showFilesSolution';
   if (!solution) return 'none';
   // Some of the user records still have JavaScript project solutions stored as
   // solution strings

--- a/client/utils/gatsby/challenge-page-creator.js
+++ b/client/utils/gatsby/challenge-page-creator.js
@@ -126,9 +126,7 @@ function getProjectPreviewConfig(challenge, allChallengeEdges) {
       challengeType !== challengeTypes.multiFileCertProject,
     challengeData: {
       challengeType: lastChallenge.challengeType,
-      challengeFiles: projectPreviewChallengeFiles,
-      required: lastChallenge.required,
-      template: lastChallenge.template
+      challengeFiles: projectPreviewChallengeFiles
     }
   };
 }

--- a/client/utils/test-utils.jsx
+++ b/client/utils/test-utils.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render as rtlRender } from '@testing-library/react';
+import { Provider } from 'react-redux';
+
+function render(ui, store) {
+  // eslint-disable-next-line react/prop-types
+  function Wrapper({ children }) {
+    return <Provider store={store}>{children}</Provider>;
+  }
+  return rtlRender(ui, { wrapper: Wrapper });
+}
+
+// re-export everything
+// eslint-disable-next-line import/export
+export * from '@testing-library/react';
+// override render method
+// eslint-disable-next-line import/export
+export { render };

--- a/utils/polyvinyl.js
+++ b/utils/polyvinyl.js
@@ -97,6 +97,19 @@ function setImportedFiles(importedFiles, poly) {
   return newPoly;
 }
 
+// This is currently only used to add back properties that are not stored in the
+// database.
+function regeneratePathAndHistory(poly) {
+  const newPath = poly.name + '.' + poly.ext;
+  const newPoly = {
+    ...poly,
+    path: newPath,
+    history: [newPath]
+  };
+  checkPoly(newPoly);
+  return newPoly;
+}
+
 // clearHeadTail(poly: PolyVinyl) => PolyVinyl
 function clearHeadTail(poly) {
   checkPoly(poly);
@@ -151,6 +164,7 @@ module.exports = {
   setExt,
   setImportedFiles,
   compileHeadTail,
+  regeneratePathAndHistory,
   transformContents,
   transformHeadTailAndContents
 };


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/44979

To make QA easier, I've left in a commit that converts a project page to use the multi-file editor.  Though, I'll take it out if CI fails.

The commit messages (should) explain what's going on, but let me know if there's anything that doesn't make sense.

Edit: turns out it was breaking the CI.

<!-- Feel free to add any additional description of changes below this line -->
