### PR TITLE
fix(curriculum): change hint from `legend` element to `p` element

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5ef9b03c81a63668521804e8.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5ef9b03c81a63668521804e8.md
@@ -30,7 +30,7 @@ const pElemClosingTags = code.match(/<\/p\>/g);
 assert(pElemClosingTags && pElemClosingTags.length === 2);
 ```
 
-Your `p` element's text should be `No Copyright - freeCodeCamp.org`. You have either omitted the text, have a typo, or it is not between the `legend` element's opening and closing tags.
+Your `p` element's text should be `No Copyright - freeCodeCamp.org`. You have either omitted the text, have a typo, or it is not between the `p` element's opening and closing tags.
 
 ```js
 const extraSpacesRemoved = $('footer > p')[0].innerText.replace(/\s+/g, ' ');


### PR DESCRIPTION
This challenge talks about a footer and a p. The hint text in line 33 talks about a legend element that is not part of it.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.