### PR TITLE
fix(a11y): update light theme code example color contrast ratios

### DIFF
--- a/client/src/components/layouts/prism.css
+++ b/client/src/components/layouts/prism.css
@@ -17,3 +17,69 @@ pre[class*='language-'] {
 * {
   text-shadow: none !important;
 }
+
+/* a11y color adjustments */
+:not(.dark-palette) .token.comment,
+:not(.dark-palette) .token.prolog,
+:not(.dark-palette) .token.doctype,
+:not(.dark-palette) .token.cdata {
+  color: #62707f;
+}
+
+:not(.dark-palette) .token.punctuation {
+  color: #38425c;
+}
+
+:not(.dark-palette) .token.property,
+:not(.dark-palette) .token.tag,
+:not(.dark-palette) .token.constant,
+:not(.dark-palette) .token.symbol,
+:not(.dark-palette) .token.deleted {
+  color: #e00000;
+}
+
+:not(.dark-palette) .token.number {
+  color: #9932cc;
+}
+
+:not(.dark-palette) .token.boolean {
+  color: #1f3a93;
+}
+
+:not(.dark-palette) .token.selector,
+:not(.dark-palette) .token.attr-name,
+:not(.dark-palette) .token.string,
+:not(.dark-palette) .token.char,
+:not(.dark-palette) .token.builtin,
+:not(.dark-palette) .token.inserted {
+  color: #008040;
+}
+
+:not(.dark-palette) .token.operator,
+:not(.dark-palette) .token.entity,
+:not(.dark-palette) .token.url,
+:not(.dark-palette) .language-css .token.string,
+:not(.dark-palette) .style .token.string {
+  color: #38425c;
+}
+
+:not(.dark-palette) .token.atrule,
+:not(.dark-palette) .token.attr-value,
+:not(.dark-palette) .token.keyword {
+  color: #2574a9;
+}
+
+:not(.dark-palette) .token.function,
+:not(.dark-palette) .token.class-name {
+  color: #992900;
+}
+
+:not(.dark-palette) .token.regex,
+:not(.dark-palette) .token.important,
+:not(.dark-palette) .token.variable {
+  color: #856514;
+}
+
+:not(.dark-palette) .line-numbers-rows > span::before {
+  color: #62707f;
+}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally on my machine.

This PR is related to #38947. Many of the colors used in the code examples under the light theme do not meet the minimum `4.5:1` contrast ratio specified by [WCAG SC 1.4.3](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html). I think you'll find that most of my color choices are very close to what is being used now, just a darker shade. The colors used under the dark theme all meet the minimum contrast ratio.