### PR TITLE
fix(a11y): improve RWD challege grid accessibility

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -73,7 +73,8 @@
     "click-start-project": "Start the project",
     "change-language": "Change Language",
     "cancel-change": "Cancel Change",
-    "resume-project": "Resume project"
+    "resume-project": "Resume project",
+    "start-project": "Start project"
   },
   "landing": {
     "big-heading-1": "Learn to code — for free.",

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -480,7 +480,9 @@
     "primary-nav": "primary",
     "breadcrumb-nav": "breadcrumb",
     "submit": "Use Ctrl + Enter to submit.",
-    "running-tests": "Running tests"
+    "running-tests": "Running tests",
+    "steps": "Steps",
+    "steps-for": "Steps for {{blockTitle}}"
   },
   "flash": {
     "honest-first": "To claim a certification, you must first accept our academic honesty policy",

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -482,6 +482,7 @@
     "breadcrumb-nav": "breadcrumb",
     "submit": "Use Ctrl + Enter to submit.",
     "running-tests": "Running tests",
+    "step": "Step",
     "steps": "Steps",
     "steps-for": "Steps for {{blockTitle}}"
   },

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -321,7 +321,8 @@
     "sorry-keep-trying":"Sorry, your code does not pass. Keep trying.",
     "sorry-getting-there":"Sorry, your code does not pass. You're getting there.",
     "sorry-hang-in-there":"Sorry, your code does not pass. Hang in there.",
-    "sorry-dont-giveup":"Sorry, your code does not pass. Don't give up."
+    "sorry-dont-giveup":"Sorry, your code does not pass. Don't give up.",
+    "challenges-completed": "{{completedCount}} of {{totalChallenges}} challenges completed"
   },
   "donate": {
     "title": "Support our nonprofit",

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -72,7 +72,8 @@
     "click-start-course": "Start the course",
     "click-start-project": "Start the project",
     "change-language": "Change Language",
-    "cancel-change": "Cancel Change"
+    "cancel-change": "Cancel Change",
+    "resume-project": "Resume project"
   },
   "landing": {
     "big-heading-1": "Learn to code — for free.",

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -199,7 +199,17 @@ export class Block extends Component<BlockProps> {
               </div>
               <div className='map-title-completed course-title'>
                 {this.renderCheckMark(isBlockCompleted)}
-                <span className='map-completed-count'>{`${completedCount}/${challengesWithCompleted.length}`}</span>
+                <span
+                  aria-hidden='true'
+                  className='map-completed-count'
+                >{`${completedCount}/${challengesWithCompleted.length}`}</span>
+                <span className='sr-only'>
+                  ,{' '}
+                  {t('learn.challenges-completed', {
+                    completedCount,
+                    totalChallenges: challengesWithCompleted.length
+                  })}
+                </span>
               </div>
             </button>
             {isExpanded && (

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -293,14 +293,12 @@ export class Block extends Component<BlockProps> {
             </div>
             {isExpanded && this.renderBlockIntros(blockIntroArr)}
             {isExpanded && (
-              <>
-                <h4>Steps</h4>
-                <Challenges
-                  challengesWithCompleted={challengesWithCompleted}
-                  isProjectBlock={isProjectBlock}
-                  superBlock={superBlock}
-                />
-              </>
+              <Challenges
+                challengesWithCompleted={challengesWithCompleted}
+                isProjectBlock={isProjectBlock}
+                superBlock={superBlock}
+                blockTitle={blockTitle}
+              />
             )}
           </div>
         </ScrollableAnchor>

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -294,6 +294,7 @@ export class Block extends Component<BlockProps> {
             {isExpanded && this.renderBlockIntros(blockIntroArr)}
             {isExpanded && (
               <>
+                <h4>Challenges</h4>
                 <Challenges
                   challengesWithCompleted={challengesWithCompleted}
                   isProjectBlock={isProjectBlock}

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -194,7 +194,8 @@ export class Block extends Component<BlockProps> {
             >
               <Caret />
               <div className='course-title'>
-                {`${isExpanded ? collapseText : expandText}`}
+                {`${isExpanded ? collapseText : expandText}`}{' '}
+                <span className='sr-only'>{blockTitle}</span>
               </div>
               <div className='map-title-completed course-title'>
                 {this.renderCheckMark(isBlockCompleted)}

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -294,7 +294,7 @@ export class Block extends Component<BlockProps> {
             {isExpanded && this.renderBlockIntros(blockIntroArr)}
             {isExpanded && (
               <>
-                <h4>Challenges</h4>
+                <h4>Steps</h4>
                 <Challenges
                   challengesWithCompleted={challengesWithCompleted}
                   isProjectBlock={isProjectBlock}

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -193,9 +193,9 @@ export class Block extends Component<BlockProps> {
               }}
             >
               <Caret />
-              <h4 className='course-title'>
+              <div className='course-title'>
                 {`${isExpanded ? collapseText : expandText}`}
-              </h4>
+              </div>
               <div className='map-title-completed course-title'>
                 {this.renderCheckMark(isBlockCompleted)}
                 <span className='map-completed-count'>{`${completedCount}/${challengesWithCompleted.length}`}</span>

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -279,7 +279,7 @@ export class Block extends Component<BlockProps> {
                 <span className='block-header-button-text map-title'>
                   {this.renderCheckMark(isBlockCompleted)}
                   <span>
-                    {blockTitle}{' '}
+                    {blockTitle}
                     <span className='sr-only'>
                       , {courseCompletionStatus()}
                     </span>

--- a/client/src/templates/Introduction/components/challenges.tsx
+++ b/client/src/templates/Introduction/components/challenges.tsx
@@ -94,6 +94,7 @@ function Challenges({
                     +challenge.isCompleted ? 'challenge-completed' : ''
                   }`}
                 >
+                  <span className='sr-only'>{t('aria.step')}</span>
                   <span>{i + 1}</span>
                   <span className='sr-only'>
                     {challenge.isCompleted

--- a/client/src/templates/Introduction/components/challenges.tsx
+++ b/client/src/templates/Introduction/components/challenges.tsx
@@ -68,11 +68,15 @@ function Challenges({
             to={firstIncompleteChallenge.fields.slug}
           >
             {t('buttons.resume-project')}{' '}
-            <span className='sr-only'>{blockTitle}</span>
+            {blockTitle && <span className='sr-only'>{blockTitle}</span>}
           </Link>
         </div>
       )}
-      <nav aria-label={`Steps ${blockTitle ? `for ${blockTitle}` : ''}`}>
+      <nav
+        aria-label={
+          blockTitle ? t('aria.steps-for', { blockTitle }) : t('aria.steps')
+        }
+      >
         <ul className={`map-challenges-ul map-challenges-grid `}>
           {challengesWithCompleted.map((challenge, i) => (
             <li

--- a/client/src/templates/Introduction/components/challenges.tsx
+++ b/client/src/templates/Introduction/components/challenges.tsx
@@ -21,6 +21,7 @@ interface Challenges {
   executeGA: (payload: ExecuteGaArg) => void;
   isProjectBlock: boolean;
   superBlock: SuperBlocks;
+  blockTitle?: string;
 }
 
 const mapIconStyle = { height: '15px', marginRight: '10px', width: '15px' };
@@ -29,7 +30,8 @@ function Challenges({
   challengesWithCompleted,
   executeGA,
   isProjectBlock,
-  superBlock
+  superBlock,
+  blockTitle
 }: Challenges): JSX.Element {
   const { t } = useTranslation();
   const handleChallengeClick = (slug: string) =>
@@ -69,44 +71,46 @@ function Challenges({
           </Link>
         </div>
       )}
-      <ul className={`map-challenges-ul map-challenges-grid `}>
-        {challengesWithCompleted.map((challenge, i) => (
-          <li
-            className={`map-challenge-title map-challenge-title-grid ${
-              isProjectBlock ? 'map-project-wrap' : 'map-challenge-wrap'
-            }`}
-            id={challenge.dashedName}
-            key={`map-challenge ${challenge.fields.slug}`}
-          >
-            {!isProjectBlock ? (
-              <Link
-                onClick={() => handleChallengeClick(challenge.fields.slug)}
-                to={challenge.fields.slug}
-                className={`map-grid-item ${
-                  +challenge.isCompleted ? 'challenge-completed' : ''
-                }`}
-              >
-                <span>{i + 1}</span>
-                <span className='sr-only'>
-                  {challenge.isCompleted
-                    ? t('icons.passed')
-                    : t('icons.not-passed')}
-                </span>
-              </Link>
-            ) : (
-              <Link
-                onClick={() => handleChallengeClick(challenge.fields.slug)}
-                to={challenge.fields.slug}
-              >
-                {challenge.title}
-                <span className=' badge map-badge map-project-checkmark'>
-                  {renderCheckMark(challenge.isCompleted)}
-                </span>
-              </Link>
-            )}
-          </li>
-        ))}
-      </ul>
+      <nav aria-label={`Steps ${blockTitle ? `for ${blockTitle}` : ''}`}>
+        <ul className={`map-challenges-ul map-challenges-grid `}>
+          {challengesWithCompleted.map((challenge, i) => (
+            <li
+              className={`map-challenge-title map-challenge-title-grid ${
+                isProjectBlock ? 'map-project-wrap' : 'map-challenge-wrap'
+              }`}
+              id={challenge.dashedName}
+              key={`map-challenge ${challenge.fields.slug}`}
+            >
+              {!isProjectBlock ? (
+                <Link
+                  onClick={() => handleChallengeClick(challenge.fields.slug)}
+                  to={challenge.fields.slug}
+                  className={`map-grid-item ${
+                    +challenge.isCompleted ? 'challenge-completed' : ''
+                  }`}
+                >
+                  <span>{i + 1}</span>
+                  <span className='sr-only'>
+                    {challenge.isCompleted
+                      ? t('icons.passed')
+                      : t('icons.not-passed')}
+                  </span>
+                </Link>
+              ) : (
+                <Link
+                  onClick={() => handleChallengeClick(challenge.fields.slug)}
+                  to={challenge.fields.slug}
+                >
+                  {challenge.title}
+                  <span className=' badge map-badge map-project-checkmark'>
+                    {renderCheckMark(challenge.isCompleted)}
+                  </span>
+                </Link>
+              )}
+            </li>
+          ))}
+        </ul>
+      </nav>
     </>
   ) : (
     <ul className={`map-challenges-ul`}>

--- a/client/src/templates/Introduction/components/challenges.tsx
+++ b/client/src/templates/Introduction/components/challenges.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'gatsby';
 import React from 'react';
-import { withTranslation } from 'react-i18next';
+import { withTranslation, useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import type { Dispatch } from 'redux';
@@ -31,6 +31,7 @@ function Challenges({
   isProjectBlock,
   superBlock
 }: Challenges): JSX.Element {
+  const { t } = useTranslation();
   const handleChallengeClick = (slug: string) =>
     executeGA({
       type: 'event',
@@ -49,40 +50,63 @@ function Challenges({
 
   const isGridMap = isNewRespCert(superBlock) || isNewJsCert(superBlock);
 
+  const firstIncompleteChallenge = challengesWithCompleted.find(
+    challenge => !challenge.isCompleted
+  );
+
   return isGridMap ? (
-    <ul className={`map-challenges-ul map-challenges-grid `}>
-      {challengesWithCompleted.map((challenge, i) => (
-        <li
-          className={`map-challenge-title map-challenge-title-grid ${
-            isProjectBlock ? 'map-project-wrap' : 'map-challenge-wrap'
-          }`}
-          id={challenge.dashedName}
-          key={`map-challenge ${challenge.fields.slug}`}
-        >
-          {!isProjectBlock ? (
-            <Link
-              onClick={() => handleChallengeClick(challenge.fields.slug)}
-              to={challenge.fields.slug}
-              className={`map-grid-item ${
-                challenge.isCompleted ? 'challenge-completed' : ''
-              }`}
-            >
-              {i + 1}
-            </Link>
-          ) : (
-            <Link
-              onClick={() => handleChallengeClick(challenge.fields.slug)}
-              to={challenge.fields.slug}
-            >
-              {challenge.title}
-              <span className=' badge map-badge map-project-checkmark'>
-                {renderCheckMark(challenge.isCompleted)}
-              </span>
-            </Link>
-          )}
-        </li>
-      ))}
-    </ul>
+    <>
+      {firstIncompleteChallenge && (
+        <div className='challenge-jump-link'>
+          <Link
+            onClick={() =>
+              handleChallengeClick(firstIncompleteChallenge.fields.slug)
+            }
+            to={firstIncompleteChallenge.fields.slug}
+          >
+            Jump to next incomplete challenge
+          </Link>
+        </div>
+      )}
+      <ul className={`map-challenges-ul map-challenges-grid `}>
+        {challengesWithCompleted.map((challenge, i) => (
+          <li
+            className={`map-challenge-title map-challenge-title-grid ${
+              isProjectBlock ? 'map-project-wrap' : 'map-challenge-wrap'
+            }`}
+            id={challenge.dashedName}
+            key={`map-challenge ${challenge.fields.slug}`}
+          >
+            {!isProjectBlock ? (
+              <Link
+                onClick={() => handleChallengeClick(challenge.fields.slug)}
+                to={challenge.fields.slug}
+                className={`map-grid-item ${
+                  +challenge.isCompleted ? 'challenge-completed' : ''
+                }`}
+              >
+                <span>{i + 1}</span>
+                <span className='sr-only'>
+                  {challenge.isCompleted
+                    ? t('icons.passed')
+                    : t('icons.not-passed')}
+                </span>
+              </Link>
+            ) : (
+              <Link
+                onClick={() => handleChallengeClick(challenge.fields.slug)}
+                to={challenge.fields.slug}
+              >
+                {challenge.title}
+                <span className=' badge map-badge map-project-checkmark'>
+                  {renderCheckMark(challenge.isCompleted)}
+                </span>
+              </Link>
+            )}
+          </li>
+        ))}
+      </ul>
+    </>
   ) : (
     <ul className={`map-challenges-ul`}>
       {challengesWithCompleted.map(challenge => (

--- a/client/src/templates/Introduction/components/challenges.tsx
+++ b/client/src/templates/Introduction/components/challenges.tsx
@@ -64,7 +64,7 @@ function Challenges({
             }
             to={firstIncompleteChallenge.fields.slug}
           >
-            Jump to next incomplete challenge
+            Jump to next incomplete step
           </Link>
         </div>
       )}

--- a/client/src/templates/Introduction/components/challenges.tsx
+++ b/client/src/templates/Introduction/components/challenges.tsx
@@ -67,7 +67,8 @@ function Challenges({
             }
             to={firstIncompleteChallenge.fields.slug}
           >
-            Jump to next incomplete step
+            {t('buttons.resume-project')}{' '}
+            <span className='sr-only'>{blockTitle}</span>
           </Link>
         </div>
       )}

--- a/client/src/templates/Introduction/components/challenges.tsx
+++ b/client/src/templates/Introduction/components/challenges.tsx
@@ -59,6 +59,7 @@ function Challenges({
       {firstIncompleteChallenge && (
         <div className='challenge-jump-link'>
           <Link
+            className='btn btn-primary'
             onClick={() =>
               handleChallengeClick(firstIncompleteChallenge.fields.slug)
             }

--- a/client/src/templates/Introduction/components/challenges.tsx
+++ b/client/src/templates/Introduction/components/challenges.tsx
@@ -21,7 +21,7 @@ interface Challenges {
   executeGA: (payload: ExecuteGaArg) => void;
   isProjectBlock: boolean;
   superBlock: SuperBlocks;
-  blockTitle?: string;
+  blockTitle?: string | null;
 }
 
 const mapIconStyle = { height: '15px', marginRight: '10px', width: '15px' };

--- a/client/src/templates/Introduction/components/challenges.tsx
+++ b/client/src/templates/Introduction/components/challenges.tsx
@@ -56,6 +56,10 @@ function Challenges({
     challenge => !challenge.isCompleted
   );
 
+  const isChallengeStarted = !!challengesWithCompleted.find(
+    challenge => challenge.isCompleted
+  );
+
   return isGridMap ? (
     <>
       {firstIncompleteChallenge && (
@@ -67,7 +71,9 @@ function Challenges({
             }
             to={firstIncompleteChallenge.fields.slug}
           >
-            {t('buttons.resume-project')}{' '}
+            {!isChallengeStarted
+              ? t('buttons.start-project')
+              : t('buttons.resume-project')}{' '}
             {blockTitle && <span className='sr-only'>{blockTitle}</span>}
           </Link>
         </div>

--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -263,7 +263,8 @@ button.map-title {
 }
 
 .map-challenges-grid .map-challenge-title a:focus {
-  outline: 2px solid var(--secondary-color);
+  outline: 3px solid var(--secondary-color);
+  outline-offset: -3px;
 }
 
 .map-challenges-grid .map-challenge-title a:focus:not(:focus-visible) {
@@ -297,6 +298,14 @@ button.map-title {
 .challenge-completed {
   background: var(--highlight-background);
   position: relative;
+}
+
+.challenge-completed {
+  background-color: #3895ff;
+}
+
+.dark-palette .challenge-completed {
+  background-color: #0044ff;
 }
 
 .challenge-completed span {

--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -58,6 +58,12 @@ a.cert-tag:active {
 
 .block-grid .challenge-jump-link {
   margin-left: 25px;
+  margin-top: 0.75rem;
+}
+
+.block-grid .challenge-jump-link a {
+  border: 2px solid var(--secondary-color);
+  padding: 3px 5px;
 }
 
 .block-title-translation-cta {

--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -54,11 +54,6 @@ a.cert-tag:active {
   margin-bottom: 1.25rem;
 }
 
-.block-grid .challenge-jump-link a {
-  border: 2px solid var(--secondary-color);
-  padding: 3px 5px;
-}
-
 .block-grid .challenge-jump-link a:focus {
   outline: 3px solid var(--blue-mid);
   outline-offset: 0;

--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -256,6 +256,14 @@ button.map-title {
   padding: 0;
 }
 
+.map-challenges-grid .map-challenge-title a:focus {
+  outline: 2px solid var(--secondary-color);
+}
+
+.map-challenges-grid .map-challenge-title a:focus:not(:focus-visible) {
+  outline: none;
+}
+
 .map-challenges-grid {
   display: flex;
   flex-wrap: wrap;

--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -49,6 +49,17 @@ a.cert-tag:active {
   overflow-wrap: break-word;
 }
 
+.block-grid h4 {
+  font-weight: 700;
+  margin-left: 25px;
+  margin-bottom: 0.25rem;
+  font-size: 1.1rem;
+}
+
+.block-grid .challenge-jump-link {
+  margin-left: 25px;
+}
+
 .block-title-translation-cta {
   white-space: nowrap;
   padding: 0.2em 0.5em;
@@ -234,11 +245,21 @@ button.map-title {
 .map-challenge-title a {
   width: 100%;
   padding: 10px 15px;
+  align-items: center;
+}
+
+.map-challenges-grid .map-challenge-title a {
+  width: 3.4rem;
+  height: 2.75rem;
+  min-width: 24px;
+  min-height: 24px;
+  padding: 0;
 }
 
 .map-challenges-grid {
   display: flex;
   flex-wrap: wrap;
+  margin-top: 1rem;
 }
 .map-challenge-title-grid {
   flex: 0 1 60px;
@@ -261,6 +282,13 @@ button.map-title {
 
 .challenge-completed {
   background: var(--highlight-background);
+  position: relative;
+}
+
+.challenge-completed span {
+  font-weight: 700;
+  font-size: 1.3rem;
+  margin-top: -0.05rem;
 }
 
 @media screen and (max-width: 500px) {

--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -49,13 +49,6 @@ a.cert-tag:active {
   overflow-wrap: break-word;
 }
 
-.block-grid h4 {
-  font-weight: 700;
-  margin-left: 25px;
-  margin-bottom: 0.25rem;
-  font-size: 1.1rem;
-}
-
 .block-grid .challenge-jump-link {
   margin-left: 25px;
   margin-bottom: 1.25rem;

--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -298,9 +298,6 @@ button.map-title {
 .challenge-completed {
   background: var(--highlight-background);
   position: relative;
-}
-
-.challenge-completed {
   background-color: #3895ff;
 }
 

--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -49,7 +49,7 @@ a.cert-tag:active {
 }
 
 .block-grid .challenge-jump-link {
-  margin: 0 25px 25px 25px;
+  margin: 0 25px 25px;
 }
 
 .block-grid .challenge-jump-link a:focus {

--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -66,6 +66,15 @@ a.cert-tag:active {
   padding: 3px 5px;
 }
 
+.block-grid .challenge-jump-link a:focus {
+  outline: 3px solid var(--blue-mid);
+  outline-offset: 0;
+}
+
+.block-grid .challenge-jump-link a:focus:not(:focus-visible) {
+  outline: none;
+}
+
 .block-title-translation-cta {
   white-space: nowrap;
   padding: 0.2em 0.5em;

--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -44,14 +44,12 @@ a.cert-tag:active {
 }
 
 .block-grid-title {
-  font-size: 1.2rem;
   margin: 0;
   overflow-wrap: break-word;
 }
 
 .block-grid .challenge-jump-link {
-  margin-left: 25px;
-  margin-bottom: 1.25rem;
+  margin: 0 25px 25px 25px;
 }
 
 .block-grid .challenge-jump-link a:focus {
@@ -295,11 +293,6 @@ button.map-title {
 .challenge-completed {
   background: var(--highlight-background);
   position: relative;
-  background-color: #3895ff;
-}
-
-.dark-palette .challenge-completed {
-  background-color: #0044ff;
 }
 
 .challenge-completed span {
@@ -391,7 +384,7 @@ button.map-title {
 }
 
 .block-grid {
-  border-bottom: 3px solid var(--secondary-background);
+  border-bottom: 4px solid var(--secondary-background);
 }
 
 .block-grid .block-header {
@@ -411,7 +404,7 @@ button.map-title {
 }
 
 .block-grid .block-header[aria-expanded='true'] {
-  border-bottom: 3px solid var(--secondary-background);
+  border-bottom: 2px solid var(--secondary-background);
 }
 
 .block-header-button-text {

--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -58,7 +58,7 @@ a.cert-tag:active {
 
 .block-grid .challenge-jump-link {
   margin-left: 25px;
-  margin-top: 0.75rem;
+  margin-bottom: 1.25rem;
 }
 
 .block-grid .challenge-jump-link a {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes on my machine.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #45419

<!-- Feel free to add any additional description of changes below this line -->

My second batch of accessibility fixes for this issue. The primary fix is to announce the status of each challenge to screen reader users (they will hear either "Passed" or "Not Passed" after each number). I've also added a jump link so that keyboard users can immediately jump to the next challenge waiting to be completed (potentially saving them a lot of tabbing). I've added the "Challenges" heading above the grid because it seems appropriate here and could help with screen reader navigation. I made a few CSS changes as well, such as using `rem`s to set the width/height on each link so that it will scale better if the user manually increases the font size. Also put a min width/height on them of `24px` in anticipation of WCAG 2.5.8 coming later this year.

I don't consider this 100% complete at the moment as I have some questions that could require changes.

1. The jump link doesn't really look like a link. We could underline it, but I wonder if there is something else we could do to indicate that it's clickable?
2. Do we want to announce Passed/Not Passed, or Completed/Not Completed, or something else to screen reader users?
3. [WCAG 1.4.1](https://www.w3.org/TR/WCAG21/#use-of-color) says that you can't rely on color alone to convey information, so for the challenges that have been completed I increased the font size just slightly (and font weight) in order to have a second visual indicator. I did play around with adding some sort of check mark, but I wasn't happy with it (possibly because I'm not an artist). If anyone has a better idea for identifying the completed challenges I'd love to hear it. Oh, and let me add that there is a very technical loophole that would actually allow us to only use a change in background color, but a lot of accessibility experts consider it illegitimate. Regardless, if we wanted to stick to just a change in background color then it would require increasing the darkness of the blue a little so that it has a 3:1 contrast with the white background.
4. If you don't like the Steps heading above the grid then we could visually hide it.