### PR TITLE
fix(github): update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01--issues-with-coding-challenges.yml
+++ b/.github/ISSUE_TEMPLATE/01--issues-with-coding-challenges.yml
@@ -1,4 +1,4 @@
-name: Report issues with coding challenges & curriculum
+name: Issue - Content in our Coding Challenges
 description: Report issues with a specific challenge, like broken tests, unclear instructions, etc.
 labels: ['scope: curriculum', 'type: bug', 'status: waiting triage']
 body:

--- a/.github/ISSUE_TEMPLATE/02--issues-with-software-on-platforms.yml
+++ b/.github/ISSUE_TEMPLATE/02--issues-with-software-on-platforms.yml
@@ -1,4 +1,4 @@
-name: Report issues with software on freeCodeCamp.org's platforms
+name: Issue - User Interface on our Platforms
 description: Report a software bug on /learn, /news, Community Forum, Code Radio, or any of the platforms.
 labels: ['type: bug', 'status: waiting triage']
 body:

--- a/.github/ISSUE_TEMPLATE/03--issues-with-content-on-articles-and-docs.yml
+++ b/.github/ISSUE_TEMPLATE/03--issues-with-content-on-articles-and-docs.yml
@@ -1,4 +1,4 @@
-name: Report issues with content on guide articles or documentation.
+name: Issues - Content in our Articles and other Documentation
 description: Report issues with content on a specific article, like broken links, typos, missing parts, etc.
 labels: ['type: bug', 'status: waiting triage']
 body:

--- a/.github/ISSUE_TEMPLATE/04--feature-request-for-freecodecamp-org-s-platforms.yml
+++ b/.github/ISSUE_TEMPLATE/04--feature-request-for-freecodecamp-org-s-platforms.yml
@@ -1,4 +1,4 @@
-name: Request a new feature on freeCodeCamp.org's platforms
+name: New Feature - Request a new feature for our Platforms
 description: Suggest an idea for freeCodeCamp.org's /learn, /news, Community Forum, Code Radio, or other platforms.
 labels: ['type: feature request']
 body:


### PR DESCRIPTION
I noticed that most users report in wrong categories including seasoned @freeCodeCamp/moderators - likely due to the fact the usually one would be in a rush to just report a bug. This update should help a bit.
