### PR TITLE
fix(curriculum): fixed incorrect exponent display

### DIFF
--- a/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-250-250250.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-250-250250.md
@@ -8,7 +8,7 @@ dashedName: problem-250-250250
 
 # --description--
 
-Find the number of non-empty subsets of $\\{11, 22, 33, \ldots, {250250}^{250250}\\}$, the sum of whose elements is divisible by 250. Enter the rightmost 16 digits as your answer.
+Find the number of non-empty subsets of $\\{{1}^{1}, {2}^{2}, {3}^{3}, \ldots, {250250}^{250250}\\}$, the sum of whose elements is divisible by 250. Enter the rightmost 16 digits as your answer.
 
 # --hints--
 


### PR DESCRIPTION
Fixed incorrect display of exponents,

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #45281

<!-- Feel free to add any additional description of changes below this line -->
