### PR TITLE
fix(curriculum): fix hint to match its test in Step 88 of RWD Cafe Menu

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f46e7a4750dd05b5a673920.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f46e7a4750dd05b5a673920.md
@@ -23,7 +23,7 @@ Your `.address` element should be your `p` element.
 assert($('.address')[0].tagName === 'P');
 ```
 
-Your `.address` element should have the text `123 freeCodeCamp Drive`.
+Your `.address` element should have the text `123 Free Code Camp Drive`.
 
 ```js
 assert($('.address')[0].innerText.match(/123 Free Code Camp Drive/i));


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
The current hint is "Your .address element should have the text `123 freeCodeCamp Drive`" but the test is actually checking for `123 Free Code Camp Drive`.

Affected page:
https://www.freecodecamp.org/learn/2022/responsive-web-design/learn-basic-css-by-building-a-cafe-menu/step-88

I noticed it while I was looking into this forum post:
https://forum.freecodecamp.org/t/resposive-web-design-cafe-menu-step-88/510542