### PR TITLE
chore: use global config repo

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,17 +1,6 @@
 {
-  "labels": ["renovate"],
-  "extends": ["config:base"],
-  "branchConcurrentLimit": 20,
-  "dependencyDashboard": true,
-  "major": {
-    "dependencyDashboardApproval": true
-  },
+  "extends": ["github>freecodecamp/renovate-config"],
   "packageRules": [
-    {
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "matchCurrentVersion": "!/^0/",
-      "automerge": true
-    },
     {
       "groupName": "Monaco Editor",
       "matchPackageNames": [


### PR DESCRIPTION
Moving to a standardized set of rules we have been using elsewhere.
