### PR TITLE
fix(curriculum): force att in tag

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60f0286404aefb0562a4fdf9.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60f0286404aefb0562a4fdf9.md
@@ -56,7 +56,7 @@ assert.equal(heads?.length, 1);
 Your `link` element should be a self-closing element.
 
 ```js
-assert(code.match(/<link[\w\W\s]+\/>/i));
+assert(code.match(/<link[\w\W\s]*\/>/i));
 ```
 
 Your `link` element should be within your `head` element.
@@ -68,19 +68,19 @@ assert(code.match(/<head>[\w\W\s]*<link[\w\W\s]*\/>[\w\W\s]*<\/head>/i))
 Your `link` element should have a `rel` attribute with the value `stylesheet`.
 
 ```js
-assert.match(code, /<link[\s\S]*?rel=('|"|`)stylesheet\1/)
+assert(__helpers.removeWhiteSpace(code).match(/<.*?link.*.*?rel=('|"|`)stylesheet('|"|`).*\/>/))
 ```
 
 Your `link` element should have a `type` attribute with the value `text/css`.
 
 ```js
-assert.match(code, /<link[\s\S]*?type=('|"|`)text\/css\1/)
+assert(__helpers.removeWhiteSpace(code).match(/<.*?link.*.*?type=('|"|`)text\/css('|"|`).*\/>/))
 ```
 
 Your `link` element should have an `href` attribute with the value `styles.css`.
 
 ```js
-assert.match(code, /<link[\s\S]*?href=('|"|`)(\.\/)?styles\.css\1/)
+assert(__helpers.removeWhiteSpace(code).match(/<.*?link.*.*?href=('|"|`)styles[.]css('|"|`).*\/>/))
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #45215

<!-- Feel free to add any additional description of changes below this line -->
fixed the attributes to be inside the tag.
didnt change the closing tag so it wont cause inconsistensy, if it's desired i could do an easy fix to allow that.
@raisedadead gitpod messed me up - heres the fixed version