### PR TITLE
fix: cert project links going to english

### DIFF
--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -334,7 +334,6 @@ export class Block extends Component<BlockProps> {
     );
 
     const blockrenderer = () => {
-      console.log(challengesWithCompleted);
       if (isProjectBlock)
         return isNewResponsiveWebDesign ? GridProjectBlock : ProjectBlock;
       return isNewResponsiveWebDesign ? GridBlock : Block;

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -306,12 +306,12 @@ export class Block extends Component<BlockProps> {
 
     const GridProjectBlock = (
       <div className='block block-grid grid-project-block'>
-        <a
+        <Link
           className='block-header'
           onClick={() => {
             this.handleBlockClick();
           }}
-          href={challengesWithCompleted[0].fields.slug}
+          to={challengesWithCompleted[0].fields.slug}
         >
           <div className='tags-wrapper'>
             <span className='cert-tag'>{t('misc.certification-project')}</span>
@@ -329,11 +329,12 @@ export class Block extends Component<BlockProps> {
             <h3 className='block-grid-title'>{blockTitle}</h3>
           </div>
           {this.renderBlockIntros(blockIntroArr)}
-        </a>
+        </Link>
       </div>
     );
 
     const blockrenderer = () => {
+      console.log(challengesWithCompleted);
       if (isProjectBlock)
         return isNewResponsiveWebDesign ? GridProjectBlock : ProjectBlock;
       return isNewResponsiveWebDesign ? GridBlock : Block;


### PR DESCRIPTION
I couldn't actually find a way locally to figure out if this fixes the problem - but I feel like it's probably what's causing it. It's the only anomaly I see - all the other links on /learn use gatsby link, this was the only one using a plain anchor tag. 

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #45920 (hopefully)

<!-- Feel free to add any additional description of changes below this line -->
