### PR TITLE
fix(client): prevent lower jaw breaking on code evaluation

### DIFF
--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -38,6 +38,9 @@ const LowerJaw = ({
   const submitButtonRef = React.createRef<HTMLButtonElement>();
   const testFeedbackRef = React.createRef<HTMLDivElement>();
 
+  const [challengeHasBeenCompleted, setChallengeHasBennCompleted] =
+    useState(false);
+
   useEffect(() => {
     if (attemptsNumber && attemptsNumber > 0) {
       //hide the feedback from SR untill the "Running tests" are displayed and removed.
@@ -67,11 +70,20 @@ const LowerJaw = ({
   }, [challengeHasErrors, hint]);
 
   useEffect(() => {
-    if (challengeIsCompleted && submitButtonRef?.current) {
+    if (challengeHasBeenCompleted && submitButtonRef?.current) {
       submitButtonRef.current.focus();
       setTimeout(() => {
         setTestBtnariaHidden(true);
       }, 500);
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [challengeHasBeenCompleted]);
+
+  useEffect(() => {
+    if (!challengeHasBeenCompleted) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      setChallengeHasBennCompleted(challengeIsCompleted!);
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -89,7 +101,7 @@ const LowerJaw = ({
       return '';
     } else if (runningTests) {
       return <span className='sr-only'>{t('aria.running-tests')}</span>;
-    } else if (challengeIsCompleted) {
+    } else if (challengeHasBeenCompleted) {
       const submitKeyboardInstructions = isEditorInFocus ? (
         <span className='sr-only'>{t('aria.submit')}</span>
       ) : (
@@ -163,7 +175,7 @@ const LowerJaw = ({
     const isAtteptsLargerThanTest =
       attemptsNumber && testsLength && attemptsNumber >= testsLength;
 
-    if (isAtteptsLargerThanTest && !challengeIsCompleted)
+    if (isAtteptsLargerThanTest && !challengeHasBeenCompleted)
       return (
         <button
           className='btn-block btn fade-in'
@@ -180,7 +192,9 @@ const LowerJaw = ({
       <>
         <button
           id='test-button'
-          className={`btn-block btn ${challengeIsCompleted ? 'sr-only' : ''}`}
+          className={`btn-block btn ${
+            challengeHasBeenCompleted ? 'sr-only' : ''
+          }`}
           aria-hidden={testBtnariaHidden}
           onClick={tryToExecuteChallenge}
         >
@@ -189,7 +203,7 @@ const LowerJaw = ({
         <div id='action-buttons-container'>
           <button
             id='submit-button'
-            aria-hidden={!challengeIsCompleted}
+            aria-hidden={!challengeHasBeenCompleted}
             className='btn-block btn'
             onClick={tryToSubmitChallenge}
             ref={submitButtonRef}

--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -37,8 +37,7 @@ const LowerJaw = ({
   const { t } = useTranslation();
   const submitButtonRef = React.createRef<HTMLButtonElement>();
   const testFeedbackRef = React.createRef<HTMLDivElement>();
-
-  const [challengeHasBeenCompleted, setChallengeHasBennCompleted] =
+  const [challengeHasBeenCompleted, setChallengeHasBeenCompleted] =
     useState(false);
 
   useEffect(() => {
@@ -83,7 +82,7 @@ const LowerJaw = ({
   useEffect(() => {
     if (!challengeHasBeenCompleted) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      setChallengeHasBennCompleted(challengeIsCompleted!);
+      setChallengeHasBeenCompleted(challengeIsCompleted!);
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -96,12 +95,22 @@ const LowerJaw = ({
     }
   });
 
+  /*
+    Retun early in lifecycle based on the earliest available conditions to help the editor 
+    calcuate the correct editor gap for the lower jaw.
+
+    For consistency, use the persisted version if the conditions has been met before.
+  */
+  const earliestAvailableCompletion =
+    challengeHasBeenCompleted || challengeIsCompleted;
+  const earliestAvailableHint = hint || previousHint;
+
   const renderTestFeedbackContainer = () => {
     if (attemptsNumber === 0) {
       return '';
     } else if (runningTests) {
       return <span className='sr-only'>{t('aria.running-tests')}</span>;
-    } else if (challengeHasBeenCompleted) {
+    } else if (earliestAvailableCompletion) {
       const submitKeyboardInstructions = isEditorInFocus ? (
         <span className='sr-only'>{t('aria.submit')}</span>
       ) : (
@@ -123,12 +132,10 @@ const LowerJaw = ({
           </div>
         </div>
       );
-
-      // show the hint if the previousHint is not set
-    } else if (hint || previousHint) {
-      const hintDiscription = `<h2 class="hint">${t('learn.hint')}</h2> ${
-        hint || previousHint
-      }`;
+    } else if (earliestAvailableHint) {
+      const hintDiscription = `<h2 class="hint">${t(
+        'learn.hint'
+      )}</h2> ${earliestAvailableHint}`;
       return (
         <>
           <div className='test-status fade-in' aria-hidden={isFeedbackHidden}>
@@ -175,7 +182,7 @@ const LowerJaw = ({
     const isAtteptsLargerThanTest =
       attemptsNumber && testsLength && attemptsNumber >= testsLength;
 
-    if (isAtteptsLargerThanTest && !challengeHasBeenCompleted)
+    if (isAtteptsLargerThanTest && !earliestAvailableCompletion)
       return (
         <button
           className='btn-block btn fade-in'
@@ -193,7 +200,7 @@ const LowerJaw = ({
         <button
           id='test-button'
           className={`btn-block btn ${
-            challengeHasBeenCompleted ? 'sr-only' : ''
+            earliestAvailableCompletion ? 'sr-only' : ''
           }`}
           aria-hidden={testBtnariaHidden}
           onClick={tryToExecuteChallenge}
@@ -203,7 +210,7 @@ const LowerJaw = ({
         <div id='action-buttons-container'>
           <button
             id='submit-button'
-            aria-hidden={!challengeHasBeenCompleted}
+            aria-hidden={!earliestAvailableCompletion}
             className='btn-block btn'
             onClick={tryToSubmitChallenge}
             ref={submitButtonRef}

--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -80,9 +80,8 @@ const LowerJaw = ({
   }, [challengeHasBeenCompleted]);
 
   useEffect(() => {
-    if (!challengeHasBeenCompleted) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      setChallengeHasBeenCompleted(challengeIsCompleted!);
+    if (!challengeHasBeenCompleted && challengeIsCompleted) {
+      setChallengeHasBeenCompleted(challengeIsCompleted);
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #46062

<!-- Feel free to add any additional description of changes below this line -->
I created a variable that gets the value from 'challengeIsCompleted' when 'challengeIsCompleted' variable updates from the 'check code' button press. After that, I replaced 'challengeIsCompleted' with that variable everywhere 'challengeIsCompleted' is used.