### PR TITLE
fix(curriculum): change the word "property" to "attribute"

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f4701b942c824109626c3d8.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f4701b942c824109626c3d8.md
@@ -11,7 +11,7 @@ Now add the `bottom-line` class to the second `hr` element so the styling is app
 
 # --hints--
 
-You should apply the `class="bottom-line"` property.
+You should apply the `class="bottom-line"` attribute.
 
 ```js
 assert(code.match(/class=('|")bottom-line\1/i));

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f4701b942c824109626c3d8.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f4701b942c824109626c3d8.md
@@ -11,7 +11,7 @@ Now add the `bottom-line` class to the second `hr` element so the styling is app
 
 # --hints--
 
-You should apply the `class="bottom-line"` attribute.
+You should add the `class` attribute with the value `bottom-line`.
 
 ```js
 assert(code.match(/class=('|")bottom-line\1/i));


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Affected page:
(New) Responsive Web Design > Learn Basic CSS by Building a Cafe Menu > Step 77
https://www.freecodecamp.org/learn/2022/responsive-web-design/learn-basic-css-by-building-a-cafe-menu/step-77

I think we should call `class="bottom-line"` an attribute.