### PR TITLE
fix: disable button during debounce

### DIFF
--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -167,6 +167,13 @@ const LowerJaw = ({
     if (onAttempt) onAttempt();
   };
 
+  const onSubmitButtonClick = () => {
+    if (submitButtonRef.current) {
+      submitButtonRef.current.disabled = true;
+    }
+    debounce(submitChallenge, 2000);
+  };
+
   const renderHelpButton = () => {
     const isAtteptsLargerThanTest =
       attemptsNumber && testsLength && attemptsNumber >= testsLength;
@@ -199,7 +206,7 @@ const LowerJaw = ({
             id='submit-button'
             aria-hidden={!challengeIsCompleted}
             className='btn-block btn'
-            onClick={debounce(submitChallenge, 2000)}
+            onClick={onSubmitButtonClick}
             ref={submitButtonRef}
           >
             {t('buttons.submit-and-go')}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

I've hit a wall on this one I think I'm too tired to see the fix.

Trying to get the button to disable without triggering a re-render (and thus breaking the debounce call):
- tried setting an `isSubmitting` state but state changes trigger a re-render
- tried coupling that with a `useEffect` to check `isSubmitting` and call the debounce there - no luck
- Initially tried with the `Loader` component but switched to disabling the button to avoid re-redners
- Using the buttonRef didn't do the trick either

Will try again tomorrow after some rest, unless @ShaunSHamilton has a brilliant idea.