### PR TITLE
fix(curriculum): removed space for consistency

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/adding-a-default-option-in-switch-statements.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/adding-a-default-option-in-switch-statements.md
@@ -14,7 +14,7 @@ In a `switch` statement you may not be able to specify all possible values as `c
 A `default` statement should be the last case.
 
 ```js
-switch (num) {
+switch(num) {
   case value1:
     statement1;
     break;


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

I'm not sure if it's best practice to include or exclude spaces around switch statements, but just for consistency's sake I removed a space since the other challenges did not have a space.

[Selecting from Many Options with Switch Statements](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-javascript/selecting-from-many-options-with-switch-statements) --- NO SPACE
[Adding a Default Option in Switch Statements](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-javascript/adding-a-default-option-in-switch-statements) --- SPACE <-- This PR aims to remove the space
[Multiple Identical Options in Switch Statements](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-javascript/multiple-identical-options-in-switch-statements) --- NO SPACE
[Replacing If Else Chains with Switch](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-javascript/replacing-if-else-chains-with-switch) --- NO SPACE