### PR TITLE
fix: change sentence for correct backticks usage

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6145f59029474c0d3dc1c8b8.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6145f59029474c0d3dc1c8b8.md
@@ -7,7 +7,7 @@ dashedName: step-39
 
 # --description--
 
-As with the other input elements and `labels`, link the `textarea` to its corresponding `label` element, and give it a `name` attribute.
+As with the other `input` and `label` elements, link the `textarea` to its corresponding `label` element, and give it a `name` attribute.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

Found myself translating this file, `labels` is not an element name, so I reworded the sentence to have `label` being used.
