### PR TITLE
test: fix multifile tests

### DIFF
--- a/cypress/integration/learn/challenges/multifile.js
+++ b/cypress/integration/learn/challenges/multifile.js
@@ -11,16 +11,17 @@ describe('Challenge with multifile editor', () => {
   });
 
   it('renders the file tab buttons', () => {
-    cy.get(selectors.monacoTabs).should('exist');
     cy.get(selectors.monacoTabs).contains('index.html');
     cy.get(selectors.monacoTabs).contains('styles.css');
   });
 
-  it('checks for correct text at different widths', () => {
-    cy.viewport(768, 660)
-      .get(selectors.testButton)
-      .contains('Check Your Code (Ctrl + Enter)');
+  it.only('checks for correct text at different widths', () => {
+    cy.viewport(768, 660);
+    cy.get(selectors.testButton).contains('Check Your Code (Ctrl + Enter)');
 
-    cy.viewport(767, 660).get(selectors.testButton).contains('Check Your Code');
+    cy.viewport(767, 660);
+    cy.get(selectors.testButton)
+      .should('not.contain.text', '(Ctrl + Enter)')
+      .contains('Check Your Code');
   });
 });


### PR DESCRIPTION
cy.viewport should not be chainable, hence the failure in CI. Also, the
tests need to check for the absence of (Ctrl + Enter), not the presence
Check Your Code since that's present for all viewports.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
