### PR TITLE
fix: temporarily prevent the client from retrying

### DIFF
--- a/client/src/redux/failed-updates-epic.js
+++ b/client/src/redux/failed-updates-epic.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 import { ofType } from 'redux-observable';
 import { merge, empty } from 'rxjs';
 import {
@@ -103,7 +104,8 @@ function failedUpdateEpic(action$, state$) {
     ignoreElements()
   );
 
-  return merge(storeUpdates, flushUpdates);
+  return storeUpdates;
+  // return merge(storeUpdates, flushUpdates);
 }
 
 export default failedUpdateEpic;


### PR DESCRIPTION
It will still store failed updates, it just won't (for now) try to do submit them.