### PR TITLE
fix: only test mobile curriculum on english

### DIFF
--- a/tools/scripts/build/mobile-curriculum.test.js
+++ b/tools/scripts/build/mobile-curriculum.test.js
@@ -2,52 +2,59 @@ const path = require('path');
 const fs = require('fs');
 const { AssertionError } = require('chai');
 const { getChallengesForLang } = require('../../../curriculum/getChallenges');
+const envData = require('../../../config/env.json');
 const { buildMobileCurriculum } = require('./build-mobile-curriculum');
 const { mobileSchemaValidator } = require('./mobileSchema');
 
-describe('mobile curriculum build', () => {
-  const mobileStaticPath = path.resolve(__dirname, '../../../client/static');
-  const blockIntroPath = path.resolve(
-    __dirname,
-    '../../../client/i18n/locales/english/intro.json'
-  );
-
-  const validateMobileSuperBlock = mobileSchemaValidator();
-
-  let curriculum;
-
-  beforeAll(async () => {
-    curriculum = await getChallengesForLang('english');
-    await buildMobileCurriculum(curriculum);
-  }, 20000);
-
-  test('the mobile curriculum should have a static folder with multiple files', () => {
-    expect(fs.existsSync(`${mobileStaticPath}/mobile`)).toBe(true);
-
-    expect(fs.readdirSync(`${mobileStaticPath}/mobile`).length).toBeGreaterThan(
-      0
+if (envData.clientLocale == 'english') {
+  describe('mobile curriculum build', () => {
+    const mobileStaticPath = path.resolve(__dirname, '../../../client/static');
+    const blockIntroPath = path.resolve(
+      __dirname,
+      '../../../client/i18n/locales/english/intro.json'
     );
+
+    const validateMobileSuperBlock = mobileSchemaValidator();
+
+    let curriculum;
+
+    beforeAll(async () => {
+      curriculum = await getChallengesForLang('english');
+      await buildMobileCurriculum(curriculum);
+    }, 20000);
+
+    test('the mobile curriculum should have a static folder with multiple files', () => {
+      expect(fs.existsSync(`${mobileStaticPath}/mobile`)).toBe(true);
+
+      expect(
+        fs.readdirSync(`${mobileStaticPath}/mobile`).length
+      ).toBeGreaterThan(0);
+    });
+
+    test('the mobile curriculum should have access to the intro.json file', () => {
+      expect(fs.existsSync(blockIntroPath)).toBe(true);
+    });
+
+    test('the files generated should have the correct schema', () => {
+      const fileArray = fs.readdirSync(`${mobileStaticPath}/mobile`);
+
+      fileArray
+        .filter(fileInArray => fileInArray !== 'availableSuperblocks.json')
+        .forEach(fileInArray => {
+          const fileContent = fs.readFileSync(
+            `${mobileStaticPath}/mobile/${fileInArray}`
+          );
+
+          const result = validateMobileSuperBlock(JSON.parse(fileContent));
+
+          if (result.error) {
+            throw new AssertionError(result.error, `file: ${fileInArray}`);
+          }
+        });
+    });
   });
-
-  test('the mobile curriculum should have access to the intro.json file', () => {
-    expect(fs.existsSync(blockIntroPath)).toBe(true);
+} else {
+  describe.skip('Mobile curriculum is not localized', () => {
+    test.todo('localized tests');
   });
-
-  test('the files generated should have the correct schema', () => {
-    const fileArray = fs.readdirSync(`${mobileStaticPath}/mobile`);
-
-    fileArray
-      .filter(fileInArray => fileInArray !== 'availableSuperblocks.json')
-      .forEach(fileInArray => {
-        const fileContent = fs.readFileSync(
-          `${mobileStaticPath}/mobile/${fileInArray}`
-        );
-
-        const result = validateMobileSuperBlock(JSON.parse(fileContent));
-
-        if (result.error) {
-          throw new AssertionError(result.error, `file: ${fileInArray}`);
-        }
-      });
-  });
-});
+}

--- a/tools/scripts/build/mobile-curriculum.test.js
+++ b/tools/scripts/build/mobile-curriculum.test.js
@@ -6,7 +6,7 @@ const envData = require('../../../config/env.json');
 const { buildMobileCurriculum } = require('./build-mobile-curriculum');
 const { mobileSchemaValidator } = require('./mobileSchema');
 
-if (envData.clientLocale == 'english') {
+if (envData.clientLocale == 'english' && !envData.showUpcomingChanges) {
   describe('mobile curriculum build', () => {
     const mobileStaticPath = path.resolve(__dirname, '../../../client/static');
     const blockIntroPath = path.resolve(


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes nothing, but should make the tests less flaky.

<!-- Feel free to add any additional description of changes below this line -->
