### PR TITLE
feat: enable RWD on i18n

### DIFF
--- a/client/src/resources/cert-and-project-map.ts
+++ b/client/src/resources/cert-and-project-map.ts
@@ -1,5 +1,7 @@
 import { SuperBlocks } from '../../../config/certification-settings';
-import { showUpcomingChanges } from '../../../config/env.json';
+import envData from '../../../config/env.json';
+
+const { showUpcomingChanges } = envData;
 
 const responsiveWebBase =
   '/learn/responsive-web-design/responsive-web-design-projects';

--- a/client/src/resources/cert-and-project-map.ts
+++ b/client/src/resources/cert-and-project-map.ts
@@ -1,4 +1,5 @@
 import { SuperBlocks } from '../../../config/certification-settings';
+import { showUpcomingChanges } from '../../../config/env.json';
 
 const responsiveWebBase =
   '/learn/responsive-web-design/responsive-web-design-projects';
@@ -713,7 +714,9 @@ const certMap = [
 ] as const;
 
 function getResponsiveWebDesignPath(project: string) {
-  return `${responsiveWeb22Base}/${project}-project/${project}`;
+  return showUpcomingChanges
+    ? `${responsiveWeb22Base}/${project}-project/${project}`
+    : `${responsiveWebBase}/${project}`;
 }
 
 const titles = certMap.map(({ title }) => title);

--- a/client/src/resources/cert-and-project-map.ts
+++ b/client/src/resources/cert-and-project-map.ts
@@ -1,7 +1,4 @@
 import { SuperBlocks } from '../../../config/certification-settings';
-import envData from '../../../config/env.json';
-
-const { showNewCurriculum, showUpcomingChanges } = envData;
 
 const responsiveWebBase =
   '/learn/responsive-web-design/responsive-web-design-projects';
@@ -300,42 +297,33 @@ const certMap = [
       {
         id: '587d78af367417b2b2512b03',
         title: 'Build a Survey Form',
-        link: getResponsiveWebDesignPath('build-a-survey-form', {
-          showNewCurriculum
-        }),
+        link: getResponsiveWebDesignPath('build-a-survey-form'),
         certSlug: SuperBlocks.RespWebDesign
       },
       {
         id: 'bd7158d8c442eddfaeb5bd18',
         title: 'Build a Tribute Page',
-        link: getResponsiveWebDesignPath('build-a-tribute-page', {
-          showNewCurriculum
-        }),
+        link: getResponsiveWebDesignPath('build-a-tribute-page'),
         certSlug: SuperBlocks.RespWebDesign
       },
       {
         id: '587d78b0367417b2b2512b05',
         title: 'Build a Technical Documentation Page',
         link: getResponsiveWebDesignPath(
-          'build-a-technical-documentation-page',
-          { showNewCurriculum }
+          'build-a-technical-documentation-page'
         ),
         certSlug: SuperBlocks.RespWebDesign
       },
       {
         id: '587d78af367417b2b2512b04',
         title: 'Build a Product Landing Page',
-        link: getResponsiveWebDesignPath('build-a-product-landing-page', {
-          showNewCurriculum
-        }),
+        link: getResponsiveWebDesignPath('build-a-product-landing-page'),
         certSlug: SuperBlocks.RespWebDesign
       },
       {
         id: 'bd7158d8c242eddfaeb5bd13',
         title: 'Build a Personal Portfolio Webpage',
-        link: getResponsiveWebDesignPath('build-a-personal-portfolio-webpage', {
-          showNewCurriculum
-        }),
+        link: getResponsiveWebDesignPath('build-a-personal-portfolio-webpage'),
         certSlug: SuperBlocks.RespWebDesign
       }
     ]
@@ -724,14 +712,8 @@ const certMap = [
   }
 ] as const;
 
-function getResponsiveWebDesignPath(
-  project: string,
-  { showNewCurriculum }: { showNewCurriculum: boolean }
-) {
-  // TODO: for the hard launch, the conditional should just be `showNewCurriculum`
-  return showNewCurriculum && showUpcomingChanges
-    ? `${responsiveWeb22Base}/${project}-project/${project}`
-    : `${responsiveWebBase}/${project}/`;
+function getResponsiveWebDesignPath(project: string) {
+  return `${responsiveWeb22Base}/${project}-project/${project}`;
 }
 
 const titles = certMap.map(({ title }) => title);

--- a/curriculum/getChallenges.js
+++ b/curriculum/getChallenges.js
@@ -242,6 +242,7 @@ async function buildChallenges({ path: filePath }, curriculum, lang) {
   // ) {
   //   return;
   // }
+  const createChallenge = generateChallengeCreator(CHALLENGES_DIR, lang);
   const challenge = isCert
     ? await createCertification(CHALLENGES_DIR, filePath, lang)
     : await createChallenge(filePath, meta);
@@ -312,9 +313,11 @@ No audited challenges should fallback to English.
     challenge.block = meta.name ? dasherize(meta.name) : null;
     challenge.hasEditableBoundaries = !!meta.hasEditableBoundaries;
     challenge.order = meta.order;
-    const superOrder = getSuperOrder(meta.superBlock, {
-      showNewCurriculum: process.env.SHOW_NEW_CURRICULUM === 'true'
-    });
+    const superOrder = getSuperOrder(meta.superBlock);
+    // NOTE: Use this version when a super block is in beta.
+    // const superOrder = getSuperOrder(meta.superBlock, {
+    //   showNewCurriculum: process.env.SHOW_NEW_CURRICULUM === 'true'
+    // });
     if (superOrder !== null) challenge.superOrder = superOrder;
     /* Since there can be more than one way to complete a certification (using the
    legacy curriculum or the new one, for instance), we need a certification

--- a/curriculum/getChallenges.js
+++ b/curriculum/getChallenges.js
@@ -236,13 +236,12 @@ async function buildChallenges({ path: filePath }, curriculum, lang) {
   const isCert = path.extname(filePath) === '.yml';
   // TODO: there's probably a better way, but this makes sure we don't build any
   // of the new curriculum when we don't want it.
-  if (
-    process.env.SHOW_NEW_CURRICULUM !== 'true' &&
-    meta?.superBlock === '2022/responsive-web-design'
-  ) {
-    return;
-  }
-  const createChallenge = generateChallengeCreator(CHALLENGES_DIR, lang);
+  // if (
+  //   process.env.SHOW_NEW_CURRICULUM !== 'true' &&
+  //   meta?.superBlock === '2022/responsive-web-design'
+  // ) {
+  //   return;
+  // }
   const challenge = isCert
     ? await createCertification(CHALLENGES_DIR, filePath, lang)
     : await createChallenge(filePath, meta);

--- a/curriculum/utils.js
+++ b/curriculum/utils.js
@@ -32,12 +32,12 @@ const superBlockToOrder = {
   'information-security': 8,
   'machine-learning-with-python': 9,
   'coding-interview-prep': 10,
+  '2022/responsive-web-design': 11,
   'relational-database': 12
 };
 
 const superBlockToNewOrder = {
-  ...superBlockToOrder,
-  '2022/responsive-web-design': 11
+  ...superBlockToOrder
 };
 
 function getSuperOrder(

--- a/curriculum/utils.test.ts
+++ b/curriculum/utils.test.ts
@@ -26,7 +26,7 @@ describe('getSuperOrder', () => {
   });
 
   it('returns unique numbers for all current superblocks', () => {
-    expect.assertions(12);
+    expect.assertions(13);
     expect(getSuperOrder('responsive-web-design')).toBe(0);
     expect(getSuperOrder('javascript-algorithms-and-data-structures')).toBe(1);
     expect(getSuperOrder('front-end-development-libraries')).toBe(2);
@@ -38,10 +38,12 @@ describe('getSuperOrder', () => {
     expect(getSuperOrder('information-security')).toBe(8);
     expect(getSuperOrder('machine-learning-with-python')).toBe(9);
     expect(getSuperOrder('coding-interview-prep')).toBe(10);
+    expect(getSuperOrder('2022/responsive-web-design')).toBe(11);
     expect(getSuperOrder('relational-database')).toBe(12);
   });
 
-  it('returns a different order if passed the option showNewCurriculum: true', () => {
+  // Skipping these tests instead of deleting, so the infrastructure is there when we do the next superblock
+  it.skip('returns a different order if passed the option showNewCurriculum: true', () => {
     expect.assertions(13);
     expect(
       getSuperOrder('responsive-web-design', { showNewCurriculum: true })


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
This enables the RWD beta to appear on i18n instances of learn. The third commit copies the files from english to avoid build issues. Don't look at that one it'll crash things :)