### PR TITLE
fix(curriculum): Missing code tags in hint for `strong`

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5ef9b03c81a63668521804d4.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5ef9b03c81a63668521804d4.md
@@ -19,13 +19,13 @@ Your `strong` element should have an opening tag. Opening tags have this syntax:
 assert(document.querySelector('strong'));
 ```
 
-Your strong element should have a closing tag. Closing tags have a `/` just after the `<` character.
+Your `strong` element should have a closing tag. Closing tags have a `/` just after the `<` character.
 
 ```js
 assert(code.match(/<\/strong\>/));
 ```
 
-Your strong element should surround the word `hate` in the text `Cats hate other cats.` You have either omitted the text or have a typo.
+Your `strong` element should surround the word `hate` in the text `Cats hate other cats.` You have either omitted the text or have a typo.
 
 ```js
 assert(


### PR DESCRIPTION
The `strong` element is not surrounded by code tags in lines 22 and 28, causing an inconsistency with other lines in this file and the challenges in general.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.