### PR TITLE
chore: add no-only-tests to eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,7 @@
     "plugin:jsx-a11y/recommended",
     "prettier"
   ],
+  "plugins": ["no-only-tests"],
   "globals": {
     "Promise": true,
     "window": true,
@@ -31,11 +32,12 @@
     }
   },
   "rules": {
-    "import/named": 2,
-    "import/no-named-as-default": 0,
-    "import/no-named-as-default-member": 0,
-    "import/order": 2,
-    "react/prop-types": "off"
+    "import/named": "error",
+    "import/no-named-as-default": "off",
+    "import/no-named-as-default-member": "off",
+    "import/order": "error",
+    "react/prop-types": "off",
+    "no-only-tests/no-only-tests": "error"
   },
   "overrides": [
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,6 +78,7 @@
         "eslint-plugin-import": "2.26.0",
         "eslint-plugin-jest-dom": "3.9.4",
         "eslint-plugin-jsx-a11y": "6.5.1",
+        "eslint-plugin-no-only-tests": "^2.6.0",
         "eslint-plugin-prefer-object-spread": "1.2.1",
         "eslint-plugin-react": "7.29.4",
         "eslint-plugin-react-hooks": "4.5.0",
@@ -23424,6 +23425,15 @@
       },
       "engines": {
         "node": ">=6.0"
+      }
+    },
+    "node_modules/eslint-plugin-no-only-tests": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.6.0.tgz",
+      "integrity": "sha512-T9SmE/g6UV1uZo1oHAqOvL86XWl7Pl2EpRpnLI8g/bkJu+h7XBCB+1LnubRZ2CUQXj805vh4/CYZdnqtVaEo2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/eslint-plugin-prefer-object-spread": {
@@ -70534,6 +70544,12 @@
           }
         }
       }
+    },
+    "eslint-plugin-no-only-tests": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.6.0.tgz",
+      "integrity": "sha512-T9SmE/g6UV1uZo1oHAqOvL86XWl7Pl2EpRpnLI8g/bkJu+h7XBCB+1LnubRZ2CUQXj805vh4/CYZdnqtVaEo2Q==",
+      "dev": true
     },
     "eslint-plugin-prefer-object-spread": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-jest-dom": "3.9.4",
     "eslint-plugin-jsx-a11y": "6.5.1",
+    "eslint-plugin-no-only-tests": "^2.6.0",
     "eslint-plugin-prefer-object-spread": "1.2.1",
     "eslint-plugin-react": "7.29.4",
     "eslint-plugin-react-hooks": "4.5.0",


### PR DESCRIPTION
It's too easy to commit them otherwise.