### PR TITLE
fix: use certification hours consistently

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -290,7 +290,7 @@
     "scrimba-tip": "Tip: If the mini-browser is covering the code, click and drag to move it. Also, feel free to stop and edit the code in the video at any time.",
     "chal-preview": "Challenge Preview",
     "cert-map-estimates": {
-      "certs": "{{title}} Certification (300\u00A0hours)",
+      "certs": "{{title}} Certification ({{hours}}\u00A0hours)",
       "coding-prep": "{{title}} (Thousands of hours of challenges)"
     },
     "editor-tabs": {

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -290,8 +290,7 @@
     "scrimba-tip": "Tip: If the mini-browser is covering the code, click and drag to move it. Also, feel free to stop and edit the code in the video at any time.",
     "chal-preview": "Challenge Preview",
     "cert-map-estimates": {
-      "certs": "{{title}} Certification ({{hours}}\u00A0hours)",
-      "coding-prep": "{{title}} (Thousands of hours of challenges)"
+      "certs": "{{title}} Certification"
     },
     "editor-tabs": {
       "info": "Info",

--- a/client/src/components/Map/index.tsx
+++ b/client/src/components/Map/index.tsx
@@ -2,11 +2,7 @@ import { graphql, useStaticQuery } from 'gatsby';
 import i18next from 'i18next';
 import React from 'react';
 
-import {
-  SuperBlocks,
-  completionHours,
-  superBlockCertTypeMap
-} from '../../../../config/certification-settings';
+import { SuperBlocks } from '../../../../config/certification-settings';
 import envData from '../../../../config/env.json';
 import { isAuditedCert } from '../../../../utils/is-audited';
 import { generateIconComponent } from '../../assets/icons';
@@ -32,12 +28,9 @@ interface MapData {
 function createSuperBlockTitle(superBlock: SuperBlocks) {
   const superBlockTitle = i18next.t(`intro:${superBlock}.title`);
   return superBlock === 'coding-interview-prep'
-    ? i18next.t('learn.cert-map-estimates.coding-prep', {
-        title: superBlockTitle
-      })
+    ? superBlockTitle
     : i18next.t('learn.cert-map-estimates.certs', {
-        title: superBlockTitle,
-        hours: completionHours[superBlockCertTypeMap[superBlock]]
+        title: superBlockTitle
       });
 }
 

--- a/client/src/components/Map/index.tsx
+++ b/client/src/components/Map/index.tsx
@@ -2,7 +2,11 @@ import { graphql, useStaticQuery } from 'gatsby';
 import i18next from 'i18next';
 import React from 'react';
 
-import { SuperBlocks } from '../../../../config/certification-settings';
+import {
+  SuperBlocks,
+  completionHours,
+  superBlockCertTypeMap
+} from '../../../../config/certification-settings';
 import envData from '../../../../config/env.json';
 import { isAuditedCert } from '../../../../utils/is-audited';
 import { generateIconComponent } from '../../assets/icons';
@@ -31,7 +35,10 @@ function createSuperBlockTitle(superBlock: SuperBlocks) {
     ? i18next.t('learn.cert-map-estimates.coding-prep', {
         title: superBlockTitle
       })
-    : i18next.t('learn.cert-map-estimates.certs', { title: superBlockTitle });
+    : i18next.t('learn.cert-map-estimates.certs', {
+        title: superBlockTitle,
+        hours: completionHours[superBlockCertTypeMap[superBlock]]
+      });
 }
 
 const linkSpacingStyle = {

--- a/config/certification-settings.ts
+++ b/config/certification-settings.ts
@@ -15,7 +15,7 @@ export const certTypes = {
   machineLearningPyV7: 'isMachineLearningPyCertV7',
   fullStack: 'isFullStackCert',
   relationalDatabaseV8: 'isRelationalDatabaseCertV8'
-};
+} as const;
 
 export enum SuperBlocks {
   RespWebDesignNew = '2022/responsive-web-design',
@@ -54,9 +54,9 @@ export const certIds = {
 };
 
 export const completionHours = {
-  [certTypes.frontEnd]: 400,
-  [certTypes.backEnd]: 400,
-  [certTypes.dataVis]: 400,
+  [certTypes.frontEnd]: 300,
+  [certTypes.backEnd]: 300,
+  [certTypes.dataVis]: 300,
   [certTypes.infosecQa]: 300,
   [certTypes.fullStack]: 1800,
   [certTypes.respWebDesign]: 300,

--- a/cypress/integration/learn/index.js
+++ b/cypress/integration/learn/index.js
@@ -18,7 +18,7 @@ const superBlockNames = [
   'Data Analysis with Python Certification',
   'Information Security Certification',
   'Machine Learning with Python Certification',
-  'Coding Interview Prep (Thousands of hours of challenges)',
+  'Coding Interview Prep',
   'Relational Database (Beta) Certification'
 ];
 


### PR DESCRIPTION
Since the value appearing on the /learn map was hardcoded, it could have
gone out of sync with the certifications, which were relying on
certification-settings

Also, for simplicity (and because it's hard to estimate accurately), all
the certifications are set to 300 hours.  Fullstack being the exception,
as it is a set of certifications.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
