### PR TITLE
fix(client): remove duplicate css properties 

### DIFF
--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -1,5 +1,4 @@
 .universal-nav {
-  z-index: 300;
   display: flex;
   justify-content: space-between;
   align-items: flex-start;

--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -105,7 +105,6 @@
   white-space: normal;
   min-height: var(--header-height);
   width: 100%;
-  align-items: center;
   border: none;
 }
 

--- a/client/src/templates/Challenges/video/show.css
+++ b/client/src/templates/Challenges/video/show.css
@@ -89,7 +89,6 @@
   border-radius: 50%;
   background-color: var(--secondary-background);
   border: 2px solid var(--primary-color);
-  position: relative;
 }
 
 .video-quiz-selected-input {


### PR DESCRIPTION
Fix tasks 7, 8, 9 (duplicate css properties) of issue #45885.

Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.


Details:
I assumed we want to keep the second z-index for class `universal-nav` appearing since it is the one currently taking effect in production.
