### PR TITLE
fix: interfering style elements

### DIFF
--- a/client/src/templates/Challenges/rechallenge/transformers.js
+++ b/client/src/templates/Challenges/rechallenge/transformers.js
@@ -218,6 +218,7 @@ export const embedFilesInHtml = async function (challengeFiles) {
       documentElement.querySelector('script[src="./script.js"]');
     if (link) {
       const style = contentDocument.createElement('style');
+      style.classList.add('fcc-injected-styles');
       style.innerHTML = stylesCss?.contents;
 
       link.parentNode.replaceChild(style, link);

--- a/client/src/utils/css-help.test.ts
+++ b/client/src/utils/css-help.test.ts
@@ -6,7 +6,6 @@ describe('css-help', () => {
   let t: CSSHelp;
   beforeEach(() => {
     const style = doc.createElement('style');
-    style.classList.add('fcc-injected-styles');
     style.innerHTML = cssString as string;
     doc.head.appendChild(style);
     t = new CSSHelp(doc);

--- a/client/src/utils/css-help.test.ts
+++ b/client/src/utils/css-help.test.ts
@@ -6,6 +6,7 @@ describe('css-help', () => {
   let t: CSSHelp;
   beforeEach(() => {
     const style = doc.createElement('style');
+    style.classList.add('fcc-injected-styles');
     style.innerHTML = cssString as string;
     doc.head.appendChild(style);
     t = new CSSHelp(doc);

--- a/client/src/utils/css-help.ts
+++ b/client/src/utils/css-help.ts
@@ -97,13 +97,23 @@ class CSSHelp {
     const link: HTMLLinkElement | null = this.doc?.querySelector(
       "link[href*='styles']"
     );
-    const style: HTMLStyleElement | null = this.doc?.querySelector(
+
+    // When using the styles.css tab, we add a 'fcc-injected-styles' class so we can target that. This allows users to add external scripts without them interfering
+    const stylesDotCss: HTMLStyleElement | null = this.doc?.querySelector(
       'style.fcc-injected-styles'
     );
+
+    // For steps that use <style> tags, where they don't add the above class - most* browser extensions inject styles with class/media attributes, so it filters those
+    const styleTag: HTMLStyleElement | null = this.doc?.querySelector(
+      'style:not([class]):not([media])'
+    );
+
     if (link?.sheet?.cssRules?.length) {
       return link.sheet;
-    } else if (style) {
-      return style.sheet;
+    } else if (stylesDotCss) {
+      return stylesDotCss.sheet;
+    } else if (styleTag) {
+      return styleTag.sheet;
     } else {
       return null;
     }

--- a/client/src/utils/css-help.ts
+++ b/client/src/utils/css-help.ts
@@ -97,9 +97,8 @@ class CSSHelp {
     const link: HTMLLinkElement | null = this.doc?.querySelector(
       "link[href*='styles']"
     );
-    // Most* browser extensions inject styles with class/media attributes
     const style: HTMLStyleElement | null = this.doc?.querySelector(
-      'style:not([class]):not([media])'
+      'style.fcc-injected-styles'
     );
     if (link?.sheet?.cssRules?.length) {
       return link.sheet;


### PR DESCRIPTION
Imported script's were adding extra style tags:

<img width="337" alt="Screen Shot 2022-05-16 at 3 16 27 PM" src="https://user-images.githubusercontent.com/20648924/168675963-5d704090-eff4-49ee-8c34-feb1087852e7.png">

Causing tests to fail cause the CSS helper functions weren't selecting the right element. This adds a `fcc-injected-styles` class to the one we add so we can target it directly.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #45977

<!-- Feel free to add any additional description of changes below this line -->
