### PR TITLE
fix: set _csrf to be httpOnly

### DIFF
--- a/api-server/src/server/middlewares/csurf.js
+++ b/api-server/src/server/middlewares/csurf.js
@@ -8,7 +8,7 @@ export const csrfOptions = {
 
 export default function getCsurf() {
   const protection = csurf({
-    cookie: csrfOptions
+    cookie: { ...csrfOptions, httpOnly: true }
   });
   return function csrf(req, res, next) {
     const { path } = req;

--- a/client/gatsby-browser.js
+++ b/client/gatsby-browser.js
@@ -30,9 +30,6 @@ export const wrapPageElement = layoutSelector;
 export const disableCorePrefetching = () => true;
 
 export const onClientEntry = () => {
-  // purge the csrf cookies, rather than relying what the browser decides a
-  // Session duration is
-  cookies.erase('_csrf');
   // the token must be erased since it is only valid for the old _csrf secret
   cookies.erase('csrf_token');
 };


### PR DESCRIPTION
There's no need for JS to access it, so we can safely set it to be
httpOnly

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
