### PR TITLE
fix(curriculum): remove unnecessary code tags to allow translation

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f3c866dbf362f99b9a0c6d0.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f3c866dbf362f99b9a0c6d0.md
@@ -13,7 +13,7 @@ The `p` elements are nested in an `article` element with the class attribute of 
 .item p { }
 ```
 
-Using the above selector, add a `display` property with value `inline-block` so the `p` elements behave more like `inline` elements.
+Using the above selector, add a `display` property with value `inline-block` so the `p` elements behave more like inline elements.
 
 # --hints--
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f3c866de7a5b784048f94b1.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f3c866de7a5b784048f94b1.md
@@ -9,7 +9,7 @@ dashedName: step-37
 
 That is kind of what you want, but now it would be nice if the flavor and price were on the same line. `p` elements are <dfn>block-level</dfn> elements, so they take up the entire width of their parent element.
 
-To get them on the same line, you need to apply some styling to the `p` elements, so they behave more like `inline` elements. Add a `class` attribute with the value `item` to the first `article` element under the `Coffee` heading.
+To get them on the same line, you need to apply some styling to the `p` elements, so they behave more like <dfn>inline</dfn> elements. Add a `class` attribute with the value `item` to the first `article` element under the `Coffee` heading.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Affected page:
New Responsive Web Design > Learn Basic CSS by Building a Cafe Menu
Step 37
https://www.freecodecamp.org/learn/2022/responsive-web-design/learn-basic-css-by-building-a-cafe-menu/step-37
Step 38
https://www.freecodecamp.org/learn/2022/responsive-web-design/learn-basic-css-by-building-a-cafe-menu/step-38

The word "inline" is not a keyword the camper will write in their code here.

In step 37, I used the `<dfn>` tags instead since the paragraph just before it is explaining block-level elements with using `<dfn>` tags. I simply removed the code tags in step 38.