### PR TITLE
fix(docs): update codebase link for contributing

### DIFF
--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -7,6 +7,6 @@
 - <span class='cover-icon'><i class="fas fa-question-circle"></i></span> [Help by answering coding questions](https://forum.freecodecamp.org) on our community forum.
 - <span class='cover-icon'><i class="fas fa-comments"></i></span> [Give feedback on coding projects](https://forum.freecodecamp.org/c/project-feedback?max_posts=1) built by campers.
 - <span class='cover-icon'><i class="fas fa-language"></i></span> [Help us translate](/index?id=translations) freeCodeCamp.org's resources.
-- <span class='cover-icon'><i class="fab fa-github"></i></span> [Contribute to our open source codebase](/index?id=our-open-source-codebase) on GitHub.
+- <span class='cover-icon'><i class="fab fa-github"></i></span> [Contribute to our open source codebase](/index?id=learning-platform) on GitHub.
 
 [Read our contributing guidelines](/index.md)


### PR DESCRIPTION
I appears the main contributing page got updated headers. This commit
updates a link to said page.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

The contributing page (https://contribute.freecodecamp.org/#/) almost links correctly when clicking on the link "Contribute to our open source codebase on GitHub". But it doesn't get it quite right because the heading on that page got updated.

This commit updates it to what it should be https://contribute.freecodecamp.org/#/index?id=learning-platform