### PR TITLE
fix: throw sound into local storage

### DIFF
--- a/client/src/redux/settings/settings-sagas.js
+++ b/client/src/redux/settings/settings-sagas.js
@@ -7,6 +7,7 @@ import {
   takeEvery,
   debounce
 } from 'redux-saga/effects';
+import store from 'store';
 
 import { createFlashMessage } from '../../components/Flash/redux';
 import {
@@ -106,6 +107,7 @@ function* updateMySocialsSaga({ payload: update }) {
 
 function* updateMySoundSaga({ payload: update }) {
   try {
+    store.set('fcc-sound', !!update.sound);
     const response = yield call(putUpdateMySound, update);
     yield put(updateMySoundComplete({ ...response, payload: update }));
     yield put(createFlashMessage({ ...response }));


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This is a quick fix for #46098 - updating the sound saga to throw the value in local storage again.

An ideal long-term fix should probably be to grab the property from the user object itself, but for now this will at least allow folks to turn the sound mode off again.
<!-- Feel free to add any additional description of changes below this line -->
