### PR TITLE
fix: use standard path names for chunks

### DIFF
--- a/client/webpack-workers.js
+++ b/client/webpack-workers.js
@@ -28,7 +28,7 @@ module.exports = (env = {}) => {
         );
         return filename + '.js';
       },
-      chunkFilename: '[name].[contenthash].js',
+      chunkFilename: '[name]-[contenthash].js',
       path: staticPath
     },
     stats: {


### PR DESCRIPTION
This simplifies client-config by reducing the number of patterns we need to match

Ideally this should go in before https://github.com/freeCodeCamp/client-config/pull/8 so we provide the headers immediately.