### PR TITLE
feat: add workflow for new contributors

### DIFF
--- a/.github/workflows/crowdin-download.client-ui.yml
+++ b/.github/workflows/crowdin-download.client-ui.yml
@@ -1,4 +1,4 @@
-name: Crowdin - Download Client UI
+name: i18n - Download Client UI
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/crowdin-download.curriculum.yml
+++ b/.github/workflows/crowdin-download.curriculum.yml
@@ -1,4 +1,4 @@
-name: Crowdin - Download Curriculum
+name: i18n - Download Curriculum
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/crowdin-download.docs.yml
+++ b/.github/workflows/crowdin-download.docs.yml
@@ -1,4 +1,4 @@
-name: Crowdin - Download Docs
+name: i18n - Download Docs
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/crowdin-upload.client-ui.yml
+++ b/.github/workflows/crowdin-upload.client-ui.yml
@@ -1,4 +1,4 @@
-name: Crowdin - Upload Client UI
+name: i18n - Upload Client UI
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/crowdin-upload.curriculum.yml
+++ b/.github/workflows/crowdin-upload.curriculum.yml
@@ -1,4 +1,4 @@
-name: Crowdin - Upload Curriculum
+name: i18n - Upload Curriculum
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/crowdin-upload.docs.yml
+++ b/.github/workflows/crowdin-upload.docs.yml
@@ -1,4 +1,4 @@
-name: Crowdin - Upload Docs
+name: i18n - Upload Docs
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/welcome-new-lgtm.yml
+++ b/.github/workflows/welcome-new-lgtm.yml
@@ -1,0 +1,19 @@
+name: Github - Welcome First-timers
+on:
+  pull_request:
+    types: [opened, closed]
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: wow-actions/welcome@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FIRST_PR_MERGED: |
+            #### :sparkles: :tada: **AWESOME!** :tada: :sparkles:
+
+            Hi @{{ author }},
+
+            Thanks for this pull request and for contributing to the code-base for the first time. We are looking forward to more contributions from you in the future.
+
+            Cheers & happy contributing!


### PR DESCRIPTION
Sometimes we miss congratulating new contributors because sometimes we merge PRs automatically when requirements are met. This should ensure we are not missing the courtesy of welcoming new contributors.

Also. I updated some naming conventions for our actions earlier. This PR updates that slightly too.