### PR TITLE
fix(curriculum): don't block fragment links

### DIFF
--- a/client/src/templates/Challenges/utils/frame.ts
+++ b/client/src/templates/Challenges/utils/frame.ts
@@ -67,7 +67,7 @@ const createHeader = (id = mainPreviewId) => `
       while(element && element.nodeName !== 'A') {
         element = element.parentElement;
       }
-      if(element && element.nodeName === 'A'){
+      if (element && element.nodeName === 'A' && new URL(element.href).hash === '') {
         e.preventDefault();
         window.parent.window.alert('Normally this link would bring you to another website! It works!' + ' This is a link to: ' + '(' + element.href + ')');
       }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #46244 

<!-- Feel free to add any additional description of changes below this line -->

Fix for fragment links counting as external links blocking the fragment navigation.
