### PR TITLE
test: fix donate page for existing donors

### DIFF
--- a/client/src/components/Donation/donation-text-components.tsx
+++ b/client/src/components/Donation/donation-text-components.tsx
@@ -58,10 +58,12 @@ export const DonationOptionsText = (): JSX.Element => {
 export const DonationOptionsAlertText = (): JSX.Element => {
   const { t } = useTranslation();
   return (
-    <p>
+    <p data-cy='donate.bigger-donation'>
       <Trans>donate.bigger-donation</Trans>{' '}
       <Trans i18nKey='donate.other-ways'>
-        <a href={t('links:donate.other-ways-url')}>placeholder</a>
+        <a data-cy='donate-link' href={t('links:donate.other-ways-url')}>
+          placeholder
+        </a>
       </Trans>
     </p>
   );

--- a/client/src/pages/donate.tsx
+++ b/client/src/pages/donate.tsx
@@ -100,8 +100,8 @@ function DonatePage({
                 </Col>
               </Row>
               {isDonating ? (
-                <Alert closeLabel={t('buttons.close')}>
-                  <p>{t('donate.thank-you-2')}</p>
+                <Alert data-cy='donate-alert' closeLabel={t('buttons.close')}>
+                  <p data-cy='donate.thank-you'>{t('donate.thank-you-2')}</p>
                   <br />
                   <DonationOptionsAlertText />
                 </Alert>

--- a/cypress/integration/learn/donate/donate-page-donor.js
+++ b/cypress/integration/learn/donate/donate-page-donor.js
@@ -1,41 +1,24 @@
-const selectors = {
-  donateAlert: {
-    firstText: '.alert-info p:first-child',
-    secondText: '.alert-info p:last-child',
-    link: '.alert-info a'
-  }
-};
-
 describe('Donate page', () => {
-  before(() => {
-    cy.clearCookies();
+  beforeEach(() => {
     cy.exec('npm run seed -- --donor');
     cy.login();
-    cy.visit('/donate');
-  });
-
-  after(() => {
-    cy.exec('npm run seed');
   });
 
   it('Donor alert should be visible for donor', () => {
-    cy.get('.alert-info').should('be.visible');
-  });
+    cy.visit('/donate');
 
-  it('Donor should see alert message', () => {
-    cy.contains(
-      selectors.donateAlert.firstText,
+    cy.get('[data-cy="donate-alert"]').should('be.visible');
+
+    cy.get('[data-cy="donate.thank-you"]').should(
+      'have.text',
       'Thank you for being a supporter of freeCodeCamp. You currently have a recurring donation.'
     );
-    cy.contains(
-      selectors.donateAlert.lastText,
+    cy.get('[data-cy="donate.bigger-donation"]').should(
+      'have.text',
       "Want to make a bigger one-time donation, mail us a check, or give in other ways? Here are many other ways you can support our non-profit's mission."
     );
-  });
-
-  it('Donor alert section should have donation link', () => {
-    cy.get(selectors.donateAlert.link).should(
-      'have.attr',
+    cy.get('[data-cy="donate-link"]').should(
+      'contain.attr',
       'href',
       'https://www.freecodecamp.org/news/how-to-donate-to-free-code-camp'
     );


### PR DESCRIPTION
This time we very much care about the user, so we have to have them log
in.

I removed the 'after' hook, because it's something to be avoided if
possible. It should be possible to run each Cypress test independently
and not rely on any previous test to clean up.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
