### PR TITLE
fix: allow for additional solution of step 77 of Learn CSS Variables by Building a City Skyline

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-variables-by-building-a-city-skyline/5d822fd413a79914d39e9916.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-variables-by-building-a-city-skyline/5d822fd413a79914d39e9916.md
@@ -28,13 +28,13 @@ assert.include(new __helpers.CSSHelp(document).getStyle(".fb1c")?.getPropVal('ba
 You should use a first color of `--building-color4` from `0%` to `10%`.
 
 ```js
-assert.match(new __helpers.CSSHelp(document).getStyle(".fb1c")?.getPropVal('background', true), /repeating-linear-gradient\(90deg,var\(--building-color4\)(0%)?,var\(--building-color4\)10%/);
+assert.match(new __helpers.CSSHelp(document).getStyle(".fb1c")?.getPropVal('background', true), /repeating-linear-gradient\(90deg,var(\(--building-color4\)(0%)?,var\(--building-color4\)10%|\(--building-color4\)0%10%)/);
 ```
 
 You should use a second color of `transparent` from `10%` to `15%`.
 
 ```js
-assert.match(new __helpers.CSSHelp(document).getStyle(".fb1c")?.getPropVal('background', true), /repeating-linear-gradient\(90deg,var\(--building-color4\)(0%)?,var\(--building-color4\)10%,transparent10%,transparent15%\)/);
+assert.match(new __helpers.CSSHelp(document).getStyle(".fb1c")?.getPropVal('background', true), /,(transparent10%,transparent15%\)|transparent10%15%\))$/);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I was helping a forum user with [step 77 of Learn CSS Variables by Building a City Skyline](https://www.freecodecamp.org/learn/2022/responsive-web-design/learn-css-variables-by-building-a-city-skyline/step-77) and discovered a valid solution did not pass.  You can see the solution below.  It is a more concise way (a way shown on MDN) of how to accomplish the 4 color stops. 
```
.fb1c {
  width: 100%;
  height: 80%;
  background: repeating-linear-gradient(90deg, var(--building-color4)  0% 10%, transparent 10% 15%);
}
```
The original two tests for checking for the color stops were looking for a specific way of doing it (valid also).  Honestly, the biggest issue with this step is the lack of an example of how to accomplish the task as expected (but I will save that for someone else to figure out).  For now, I have modified the two tests to allow the original solution and the solution shown above.