### PR TITLE
fix(a11y): beta RWD feedback for code check

### DIFF
--- a/client/src/templates/Challenges/classic/editor.css
+++ b/client/src/templates/Challenges/classic/editor.css
@@ -62,6 +62,10 @@
   animation-delay: 0.5s;
 }
 
+.action-row-container button[aria-hidden='true'] {
+  display: none;
+}
+
 @keyframes example {
   from {
     background-color: var(--highlight-background);
@@ -78,6 +82,23 @@
 #test-status {
   padding-bottom: 5px;
   padding-top: 5px;
+}
+
+#test-status .status {
+  font-family: revert;
+}
+
+#test-status p {
+  margin: 0.5rem 0 0;
+}
+
+#test-status h2 {
+  font-size: 1rem;
+  line-height: 1.5;
+  padding-right: 0.5rem;
+  /* using float instead of inline display so screen readers recognize h2 as a block element */
+  float: left;
+  margin: 0;
 }
 
 .myEditableLineDecoration {

--- a/client/src/templates/Challenges/classic/editor.css
+++ b/client/src/templates/Challenges/classic/editor.css
@@ -92,13 +92,17 @@
   margin: 0.5rem 0 0;
 }
 
-#test-status h2 {
+#test-status h2.hint {
   font-size: 1rem;
   line-height: 1.5;
   padding-right: 0.5rem;
   /* using float instead of inline display so screen readers recognize h2 as a block element */
   float: left;
   margin: 0;
+}
+
+#test-status h2.hint::after {
+  content: ':';
 }
 
 .myEditableLineDecoration {

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -572,13 +572,11 @@ const Editor = (props: EditorProps): JSX.Element => {
   function createOutputNode(editor: editor.IStandaloneCodeEditor) {
     if (dataRef.current.outputNode) return dataRef.current.outputNode;
     const outputNode = document.createElement('div');
-    //const ariaLiveNode = document.createElement('div');
     const statusNode = document.createElement('div');
     const editorActionRow = document.createElement('div');
     editorActionRow.classList.add('action-row-container');
     outputNode.classList.add('editor-lower-jaw');
     outputNode.appendChild(editorActionRow);
-    //ariaLiveNode.setAttribute('aria-live', 'assertive');
     statusNode.setAttribute('id', 'test-status');
     statusNode.setAttribute('aria-live', 'assertive');
     const button = document.createElement('button');
@@ -592,8 +590,6 @@ const Editor = (props: EditorProps): JSX.Element => {
     submitButton.classList.add('btn-block');
     editorActionRow.appendChild(button);
     editorActionRow.appendChild(submitButton);
-    //ariaLiveNode.appendChild(statusNode);
-    //ariaLiveNode.appendChild(hintNode);
     editorActionRow.appendChild(statusNode);
     button.onclick = () => {
       clearTestFeedback();
@@ -1002,9 +998,8 @@ const Editor = (props: EditorProps): JSX.Element => {
       const testStatus = document.getElementById('test-status');
       if (challengeIsComplete()) {
         const testButton = document.getElementById('test-button');
-        // We don't want to remove the test button from the accessibility API
-        // at this point because we don't want to lose focus until we set it
-        // on the submit button, so just visually hide it for now.
+        // In case test button has focus, only visually hide it for now so we
+        // don't lose the focus before we set it on submit button.
         testButton?.classList.add('sr-only');
         const submitButton = document.getElementById('submit-button');
         if (submitButton) {
@@ -1014,12 +1009,11 @@ const Editor = (props: EditorProps): JSX.Element => {
             const { submitChallenge } = props;
             submitChallenge();
           };
-          // Give the aria-live announcement a little time before setting
-          // focus on submit button to make sure it gets announced first.
+          // Delay setting focus on submit button to ensure aria-live status
+          // message is announced first by screen reader.
           setTimeout(() => {
-            // Order is important. Must set focus on submit button before
-            // removing test button from accessibility API since test button
-            // might have focus.
+            // Must set focus on submit button before removing test button from
+            // accessibility API since test button might have focus.
             if (!isEditorInFocus) {
               submitButton.focus();
             }
@@ -1039,7 +1033,7 @@ const Editor = (props: EditorProps): JSX.Element => {
         }
 
         const submitKeyboardInstructions = isEditorInFocus
-          ? '<span class="sr-only">Use Ctrl + Enter to submit.'
+          ? '<span class="sr-only">Use Ctrl + Enter to submit.</span>'
           : '';
 
         if (testStatus) {

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -1049,9 +1049,7 @@ const Editor = (props: EditorProps): JSX.Element => {
         ];
         testStatus.innerHTML = `<p class="status"><span aria-hidden="true">✖️</span> Sorry, your code does not pass. ${
           wordsArray[Math.floor(Math.random() * wordsArray.length)]
-        }</p><div><h2 class="hint">Hint<span aria-hidden="true">:</span></h2> ${
-          output[1]
-        }</div>`;
+        }</p><div><h2 class="hint">Hint</h2> ${output[1]}</div>`;
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -564,7 +564,10 @@ const Editor = (props: EditorProps): JSX.Element => {
 
   function clearTestFeedback() {
     const testStatus = document.getElementById('test-status');
-    if (testStatus) {
+    if (testStatus && testStatus.innerHTML) {
+      const currentHeight = `${testStatus.offsetHeight}px`;
+      // Height will be cleared after status message has been displayed
+      testStatus.style.height = currentHeight;
       testStatus.innerHTML = '';
     }
   }
@@ -1038,6 +1041,7 @@ const Editor = (props: EditorProps): JSX.Element => {
 
         if (testStatus) {
           testStatus.innerHTML = `<p class="status"><span aria-hidden="true">&#9989;</span> Congratulations, your code passes. Submit your code to complete this step and move on to the next one. ${submitKeyboardInstructions}</p>`;
+          testStatus.style.height = '';
         }
       } else if (challengeHasErrors() && testStatus) {
         const wordsArray = [
@@ -1050,6 +1054,7 @@ const Editor = (props: EditorProps): JSX.Element => {
         testStatus.innerHTML = `<p class="status"><span aria-hidden="true">✖️</span> Sorry, your code does not pass. ${
           wordsArray[Math.floor(Math.random() * wordsArray.length)]
         }</p><div><h2 class="hint">Hint</h2> ${output[1]}</div>`;
+        testStatus.style.height = '';
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Currently, when a screen reader user triggers the "Check Your Code" functionality in a Step (either by clicking the button or using the `Ctrl + Enter` shortcut) there is no audible feedback and thus the user does not immediately know that the code check took place, and furthermore does not know the results of the code check. This PR addresses those issues.

This required the reworking of the status area under the button so that I could implement it as a live region, which will then force the screen reader to announce the content in the status area when the code check is triggered. This included having to reword the feedback in order to make it announce more logically for people listening to the page and to make sure all information is conveyed clearly for these users. Additionally, I added an `<h2>` for the Hint in order to help screen reader users find the hint text if they need to explore it more thoroughly.

I also forced the status area to refresh each time the test is triggered so that it is apparent to visual users that the test executed.

