### PR TITLE
fix: disable code folding when editable regions present

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -1084,7 +1084,7 @@ const Editor = (props: EditorProps): JSX.Element => {
           editorDidMount={editorDidMount}
           editorWillMount={editorWillMount}
           onChange={onChange}
-          options={options}
+          options={{ ...options, folding: !hasEditableRegion() }}
           theme={editorTheme}
         />
       </span>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #45481 

<!-- Feel free to add any additional description of changes below this line -->

I couldn't add the property directly in the object because it threw errors on the `hasEditableRegions` call - so destructred it within the component prop instead.