### PR TITLE
fix(curriculum): allow spaces before opening parenthesis in .log call

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/debugging/use-typeof-to-check-the-type-of-a-variable.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/debugging/use-typeof-to-check-the-type-of-a-variable.md
@@ -32,7 +32,7 @@ Add two `console.log()` statements to check the `typeof` each of the two variabl
 Your code should use `typeof` in two `console.log()` statements to check the type of the variables.
 
 ```js
-assert(code.match(/console\.log\(typeof[\( ].*\)?\)/g).length == 2);
+assert(code.match(/console\.log\s*\(typeof[\( ].*\)?\)/g).length == 2);
 ```
 
 Your code should use `typeof` to check the type of the variable `seven`.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #45570

<!-- Feel free to add any additional description of changes below this line -->

Only changed the assert statement to allow console.log () as well as console.log() in this exercise
