### PR TITLE
fix(tools): welcomer workflow

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -14,13 +14,18 @@ jobs:
         uses: actions/github-script@7a5c598405937d486b0331594b5da2b14db670da # tag=v6
         with:
           script: |
-            const creator = context.payload.sender.login;
+            const pull = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            const creator = pull.data.user.login;
             const repo = `${context.repo.owner}/${context.repo.repo}`;
             const pulls = await github.rest.search.issuesAndPullRequests({
               q: `repo:${repo}+author:${creator}+is:pr+is:merged`
             });
             // This means they've got merged PRs.
-            if (pulls?.data?.total_count) {
+            if (pulls?.data?.total_count > 1) {
               return;
             }
             github.rest.issues.createComment({
@@ -29,11 +34,8 @@ jobs:
               repo: context.repo.repo,
               body: `
               #### :sparkles: :tada: **AWESOME!** :tada: :sparkles:
-
               Hi @${creator},
-
               Thanks for this pull request and for contributing to the code-base for the first time. We are looking forward to more contributions from you in the future.
-
               Cheers & happy contributing!
               `
             });

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -34,8 +34,11 @@ jobs:
               repo: context.repo.repo,
               body: `
               #### :sparkles: :tada: **AWESOME!** :tada: :sparkles:
+
               Hi @${creator},
+
               Thanks for this pull request and for contributing to the code-base for the first time. We are looking forward to more contributions from you in the future.
+
               Cheers & happy contributing!
               `
             });


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #46603 (i hope)

<!-- Feel free to add any additional description of changes below this line -->

There were two bugs here:

- First, the action was running on the close event, which meant the `payload.sender` was the maintainer who merged it. So instead, we need to fetch the pull request and get the creator data from there.
- Second, it runs *after* the pull request is merged. Which means the length of merged pulls will be 1, so we want to return only if the number of merged pulls is greater than 1.