### PR TITLE
Contributing Chat Server - Direct Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ If you're confident it's a new bug and have confirmed that someone else is facin
 The freeCodeCamp.org community is possible thanks to thousands of kind volunteers like you. We welcome all contributions to the community and are excited to welcome you aboard.
 
 > #### [Please follow these steps to contribute](https://contribute.freecodecamp.org).
+> #### [Here for the contribution chat server](https://chat.freecodecamp.org/home).
 
 ### Platform, Build, and Deployment Status
 


### PR DESCRIPTION
A link that took you straight to the chat server.  There is only one location on the README and it is not located in the contribution section.  The other location is deeper into the documentation.  Proposal is to have a link that is in the READMEs contribution section so new contributors can ask questions and see the community straight away.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
