### PR TITLE
fix(curriculum): improve explanation of prefers-reduced-motion

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148e41c728f65138addf9cc.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148e41c728f65138addf9cc.md
@@ -7,14 +7,24 @@ dashedName: step-66
 
 # --description--
 
-Setting the `scroll-behavior` to `smooth` is preferred by most users. However, some users find this to be too slow, and prefer to have the scrolling happen instantaneously.
+Certain types of motion-based animations can cause discomfort for some users. In particular, people with <dfn>vestibular</dfn> disorders have sensitivity to certain motion triggers.
 
-There exists a media rule to set CSS based on the user's browser settings. This media rule is called `prefers-reduced-motion`, and expects one of the following values:
+The `@media` at-rule has a media feature called `prefers-reduced-motion` to set CSS based on the user's preferences. It can take one of the following values:
 
-- `reduce`
-- `no-preference`
+-   `reduce`
+-   `no-preference`
 
-Wrap the appropriate rule within a `prefers-reduced-motion` media rule such that a `scroll-behavior` of `smooth` is only set if the user's browser setting is `no-preference`.
+```CSS
+@media (feature: value) {
+  selector {
+    styles
+  }
+}
+```
+
+---
+
+Wrap the style rule that sets `scroll-behavior: smooth` within an `@media` at-rule with the media feature `prefers-reduced-motion` having `no-preference` set as the value.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

I think this challenge needs an update. The reason given for the media feature seems odd. I also think it doesn't do a very good job of explaining how to implement it.

Now, it's not like there isn't still room for improvement here, but I think it's at least a start. Let me know what you think.

I added a full syntax example with placeholder values as I think it might be necessary but I'm open to the idea of removing it if needed.

---

As an aside, I was thinking of putting the syntax example inside a `details` element but that seems to break the layout. If you expand the `details` element and scroll down and then back up the text block is cut off at the top. The styles for it also isn't really there, but that might be fixed.

I was wondering what the general consensus might be about using an `details` element as a way to include more "optional" content for the challenge text block?
