### PR TITLE
feat(action): auto-assign issues

### DIFF
--- a/.github/workflows/assign-issue.yml
+++ b/.github/workflows/assign-issue.yml
@@ -1,0 +1,15 @@
+name: Assign Issues
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Auto-assign issues'
+        uses: pozil/auto-assign-issue@v1.5.0
+        with:
+          assignees: ojeytonwilliams,ShaunSHamilton,nhcarrigan,moT01
+          numOfAssignee: 2


### PR DESCRIPTION
I'm not sure if this is something we want - I thought I would open it up and we can discuss. It will auto assign issues to two random users in the list - which should probably be expanded.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes ~~either locally on my machine, or GitPod~~ on github.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
