### PR TITLE
fix(curriculum): incorrect hint

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-variables-by-building-a-city-skyline/5d822fd413a79914d39e98e0.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-variables-by-building-a-city-skyline/5d822fd413a79914d39e98e0.md
@@ -17,7 +17,7 @@ You should define a new property variable called `--building-color3`.
 assert.exists(new __helpers.CSSHelp(document).isPropertyUsed('--building-color3'));
 ```
 
-You should give `--building-color3` a value of `#66cc99`.
+You should give `--building-color3` a value of `#cc6699`.
 
 ```js
 assert.equal(new __helpers.CSSHelp(document).getStyle('.bb1')?.getPropertyValue('--building-color3')?.trim(), '#cc6699');


### PR DESCRIPTION
 The hint didn't match the requested value

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #45842

<!-- Feel free to add any additional description of changes below this line -->

The requested value is #cc6699 and the hint uses #66cc99
