### PR TITLE
fix(tests): windows pathing

### DIFF
--- a/tools/challenge-helper-scripts/helpers/get-project-info.test.ts
+++ b/tools/challenge-helper-scripts/helpers/get-project-info.test.ts
@@ -24,7 +24,7 @@ describe('getProjectPath helper', () => {
 describe('getProjectName helper', () => {
   it('should return the last path segment of the calling dir', () => {
     const mockCallingDir = 'calling/dir';
-    const expected = `dir`;
+    const expected = 'dir';
 
     // Add mock to test condition
     process.env.CALLING_DIR = mockCallingDir;

--- a/tools/challenge-helper-scripts/helpers/get-project-info.ts
+++ b/tools/challenge-helper-scripts/helpers/get-project-info.ts
@@ -1,9 +1,7 @@
-import path from 'path';
-
 export function getProjectPath(): string {
-  return (process.env.CALLING_DIR || process.cwd()) + path.sep;
+  return (process.env.CALLING_DIR || process.cwd()) + '/';
 }
 
 export function getProjectName(): string {
-  return getProjectPath().split(path.sep).slice(-2)[0];
+  return getProjectPath().split('/').slice(-2)[0];
 }

--- a/tools/challenge-helper-scripts/helpers/project-metadata.test.ts
+++ b/tools/challenge-helper-scripts/helpers/project-metadata.test.ts
@@ -69,11 +69,17 @@ describe('getMetaData helper', () => {
   it('should throw if file is not found', () => {
     process.env.CALLING_DIR =
       'curriculum/challenges/english/superblock/mick-priject';
+
+    // determine if path is from Linux based or Windows based systems
+    const pathFromLinuxOrWin = path.sep.includes('/')
+      ? 'curriculum/challenges/_meta/mick-priject/meta.json'
+      : 'curriculum\\challenges\\_meta\\mick-priject\\meta.json';
+
     expect(() => {
       getMetaData();
     }).toThrowError(
       new Error(
-        `ENOENT: no such file or directory, open 'curriculum/challenges/_meta/mick-priject/meta.json'`
+        `ENOENT: no such file or directory, open '${pathFromLinuxOrWin}'`
       )
     );
   });

--- a/tools/challenge-helper-scripts/helpers/project-metadata.test.ts
+++ b/tools/challenge-helper-scripts/helpers/project-metadata.test.ts
@@ -70,17 +70,17 @@ describe('getMetaData helper', () => {
     process.env.CALLING_DIR =
       'curriculum/challenges/english/superblock/mick-priject';
 
-    // determine if path is from Linux based or Windows based systems
-    const pathFromLinuxOrWin = path.sep.includes('/')
-      ? 'curriculum/challenges/_meta/mick-priject/meta.json'
-      : 'curriculum\\challenges\\_meta\\mick-priject\\meta.json';
-
+    const errorPath = path.join(
+      'curriculum',
+      'challenges',
+      '_meta',
+      'mick-priject',
+      'meta.json'
+    );
     expect(() => {
       getMetaData();
     }).toThrowError(
-      new Error(
-        `ENOENT: no such file or directory, open '${pathFromLinuxOrWin}'`
-      )
+      new Error(`ENOENT: no such file or directory, open '${errorPath}'`)
     );
   });
 


### PR DESCRIPTION
Testing did not work on windows because of a Linux/Windows path issue.


```js
export function getProjectPath(): string {
  return (process.env.CALLING_DIR || process.cwd()) + path.sep;
}
```

returns `calling/dir\` on windows because the official separator on Windows seems to be ` "\" ` coming from `path.sep`

```js
export function getProjectName(): string {
  return getProjectPath().split(path.sep).slice(-2)[0];
}
```
thus having the string: ` "calling/dir\".split("\")` would return  an array `[calling/dir]`. This fails the test.

Windows works fine with using a front-slash and a back-slash to access any folder.