### PR TITLE
fix: display certs on profile for username with upper chars

### DIFF
--- a/client/src/components/profile/components/certifications.tsx
+++ b/client/src/components/profile/components/certifications.tsx
@@ -48,7 +48,7 @@ function renderCertShow(username: string, cert: CurrentCert): React.ReactNode {
           <Link
             className='btn btn-lg btn-primary btn-block'
             to={`/certification/${username}/${cert.certSlug}`}
-            data-test-label='claimed-certification'
+            data-cy='claimed-certification'
           >
             View {cert.title}
           </Link>

--- a/client/src/components/profile/components/certifications.tsx
+++ b/client/src/components/profile/components/certifications.tsx
@@ -48,6 +48,7 @@ function renderCertShow(username: string, cert: CurrentCert): React.ReactNode {
           <Link
             className='btn btn-lg btn-primary btn-block'
             to={`/certification/${username}/${cert.certSlug}`}
+            data-test-label='claimed-certification'
           >
             View {cert.title}
           </Link>

--- a/client/src/components/profile/components/certifications.tsx
+++ b/client/src/components/profile/components/certifications.tsx
@@ -15,7 +15,7 @@ const mapStateToProps = (
   props: CertificationProps
 ) =>
   createSelector(
-    certificatesByNameSelector(props.username),
+    certificatesByNameSelector(props.username.toLowerCase()),
     ({
       hasModernCert,
       hasLegacyCert,

--- a/client/src/components/settings/username.tsx
+++ b/client/src/components/settings/username.tsx
@@ -212,7 +212,11 @@ class UsernameSettings extends Component<UsernameProps, UsernameState> {
     const { isValidUsername, t, validating } = this.props;
 
     return (
-      <form id='usernameSettings' onSubmit={this.handleSubmit}>
+      <form
+        id='usernameSettings'
+        onSubmit={this.handleSubmit}
+        data-cy='username-form'
+      >
         <FullWidthRow>
           <FormGroup>
             <ControlLabel htmlFor='username-settings'>
@@ -222,6 +226,7 @@ class UsernameSettings extends Component<UsernameProps, UsernameState> {
               name='username-settings'
               onChange={this.handleChange}
               value={formValue}
+              data-cy='username-input'
             />
           </FormGroup>
         </FullWidthRow>

--- a/cypress/integration/settings/username-change.js
+++ b/cypress/integration/settings/username-change.js
@@ -1,29 +1,15 @@
 describe('Username input field', () => {
   beforeEach(() => {
     cy.login();
+    cy.goToSettings();
   });
 
-  function goToSettings() {
-    cy.visit('/settings');
-
-    // Setting aliases here
-    cy.get('input[name=username-settings]').as('usernameInput');
-    cy.get('form#usernameSettings').as('usernameForm');
-  }
-
   it('Should be possible to type', () => {
-    goToSettings();
-    cy.get('@usernameInput')
-      .clear({ force: true })
-      .type('twaha', { force: true })
-      .should('have.attr', 'value', 'twaha');
+    cy.typeUsername('twaha').should('have.attr', 'value', 'twaha');
   });
 
   it('Should show message when validating name', () => {
-    goToSettings();
-    cy.get('@usernameInput')
-      .clear({ force: true })
-      .type('twaha', { force: true });
+    cy.typeUsername('twaha');
 
     cy.contains('Validating username...')
       .should('have.attr', 'role', 'alert')
@@ -33,10 +19,7 @@ describe('Username input field', () => {
   });
 
   it('Should show username is available if it is', () => {
-    goToSettings();
-    cy.get('@usernameInput')
-      .clear({ force: true })
-      .type('brad', { force: true });
+    cy.typeUsername('brad');
 
     cy.contains('Username is available')
       .should('be.visible')
@@ -47,10 +30,7 @@ describe('Username input field', () => {
   });
 
   it('Should info message if username is available', () => {
-    goToSettings();
-    cy.get('@usernameInput')
-      .clear({ force: true })
-      .type('mrugesh', { force: true });
+    cy.typeUsername('mrugesh');
 
     cy.contains(
       'Please note, changing your username will also change ' +
@@ -64,11 +44,8 @@ describe('Username input field', () => {
   });
 
   // eslint-disable-next-line
-  it('Should be able to click the `Save` button if username is avalable', () => {
-    goToSettings();
-    cy.get('@usernameInput')
-      .clear({ force: true })
-      .type('oliver', { force: true });
+  it('Should be able to click the `Save` button if username is available', () => {
+    cy.typeUsername('oliver');
 
     cy.get('@usernameForm').within(() => {
       cy.contains('Save').should('not.be.disabled');
@@ -76,10 +53,7 @@ describe('Username input field', () => {
   });
 
   it('Should show username is unavailable if it is', () => {
-    goToSettings();
-    cy.get('@usernameInput')
-      .clear({ force: true })
-      .type('twaha', { force: true });
+    cy.typeUsername('twaha');
 
     cy.contains('Username not available')
       .should('be.visible')
@@ -91,10 +65,7 @@ describe('Username input field', () => {
 
   // eslint-disable-next-line
   it('Should not be possible to click the `Save` button if username is unavailable', () => {
-    goToSettings();
-    cy.get('@usernameInput')
-      .clear({ force: true })
-      .type('twaha', { force: true });
+    cy.typeUsername('twaha');
 
     cy.contains('Username is available').should('not.exist');
     cy.contains('Username not available').should('not.exist');
@@ -107,29 +78,20 @@ describe('Username input field', () => {
   });
 
   it('Should not show anything if user types their current name', () => {
-    goToSettings();
-    cy.get('@usernameInput')
-      .clear({ force: true })
-      .type('developmentuser', { force: true });
+    cy.typeUsername('developmentuser');
 
     cy.get('@usernameForm').contains('Save').should('be.disabled');
   });
 
   // eslint-disable-next-line max-len
   it('Should not be possible to click the `Save` button if user types their current name', () => {
-    goToSettings();
-    cy.get('@usernameInput')
-      .clear({ force: true })
-      .type('developmentuser', { force: true });
+    cy.typeUsername('developmentuser');
 
     cy.get('@usernameForm').contains('Save').should('be.disabled');
   });
 
   it('Should show warning if username includes invalid character', () => {
-    goToSettings();
-    cy.get('@usernameInput')
-      .clear({ force: true })
-      .type('Quincy Larson', { force: true });
+    cy.typeUsername('Quincy Larson');
 
     cy.contains('Username "Quincy Larson" contains invalid characters')
       .should('be.visible')
@@ -141,19 +103,13 @@ describe('Username input field', () => {
 
   // eslint-disable-next-line max-len
   it('Should not be able to click the `Save` button if username includes invalid character', () => {
-    goToSettings();
-    cy.get('@usernameInput')
-      .clear({ force: true })
-      .type('Quincy Larson', { force: true });
+    cy.typeUsername('Quincy Larson');
 
     cy.get('@usernameForm').contains('Save').should('be.disabled');
   });
 
   it('Should change username if `Save` button is clicked', () => {
-    goToSettings();
-    cy.get('@usernameInput')
-      .clear({ force: true })
-      .type('quincy', { force: true });
+    cy.typeUsername('quincy');
 
     cy.contains('Username is available');
 
@@ -164,10 +120,7 @@ describe('Username input field', () => {
   });
 
   it('Should change username with uppercase characters if `Save` button is clicked', () => {
-    goToSettings();
-    cy.get('@usernameInput')
-      .clear({ force: true })
-      .type('Quincy', { force: true });
+    cy.typeUsername('Quincy');
 
     cy.contains('Username is available');
 
@@ -178,10 +131,7 @@ describe('Username input field', () => {
   });
 
   it('Should show flash message showing username has been updated', () => {
-    goToSettings();
-    cy.get('@usernameInput')
-      .clear({ force: true })
-      .type('nhcarrigan', { force: true });
+    cy.typeUsername('nhcarrigan');
     cy.contains('Username is available');
 
     // temporary fix until https://github.com/cypress-io/cypress/issues/20562 is fixed
@@ -203,10 +153,7 @@ describe('Username input field', () => {
   });
 
   it('Should be able to close the shown flash message', () => {
-    goToSettings();
-    cy.get('@usernameInput')
-      .clear({ force: true })
-      .type('bjorno', { force: true });
+    cy.typeUsername('bjorno');
     cy.contains('Username is available');
 
     // temporary fix until https://github.com/cypress-io/cypress/issues/20562 is fixed
@@ -225,10 +172,7 @@ describe('Username input field', () => {
   });
 
   it('Should change username if enter is pressed', () => {
-    goToSettings();
-    cy.get('@usernameInput')
-      .clear({ force: true })
-      .type('symbol', { force: true });
+    cy.typeUsername('symbol');
     cy.contains('Username is available');
 
     // temporary fix until https://github.com/cypress-io/cypress/issues/20562 is fixed

--- a/cypress/integration/user/certifications.js
+++ b/cypress/integration/user/certifications.js
@@ -26,6 +26,7 @@ describe('Public profile certifications', () => {
       // Modify username to include uppercase characters
       cy.goToSettings();
       cy.typeUsername('CertifiedUser');
+      cy.contains('Username is available');
       cy.get('@usernameForm').contains('Save').click();
       cy.contains('We have updated your username to CertifiedUser').should(
         'be.visible'

--- a/cypress/integration/user/certifications.js
+++ b/cypress/integration/user/certifications.js
@@ -12,7 +12,7 @@ describe('Public profile certifications', () => {
       cy.visit('/certifieduser', { failOnStatusCode: false });
 
       // The following line is only required if you want to test it in development
-      cy.contains('Preview custom 404 page').click();
+      // cy.contains('Preview custom 404 page').click();
 
       cy.get('.certifications.row > div')
         .children()
@@ -35,7 +35,7 @@ describe('Public profile certifications', () => {
       cy.visit('/certifieduser', { failOnStatusCode: false });
 
       // The following line is only required if you want to test it in development
-      cy.contains('Preview custom 404 page').click();
+      // cy.contains('Preview custom 404 page').click();
 
       cy.get('.certifications.row > div')
         .children()

--- a/cypress/integration/user/certifications.js
+++ b/cypress/integration/user/certifications.js
@@ -1,9 +1,9 @@
 describe('Public profile certifications', () => {
-  before(() => {
-    cy.exec('npm run seed:certified-user');
-  });
-
   context('Signed in user viewing their own public profile', () => {
+    before(() => {
+      cy.exec('npm run seed:certified-user');
+    });
+
     beforeEach(() => {
       cy.login();
     });

--- a/cypress/integration/user/certifications.js
+++ b/cypress/integration/user/certifications.js
@@ -1,0 +1,51 @@
+describe('Public profile certifications', () => {
+  before(() => {
+    cy.exec('npm run seed:certified-user');
+  });
+
+  context('Signed in user viewing their own public profile', () => {
+    beforeEach(() => {
+      cy.login();
+    });
+
+    it('Should show claimed certifications if the username has all lowercase characters', () => {
+      cy.visit('/certifieduser', { failOnStatusCode: false });
+
+      // The following line is only required if you want to test it in development
+      cy.contains('Preview custom 404 page').click();
+
+      cy.get('.certifications.row > div')
+        .children()
+        .should('contain', 'freeCodeCamp Certifications')
+        .and('contain', 'Legacy Certifications')
+        .get('.certifications > .btn')
+        .should('have.length.greaterThan', 0);
+    });
+
+    it('Should show claimed certifications if the username includes uppercase characters', () => {
+      // Modify username to include uppercase characters
+      cy.goToSettings();
+      cy.typeUsername('CertifiedUser');
+      cy.get('@usernameForm').contains('Save').click();
+      cy.contains('We have updated your username to CertifiedUser').should(
+        'be.visible'
+      );
+
+      cy.visit('/certifieduser', { failOnStatusCode: false });
+
+      // The following line is only required if you want to test it in development
+      cy.contains('Preview custom 404 page').click();
+
+      cy.get('.certifications.row > div')
+        .children()
+        .should('contain', 'freeCodeCamp Certifications')
+        .and('contain', 'Legacy Certifications')
+        .get('.certifications > .btn')
+        .should('have.length.greaterThan', 0);
+    });
+  });
+
+  // To do: Add another context to test for cases where a logged out user views
+  // a profile where the username has all lowercase chars, and some uppercase chars
+  // when that's fixed
+});

--- a/cypress/integration/user/certifications.js
+++ b/cypress/integration/user/certifications.js
@@ -14,10 +14,7 @@ describe('Public profile certifications', () => {
       // The following line is only required if you want to test it in development
       cy.contains('Preview custom 404 page').click();
 
-      cy.get("[data-test-label='claimed-certification']").should(
-        'have.length',
-        16
-      );
+      cy.get("[data-cy='claimed-certification']").should('have.length', 16);
     });
 
     it('Should show claimed certifications if the username includes uppercase characters', () => {
@@ -35,10 +32,7 @@ describe('Public profile certifications', () => {
       // The following line is only required if you want to test it in development
       cy.contains('Preview custom 404 page').click();
 
-      cy.get("[data-test-label='claimed-certification']").should(
-        'have.length',
-        16
-      );
+      cy.get("[data-cy='claimed-certification']").should('have.length', 16);
     });
   });
 

--- a/cypress/integration/user/certifications.js
+++ b/cypress/integration/user/certifications.js
@@ -12,14 +12,12 @@ describe('Public profile certifications', () => {
       cy.visit('/certifieduser', { failOnStatusCode: false });
 
       // The following line is only required if you want to test it in development
-      // cy.contains('Preview custom 404 page').click();
+      cy.contains('Preview custom 404 page').click();
 
-      cy.get('.certifications.row > div')
-        .children()
-        .should('contain', 'freeCodeCamp Certifications')
-        .and('contain', 'Legacy Certifications')
-        .get('.certifications > .btn')
-        .should('have.length.greaterThan', 0);
+      cy.get("[data-test-label='claimed-certification']").should(
+        'have.length',
+        16
+      );
     });
 
     it('Should show claimed certifications if the username includes uppercase characters', () => {
@@ -35,14 +33,12 @@ describe('Public profile certifications', () => {
       cy.visit('/certifieduser', { failOnStatusCode: false });
 
       // The following line is only required if you want to test it in development
-      // cy.contains('Preview custom 404 page').click();
+      cy.contains('Preview custom 404 page').click();
 
-      cy.get('.certifications.row > div')
-        .children()
-        .should('contain', 'freeCodeCamp Certifications')
-        .and('contain', 'Legacy Certifications')
-        .get('.certifications > .btn')
-        .should('have.length.greaterThan', 0);
+      cy.get("[data-test-label='claimed-certification']").should(
+        'have.length',
+        16
+      );
     });
   });
 

--- a/cypress/integration/user/certifications.js
+++ b/cypress/integration/user/certifications.js
@@ -14,7 +14,7 @@ describe('Public profile certifications', () => {
       // The following line is only required if you want to test it in development
       cy.contains('Preview custom 404 page').click();
 
-      cy.get("[data-cy='claimed-certification']").should('have.length', 16);
+      cy.get('[data-cy=claimed-certification]').should('have.length', 16);
     });
 
     it('Should show claimed certifications if the username includes uppercase characters', () => {
@@ -32,7 +32,7 @@ describe('Public profile certifications', () => {
       // The following line is only required if you want to test it in development
       cy.contains('Preview custom 404 page').click();
 
-      cy.get("[data-cy='claimed-certification']").should('have.length', 16);
+      cy.get('[data-cy=claimed-certification]').should('have.length', 16);
     });
   });
 

--- a/cypress/integration/user/certifications.js
+++ b/cypress/integration/user/certifications.js
@@ -12,7 +12,7 @@ describe('Public profile certifications', () => {
       cy.visit('/certifieduser', { failOnStatusCode: false });
 
       // The following line is only required if you want to test it in development
-      cy.contains('Preview custom 404 page').click();
+      // cy.contains('Preview custom 404 page').click();
 
       cy.get('[data-cy=claimed-certification]').should('have.length', 16);
     });
@@ -30,7 +30,7 @@ describe('Public profile certifications', () => {
       cy.visit('/certifieduser', { failOnStatusCode: false });
 
       // The following line is only required if you want to test it in development
-      cy.contains('Preview custom 404 page').click();
+      // cy.contains('Preview custom 404 page').click();
 
       cy.get('[data-cy=claimed-certification]').should('have.length', 16);
     });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -62,12 +62,24 @@ Cypress.Commands.add('toggleAll', () => {
   cy.get('#honesty-policy').find('button').click().wait(300);
 });
 
+Cypress.Commands.add('goToSettings', () => {
+  cy.visit('/settings');
+
+  // Setting aliases here
+  cy.get('input[name=username-settings]').as('usernameInput');
+  cy.get('form#usernameSettings').as('usernameForm');
+});
+
+Cypress.Commands.add('typeUsername', username => {
+  cy.get('@usernameInput')
+    .clear({ force: true })
+    .type(username, { force: true });
+});
+
 Cypress.Commands.add('resetUsername', () => {
   cy.visit('/settings');
 
-  cy.get('@usernameInput')
-    .clear({ force: true })
-    .type('developmentuser', { force: true });
+  cy.typeUsername('developmentuser');
 
   cy.contains('Username is available');
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -66,8 +66,8 @@ Cypress.Commands.add('goToSettings', () => {
   cy.visit('/settings');
 
   // Setting aliases here
-  cy.get('input[name=username-settings]').as('usernameInput');
-  cy.get('form#usernameSettings').as('usernameForm');
+  cy.get('[data-cy=username-input]').as('usernameInput');
+  cy.get('[data-cy=username-form]').as('usernameForm');
 });
 
 Cypress.Commands.add('typeUsername', username => {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
We got a report in the support inbox recently that pointed out a bug with usernames that include uppercase characters.

Currently, if your username has uppercase characters in it and you visit your public profile while signed in, you can't view any certifications you claimed.

Here's what I see after changing my username to ScissorsNeedFoodToo:

![image](https://user-images.githubusercontent.com/2051070/169785218-60e28e0b-9dc2-443f-9945-46b35506ad78.png)

But this doesn't affect viewing profiles while signed out. Here's what that section of my profile looks like in an incognito window:

![image](https://user-images.githubusercontent.com/2051070/169785498-10feb20a-3a69-408c-9a90-76dadd04b4fa.png)

This PR is more of a quick fix for this specific issue -- it doesn't handle other cases where it might be better to differentiate between `username` and `usernameDisplay`, like viewing a public profile for another user whose username includes uppercase characters.

These changes also include some refactoring of existing Cypress tests to use commands to make it easier to update the username in new tests.