### PR TITLE
fix: stop linting web for now

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,4 @@ api-server/src/public/**
 api-server/lib/**
 config/i18n/all-langs.js
 config/certification-settings.js
+web/**


### PR DESCRIPTION
It's annoying for everyone, since it fails when web is not installed and
web does not get installed when the rest of the packages do