### PR TITLE
fix(a11y): beta RWD course toggle button accessibility

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -305,7 +305,9 @@
     "step-2": "Step 2: Submit your code",
     "submit-public-url": "When you have completed the project, save all the required files into a public repository and submit the URL to it below.",
     "complete-both-steps": "Complete both steps below to finish the challenge.",
-    "runs-in-vm": "The project runs in a virtual machine, complete the user stories described in there and get all the tests to pass to finish step 1."
+    "runs-in-vm": "The project runs in a virtual machine, complete the user stories described in there and get all the tests to pass to finish step 1.",
+    "completed": "Completed",
+    "not-started": "Not started"
   },
   "donate": {
     "title": "Support our nonprofit",

--- a/client/src/assets/icons/dropdown.tsx
+++ b/client/src/assets/icons/dropdown.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 function DropDown(): JSX.Element {
   return (
     <svg
+      aria-hidden='true'
       xmlns='http://www.w3.org/2000/svg'
       width='10'
       height='10'

--- a/client/src/assets/icons/green-not-completed.tsx
+++ b/client/src/assets/icons/green-not-completed.tsx
@@ -4,15 +4,15 @@ import { useTranslation } from 'react-i18next';
 interface GreenNotCompletedProps
   extends JSX.IntrinsicAttributes,
     React.SVGProps<SVGSVGElement> {
-  suppressSrOnly: boolean;
+  hushScreenReaderText?: boolean;
 }
 
 function GreenNotCompleted(props: GreenNotCompletedProps): JSX.Element {
   const { t } = useTranslation();
-  const { suppressSrOnly, ...rest } = props;
+  const { hushScreenReaderText = false, ...rest } = props;
   return (
     <>
-      {!suppressSrOnly && (
+      {!hushScreenReaderText && (
         <span className='sr-only'>{t('icons.not-passed')}</span>
       )}
       <svg

--- a/client/src/assets/icons/green-not-completed.tsx
+++ b/client/src/assets/icons/green-not-completed.tsx
@@ -1,15 +1,18 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-function GreenNotCompleted(
-  props: JSX.IntrinsicAttributes & React.SVGProps<SVGSVGElement>
-): JSX.Element {
+interface GreenNotCompletedProps
+  extends JSX.IntrinsicAttributes,
+    React.SVGProps<SVGSVGElement> {
+  suppressSrOnly: boolean;
+}
+
+function GreenNotCompleted(props: GreenNotCompletedProps): JSX.Element {
   const { t } = useTranslation();
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const suppressSrOnly = props['data-suppress-sronly'];
+  const { suppressSrOnly, ...rest } = props;
   return (
     <>
-      {suppressSrOnly !== 'true' && (
+      {!suppressSrOnly && (
         <span className='sr-only'>{t('icons.not-passed')}</span>
       )}
       <svg
@@ -18,7 +21,7 @@ function GreenNotCompleted(
         viewBox='0 0 200 200'
         width='50'
         xmlns='http://www.w3.org/2000/svg'
-        {...props}
+        {...rest}
       >
         <g>
           <title>{t('icons.not-passed')}</title>

--- a/client/src/assets/icons/green-not-completed.tsx
+++ b/client/src/assets/icons/green-not-completed.tsx
@@ -5,11 +5,15 @@ function GreenNotCompleted(
   props: JSX.IntrinsicAttributes & React.SVGProps<SVGSVGElement>
 ): JSX.Element {
   const { t } = useTranslation();
-
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const suppressSrOnly = props['data-suppress-sronly'];
   return (
     <>
-      <span className='sr-only'>{t('icons.not-passed')}</span>
+      {suppressSrOnly !== 'true' && (
+        <span className='sr-only'>{t('icons.not-passed')}</span>
+      )}
       <svg
+        aria-hidden='true'
         height='50'
         viewBox='0 0 200 200'
         width='50'

--- a/client/src/assets/icons/green-pass.tsx
+++ b/client/src/assets/icons/green-pass.tsx
@@ -9,7 +9,6 @@ interface GreenPassProps
 function GreenPass(props: GreenPassProps): JSX.Element {
   const { t } = useTranslation();
   const { hushScreenReaderText = false, ...rest } = props;
-  console.log('hushScreenReaderText = ', hushScreenReaderText);
   return (
     <>
       <svg

--- a/client/src/assets/icons/green-pass.tsx
+++ b/client/src/assets/icons/green-pass.tsx
@@ -1,23 +1,24 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-function GreenPass(
-  props: JSX.IntrinsicAttributes & React.SVGProps<SVGSVGElement>
-): JSX.Element {
+interface GreenPassProps
+  extends JSX.IntrinsicAttributes,
+    React.SVGProps<SVGSVGElement> {
+  suppressLabel: boolean;
+}
+function GreenPass(props: GreenPassProps): JSX.Element {
   const { t } = useTranslation();
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const suppressLabel = props['data-suppress-label'];
-
+  const { suppressLabel, ...rest } = props;
   return (
     <>
       <svg
-        {...(suppressLabel === 'true' && { 'aria-hidden': true })}
-        {...(suppressLabel !== 'true' && { 'aria-label': t('icons.passed') })}
+        {...(suppressLabel && { 'aria-hidden': true })}
+        {...(!suppressLabel && { 'aria-label': t('icons.passed') })}
         height='50'
         viewBox='0 0 200 200'
         width='50'
         xmlns='http://www.w3.org/2000/svg'
-        {...props}
+        {...rest}
       >
         <g aria-hidden='true'>
           <title>{t('icons.passed')}</title>

--- a/client/src/assets/icons/green-pass.tsx
+++ b/client/src/assets/icons/green-pass.tsx
@@ -5,11 +5,14 @@ function GreenPass(
   props: JSX.IntrinsicAttributes & React.SVGProps<SVGSVGElement>
 ): JSX.Element {
   const { t } = useTranslation();
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const suppressLabel = props['data-suppress-label'];
 
   return (
     <>
       <svg
-        aria-label={t('icons.passed')}
+        {...(suppressLabel === 'true' && { 'aria-hidden': true })}
+        {...(suppressLabel !== 'true' && { 'aria-label': t('icons.passed') })}
         height='50'
         viewBox='0 0 200 200'
         width='50'

--- a/client/src/assets/icons/green-pass.tsx
+++ b/client/src/assets/icons/green-pass.tsx
@@ -4,16 +4,17 @@ import { useTranslation } from 'react-i18next';
 interface GreenPassProps
   extends JSX.IntrinsicAttributes,
     React.SVGProps<SVGSVGElement> {
-  suppressLabel: boolean;
+  hushScreenReaderText?: boolean;
 }
 function GreenPass(props: GreenPassProps): JSX.Element {
   const { t } = useTranslation();
-  const { suppressLabel, ...rest } = props;
+  const { hushScreenReaderText = false, ...rest } = props;
+  console.log('hushScreenReaderText = ', hushScreenReaderText);
   return (
     <>
       <svg
-        {...(suppressLabel && { 'aria-hidden': true })}
-        {...(!suppressLabel && { 'aria-label': t('icons.passed') })}
+        {...(hushScreenReaderText && { 'aria-hidden': true })}
+        {...(!hushScreenReaderText && { 'aria-label': t('icons.passed') })}
         height='50'
         viewBox='0 0 200 200'
         width='50'

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -153,14 +153,14 @@ export class Block extends Component<BlockProps> {
 
     const isBlockCompleted = completedCount === challengesWithCompleted.length;
 
-    const percentageComplated = Math.floor(
+    const percentageCompleted = Math.floor(
       (completedCount / challengesWithCompleted.length) * 100
     );
 
     const progressBarRender = (
       <div aria-hidden='true' className='progress-wrapper'>
-        <ProgressBar now={percentageComplated} />
-        <span>{`${percentageComplated}%`}</span>
+        <ProgressBar now={percentageCompleted} />
+        <span>{`${percentageCompleted}%`}</span>
       </div>
     );
 
@@ -246,7 +246,7 @@ export class Block extends Component<BlockProps> {
       if (completedCount === challengesWithCompleted.length) {
         return t('learn.completed');
       }
-      return `${percentageComplated}% ${t('learn.completed')}`;
+      return `${percentageCompleted}% ${t('learn.completed')}`;
     };
 
     const GridBlock = (

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -78,9 +78,9 @@ export class Block extends Component<BlockProps> {
 
   renderCheckMark(isCompleted: boolean): JSX.Element {
     return isCompleted ? (
-      <GreenPass style={mapIconStyle} />
+      <GreenPass data-suppress-label='true' style={mapIconStyle} />
     ) : (
-      <GreenNotCompleted style={mapIconStyle} />
+      <GreenNotCompleted data-suppress-sronly='true' style={mapIconStyle} />
     );
   }
 
@@ -158,7 +158,7 @@ export class Block extends Component<BlockProps> {
     );
 
     const progressBarRender = (
-      <div className='progress-wrapper'>
+      <div aria-hidden='true' className='progress-wrapper'>
         <ProgressBar now={percentageComplated} />
         <span>{`${percentageComplated}%`}</span>
       </div>
@@ -239,39 +239,54 @@ export class Block extends Component<BlockProps> {
       </>
     );
 
+    const courseCompletionStatus = () => {
+      if (completedCount === 0) {
+        return 'not started';
+      }
+      if (completedCount === challengesWithCompleted.length) {
+        return 'completed';
+      }
+      return `${completedCount} of ${challengesWithCompleted.length} steps completed`;
+    };
+
     const GridBlock = (
       <>
         {' '}
         <ScrollableAnchor id={blockDashedName}>
           <div className={`block block-grid ${isExpanded ? 'open' : ''}`}>
-            <a
-              className='block-header'
-              onClick={() => {
-                this.handleBlockClick();
-              }}
-              href={`#${blockDashedName}`}
-            >
-              <div className='tags-wrapper'>
-                {!isAuditedCert(curriculumLocale, superBlock) && (
-                  <Link
-                    className='cert-tag'
-                    to={t('links:help-translate-link-url')}
-                  >
-                    {t('misc.translation-pending')}
-                  </Link>
-                )}
-              </div>
-              <div className='title-wrapper map-title'>
-                {this.renderCheckMark(isBlockCompleted)}
-                <h3 className='block-grid-title'>{blockTitle}</h3>
-                <DropDown />
-              </div>
-              {isExpanded && this.renderBlockIntros(blockIntroArr)}
-              {!isExpanded &&
-                !isBlockCompleted &&
-                completedCount > 0 &&
-                progressBarRender}
-            </a>
+            <h3 className='block-grid-title'>
+              <button
+                aria-expanded={isExpanded ? 'true' : 'false'}
+                className='block-header'
+                onClick={() => {
+                  this.handleBlockClick();
+                }}
+              >
+                <span className='block-header-button-text map-title'>
+                  {this.renderCheckMark(isBlockCompleted)}
+                  <span>
+                    {blockTitle}{' '}
+                    <span className='sr-only'>{courseCompletionStatus()}</span>
+                  </span>
+                  <DropDown />
+                </span>
+                {!isExpanded &&
+                  !isBlockCompleted &&
+                  completedCount > 0 &&
+                  progressBarRender}
+              </button>
+            </h3>
+            <div className='tags-wrapper'>
+              {!isAuditedCert(curriculumLocale, superBlock) && (
+                <Link
+                  className='cert-tag'
+                  to={t('links:help-translate-link-url')}
+                >
+                  {t('misc.translation-pending')}
+                </Link>
+              )}
+            </div>
+            {isExpanded && this.renderBlockIntros(blockIntroArr)}
             {isExpanded && (
               <>
                 <Challenges

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -78,9 +78,9 @@ export class Block extends Component<BlockProps> {
 
   renderCheckMark(isCompleted: boolean): JSX.Element {
     return isCompleted ? (
-      <GreenPass suppressLabel style={mapIconStyle} />
+      <GreenPass hushScreenReaderText style={mapIconStyle} />
     ) : (
-      <GreenNotCompleted suppressSrOnly style={mapIconStyle} />
+      <GreenNotCompleted hushScreenReaderText style={mapIconStyle} />
     );
   }
 

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -266,7 +266,9 @@ export class Block extends Component<BlockProps> {
                   {this.renderCheckMark(isBlockCompleted)}
                   <span>
                     {blockTitle}{' '}
-                    <span className='sr-only'>{courseCompletionStatus()}</span>
+                    <span className='sr-only'>
+                      , {courseCompletionStatus()}
+                    </span>
                   </span>
                   <DropDown />
                 </span>

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -78,9 +78,9 @@ export class Block extends Component<BlockProps> {
 
   renderCheckMark(isCompleted: boolean): JSX.Element {
     return isCompleted ? (
-      <GreenPass data-suppress-label='true' style={mapIconStyle} />
+      <GreenPass suppressLabel style={mapIconStyle} />
     ) : (
-      <GreenNotCompleted data-suppress-sronly='true' style={mapIconStyle} />
+      <GreenNotCompleted suppressSrOnly style={mapIconStyle} />
     );
   }
 

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -246,7 +246,7 @@ export class Block extends Component<BlockProps> {
       if (completedCount === challengesWithCompleted.length) {
         return t('learn.completed');
       }
-      return `${completedCount} of ${challengesWithCompleted.length} steps completed`;
+      return `${percentageComplated}% ${t('learn.completed')}`;
     };
 
     const GridBlock = (

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -241,10 +241,10 @@ export class Block extends Component<BlockProps> {
 
     const courseCompletionStatus = () => {
       if (completedCount === 0) {
-        return 'not started';
+        return t('learn.not-started');
       }
       if (completedCount === challengesWithCompleted.length) {
-        return 'completed';
+        return t('learn.completed');
       }
       return `${completedCount} of ${challengesWithCompleted.length} steps completed`;
     };

--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -366,13 +366,24 @@ button.map-title {
   background-color: var(--tertiary-background);
 }
 
+.block-grid .block-header[aria-expanded='true'] {
+  border-bottom: 3px solid var(--secondary-background);
+}
+
+.block-header-button-text {
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
 .block-grid .block-header .block-link {
   flex-direction: row;
 }
 
 .block-ui .block-grid .block-description {
   border: none;
-  padding: 0 10px 10px;
+  padding: 25px;
 }
 
 .block-grid .map-title > svg {
@@ -414,7 +425,6 @@ button.map-title {
 .tags-wrapper {
   display: flex;
   width: 100%;
-  padding: 10px 10px 0;
 }
 
 .grid-project-block {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally on my machine.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
This PR is my first accessibility enhancement for the RWD beta landing page. This is related to issue #45419. The updates for this PR include:

- Converting the course toggle button from an anchor link to an actual button and adding the aria-expanded attribute to the button to convey state to screen reader users
- Nesting the button in the h3 heading to comply with best practices for an accordion header
- Removing the course description paragraphs from the button
- Adding screen reader only text to the end of the button header to indicate current status for the course
  - If the user has not completed any steps then status will be "Not started"
  - If the user has completed all steps then status will be "Completed"
  - Otherwise, status will be "N of M steps completed"