### PR TITLE
fix(client): Code solution modal on timeline

### DIFF
--- a/client/src/components/SolutionViewer/ProjectModal.tsx
+++ b/client/src/components/SolutionViewer/ProjectModal.tsx
@@ -26,6 +26,7 @@ const ProjectModal = ({
       bsSize='large'
       onHide={handleSolutionModalHide}
       show={isOpen}
+      size='lg'
     >
       <Modal.Header closeButton={true}>
         <Modal.Title id='solution-viewer-modal-title'>


### PR DESCRIPTION
First open source commit
I added a size attribute of large to the modal so that its size increases on lg display. The rest of the behavior remains same. 
I have tested it in my local code.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #45948

<!-- Feel free to add any additional description of changes below this line -->
