### PR TITLE
fix: use an invalid TLD for the test URL

### DIFF
--- a/curriculum/challenges/english/05-back-end-development-and-apis/back-end-development-and-apis-projects/url-shortener-microservice.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/back-end-development-and-apis-projects/url-shortener-microservice.md
@@ -96,7 +96,7 @@ async (getUserInput) => {
   const res = await fetch(url + '/api/shorturl', {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: `url=ftp:/john-doe.org`
+    body: `url=ftp:/john-doe.invalidTLD`
   });
   if (res.ok) {
     const { error } = await res.json();


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #45319

<!-- Feel free to add any additional description of changes below this line -->

Changes the TLD in the test URL to something invalid so `dns.lookup` will fail the test.