### PR TITLE
fix: Make links to challenges more accessible to SR

### DIFF
--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -193,12 +193,14 @@ export class Block extends Component<BlockProps> {
               }}
             >
               <Caret />
-              <h4 className='course-title'>
+              <div className='course-title'>
                 {`${isExpanded ? collapseText : expandText}`}
-              </h4>
+              </div>
               <div className='map-title-completed course-title'>
                 {this.renderCheckMark(isBlockCompleted)}
+                <span className='sr-only'>{blockTitle}</span>
                 <span className='map-completed-count'>{`${completedCount}/${challengesWithCompleted.length}`}</span>
+                <span className='sr-only'>lessons completed</span>
               </div>
             </button>
             {isExpanded && (

--- a/client/src/templates/Introduction/components/challenges.tsx
+++ b/client/src/templates/Introduction/components/challenges.tsx
@@ -67,6 +67,7 @@ function Challenges({
                 challenge.isCompleted ? 'challenge-completed' : ''
               }`}
             >
+              <span className='fcc_sr_only'>Challenge</span>
               {i + 1}
             </Link>
           ) : (


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x ] My pull request targets the `main` branch of freeCodeCamp.
- [x ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
When using a screen reader to navigate the courses because there were just numbers 1 - 67 it would read out 1 link, 2 link, 3 link without any context where the link led. I added a screen reader only text so it instead reads out challenge 1 link, challenge 2 link etc.

The same on the pages with many expand course buttons. I removed the h4 tag as there shouldn't be heading tags inside of buttons and then added some screen reader only text to give more context so instead of hearing 'Expand course for 0/35' they will hear 'Expand course for bootstrap 0/35 lessons completed'