### PR TITLE
feat: change monaco shortcut

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -394,6 +394,7 @@ const Editor = (props: EditorProps): JSX.Element => {
         newLine.run();
       }
     );
+    /* eslint-enable */
     editor.addAction({
       id: 'execute-challenge',
       label: 'Run tests',

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -379,7 +379,21 @@ const Editor = (props: EditorProps): JSX.Element => {
       null,
       () => {}
     );
-    /* eslint-enable */
+    const newLine = editor.getAction('editor.action.insertLineAfter');
+    // @ts-ignore
+    editor._standaloneKeybindingService.addDynamicKeybinding(
+      '-editor.action.insertLineAfter',
+      null,
+      () => {}
+    );
+    // @ts-ignore
+    editor._standaloneKeybindingService.addDynamicKeybinding(
+      'editor.action.insertLineAfter',
+      monaco.KeyMod.Alt | monaco.KeyCode.Enter,
+      () => {
+        newLine.run();
+      }
+    );
     editor.addAction({
       id: 'execute-challenge',
       label: 'Run tests',

--- a/cypress/integration/learn/common-components/editor.js
+++ b/cypress/integration/learn/common-components/editor.js
@@ -1,0 +1,29 @@
+const selectors = {
+  editor: '.monaco-editor'
+};
+
+describe('Editor Shortcuts', () => {
+  it('Should handle Alt+Enter', () => {
+    cy.visit(
+      'learn/responsive-web-design/basic-html-and-html5/say-hello-to-html-elements'
+    );
+    cy.get(selectors.editor, { timeout: 15000 })
+      .first()
+      .click()
+      .focused()
+      .type('{alt}{enter}')
+      .should('have.value', '<h1>Hello</h1>\n');
+  });
+
+  it('Should ignore Ctrl+Enter', () => {
+    cy.visit(
+      'learn/responsive-web-design/basic-html-and-html5/say-hello-to-html-elements'
+    );
+    cy.get(selectors.editor, { timeout: 15000 })
+      .first()
+      .click()
+      .focused()
+      .type('{ctrl}{enter}')
+      .should('have.value', '<h1>Hello</h1>');
+  });
+});


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #45571 

<!-- Feel free to add any additional description of changes below this line -->

I went with the `Alt + Enter` for this.

The approach here follows the issue linked in the comment block above, mentioning a lack of a public API to modify the default keybindings. Have to remove the existing keybinding, then mount the new one.