### PR TITLE
fix(actions): drop npm caching

### DIFF
--- a/.github/workflows/codesee-diagram.yml
+++ b/.github/workflows/codesee-diagram.yml
@@ -43,7 +43,6 @@ jobs:
         if: ${{ fromJSON(steps.detect-languages.outputs.languages).javascript }}
         with:
           node-version: '16'
-          cache: npm
 
       - name: Configure Python 3.x
         uses: actions/setup-python@98f2ad02fd48d057ee3b4d4f66525b231c3e52b6 # tag=v3

--- a/.github/workflows/node.js-tests-upcoming.yml
+++ b/.github/workflows/node.js-tests-upcoming.yml
@@ -67,7 +67,6 @@ jobs:
         uses: actions/setup-node@eeb10cff27034e7acf239c5d29f62154018672fd # tag=v3
         with:
           node-version: ${{ matrix.node-version }}
-          cache: npm
 
       - name: Set Environment variables
         run: |

--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -72,7 +72,6 @@ jobs:
         uses: actions/setup-node@eeb10cff27034e7acf239c5d29f62154018672fd # tag=v3
         with:
           node-version: ${{ matrix.node-version }}
-          cache: npm
 
       - name: Set Environment variables
         run: |
@@ -107,7 +106,6 @@ jobs:
         uses: actions/setup-node@eeb10cff27034e7acf239c5d29f62154018672fd # tag=v3
         with:
           node-version: ${{ matrix.node-version }}
-          cache: npm
 
       - name: Set Environment variables
         run: |
@@ -144,7 +142,6 @@ jobs:
         uses: actions/setup-node@eeb10cff27034e7acf239c5d29f62154018672fd # tag=v3
         with:
           node-version: ${{ matrix.node-version }}
-          cache: npm
 
       - name: Set Environment variables
         run: |


### PR DESCRIPTION
Going ahead and dropping the caching for npm node modules installation steps. This is prone to error and doesn't help our case much. 

<img width="852" alt="image" src="https://user-images.githubusercontent.com/1884376/173332743-17fb008e-e636-461a-8d8d-bbbb646176c8.png">


More details in https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-data, which basically means we have not been using caching the way we thought it was supposed to work in our favor.

That is the cache is not available across runs but within the run, across jobs & steps.
