### PR TITLE
feat: add secure donation border to donation form

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -357,6 +357,7 @@
     "try-again": "Please try again.",
     "card-number": "Your Card Number:",
     "expiration": "Expiration Date:",
+    "secure-donation": "Secure donation",
     "faq": "Frequently asked questions",
     "only-you": "Only you can see this message. Congratulations on earning this certification. It's no easy task. Running freeCodeCamp isn't easy either. Nor is it cheap. Help us help you and many other people around the world. Make a tax-deductible supporting donation to our nonprofit today.",
     "get-help": "How can I get help with my donations?",

--- a/client/src/components/Donation/donate-form.tsx
+++ b/client/src/components/Donation/donate-form.tsx
@@ -332,8 +332,6 @@ class DonateForm extends Component<DonateFormProps, DonateFormComponentState> {
     )}:`;
     const showMinimalPayments = isSignedIn && (isMinimalForm || !isDonating);
 
-    const isAsVariant = !isAVariant;
-
     return (
       <>
         <b className={isMinimalForm ? 'donation-label-modal' : ''}>
@@ -341,11 +339,9 @@ class DonateForm extends Component<DonateFormProps, DonateFormComponentState> {
         </b>
         <Spacer />
         <fieldset
-          className={`donate-btn-group ${
-            isAVariant ? 'test-btn-group' : ''
-          }`}
+          className={`donate-btn-group ${isAVariant ? '' : 'test-btn-group'}`}
         >
-          {isAsVariant === false && (
+          {!isAVariant && (
             <legend>
               <SecurityLockIcon />
               {t('donate.secure-donation')}

--- a/client/src/components/Donation/donate-form.tsx
+++ b/client/src/components/Donation/donate-form.tsx
@@ -332,14 +332,25 @@ class DonateForm extends Component<DonateFormProps, DonateFormComponentState> {
     )}:`;
     const showMinimalPayments = isSignedIn && (isMinimalForm || !isDonating);
 
+    const isAsVariant = !isAVariant;
+
     return (
       <>
         <b className={isMinimalForm ? 'donation-label-modal' : ''}>
-          {isAVariant === false && <SecurityLockIcon />}
           {this.getDonationButtonLabel()}:
         </b>
         <Spacer />
-        <div className={'donate-btn-group'}>
+        <fieldset
+          className={`donate-btn-group ${
+            isAsVariant === false ? 'test-btn-group' : ''
+          }`}
+        >
+          {isAsVariant === false && (
+            <legend>
+              <SecurityLockIcon />
+              Secure donation
+            </legend>
+          )}
           {loading.stripe && loading.paypal && this.paymentButtonsLoader()}
           <WalletsWrapper
             amount={donationAmount}
@@ -374,11 +385,10 @@ class DonateForm extends Component<DonateFormProps, DonateFormComponentState> {
                 processing={processing}
                 t={t}
                 theme={priorityTheme}
-                isAVariant={isAVariant}
               />
             </>
           )}
-        </div>
+        </fieldset>
       </>
     );
   }

--- a/client/src/components/Donation/donate-form.tsx
+++ b/client/src/components/Donation/donate-form.tsx
@@ -348,7 +348,7 @@ class DonateForm extends Component<DonateFormProps, DonateFormComponentState> {
           {isAsVariant === false && (
             <legend>
               <SecurityLockIcon />
-              Secure donation
+              {t('donate.secure-donation')}
             </legend>
           )}
           {loading.stripe && loading.paypal && this.paymentButtonsLoader()}

--- a/client/src/components/Donation/donate-form.tsx
+++ b/client/src/components/Donation/donate-form.tsx
@@ -342,7 +342,7 @@ class DonateForm extends Component<DonateFormProps, DonateFormComponentState> {
         <Spacer />
         <fieldset
           className={`donate-btn-group ${
-            isAsVariant === false ? 'test-btn-group' : ''
+            isAVariant ? 'test-btn-group' : ''
           }`}
         >
           {isAsVariant === false && (

--- a/client/src/components/Donation/donation.css
+++ b/client/src/components/Donation/donation.css
@@ -334,10 +334,6 @@ li.disabled > a {
   height: 22px;
 }
 
-.confirm-donation-btn svg.svg-inline--fa.fa-lock {
-  margin-bottom: 2px;
-}
-
 @media screen and (min-width: 355px) {
   .form-payment-methods {
     height: 30px;
@@ -540,4 +536,21 @@ a.patreon-button:hover {
 .faq-item blockquote {
   font-size: 1em;
   border-left-color: var(--quaternary-background);
+}
+
+.test-btn-group {
+  padding: 10px;
+  border: 2px solid var(--quaternary-background);
+  border-radius: 4px;
+}
+
+.test-btn-group > legend {
+  width: fit-content;
+  font-size: 0.9em;
+  color: var(--quaternary-color);
+  border: none;
+  margin-bottom: 0;
+  padding: 0 4px;
+  left: 0;
+  margin-left: -2px;
 }

--- a/client/src/components/Donation/stripe-card-form.tsx
+++ b/client/src/components/Donation/stripe-card-form.tsx
@@ -17,7 +17,6 @@ import React, { useState } from 'react';
 import envData from '../../../../config/env.json';
 import { Themes } from '../settings/theme';
 import { AddDonationData } from './paypal-button';
-import SecurityLockIcon from './security-lock-icon';
 
 const { stripePublicKey }: { stripePublicKey: string | null } = envData;
 
@@ -35,7 +34,6 @@ interface FormPropTypes {
   t: (label: string) => string;
   theme: Themes;
   processing: boolean;
-  isAVariant: boolean;
 }
 
 interface Element {
@@ -51,8 +49,7 @@ const StripeCardForm = ({
   t,
   onDonationStateChange,
   postStripeCardDonation,
-  processing,
-  isAVariant
+  processing
 }: FormPropTypes): JSX.Element => {
   const [isSubmissionValid, setSubmissionValidity] = useState(true);
   const [isTokenizing, setTokenizing] = useState(false);
@@ -170,7 +167,6 @@ const StripeCardForm = ({
         disabled={!stripe || !elements || isSubmitting}
         type='submit'
       >
-        {isAVariant === false && <SecurityLockIcon />}
         {t('buttons.donate')}
       </Button>
     </Form>

--- a/config/donation-settings.js
+++ b/config/donation-settings.js
@@ -94,7 +94,7 @@ const patreonDefaultPledgeAmount = 500;
 
 const aBTestConfig = {
   isTesting: true,
-  type: 'addSecurityLock'
+  type: 'secureDonationBorder'
 };
 
 module.exports = {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This pr adds a changes the div wrapping the donation forms to a fieldset element for all test variations and tests if showing a security lock would increase conversion.


### How to test:
#### A variant: 
Seed the db, login, check the email (foo@bar.com), and pop the donation modal. 
It should not include lock icons.

#### B variant: 
Seed the db, login, change the email to (foo@foo.com), and pop the donation modal It should have a border around the donation form and  lock icon followed by "Secure donation".

B variant screenshot of the donation modal:

<img width="989" alt="Screen Shot 2022-04-07 at 11 08 28 AM" src="https://user-images.githubusercontent.com/4591597/162159294-1cae3cd0-1e2e-4b09-b10f-4a15be72b956.png">
