### PR TITLE
fix: hint isn't descriptive enough

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/add-images-to-your-website.md
+++ b/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/add-images-to-your-website.md
@@ -54,7 +54,7 @@ Your image should have a `src` attribute that points to the kitten image.
 assert(/^https:\/\/cdn\.freecodecamp\.org\/curriculum\/cat-photo-app\/relaxing-cat\.jpg$/i.test($('img').attr('src')));
 ```
 
-Your image element's `alt` attribute should not be empty.
+Your `img` have to be in the right format, and your `alt` attribute should not be empty.
 
 ```js
 assert(


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.


Closes #45717

Changed the 3rd hint in [add-image-to-your-website.md](https://github.com/freeCodeCamp/freeCodeCamp/blob/main/curriculum/challenges/english/01-responsive-web-design/basic-html-and-html5/add-images-to-your-website.md) 

``` md
- Your image element's `alt` attribute should not be empty.
 
+ Your `img` have to be in the right format, and your `alt` attribute should not be empty.
```