### PR TITLE
test: reduce flake

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -64,12 +64,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        browsers: [chrome, firefox, electron]
         node-version: [16.x]
-        browsers: [chrome, firefox]
-    #         browsers: [chrome, firefox, electron]
-    #         include:
-    #           - browsers: electron
-    #             spec: cypress/integration/learn/challenges/projects.js
+        include:
+          - browsers: electron
+            spec: cypress/integration/learn/challenges/projects.js
     services:
       mongodb:
         image: mongo:4

--- a/cypress/integration/learn/challenges/projects.js
+++ b/cypress/integration/learn/challenges/projects.js
@@ -88,7 +88,7 @@ describe('project submission', () => {
 
             solutions.forEach(files => {
               files.forEach(({ contents }) => {
-                cy.get(selectors.editor).as('editor');
+                cy.get(selectors.editor, { timeout: 16000 }).as('editor');
                 cy.get('@editor').click().focused().type('{ctrl+a}{del}');
                 // NOTE: clipboard operations are flaky in watch mode, because
                 // the document can lose focus
@@ -98,7 +98,7 @@ describe('project submission', () => {
                 cy.document().invoke('execCommand', 'paste');
                 cy.contains('Run the Tests').click();
                 cy.contains('Submit and go to next challenge', {
-                  timeout: 8000
+                  timeout: 16000
                 }).click();
                 cy.contains(textInNextPage[i]);
               });

--- a/cypress/integration/learn/challenges/projects.js
+++ b/cypress/integration/learn/challenges/projects.js
@@ -88,8 +88,10 @@ describe('project submission', () => {
 
             solutions.forEach(files => {
               files.forEach(({ contents }) => {
-                cy.get(selectors.editor, { timeout: 16000 }).as('editor');
-                cy.get('@editor').click().focused().type('{ctrl+a}{del}');
+                cy.get(selectors.editor, { timeout: 16000 })
+                  .click()
+                  .focused()
+                  .type('{ctrl+a}{del}');
                 // NOTE: clipboard operations are flaky in watch mode, because
                 // the document can lose focus
                 cy.window()
@@ -118,8 +120,7 @@ describe('project submission', () => {
 
         // Claim and view solutions on certification page
 
-        cy.toggleAll();
-        cy.visit('/settings');
+        cy.setPrivacyTogglesToPublic();
         cy.get(
           `a[href="/certification/developmentuser/${projectsInOrder[0]?.superBlock}"]`
         ).click();

--- a/cypress/integration/learn/responsive-web-design/show-cert-from-superblock.js
+++ b/cypress/integration/learn/responsive-web-design/show-cert-from-superblock.js
@@ -36,14 +36,15 @@ describe('Front End Development Libraries Superblock', () => {
   describe('Before submitting projects', () => {
     it('should navigate to "/settings#certification-settings" when clicking the "Go to settings to claim your certification" anchor', () => {
       cy.contains('Go to settings to claim your certification').click();
-      cy.url().should('include', '/settings#certification-settings');
+      cy.url().should('match', /\/settings\/?#certification-settings/);
     });
   });
   describe('After submitting all 5 projects', () => {
     before(() => {
       cy.exec('npm run seed');
       cy.login();
-      cy.toggleAll();
+      cy.visit('/settings');
+      cy.setPrivacyTogglesToPublic();
     });
 
     it('should be possible to view certifications from the settings page', () => {
@@ -51,12 +52,12 @@ describe('Front End Development Libraries Superblock', () => {
       cy.visit(`/learn/${projects.superBlock}/`);
       cy.contains('Go to settings to claim your certification').click();
       cy.location().should(loc => {
-        expect(loc.pathname).to.eq(`/settings`);
+        expect(loc.pathname).to.include(`/settings`);
       });
       cy.get('[data-cy=btn-for-front-end-development-libraries]').click();
       cy.contains('Show Certification').click();
       cy.location().should(loc => {
-        expect(loc.pathname).to.eq(
+        expect(loc.pathname).to.include(
           `/certification/developmentuser/${projects.superBlock}`
         );
       });
@@ -81,7 +82,7 @@ describe('Front End Development Libraries Superblock', () => {
           .its('response.statusCode')
           .should('eq', 200);
         cy.location().should(loc => {
-          expect(loc.pathname).to.not.eq(url);
+          expect(loc.pathname).to.not.include(url);
         });
       });
     }

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -46,8 +46,7 @@ Cypress.Commands.add('preserveSession', () => {
   );
 });
 
-Cypress.Commands.add('toggleAll', () => {
-  cy.visit('/settings');
+Cypress.Commands.add('setPrivacyTogglesToPublic', () => {
   cy.get('#privacy-settings')
     .find('.toggle-not-active')
     .each(element => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -48,18 +48,14 @@ Cypress.Commands.add('preserveSession', () => {
 
 Cypress.Commands.add('toggleAll', () => {
   cy.visit('/settings');
-  // cy.get('input[name="isLocked"]').click();
-  // cy.get('input[name="name"]').click();
   cy.get('#privacy-settings')
     .find('.toggle-not-active')
     .each(element => {
       cy.wrap(element).click().should('have.class', 'toggle-active');
     });
-  new Cypress.Promise(resolve => {
-    cy.get('[data-cy=save-privacy-settings]').click();
-    resolve();
-  });
-  cy.get('#honesty-policy').find('button').click().wait(300);
+  cy.get('[data-cy=save-privacy-settings]').click();
+  cy.get('#honesty-policy').find('button').click();
+  cy.contains('You have accepted our Academic Honesty Policy');
 });
 
 Cypress.Commands.add('goToSettings', () => {
@@ -77,17 +73,13 @@ Cypress.Commands.add('typeUsername', username => {
 });
 
 Cypress.Commands.add('resetUsername', () => {
-  cy.visit('/settings');
+  cy.goToSettings();
 
   cy.typeUsername('developmentuser');
 
   cy.contains('Username is available');
 
-  // temporary fix until https://github.com/cypress-io/cypress/issues/20562 is fixed
-  cy.contains(`Save`).click();
-
-  // revert to this when it is
-  // cy.get('@usernameInput').type('{enter}', { force: true, release: false });
+  cy.get('@usernameInput').type('{enter}', { force: true, release: false });
 
   cy.contains('Account Settings for developmentuser').should('be.visible');
 });

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -21,12 +21,10 @@ import './commands';
 
 Cypress.on('uncaught:exception', err => {
   console.log('Cypress detected uncaught exception', err.name);
-  // Rapidly cy.visiting pages seems to cause an uncaught exception. This seems
-  // to be a testing artifact, since users can't click fast enough to cause this
-  // (to our knowledge).
-  // UPDATE: this may have morphed into NS_ERROR_UNEXPECTED with the move to
-  // Cypress 9.  Quite why, I'm not sure.
-  if (err.name === 'NS_ERROR_UNEXPECTED') {
+  // Rapidly cy.visiting pages seems to cause uncaught exceptions. It remains
+  // unclear why this is happening, but we need to ignore them in testing so
+  // that we can test other behaviour.
+  if (err.name === 'NS_ERROR_UNEXPECTED' || err.name === 'ChunkLoadError') {
     return false;
   }
   // We are still interested in other errors.


### PR DESCRIPTION
- test: increase timeouts for slow operations
- test: ignore ChunkLoadErrors again
- test: clean up commands
- Revert "fix(cypress): disable electron due to timeouts (#46231)"
- test: various minor refactors

The increased timeouts should make the Electron tests more reliable and ignoring ChunkLoadError should also speed up Firefox.  I don't know why either the tests are so slow or how to avoid generating the errors, but, pending figuring those out, this should calm the tests down.
