### PR TITLE
fix: submit editor keyboard shortcut

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -415,7 +415,7 @@ const Editor = (props: EditorProps): JSX.Element => {
       run: () => {
         if (props.usesMultifileEditor) {
           if (challengeIsComplete()) {
-            debounce(props.submitChallenge, 2000);
+            debounce(props.submitChallenge, 2000)();
           } else {
             props.executeChallenge();
             attemptRef.current.attempts++;

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -19,7 +19,7 @@ import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 import store from 'store';
 
-import { debounce } from 'lodash';
+import { debounce } from 'lodash-es';
 import { Loader } from '../../../components/helpers';
 import { Themes } from '../../../components/settings/theme';
 import {
@@ -247,10 +247,7 @@ const Editor = (props: EditorProps): JSX.Element => {
   const testRef = useRef<Test[]>([]);
   testRef.current = props.tests;
 
-  // TENATIVE PLAN: create a typical order [html/jsx, css, js], put the
-  // available files into that order.  i.e. if it's just one file it will
-  // automatically be first, but  if there's jsx and js (for some reason) it
-  //  will be [jsx, js].
+  const debouncedSubmitChallenge = debounce(props.submitChallenge, 2000);
 
   const options: editor.IStandaloneEditorConstructionOptions = {
     fontSize: 18,
@@ -415,7 +412,7 @@ const Editor = (props: EditorProps): JSX.Element => {
       run: () => {
         if (props.usesMultifileEditor) {
           if (challengeIsComplete()) {
-            debounce(props.submitChallenge, 2000)();
+            debouncedSubmitChallenge();
           } else {
             props.executeChallenge();
             attemptRef.current.attempts++;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Currently the user can't submit the challenge using the keyboard shortcut while the editor is focused. The shortcut works for running the tests but not for submitting the challenge.

Debounce returns a function but here the returned function isn't executed so the challenge doesn't get submitted.

Source - https://lodash.com/docs/4.17.15#debounce