### PR TITLE
feat: hide things when cheater or banned

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -223,7 +223,8 @@
     "points": "{{count}} point on {{date}}",
     "points_plural": "{{count}} points on {{date}}",
     "screen-shot": "A screen shot of {{title}}",
-    "page-number": "{{pageNumber}} of {{totalPages}}"
+    "page-number": "{{pageNumber}} of {{totalPages}}",
+    "ineligible": "This camper is not eligible for freecodecamp.org certifications at this time."
   },
   "footer": {
     "tax-exempt-status": "freeCodeCamp is a donor-supported tax-exempt 501(c)(3) charitable organization (United States Federal Tax Identification Number: 82-0779546)",

--- a/client/src/client-only-routes/show-certification.tsx
+++ b/client/src/client-only-routes/show-certification.tsx
@@ -14,6 +14,7 @@ import DonateForm from '../components/Donation/donate-form';
 
 import { createFlashMessage } from '../components/Flash/redux';
 import { Loader, Spacer } from '../components/helpers';
+import Profile from '../components/profile/profile';
 import RedirectHome from '../components/redirect-home';
 import { Themes } from '../components/settings/theme';
 import { showCert, executeGA, fetchProfileForUser } from '../redux/actions';
@@ -313,6 +314,10 @@ const ShowCertification = (props: ShowCertificationProps): JSX.Element => {
       <Spacer size={2} />
     </Row>
   );
+
+  if (user.isCheater || user.isBanned) {
+    return <Profile user={user} isSessionUser={false}></Profile>;
+  }
 
   return (
     <Grid className='certificate-outer-wrapper'>

--- a/client/src/components/profile/profile.tsx
+++ b/client/src/components/profile/profile.tsx
@@ -48,7 +48,7 @@ function renderMessage(
   );
 }
 
-function renderProfile(user: ProfileProps['user']): JSX.Element {
+function renderProfile(user: ProfileProps['user'], t: TFunction): JSX.Element {
   const {
     profileUI: {
       showAbout = false,
@@ -77,7 +77,9 @@ function renderProfile(user: ProfileProps['user']): JSX.Element {
     portfolio,
     about,
     yearsTopContributor,
-    isDonating
+    isDonating,
+    isCheater,
+    isBanned
   } = user;
   return (
     <>
@@ -96,13 +98,21 @@ function renderProfile(user: ProfileProps['user']): JSX.Element {
         website={website}
         yearsTopContributor={yearsTopContributor}
       />
-      {/* eslint-disable-next-line @typescript-eslint/no-unsafe-assignment */}
-      {showHeatMap ? <HeatMap calendar={calendar} /> : null}
-      {showCerts ? <Certifications username={username} /> : null}
-      {showPortfolio ? <Portfolio portfolio={portfolio} /> : null}
-      {showTimeLine ? (
-        <Timeline completedMap={completedChallenges} username={username} />
-      ) : null}
+      {isBanned || isCheater ? (
+        <>
+          <p>{t('intro:profile.ineligible')}</p>
+        </>
+      ) : (
+        <>
+          {/* eslint-disable-next-line @typescript-eslint/no-unsafe-assignment */}
+          {showHeatMap ? <HeatMap calendar={calendar} /> : null}
+          {showCerts ? <Certifications username={username} /> : null}
+          {showPortfolio ? <Portfolio portfolio={portfolio} /> : null}
+          {showTimeLine ? (
+            <Timeline completedMap={completedChallenges} username={username} />
+          ) : null}
+        </>
+      )}
       <Spacer />
     </>
   );
@@ -124,7 +134,7 @@ function Profile({ user, isSessionUser }: ProfileProps): JSX.Element {
       <Grid>
         <Spacer />
         {isLocked ? renderMessage(isSessionUser, username, t) : null}
-        {!isLocked || isSessionUser ? renderProfile(user) : null}
+        {!isLocked || isSessionUser ? renderProfile(user, t) : null}
         {isSessionUser ? null : (
           <Row className='text-center'>
             <Link to={`/user/${username}/report-user`}>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Spiking on some implementation for https://github.com/freeCodeCamp/superboard/issues/41...

This PR:
- Hides the profile progress when a camper is `isCheater` or `isBanned`.
- Replaces the certification view with the hidden profile view when those flags are true
  - Removes the check in the API
  - Took this approach because Quincy wanted to preserve the URL

To discuss/evaluate:
- Styling for the certification profile (it defaults to light theme because it's the certification)
- Is it safe to move this check client side? 
- Mrugesh proposes specifying the message based on whether the camper is a cheater or banned.