### PR TITLE
fix(ci/cd): chill-out on weekends

### DIFF
--- a/.github/workflows/codesee-diagram.yml
+++ b/.github/workflows/codesee-diagram.yml
@@ -1,7 +1,7 @@
 on:
   workflow_dispatch:
   schedule:
-    - cron: '25 0/12 * * *' # Build once every 12 hours, starting at 25 minutes past the hour (UTC)
+    - cron: '25 0/12 * * 1-5' # Build once every 12 hours, starting at 25 minutes past the hour (UTC)
 
   pull_request_target:
     paths-ignore:

--- a/.github/workflows/crowdin-download.client-ui.yml
+++ b/.github/workflows/crowdin-download.client-ui.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   schedule:
     # runs every day at 12:15 PM UTC
-    - cron: '15 12 * * *'
+    - cron: '15 12 * * 1-5'
 
 env:
   GITHUB_TOKEN: ${{ secrets.CROWDIN_CAMPERBOT_PAT }}

--- a/.github/workflows/crowdin-download.curriculum.yml
+++ b/.github/workflows/crowdin-download.curriculum.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   schedule:
     # runs every day at 12:30 PM UTC
-    - cron: '30 12 * * *'
+    - cron: '30 12 * * 1-5'
 
 env:
   GITHUB_TOKEN: ${{ secrets.CROWDIN_CAMPERBOT_PAT }}

--- a/.github/workflows/crowdin-download.docs.yml
+++ b/.github/workflows/crowdin-download.docs.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   schedule:
     # runs every day at 12:00 noon UTC
-    - cron: '0 12 * * *'
+    - cron: '0 12 * * 1-5'
 
 env:
   GITHUB_TOKEN: ${{ secrets.CROWDIN_CAMPERBOT_PAT }}

--- a/.github/workflows/crowdin-upload.client-ui.yml
+++ b/.github/workflows/crowdin-upload.client-ui.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   schedule:
     # runs everyday at 11:15 AM UTC
-    - cron: '15 11 * * *'
+    - cron: '15 11 * * 1-5'
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/crowdin-upload.curriculum.yml
+++ b/.github/workflows/crowdin-upload.curriculum.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   schedule:
     # runs everyday at 11:30 AM UTC
-    - cron: '30 11 * * *'
+    - cron: '30 11 * * 1-5'
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/crowdin-upload.docs.yml
+++ b/.github/workflows/crowdin-upload.docs.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   schedule:
     # runs everyday at 11:00 AM UTC
-    - cron: '0 11 * * *'
+    - cron: '0 11 * * 1-5'
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We should probably avoid bothering running these during the weekends, and "enforce" some time-off. 

I know some of us like working on the weekends too (including but not limited to yours truly), but we should cut the notification noise (not talking about GitHub notifications only) or the "expectation" to get something crossed off the checklists.

Probably an unpopular opinion but not a bad idea IMHO.