### PR TITLE
feat(ui-components): add info variant and hover state to Button component

### DIFF
--- a/tools/ui-components/src/button/button.stories.tsx
+++ b/tools/ui-components/src/button/button.stories.tsx
@@ -13,7 +13,7 @@ const story = {
   },
   argTypes: {
     variant: {
-      options: ['primary', 'danger']
+      options: ['primary', 'danger', 'info']
     },
     size: {
       options: ['small', 'medium', 'large']

--- a/tools/ui-components/src/button/button.stories.tsx
+++ b/tools/ui-components/src/button/button.stories.tsx
@@ -36,6 +36,12 @@ Danger.args = {
   children: 'Button'
 };
 
+export const Info = Template.bind({});
+Info.args = {
+  variant: 'info',
+  children: 'Button'
+};
+
 export const Large = Template.bind({});
 Large.args = {
   size: 'large',

--- a/tools/ui-components/src/button/button.tsx
+++ b/tools/ui-components/src/button/button.tsx
@@ -18,14 +18,18 @@ const computeClassNames = ({
       classNames.push(
         'border-default-foreground-danger',
         'bg-default-background-danger',
-        'text-default-foreground-danger'
+        'text-default-foreground-danger',
+        'hover:bg-default-background-danger-hover',
+        'hover:text-default-foreground-danger-hover'
       );
       break;
     case 'info':
       classNames.push(
         'border-default-foreground-info',
         'bg-default-background-info',
-        'text-default-foreground-info'
+        'text-default-foreground-info',
+        'hover:bg-default-background-info-hover',
+        'hover:text-default-foreground-info-hover'
       );
       break;
     // default variant is 'primary'
@@ -33,7 +37,9 @@ const computeClassNames = ({
       classNames.push(
         'border-default-foreground-secondary',
         'bg-default-background-quaternary',
-        'text-default-foreground-secondary'
+        'text-default-foreground-secondary',
+        'hover:bg-default-background-primary-hover',
+        'hover:text-default-foreground-primary-hover'
       );
   }
 

--- a/tools/ui-components/src/button/button.tsx
+++ b/tools/ui-components/src/button/button.tsx
@@ -21,6 +21,13 @@ const computeClassNames = ({
         'text-default-foreground-danger'
       );
       break;
+    case 'info':
+      classNames.push(
+        'border-default-foreground-info',
+        'bg-default-background-info',
+        'text-default-foreground-info'
+      );
+      break;
     // default variant is 'primary'
     default:
       classNames.push(

--- a/tools/ui-components/src/button/types.ts
+++ b/tools/ui-components/src/button/types.ts
@@ -1,6 +1,6 @@
 import { MouseEventHandler } from 'react';
 
-export type ButtonVariant = 'primary' | 'danger';
+export type ButtonVariant = 'primary' | 'danger' | 'info';
 
 export type ButtonSize = 'small' | 'medium' | 'large';
 

--- a/tools/ui-components/src/colors.css
+++ b/tools/ui-components/src/colors.css
@@ -96,12 +96,14 @@ div.light {
   --default-foreground-tertiary: var(--gray80);
   --default-foreground-quaternary: var(--gray75);
   --default-foreground-danger: var(--red15);
+  --default-foreground-info: var(--blue30);
 
   --default-background-primary: var(--gray00);
   --default-background-secondary: var(--gray05);
   --default-background-tertiary: var(--gray10);
   --default-background-quaternary: var(--gray15);
   --default-background-danger: var(--red90);
+  --default-background-info: var(--blue90);
 }
 
 html.dark,
@@ -110,10 +112,12 @@ div.dark {
   --default-foreground-secondary: var(--gray05);
   --default-foreground-quaternary: var(--gray15);
   --default-foreground-danger: var(--red90);
+  --default-foreground-info: var(--blue90);
 
   --default-background-primary: var(--gray90);
   --default-background-secondary: var(--gray85);
   --default-background-tertiary: var(--gray80);
   --default-background-quaternary: var(--gray75);
   --default-background-danger: var(--red15);
+  --default-background-info: var(--blue30);
 }

--- a/tools/ui-components/src/colors.css
+++ b/tools/ui-components/src/colors.css
@@ -104,6 +104,14 @@ div.light {
   --default-background-quaternary: var(--gray15);
   --default-background-danger: var(--red90);
   --default-background-info: var(--blue90);
+
+  --default-foreground-primary-hover: var(--gray00);
+  --default-foreground-danger-hover: var(--red90);
+  --default-foreground-info-hover: var(--blue90);
+
+  --default-background-primary-hover: var(--gray90);
+  --default-background-danger-hover: var(--red15);
+  --default-background-info-hover: var(--blue30);
 }
 
 html.dark,
@@ -120,4 +128,12 @@ div.dark {
   --default-background-quaternary: var(--gray75);
   --default-background-danger: var(--red15);
   --default-background-info: var(--blue30);
+
+  --default-foreground-primary-hover: var(--gray90);
+  --default-foreground-danger-hover: var(--red15);
+  --default-foreground-info-hover: var(--blue30);
+
+  --default-background-primary-hover: var(--gray00);
+  --default-background-danger-hover: var(--red90);
+  --default-background-info-hover: var(--blue90);
 }

--- a/tools/ui-components/tailwind.config.js
+++ b/tools/ui-components/tailwind.config.js
@@ -16,11 +16,13 @@ module.exports = {
       'default-foreground-tertiary': 'var(--default-foreground-tertiary)',
       'default-foreground-quaternary': 'var(--default-foreground-quaternary)',
       'default-foreground-danger': 'var(--default-foreground-danger)',
+      'default-foreground-info': 'var(--default-foreground-info)',
       'default-background-primary': 'var(--default-background-primary)',
       'default-background-secondary': 'var(--default-background-secondary)',
       'default-background-tertiary': 'var(--default-background-tertiary)',
       'default-background-quaternary': 'var(--default-background-quaternary)',
       'default-background-danger': 'var(--default-background-danger)',
+      'default-background-info': 'var(--default-background-info)',
       green: {
         50: 'var(--green05)',
         100: 'var(--green10)',

--- a/tools/ui-components/tailwind.config.js
+++ b/tools/ui-components/tailwind.config.js
@@ -11,18 +11,32 @@ module.exports = {
       transparent: 'transparent',
       'dark-theme-background': 'var(--gray90)',
       'light-theme-background': 'var(--gray00)',
+      // Foreground
       'default-foreground-primary': 'var(--default-foreground-primary)',
       'default-foreground-secondary': 'var(--default-foreground-secondary)',
       'default-foreground-tertiary': 'var(--default-foreground-tertiary)',
       'default-foreground-quaternary': 'var(--default-foreground-quaternary)',
       'default-foreground-danger': 'var(--default-foreground-danger)',
       'default-foreground-info': 'var(--default-foreground-info)',
+      // Background
       'default-background-primary': 'var(--default-background-primary)',
       'default-background-secondary': 'var(--default-background-secondary)',
       'default-background-tertiary': 'var(--default-background-tertiary)',
       'default-background-quaternary': 'var(--default-background-quaternary)',
       'default-background-danger': 'var(--default-background-danger)',
       'default-background-info': 'var(--default-background-info)',
+      // Foreground hover
+      'default-foreground-primary-hover':
+        'var(--default-foreground-primary-hover)',
+      'default-foreground-danger-hover':
+        'var(--default-foreground-danger-hover)',
+      'default-foreground-info-hover': 'var(--default-foreground-info-hover)',
+      // Background hover
+      'default-background-primary-hover':
+        'var(--default-background-primary-hover)',
+      'default-background-danger-hover':
+        'var(--default-background-danger-hover)',
+      'default-background-info-hover': 'var(--default-background-info-hover)',
       green: {
         50: 'var(--green05)',
         100: 'var(--green10)',


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Ref #45357

<!-- Feel free to add any additional description of changes below this line -->

This PR adds `info` variant and hover styles to Button component. I'll leave the focus and active state in a next PR, since I'll need to do some research on them.

**Note:** Reviewing by commits is recommended.

## Screenshot

### Info variant

| Light | Dark |
| --- | --- |
| <img width="110" alt="Screen Shot 2022-03-26 at 23 22 11" src="https://user-images.githubusercontent.com/25715018/160248354-6fb8e11d-c4cb-44bb-a3f1-157820dedffb.png"> | <img width="102" alt="Screen Shot 2022-03-26 at 23 22 19" src="https://user-images.githubusercontent.com/25715018/160248363-3d2521ce-de1a-44ce-ae07-6de380979099.png"> |

### Hover state

| Variant | Light | Dark |
| --- | --- | --- |
| Primary | <img width="104" alt="Screen Shot 2022-03-26 at 23 23 59" src="https://user-images.githubusercontent.com/25715018/160248413-245faf47-9e43-43d0-b728-02e51a691cc5.png"> | <img width="104" alt="Screen Shot 2022-03-26 at 23 23 52" src="https://user-images.githubusercontent.com/25715018/160248416-e74c51a1-20a4-4074-a82b-63f56d771b50.png"> |
| Danger | <img width="101" alt="Screen Shot 2022-03-26 at 23 24 34" src="https://user-images.githubusercontent.com/25715018/160248443-aca90ce3-c581-43ad-9c48-21da98ad5049.png"> | <img width="100" alt="Screen Shot 2022-03-26 at 23 24 41" src="https://user-images.githubusercontent.com/25715018/160248447-3297d185-63fe-45d0-81b9-5751f01c1fb3.png"> |
| Info | <img width="96" alt="Screen Shot 2022-03-26 at 23 24 55" src="https://user-images.githubusercontent.com/25715018/160248459-e5e2dad2-f996-41b2-bb36-3374d6def07e.png"> | <img width="99" alt="Screen Shot 2022-03-26 at 23 24 48" src="https://user-images.githubusercontent.com/25715018/160248472-7cc17e9d-1c3d-4643-8451-d3b12d123604.png"> |
