### PR TITLE
fix: make pm2 name match deployment env

### DIFF
--- a/api-server/ecosystem.config.js
+++ b/api-server/ecosystem.config.js
@@ -14,7 +14,7 @@ module.exports = {
       max_memory_restart: '600M',
       instances: 'max',
       exec_mode: 'cluster',
-      name: 'org'
+      name: env.DEPLOYMENT_ENV === 'staging' ? 'dev' : 'org'
     }
   ]
 };


### PR DESCRIPTION
@raisedadead I noticed there are some pm2 specific variables we *could* use to set stuff like this, but this will at least make sure the next deploy updates both staging and live.
