### PR TITLE
fix:enable default mouse/touch events on monaco content widget

### DIFF
--- a/client/src/templates/Challenges/classic/editor.css
+++ b/client/src/templates/Challenges/classic/editor.css
@@ -3,6 +3,15 @@
   color: var(--primary-color);
 }
 
+.monaco-scrollable-element {
+  overflow: visible !important;
+}
+
+.monaco-editor-background {
+  overflow: visible !important;
+  contain: none !important;
+}
+
 .vs .monaco-scrollable-element > .scrollbar > .slider {
   z-index: 11;
 }

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -500,9 +500,7 @@ const Editor = (props: EditorProps): JSX.Element => {
     const scrollGutterWidget = createWidget(
       editor,
       'scrollgutter.widget',
-      scrollGutterNode,
-      () => '0',
-      false
+      scrollGutterNode
     );
     editor.addContentWidget(scrollGutterWidget);
   };
@@ -909,14 +907,14 @@ const Editor = (props: EditorProps): JSX.Element => {
     editor: editor.IStandaloneCodeEditor,
     id: string,
     domNode: HTMLDivElement,
-    getTop: () => string,
-    // scroll gutter sets this to false since positioning is done elsewhere
-    setPosition?: boolean
+    // If getTop function is not provided then no positioning will be done here.
+    // This allows scroll gutter to do its positioning elsewhere.
+    getTop?: () => string
   ) => {
     const getId = () => id;
     const getDomNode = () => domNode;
     const getPosition = () => {
-      if (setPosition !== false) {
+      if (getTop) {
         domNode.style.width = `${editor.getLayoutInfo().contentWidth}px`;
         domNode.style.top = getTop();
       }
@@ -927,7 +925,7 @@ const Editor = (props: EditorProps): JSX.Element => {
     // Only the description content widget uses this method but it
     // is harmless to pass it to the overlay widget.
     const afterRender = () => {
-      if (setPosition !== false) {
+      if (getTop) {
         domNode.style.left = '0';
       }
       domNode.style.visibility = 'visible';

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -700,6 +700,16 @@ const Editor = (props: EditorProps): JSX.Element => {
     return outputNode;
   }
 
+  function createScrollGutterNode(): HTMLDivElement {
+    const scrollGutterNode = document.createElement('div');
+    scrollGutterNode.setAttribute('id', 'scroll-gutter');
+    scrollGutterNode.style.width = `32px`;
+    scrollGutterNode.style.left = `0`;
+    scrollGutterNode.style.height = '100vh';
+    scrollGutterNode.style.background = 'transparent';
+    return scrollGutterNode;
+  }
+
   function resetMarginDecorations() {
     const { model, insideEditDecId } = dataRef.current;
     const range = model?.getDecorationRange(insideEditDecId);
@@ -884,12 +894,14 @@ const Editor = (props: EditorProps): JSX.Element => {
     const createWidget = (
       id: string,
       domNode: HTMLDivElement,
-      getTop: () => string
+      getTop: () => string,
+      width?: string
     ) => {
       const getId = () => id;
       const getDomNode = () => domNode;
       const getPosition = () => {
-        domNode.style.width = `${editor.getLayoutInfo().contentWidth}px`;
+        domNode.style.width =
+          width || `${editor.getLayoutInfo().contentWidth}px`;
         domNode.style.top = getTop();
 
         // must return null, so that Monaco knows the widget will position
@@ -913,6 +925,8 @@ const Editor = (props: EditorProps): JSX.Element => {
     const descriptionNode = createDescription(editor);
 
     const outputNode = createOutputNode(editor);
+
+    const scrollGutterNode = createScrollGutterNode();
 
     if (!dataRef.current.descriptionWidget) {
       dataRef.current.descriptionWidget = createWidget(
@@ -942,6 +956,15 @@ const Editor = (props: EditorProps): JSX.Element => {
       editor.addOverlayWidget(dataRef.current.outputWidget);
       editor.changeViewZones(updateOutputZone);
     }
+
+    /* Add invisible overlay over line numbers so touch users will always have a place to vertically scroll the editor */
+    const scrollGutterWidget = createWidget(
+      'scrollgutter.widget',
+      scrollGutterNode,
+      () => '0',
+      '32px'
+    );
+    editor.addOverlayWidget(scrollGutterWidget);
 
     editor.onDidScrollChange(() => {
       if (dataRef.current.descriptionWidget)

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -957,17 +957,15 @@ const Editor = (props: EditorProps): JSX.Element => {
       editor.changeViewZones(updateOutputZone);
     }
 
-    /* Add invisible overlay over line numbers so touch users will always have a place to vertically scroll the editor */
-    /*
+    // Add invisible content overlay over line numbers so touch users will
+    // always have a place to vertically scroll the editor.
     const scrollGutterWidget = createWidget(
       'scrollgutter.widget',
       scrollGutterNode,
       () => '0',
       '32px'
     );
-    editor.addOverlayWidget(scrollGutterWidget);
-    */
-    console.log(scrollGutterNode);
+    editor.addContentWidget(scrollGutterWidget);
 
     editor.onDidScrollChange(() => {
       if (dataRef.current.descriptionWidget)

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -704,7 +704,7 @@ const Editor = (props: EditorProps): JSX.Element => {
     const scrollGutterNode = document.createElement('div');
     scrollGutterNode.setAttribute('id', 'scroll-gutter');
     scrollGutterNode.style.width = `32px`;
-    scrollGutterNode.style.left = `0`;
+    scrollGutterNode.style.left = `-32px`;
     scrollGutterNode.style.height = '100vh';
     scrollGutterNode.style.background = 'transparent';
     return scrollGutterNode;

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -958,6 +958,7 @@ const Editor = (props: EditorProps): JSX.Element => {
     }
 
     /* Add invisible overlay over line numbers so touch users will always have a place to vertically scroll the editor */
+    /*
     const scrollGutterWidget = createWidget(
       'scrollgutter.widget',
       scrollGutterNode,
@@ -965,6 +966,8 @@ const Editor = (props: EditorProps): JSX.Element => {
       '32px'
     );
     editor.addOverlayWidget(scrollGutterWidget);
+    */
+    console.log(scrollGutterNode);
 
     editor.onDidScrollChange(() => {
       if (dataRef.current.descriptionWidget)

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -911,7 +911,11 @@ const Editor = (props: EditorProps): JSX.Element => {
       // Only the description content widget uses this method but it
       // is harmless to pass it to the overlay widget.
       const afterRender = () => {
-        domNode.style.left = '0';
+        // If we passed a width in then this is the scroll gutter and we don't
+        // want to adjust the left property.
+        if (!width) {
+          domNode.style.left = '0';
+        }
         domNode.style.visibility = 'visible';
       };
       return {

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -705,7 +705,7 @@ const Editor = (props: EditorProps): JSX.Element => {
     scrollGutterNode.setAttribute('id', 'scroll-gutter');
     scrollGutterNode.style.width = `32px`;
     scrollGutterNode.style.left = `-32px`;
-    scrollGutterNode.style.height = '100vh';
+    scrollGutterNode.style.height = '10000px';
     scrollGutterNode.style.background = 'transparent';
     return scrollGutterNode;
   }

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -139,6 +139,15 @@ const BASE_LAYOUT = {
   testsPane: { flex: 0.3 }
 };
 
+// Used to prevent monaco from stealing mouse events on the content widget
+// so they can trigger their default actions. (Issue #46166)
+const handleContentWidgetMouseEvents = (e: MouseEvent): void => {
+  const target = e.target as HTMLElement;
+  if (target?.closest('.editor-upper-jaw')) {
+    e.stopPropagation();
+  }
+};
+
 // Component
 class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
   static displayName: string;
@@ -224,6 +233,18 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
       }
     } = this.props;
     this.initializeComponent(title);
+    // Bug fix for the monaco content widget and touch devices/right mouse
+    // click. (Issue #46166)
+    document.addEventListener(
+      'mousedown',
+      handleContentWidgetMouseEvents,
+      true
+    );
+    document.addEventListener(
+      'contextmenu',
+      handleContentWidgetMouseEvents,
+      true
+    );
   }
 
   componentDidUpdate(prevProps: ShowClassicProps) {
@@ -301,6 +322,16 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
     const { createFiles, cancelTests } = this.props;
     createFiles([]);
     cancelTests();
+    document.removeEventListener(
+      'mousedown',
+      handleContentWidgetMouseEvents,
+      true
+    );
+    document.removeEventListener(
+      'contextmenu',
+      handleContentWidgetMouseEvents,
+      true
+    );
   }
 
   getChallenge = () => this.props.data.challengeNode.challenge;

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -148,6 +148,13 @@ const handleContentWidgetMouseEvents = (e: MouseEvent): void => {
   }
 };
 
+const handleContentWidgetTouchEvents = (e: TouchEvent): void => {
+  const target = e.target as HTMLElement;
+  if (target?.closest('.editor-upper-jaw')) {
+    e.stopPropagation();
+  }
+};
+
 // Component
 class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
   static displayName: string;
@@ -245,6 +252,17 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
       handleContentWidgetMouseEvents,
       true
     );
+    document.addEventListener(
+      'touchstart',
+      handleContentWidgetTouchEvents,
+      true
+    );
+    document.addEventListener(
+      'touchmove',
+      handleContentWidgetTouchEvents,
+      true
+    );
+    document.addEventListener('touchend', handleContentWidgetTouchEvents, true);
   }
 
   componentDidUpdate(prevProps: ShowClassicProps) {
@@ -330,6 +348,21 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
     document.removeEventListener(
       'contextmenu',
       handleContentWidgetMouseEvents,
+      true
+    );
+    document.removeEventListener(
+      'touchstart',
+      handleContentWidgetTouchEvents,
+      true
+    );
+    document.removeEventListener(
+      'touchmove',
+      handleContentWidgetTouchEvents,
+      true
+    );
+    document.removeEventListener(
+      'touchend',
+      handleContentWidgetTouchEvents,
       true
     );
   }

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -139,16 +139,9 @@ const BASE_LAYOUT = {
   testsPane: { flex: 0.3 }
 };
 
-// Used to prevent monaco from stealing mouse events on the content widget
-// so they can trigger their default actions. (Issue #46166)
-const handleContentWidgetMouseEvents = (e: MouseEvent): void => {
-  const target = e.target as HTMLElement;
-  if (target?.closest('.editor-upper-jaw')) {
-    e.stopPropagation();
-  }
-};
-
-const handleContentWidgetTouchEvents = (e: TouchEvent): void => {
+// Used to prevent monaco from stealing mouse/touch events on the upper jaw
+// content widget so they can trigger their default actions. (Issue #46166)
+const handleContentWidgetEvents = (e: MouseEvent | TouchEvent): void => {
   const target = e.target as HTMLElement;
   if (target?.closest('.editor-upper-jaw')) {
     e.stopPropagation();
@@ -242,27 +235,11 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
     this.initializeComponent(title);
     // Bug fix for the monaco content widget and touch devices/right mouse
     // click. (Issue #46166)
-    document.addEventListener(
-      'mousedown',
-      handleContentWidgetMouseEvents,
-      true
-    );
-    document.addEventListener(
-      'contextmenu',
-      handleContentWidgetMouseEvents,
-      true
-    );
-    document.addEventListener(
-      'touchstart',
-      handleContentWidgetTouchEvents,
-      true
-    );
-    document.addEventListener(
-      'touchmove',
-      handleContentWidgetTouchEvents,
-      true
-    );
-    document.addEventListener('touchend', handleContentWidgetTouchEvents, true);
+    document.addEventListener('mousedown', handleContentWidgetEvents, true);
+    document.addEventListener('contextmenu', handleContentWidgetEvents, true);
+    document.addEventListener('touchstart', handleContentWidgetEvents, true);
+    document.addEventListener('touchmove', handleContentWidgetEvents, true);
+    document.addEventListener('touchend', handleContentWidgetEvents, true);
   }
 
   componentDidUpdate(prevProps: ShowClassicProps) {
@@ -340,31 +317,15 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
     const { createFiles, cancelTests } = this.props;
     createFiles([]);
     cancelTests();
-    document.removeEventListener(
-      'mousedown',
-      handleContentWidgetMouseEvents,
-      true
-    );
+    document.removeEventListener('mousedown', handleContentWidgetEvents, true);
     document.removeEventListener(
       'contextmenu',
-      handleContentWidgetMouseEvents,
+      handleContentWidgetEvents,
       true
     );
-    document.removeEventListener(
-      'touchstart',
-      handleContentWidgetTouchEvents,
-      true
-    );
-    document.removeEventListener(
-      'touchmove',
-      handleContentWidgetTouchEvents,
-      true
-    );
-    document.removeEventListener(
-      'touchend',
-      handleContentWidgetTouchEvents,
-      true
-    );
+    document.removeEventListener('touchstart', handleContentWidgetEvents, true);
+    document.removeEventListener('touchmove', handleContentWidgetEvents, true);
+    document.removeEventListener('touchend', handleContentWidgetEvents, true);
   }
 
   getChallenge = () => this.props.data.challengeNode.challenge;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally on my machine.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #46166 

<!-- Feel free to add any additional description of changes below this line -->

Unfortunately, I can find no way to fix this issue using the monaco API. I'm actually not surprised as they make it quite clear that the monaco editor is not supported in mobile browsers. So I had to hack this by adding some event listeners on the document to intercept certain mouse events before monaco could get to them, and then stop their propagation in order to allow their default behaviors to take place. This could be made a little more efficient by only adding the listeners for the new editor interface but I couldn't find a way to determine this. Please let me know if there is one.

Also, I have not been able to test this on an actual touch device yet. The monaco editor does not listen for any touch events as far as I can tell, so I believe just handling the mouse events will solve this problem. Is there a public facing dev server we can put these changes on so I can test from a phone?