### PR TITLE
fix(client): add debounce to challenge submission

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -219,6 +219,10 @@ const Editor = (props: EditorProps): JSX.Element => {
     minTimeout.current = setTimeout(() => {
       setTimeoutHasElapsed(true);
     }, 1000 * 60);
+
+    return () => {
+      clearTimeout(minTimeout.current);
+    };
   }, []);
   const { editorRef, initTests } = props;
   // These refs are used during initialisation of the editor as well as by

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -416,7 +416,14 @@ const Editor = (props: EditorProps): JSX.Element => {
       run: () => {
         if (props.usesMultifileEditor) {
           if (challengeIsComplete()) {
-            props.submitChallenge();
+            const { submitChallenge } = props;
+            if (timeoutHasElapsed) {
+              submitChallenge();
+            } else {
+              debounce.current = setTimeout(() => {
+                submitChallenge();
+              }, 750);
+            }
           } else {
             clearTestFeedback();
             props.executeChallenge();


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Adds a temporary debounce to the submission of challenges **using the button**. If this is not a debounce, then I do not know 🤷‍♂️ 