### PR TITLE
fix(a11y):add main landmark to super block intro

### DIFF
--- a/client/src/templates/Introduction/super-block-intro.tsx
+++ b/client/src/templates/Introduction/super-block-intro.tsx
@@ -193,57 +193,59 @@ const SuperBlockIntroductionPage = (props: SuperBlockProp) => {
         <title>{i18nTitle} | freeCodeCamp.org</title>
       </Helmet>
       <Grid>
-        <Row className='super-block-intro-page'>
-          <Col md={8} mdOffset={2} sm={10} smOffset={1} xs={12}>
-            <Spacer size={2} />
-            <LegacyLinks superBlock={superBlock} />
-            <SuperBlockIntro superBlock={superBlock} />
-            <Spacer size={2} />
-            <h2 className='text-center big-subheading'>
-              {t(`intro:misc-text.courses`)}
-            </h2>
-            <Spacer />
-            <div className='block-ui'>
-              {defaultCurriculumNames.map(blockDashedName => (
-                <Fragment key={blockDashedName}>
-                  <Block
-                    blockDashedName={blockDashedName}
-                    challenges={nodesForSuperBlock.filter(
-                      node => node.challenge.block === blockDashedName
-                    )}
-                    superBlock={superBlock}
-                  />
-                </Fragment>
-              ))}
-              {superBlock !== SuperBlocks.CodingInterviewPrep && (
+        <main>
+          <Row className='super-block-intro-page'>
+            <Col md={8} mdOffset={2} sm={10} smOffset={1} xs={12}>
+              <Spacer size={2} />
+              <LegacyLinks superBlock={superBlock} />
+              <SuperBlockIntro superBlock={superBlock} />
+              <Spacer size={2} />
+              <h2 className='text-center big-subheading'>
+                {t(`intro:misc-text.courses`)}
+              </h2>
+              <Spacer />
+              <div className='block-ui'>
+                {defaultCurriculumNames.map(blockDashedName => (
+                  <Fragment key={blockDashedName}>
+                    <Block
+                      blockDashedName={blockDashedName}
+                      challenges={nodesForSuperBlock.filter(
+                        node => node.challenge.block === blockDashedName
+                      )}
+                      superBlock={superBlock}
+                    />
+                  </Fragment>
+                ))}
+                {superBlock !== SuperBlocks.CodingInterviewPrep && (
+                  <div>
+                    <CertChallenge
+                      certification={certification}
+                      superBlock={superBlock}
+                      title={title}
+                      user={user}
+                    />
+                  </div>
+                )}
+              </div>
+              {!isSignedIn && !signInLoading && (
                 <div>
-                  <CertChallenge
-                    certification={certification}
-                    superBlock={superBlock}
-                    title={title}
-                    user={user}
-                  />
+                  <Spacer size={2} />
+                  <Login block={true}>{t('buttons.logged-out-cta-btn')}</Login>
                 </div>
               )}
-            </div>
-            {!isSignedIn && !signInLoading && (
-              <div>
-                <Spacer size={2} />
-                <Login block={true}>{t('buttons.logged-out-cta-btn')}</Login>
-              </div>
-            )}
-            <Spacer size={2} />
-            <h3
-              className='text-center big-block-title'
-              style={{ whiteSpace: 'pre-line' }}
-            >
-              {t(`intro:misc-text.browse-other`)}
-            </h3>
-            <Spacer />
-            <Map currentSuperBlock={superBlock} />
-            <Spacer size={2} />
-          </Col>
-        </Row>
+              <Spacer size={2} />
+              <h3
+                className='text-center big-block-title'
+                style={{ whiteSpace: 'pre-line' }}
+              >
+                {t(`intro:misc-text.browse-other`)}
+              </h3>
+              <Spacer />
+              <Map currentSuperBlock={superBlock} />
+              <Spacer size={2} />
+            </Col>
+          </Row>
+        </main>
       </Grid>
       <DonateModal location={props.location} />
     </>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

The super block intro page didn't have a main landmark. Probably a good idea to wrap one around the main content. The only change I made was to wrap the Row in a `<main>` element which caused the indentation to change, so it looks worse than it really is.
