### PR TITLE
fix(tools): use correct superblock paths

### DIFF
--- a/tools/challenge-helper-scripts/create-project.ts
+++ b/tools/challenge-helper-scripts/create-project.ts
@@ -54,29 +54,15 @@ async function createProject(
   if (!title) {
     title = blockNameify(block);
   } else if (title !== blockNameify(block)) {
-    updateBlockNames(block, title).catch(reason => {
-      throw reason;
-    });
+    void updateBlockNames(block, title);
   }
-  updateIntroJson(superBlock, block, title).catch(reason => {
-    throw reason;
-  });
-  updateHelpCategoryMap(block, helpCategory).catch(reason => {
-    throw reason;
-  });
+  void updateIntroJson(superBlock, block, title);
+  void updateHelpCategoryMap(block, helpCategory);
 
-  const challengeId = await createFirstChallenge(superBlock, block).catch(
-    reason => {
-      throw reason;
-    }
-  );
-  createMetaJson(superBlock, block, title, order, challengeId).catch(reason => {
-    throw reason;
-  });
+  const challengeId = await createFirstChallenge(superBlock, block);
+  void createMetaJson(superBlock, block, title, order, challengeId);
   // TODO: remove once we stop relying on markdown in the client.
-  createIntroMD(superBlock, block, title).catch(reason => {
-    throw reason;
-  });
+  void createIntroMD(superBlock, block, title);
 }
 
 async function updateIntroJson(
@@ -93,12 +79,11 @@ async function updateIntroJson(
     title,
     intro: ['', '']
   };
-  fs.writeFile(
+  void withTrace(
+    fs.writeFile,
     introJsonPath,
     format(JSON.stringify(newIntro), { parser: 'json' })
-  ).catch(reason => {
-    throw reason;
-  });
+  );
 }
 
 async function updateHelpCategoryMap(block: string, helpCategory: string) {
@@ -108,12 +93,11 @@ async function updateHelpCategoryMap(block: string, helpCategory: string) {
   );
   const helpMap = await parseJson<Record<string, string>>(helpCategoryPath);
   helpMap[block] = helpCategory;
-  fs.writeFile(
+  void withTrace(
+    fs.writeFile,
     helpCategoryPath,
     format(JSON.stringify(helpMap), { parser: 'json' })
-  ).catch(reason => {
-    throw reason;
-  });
+  );
 }
 
 async function updateBlockNames(block: string, title: string) {
@@ -123,12 +107,11 @@ async function updateBlockNames(block: string, title: string) {
   );
   const blockNames = await parseJson<Record<string, string>>(blockNamesPath);
   blockNames[block] = title;
-  fs.writeFile(
+  void withTrace(
+    fs.writeFile,
     blockNamesPath,
     format(JSON.stringify(blockNames), { parser: 'json' })
-  ).catch(reason => {
-    throw reason;
-  });
+  );
 }
 
 async function createMetaJson(
@@ -148,14 +131,14 @@ async function createMetaJson(
   newMeta.challengeOrder = [[challengeId.toString(), 'Step 1']];
   const newMetaDir = path.resolve(metaDir, block);
   if (!existsSync(newMetaDir)) {
-    await fs.mkdir(newMetaDir);
+    await withTrace(fs.mkdir, newMetaDir);
   }
-  fs.writeFile(
+
+  void withTrace(
+    fs.writeFile,
     path.resolve(metaDir, `${block}/meta.json`),
     format(JSON.stringify(newMeta), { parser: 'json' })
-  ).catch(reason => {
-    throw reason;
-  });
+  );
 }
 
 async function createIntroMD(superBlock: string, block: string, title: string) {
@@ -176,11 +159,9 @@ This is a test for the new project-based curriculum.
   );
   const filePath = path.resolve(dirPath, 'index.md');
   if (!existsSync(dirPath)) {
-    await fs.mkdir(dirPath);
+    await withTrace(fs.mkdir, dirPath);
   }
-  fs.writeFile(filePath, introMD, { encoding: 'utf8' }).catch(reason => {
-    throw reason;
-  });
+  void withTrace(fs.writeFile, filePath, introMD, { encoding: 'utf8' });
 }
 
 async function createFirstChallenge(
@@ -195,7 +176,7 @@ async function createFirstChallenge(
     `../../curriculum/challenges/english/${superBlockId}-${superBlock}/${block}`
   );
   if (!existsSync(newChallengeDir)) {
-    await fs.mkdir(newChallengeDir);
+    await withTrace(fs.mkdir, newChallengeDir);
   }
   // TODO: would be nice if the extension made sense for the challenge, but, at
   // least until react I think they're all going to be html anyway.
@@ -216,15 +197,26 @@ async function createFirstChallenge(
 }
 
 function parseJson<JsonSchema>(filePath: string) {
-  return fs
-    .readFile(filePath, { encoding: 'utf8' })
-    .then(result => JSON.parse(result) as JsonSchema)
-    .catch(reason => {
-      throw reason;
-    });
+  return withTrace(fs.readFile, filePath, 'utf8').then(
+    // unfortunately, withTrace does not correctly infer that the third argument
+    // is a string, so it uses the (path, options?) overload and we have to cast
+    // result to string.
+    result => JSON.parse(result as string) as JsonSchema
+  );
 }
 
-prompt([
+// fs Promise functions return errors, but no stack trace.  This adds back in
+// the stack trace.
+function withTrace<Args extends unknown[], Result>(
+  fn: (...x: Args) => Promise<Result>,
+  ...args: Args
+): Promise<Result> {
+  return fn(...args).catch((reason: Error) => {
+    throw Error(reason.message);
+  });
+}
+
+void prompt([
   {
     name: 'superBlock',
     message: 'Which certification does this belong to?',
@@ -274,12 +266,17 @@ prompt([
   }
 ])
   .then(
-    ({ superBlock, block, title, helpCategory, order }: CreateProjectArgs) =>
-      createProject(superBlock, block, helpCategory, order, title)
+    async ({
+      superBlock,
+      block,
+      title,
+      helpCategory,
+      order
+    }: CreateProjectArgs) =>
+      await createProject(superBlock, block, helpCategory, order, title)
   )
   .then(() =>
     console.log(
       'All set.  Now use npm run clean:client in the root and it should be good to go.'
     )
-  )
-  .catch(console.error);
+  );

--- a/tools/challenge-helper-scripts/create-project.ts
+++ b/tools/challenge-helper-scripts/create-project.ts
@@ -230,7 +230,7 @@ prompt([
     message: 'Which certification does this belong to?',
     default: SuperBlocks.RespWebDesign,
     type: 'list',
-    choices: SuperBlocks
+    choices: Object.values(SuperBlocks)
   },
   {
     name: 'block',

--- a/tools/challenge-helper-scripts/create-project.ts
+++ b/tools/challenge-helper-scripts/create-project.ts
@@ -8,6 +8,7 @@ import ObjectID from 'bson-objectid';
 import { SuperBlocks } from '../../config/certification-settings';
 import { blockNameify } from '../../utils/block-nameify';
 import { createStepFile } from './utils';
+import { getSuperBlockSubPath } from './fs-utils';
 
 const helpCategories = ['HTML-CSS', 'JavaScript', 'Python'] as const;
 
@@ -168,12 +169,10 @@ async function createFirstChallenge(
   superBlock: SuperBlocks,
   block: string
 ): Promise<ObjectID> {
-  const superBlockId = (Object.values(SuperBlocks).indexOf(superBlock) + 1)
-    .toString()
-    .padStart(2, '0');
+  const superBlockSubPath = getSuperBlockSubPath(superBlock);
   const newChallengeDir = path.resolve(
     __dirname,
-    `../../curriculum/challenges/english/${superBlockId}-${superBlock}/${block}`
+    `../../curriculum/challenges/english/${superBlockSubPath}/${block}`
   );
   if (!existsSync(newChallengeDir)) {
     await withTrace(fs.mkdir, newChallengeDir);

--- a/tools/challenge-helper-scripts/fs-utils.test.ts
+++ b/tools/challenge-helper-scripts/fs-utils.test.ts
@@ -1,0 +1,15 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { SuperBlocks } from '../../config/certification-settings';
+import { getSuperBlockSubPath } from './fs-utils';
+
+describe('getSuperBlockSubPath', () => {
+  it('should return sub-paths that exist', async () => {
+    const subPaths = Object.values(SuperBlocks).map(getSuperBlockSubPath);
+    const paths = subPaths.map(sub =>
+      path.resolve(__dirname, '../../curriculum/challenges/english', sub)
+    );
+
+    await Promise.all(paths.map(path => fs.access(path)));
+  });
+});

--- a/tools/challenge-helper-scripts/fs-utils.ts
+++ b/tools/challenge-helper-scripts/fs-utils.ts
@@ -1,0 +1,21 @@
+import { SuperBlocks } from '../../config/certification-settings';
+
+export function getSuperBlockSubPath(superBlock: SuperBlocks): string {
+  const pathMap = {
+    [SuperBlocks.RespWebDesign]: '01-responsive-web-design',
+    [SuperBlocks.JsAlgoDataStruct]:
+      '02-javascript-algorithms-and-data-structures',
+    [SuperBlocks.FrontEndDevLibs]: '03-front-end-development-libraries',
+    [SuperBlocks.DataVis]: '04-data-visualization',
+    [SuperBlocks.BackEndDevApis]: '05-back-end-development-and-apis',
+    [SuperBlocks.QualityAssurance]: '06-quality-assurance',
+    [SuperBlocks.SciCompPy]: '07-scientific-computing-with-python',
+    [SuperBlocks.DataAnalysisPy]: '08-data-analysis-with-python',
+    [SuperBlocks.InfoSec]: '09-information-security',
+    [SuperBlocks.CodingInterviewPrep]: '10-coding-interview-prep',
+    [SuperBlocks.MachineLearningPy]: '11-machine-learning-with-python',
+    [SuperBlocks.RelationalDb]: '13-relational-databases',
+    [SuperBlocks.RespWebDesignNew]: '14-responsive-web-design-22'
+  };
+  return pathMap[superBlock];
+}


### PR DESCRIPTION
It bugged me that you didn't get a sensible stack trace if an `fs` call failed, hence `withTrace`.  The fix to create-projects itself is trivial: we just needed a map from superblocks to their subpaths.

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
