### PR TITLE
fix(ui-components): add an & prefix to custom variant

### DIFF
--- a/tools/ui-components/tailwind.config.js
+++ b/tools/ui-components/tailwind.config.js
@@ -96,7 +96,7 @@ module.exports = {
   },
   plugins: [
     plugin(({ addVariant }) => {
-      addVariant('aria-disabled', '[aria-disabled="true"]');
+      addVariant('aria-disabled', '&[aria-disabled="true"]');
     })
   ]
 };


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes freeCodeCamp/freeCodeCamp#46584

Storybook failed to start after we bumped TailwindCSS version from 3.0 to 3.1. This was due to a breaking change in Tailwind, in which the CSS selector of a custom variant is considered invalid if it is not prefixed with an `@` or an `&`, and the library will throw an exception in this case. It would have been nicer if the author bumped the library's major version instead, so that we could avoid this 😢  

I've split the smoke test setup to a separate issue (https://github.com/freeCodeCamp/ui/issues/9) and will work on this later.

<!-- Feel free to add any additional description of changes below this line -->

To test the change:
- Run `npm run storybook` and confirm that Storybook starts successfully
- Confirm that the Button component still has `opacity: 0.5` and `cursor: not-allowed` set

## Screenshots

<img width="1121" alt="Screen Shot 2022-06-21 at 23 46 22" src="https://user-images.githubusercontent.com/25715018/174858015-0118bbd6-fc90-4295-8072-0e2ca7e0ed3f.png">
