### PR TITLE
fix: make crtl+s save to appropriate location

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -533,6 +533,7 @@
     "local-code-saved": "Saved! Your code was saved to your browser's local storage.",
     "code-saved": "Your code was saved to the database. It will be here when you return.",
     "code-save-error": "An error occurred trying to save your code.",
+    "code-save-less": "Slow Down! Your code was not saved. Try again in a few seconds.",
     "challenge-save-too-big": "Sorry, you cannot save your code. Your code is {{user-size}} bytes. We allow a maximum of {{max-size}} bytes. Please make your code smaller and try again or request assistance on https://forum.freecodecamp.org",
     "challenge-submit-too-big": "Sorry, you cannot submit your code. Your code is {{user-size}} bytes. We allow a maximum of {{max-size}} bytes. Please make your code smaller and try again or request assistance on https://forum.freecodecamp.org"
   },

--- a/client/src/components/Flash/redux/flash-messages.ts
+++ b/client/src/components/Flash/redux/flash-messages.ts
@@ -9,6 +9,7 @@ export enum FlashMessages {
   ChallengeSubmitTooBig = 'flash.challenge-submit-too-big',
   CodeSaved = 'flash.code-saved',
   CodeSaveError = 'flash.code-save-error',
+  CodeSaveLess = 'flash.code-save-less',
   CompleteProjectFirst = 'flash.complete-project-first',
   DeleteTokenErr = 'flash.delete-token-err',
   EmailValid = 'flash.email-valid',

--- a/client/src/redux/save-challenge-saga.js
+++ b/client/src/redux/save-challenge-saga.js
@@ -13,11 +13,23 @@ import {
   bodySizeFits,
   MAX_BODY_SIZE
 } from '../utils/challenge-request-helpers';
-import { saveChallengeComplete } from './';
+import { saveChallengeComplete, savedChallengesSelector } from './';
 
 export function* saveChallengeSaga() {
   const { id, challengeType } = yield select(challengeMetaSelector);
   const { challengeFiles } = yield select(challengeDataSelector);
+  const savedChallenges = yield select(savedChallengesSelector);
+  const savedChallenge = savedChallenges.find(challenge => challenge.id === id);
+
+  // don't let users save more than once every 5 seconds
+  if (Date.now() - savedChallenge?.lastSavedDate < 5000) {
+    return yield put(
+      createFlashMessage({
+        type: 'danger',
+        message: FlashMessages.CodeSaveLess
+      })
+    );
+  }
 
   // only allow saving of multiFileCertProject's
   if (challengeType === challengeTypes.multiFileCertProject) {

--- a/client/src/redux/save-challenge-saga.js
+++ b/client/src/redux/save-challenge-saga.js
@@ -16,7 +16,6 @@ import {
 import { saveChallengeComplete } from './';
 
 export function* saveChallengeSaga() {
-  console.log('saveChallengeSaga');
   const { id, challengeType } = yield select(challengeMetaSelector);
   const { challengeFiles } = yield select(challengeDataSelector);
 

--- a/client/src/redux/save-challenge-saga.js
+++ b/client/src/redux/save-challenge-saga.js
@@ -16,6 +16,7 @@ import {
 import { saveChallengeComplete } from './';
 
 export function* saveChallengeSaga() {
+  console.log('saveChallengeSaga');
   const { id, challengeType } = yield select(challengeMetaSelector);
   const { challengeFiles } = yield select(challengeDataSelector);
 

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -412,10 +412,10 @@ const Editor = (props: EditorProps): JSX.Element => {
       keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_S],
       run:
         props.challengeType === challengeTypes.multiFileCertProject
-          // save to database
-          ? props.saveChallenge
-          // save to local storage
-          : props.saveEditorContent
+          ? // save to database
+            props.saveChallenge
+          : // save to local storage
+            props.saveEditorContent
     });
     editor.addAction({
       id: 'toggle-accessibility',

--- a/client/src/templates/Challenges/redux/code-storage-epic.js
+++ b/client/src/templates/Challenges/redux/code-storage-epic.js
@@ -7,6 +7,7 @@ import { setContent, isPoly } from '../../../../../utils/polyvinyl';
 import { createFlashMessage } from '../../../components/Flash/redux';
 import { FlashMessages } from '../../../components/Flash/redux/flash-messages';
 import { actionTypes as appTypes } from '../../../redux/action-types';
+import { challengeTypes } from '../../../../utils/challenge-types';
 
 import { actionTypes } from './action-types';
 import {
@@ -16,6 +17,7 @@ import {
   challengeFilesSelector,
   challengeMetaSelector
 } from './';
+import { saveChallenge } from '../../../redux';
 
 const legacyPrefixes = [
   'Bonfire: ',
@@ -84,24 +86,25 @@ function clearCodeEpic(action$, state$) {
 }
 
 function saveCodeEpic(action$, state$) {
+  console.log('saveCodeEpic');
   return action$.pipe(
     ofType(actionTypes.executeChallenge, actionTypes.saveEditorContent),
     // do not save challenge if code is locked
     filter(() => !isCodeLockedSelector(state$.value)),
     map(action => {
       const state = state$.value;
-      const { id } = challengeMetaSelector(state);
+      const { id, challengeType } = challengeMetaSelector(state);
       const challengeFiles = challengeFilesSelector(state);
       try {
-        store.set(id, challengeFiles);
-        const fileKey = challengeFiles[0].fileKey;
-        if (
-          store.get(id).find(challengeFile => challengeFile.fileKey === fileKey)
-            .contents !==
-          challengeFiles.find(challengeFile => challengeFile.fileKey).contents
-        ) {
-          throw Error('Failed to save to localStorage');
-        }
+          store.set(id, challengeFiles);
+          const fileKey = challengeFiles[0].fileKey;
+          if (
+            store.get(id).find(challengeFile => challengeFile.fileKey === fileKey)
+              .contents !==
+            challengeFiles.find(challengeFile => challengeFile.fileKey).contents
+          ) {
+            throw Error('Failed to save to localStorage');
+          }
         return action;
       } catch (e) {
         return { ...action, error: true };
@@ -122,6 +125,7 @@ function saveCodeEpic(action$, state$) {
 }
 
 function loadCodeEpic(action$, state$) {
+  console.log('loadCodeEpic');
   return action$.pipe(
     ofType(actionTypes.challengeMounted),
     filter(() => {

--- a/client/src/templates/Challenges/redux/code-storage-epic.js
+++ b/client/src/templates/Challenges/redux/code-storage-epic.js
@@ -7,7 +7,6 @@ import { setContent, isPoly } from '../../../../../utils/polyvinyl';
 import { createFlashMessage } from '../../../components/Flash/redux';
 import { FlashMessages } from '../../../components/Flash/redux/flash-messages';
 import { actionTypes as appTypes } from '../../../redux/action-types';
-import { challengeTypes } from '../../../../utils/challenge-types';
 
 import { actionTypes } from './action-types';
 import {
@@ -17,7 +16,6 @@ import {
   challengeFilesSelector,
   challengeMetaSelector
 } from './';
-import { saveChallenge } from '../../../redux';
 
 const legacyPrefixes = [
   'Bonfire: ',
@@ -86,25 +84,24 @@ function clearCodeEpic(action$, state$) {
 }
 
 function saveCodeEpic(action$, state$) {
-  console.log('saveCodeEpic');
   return action$.pipe(
     ofType(actionTypes.executeChallenge, actionTypes.saveEditorContent),
     // do not save challenge if code is locked
     filter(() => !isCodeLockedSelector(state$.value)),
     map(action => {
       const state = state$.value;
-      const { id, challengeType } = challengeMetaSelector(state);
+      const { id } = challengeMetaSelector(state);
       const challengeFiles = challengeFilesSelector(state);
       try {
-          store.set(id, challengeFiles);
-          const fileKey = challengeFiles[0].fileKey;
-          if (
-            store.get(id).find(challengeFile => challengeFile.fileKey === fileKey)
-              .contents !==
-            challengeFiles.find(challengeFile => challengeFile.fileKey).contents
-          ) {
-            throw Error('Failed to save to localStorage');
-          }
+        store.set(id, challengeFiles);
+        const fileKey = challengeFiles[0].fileKey;
+        if (
+          store.get(id).find(challengeFile => challengeFile.fileKey === fileKey)
+            .contents !==
+          challengeFiles.find(challengeFile => challengeFile.fileKey).contents
+        ) {
+          throw Error('Failed to save to localStorage');
+        }
         return action;
       } catch (e) {
         return { ...action, error: true };
@@ -125,7 +122,6 @@ function saveCodeEpic(action$, state$) {
 }
 
 function loadCodeEpic(action$, state$) {
-  console.log('loadCodeEpic');
   return action$.pipe(
     ofType(actionTypes.challengeMounted),
     filter(() => {

--- a/client/src/utils/tone/index.ts
+++ b/client/src/utils/tone/index.ts
@@ -24,6 +24,7 @@ const toneUrls = {
   [FlashMessages.ChallengeSubmitTooBig]: TRY_AGAIN,
   [FlashMessages.CodeSaved]: CHAL_COMP,
   [FlashMessages.CodeSaveError]: TRY_AGAIN,
+  [FlashMessages.CodeSaveLess]: TRY_AGAIN,
   [FlashMessages.CompleteProjectFirst]: TRY_AGAIN,
   [FlashMessages.DeleteTokenErr]: TRY_AGAIN,
   [FlashMessages.EmailValid]: CHAL_COMP,


### PR DESCRIPTION
This changes the save location to the database for multifile cert projects when using `ctrl+s`. I added a limit of allowing a save no more than once every five seconds.

I was going to add some cypress tests here, but decided not to. I will add them on the PR that converts the projects.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
