### PR TITLE
docs: consistent spelling in how to work on component library

### DIFF
--- a/docs/how-to-work-on-the-component-library.md
+++ b/docs/how-to-work-on-the-component-library.md
@@ -15,7 +15,7 @@ The following steps are recommended when working on a new component:
 
 ## Researching and planning
 
-Before building a component, you need to research and document on how the existing version behaves and looks, to ensure that the new one has matching styles and supports all the current usages. In order to meet the web accesibility requirements, you should also pay attention to the accessibility aspect of the component, see which HTML elements and ARIA attributes are used under the hood.
+Before building a component, you need to research and document on how the existing version behaves and looks, to ensure that the new one has matching styles and supports all the current usages. In order to meet the web accessibility requirements, you should also pay attention to the accessibility aspect of the component, see which HTML elements and ARIA attributes are used under the hood.
 
 Once you have gathered enough information about the component, you can start thinking about the props interface. Ideally, the interface should be as similar to the current version as possible, to ease the adoption later on. Since we are using Bootstrap components, the simplest approach is to mimic [their implementation](https://github.com/react-bootstrap/react-bootstrap/tree/master/src).
 

--- a/docs/how-to-work-on-the-component-library.md
+++ b/docs/how-to-work-on-the-component-library.md
@@ -15,7 +15,7 @@ The following steps are recommended when working on a new component:
 
 ## Researching and planning
 
-Before building a component, you need to research and document on how the existing version behaves and looks, to ensure that the new one has matching styles and supports all the current usages. In order to meet the web accesibility requirements, you should also pay attention to the accessibility aspect of the components, see which HTML elements and ARIA attributes are used under the hood.
+Before building a component, you need to research and document on how the existing version behaves and looks, to ensure that the new one has matching styles and supports all the current usages. In order to meet the web accesibility requirements, you should also pay attention to the accessibility aspect of the component, see which HTML elements and ARIA attributes are used under the hood.
 
 Once you have gathered enough information about the component, you can start thinking about the props interface. Ideally, the interface should be as similar to the current version as possible, to ease the adoption later on. Since we are using Bootstrap components, the simplest approach is to mimic [their implementation](https://github.com/react-bootstrap/react-bootstrap/tree/master/src).
 
@@ -43,11 +43,11 @@ The command will generate a new folder inside the `ui-components` directory, wit
 | `my-component.tsx`         | It is where we implement the component.                |
 | `types.ts`                 | Is is where we locate component's interface and types. |
 
-Each component is different, but in general the components should:
+Each component is different, but in general a component should:
 
 - Support forwarding ref
 - Be styled for both light and dark themes
-- Be styled internally based on their props (the consumers should not need to restyle the components with the `className` prop)
+- Be styled internally based on their props (the consumers should not need to restyle the component with the `className` prop)
 - Utilize the built-in styling system from Tailwind instead of having custom styles
 
 ### Useful links


### PR DESCRIPTION
made changes between "component" and "components" more consistent.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
