### PR TITLE
docs: update the security policy

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -1,20 +1,25 @@
-# Security Policy
+# freeCodeCamp.org's Security Policy
 
 This document outlines our security policy for the codebases, platforms that we operate, and how to report vulnerabilities.
 
 ## Reporting a Vulnerability
 
-If you think you have found a vulnerability, _please report responsibly_. Don't create GitHub issues for security issues. Instead, please send an email to `security@freecodecamp.org` and we'll look into it immediately.
+> [!NOTE]
+> If you think you have found a vulnerability, **please report responsibly**. Do not create GitHub issues for security issues. Instead follow this guide.
 
-Ensure that you are using the **latest**, **stable** and **updated** version of the Operating System and Web Browser available to you on your machine.
+### Guidelines
 
-We appreciate any responsible disclosure of vulnerabilities that might impact the integrity of our platforms and users.
+We appreciate a responsible disclosure of vulnerabilities that might impact the integrity of our platforms and users. In interest of saving everyone time, we encourage you to report vulnerabilities with these in mind:
 
-Once you report a vulnerability, we will look into it and make sure that it is not a false positive. We will get back to you if we need to clarify any details. You can submit separate reports for each issue you find.
+1. Ensure that you are using the **latest**, **stable** and **updated** versions of the Operating System and Web Browser(s) available to you on your machine.
+2. We consider using tools & online utilities to report issues with SPF & DKIM configs, or SSL Server tests, etc. in the category of ["beg bounties"](https://www.troyhunt.com/beg-bounties/) and are unable to respond to these reports.
+3. While we do not offer any bounties or swags at the moment, we'll be happy to list your name in our [Hall of Fame](security-hall-of-fame.md) list, provided the reports are not low-effort.
 
-While we do not offer any bounties or swags at the moment, we'll be happy to list your name in our [Hall of Fame](security-hall-of-fame.md) list, provided the reports are not low-effort.
+### Reporting
 
-We consider using tools & online utilities to report issues with SPF & DKIM configs, or SSL Server tests, etc. in the category of ["beg bounties"](https://www.troyhunt.com/beg-bounties/) and are unable to respond to these reports.
+After confirming the above guidelines, please feel free to either send an email to `possible-security-issue [at] freecodecamp.org`. You can also send us an PGP encrypted message at `flowcrypt.com/me/freecodecamp` if you prefer.
+
+Once you report a vulnerability, we will look into it and make sure that it is not a false positive. If we need to clarify any details, we will get back to you. You can submit separate reports for each issue you find. Please note that we will not be able to respond to any issues that we think are outside the guidelines.
 
 ## Platforms & Codebases
 
@@ -35,12 +40,16 @@ Here is a list of the platforms and codebases we are accepting reports for:
 | production | Yes       | `freecodecamp.org/news`            |
 | localized  | Yes       | `freecodecamp.org/<language>/news` |
 
-### Mobile app
+### Mobile App
 
 | Version    | Supported | Website active                                                   |
 | ---------- | --------- | ---------------------------------------------------------------- |
 | production | Yes       | `https://play.google.com/store/apps/details?id=org.freecodecamp` |
 
+### Other Platforms
+
 Apart from the above, we are also accepting reports for repositories hosted on GitHub, under the freeCodeCamp organization.
+
+### Other Self-hosted Applications
 
 We self-host some of our platforms using open-source software like Ghost & Discourse. If you are reporting a vulnerability please ensure that it is not a bug in the upstream software.

--- a/docs/security.md
+++ b/docs/security.md
@@ -9,7 +9,7 @@ This document outlines our security policy for the codebases, platforms that we 
 
 ### Guidelines
 
-We appreciate a responsible disclosure of vulnerabilities that might impact the integrity of our platforms and users. In interest of saving everyone time, we encourage you to report vulnerabilities with these in mind:
+We appreciate a responsible disclosure of vulnerabilities that might impact the integrity of our platforms and users. In the interest of saving everyone time, we encourage you to report vulnerabilities with these in mind:
 
 1. Ensure that you are using the **latest**, **stable** and **updated** versions of the Operating System and Web Browser(s) available to you on your machine.
 2. We consider using tools & online utilities to report issues with SPF & DKIM configs, or SSL Server tests, etc. in the category of ["beg bounties"](https://www.troyhunt.com/beg-bounties/) and are unable to respond to these reports.


### PR DESCRIPTION
Updates the security policy to the new email and adds the PGP form on FlowCrypt
