### PR TITLE
test: simplify donation page tests

### DIFF
--- a/cypress/integration/learn/donate/donate-page-default.js
+++ b/cypress/integration/learn/donate/donate-page-default.js
@@ -1,20 +1,10 @@
 describe('Donate page', () => {
-  before(() => {
-    cy.clearCookies();
-    cy.exec('npm run seed');
-    cy.login();
+  it('Should render correctly', () => {
     cy.visit('/donate');
-  });
-
-  it('Should render', () => {
     cy.title().should('eq', 'Support our nonprofit | freeCodeCamp.org');
-  });
 
-  it('Should display default amount and duration', () => {
     cy.contains('Confirm your donation of $5 / month:').should('be.visible');
-  });
 
-  it('Should have FAQ section', () => {
     cy.contains('Frequently asked questions');
     cy.contains('How can I get help with my donations?');
     cy.contains('How transparent is freeCodeCamp.org?');


### PR DESCRIPTION
None of the tests care about the user, so we can skip seeding and
logging in.  Also, the tests are all basically just checking the page is
rendering correctly, so we can do them all in one 'it' and save time.
