### PR TITLE
fix(gitpod): notify user for open port

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,7 +3,7 @@ ports:
   - port: 27017 # mongodb
     onOpen: ignore
   - port: 8000 # client
-    onOpen: open-browser
+    onOpen: notify
     visibility: public
   - port: 9228 # node debug
     onOpen: ignore


### PR DESCRIPTION
This uses the notification dialog because the `open-browser` method almost certainly doesn't work in most cases (at least for me).

With this change, you get a nice dialog to open the URL once the port is ready. Considering there is only one port, the notification is not intrusive.

<img width="904" alt="image" src="https://user-images.githubusercontent.com/1884376/168764944-bdfeba9f-08cd-4cb4-a9c7-c6c9048c6198.png">
