### PR TITLE
fix: update path of webpack bundles

### DIFF
--- a/client/webpack-workers.js
+++ b/client/webpack-workers.js
@@ -21,7 +21,7 @@ module.exports = (env = {}) => {
       filename: chunkData => {
         // construct and output the filename here, so the client can use the
         // json to find the file.
-        const filename = `${chunkData.chunk.name}.${chunkData.chunk.contentHash.javascript}`;
+        const filename = `${chunkData.chunk.name}-${chunkData.chunk.contentHash.javascript}`;
         writeFileSync(
           path.join(configPath, `${chunkData.chunk.name}.json`),
           `{"filename": "${filename}"}`


### PR DESCRIPTION
With this both the bundles and their chunks will have the correct path
names

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
