### PR TITLE
chore: dry out 410 logic

### DIFF
--- a/api-server/src/server/boot/certificate.js
+++ b/api-server/src/server/boot/certificate.js
@@ -16,6 +16,7 @@ import {
 } from '../../../../config/certification-settings';
 import { reportError } from '../middlewares/sentry-error-handler.js';
 
+import { deprecatedEndpoint } from '../utils/deprecatedEndpoint';
 import { getChallenges } from '../utils/get-curriculum';
 import { ifNoUser401 } from '../utils/middleware';
 import { observeQuery } from '../utils/rx';
@@ -51,17 +52,8 @@ export default function bootCertificate(app) {
 
   api.put('/certificate/verify', ifNoUser401, ifNoSuperBlock404, verifyCert);
   api.get('/certificate/showCert/:username/:certSlug', showCert);
-  api.get('/certificate/verify-can-claim-cert', verifyCanClaimCert);
+  api.get('/certificate/verify-can-claim-cert', deprecatedEndpoint);
   app.use(api);
-}
-
-function verifyCanClaimCert(_req, res) {
-  return res.status(410).json({
-    message: {
-      type: 'info',
-      message: 'Please reload the app, this feature is no longer available.'
-    }
-  });
 }
 
 export function getFallbackFullStackDate(completedChallenges, completedDate) {

--- a/api-server/src/server/boot/randomAPIs.js
+++ b/api-server/src/server/boot/randomAPIs.js
@@ -1,25 +1,17 @@
 import { getRedirectParams } from '../utils/redirection';
+import { deprecatedEndpoint } from '../utils/deprecatedEndpoint';
 
 module.exports = function (app) {
   const router = app.loopback.Router();
   const User = app.models.User;
 
-  router.get('/api/github', gone);
+  router.get('/api/github', deprecatedEndpoint);
   router.get('/u/:email', unsubscribeDeprecated);
   router.get('/unsubscribe/:email', unsubscribeDeprecated);
   router.get('/ue/:unsubscribeId', unsubscribeById);
   router.get('/resubscribe/:unsubscribeId', resubscribe);
 
   app.use(router);
-
-  function gone(_, res) {
-    return res.status(410).json({
-      message: {
-        type: 'info',
-        message: 'Please reload the app, this feature is no longer available.'
-      }
-    });
-  }
 
   function unsubscribeDeprecated(req, res) {
     req.flash(

--- a/api-server/src/server/boot/settings.js
+++ b/api-server/src/server/boot/settings.js
@@ -4,6 +4,7 @@ import isURL from 'validator/lib/isURL';
 
 import { isValidUsername } from '../../../../utils/validate';
 import { alertTypes } from '../../common/utils/flash.js';
+import { deprecatedEndpoint } from '../utils/deprecatedEndpoint';
 import { ifNoUser401, createValidatorErrorHandler } from '../utils/middleware';
 
 const log = debug('fcc:boot:settings');
@@ -15,7 +16,7 @@ export default function settingsController(app) {
 
   api.put('/update-privacy-terms', ifNoUser401, updatePrivacyTerms);
 
-  api.post('/refetch-user-completed-challenges', gone);
+  api.post('/refetch-user-completed-challenges', deprecatedEndpoint);
   api.post(
     '/update-my-current-challenge',
     ifNoUser401,
@@ -24,7 +25,7 @@ export default function settingsController(app) {
     updateMyCurrentChallenge
   );
   api.post('/update-my-portfolio', ifNoUser401, updateMyPortfolio);
-  api.post('/update-my-theme', gone);
+  api.post('/update-my-theme', deprecatedEndpoint);
   api.put('/update-my-about', ifNoUser401, updateMyAbout);
   api.put(
     '/update-my-email',
@@ -49,15 +50,6 @@ const standardSuccessMessage = {
   type: 'success',
   message: 'flash.updated-preferences'
 };
-
-function gone(_, res) {
-  return res.status(410).json({
-    message: {
-      type: 'info',
-      message: 'Please reload the app, this feature is no longer available.'
-    }
-  });
-}
 
 const createStandardHandler = (req, res, next) => err => {
   if (err) {

--- a/api-server/src/server/utils/deprecatedEndpoint.js
+++ b/api-server/src/server/utils/deprecatedEndpoint.js
@@ -1,0 +1,8 @@
+export function deprecatedEndpoint(_, res) {
+  return res.status(410).json({
+    message: {
+      type: 'info',
+      message: 'Please reload the app, this feature is no longer available.'
+    }
+  });
+}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
We had the same 410 logic in three different places - makes more sense to me to DRY it out a bit and use a single export. @ojeytonwilliams thoughts?