### PR TITLE
fix(a11y): place textarea between the jaws

### DIFF
--- a/client/src/templates/Challenges/classic/editor.css
+++ b/client/src/templates/Challenges/classic/editor.css
@@ -7,6 +7,12 @@
   z-index: 11;
 }
 
+/* NVDA skips the textarea in browse mode if there is no size */
+textarea.inputarea {
+  width: 1px !important;
+  height: 1px !important;
+}
+
 .editor-container {
   background: var(--editor-background);
 }

--- a/client/src/templates/Challenges/classic/editor.css
+++ b/client/src/templates/Challenges/classic/editor.css
@@ -43,6 +43,10 @@ textarea.inputarea {
   padding: 15px 15px 15px 0px;
 }
 
+.editor-upper-jaw {
+  max-width: unset !important;
+}
+
 .action-row-container,
 .description-container {
   background-color: var(--secondary-background);

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -464,6 +464,16 @@ const Editor = (props: EditorProps): JSX.Element => {
     if (!getStoredAriaRoledescription()) {
       setAriaRoledescription(false);
     }
+
+    // Move textarea between the jaws so DOM order follows visual ordering
+    // and makes navigation more sensible for screen reader users.
+    const overlayWidgetsDiv = document.querySelector('.overlayWidgets');
+    const textarea = document.querySelector('.monaco-editor textarea');
+    const lowerJaw = document.querySelector('.editor-lower-jaw');
+    overlayWidgetsDiv &&
+      textarea &&
+      lowerJaw &&
+      overlayWidgetsDiv.insertBefore(textarea, lowerJaw);
   };
 
   const toggleAriaRoledescription = () => {

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -855,6 +855,8 @@ const Editor = (props: EditorProps): JSX.Element => {
         // itself.
         return null;
       };
+      // Only the description content widget uses this method but it
+      // is harmless to pass it to the overlay widget.
       const afterRender = () => {
         domNode.style.left = '0';
         domNode.style.visibility = 'visible';

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -597,12 +597,20 @@ const Editor = (props: EditorProps): JSX.Element => {
     return domNode;
   }
 
+  function setTestFeedbackHeight(height?: number): void {
+    const testStatus = document.getElementById('test-status');
+    const newHeight = height === undefined ? 'auto' : `${height}px`;
+    if (testStatus) {
+      testStatus.style.height = newHeight;
+    }
+  }
+
   function clearTestFeedback() {
     const testStatus = document.getElementById('test-status');
     if (testStatus && testStatus.innerHTML) {
-      const currentHeight = `${testStatus.offsetHeight}px`;
-      // Height will be cleared after status message has been displayed
-      testStatus.style.height = currentHeight;
+      // Explicitly set the height to what it currently is so that we
+      // don't get a big content shift every time the code is checked.
+      setTestFeedbackHeight(testStatus.offsetHeight);
       testStatus.innerHTML = '';
     }
   }
@@ -656,8 +664,7 @@ const Editor = (props: EditorProps): JSX.Element => {
 
     // Must manually set test feedback height back to zero since
     // clearTestFeedback does not.
-    const testStatus = document.getElementById('test-status');
-    if (testStatus) testStatus.style.height = '0';
+    setTestFeedbackHeight(0);
     clearTestFeedback();
 
     // Resetting margin decorations
@@ -1081,7 +1088,7 @@ const Editor = (props: EditorProps): JSX.Element => {
 
         if (testStatus) {
           testStatus.innerHTML = `<p class="status"><span aria-hidden="true">&#9989;</span> Congratulations, your code passes. Submit your code to complete this step and move on to the next one. ${submitKeyboardInstructions}</p>`;
-          testStatus.style.height = '';
+          setTestFeedbackHeight();
         }
       } else if (challengeHasErrors() && testStatus) {
         const wordsArray = [
@@ -1094,7 +1101,7 @@ const Editor = (props: EditorProps): JSX.Element => {
         testStatus.innerHTML = `<p class="status"><span aria-hidden="true">✖️</span> Sorry, your code does not pass. ${
           wordsArray[Math.floor(Math.random() * wordsArray.length)]
         }</p><div><h2 class="hint">Hint</h2> ${output[1]}</div>`;
-        testStatus.style.height = '';
+        setTestFeedbackHeight();
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -201,7 +201,9 @@ const defineMonacoThemes = (
 const initialData: EditorProperties = {
   descriptionZoneId: '',
   insideEditDecId: '',
-  descriptionZoneTop: 0,
+  // This needs to be less than 0 so we can determine if the description has
+  // been placed and it could be placed at the very top (0).
+  descriptionZoneTop: -1,
   outputZoneId: '',
   outputZoneTop: 0
 };
@@ -525,13 +527,10 @@ const Editor = (props: EditorProps): JSX.Element => {
       heightInPx: domNode.offsetHeight,
       domNode: document.createElement('div'),
       onComputedHeight: () => {
-        console.log('onComputedHeight()');
         dataRef.current.descriptionWidget &&
           editor.layoutContentWidget(dataRef.current.descriptionWidget);
       },
-      onDomNodeTop: (/*top: number*/) => {
-        console.log('onDomNodeTop()');
-        //dataRef.current.descriptionZoneTop = top;
+      onDomNodeTop: () => {
         if (dataRef.current.descriptionWidget)
           editor.layoutContentWidget(dataRef.current.descriptionWidget);
       }
@@ -834,13 +833,14 @@ const Editor = (props: EditorProps): JSX.Element => {
       model
     })[0];
 
-    // This isn't strictly necessary, but it makes sure the description zone and
-    // widget are always rendered in the correct place. The reason it's not
-    // strictly necessary is that, somehow, the first (incorrect) position was
-    // never rendered.
-    dataRef.current.descriptionZoneTop = editor.getTopForLineNumber(
-      getLineBeforeEditableRegion() + 1
+    console.log(
+      'initializeRegions: descriptionZoneTop = ',
+      dataRef.current.descriptionZoneTop
     );
+    if (dataRef.current.descriptionZoneTop < 0)
+      dataRef.current.descriptionZoneTop = editor.getTopForLineNumber(
+        getLineBeforeEditableRegion() + 1
+      );
   }
 
   function addWidgetsToRegions(editor: editor.IStandaloneCodeEditor) {
@@ -994,6 +994,8 @@ const Editor = (props: EditorProps): JSX.Element => {
     // If a challenge is reset, it needs to communicate that change to the
     // editor.
     const { editor } = dataRef.current;
+
+    //console.log('useEffect1');
 
     if (props.isResetting) {
       // NOTE: this looks a lot like a race condition, since stopResetting gets

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -201,9 +201,7 @@ const defineMonacoThemes = (
 const initialData: EditorProperties = {
   descriptionZoneId: '',
   insideEditDecId: '',
-  // This needs to be less than 0 so we can determine if the description has
-  // been placed and it could be placed at the very top (0).
-  descriptionZoneTop: -1,
+  descriptionZoneTop: 0,
   outputZoneId: '',
   outputZoneTop: 0
 };
@@ -839,11 +837,6 @@ const Editor = (props: EditorProps): JSX.Element => {
       monaco,
       model
     })[0];
-
-    if (dataRef.current.descriptionZoneTop < 0)
-      dataRef.current.descriptionZoneTop = editor.getTopForLineNumber(
-        getLineBeforeEditableRegion() + 1
-      );
   }
 
   function addWidgetsToRegions(editor: editor.IStandaloneCodeEditor) {

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -520,18 +520,21 @@ const Editor = (props: EditorProps): JSX.Element => {
     domNode.style.width = `${editor.getLayoutInfo().contentWidth}px`;
 
     // We have to wait for the viewZone to finish rendering before adjusting the
-    // position of the overlayWidget (i.e. trigger it via onComputedHeight). If
+    // position of the content widget (i.e. trigger it via onDomNodeTop). If
     // not the editor may report the wrong value for position of the lines.
     const viewZone = {
       afterLineNumber: getLineBeforeEditableRegion(),
       heightInPx: domNode.offsetHeight,
       domNode: document.createElement('div'),
-      onComputedHeight: () => {
-        dataRef.current.descriptionWidget &&
-          editor.layoutContentWidget(dataRef.current.descriptionWidget);
-      },
+      // This is called when the editor dimensions change and AFTER the
+      // text in the editor has shifted.
       onDomNodeTop: () => {
-        if (dataRef.current.descriptionWidget)
+        // The return value for getTopLineNumber includes the height of
+        // the content widget so we need to remove it.
+        dataRef.current.descriptionZoneTop =
+          editor.getTopForLineNumber(getLineBeforeEditableRegion() + 1) -
+          domNode.offsetHeight;
+        dataRef.current.descriptionWidget &&
           editor.layoutContentWidget(dataRef.current.descriptionWidget);
       }
     };

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -653,6 +653,10 @@ const Editor = (props: EditorProps): JSX.Element => {
       };
     }
 
+    // Must manually set test feedback height back to zero since
+    // clearTestFeedback does not.
+    const testStatus = document.getElementById('test-status');
+    if (testStatus) testStatus.style.height = '0';
     clearTestFeedback();
 
     // Resetting margin decorations
@@ -833,10 +837,6 @@ const Editor = (props: EditorProps): JSX.Element => {
       model
     })[0];
 
-    console.log(
-      'initializeRegions: descriptionZoneTop = ',
-      dataRef.current.descriptionZoneTop
-    );
     if (dataRef.current.descriptionZoneTop < 0)
       dataRef.current.descriptionZoneTop = editor.getTopForLineNumber(
         getLineBeforeEditableRegion() + 1
@@ -994,8 +994,6 @@ const Editor = (props: EditorProps): JSX.Element => {
     // If a challenge is reset, it needs to communicate that change to the
     // editor.
     const { editor } = dataRef.current;
-
-    //console.log('useEffect1');
 
     if (props.isResetting) {
       // NOTE: this looks a lot like a race condition, since stopResetting gets


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes locally on my machine.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Currently in the RWD beta, the `<textarea>` for the monaco editor precedes the upper jaw in the DOM. This has the potential to make navigation confusing for screen reader users as the instructions for the Step in the upper jaw come after the editor, which means they would have to go backwards in the DOM after reading the instructions. Based on the way the page is layed out I think it makes sense to have the instructions come before the editor. Then screen reader users will be able to navigate to the instructions, then to the editor, then to the hint (if needed) in a logical order.

I'm not sure if this is the best way to move the `<textarea>`. Feel free to suggest a better method. I've been testing this for a few days now and I'm not seeing any adverse effects of moving it.

Also, while I was testing I discovered that the NVDA screen reader will skip the `<textarea>` completely in browse mode if it has zero size, so I forced the size to a 1px square. 