### PR TITLE
fix(a11y): hotkeys for toggle-aria-roledescription

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -420,7 +420,7 @@ const Editor = (props: EditorProps): JSX.Element => {
       id: 'toggle-aria-roledescription',
       label: 'Toggle aria-roledescription',
       keybindings: [
-        monaco.KeyMod.CtrlCmd | monaco.KeyMod.Alt | monaco.KeyCode.KEY_J
+        monaco.KeyMod.Shift | monaco.KeyMod.Alt | monaco.KeyCode.KEY_R
       ],
       run: toggleAriaRoledescription
     });


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally on my machine.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #44639

<!-- Feel free to add any additional description of changes below this line -->

One of our screen reader users [suggested](https://forum.freecodecamp.org/t/i-am-having-issues-with-jaws-screen-reader-in-code-editor-in-css-course-part-of-responsive-web-design-certification/490279/17) that the current hotkey combination for toggling aria-roledescription on the monaco editor is too similar to a popular combination used in JAWS. After doing some searching I believe I have one that won't conflict with any screen readers (SHIFT + ALT + R).