### PR TITLE
fix(API): user object on account reset

### DIFF
--- a/api-server/src/server/boot/user.js
+++ b/api-server/src/server/boot/user.js
@@ -268,7 +268,10 @@ function postResetProgress(req, res, next) {
       isDataAnalysisPyCertV7: false,
       isMachineLearningPyCertV7: false,
       isRelationalDatabaseCertV8: false,
-      completedChallenges: []
+      completedChallenges: [],
+      savedChallenges: [],
+      partiallyCompletedChallenges: [],
+      needsModeration: false
     },
     function (err) {
       if (err) {


### PR DESCRIPTION
Noticed a few things weren't getting reset on the user object after an account reset.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
