### PR TITLE
fix(curriculum): add hint about using media types

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-flexbox-by-building-a-photo-gallery/6153a3952facd25a83fe8083.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-flexbox-by-building-a-photo-gallery/6153a3952facd25a83fe8083.md
@@ -17,7 +17,7 @@ You should add a new `@media` query.
 assert(new __helpers.CSSHelp(document).getCSSRules('media')?.length === 1);
 ```
 
-Your new `@media` query should have a `max-width` of `800px`.
+Your new `@media` query should have a `max-width` of `800px`, without [media types](https://developer.mozilla.org/en-US/docs/Web/CSS/@media#media_types) like `screen`.
 
 ```js
 assert(new __helpers.CSSHelp(document).getCSSRules('media')?.[0]?.media?.mediaText === '(max-width: 800px)');

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-flexbox-by-building-a-photo-gallery/6153a3952facd25a83fe8083.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-flexbox-by-building-a-photo-gallery/6153a3952facd25a83fe8083.md
@@ -17,7 +17,7 @@ You should add a new `@media` query.
 assert(new __helpers.CSSHelp(document).getCSSRules('media')?.length === 1);
 ```
 
-Your new `@media` query should have a `max-width` of `800px`, You should have a `@media (max-width: 800px)` rule in it.
+Your new `@media` query should have a `max-width` of `800px` like this: `@media (max-width: 800px)`.
 
 ```js
 assert(new __helpers.CSSHelp(document).getCSSRules('media')?.[0]?.media?.mediaText === '(max-width: 800px)');

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-flexbox-by-building-a-photo-gallery/6153a3952facd25a83fe8083.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-flexbox-by-building-a-photo-gallery/6153a3952facd25a83fe8083.md
@@ -17,7 +17,7 @@ You should add a new `@media` query.
 assert(new __helpers.CSSHelp(document).getCSSRules('media')?.length === 1);
 ```
 
-Your new `@media` query should have a `max-width` of `800px`, without [media types](https://developer.mozilla.org/en-US/docs/Web/CSS/@media#media_types) like `screen`.
+Your new `@media` query should have a `max-width` of `800px`, You should have a `@media (max-width: 800px)` rule in it.
 
 ```js
 assert(new __helpers.CSSHelp(document).getCSSRules('media')?.[0]?.media?.mediaText === '(max-width: 800px)');

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-flexbox-by-building-a-photo-gallery/6153a3ebb4f7f05b8401b716.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-flexbox-by-building-a-photo-gallery/6153a3ebb4f7f05b8401b716.md
@@ -21,10 +21,10 @@ You should have a second `@media` query.
 assert(new __helpers.CSSHelp(document).getCSSRules('media')?.length === 2);
 ```
 
-Your new `@media` query should come after your existing one. Like this `@media (max-width: 600px)` code.
+Your new `@media` query should come after your existing one. You should have a `@media (max-width: 800px)` rule.
 
 ```js
-assert(new __helpers.CSSHelp(document).getCSSRules('media')?.[0]?.media?.mediaText === '(max-width: 600px)');
+assert(new __helpers.CSSHelp(document).getCSSRules('media')?.[0]?.media?.mediaText === '(max-width: 800px)');
 ```
 
 Your new `@media` query should have a `max-width` of `600px` like this: `@media (max-width: 600px)`.

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-flexbox-by-building-a-photo-gallery/6153a3ebb4f7f05b8401b716.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-flexbox-by-building-a-photo-gallery/6153a3ebb4f7f05b8401b716.md
@@ -21,10 +21,10 @@ You should have a second `@media` query.
 assert(new __helpers.CSSHelp(document).getCSSRules('media')?.length === 2);
 ```
 
-Your new `@media` query should come after your existing one. You should have a `@media (max-width: 800px)` rule.
+Your new `@media` query should come after your existing one. Like this `@media (max-width: 600px)` code.
 
 ```js
-assert(new __helpers.CSSHelp(document).getCSSRules('media')?.[0]?.media?.mediaText === '(max-width: 800px)');
+assert(new __helpers.CSSHelp(document).getCSSRules('media')?.[0]?.media?.mediaText === '(max-width: 600px)');
 ```
 
 Your new `@media` query should have a `max-width` of `600px` like this: `@media (max-width: 600px)`.

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-flexbox-by-building-a-photo-gallery/6153a3ebb4f7f05b8401b716.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-flexbox-by-building-a-photo-gallery/6153a3ebb4f7f05b8401b716.md
@@ -27,7 +27,7 @@ Your new `@media` query should come after your existing one.
 assert(new __helpers.CSSHelp(document).getCSSRules('media')?.[0]?.media?.mediaText === '(max-width: 800px)');
 ```
 
-Your new `@media` query should have a `max-width` of `600px`.
+Your new `@media` query should have a `max-width` of `600px`, without [media types](https://developer.mozilla.org/en-US/docs/Web/CSS/@media#media_types) like `screen`.
 
 ```js
 assert(new __helpers.CSSHelp(document).getCSSRules('media')?.[1]?.media?.mediaText === '(max-width: 600px)');

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-flexbox-by-building-a-photo-gallery/6153a3ebb4f7f05b8401b716.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-flexbox-by-building-a-photo-gallery/6153a3ebb4f7f05b8401b716.md
@@ -21,13 +21,13 @@ You should have a second `@media` query.
 assert(new __helpers.CSSHelp(document).getCSSRules('media')?.length === 2);
 ```
 
-Your new `@media` query should come after your existing one.
+Your new `@media` query should come after your existing one, You should have a `@media (max-width: 800px)` rule.
 
 ```js
 assert(new __helpers.CSSHelp(document).getCSSRules('media')?.[0]?.media?.mediaText === '(max-width: 800px)');
 ```
 
-Your new `@media` query should have a `max-width` of `600px`, without [media types](https://developer.mozilla.org/en-US/docs/Web/CSS/@media#media_types) like `screen`.
+Your new `@media` query should have a `max-width` of `600px`, You should have a `@media (max-width: 600px)` rule in it.
 
 ```js
 assert(new __helpers.CSSHelp(document).getCSSRules('media')?.[1]?.media?.mediaText === '(max-width: 600px)');

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-flexbox-by-building-a-photo-gallery/6153a3ebb4f7f05b8401b716.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-flexbox-by-building-a-photo-gallery/6153a3ebb4f7f05b8401b716.md
@@ -27,7 +27,7 @@ Your new `@media` query should come after your existing one. You should have a `
 assert(new __helpers.CSSHelp(document).getCSSRules('media')?.[0]?.media?.mediaText === '(max-width: 800px)');
 ```
 
-Your new `@media` query should have a `max-width` of `600px`, You should have a `@media (max-width: 600px)` rule in it.
+Your new `@media` query should have a `max-width` of `600px` like this: `@media (max-width: 600px)`.
 
 ```js
 assert(new __helpers.CSSHelp(document).getCSSRules('media')?.[1]?.media?.mediaText === '(max-width: 600px)');

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-flexbox-by-building-a-photo-gallery/6153a3ebb4f7f05b8401b716.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-flexbox-by-building-a-photo-gallery/6153a3ebb4f7f05b8401b716.md
@@ -21,7 +21,7 @@ You should have a second `@media` query.
 assert(new __helpers.CSSHelp(document).getCSSRules('media')?.length === 2);
 ```
 
-Your new `@media` query should come after your existing one, You should have a `@media (max-width: 800px)` rule.
+Your new `@media` query should come after your existing one. You should have a `@media (max-width: 800px)` rule.
 
 ```js
 assert(new __helpers.CSSHelp(document).getCSSRules('media')?.[0]?.media?.mediaText === '(max-width: 800px)');


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #45515

<!-- Feel free to add any additional description of changes below this line -->

although docs have screen with (max-width) on `media` queries, the curriculum doesn't teach media type,.

but giving the answer outright is weird with *ask for help* button added.

so I added a link about media type, and example if needed.

Edit: should I remove the link, so the people wouldn't assume that the camp is associated with Mozilla? or am I overthink it 