### PR TITLE
fix(client): remove unneeded explicit padding-bottom 

### DIFF
--- a/client/src/components/Footer/footer.css
+++ b/client/src/components/Footer/footer.css
@@ -38,7 +38,6 @@
 
 .footer-container .col-header {
   flex: 0 0 100%;
-  padding-bottom: 15px;
   font-weight: 700;
   font-size: 16px;
   text-align: center;
@@ -49,7 +48,7 @@
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
-  margin: 0px;
+  margin: 0;
 }
 
 .footer-col {
@@ -69,7 +68,7 @@
 }
 
 .footer-col a {
-  padding: 5px 0px;
+  padding: 5px 0;
 }
 
 .footer-desc-col {
@@ -151,7 +150,7 @@ p.footer-donation a:hover {
     flex-direction: column;
   }
   .footer-right {
-    padding-left: 0px;
+    padding-left: 0;
   }
   .footer-container .col-spacer {
     margin-top: 40px;


### PR DESCRIPTION
Remove unneeded explicit padding-bottom to use shorthand that overwrote it with extra values.  Removed units from padding and margin 0 values as flagged by CodeFactor bot.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #45907

<!-- Feel free to add any additional description of changes below this line -->
