### PR TITLE
fix(ci): reduce runners consumption - codesee

### DIFF
--- a/.github/workflows/codesee-diagram.yml
+++ b/.github/workflows/codesee-diagram.yml
@@ -1,9 +1,7 @@
 on:
-  push:
-    paths-ignore:
-      - 'docs/**'
-    branches:
-      - main
+  workflow_dispatch:
+  schedule:
+    - cron: '25 0/12 * * *' # Build once every 12 hours, starting at 25 minutes past the hour (UTC)
 
   pull_request_target:
     paths-ignore:


### PR DESCRIPTION
With this change, the builds happen twice a day with a fallback of a manual trigger in case it's required. The PRs are left as is, that is they build one for each request.