### PR TITLE
fix(curriculum): correct challenge title of Project Euler Problem 421

### DIFF
--- a/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-421-prime-factors-of-n151.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/project-euler/problem-421-prime-factors-of-n151.md
@@ -1,6 +1,6 @@
 ---
 id: 5900f5131000cf542c510024
-title: 'Problem 421: Prime factors of n15+1'
+title: 'Problem 421: Prime factors of n^15+1'
 challengeType: 5
 forumTopicId: 302091
 dashedName: problem-421-prime-factors-of-n151


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

The current title is "Prime factors of n15+1", but if you look into the content of the challenge it's actually "n^15+1". Since MathJax syntax doesn't work in the title, I used `^` character.

Challenge: Coding Interview Prep > Project Euler > Problem 421: Prime factors of n15+1
https://www.freecodecamp.org/learn/coding-interview-prep/project-euler/problem-421-prime-factors-of-n151

Originally reported in a Crowdin comment:
https://freecodecamp.crowdin.com/translate/690087755819f2f67b26dbee3be0eb53/22182/en-ja/130#653092
