### PR TITLE
fix: simplify savedChallenges update

### DIFF
--- a/api-server/src/common/utils/index.js
+++ b/api-server/src/common/utils/index.js
@@ -21,5 +21,8 @@ export const fixCompletedChallengeItem = obj =>
     'isManuallyApproved'
   ]);
 
+export const fixSavedChallengeItem = obj =>
+  pick(obj, ['id', 'lastSavedDate', 'files']);
+
 export const fixPartiallyCompletedChallengeItem = obj =>
   pick(obj, ['id', 'completedDate']);

--- a/api-server/src/common/utils/index.js
+++ b/api-server/src/common/utils/index.js
@@ -21,8 +21,5 @@ export const fixCompletedChallengeItem = obj =>
     'isManuallyApproved'
   ]);
 
-export const fixSavedChallengeItem = obj =>
-  pick(obj, ['id', 'lastSavedDate', 'files']);
-
 export const fixPartiallyCompletedChallengeItem = obj =>
   pick(obj, ['id', 'completedDate']);

--- a/api-server/src/server/boot/challenge.js
+++ b/api-server/src/server/boot/challenge.js
@@ -98,29 +98,6 @@ const savableChallenges = getChallenges()
   .filter(challenge => challenge.challengeType === 14)
   .map(challenge => challenge.id);
 
-/*function buildNewSavedChallenges({
-  user,
-  challengeId,
-  completedDate = Date.now(),
-  files
-}) {
-  const { savedChallenges } = user;
-  const challengeToSave = {
-    id: challengeId,
-    lastSavedDate: completedDate,
-    files: files?.map(file =>
-      pick(file, ['contents', 'key', 'name', 'ext', 'history'])
-    )
-  };
-
-  const newSavedChallenges = uniqBy(
-    [challengeToSave, ...savedChallenges.map(fixSavedChallengeItem)],
-    'id'
-  );
-
-  return newSavedChallenges;
-}*/
-
 export function buildUserUpdate(
   user,
   challengeId,
@@ -149,7 +126,8 @@ export function buildUserUpdate(
   const {
     timezone: userTimezone,
     completedChallenges = [],
-    needsModeration = false
+    needsModeration = false,
+    savedChallenges = []
   } = user;
 
   const oldIndex = completedChallenges.findIndex(
@@ -174,7 +152,6 @@ export function buildUserUpdate(
   }
 
   if (savableChallenges.includes(challengeId)) {
-    const { savedChallenges = [] } = user;
     const challengeToSave = {
       id: challengeId,
       lastSavedDate: completedDate,
@@ -217,8 +194,8 @@ export function buildUserUpdate(
   return {
     alreadyCompleted,
     updateData,
-    completedDate: finalChallenge.completedDate // ,
-    // savedChallenges: newSavedChallenges
+    completedDate: finalChallenge.completedDate,
+    savedChallenges
   };
 }
 

--- a/api-server/src/server/boot/challenge.js
+++ b/api-server/src/server/boot/challenge.js
@@ -19,10 +19,7 @@ import jwt from 'jsonwebtoken';
 import { jwtSecret } from '../../../../config/secrets';
 
 import { environment, deploymentEnv } from '../../../../config/env.json';
-import {
-  fixPartiallyCompletedChallengeItem,
-  fixSavedChallengeItem
-} from '../../common/utils';
+import { fixPartiallyCompletedChallengeItem } from '../../common/utils';
 import { getChallenges } from '../utils/get-curriculum';
 import { ifNoUserSend } from '../utils/middleware';
 import {
@@ -101,7 +98,7 @@ const savableChallenges = getChallenges()
   .filter(challenge => challenge.challengeType === 14)
   .map(challenge => challenge.id);
 
-function buildNewSavedChallenges({
+/*function buildNewSavedChallenges({
   user,
   challengeId,
   completedDate = Date.now(),
@@ -122,7 +119,7 @@ function buildNewSavedChallenges({
   );
 
   return newSavedChallenges;
-}
+}*/
 
 export function buildUserUpdate(
   user,
@@ -176,18 +173,27 @@ export function buildUserUpdate(
     $push.completedChallenges = finalChallenge;
   }
 
-  let newSavedChallenges;
-
   if (savableChallenges.includes(challengeId)) {
-    newSavedChallenges = buildNewSavedChallenges({
-      user,
-      challengeId,
-      completedDate,
-      files
-    });
+    const { savedChallenges = [] } = user;
+    const challengeToSave = {
+      id: challengeId,
+      lastSavedDate: completedDate,
+      files: files?.map(file =>
+        pick(file, ['contents', 'key', 'name', 'ext', 'history'])
+      )
+    };
 
-    // if savableChallenge, update saved array when submitting
-    $set.savedChallenges = newSavedChallenges;
+    const savedIndex = savedChallenges.findIndex(
+      ({ id }) => challengeId === id
+    );
+
+    if (savedIndex >= 0) {
+      $set[`savedChallenges.${savedIndex}`] = challengeToSave;
+      savedChallenges[savedIndex] = challengeToSave;
+    } else {
+      $push.savedChallenges = challengeToSave;
+      savedChallenges.push(challengeToSave);
+    }
   }
 
   // remove from partiallyCompleted on submit
@@ -211,8 +217,8 @@ export function buildUserUpdate(
   return {
     alreadyCompleted,
     updateData,
-    completedDate: finalChallenge.completedDate,
-    savedChallenges: newSavedChallenges
+    completedDate: finalChallenge.completedDate // ,
+    // savedChallenges: newSavedChallenges
   };
 }
 
@@ -451,26 +457,42 @@ function backendChallengeCompleted(req, res, next) {
 
 function saveChallenge(req, res, next) {
   const user = req.user;
+  const { savedChallenges = [] } = user;
   const { id: challengeId, files = [] } = req.body;
 
   if (!savableChallenges.includes(challengeId)) {
     return res.status(403).send('That challenge type is not savable');
   }
 
-  const newSavedChallenges = buildNewSavedChallenges({
-    user,
-    challengeId,
-    completedDate: Date.now(),
-    files
-  });
+  const challengeToSave = {
+    id: challengeId,
+    lastSavedDate: Date.now(),
+    files: files?.map(file =>
+      pick(file, ['contents', 'key', 'name', 'ext', 'history'])
+    )
+  };
 
   return user
     .getSavedChallenges$()
     .flatMap(() => {
+      const savedIndex = savedChallenges.findIndex(
+        ({ id }) => challengeId === id
+      );
+      const $push = {},
+        $set = {};
+
+      if (savedIndex >= 0) {
+        $set[`savedChallenges.${savedIndex}`] = challengeToSave;
+        savedChallenges[savedIndex] = challengeToSave;
+      } else {
+        $push.savedChallenges = challengeToSave;
+        savedChallenges.push(challengeToSave);
+      }
+
       const updateData = {};
-      updateData.$set = {
-        savedChallenges: newSavedChallenges
-      };
+      if (!isEmpty($set)) updateData.$set = $set;
+      if (!isEmpty($push)) updateData.$push = $push;
+
       const updatePromise = new Promise((resolve, reject) =>
         user.updateAttributes(updateData, err => {
           if (err) {
@@ -481,7 +503,7 @@ function saveChallenge(req, res, next) {
       );
       return Observable.fromPromise(updatePromise).doOnNext(() => {
         return res.json({
-          savedChallenges: newSavedChallenges
+          savedChallenges
         });
       });
     })


### PR DESCRIPTION
Give this a good review - I finished up kind of late.

I focused on the database writes, I didn't want to mess with the request responses or anything on the client - so there may be some questionable looking code.

It appears that this and Oliver's PR make it so the database doesn't write all that extra "stuff". That seems to be the case anyway - so that's good. Don't know why.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #46024

<!-- Feel free to add any additional description of changes below this line -->
