### PR TITLE
Remove .only from test

### DIFF
--- a/cypress/integration/learn/challenges/multifile.js
+++ b/cypress/integration/learn/challenges/multifile.js
@@ -15,7 +15,7 @@ describe('Challenge with multifile editor', () => {
     cy.get(selectors.monacoTabs).contains('styles.css');
   });
 
-  it.only('checks for correct text at different widths', () => {
+  it('checks for correct text at different widths', () => {
     cy.viewport(768, 660);
     cy.get(selectors.testButton).contains('Check Your Code (Ctrl + Enter)');
 


### PR DESCRIPTION
- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Removes `.only` left behind (I assume) in #46384

cc @raisedadead, @ojeytonwilliams 
