### PR TITLE
fix(curriculum): add switch statement spaces for consistency

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/multiple-identical-options-in-switch-statements.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/multiple-identical-options-in-switch-statements.md
@@ -13,7 +13,7 @@ If the `break` statement is omitted from a `switch` statement's `case`, the foll
 
 ```js
 let result = "";
-switch(val) {
+switch (val) {
   case 1:
   case 2:
   case 3:
@@ -127,7 +127,7 @@ sequentialSizes(1);
 function sequentialSizes(val) {
   let answer = "";
 
-  switch(val) {
+  switch (val) {
     case 1:
     case 2:
     case 3:

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/replacing-if-else-chains-with-switch.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/replacing-if-else-chains-with-switch.md
@@ -24,7 +24,7 @@ if (val === 1) {
 can be replaced with:
 
 ```js
-switch(val) {
+switch (val) {
   case 1:
     answer = "a";
     break;
@@ -136,7 +136,7 @@ chainToSwitch(7);
 function chainToSwitch(val) {
   let answer = "";
 
-  switch(val) {
+  switch (val) {
     case "bob":
       answer = "Marley";
       break;

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/selecting-from-many-options-with-switch-statements.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/selecting-from-many-options-with-switch-statements.md
@@ -14,7 +14,7 @@ If you have many options to choose from, use a <dfn>switch</dfn> statement. A `s
 Here is an example of a `switch` statement:
 
 ```js
-switch(lowercaseLetter) {
+switch (lowercaseLetter) {
   case "a":
     console.log("A");
     break;
@@ -96,7 +96,7 @@ caseInSwitch(1);
 function caseInSwitch(val) {
   let answer = "";
 
-  switch(val) {
+  switch (val) {
     case 1:
       answer = "alpha";
       break;


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.


<!-- Feel free to add any additional description of changes below this line -->

Since the space inclusion was a bit inconsistent, I first decided to remove the space in a challenge (#46135) so it would match the others, however, it seems adding the space is more commonly seen, so this PR aims to fix the consistency issue and add spaces for all the challenges.

[Selecting from Many Options with Switch Statements](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-javascript/selecting-from-many-options-with-switch-statements) --- NO SPACE
[Adding a Default Option in Switch Statements](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-javascript/adding-a-default-option-in-switch-statements) --- SPACE
[Multiple Identical Options in Switch Statements](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-javascript/multiple-identical-options-in-switch-statements) --- NO SPACE
[Replacing If Else Chains with Switch](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-javascript/replacing-if-else-chains-with-switch) --- NO SPACE