### PR TITLE
feat: add two second debounce to confirm username validity check intention

### DIFF
--- a/client/src/redux/settings/settings-sagas.js
+++ b/client/src/redux/settings/settings-sagas.js
@@ -1,11 +1,11 @@
 import { omit } from 'lodash-es';
 import {
   call,
-  delay,
   put,
   select,
   takeLatest,
-  takeEvery
+  takeEvery,
+  debounce
 } from 'redux-saga/effects';
 
 import { createFlashMessage } from '../../components/Flash/redux';
@@ -78,7 +78,6 @@ function* updateUserFlagSaga({ payload: update }) {
 
 function* validateUsernameSaga({ payload }) {
   try {
-    yield delay(500);
     const { exists } = yield call(getUsernameExists, payload);
     yield put(validateUsernameComplete(exists));
   } catch (e) {
@@ -137,7 +136,7 @@ export function createSettingsSagas(types) {
     takeEvery(types.updateUserFlag, updateUserFlagSaga),
     takeLatest(types.submitNewAbout, submitNewAboutSaga),
     takeLatest(types.submitNewUsername, submitNewUsernameSaga),
-    takeLatest(types.validateUsername, validateUsernameSaga),
+    debounce(2000, types.validateUsername, validateUsernameSaga),
     takeLatest(types.submitProfileUI, submitProfileUISaga),
     takeEvery(types.verifyCert, verifyCertificationSaga)
   ];


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #46027 

<!-- Feel free to add any additional description of changes below this line -->
Change the delay to an actual debounce with a meaningful pause. This would assure that username validation takes place after the user has stopped typing for two second.
