### PR TITLE
fix: make superblock data paths match normal paths

### DIFF
--- a/config/certification-settings.ts
+++ b/config/certification-settings.ts
@@ -120,7 +120,6 @@ export const superBlockCertTypeMap = {
   [SuperBlocks.RelationalDb]: certTypes.relationalDatabaseV8,
 
   // post-modern
-  // TODO: use enum
   [SuperBlocks.RespWebDesignNew]: certTypes.respWebDesign,
   [SuperBlocks.JsAlgoDataStructNew]: certTypes.jsAlgoDataStruct
 };

--- a/config/certification-settings.ts
+++ b/config/certification-settings.ts
@@ -120,6 +120,7 @@ export const superBlockCertTypeMap = {
   [SuperBlocks.RelationalDb]: certTypes.relationalDatabaseV8,
 
   // post-modern
+  // TODO: use enum
   [SuperBlocks.RespWebDesignNew]: certTypes.respWebDesign,
   [SuperBlocks.JsAlgoDataStructNew]: certTypes.jsAlgoDataStruct
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -44235,7 +44235,8 @@
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -53678,7 +53679,8 @@
       "license": "BSD-3-Clause",
       "devDependencies": {
         "debug": "4.3.2",
-        "dotenv": "10.0.0"
+        "dotenv": "10.0.0",
+        "readdirp": "^3.6.0"
       },
       "engines": {
         "node": ">=16",
@@ -56061,7 +56063,8 @@
       "version": "file:tools/scripts/build",
       "requires": {
         "debug": "4.3.2",
-        "dotenv": "10.0.0"
+        "dotenv": "10.0.0",
+        "readdirp": "*"
       },
       "dependencies": {
         "debug": {
@@ -83802,6 +83805,8 @@
     },
     "readdirp": {
       "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "requires": {
         "picomatch": "^2.2.1"
       }

--- a/tools/scripts/build/build-external-curricula-data.test.ts
+++ b/tools/scripts/build/build-external-curricula-data.test.ts
@@ -1,5 +1,7 @@
 import path from 'path';
 import fs from 'fs';
+
+import readdirp from 'readdirp';
 import { AssertionError } from 'chai';
 import envData from '../../../config/env.json';
 import { SuperBlocks } from '../../../config/certification-settings';
@@ -32,10 +34,10 @@ if (envData.clientLocale == 'english' && !envData.showUpcomingChanges) {
       expect(fs.existsSync(blockIntroPath)).toBe(true);
     });
 
-    test('the files generated should have the correct schema', () => {
-      const fileArray = fs.readdirSync(
-        `${mobileStaticPath}/curriculum-data/${VERSION}`
-      );
+    test('the files generated should have the correct schema', async () => {
+      const fileArray = (
+        await readdirp.promise(`${mobileStaticPath}/curriculum-data/${VERSION}`)
+      ).map(file => file.path);
 
       fileArray
         .filter(fileInArray => fileInArray !== 'available-superblocks.json')

--- a/tools/scripts/build/build-external-curricula-data.test.ts
+++ b/tools/scripts/build/build-external-curricula-data.test.ts
@@ -5,7 +5,10 @@ import readdirp from 'readdirp';
 import { AssertionError } from 'chai';
 import envData from '../../../config/env.json';
 import { SuperBlocks } from '../../../config/certification-settings';
-import { mobileSchemaValidator } from './mobileSchema';
+import {
+  mobileSchemaValidator,
+  availableSuperBlocksValidator
+} from './mobileSchema';
 import { superBlockMobileAppOrder } from './build-external-curricula-data';
 
 if (envData.clientLocale == 'english' && !envData.showUpcomingChanges) {
@@ -35,15 +38,22 @@ if (envData.clientLocale == 'english' && !envData.showUpcomingChanges) {
     });
 
     test('the available-superblocks file should have the correct structure', async () => {
-      const availableSuperblocks = JSON.parse(
+      const availableSuperblocks: unknown = JSON.parse(
         await fs.promises.readFile(
           `${mobileStaticPath}/curriculum-data/${VERSION}/available-superblocks.json`,
           'utf-8'
         )
-      ) as { superblocks: unknown[][] };
-      const superblockOrder = availableSuperblocks.superblocks[0];
-      const superblockNames = availableSuperblocks.superblocks[1];
-      expect(superblockOrder.length).toBe(superblockNames.length);
+      );
+      const validateAvailableSuperBlocks = availableSuperBlocksValidator();
+      console.log(availableSuperblocks);
+      const result = validateAvailableSuperBlocks(availableSuperblocks);
+
+      if (result.error) {
+        throw new AssertionError(
+          result.error.toString(),
+          `file: available-superblocks.json`
+        );
+      }
     });
 
     test('the files generated should have the correct schema', async () => {

--- a/tools/scripts/build/build-external-curricula-data.test.ts
+++ b/tools/scripts/build/build-external-curricula-data.test.ts
@@ -34,6 +34,18 @@ if (envData.clientLocale == 'english' && !envData.showUpcomingChanges) {
       expect(fs.existsSync(blockIntroPath)).toBe(true);
     });
 
+    test('the available-superblocks file should have the correct structure', async () => {
+      const availableSuperblocks = JSON.parse(
+        await fs.promises.readFile(
+          `${mobileStaticPath}/curriculum-data/${VERSION}/available-superblocks.json`,
+          'utf-8'
+        )
+      ) as { superblocks: unknown[][] };
+      const superblockOrder = availableSuperblocks.superblocks[0];
+      const superblockNames = availableSuperblocks.superblocks[1];
+      expect(superblockOrder.length).toBe(superblockNames.length);
+    });
+
     test('the files generated should have the correct schema', async () => {
       const fileArray = (
         await readdirp.promise(`${mobileStaticPath}/curriculum-data/${VERSION}`)

--- a/tools/scripts/build/build-external-curricula-data.test.ts
+++ b/tools/scripts/build/build-external-curricula-data.test.ts
@@ -6,46 +6,38 @@ import { AssertionError } from 'chai';
 import envData from '../../../config/env.json';
 import { SuperBlocks } from '../../../config/certification-settings';
 import {
-  mobileSchemaValidator,
+  superblockSchemaValidator,
   availableSuperBlocksValidator
-} from './mobileSchema';
-import { superBlockMobileAppOrder } from './build-external-curricula-data';
+} from './external-data-schema';
+import { orderedSuperBlockInfo } from './build-external-curricula-data';
 
 if (envData.clientLocale == 'english' && !envData.showUpcomingChanges) {
   const VERSION = 'v1';
 
-  describe('mobile curriculum build', () => {
-    const mobileStaticPath = path.resolve(__dirname, '../../../client/static');
-    const blockIntroPath = path.resolve(
-      __dirname,
-      '../../../client/i18n/locales/english/intro.json'
-    );
+  describe('external curriculum data build', () => {
+    const clientStaticPath = path.resolve(__dirname, '../../../client/static');
 
-    const validateMobileSuperBlock = mobileSchemaValidator();
+    const validateSuperBlock = superblockSchemaValidator();
 
-    test('the mobile curriculum should have a static folder with multiple files', () => {
+    test("the external curriculum data should be in the client's static directory", () => {
       expect(
-        fs.existsSync(`${mobileStaticPath}/curriculum-data/${VERSION}`)
+        fs.existsSync(`${clientStaticPath}/curriculum-data/${VERSION}`)
       ).toBe(true);
 
       expect(
-        fs.readdirSync(`${mobileStaticPath}/curriculum-data/${VERSION}`).length
+        fs.readdirSync(`${clientStaticPath}/curriculum-data/${VERSION}`).length
       ).toBeGreaterThan(0);
     });
 
-    test('the mobile curriculum should have access to the intro.json file', () => {
-      expect(fs.existsSync(blockIntroPath)).toBe(true);
-    });
-
     test('the available-superblocks file should have the correct structure', async () => {
+      const validateAvailableSuperBlocks = availableSuperBlocksValidator();
       const availableSuperblocks: unknown = JSON.parse(
         await fs.promises.readFile(
-          `${mobileStaticPath}/curriculum-data/${VERSION}/available-superblocks.json`,
+          `${clientStaticPath}/curriculum-data/${VERSION}/available-superblocks.json`,
           'utf-8'
         )
       );
-      const validateAvailableSuperBlocks = availableSuperBlocksValidator();
-      console.log(availableSuperblocks);
+
       const result = validateAvailableSuperBlocks(availableSuperblocks);
 
       if (result.error) {
@@ -58,18 +50,18 @@ if (envData.clientLocale == 'english' && !envData.showUpcomingChanges) {
 
     test('the files generated should have the correct schema', async () => {
       const fileArray = (
-        await readdirp.promise(`${mobileStaticPath}/curriculum-data/${VERSION}`)
+        await readdirp.promise(`${clientStaticPath}/curriculum-data/${VERSION}`)
       ).map(file => file.path);
 
       fileArray
         .filter(fileInArray => fileInArray !== 'available-superblocks.json')
         .forEach(fileInArray => {
           const fileContent = fs.readFileSync(
-            `${mobileStaticPath}/curriculum-data/${VERSION}/${fileInArray}`,
+            `${clientStaticPath}/curriculum-data/${VERSION}/${fileInArray}`,
             'utf-8'
           );
 
-          const result = validateMobileSuperBlock(JSON.parse(fileContent));
+          const result = validateSuperBlock(JSON.parse(fileContent));
 
           if (result.error) {
             throw new AssertionError(
@@ -80,8 +72,8 @@ if (envData.clientLocale == 'english' && !envData.showUpcomingChanges) {
         });
     });
 
-    test('All SuperBlocks should be present in the mobile SuperBlock object', () => {
-      const dashedNames = superBlockMobileAppOrder.map(
+    test('All public SuperBlocks should be present in the SuperBlock object', () => {
+      const dashedNames = orderedSuperBlockInfo.map(
         ({ dashedName }) => dashedName
       );
       // TODO: this is a hack, we should have a single source of truth for the
@@ -93,13 +85,13 @@ if (envData.clientLocale == 'english' && !envData.showUpcomingChanges) {
       expect(dashedNames).toEqual(
         expect.arrayContaining(publicSuperBlockNames)
       );
-      expect(Object.keys(superBlockMobileAppOrder)).toHaveLength(
+      expect(Object.keys(orderedSuperBlockInfo)).toHaveLength(
         publicSuperBlockNames.length
       );
     });
   });
 } else {
-  describe.skip('Mobile curriculum is not localized', () => {
+  describe.skip('External curriculum data is localized', () => {
     test.todo('localized tests');
   });
 }

--- a/tools/scripts/build/build-external-curricula-data.ts
+++ b/tools/scripts/build/build-external-curricula-data.ts
@@ -22,19 +22,19 @@ interface Block {
 }
 
 export const orderedSuperBlockInfo = [
-  { dashedName: '2022/responsive-web-design', public: false },
-  { dashedName: 'responsive-web-design', public: true },
-  { dashedName: 'javascript-algorithms-and-data-structures', public: true },
-  { dashedName: 'front-end-development-libraries', public: false },
-  { dashedName: 'data-visualization', public: false },
-  { dashedName: 'back-end-development-and-apis', public: false },
-  { dashedName: 'quality-assurance', public: false },
-  { dashedName: 'scientific-computing-with-python', public: false },
-  { dashedName: 'data-analysis-with-python', public: false },
-  { dashedName: 'information-security', public: false },
-  { dashedName: 'machine-learning-with-python', public: false },
-  { dashedName: 'coding-interview-prep', public: false },
-  { dashedName: 'relational-database', public: false }
+  { dashedName: SuperBlocks.RespWebDesignNew, public: false },
+  { dashedName: SuperBlocks.RespWebDesign, public: true },
+  { dashedName: SuperBlocks.JsAlgoDataStruct, public: true },
+  { dashedName: SuperBlocks.FrontEndDevLibs, public: false },
+  { dashedName: SuperBlocks.DataVis, public: false },
+  { dashedName: SuperBlocks.BackEndDevApis, public: false },
+  { dashedName: SuperBlocks.QualityAssurance, public: false },
+  { dashedName: SuperBlocks.SciCompPy, public: false },
+  { dashedName: SuperBlocks.DataAnalysisPy, public: false },
+  { dashedName: SuperBlocks.InfoSec, public: false },
+  { dashedName: SuperBlocks.MachineLearningPy, public: false },
+  { dashedName: SuperBlocks.CodingInterviewPrep, public: false },
+  { dashedName: SuperBlocks.RelationalDb, public: false }
 ];
 
 const dashedNames = orderedSuperBlockInfo.map(({ dashedName }) => dashedName);
@@ -62,7 +62,7 @@ export function buildExtCurriculumData(
     writeToFile('available-superblocks', {
       superblocks: orderedSuperBlockInfo.map(x => ({
         ...x,
-        title: getSuperBlockTitle(x.dashedName as SuperBlocks)
+        title: getSuperBlockTitle(x.dashedName)
       }))
     });
 
@@ -104,11 +104,11 @@ export function buildExtCurriculumData(
     return intros[superBlockKeys]['blocks'][blockKey]['intro'];
   }
 
-  function getSuperBlockTitle(superBlockKeys: SuperBlocks): string {
+  function getSuperBlockTitle(superBlock: SuperBlocks): string {
     const superBlocks = JSON.parse(
       readFileSync(blockIntroPath, 'utf-8')
     ) as Intro;
 
-    return superBlocks[superBlockKeys].title;
+    return superBlocks[superBlock].title;
   }
 }

--- a/tools/scripts/build/build-external-curricula-data.ts
+++ b/tools/scripts/build/build-external-curricula-data.ts
@@ -4,8 +4,6 @@ import { SuperBlocks } from '../../../config/certification-settings';
 
 type Intro = { [keyValue in SuperBlocks]: IntroProps };
 export type Curriculum = { [keyValue in SuperBlocks]: CurriculumProps };
-type SuperBlockKeys = keyof typeof SuperBlocks;
-type SuperBlockValues = typeof SuperBlocks[SuperBlockKeys];
 
 interface IntroProps extends CurriculumProps {
   title: string;
@@ -64,10 +62,10 @@ export function buildExtCurriculumData(
     );
 
     writeToFile('available-superblocks', {
-      superblocks: [
-        superBlockMobileAppOrder,
-        superBlockKeys.map(superblock => getSuperBlockName(superblock))
-      ]
+      superblocks: superBlockMobileAppOrder.map(x => ({
+        ...x,
+        title: getSuperBlockTitle(x.dashedName as SuperBlocks)
+      }))
     });
 
     for (const superBlockKey of superBlockKeys) {
@@ -100,7 +98,7 @@ export function buildExtCurriculumData(
   }
 
   function getBlockDescription(
-    superBlockKeys: SuperBlockValues,
+    superBlockKeys: SuperBlocks,
     blockKey: string
   ): string[] {
     const intros = JSON.parse(readFileSync(blockIntroPath, 'utf-8')) as Intro;
@@ -108,7 +106,7 @@ export function buildExtCurriculumData(
     return intros[superBlockKeys]['blocks'][blockKey]['intro'];
   }
 
-  function getSuperBlockName(superBlockKeys: SuperBlockValues): string {
+  function getSuperBlockTitle(superBlockKeys: SuperBlocks): string {
     const superBlocks = JSON.parse(
       readFileSync(blockIntroPath, 'utf-8')
     ) as Intro;

--- a/tools/scripts/build/build-external-curricula-data.ts
+++ b/tools/scripts/build/build-external-curricula-data.ts
@@ -21,7 +21,7 @@ interface Block {
   meta: Record<string, unknown>;
 }
 
-export const superBlockMobileAppOrder = [
+export const orderedSuperBlockInfo = [
   { dashedName: '2022/responsive-web-design', public: false },
   { dashedName: 'responsive-web-design', public: true },
   { dashedName: 'javascript-algorithms-and-data-structures', public: true },
@@ -37,9 +37,7 @@ export const superBlockMobileAppOrder = [
   { dashedName: 'relational-database', public: false }
 ];
 
-const dashedNames = superBlockMobileAppOrder.map(
-  ({ dashedName }) => dashedName
-);
+const dashedNames = orderedSuperBlockInfo.map(({ dashedName }) => dashedName);
 
 export function buildExtCurriculumData(
   ver: string,
@@ -62,7 +60,7 @@ export function buildExtCurriculumData(
     );
 
     writeToFile('available-superblocks', {
-      superblocks: superBlockMobileAppOrder.map(x => ({
+      superblocks: orderedSuperBlockInfo.map(x => ({
         ...x,
         title: getSuperBlockTitle(x.dashedName as SuperBlocks)
       }))

--- a/tools/scripts/build/build-external-curricula-data.ts
+++ b/tools/scripts/build/build-external-curricula-data.ts
@@ -1,6 +1,10 @@
 import { mkdirSync, writeFileSync, readFileSync } from 'fs';
 import { resolve, dirname } from 'path';
-import { SuperBlocks } from '../../../config/certification-settings';
+import {
+  SuperBlocks,
+  completionHours,
+  superBlockCertTypeMap
+} from '../../../config/certification-settings';
 
 type Intro = { [keyValue in SuperBlocks]: IntroProps };
 export type Curriculum = { [keyValue in SuperBlocks]: CurriculumProps };
@@ -35,9 +39,16 @@ export const orderedSuperBlockInfo = [
   { dashedName: SuperBlocks.MachineLearningPy, public: false },
   { dashedName: SuperBlocks.CodingInterviewPrep, public: false },
   { dashedName: SuperBlocks.RelationalDb, public: false }
-];
+].map(info => ({ ...info, hours: dashedNameToHours(info.dashedName) }));
 
 const dashedNames = orderedSuperBlockInfo.map(({ dashedName }) => dashedName);
+
+function dashedNameToHours(dashedName: SuperBlocks): number {
+  const certType =
+    superBlockCertTypeMap[dashedName as keyof typeof superBlockCertTypeMap];
+
+  return completionHours[certType];
+}
 
 export function buildExtCurriculumData(
   ver: string,

--- a/tools/scripts/build/build-external-curricula-data.ts
+++ b/tools/scripts/build/build-external-curricula-data.ts
@@ -1,10 +1,6 @@
 import { mkdirSync, writeFileSync, readFileSync } from 'fs';
 import { resolve, dirname } from 'path';
-import {
-  SuperBlocks,
-  completionHours,
-  superBlockCertTypeMap
-} from '../../../config/certification-settings';
+import { SuperBlocks } from '../../../config/certification-settings';
 
 type Intro = { [keyValue in SuperBlocks]: IntroProps };
 export type Curriculum = { [keyValue in SuperBlocks]: CurriculumProps };
@@ -39,16 +35,9 @@ export const orderedSuperBlockInfo = [
   { dashedName: SuperBlocks.MachineLearningPy, public: false },
   { dashedName: SuperBlocks.CodingInterviewPrep, public: false },
   { dashedName: SuperBlocks.RelationalDb, public: false }
-].map(info => ({ ...info, hours: dashedNameToHours(info.dashedName) }));
+];
 
 const dashedNames = orderedSuperBlockInfo.map(({ dashedName }) => dashedName);
-
-function dashedNameToHours(dashedName: SuperBlocks): number {
-  const certType =
-    superBlockCertTypeMap[dashedName as keyof typeof superBlockCertTypeMap];
-
-  return completionHours[certType];
-}
 
 export function buildExtCurriculumData(
   ver: string,

--- a/tools/scripts/build/build-external-curricula-data.ts
+++ b/tools/scripts/build/build-external-curricula-data.ts
@@ -1,5 +1,5 @@
 import { mkdirSync, writeFileSync, readFileSync } from 'fs';
-import { resolve } from 'path';
+import { resolve, dirname } from 'path';
 import { SuperBlocks } from '../../../config/certification-settings';
 
 type Intro = { [keyValue in SuperBlocks]: IntroProps };
@@ -86,15 +86,13 @@ export function buildExtCurriculumData(
           curriculum[superBlockKey]['blocks'][blockNames[j]]['meta'];
       }
 
-      writeToFile(superBlockKeys[i].replace(/\//, '-'), superBlock);
+      writeToFile(superBlockKeys[i], superBlock);
     }
   }
 
   function writeToFile(fileName: string, data: Record<string, unknown>): void {
-    mkdirSync(versionPath, { recursive: true });
-
     const filePath = `${versionPath}/${fileName}.json`;
-
+    mkdirSync(dirname(filePath), { recursive: true });
     writeFileSync(filePath, JSON.stringify(data, null, 2));
   }
 

--- a/tools/scripts/build/build-external-curricula-data.ts
+++ b/tools/scripts/build/build-external-curricula-data.ts
@@ -39,6 +39,10 @@ export const superBlockMobileAppOrder = [
   { dashedName: 'relational-database', public: false }
 ];
 
+const dashedNames = superBlockMobileAppOrder.map(
+  ({ dashedName }) => dashedName
+);
+
 export function buildExtCurriculumData(
   ver: string,
   curriculum: Curriculum
@@ -55,21 +59,20 @@ export function buildExtCurriculumData(
   parseCurriculumData();
 
   function parseCurriculumData() {
-    const superBlockKeys = Object.values(SuperBlocks);
+    const superBlockKeys = Object.values(SuperBlocks).filter(x =>
+      dashedNames.includes(x)
+    );
 
     writeToFile('available-superblocks', {
       superblocks: [
         superBlockMobileAppOrder,
-        Object.values(SuperBlocks).map(superblock =>
-          getSuperBlockName(superblock)
-        )
+        superBlockKeys.map(superblock => getSuperBlockName(superblock))
       ]
     });
 
-    for (let i = 0; i < superBlockKeys.length; i++) {
+    for (const superBlockKey of superBlockKeys) {
       const superBlock = <Curriculum>{};
-      const superBlockKey = Object.values(SuperBlocks)[i];
-      const blockNames = Object.keys(curriculum[superBlockKeys[i]].blocks);
+      const blockNames = Object.keys(curriculum[superBlockKey].blocks);
 
       if (blockNames.length === 0) continue;
 
@@ -86,7 +89,7 @@ export function buildExtCurriculumData(
           curriculum[superBlockKey]['blocks'][blockNames[j]]['meta'];
       }
 
-      writeToFile(superBlockKeys[i], superBlock);
+      writeToFile(superBlockKey, superBlock);
     }
   }
 

--- a/tools/scripts/build/external-data-schema.js
+++ b/tools/scripts/build/external-data-schema.js
@@ -32,8 +32,7 @@ const availableSuperBlocksSchema = Joi.object({
     Joi.object({
       dashedName: Joi.string().required(),
       title: Joi.string().required(),
-      public: Joi.bool().required(),
-      hours: Joi.number()
+      public: Joi.bool().required()
     })
   )
 });

--- a/tools/scripts/build/external-data-schema.js
+++ b/tools/scripts/build/external-data-schema.js
@@ -37,7 +37,8 @@ const availableSuperBlocksSchema = Joi.object({
   )
 });
 
-exports.mobileSchemaValidator = () => superblock => schema.validate(superblock);
+exports.superblockSchemaValidator = () => superblock =>
+  schema.validate(superblock);
 
 exports.availableSuperBlocksValidator = () => data =>
   availableSuperBlocksSchema.validate(data);

--- a/tools/scripts/build/external-data-schema.js
+++ b/tools/scripts/build/external-data-schema.js
@@ -32,7 +32,8 @@ const availableSuperBlocksSchema = Joi.object({
     Joi.object({
       dashedName: Joi.string().required(),
       title: Joi.string().required(),
-      public: Joi.bool().required()
+      public: Joi.bool().required(),
+      hours: Joi.number()
     })
   )
 });

--- a/tools/scripts/build/mobileSchema.js
+++ b/tools/scripts/build/mobileSchema.js
@@ -27,6 +27,17 @@ const schema = Joi.object({}).pattern(
   Joi.object().concat(subSchema)
 );
 
-exports.mobileSchemaValidator = () => {
-  return superblock => schema.validate(superblock);
-};
+const availableSuperBlocksSchema = Joi.object({
+  superblocks: Joi.array().items(
+    Joi.object({
+      dashedName: Joi.string().required(),
+      title: Joi.string().required(),
+      public: Joi.bool().required()
+    })
+  )
+});
+
+exports.mobileSchemaValidator = () => superblock => schema.validate(superblock);
+
+exports.availableSuperBlocksValidator = () => data =>
+  availableSuperBlocksSchema.validate(data);

--- a/tools/scripts/build/package.json
+++ b/tools/scripts/build/package.json
@@ -20,6 +20,7 @@
   "main": "none",
   "devDependencies": {
     "debug": "4.3.2",
-    "dotenv": "10.0.0"
+    "dotenv": "10.0.0",
+    "readdirp": "^3.6.0"
   }
 }


### PR DESCRIPTION
@Sembauke I know you had reservations about this, but it's less hacky if the /curriculum-data paths match the /learn paths.  I figured I'd create the PR quickly, so we have something concrete to discuss!