### PR TITLE
fix(curriculum): put correct marker in the hint of step 85 of markers project

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/61b0a1b2af494934b7ec1a72.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/61b0a1b2af494934b7ec1a72.md
@@ -36,7 +36,7 @@ const blueMarkerChildren = [...document.querySelector('.blue')?.children];
 assert(blueMarkerChildren.every(child => child?.localName === 'div') && blueMarkerChildren.length === 2);
 ```
 
-Your green marker's cap `div` element should be before the sleeve `div` element.
+Your blue marker's cap `div` element should be before the sleeve `div` element.
 
 ```js
 const blueMarkerChildren = [...document.querySelector('.blue')?.children];


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
I found a hint that was referring to the green marker while the test was referring to the blue one.
