### PR TITLE
chore(i18n, doc): fix links that don't work for translated pages

### DIFF
--- a/docs/how-to-add-cypress-tests.md
+++ b/docs/how-to-add-cypress-tests.md
@@ -13,13 +13,13 @@ To learn how to write Cypress tests, or 'specs', please see Cypress' official [d
 ## How to run tests
 
 > [!NOTE]
-> If using GitPod, please see [Cypress-GitPod Setup](how-to-add-cypress-tests#cypress-gitpod-setup)
+> If using GitPod, please see [Cypress-GitPod Setup](how-to-add-cypress-tests.md#cypress-gitpod-setup)
 
 ### 1. Ensure that MongoDB and client applications are running
 
-- [Start MongoDB and seed the database](how-to-setup-freecodecamp-locally#step-3-start-mongodb-and-seed-the-database)
+- [Start MongoDB and seed the database](how-to-setup-freecodecamp-locally.md#step-3-start-mongodb-and-seed-the-database)
 
-- [Start the freeCodeCamp client application and API server](how-to-setup-freecodecamp-locally#step-4-start-the-freecodecamp-client-application-and-api-server)
+- [Start the freeCodeCamp client application and API server](how-to-setup-freecodecamp-locally.md#step-4-start-the-freecodecamp-client-application-and-api-server)
 
 ### 2. Run the cypress tests
 
@@ -75,4 +75,4 @@ npm run cypress:install-build-tools
 
 - When prompted in the terminal, select your keyboard layout by language/area
 
-Now, [Cypress can be run](how-to-add-cypress-tests#_2-run-the-cypress-tests)
+Now, [Cypress can be run](how-to-add-cypress-tests.md#_2-run-the-cypress-tests)


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
These links were modified in #46469, but as discussed in #46483, they won't work for translated pages. (They will go to the English page. See also: #45187)

To make them work on translated pages, they have to follow these format :
- no `/` before filename
- requires `.md` after filename

As far as I checked, other links in the current docs are fine.