### PR TITLE
feat(i18n): enable italian new RWD

### DIFF
--- a/config/i18n/all-langs.ts
+++ b/config/i18n/all-langs.ts
@@ -75,6 +75,7 @@ export const auditedCerts = {
     SuperBlocks.MachineLearningPy
   ],
   italian: [
+    SuperBlocks.RespWebDesignNew,
     SuperBlocks.RespWebDesign,
     SuperBlocks.JsAlgoDataStruct,
     SuperBlocks.FrontEndDevLibs,
@@ -136,7 +137,11 @@ export const auditedCerts = {
  * that has been 100% translated. This will only be used during the window
  * where a beta goes to stable but the translation isn't complete yet.
  */
-export const languagesWithAuditedBetaReleases = ['english', 'portuguese'];
+export const languagesWithAuditedBetaReleases = [
+  'english',
+  'portuguese',
+  'italian'
+];
 
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
I have not been able to test as during the build process I got this error

```
  Error: Missing italian audited challenge for
  14-responsive-web-design-22/learn-css-grid-by-building-a-magazine/6148d4d57b965358c9fa38bf.md
  No audited challenges should fallback to English.
```