### PR TITLE
Add "Support Ukraine" badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![freeCodeCamp Social Banner](https://s3.amazonaws.com/freecodecamp/wide-social-banner.png)](https://www.freecodecamp.org/)
 
+[![Support Ukraine](https://img.shields.io/badge/Support-Ukraine-blue?style=flat&logo=adguard)](https://bank.gov.ua/en/news/all/natsionalniy-bank-vidkriv-spetsrahunok-dlya-zboru-koshtiv-na-potrebi-armiyi)
 [![Pull Requests Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat)](http://makeapullrequest.com)
 [![first-timers-only Friendly](https://img.shields.io/badge/first--timers--only-friendly-blue.svg)](http://www.firsttimersonly.com/)
 [![Open Source Helpers](https://www.codetriage.com/freecodecamp/freecodecamp/badges/users.svg)](https://www.codetriage.com/freecodecamp/freecodecamp)


### PR DESCRIPTION
## Summary

This Pull Request is aimed at helping Ukrainian Army get necessary funding in time of open-scale war with Russia by providing link to official international account created by National Bank of Ukraine.

## Changelog:

[General] [Added] - Add badge with link to National Bank of Ukraine's website

## Test Plan

Badge image: 
<img width="636" alt="155879304-107042dc-005c-4ea9-9967-dc05881c35e4" src="https://user-images.githubusercontent.com/40458927/155880515-33cc74b9-7559-4389-a1a0-406ed41328d4.png">

## Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.


