### PR TITLE
feat: only 3 attempts before showing buttons

### DIFF
--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -186,7 +186,9 @@ const LowerJaw = ({
 
   const renderContextualActionRow = () => {
     const isAttemptsLargerThanTest =
-      attemptsNumber && testsLength && (attemptsNumber >= testsLength || attemptsNumber > 3);
+      attemptsNumber &&
+      testsLength &&
+      (attemptsNumber >= testsLength || attemptsNumber > 3);
 
     if (isAttemptsLargerThanTest && !earliestAvailableCompletion)
       return (

--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -186,7 +186,7 @@ const LowerJaw = ({
 
   const renderContextualActionRow = () => {
     const isAttemptsLargerThanTest =
-      attemptsNumber && testsLength && attemptsNumber >= testsLength;
+      attemptsNumber && testsLength && (attemptsNumber >= testsLength || attemptsNumber > 3);
 
     if (isAttemptsLargerThanTest && !earliestAvailableCompletion)
       return (


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

We've talked about this for a while but never did it. This sets a maximum of 3 attempts before showing the hint buttons.