### PR TITLE
fix: code duplication in tests for create-language-redirect

### DIFF
--- a/client/src/components/create-language-redirect.test.ts
+++ b/client/src/components/create-language-redirect.test.ts
@@ -30,44 +30,25 @@ describe('createLanguageRedirect for clientLocale === english', () => {
       window.location = originalLocation;
     });
 
-    it('should redirect to same version of page for lang == english', () => {
-      const receivedPageURL = createLanguageRedirect({
-        ...envVars,
-        lang: 'english'
-      });
-      expect(receivedPageURL).toBe(currentPageURL);
-    });
-
-    it('should redirect to chinese version of page', () => {
-      const receivedPageURL = createLanguageRedirect({
-        ...envVars,
-        lang: 'chinese'
-      });
-      expect(receivedPageURL).toBe(chinesePageURL);
-    });
-
-    it('should redirect to espanol version of page', () => {
-      const receivedPageURL = createLanguageRedirect({
-        ...envVars,
-        lang: 'espanol'
-      });
-      expect(receivedPageURL).toBe(espanolPageURL);
-    });
-
-    it('should redirect to chinese-traditional version of page', () => {
-      const receivedPageURL = createLanguageRedirect({
-        ...envVars,
-        lang: 'chinese-traditional'
-      });
-      expect(receivedPageURL).toBe(chineseTraditionalPageURL);
-    });
-
-    it('should redirect to dothraki version of page', () => {
-      const receivedPageURL = createLanguageRedirect({
-        ...envVars,
-        lang: 'dothraki'
-      });
-      expect(receivedPageURL).toBe(dothrakiPageURL);
+    [
+      { lang: 'english', url: currentPageURL },
+      { lang: 'chinese', url: chinesePageURL },
+      { lang: 'espanol', url: espanolPageURL },
+      { lang: 'chinese-traditional', url: chineseTraditionalPageURL },
+      { lang: 'dothraki', url: dothrakiPageURL }
+    ].forEach(({ lang, url }) => {
+      it(
+        lang === 'english'
+          ? `should redirect to same version of page for lang == english`
+          : `should redirect to ${lang} version of page`,
+        () => {
+          const receivedPageURL = createLanguageRedirect({
+            ...envVars,
+            lang
+          });
+          expect(receivedPageURL).toBe(url);
+        }
+      );
     });
   });
 
@@ -92,44 +73,25 @@ describe('createLanguageRedirect for clientLocale === english', () => {
       window.location = originalLocation;
     });
 
-    it('should redirect to same version of page for lang == english', () => {
-      const receivedPageURL = createLanguageRedirect({
-        ...envVars,
-        lang: 'english'
-      });
-      expect(receivedPageURL).toBe(currentPageURL);
-    });
-
-    it('should redirect to chinese version of page', () => {
-      const receivedPageURL = createLanguageRedirect({
-        ...envVars,
-        lang: 'chinese'
-      });
-      expect(receivedPageURL).toBe(chinesePageURL);
-    });
-
-    it('should redirect to espanol version of page', () => {
-      const receivedPageURL = createLanguageRedirect({
-        ...envVars,
-        lang: 'espanol'
-      });
-      expect(receivedPageURL).toBe(espanolPageURL);
-    });
-
-    it('should redirect to chinese-traditional version of page', () => {
-      const receivedPageURL = createLanguageRedirect({
-        ...envVars,
-        lang: 'chinese-traditional'
-      });
-      expect(receivedPageURL).toBe(chineseTraditionalPageURL);
-    });
-
-    it('should redirect to dothraki version of page', () => {
-      const receivedPageURL = createLanguageRedirect({
-        ...envVars,
-        lang: 'dothraki'
-      });
-      expect(receivedPageURL).toBe(dothrakiPageURL);
+    [
+      { lang: 'english', url: currentPageURL },
+      { lang: 'chinese', url: chinesePageURL },
+      { lang: 'espanol', url: espanolPageURL },
+      { lang: 'chinese-traditional', url: chineseTraditionalPageURL },
+      { lang: 'dothraki', url: dothrakiPageURL }
+    ].forEach(({ lang, url }) => {
+      it(
+        lang === 'english'
+          ? `should redirect to same version of page for lang == english`
+          : `should redirect to ${lang} version of page`,
+        () => {
+          const receivedPageURL = createLanguageRedirect({
+            ...envVars,
+            lang
+          });
+          expect(receivedPageURL).toBe(url);
+        }
+      );
     });
   });
 });
@@ -164,44 +126,25 @@ describe('createLanguageRedirect for clientLocale === chinese', () => {
       window.location = originalLocation;
     });
 
-    it('should redirect to same version of page for lang == chinese', () => {
-      const receivedPageURL = createLanguageRedirect({
-        ...envVars,
-        lang: 'chinese'
-      });
-      expect(receivedPageURL).toBe(currentPageURL);
-    });
-
-    it('should redirect to english version of page', () => {
-      const receivedPageURL = createLanguageRedirect({
-        ...envVars,
-        lang: 'english'
-      });
-      expect(receivedPageURL).toBe(englishPageURL);
-    });
-
-    it('should redirect to espanol version of page', () => {
-      const receivedPageURL = createLanguageRedirect({
-        ...envVars,
-        lang: 'espanol'
-      });
-      expect(receivedPageURL).toBe(espanolPageURL);
-    });
-
-    it('should redirect to chinese-traditional version of page', () => {
-      const receivedPageURL = createLanguageRedirect({
-        ...envVars,
-        lang: 'chinese-traditional'
-      });
-      expect(receivedPageURL).toBe(chineseTraditionalPageURL);
-    });
-
-    it('should redirect to dothraki version of page', () => {
-      const receivedPageURL = createLanguageRedirect({
-        ...envVars,
-        lang: 'dothraki'
-      });
-      expect(receivedPageURL).toBe(dothrakiPageURL);
+    [
+      { lang: 'chinese', url: currentPageURL },
+      { lang: 'english', url: englishPageURL },
+      { lang: 'espanol', url: espanolPageURL },
+      { lang: 'chinese-traditional', url: chineseTraditionalPageURL },
+      { lang: 'dothraki', url: dothrakiPageURL }
+    ].forEach(({ lang, url }) => {
+      it(
+        lang === 'chinese'
+          ? `should redirect to same version of page for lang == chinese`
+          : `should redirect to ${lang} version of page`,
+        () => {
+          const receivedPageURL = createLanguageRedirect({
+            ...envVars,
+            lang
+          });
+          expect(receivedPageURL).toBe(url);
+        }
+      );
     });
   });
 
@@ -226,44 +169,25 @@ describe('createLanguageRedirect for clientLocale === chinese', () => {
       window.location = originalLocation;
     });
 
-    it('should redirect to same version of page for lang == chinese', () => {
-      const receivedPageURL = createLanguageRedirect({
-        ...envVars,
-        lang: 'chinese'
-      });
-      expect(receivedPageURL).toBe(currentPageURL);
-    });
-
-    it('should redirect to english version of page', () => {
-      const receivedPageURL = createLanguageRedirect({
-        ...envVars,
-        lang: 'english'
-      });
-      expect(receivedPageURL).toBe(englishPageURL);
-    });
-
-    it('should redirect to espanol version of page', () => {
-      const receivedPageURL = createLanguageRedirect({
-        ...envVars,
-        lang: 'espanol'
-      });
-      expect(receivedPageURL).toBe(espanolPageURL);
-    });
-
-    it('should redirect to chinese-traditional version of page', () => {
-      const receivedPageURL = createLanguageRedirect({
-        ...envVars,
-        lang: 'chinese-traditional'
-      });
-      expect(receivedPageURL).toBe(chineseTraditionalPageURL);
-    });
-
-    it('should redirect to dothraki version of page', () => {
-      const receivedPageURL = createLanguageRedirect({
-        ...envVars,
-        lang: 'dothraki'
-      });
-      expect(receivedPageURL).toBe(dothrakiPageURL);
+    [
+      { lang: 'chinese', url: currentPageURL },
+      { lang: 'english', url: englishPageURL },
+      { lang: 'espanol', url: espanolPageURL },
+      { lang: 'chinese-traditional', url: chineseTraditionalPageURL },
+      { lang: 'dothraki', url: dothrakiPageURL }
+    ].forEach(({ lang, url }) => {
+      it(
+        lang === 'chinese'
+          ? `should redirect to same version of page for lang == chinese`
+          : `should redirect to ${lang} version of page`,
+        () => {
+          const receivedPageURL = createLanguageRedirect({
+            ...envVars,
+            lang
+          });
+          expect(receivedPageURL).toBe(url);
+        }
+      );
     });
   });
 });


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #45924

<!-- Feel free to add any additional description of changes below this line -->
Using `foreach` to reduce code duplication. We can probably reduce this further by creating a function for the test body and calling that for each of the tests.
