### PR TITLE
fix: use keys in curriculum.json

### DIFF
--- a/client/utils/build-challenges.js
+++ b/client/utils/build-challenges.js
@@ -41,7 +41,7 @@ exports.buildChallenges = async function buildChallenges() {
 
   // temp removal of rdbms from production
   if (deploymentEnv !== 'staging') {
-    delete curriculum['13-relational-databases'];
+    delete curriculum['relational-database'];
   }
 
   const superBlocks = Object.keys(curriculum);

--- a/curriculum/utils.js
+++ b/curriculum/utils.js
@@ -53,4 +53,29 @@ function getSuperOrder(
   return order;
 }
 
+const directoryToSuperblock = {
+  '00-certifications': 'certifications', // treating certifications as a superblock for simplicity
+  '01-responsive-web-design': 'responsive-web-design',
+  '02-javascript-algorithms-and-data-structures':
+    'javascript-algorithms-and-data-structures',
+  '03-front-end-development-libraries': 'front-end-development-libraries',
+  '04-data-visualization': 'data-visualization',
+  '05-back-end-development-and-apis': 'back-end-development-and-apis',
+  '06-quality-assurance': 'quality-assurance',
+  '07-scientific-computing-with-python': 'scientific-computing-with-python',
+  '08-data-analysis-with-python': 'data-analysis-with-python',
+  '09-information-security': 'information-security',
+  '10-coding-interview-prep': 'coding-interview-prep',
+  '11-machine-learning-with-python': 'machine-learning-with-python',
+  '13-relational-databases': 'relational-database',
+  '14-responsive-web-design-22': '2022/responsive-web-design'
+};
+
+function getSuperBlockFromDir(dir) {
+  const superBlock = directoryToSuperblock[dir];
+  if (!superBlock) throw Error(`${dir} does not map to a superblock`);
+  return directoryToSuperblock[dir];
+}
+
 exports.getSuperOrder = getSuperOrder;
+exports.getSuperBlockFromDir = getSuperBlockFromDir;

--- a/curriculum/utils.test.ts
+++ b/curriculum/utils.test.ts
@@ -1,4 +1,10 @@
-import { getSuperOrder } from './utils';
+// utils are not typed (yet), so we have to disable some checks
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+import fs from 'fs';
+import path from 'path';
+import { SuperBlocks } from '../config/certification-settings';
+import { getSuperOrder, getSuperBlockFromDir } from './utils';
 
 describe('getSuperOrder', () => {
   it('returns a number for valid superblocks', () => {
@@ -84,5 +90,50 @@ describe('getSuperOrder', () => {
     expect(
       getSuperOrder('2022/responsive-web-design', { showNewCurriculum: true })
     ).toBe(12);
+  });
+});
+
+describe('getSuperBlockFromPath', () => {
+  const directories = fs.readdirSync(
+    path.join(__dirname, './challenges/english')
+  );
+
+  it('handles all the directories in ./challenges/english', () => {
+    expect.assertions(14);
+
+    for (const directory of directories) {
+      expect(() => getSuperBlockFromDir(directory)).not.toThrow();
+    }
+  });
+
+  it("returns valid superblocks (or 'certifications') for all valid arguments", () => {
+    expect.assertions(14);
+
+    const superBlockPaths = directories.filter(x => x !== '00-certifications');
+
+    for (const directory of superBlockPaths) {
+      expect(Object.values(SuperBlocks)).toContain(
+        getSuperBlockFromDir(directory)
+      );
+    }
+    expect(getSuperBlockFromDir('00-certifications')).toBe('certifications');
+  });
+
+  it("returns all valid superblocks (and 'certifications')", () => {
+    expect.assertions(1);
+
+    const superBlocks = new Set();
+    for (const directory of directories) {
+      superBlocks.add(getSuperBlockFromDir(directory));
+    }
+
+    // + 1 for 'certifications'
+    expect(superBlocks.size).toBe(Object.values(SuperBlocks).length + 1);
+  });
+
+  it('throws if a directory is unknown', () => {
+    expect.assertions(1);
+
+    expect(() => getSuperBlockFromDir('unknown')).toThrow();
   });
 });

--- a/tools/scripts/build/build-mobile-curriculum.js
+++ b/tools/scripts/build/build-mobile-curriculum.js
@@ -9,7 +9,7 @@ exports.buildMobileCurriculum = function buildMobileCurriculum(json) {
 
   function writeAndParseCurriculumJson(curriculum) {
     const superBlockKeys = Object.keys(curriculum).filter(
-      key => key !== '00-certifications'
+      key => key !== 'certifications'
     );
 
     writeToFile('availableSuperblocks', { superblocks: superBlockKeys });
@@ -34,9 +34,8 @@ exports.buildMobileCurriculum = function buildMobileCurriculum(json) {
   }
 
   function writeToFile(filename, json) {
-    fs.writeFileSync(
-      `${mobileStaticPath}/mobile/${filename}.json`,
-      JSON.stringify(json, null, 2)
-    );
+    const fullPath = `${mobileStaticPath}/mobile/${filename}.json`;
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+    fs.writeFileSync(fullPath, JSON.stringify(json, null, 2));
   }
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "client/plugins/**/*",
     "client/src/**/*",
     "client/utils/**/*",
+    "curriculum/*.test.ts",
     "tools/challenge-helper-scripts/**/*.ts",
     "tools/scripts/**/*.ts"
   ],


### PR DESCRIPTION
The appearance of the curriculum directories (01-responsive-web-design and so on) was basically an accident - keys were needed and the directories were unique.

This PR uses the superblock keys defined [here](https://github.com/freeCodeCamp/freeCodeCamp/blob/main/config/certification-settings.ts), so there's no need to convert between similar keys.  They're always the same.

This should make it possible to simplify https://github.com/freeCodeCamp/freeCodeCamp/pull/45370