### PR TITLE
fix: skip untranslated files

### DIFF
--- a/.github/workflows/crowdin-download.curriculum.yml
+++ b/.github/workflows/crowdin-download.curriculum.yml
@@ -194,7 +194,7 @@ jobs:
           # downloads
           download_translations: true
           download_language: ja
-          skip_untranslated_files: false
+          skip_untranslated_files: true
           export_only_approved: true
 
           push_translations: false


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Not sure how I set this one differently, but we skip the download of untranslated files as we don't enable certs until they're fully approved.