### PR TITLE
fix(UI): render Rosetta as block

### DIFF
--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -169,6 +169,7 @@ export type ChallengeNode = {
     id: string;
     instructions: string;
     isComingSoon: boolean;
+    isStepBased: boolean;
     internal?: {
       content: string;
       contentDigest: string;

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -120,10 +120,7 @@ export class Block extends Component<BlockProps> {
     });
 
     const isProjectBlock = challenges.some(({ challenge }) => {
-      const isJsProject =
-        [3, 6, 10, 14, 17].includes(challenge.order) &&
-        challenge.challengeType === 5;
-
+      const isJsProject = challenge.isStepBased === true;
       const isOtherProject =
         challenge.challengeType === 3 ||
         challenge.challengeType === 4 ||

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -120,7 +120,7 @@ export class Block extends Component<BlockProps> {
     });
 
     const isProjectBlock = challenges.some(({ challenge }) => {
-      const isJsProject = challenge.isStepBased === true;
+      const isJsProject = challenge.isStepBased;
       const isOtherProject =
         challenge.challengeType === 3 ||
         challenge.challengeType === 4 ||

--- a/curriculum/challenges/_meta/d3-dashboard/meta.json
+++ b/curriculum/challenges/_meta/d3-dashboard/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "D3 Dashboard",
   "isUpcomingChange": true,
+  "isStepBased": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "d3-dashboard",

--- a/curriculum/challenges/_meta/learn-accessibility-by-building-a-quiz/meta.json
+++ b/curriculum/challenges/_meta/learn-accessibility-by-building-a-quiz/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Learn Accessibility by Building a Quiz",
   "isUpcomingChange": false,
+  "isStepBased": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "learn-accessibility-by-building-a-quiz",

--- a/curriculum/challenges/_meta/learn-basic-css-by-building-a-cafe-menu/meta.json
+++ b/curriculum/challenges/_meta/learn-basic-css-by-building-a-cafe-menu/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Learn Basic CSS by Building a Cafe Menu",
   "isUpcomingChange": false,
+  "isStepBased": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "learn-basic-css-by-building-a-cafe-menu",

--- a/curriculum/challenges/_meta/learn-basic-javascript-by-building-a-role-playing-game/meta.json
+++ b/curriculum/challenges/_meta/learn-basic-javascript-by-building-a-role-playing-game/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Learn Basic JavaScript By Building a Role Playing Game",
   "isUpcomingChange": true,
+  "isStepBased": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "learn-basic-javascript-by-building-a-role-playing-game",

--- a/curriculum/challenges/_meta/learn-css-animation-by-building-a-ferris-wheel/meta.json
+++ b/curriculum/challenges/_meta/learn-css-animation-by-building-a-ferris-wheel/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Learn CSS Animation by Building a Ferris Wheel",
   "isUpcomingChange": false,
+  "isStepBased": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "learn-css-animation-by-building-a-ferris-wheel",

--- a/curriculum/challenges/_meta/learn-css-colors-by-building-a-set-of-colored-markers/meta.json
+++ b/curriculum/challenges/_meta/learn-css-colors-by-building-a-set-of-colored-markers/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Learn CSS Colors by Building a Set of Colored Markers",
   "isUpcomingChange": false,
+  "isStepBased": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "learn-css-colors-by-building-a-set-of-colored-markers",

--- a/curriculum/challenges/_meta/learn-css-flexbox-by-building-a-photo-gallery/meta.json
+++ b/curriculum/challenges/_meta/learn-css-flexbox-by-building-a-photo-gallery/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Learn CSS Flexbox by Building a Photo Gallery",
   "isUpcomingChange": false,
+  "isStepBased": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "learn-css-flexbox-by-building-a-photo-gallery",

--- a/curriculum/challenges/_meta/learn-css-grid-by-building-a-magazine/meta.json
+++ b/curriculum/challenges/_meta/learn-css-grid-by-building-a-magazine/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Learn CSS Grid by Building a Magazine",
   "isUpcomingChange": false,
+  "isStepBased": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "learn-css-grid-by-building-a-magazine",

--- a/curriculum/challenges/_meta/learn-css-transforms-by-building-a-penguin/meta.json
+++ b/curriculum/challenges/_meta/learn-css-transforms-by-building-a-penguin/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Learn CSS Transforms by Building a Penguin",
   "isUpcomingChange": false,
+  "isStepBased": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "learn-css-transforms-by-building-a-penguin",

--- a/curriculum/challenges/_meta/learn-css-variables-by-building-a-city-skyline/meta.json
+++ b/curriculum/challenges/_meta/learn-css-variables-by-building-a-city-skyline/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Learn CSS Variables by Building a City Skyline",
   "isUpcomingChange": false,
+  "isStepBased": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "learn-css-variables-by-building-a-city-skyline",

--- a/curriculum/challenges/_meta/learn-form-validation-by-building-a-calorie-counter/meta.json
+++ b/curriculum/challenges/_meta/learn-form-validation-by-building-a-calorie-counter/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Learn Form Validation By Building a Calorie Counter",
   "isUpcomingChange": true,
+  "isStepBased": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "learn-form-validation-by-building-a-calorie-counter",

--- a/curriculum/challenges/_meta/learn-functional-programming-by-building-a-spreadsheet/meta.json
+++ b/curriculum/challenges/_meta/learn-functional-programming-by-building-a-spreadsheet/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Learn Functional Programming by Building a Spreadsheet",
   "isUpcomingChange": true,
+  "isStepBased": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "learn-functional-programming-by-building-a-spreadsheet",

--- a/curriculum/challenges/_meta/learn-html-by-building-a-cat-photo-app/meta.json
+++ b/curriculum/challenges/_meta/learn-html-by-building-a-cat-photo-app/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Learn HTML by Building a Cat Photo App",
   "isUpcomingChange": false,
+  "isStepBased": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "learn-html-by-building-a-cat-photo-app",

--- a/curriculum/challenges/_meta/learn-html-forms-by-building-a-registration-form/meta.json
+++ b/curriculum/challenges/_meta/learn-html-forms-by-building-a-registration-form/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Learn HTML Forms by Building a Registration Form",
   "isUpcomingChange": false,
+  "isStepBased": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "learn-html-forms-by-building-a-registration-form",

--- a/curriculum/challenges/_meta/learn-intermediate-css-by-building-a-picasso-painting/meta.json
+++ b/curriculum/challenges/_meta/learn-intermediate-css-by-building-a-picasso-painting/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Learn Intermediate CSS by Building a Picasso Painting",
   "isUpcomingChange": false,
+  "isStepBased": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "learn-intermediate-css-by-building-a-picasso-painting",

--- a/curriculum/challenges/_meta/learn-more-about-css-pseudo-selectors-by-building-a-balance-sheet/meta.json
+++ b/curriculum/challenges/_meta/learn-more-about-css-pseudo-selectors-by-building-a-balance-sheet/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Learn More About CSS Pseudo Selectors By Building A Balance Sheet",
   "isUpcomingChange": false,
+  "isStepBased": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "learn-more-about-css-pseudo-selectors-by-building-a-balance-sheet",

--- a/curriculum/challenges/_meta/learn-responsive-web-design-by-building-a-piano/meta.json
+++ b/curriculum/challenges/_meta/learn-responsive-web-design-by-building-a-piano/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Learn Responsive Web Design by Building a Piano",
   "isUpcomingChange": false,
+  "isStepBased": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "learn-responsive-web-design-by-building-a-piano",

--- a/curriculum/challenges/_meta/learn-the-css-box-model-by-building-a-rothko-painting/meta.json
+++ b/curriculum/challenges/_meta/learn-the-css-box-model-by-building-a-rothko-painting/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Learn the CSS Box Model by Building a Rothko Painting",
   "isUpcomingChange": false,
+  "isStepBased": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "learn-the-css-box-model-by-building-a-rothko-painting",

--- a/curriculum/challenges/_meta/learn-typography-by-building-a-nutrition-label/meta.json
+++ b/curriculum/challenges/_meta/learn-typography-by-building-a-nutrition-label/meta.json
@@ -1,6 +1,7 @@
 {
   "name": "Learn Typography by Building a Nutrition Label",
   "isUpcomingChange": false,
+  "isStepBased": true,
   "usesMultifileEditor": true,
   "hasEditableBoundaries": true,
   "dashedName": "learn-typography-by-building-a-nutrition-label",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #46006

<!-- Feel free to add any additional description of changes below this line -->
I've added the `isStepBased` property set to true on all step-based projects (in-production) in their `meta.json` files.

Result of Rosetta:
![image](https://user-images.githubusercontent.com/27147016/172012537-19a59fcf-9820-445e-acf4-a64b1ec3b671.png)
