### PR TITLE
feat: migrate locale test to ts v2

### DIFF
--- a/client/i18n/locales.test.ts
+++ b/client/i18n/locales.test.ts
@@ -42,12 +42,20 @@ describe('Locale tests:', () => {
         });
       });
 
-      test(`has an entry in the langDisplayNames variable`, () => {
-        expect(Object.keys(LangNames).includes(lang)).toBe(true);
+      test(`has an entry in the langDisplayNames enum`, () => {
+        expect(
+          Object.keys(LangNames)
+            .map(langCode => langCode.toLowerCase())
+            .includes(lang)
+        ).toBe(true);
       });
 
-      test(`has an entry in the langCodes variable`, () => {
-        expect(Object.keys(LangCodes).includes(lang)).toBe(true);
+      test(`has an entry in the langCodes enum`, () => {
+        expect(
+          Object.keys(LangCodes)
+            .map(langCode => langCode.toLowerCase())
+            .includes(lang)
+        ).toBe(true);
       });
     });
   });

--- a/client/i18n/locales.test.ts
+++ b/client/i18n/locales.test.ts
@@ -1,11 +1,10 @@
+import fs from 'fs';
+import { setup } from 'jest-json-schema-extended';
 import {
   availableLangs,
-  langDisplayNames,
-  langCodes
+  LangNames,
+  LangCodes
 } from '../../config/i18n/all-langs';
-
-const fs = require('fs');
-const { setup } = require('jest-json-schema-extended');
 
 setup();
 
@@ -44,11 +43,11 @@ describe('Locale tests:', () => {
       });
 
       test(`has an entry in the langDisplayNames variable`, () => {
-        expect(langDisplayNames[lang].length).toBeGreaterThan(0);
+        expect(Object.keys(LangNames).includes(lang)).toBe(true);
       });
 
       test(`has an entry in the langCodes variable`, () => {
-        expect(langCodes[lang].length).toBeGreaterThan(0);
+        expect(Object.keys(LangCodes).includes(lang)).toBe(true);
       });
     });
   });

--- a/client/src/client-only-routes/show-certification.tsx
+++ b/client/src/client-only-routes/show-certification.tsx
@@ -7,7 +7,7 @@ import { bindActionCreators, Dispatch } from 'redux';
 import { createSelector } from 'reselect';
 
 import envData from '../../../config/env.json';
-import { langCodes } from '../../../config/i18n/all-langs';
+import { langCodeIncludes } from '../../../config/i18n/all-langs';
 import FreeCodeCampLogo from '../assets/icons/FreeCodeCamp-logo';
 import DonateForm from '../components/Donation/donate-form';
 
@@ -34,9 +34,9 @@ import standardErrorMessage from '../utils/standard-error-message';
 
 import ShowProjectLinks from './show-project-links';
 
-const { clientLocale } = envData as { clientLocale: keyof typeof langCodes };
+const { clientLocale } = envData;
 
-const localeCode = langCodes[clientLocale];
+const localeCode = langCodeIncludes(clientLocale);
 type Cert = {
   username: string;
   name: string;

--- a/client/src/client-only-routes/show-certification.tsx
+++ b/client/src/client-only-routes/show-certification.tsx
@@ -7,7 +7,7 @@ import { bindActionCreators, Dispatch } from 'redux';
 import { createSelector } from 'reselect';
 
 import envData from '../../../config/env.json';
-import { langCodeIncludes } from '../../../config/i18n/all-langs';
+import { getLangCode } from '../../../config/i18n/all-langs';
 import FreeCodeCampLogo from '../assets/icons/FreeCodeCamp-logo';
 import DonateForm from '../components/Donation/donate-form';
 
@@ -36,7 +36,7 @@ import ShowProjectLinks from './show-project-links';
 
 const { clientLocale } = envData;
 
-const localeCode = langCodeIncludes(clientLocale);
+const localeCode = getLangCode(clientLocale);
 type Cert = {
   username: string;
   name: string;

--- a/client/src/components/Header/components/nav-links.tsx
+++ b/client/src/components/Header/components/nav-links.tsx
@@ -22,7 +22,7 @@ import { connect } from 'react-redux';
 import envData from '../../../../../config/env.json';
 import {
   availableLangs,
-  LangNames
+  langNameFromLocale
 } from '../../../../../config/i18n/all-langs';
 import { hardGoTo as navigate } from '../../../redux';
 import { updateUserFlag } from '../../../redux/settings';
@@ -200,11 +200,7 @@ export class NavLinks extends Component<NavLinksProps, {}> {
           >
             {locales.map(lang => (
               <option key={'lang-' + lang} value={lang}>
-                {
-                  Object.keys(LangNames).filter(
-                    langNames => langNames.toLowerCase() == lang
-                  )[0]
-                }
+                {langNameFromLocale(lang)}
               </option>
             ))}
           </select>

--- a/client/src/components/Header/components/nav-links.tsx
+++ b/client/src/components/Header/components/nav-links.tsx
@@ -22,7 +22,7 @@ import { connect } from 'react-redux';
 import envData from '../../../../../config/env.json';
 import {
   availableLangs,
-  getLangNameFromLocale
+  getLangName
 } from '../../../../../config/i18n/all-langs';
 import { hardGoTo as navigate } from '../../../redux';
 import { updateUserFlag } from '../../../redux/settings';
@@ -200,7 +200,7 @@ export class NavLinks extends Component<NavLinksProps, {}> {
           >
             {locales.map(lang => (
               <option key={'lang-' + lang} value={lang}>
-                {getLangNameFromLocale(lang)}
+                {getLangName(lang)}
               </option>
             ))}
           </select>

--- a/client/src/components/Header/components/nav-links.tsx
+++ b/client/src/components/Header/components/nav-links.tsx
@@ -22,7 +22,7 @@ import { connect } from 'react-redux';
 import envData from '../../../../../config/env.json';
 import {
   availableLangs,
-  langDisplayNames
+  LangNames
 } from '../../../../../config/i18n/all-langs';
 import { hardGoTo as navigate } from '../../../redux';
 import { updateUserFlag } from '../../../redux/settings';
@@ -200,7 +200,7 @@ export class NavLinks extends Component<NavLinksProps, {}> {
           >
             {locales.map(lang => (
               <option key={'lang-' + lang} value={lang}>
-                {langDisplayNames[lang]}
+                {Object.keys(LangNames).filter(langName => langName == lang)[0]}
               </option>
             ))}
           </select>

--- a/client/src/components/Header/components/nav-links.tsx
+++ b/client/src/components/Header/components/nav-links.tsx
@@ -200,7 +200,11 @@ export class NavLinks extends Component<NavLinksProps, {}> {
           >
             {locales.map(lang => (
               <option key={'lang-' + lang} value={lang}>
-                {Object.keys(LangNames).filter(langName => langName == lang)[0]}
+                {
+                  Object.keys(LangNames).filter(
+                    langNames => langNames.toLowerCase() == lang
+                  )[0]
+                }
               </option>
             ))}
           </select>

--- a/client/src/components/Header/components/nav-links.tsx
+++ b/client/src/components/Header/components/nav-links.tsx
@@ -22,7 +22,7 @@ import { connect } from 'react-redux';
 import envData from '../../../../../config/env.json';
 import {
   availableLangs,
-  langNameFromLocale
+  getLangNameFromLocale
 } from '../../../../../config/i18n/all-langs';
 import { hardGoTo as navigate } from '../../../redux';
 import { updateUserFlag } from '../../../redux/settings';
@@ -200,7 +200,7 @@ export class NavLinks extends Component<NavLinksProps, {}> {
           >
             {locales.map(lang => (
               <option key={'lang-' + lang} value={lang}>
-                {langNameFromLocale(lang)}
+                {getLangNameFromLocale(lang)}
               </option>
             ))}
           </select>

--- a/client/src/components/Header/header.test.tsx
+++ b/client/src/components/Header/header.test.tsx
@@ -8,7 +8,10 @@ import { create, ReactTestRendererJSON } from 'react-test-renderer';
 import ShallowRenderer from 'react-test-renderer/shallow';
 
 import envData from '../../../../config/env.json';
-import { availableLangs, LangNames } from '../../../../config/i18n/all-langs';
+import {
+  availableLangs,
+  langNameFromLocale
+} from '../../../../config/i18n/all-langs';
 import { Themes } from '../settings/theme';
 import AuthOrProfile from './components/auth-or-profile';
 import { NavLinks } from './components/nav-links';
@@ -355,9 +358,7 @@ const hasAllAvailableLanguagesInDropdown = (component: JSX.Element) => {
   return children.props.children.every(
     ({ props }: { props: { value: string; children: string } }) =>
       availableLangs.client.includes(props.value) &&
-      Object.values(LangNames).filter(
-        langName => langName == props.value
-      )[0] === props.children
+      langNameFromLocale(props.value) === props.children
   );
 };
 

--- a/client/src/components/Header/header.test.tsx
+++ b/client/src/components/Header/header.test.tsx
@@ -8,10 +8,7 @@ import { create, ReactTestRendererJSON } from 'react-test-renderer';
 import ShallowRenderer from 'react-test-renderer/shallow';
 
 import envData from '../../../../config/env.json';
-import {
-  availableLangs,
-  langDisplayNames
-} from '../../../../config/i18n/all-langs';
+import { availableLangs, LangNames } from '../../../../config/i18n/all-langs';
 import { Themes } from '../settings/theme';
 import AuthOrProfile from './components/auth-or-profile';
 import { NavLinks } from './components/nav-links';
@@ -358,8 +355,9 @@ const hasAllAvailableLanguagesInDropdown = (component: JSX.Element) => {
   return children.props.children.every(
     ({ props }: { props: { value: string; children: string } }) =>
       availableLangs.client.includes(props.value) &&
-      (langDisplayNames as Record<string, string>)[props.value] ===
-        props.children
+      Object.values(LangNames).filter(
+        langName => langName == props.value
+      )[0] === props.children
   );
 };
 

--- a/client/src/components/Header/header.test.tsx
+++ b/client/src/components/Header/header.test.tsx
@@ -10,7 +10,7 @@ import ShallowRenderer from 'react-test-renderer/shallow';
 import envData from '../../../../config/env.json';
 import {
   availableLangs,
-  langNameFromLocale
+  getLangNameFromLocale
 } from '../../../../config/i18n/all-langs';
 import { Themes } from '../settings/theme';
 import AuthOrProfile from './components/auth-or-profile';
@@ -358,7 +358,7 @@ const hasAllAvailableLanguagesInDropdown = (component: JSX.Element) => {
   return children.props.children.every(
     ({ props }: { props: { value: string; children: string } }) =>
       availableLangs.client.includes(props.value) &&
-      langNameFromLocale(props.value) === props.children
+      getLangNameFromLocale(props.value) === props.children
   );
 };
 

--- a/client/src/components/Header/header.test.tsx
+++ b/client/src/components/Header/header.test.tsx
@@ -8,10 +8,7 @@ import { create, ReactTestRendererJSON } from 'react-test-renderer';
 import ShallowRenderer from 'react-test-renderer/shallow';
 
 import envData from '../../../../config/env.json';
-import {
-  availableLangs,
-  getLangNameFromLocale
-} from '../../../../config/i18n/all-langs';
+import { availableLangs, getLangName } from '../../../../config/i18n/all-langs';
 import { Themes } from '../settings/theme';
 import AuthOrProfile from './components/auth-or-profile';
 import { NavLinks } from './components/nav-links';
@@ -358,7 +355,7 @@ const hasAllAvailableLanguagesInDropdown = (component: JSX.Element) => {
   return children.props.children.every(
     ({ props }: { props: { value: string; children: string } }) =>
       availableLangs.client.includes(props.value) &&
-      getLangNameFromLocale(props.value) === props.children
+      getLangName(props.value) === props.children
   );
 };
 

--- a/client/src/components/profile/components/camper.tsx
+++ b/client/src/components/profile/components/camper.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { TFunction, useTranslation } from 'react-i18next';
 
 import envData from '../../../../../config/env.json';
-import { langCodeIncludes } from '../../../../../config/i18n/all-langs';
+import { getLangCode } from '../../../../../config/i18n/all-langs';
 import { AvatarRenderer } from '../../helpers';
 import Link from '../../helpers/link';
 import SocialIcons from './social-icons';
@@ -18,7 +18,7 @@ import './camper.css';
 
 const { clientLocale } = envData;
 
-const localeCode = langCodeIncludes(clientLocale);
+const localeCode = getLangCode(clientLocale);
 
 interface CamperProps {
   about: string;

--- a/client/src/components/profile/components/camper.tsx
+++ b/client/src/components/profile/components/camper.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { TFunction, useTranslation } from 'react-i18next';
 
 import envData from '../../../../../config/env.json';
-import { langCodes } from '../../../../../config/i18n/all-langs';
+import { langCodeIncludes } from '../../../../../config/i18n/all-langs';
 import { AvatarRenderer } from '../../helpers';
 import Link from '../../helpers/link';
 import SocialIcons from './social-icons';
@@ -17,10 +17,8 @@ import SocialIcons from './social-icons';
 import './camper.css';
 
 const { clientLocale } = envData;
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-const localeCode = langCodes[clientLocale];
+
+const localeCode = langCodeIncludes(clientLocale);
 
 interface CamperProps {
   about: string;

--- a/client/src/components/profile/components/heat-map.tsx
+++ b/client/src/components/profile/components/heat-map.tsx
@@ -16,7 +16,7 @@ import './heatmap.css';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import envData from '../../../../../config/env.json';
-import { langCodeIncludes } from '../../../../../config/i18n/all-langs';
+import { getLangCode } from '../../../../../config/i18n/all-langs';
 import { User } from '../../../redux/prop-types';
 import FullWidthRow from '../../helpers/full-width-row';
 import Spacer from '../../helpers/spacer';
@@ -24,7 +24,7 @@ import Spacer from '../../helpers/spacer';
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 const { clientLocale } = envData;
 
-const localeCode = langCodeIncludes(clientLocale);
+const localeCode = getLangCode(clientLocale);
 
 interface HeatMapProps {
   calendar: User['calendar'];

--- a/client/src/components/profile/components/heat-map.tsx
+++ b/client/src/components/profile/components/heat-map.tsx
@@ -16,7 +16,7 @@ import './heatmap.css';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import envData from '../../../../../config/env.json';
-import { langCodes } from '../../../../../config/i18n/all-langs';
+import { langCodeIncludes } from '../../../../../config/i18n/all-langs';
 import { User } from '../../../redux/prop-types';
 import FullWidthRow from '../../helpers/full-width-row';
 import Spacer from '../../helpers/spacer';
@@ -24,10 +24,7 @@ import Spacer from '../../helpers/spacer';
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 const { clientLocale } = envData;
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-assignment
-const localeCode = langCodes[clientLocale];
+const localeCode = langCodeIncludes(clientLocale);
 
 interface HeatMapProps {
   calendar: User['calendar'];

--- a/client/src/components/profile/components/time-line.tsx
+++ b/client/src/components/profile/components/time-line.tsx
@@ -7,7 +7,7 @@ import { TFunction, withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 
 import envData from '../../../../../config/env.json';
-import { langCodeIncludes } from '../../../../../config/i18n/all-langs';
+import { getLangCode } from '../../../../../config/i18n/all-langs';
 import {
   getCertIds,
   getPathFromID,
@@ -33,7 +33,7 @@ const mapDispatchToProps = {
 };
 
 const { clientLocale } = envData;
-const localeCode = langCodeIncludes(clientLocale);
+const localeCode = getLangCode(clientLocale);
 
 // Items per page in timeline.
 const ITEMS_PER_PAGE = 15;

--- a/client/src/components/profile/components/time-line.tsx
+++ b/client/src/components/profile/components/time-line.tsx
@@ -7,7 +7,7 @@ import { TFunction, withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 
 import envData from '../../../../../config/env.json';
-import { langCodes } from '../../../../../config/i18n/all-langs';
+import { langCodeIncludes } from '../../../../../config/i18n/all-langs';
 import {
   getCertIds,
   getPathFromID,
@@ -32,8 +32,8 @@ const mapDispatchToProps = {
   openModal
 };
 
-const { clientLocale } = envData as { clientLocale: keyof typeof langCodes };
-const localeCode = langCodes[clientLocale];
+const { clientLocale } = envData;
+const localeCode = langCodeIncludes(clientLocale);
 
 // Items per page in timeline.
 const ITEMS_PER_PAGE = 15;

--- a/config/i18n/all-langs.ts
+++ b/config/i18n/all-langs.ts
@@ -177,40 +177,39 @@ export enum LangCodes {
 // returns a key-value from an enum for client locale which is initiated from a JSON file.
 // JSON does not support enums.
 
-export function langCodeIncludes(locale: string) {
-  const langCodeObj = Object.entries(LangCodes).map(([key, value]) => ({
-    id: key.toLocaleLowerCase(),
+export function getLangCode(locale: PropertyKey) {
+  const langCodeArr = Object.entries(LangCodes).map(([key, value]) => ({
+    [key.toLocaleLowerCase()]: key.toLocaleLowerCase(),
     value: value
   }));
 
-  const entryObj = (obj: Record<string, string>): boolean => {
-    if (obj.id == locale) {
-      return true;
-    }
-    return false;
-  };
+  function isPropertyOf<LangCodes>(
+    obj: Record<string, string>,
+    localeKey: PropertyKey
+  ): localeKey is keyof LangCodes {
+    return Object.prototype.hasOwnProperty.call(obj, localeKey);
+  }
 
-  const result = langCodeObj.filter(entryObj);
+  const result = langCodeArr.filter(obj => isPropertyOf(obj, locale));
 
-  return result.length > 0 ? result[0]['value'] : LangCodes.English;
+  return result[0]['value'];
 }
 
 // does the same as the above function but for language names
-
-export function langNameFromLocale(locale: string) {
-  const langCodeObj = Object.entries(LangNames).map(([key, value]) => ({
-    id: key.toLocaleLowerCase(),
+export function getLangNameFromLocale(locale: PropertyKey) {
+  const langCodeArr = Object.entries(LangNames).map(([key, value]) => ({
+    [key.toLocaleLowerCase()]: key.toLocaleLowerCase(),
     value: value
   }));
 
-  const entryObj = (obj: Record<string, string>): boolean => {
-    if (obj.id == locale) {
-      return true;
-    }
-    return false;
-  };
+  function isPropertyOf<LangNames>(
+    obj: Record<string, string>,
+    localeKey: PropertyKey
+  ): localeKey is keyof LangNames {
+    return Object.prototype.hasOwnProperty.call(obj, localeKey);
+  }
 
-  const result = langCodeObj.filter(entryObj);
+  const result = langCodeArr.filter(obj => isPropertyOf(obj, locale));
 
-  return result.length > 0 ? result[0]['value'] : '???';
+  return result[0]['value'];
 }

--- a/config/i18n/all-langs.ts
+++ b/config/i18n/all-langs.ts
@@ -148,28 +148,28 @@ export const i18nextCodes = {
 };
 
 // These are for the language selector dropdown menu in the footer
-export const langDisplayNames = {
-  english: 'English',
-  espanol: 'Español',
-  chinese: '中文（简体字）',
-  'chinese-traditional': '中文（繁體字）',
-  italian: 'Italiano',
-  portuguese: 'Português',
-  ukrainian: 'Українська',
-  japanese: '日本語'
-};
+export enum LangNames {
+  English = 'English',
+  Espanol = 'Español',
+  Chinese = '中文（简体字）',
+  'Chinese-traditional' = '中文（繁體字）',
+  Italian = 'Italiano',
+  Portuguese = 'Português',
+  Ukrainian = 'Українська',
+  Japanese = '日本語'
+}
 
 /* These are for formatting dates and numbers. Used with JS .toLocaleString().
  * There's an example in profile/components/Camper.js
  * List: https://github.com/unicode-cldr/cldr-dates-modern/tree/master/main
  */
-export const langCodes = {
-  english: 'en-US',
-  espanol: 'es-419',
-  chinese: 'zh',
-  'chinese-traditional': 'zh-Hant',
-  italian: 'it',
-  portuguese: 'pt-BR',
-  ukrainian: 'uk',
-  japanese: 'ja'
-};
+export enum LangCodes {
+  English = 'en-US',
+  Espanol = 'es-419',
+  Chinese = 'zh',
+  'Chinese-traditional' = 'zh-Hant',
+  Italian = 'it',
+  Portuguese = 'pt-BR',
+  Ukrainian = 'uk',
+  Japanese = 'ja'
+}

--- a/config/i18n/all-langs.ts
+++ b/config/i18n/all-langs.ts
@@ -148,15 +148,16 @@ export const i18nextCodes = {
 };
 
 // These are for the language selector dropdown menu in the footer
+/* eslint-disable @typescript-eslint/naming-convention */
 export enum LangNames {
-  English = 'English',
-  Espanol = 'Español',
-  Chinese = '中文（简体字）',
-  'Chinese-traditional' = '中文（繁體字）',
-  Italian = 'Italiano',
-  Portuguese = 'Português',
-  Ukrainian = 'Українська',
-  Japanese = '日本語'
+  english = 'English',
+  espanol = 'Español',
+  chinese = '中文（简体字）',
+  'chinese-traditional' = '中文（繁體字）',
+  italian = 'Italiano',
+  portuguese = 'Português',
+  ukrainian = 'Українська',
+  japanese = '日本語'
 }
 
 /* These are for formatting dates and numbers. Used with JS .toLocaleString().
@@ -164,52 +165,33 @@ export enum LangNames {
  * List: https://github.com/unicode-cldr/cldr-dates-modern/tree/master/main
  */
 export enum LangCodes {
-  English = 'en-US',
-  Espanol = 'es-419',
-  Chinese = 'zh',
-  'Chinese-traditional' = 'zh-Hant',
-  Italian = 'it',
-  Portuguese = 'pt-BR',
-  Ukrainian = 'uk',
-  Japanese = 'ja'
+  english = 'en-US',
+  espanol = 'es-419',
+  chinese = 'zh',
+  'chinese-traditional' = 'zh-Hant',
+  italian = 'it',
+  portuguese = 'pt-BR',
+  ukrainian = 'uk',
+  japanese = 'ja'
 }
+/* eslint-enable @typescript-eslint/naming-convention */
 
-// returns a key-value from an enum for client locale which is initiated from a JSON file.
-// JSON does not support enums.
+// locale is sourced from a JSON file, so we use getLangCode and getLangName to
+// find the associated enum values
 
 export function getLangCode(locale: PropertyKey) {
-  const langCodeArr = Object.entries(LangCodes).map(([key, value]) => ({
-    [key.toLocaleLowerCase()]: key.toLocaleLowerCase(),
-    value: value
-  }));
-
-  function isPropertyOf<LangCodes>(
-    obj: Record<string, string>,
-    localeKey: PropertyKey
-  ): localeKey is keyof LangCodes {
-    return Object.prototype.hasOwnProperty.call(obj, localeKey);
-  }
-
-  const result = langCodeArr.filter(obj => isPropertyOf(obj, locale));
-
-  return result[0]['value'];
+  if (isPropertyOf(LangCodes, locale)) return LangCodes[locale];
+  throw new Error(`${String(locale)} is not a valid locale`);
 }
 
-// does the same as the above function but for language names
-export function getLangNameFromLocale(locale: PropertyKey) {
-  const langCodeArr = Object.entries(LangNames).map(([key, value]) => ({
-    [key.toLocaleLowerCase()]: key.toLocaleLowerCase(),
-    value: value
-  }));
+export function getLangName(locale: PropertyKey) {
+  if (isPropertyOf(LangNames, locale)) return LangNames[locale];
+  throw new Error(`${String(locale)} is not a valid locale`);
+}
 
-  function isPropertyOf<LangNames>(
-    obj: Record<string, string>,
-    localeKey: PropertyKey
-  ): localeKey is keyof LangNames {
-    return Object.prototype.hasOwnProperty.call(obj, localeKey);
-  }
-
-  const result = langCodeArr.filter(obj => isPropertyOf(obj, locale));
-
-  return result[0]['value'];
+function isPropertyOf<O>(
+  obj: Record<string, string>,
+  key: PropertyKey
+): key is keyof O {
+  return Object.prototype.hasOwnProperty.call(obj, key);
 }

--- a/config/i18n/all-langs.ts
+++ b/config/i18n/all-langs.ts
@@ -194,3 +194,23 @@ export function langCodeIncludes(locale: string) {
 
   return result.length > 0 ? result[0]['value'] : LangCodes.English;
 }
+
+// does the same as the above function but for language names
+
+export function langNameFromLocale(locale: string) {
+  const langCodeObj = Object.entries(LangNames).map(([key, value]) => ({
+    id: key.toLocaleLowerCase(),
+    value: value
+  }));
+
+  const entryObj = (obj: Record<string, string>): boolean => {
+    if (obj.id == locale) {
+      return true;
+    }
+    return false;
+  };
+
+  const result = langCodeObj.filter(entryObj);
+
+  return result.length > 0 ? result[0]['value'] : '???';
+}

--- a/config/i18n/all-langs.ts
+++ b/config/i18n/all-langs.ts
@@ -173,3 +173,24 @@ export enum LangCodes {
   Ukrainian = 'uk',
   Japanese = 'ja'
 }
+
+// returns a key-value from an enum for client locale which is initiated from a JSON file.
+// JSON does not support enums.
+
+export function langCodeIncludes(locale: string) {
+  const langCodeObj = Object.entries(LangCodes).map(([key, value]) => ({
+    id: key.toLocaleLowerCase(),
+    value: value
+  }));
+
+  const entryObj = (obj: Record<string, string>): boolean => {
+    if (obj.id == locale) {
+      return true;
+    }
+    return false;
+  };
+
+  const result = langCodeObj.filter(entryObj);
+
+  return result.length > 0 ? result[0]['value'] : LangCodes.English;
+}


### PR DESCRIPTION
This pr converts the locale tests into TS.

Also, it was requested to covert `LangNames` and `LangCodes`  into enumerates instead of objects.

This brought some complications with it, two functions had to be written to convert the enumerates back into objects.  in order for `clientLocale` to be comparable with the enumerates. 
