### PR TITLE
test: ignore Firefox specific runtime errors

### DIFF
--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -20,10 +20,13 @@ import './commands';
 // require('./commands')
 
 Cypress.on('uncaught:exception', err => {
+  console.log('Cypress detected uncaught exception', err.name);
   // Rapidly cy.visiting pages seems to cause an uncaught exception. This seems
   // to be a testing artifact, since users can't click fast enough to cause this
   // (to our knowledge).
-  if (err.name === 'ChunkLoadError') {
+  // UPDATE: this may have morphed into NS_ERROR_UNEXPECTED with the move to
+  // Cypress 9.  Quite why, I'm not sure.
+  if (err.name === 'NS_ERROR_UNEXPECTED') {
     return false;
   }
   // We are still interested in other errors.


### PR DESCRIPTION
Frustrating, but I've not been able to pin them down

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
