### PR TITLE
Fix for #45269 - Typo in test of a challenge

### DIFF
--- a/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-184-triangles-containing-the-origin.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-184-triangles-containing-the-origin.md
@@ -20,10 +20,10 @@ How many triangles are there containing the origin in the interior and having al
 
 # --hints--
 
-`trianglesConttainingOrigin()` should return `1725323624056`.
+`trianglesContainingOrigin()` should return `1725323624056`.
 
 ```js
-assert.strictEqual(trianglesConttainingOrigin(), 1725323624056);
+assert.strictEqual(trianglesContainingOrigin(), 1725323624056);
 ```
 
 # --seed--


### PR DESCRIPTION
"Removed the extra 't' in the function call in the test description and in the assertion of the test itself."

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #45269

<!-- Feel free to add any additional description of changes below this line -->
