### PR TITLE
fix(curriculum): fix mismatch description

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-typography-by-building-a-nutrition-label/615f42a021625f656101ef93.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-typography-by-building-a-nutrition-label/615f42a021625f656101ef93.md
@@ -25,7 +25,7 @@ Your new `span` element should have the `class` attribute set to `right`.
 assert(document.querySelector('span')?.classList?.contains('right'));
 ```
 
-Your `.right` element should have the text `2/3 cup (55g)`.
+Your `span` element should have the text `2/3 cup (55g)`.
 
 ```js
 assert(document.querySelector('span')?.textContent === '2/3 cup (55g)');


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

The assertion here is looking for the `span` element, but the description is talking about `.right` element. I know they are referring to the same element, but I think we should make a change here so they have the same name.
