### PR TITLE
fix(api): add needsModeration flag to user document root

### DIFF
--- a/api-server/src/common/models/user.json
+++ b/api-server/src/common/models/user.json
@@ -120,6 +120,11 @@
       "description": "Camper has signed academic honesty policy",
       "default": false
     },
+    "needsModeration": {
+      "type": "boolean",
+      "description": "Camper has challenges needing to be moderated",
+      "default": false
+    },
     "isFrontEndCert": {
       "type": "boolean",
       "description": "Camper is front end certified",

--- a/api-server/src/common/models/user.json
+++ b/api-server/src/common/models/user.json
@@ -123,7 +123,13 @@
     "needsModeration": {
       "type": "boolean",
       "description": "Camper has challenges needing to be moderated",
-      "default": false
+      "default": false,
+      "index": {
+        "mongodb": {
+          "unique": true,
+          "background": true
+        }
+      }
     },
     "isFrontEndCert": {
       "type": "boolean",

--- a/api-server/src/server/boot/challenge.js
+++ b/api-server/src/server/boot/challenge.js
@@ -145,7 +145,11 @@ export function buildUserUpdate(
   }
   let finalChallenge;
   const updateData = {};
-  const { timezone: userTimezone, completedChallenges = [], needsModeration = false } = user;
+  const {
+    timezone: userTimezone,
+    completedChallenges = [],
+    needsModeration = false
+  } = user;
 
   const oldChallenge = find(
     completedChallenges,
@@ -215,7 +219,7 @@ export function buildUserUpdate(
     updateData.$set = {
       ...updateData.$set,
       needsModeration: true
-    }
+    };
   }
 
   return {

--- a/api-server/src/server/boot/challenge.js
+++ b/api-server/src/server/boot/challenge.js
@@ -145,7 +145,7 @@ export function buildUserUpdate(
   }
   let finalChallenge;
   const updateData = {};
-  const { timezone: userTimezone, completedChallenges = [] } = user;
+  const { timezone: userTimezone, completedChallenges = [], needsModeration = false } = user;
 
   const oldChallenge = find(
     completedChallenges,
@@ -210,6 +210,14 @@ export function buildUserUpdate(
       timezone: userTimezone
     };
   }
+
+  if (needsModeration) {
+    updateData.$set = {
+      ...updateData.$set,
+      needsModeration: true
+    }
+  }
+
   return {
     alreadyCompleted,
     updateData,
@@ -309,6 +317,7 @@ export function modernChallengeCompleted(req, res, next) {
       // if multifile cert project
       if (challengeType === 14) {
         completedChallenge.isManuallyApproved = false;
+        user.needsModeration = true;
       }
 
       // We only need to know the challenge type if it's a project. If it's a


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

For the multifile editor submissions, to avoid massive DB queries, @nhcarrigan, @moT01, and I discussed:
a) Add `needsModeration` flag to user document root to index, and make query more manageable
b) Use a separate collection for any multifile editor submissions

This implements `a`.