### PR TITLE
fix(curriculum) : remove the extra 't' in challenge Euler problem 184

### DIFF
--- a/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-184-triangles-containing-the-origin.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-184-triangles-containing-the-origin.md
@@ -20,10 +20,10 @@ How many triangles are there containing the origin in the interior and having al
 
 # --hints--
 
-`trianglesConttainingOrigin()` should return `1725323624056`.
+`trianglesContainingOrigin()` should return `1725323624056`.
 
 ```js
-assert.strictEqual(trianglesConttainingOrigin(), 1725323624056);
+assert.strictEqual(trianglesContainingOrigin(), 1725323624056);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes  #45269
Correction of the typo by removing the extra 't" 


