### PR TITLE
fix:(RWD beta): correct parent selector

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/61329b210dac0b08047fd6ab.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/61329b210dac0b08047fd6ab.md
@@ -29,7 +29,7 @@ You should give the `meta` a `content` attribute of `width=device-width, initial
 
 ```js
 // TODO: Double-check this is the only correct answer
-assert.equal(document.querySelectorAll('head > meta[content="width=device-width, initial-scale=1.0"]')?.length || document.querySelectorAll('body > meta[content="width=device-width, initial-scale=1"]')?.length, 1);
+assert.equal(document.querySelectorAll('head > meta[content="width=device-width, initial-scale=1.0"]')?.length || document.querySelectorAll('head > meta[content="width=device-width, initial-scale=1"]')?.length, 1);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #45358

<!-- Feel free to add any additional description of changes below this line -->

The parent in the second querySelectorAll should be `head`.

Haven't really used Gitpod much so hopefully this is correct and works.

BTW, I didn't look in VS Code but on Gitpod the files are not sorted the same way as they are on GitHub. Makes it kind of hard to find the file you are looking for.