### PR TITLE
chore: disable updates for monaco

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,8 @@
         "monaco-editor",
         "monaco-editor-webpack-plugin",
         "react-monaco-editor"
-      ]
+      ],
+      "enabled": false
     },
     {
       "matchPackageNames": ["normalize-url"],


### PR DESCRIPTION
Removing the updates for these packages for various reasons including dependencies on us for to be able to update to latest React version anytime soon. This should cut down noise on removate PRs
