### PR TITLE
fix: inject user's script.js contents correctly

### DIFF
--- a/client/src/templates/Challenges/rechallenge/transformers.js
+++ b/client/src/templates/Challenges/rechallenge/transformers.js
@@ -224,9 +224,9 @@ export const embedFilesInHtml = async function (challengeFiles) {
       link.parentNode.replaceChild(style, link);
     }
     if (script) {
-      const script = (contentDocument.createElement('script').innerHTML =
-        scriptJs?.contents);
-      link.parentNode.replaceChild(script, link);
+      script.innerHTML = scriptJs?.contents;
+      script.removeAttribute('src');
+      script.setAttribute('data-src', 'script.js');
     }
     return {
       contents: documentElement.innerHTML


### PR DESCRIPTION
With this change the preview should function as if the user had written
a script with script.js's contents.  <script src="script.js"> is
replaced, so the script element's position in the html matters.

