### PR TITLE
fix(client): prevent code duplication when using help button

### DIFF
--- a/client/src/templates/Challenges/redux/create-question-epic.js
+++ b/client/src/templates/Challenges/redux/create-question-epic.js
@@ -21,10 +21,10 @@ function filesToMarkdown(challengeFiles = {}) {
       return fileString;
     }
     const fileName = moreThanOneFile
-      ? `\\ file: ${challengeFile.contents}`
+      ? `\\ file: ${challengeFile.name}.${challengeFile.ext}\n`
       : '';
     const fileType = challengeFile.ext;
-    return `${fileString}\`\`\`${fileType}\n${fileName}\n${challengeFile.contents}\n\`\`\`\n\n`;
+    return `${fileString}\`\`\`${fileType}\n${fileName}${challengeFile.contents}\n\`\`\`\n\n`;
   }, '\n');
 }
 

--- a/client/src/templates/Challenges/redux/create-question-epic.js
+++ b/client/src/templates/Challenges/redux/create-question-epic.js
@@ -21,7 +21,7 @@ function filesToMarkdown(challengeFiles = {}) {
       return fileString;
     }
     const fileName = moreThanOneFile
-      ? `\\ file: ${challengeFile.name}.${challengeFile.ext}\n`
+      ? `/* file: ${challengeFile.name}.${challengeFile.ext} */\n`
       : '';
     const fileType = challengeFile.ext;
     return `${fileString}\`\`\`${fileType}\n${fileName}${challengeFile.contents}\n\`\`\`\n\n`;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #46153 

<!-- Feel free to add any additional description of changes below this line -->
I wasn't sure if `challengeFile.history` would always contain the file name in the first index so I went with `name` and `ext`