### PR TITLE
fix(actions): typo in workflow title

### DIFF
--- a/.github/workflows/no-prs-to-translation.yml
+++ b/.github/workflows/no-prs-to-translation.yml
@@ -1,4 +1,4 @@
-name: GitHub - No translions via PRs
+name: GitHub - No translations via PRs
 on:
   pull_request_target:
     branches:


### PR DESCRIPTION
fixed typo "translions" in workflow title to "translations"

Checklist:



- [ x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [ x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x ] My pull request targets the `main` branch of freeCodeCamp.
- [x ] I have tested these changes either locally on my machine, or GitPod.


Closes #46500

