### PR TITLE
fix(ui-components): correct the setup of tailwind default styles

### DIFF
--- a/tools/ui-components/.storybook/preview.js
+++ b/tools/ui-components/.storybook/preview.js
@@ -1,3 +1,5 @@
+import '../src/base.css';
+
 export const parameters = {
   controls: {
     matchers: {

--- a/tools/ui-components/package.json
+++ b/tools/ui-components/package.json
@@ -60,6 +60,7 @@
     "storybook:theming": "npm run storybook --no-manager-cache",
     "build-storybook": "build-storybook",
     "build": "cross-env NODE_ENV=production rollup -c",
+    "build:css": "npx tailwindcss -i ./src/base.css -o ./dist/base.css --minify",
     "dev": "cross-env NODE_ENV=development rollup -c -w",
     "clean": "rimraf dist/*",
     "gen-component": "ts-node ./utils/gen-component-script"

--- a/tools/ui-components/src/base.css
+++ b/tools/ui-components/src/base.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tools/ui-components/src/button.css
+++ b/tools/ui-components/src/button.css
@@ -1,5 +1,3 @@
-@import './global.css';
-
 .storybook-button {
   font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-weight: 700;

--- a/tools/ui-components/src/global.css
+++ b/tools/ui-components/src/global.css
@@ -1,4 +1,0 @@
-@import 'tailwindcss/base';
-@import 'tailwindcss/components';
-@import 'tailwindcss/utilities';
-@import './colors.css';

--- a/tools/ui-components/src/index.ts
+++ b/tools/ui-components/src/index.ts
@@ -1,5 +1,4 @@
 // Use this file as the entry point for component export
-import './global.css';
 export { Button } from './button';
 export { Alert } from './alert';
 export { Image } from './image';


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

I realized that I setup a Tailwind config wrong.

Tailwind provides us 3 default stylesheets: `base`, `components`, and `utilities`. They should be grouped in a single file, which I already did, and the file is `global.css`, but I'm currently importing it to the stylesheet of each component in the `ui-components` library. 

```css
/* button.css */
@import './global.css';

.otherStyles {}
```

While I believe the correct setup should be having that single stylesheet minified and included in the library bundle instead. Then it is the responsibility of the consumer apps to import that stylesheet as well in. Something like this:

```ts
// index.tsx - The root index file of /learn

import '@ui-components/dist/global.css'
```

---
This PR updates the setup and I'm also renaming the `global.css` file to `base.css` as I think it is more appropriate.

References:
- [Tailwind installation guide](https://tailwindcss.com/docs/installation)
- [Tailwind optimization guide](https://tailwindcss.com/docs/optimizing-for-production)
