### PR TITLE
feat: a/b test lock icon button

### DIFF
--- a/client/src/components/Donation/donate-form.tsx
+++ b/client/src/components/Donation/donate-form.tsx
@@ -24,7 +24,7 @@ import {
   userSelector,
   postChargeStripe,
   postChargeStripeCard,
-  isAVariantSelector
+  isVariantASelector
 } from '../../redux';
 import Spacer from '../helpers/spacer';
 import { Themes } from '../settings/theme';
@@ -80,7 +80,7 @@ type DonateFormProps = {
   ) => string;
   theme: Themes;
   updateDonationFormState: (state: AddDonationData) => unknown;
-  isAVariant: boolean;
+  isVariantA: boolean;
 };
 
 const mapStateToProps = createSelector(
@@ -89,14 +89,14 @@ const mapStateToProps = createSelector(
   isDonatingSelector,
   donationFormStateSelector,
   userSelector,
-  isAVariantSelector,
+  isVariantASelector,
   (
     showLoading: DonateFormProps['showLoading'],
     isSignedIn: DonateFormProps['isSignedIn'],
     isDonating: DonateFormProps['isDonating'],
     donationFormState: DonateFormState,
     { email, theme }: { email: string; theme: Themes },
-    isAVariant: boolean
+    isVariantA: boolean
   ) => ({
     isSignedIn,
     isDonating,
@@ -104,7 +104,7 @@ const mapStateToProps = createSelector(
     donationFormState,
     email,
     theme,
-    isAVariant
+    isVariantA
   })
 );
 
@@ -322,7 +322,7 @@ class DonateForm extends Component<DonateFormProps, DonateFormComponentState> {
       isMinimalForm,
       isSignedIn,
       isDonating,
-      isAVariant
+      isVariantA
     } = this.props;
     const priorityTheme = defaultTheme ? defaultTheme : theme;
     const isOneTime = donationDuration === 'onetime';
@@ -378,7 +378,7 @@ class DonateForm extends Component<DonateFormProps, DonateFormComponentState> {
                 processing={processing}
                 t={t}
                 theme={priorityTheme}
-                isAVariant={isAVariant}
+                isVariantA={isVariantA}
               />
             </>
           )}

--- a/client/src/components/Donation/donate-form.tsx
+++ b/client/src/components/Donation/donate-form.tsx
@@ -338,15 +338,12 @@ class DonateForm extends Component<DonateFormProps, DonateFormComponentState> {
           {this.getDonationButtonLabel()}:
         </b>
         <Spacer />
-        <fieldset
-          className={`donate-btn-group ${isAVariant ? '' : 'test-btn-group'}`}
-        >
-          {!isAVariant && (
-            <legend>
-              <SecurityLockIcon />
-              {t('donate.secure-donation')}
-            </legend>
-          )}
+        <fieldset className={'donate-btn-group security-legend'}>
+          <legend>
+            <SecurityLockIcon />
+            {t('donate.secure-donation')}
+          </legend>
+
           {loading.stripe && loading.paypal && this.paymentButtonsLoader()}
           <WalletsWrapper
             amount={donationAmount}
@@ -381,6 +378,7 @@ class DonateForm extends Component<DonateFormProps, DonateFormComponentState> {
                 processing={processing}
                 t={t}
                 theme={priorityTheme}
+                isAVariant={isAVariant}
               />
             </>
           )}

--- a/client/src/components/Donation/donation.css
+++ b/client/src/components/Donation/donation.css
@@ -538,13 +538,13 @@ a.patreon-button:hover {
   border-left-color: var(--quaternary-background);
 }
 
-.test-btn-group {
+.security-legend {
   padding: 10px;
   border: 2px solid var(--quaternary-background);
   border-radius: 4px;
 }
 
-.test-btn-group > legend {
+.security-legend > legend {
   width: fit-content;
   font-size: 0.9em;
   color: var(--quaternary-color);
@@ -553,4 +553,8 @@ a.patreon-button:hover {
   padding: 0 4px;
   left: 0;
   margin-left: -2px;
+}
+
+.confirm-donation-btn svg.svg-inline--fa.fa-lock {
+  margin-bottom: 2px;
 }

--- a/client/src/components/Donation/stripe-card-form.tsx
+++ b/client/src/components/Donation/stripe-card-form.tsx
@@ -17,6 +17,7 @@ import React, { useState } from 'react';
 import envData from '../../../../config/env.json';
 import { Themes } from '../settings/theme';
 import { AddDonationData } from './paypal-button';
+import SecurityLockIcon from './security-lock-icon';
 
 const { stripePublicKey }: { stripePublicKey: string | null } = envData;
 
@@ -34,6 +35,7 @@ interface FormPropTypes {
   t: (label: string) => string;
   theme: Themes;
   processing: boolean;
+  isAVariant: boolean;
 }
 
 interface Element {
@@ -49,7 +51,8 @@ const StripeCardForm = ({
   t,
   onDonationStateChange,
   postStripeCardDonation,
-  processing
+  processing,
+  isAVariant
 }: FormPropTypes): JSX.Element => {
   const [isSubmissionValid, setSubmissionValidity] = useState(true);
   const [isTokenizing, setTokenizing] = useState(false);
@@ -167,6 +170,7 @@ const StripeCardForm = ({
         disabled={!stripe || !elements || isSubmitting}
         type='submit'
       >
+        {!isAVariant && <SecurityLockIcon />}
         {t('buttons.donate')}
       </Button>
     </Form>

--- a/client/src/components/Donation/stripe-card-form.tsx
+++ b/client/src/components/Donation/stripe-card-form.tsx
@@ -35,7 +35,7 @@ interface FormPropTypes {
   t: (label: string) => string;
   theme: Themes;
   processing: boolean;
-  isAVariant: boolean;
+  isVariantA: boolean;
 }
 
 interface Element {
@@ -52,7 +52,7 @@ const StripeCardForm = ({
   onDonationStateChange,
   postStripeCardDonation,
   processing,
-  isAVariant
+  isVariantA
 }: FormPropTypes): JSX.Element => {
   const [isSubmissionValid, setSubmissionValidity] = useState(true);
   const [isTokenizing, setTokenizing] = useState(false);
@@ -170,7 +170,7 @@ const StripeCardForm = ({
         disabled={!stripe || !elements || isSubmitting}
         type='submit'
       >
-        {!isAVariant && <SecurityLockIcon />}
+        {!isVariantA && <SecurityLockIcon />}
         {t('buttons.donate')}
       </Button>
     </Form>

--- a/client/src/redux/ga-saga.js
+++ b/client/src/redux/ga-saga.js
@@ -42,7 +42,7 @@ function* callGaType({ payload: { type, data } }) {
         // Test_Type
         dimension4: aBTestConfig.type,
         // Test_Variation
-        dimension5: emailToABVariant(email).isAVariant ? 'A' : 'B',
+        dimension5: emailToABVariant(email).isVariantA ? 'A' : 'B',
         // View_Type
         dimension6: viewType
       };

--- a/client/src/redux/ga-saga.js
+++ b/client/src/redux/ga-saga.js
@@ -19,6 +19,8 @@ function* callGaType({ payload: { type, data } }) {
     aBTestConfig.isTesting
   ) {
     const email = yield select(emailSelector);
+
+    // a b test results are only reported when user is signed in and has email
     if (email) {
       const completedChallengeTotal = yield select(completedChallengesSelector);
       const completedChallengeSession = yield select(completionCountSelector);

--- a/client/src/redux/index.js
+++ b/client/src/redux/index.js
@@ -206,12 +206,12 @@ export const currentChallengeIdSelector = state =>
   state[MainApp].currentChallengeId;
 
 export const emailSelector = state => userSelector(state).email;
-export const isAVariantSelector = state => {
+export const isVariantASelector = state => {
   const email = emailSelector(state);
   // if the user is not signed in and the user info is not available.
   // always return A the control variant
   if (!email) return true;
-  return emailToABVariant(email).isAVariant;
+  return emailToABVariant(email).isVariantA;
 };
 export const isDonatingSelector = state => userSelector(state).isDonating;
 export const isOnlineSelector = state => state[MainApp].isOnline;

--- a/client/src/utils/A-B-tester.test.ts
+++ b/client/src/utils/A-B-tester.test.ts
@@ -5,7 +5,7 @@ describe('client/src is-email-variation-a', () => {
   it('Consistently returns the same result for the same input', () => {
     const preSavedResult = {
       hash: '23e3cacb302b0c759531faa8b414b23709c26029',
-      isAVariant: true,
+      isVariantA: true,
       hashInt: 2
     };
     const result = emailToABVariant('foo@freecodecamp.org');
@@ -18,7 +18,7 @@ describe('client/src is-email-variation-a', () => {
     faker.seed(123);
 
     for (let i = 0; i < sampleSize; i++) {
-      if (emailToABVariant(faker.internet.email()).isAVariant) A++;
+      if (emailToABVariant(faker.internet.email()).isVariantA) A++;
       else B++;
     }
 

--- a/client/src/utils/A-B-tester.ts
+++ b/client/src/utils/A-B-tester.ts
@@ -5,17 +5,17 @@ import sha1 from 'sha-1';
 
 export function emailToABVariant(email: string): {
   hash: string;
-  isAVariant: boolean;
+  isVariantA: boolean;
   hashInt: number;
 } {
   // turn the email into a number
   const hash: string = sha1(email);
   const hashInt = parseInt(hash.slice(0, 1), 16);
   // turn the number to A or B variant
-  const isAVariant = hashInt % 2 === 0;
+  const isVariantA = hashInt % 2 === 0;
   return {
     hash,
-    isAVariant,
+    isVariantA,
     hashInt
   };
 }

--- a/config/donation-settings.js
+++ b/config/donation-settings.js
@@ -94,7 +94,7 @@ const patreonDefaultPledgeAmount = 500;
 
 const aBTestConfig = {
   isTesting: true,
-  type: 'secureDonationBorder'
+  type: 'secureIconButtonOnly'
 };
 
 module.exports = {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
This pr adds a security lock icon to the donation cta button.

How to test:
A variant: seed the db, login, check the email (foo@bar.com), and pop the donation modal. The donation form should not include the button lock icons.
B variant: seed the db, login, change the email to (foo@foo.com), and pop the donation modal. The donation form should have two lock icons.

B variant screenshot of the donation modal form:
<img width="363" alt="Screen Shot 2022-05-05 at 2 08 51 PM" src="https://user-images.githubusercontent.com/4591597/166912532-ec093cd8-7304-4775-848d-0be6b2519c84.png">

A variant screenshot of the donation modal form:
<img width="365" alt="Screen Shot 2022-05-05 at 2 09 09 PM" src="https://user-images.githubusercontent.com/4591597/166912580-7c21bbb8-4bf2-40fb-b738-1c4592548dfa.png">
