### PR TITLE
fix: slightly improve logging from promises

### DIFF
--- a/client/src/client/workers/test-evaluator.ts
+++ b/client/src/client/workers/test-evaluator.ts
@@ -104,13 +104,13 @@ ctx.onmessage = async (e: TestEvaluatorEvent) => {
     try {
       // Logging is proxyed after the build to catch console.log messages
       // generated during testing.
-      testResult = eval(`${
+      testResult = (await eval(`${
         e.data?.removeComments ? removeJSComments(e.data.build) : e.data.build
       }
 __utils.flushLogs();
 __userCodeWasExecuted = true;
 __utils.toggleProxyLogger(true);
-${e.data.testString}`) as unknown;
+${e.data.testString}`)) as unknown;
     } catch (err) {
       if (__userCodeWasExecuted) {
         // rethrow error, since test failed.


### PR DESCRIPTION
This isn't a complete fix, but it does catch some logs from promises

```js
promise.then(x => console.log(x))
```

seems to work

```js
promise.then(x => console.log(x)).then(
 () => console.log('another'))
```

only shows the first log.

The root cause is that the worker gets terminated once the test results have been sent to it.  However, the promises are not guaranteed to be resolved before that happens.  `await`ing the evaluation seems to help a little, but for some reason doesn't handle chaining `then`s.

ref: https://github.com/freeCodeCamp/freeCodeCamp/issues/38819

To test put

```js
const makeServerRequest = new Promise((resolve, reject) => {
  // responseFromServer is set to true to represent a successful response from a server
  let responseFromServer = true;
      console.log('in promise')
  if(responseFromServer) {
    resolve("We got the data");
  } else {  
    reject("Data not received");
  }
});

makeServerRequest.then(x => {console.log(x); return x}).then(() => console.log('final log'))
```

into any JS challenge.