### PR TITLE
fix(curriculum): Anonymous Message Board test case

### DIFF
--- a/curriculum/challenges/english/09-information-security/information-security-projects/anonymous-message-board.md
+++ b/curriculum/challenges/english/09-information-security/information-security-projects/anonymous-message-board.md
@@ -313,8 +313,8 @@ async (getUserInput) => {
 
   let res = await fetch(`${url}/api/threads/fcc_test`);
   const threads = await res.json();
-  const report_id = threads[0]._id;
-  const data = { report_id };
+  const thread_id = threads[0]._id;
+  const data = { thread_id };
   
   res = await fetch(`${url}/api/threads/fcc_test`, {
     method: 'PUT',


### PR DESCRIPTION
As far as I understand, this test case is supposed to assert a PUT request to `/api/threads/:board` route but instead of sending `thread_id` field like the boilerplate's client form, it sent a `report_id` field instead.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.
