### PR TITLE
fix: prevent code fold in editor when editable region present

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -222,6 +222,7 @@ const Editor = (props: EditorProps): JSX.Element => {
   // use a ref, since it will be updated on every render.
   const testRef = useRef<Test[]>([]);
   testRef.current = props.tests;
+  const containsEditableRegion = props.canFocus;
 
   // TENATIVE PLAN: create a typical order [html/jsx, css, js], put the
   // available files into that order.  i.e. if it's just one file it will
@@ -229,6 +230,7 @@ const Editor = (props: EditorProps): JSX.Element => {
   //  will be [jsx, js].
 
   const options: editor.IStandaloneEditorConstructionOptions = {
+    folding: containsEditableRegion ? false : true,
     fontSize: 18,
     scrollBeyondLastLine: true,
     selectionHighlight: false,


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #45481
