### PR TITLE
fix(UI): Remove 'CTRL + Enter' on CTA for mobile 

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -51,6 +51,7 @@
     "run": "Run",
     "run-test": "Run the Tests (Ctrl + Enter)",
     "check-code": "Check Your Code (Ctrl + Enter)",
+    "check-code-2": "Check Your Code",
     "reset": "Reset",
     "reset-code": "Reset All Code",
     "help": "Help",

--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import Fail from '../../../assets/icons/fail';
 import LightBulb from '../../../assets/icons/lightbulb';
 import GreenPass from '../../../assets/icons/green-pass';
+import { MAX_MOBILE_WIDTH } from '../../../../../config/misc';
 
 interface LowerJawProps {
   hint?: string;
@@ -175,6 +176,8 @@ const LowerJaw = ({
       );
   };
 
+  const showDesktopButton = window.innerWidth > MAX_MOBILE_WIDTH;
+
   const renderButtons = () => {
     return (
       <>
@@ -184,9 +187,9 @@ const LowerJaw = ({
           aria-hidden={testBtnariaHidden}
           onClick={tryToExecuteChallenge}
         >
-          {window.screen.width < 768
-            ? 'Check Your Code'
-            : t('buttons.check-code')}
+          {showDesktopButton
+            ? t('buttons.check-code')
+            : t('buttons.check-code-2')}
         </button>
         <div id='action-buttons-container'>
           <button

--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -184,7 +184,9 @@ const LowerJaw = ({
           aria-hidden={testBtnariaHidden}
           onClick={tryToExecuteChallenge}
         >
-          {t('buttons.check-code')}
+          {window.screen.width < 768
+            ? 'Check Your Code'
+            : t('buttons.check-code')}
         </button>
         <div id='action-buttons-container'>
           <button

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -11,6 +11,7 @@ import store from 'store';
 import { editor } from 'monaco-editor';
 import { challengeTypes } from '../../../../utils/challenge-types';
 import LearnLayout from '../../../components/layouts/learn';
+import { MAX_MOBILE_WIDTH } from '../../../../../config/misc';
 
 import {
   ChallengeFiles,
@@ -127,7 +128,6 @@ interface ReflexLayout {
   testsPane: { flex: number };
 }
 
-const MAX_MOBILE_WIDTH = 767;
 const REFLEX_LAYOUT = 'challenge-layout';
 const BASE_LAYOUT = {
   codePane: { flex: 1 },

--- a/config/misc.js
+++ b/config/misc.js
@@ -1,1 +1,2 @@
 exports.defaultUserImage = 'https://freecodecamp.com/sample-image.png';
+exports.MAX_MOBILE_WIDTH = 767;

--- a/cypress/integration/learn/challenges/multifile.js
+++ b/cypress/integration/learn/challenges/multifile.js
@@ -1,5 +1,9 @@
 const location =
   '/learn/2022/responsive-web-design/learn-accessibility-by-building-a-quiz/step-2';
+const selectors = {
+  testButton: '#test-button',
+  monacoTabs: '.monaco-editor-tabs'
+};
 
 describe('Challenge with multifile editor', () => {
   before(() => {
@@ -7,8 +11,16 @@ describe('Challenge with multifile editor', () => {
   });
 
   it('renders the file tab buttons', () => {
-    cy.get('.monaco-editor-tabs').should('exist');
-    cy.get('.monaco-editor-tabs').contains('index.html');
-    cy.get('.monaco-editor-tabs').contains('styles.css');
+    cy.get(selectors.monacoTabs).should('exist');
+    cy.get(selectors.monacoTabs).contains('index.html');
+    cy.get(selectors.monacoTabs).contains('styles.css');
+  });
+
+  it('checks for correct text at different widths', () => {
+    cy.viewport(768, 660)
+      .get(selectors.testButton)
+      .contains('Check Your Code (Ctrl + Enter)');
+
+    cy.viewport(767, 660).get(selectors.testButton).contains('Check Your Code');
   });
 });


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Clears a mobile task in #46178☂️ 

<!-- Feel free to add any additional description of changes below this line -->
- [x]  Remove `Ctrl + Enter` on CTA

Produces following result:
![image](https://user-images.githubusercontent.com/27147016/171073692-694e1ede-4410-4122-8d2e-b7076d579326.png)

Reverts CTA on screen sizes >= 768px:
![image](https://user-images.githubusercontent.com/27147016/171073779-d64e9779-3a9d-4065-8b41-16dcd0fb3211.png)
