### PR TITLE
fix: allow for additional solution of step 78 of Learn CSS Variables by Building a City Skyline

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-variables-by-building-a-city-skyline/5d822fd413a79914d39e9917.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-variables-by-building-a-city-skyline/5d822fd413a79914d39e9917.md
@@ -31,13 +31,13 @@ assert.match(new __helpers.CSSHelp(document).getStyle(".fb1c")?.getPropVal('back
 You should add a `repeating-linear-gradient` with a first color of `--building-color4` from `0%` to `10%`.
 
 ```js
-assert.match(new __helpers.CSSHelp(document).getStyle(".fb1c")?.getPropVal('background', true), /repeating-linear-gradient\(var\(--building-color4\)(0%)?,var\(--building-color4\)10%/);
+assert.match(new __helpers.CSSHelp(document).getStyle(".fb1c")?.getPropVal('background', true), /repeating-linear-gradient\(90deg,var\(--building-color4\)(0%)?,var\(--building-color4\)10%,transparent10%,transparent15%\),repeating-linear-gradient\(var(\(--building-color4\)(0%)?,var\(--building-color4\)10%|\(--building-color4\)0%10%)/);
 ```
 
 You should use a second color of `--window-color4` from `10%` to `90%`.
 
 ```js
-assert.match(new __helpers.CSSHelp(document).getStyle(".fb1c")?.getPropVal('background', true), /repeating-linear-gradient\(90deg,var\(--building-color4\)(0%)?,var\(--building-color4\)10%,transparent10%,transparent15%\),repeating-linear-gradient\(var\(--building-color4\)(0%)?,var\(--building-color4\)10%,var\(--window-color4\)10%,var\(--window-color4\)90%\)/);
+assert.match(new __helpers.CSSHelp(document).getStyle(".fb1c")?.getPropVal('background', true), /,(var\(--window-color4\)10%,var\(--window-color4\)90%\)|var\(--window-color4\)10%90%\))$/);
 ```
 
 # --seed--


### PR DESCRIPTION
Related to PR https://github.com/freeCodeCamp/freeCodeCamp/pull/46649, I was not fast enough to add this one to the other PR, so this PR should take care of a similar problem step 77 had with respect to using the short-hand version of color stops. This is for [step 78 of Learn CSS Variables by Building a City Skyline](https://www.freecodecamp.org/learn/2022/responsive-web-design/learn-css-variables-by-building-a-city-skyline/step-78)
