### PR TITLE
chore: set permissions for GitHub actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,7 +19,7 @@ jobs:
       # for github/codeql-action/init to get workflow details
       actions: read
       # for actions/checkout to fetch code
-      contents: read 
+      contents: read
       # for github/codeql-action/analyze to upload SARIF results
       security-events: write
     name: Analyse

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,8 +10,15 @@ on:
     paths-ignore:
       - 'docs/**'
 
+permissions:
+  contents: read
+
 jobs:
   analyse:
+    permissions:
+      actions: read  # for github/codeql-action/init to get workflow details
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/analyze to upload SARIF results
     name: Analyse
     runs-on: ubuntu-20.04
     if: ${{ github.actor != 'renovate[bot]' && github.actor != 'camperbot' }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,9 +16,12 @@ permissions:
 jobs:
   analyse:
     permissions:
-      actions: read  # for github/codeql-action/init to get workflow details
-      contents: read  # for actions/checkout to fetch code
-      security-events: write  # for github/codeql-action/analyze to upload SARIF results
+      # for github/codeql-action/init to get workflow details
+      actions: read
+      # for actions/checkout to fetch code
+      contents: read 
+      # for github/codeql-action/analyze to upload SARIF results
+      security-events: write
     name: Analyse
     runs-on: ubuntu-20.04
     if: ${{ github.actor != 'renovate[bot]' && github.actor != 'camperbot' }}

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -11,7 +11,7 @@ jobs:
       # for actions/labeler to determine modified files
       contents: read
       # for actions/labeler to add labels to PRs
-      pull-requests: write  
+      pull-requests: write
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/labeler@v4

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -8,8 +8,10 @@ permissions:
 jobs:
   triage:
     permissions:
-      contents: read  # for actions/labeler to determine modified files
-      pull-requests: write  # for actions/labeler to add labels to PRs
+      # for actions/labeler to determine modified files
+      contents: read
+      # for actions/labeler to add labels to PRs  
+      pull-requests: write  
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/labeler@v4

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       # for actions/labeler to determine modified files
       contents: read
-      # for actions/labeler to add labels to PRs  
+      # for actions/labeler to add labels to PRs
       pull-requests: write  
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -2,8 +2,14 @@ name: 'Pull Request Labeler'
 on:
   - pull_request_target
 
+permissions:
+  contents: read
+
 jobs:
   triage:
+    permissions:
+      contents: read  # for actions/labeler to determine modified files
+      pull-requests: write  # for actions/labeler to add labels to PRs
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/labeler@v4

--- a/.github/workflows/node.js-tests-upcoming.yml
+++ b/.github/workflows/node.js-tests-upcoming.yml
@@ -9,6 +9,7 @@ on:
     # run this Action every 14 days
     - cron: '0 * */14 * *'
   workflow_dispatch:
+
 permissions:
   contents: read
 

--- a/.github/workflows/node.js-tests-upcoming.yml
+++ b/.github/workflows/node.js-tests-upcoming.yml
@@ -9,6 +9,9 @@ on:
     # run this Action every 14 days
     - cron: '0 * */14 * *'
   workflow_dispatch:
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -4,6 +4,9 @@ on:
     branches-ignore:
       - 'renovate/**'
   pull_request:
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -4,6 +4,7 @@ on:
     branches-ignore:
       - 'renovate/**'
   pull_request:
+
 permissions:
   contents: read
 


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
