### PR TITLE
fix(curriculum): make space optional

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5ef9b03c81a63668521804dc.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5ef9b03c81a63668521804dc.md
@@ -72,12 +72,12 @@ const radioInputElem = $('input')[0];
 assert(!radioInputElem.previousSibling.nodeValue.match(/Indoor/i));
 ```
 
-The text ` Indoor` should be located directly to the right of your `radio` button. Make sure there is a space between the element and the text. You have either omitted the text or have a typo.
+The text ` Indoor` should be located directly to the right of your `radio` button. You have either omitted the text or have a typo.
 
 ```js
 const radioInputElem = $('input')[0];
 assert(
-  radioInputElem.nextSibling.nodeValue.replace(/\s+/g, ' ').match(/ Indoor/i)
+  radioInputElem.nextSibling.nodeValue.replace(/\s+/g, ' ').match(/Indoor/i)
 );
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #46527 

<!-- Feel free to add any additional description of changes below this line -->

Made space between <input /> tag and text optional in challenge 43 of "Learn HTML by Building a Cat Photo App" section of the Responsive Web Design curriculum.  Also updated hint message to reflect the fact that the space is no longer required.