### PR TITLE
fix(curriculum): allow valid link tags in curriculum

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f3477cb2e27333b1ab2b955.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f3477cb2e27333b1ab2b955.md
@@ -24,7 +24,7 @@ You should not change your existing `head` element. Make sure you did not delete
 assert($('head').length === 1);
 ```
 
-You should have a one a self-closing element `link` element.
+You should have a one a self-closing `link` element.
 
 ```js
 const link = document.querySelectorAll('link');

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f3477cb2e27333b1ab2b955.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f3477cb2e27333b1ab2b955.md
@@ -24,10 +24,11 @@ You should not change your existing `head` element. Make sure you did not delete
 assert($('head').length === 1);
 ```
 
-Your `link` element should be a self-closing element.
+You should have a one a self-closing element `link` element.
 
 ```js
-assert(code.match(/<link[\w\W\s]+\/?>/i));
+const link = document.querySelectorAll('link');
+assert(link.length === 1);
 ```
 
 Your `link` element should be within your `head` element.

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-animation-by-building-a-ferris-wheel/6140c7e645d8e905819f1dd4.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-animation-by-building-a-ferris-wheel/6140c7e645d8e905819f1dd4.md
@@ -139,28 +139,31 @@ Your code should have a `link` element.
 assert.match(code, /<link/)
 ```
 
-Your `link` element should be a self-closing element.
+You should have a one a self-closing `link` element.
 
 ```js
-assert(code.match(/<link[\w\W\s]+\/>/i));
+assert(document.querySelectorAll('link').length === 1);
 ```
 
 Your `link` element should be within your `head` element.
 
 ```js
-assert(code.match(/<head>[\w\W\s]*<link[\w\W\s]*\/>[\w\W\s]*<\/head>/i))
+assert.exists(document.querySelector('head > link'));
 ```
 
 Your `link` element should have a `rel` attribute with the value `stylesheet`.
 
 ```js
-assert.match(code, /<link[\s\S]*?rel=('|"|`)stylesheet\1/)
+const link_element = document.querySelector('link');
+const rel = link_element.getAttribute("rel");
+assert.equal(rel, "stylesheet");
 ```
 
 Your `link` element should have an `href` attribute with the value `styles.css`.
 
 ```js
-assert.match(code, /<link[\s\S]*?href=('|"|`)(\.\/)?styles\.css\1/)
+const link = document.querySelector('link');
+assert.equal(link.dataset.href, "styles.css");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/61696ef7ac756c829f9e4048.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/61696ef7ac756c829f9e4048.md
@@ -13,35 +13,31 @@ Nest a `link` element within the `head`. Give it a `rel` attribute set to `style
 
 # --hints--
 
-Your code should have one `link` element.
+You should have a one a self-closing `link` element.
 
 ```js
-assert(code.match(/<link/i)?.length === 1);
-```
-
-Your `link` element should be a self-closing element.
-
-```js
-assert(code.match(/<\/link>/i) === null);
+assert(document.querySelectorAll('link').length === 1);
 ```
 
 Your `link` element should be within your `head` element.
 
 ```js
-const head = code.match(/<head>(.|\r|\n)*<\/head>/i)?.[0];
-assert(head.match(/<link/i)?.length === 1)
+assert.exists(document.querySelector('head > link'));
 ```
 
 Your `link` element should have a `rel` attribute with the value `stylesheet`.
 
 ```js
-assert(code.match(/<link[\s\S]*?rel=('|"|`)stylesheet\1/gi)?.length === 1);
+const link_element = document.querySelector('link');
+const rel = link_element.getAttribute("rel");
+assert.equal(rel, "stylesheet");
 ```
 
-Your `link` element should have an `href` attribute with the value `styles.css`. Remember, casing matters when you link to an external file.
+Your `link` element should have an `href` attribute with the value `styles.css`.
 
 ```js
-assert.match(code, /<link[\s\S]*?href=('|"|`)(\.\/)?styles\.css\1/);
+const link = document.querySelector('link');
+assert.equal(link.dataset.href, "styles.css");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-grid-by-building-a-magazine/614385513d91ae5c251c2052.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-grid-by-building-a-magazine/614385513d91ae5c251c2052.md
@@ -13,29 +13,23 @@ Your font stylesheet will load three separate fonts: `Anton`, `Baskervville`, an
 
 # --hints--
 
-Your code should have three `link` elements.
+Your code should have three self-closing `link` elements.
 
 ```js
-assert(code.match(/<link/g)?.length === 3);
+assert(document.querySelectorAll('link').length === 3);
 ```
 
-Your `link` elements should be self-closing elements.
+Your `link` element should be within your `head` element.
 
 ```js
-assert(code.match(/<\/link>/i) === null);
-```
-
-Your `link` elements should be within your `head` element.
-
-```js
-const head = code.match(/<head>(.|\r|\n)*<\/head>/i)?.[0];
-assert(head.match(/<link/g)?.length === 3)
+assert(document.querySelectorAll('head > link').length === 3);
 ```
 
 Your three `link` elements should have a `rel` attribute with the value `stylesheet`.
 
 ```js
-assert(code.match(/<link[\s\S]*?rel=('|"|`)stylesheet\1/gi)?.length === 3);
+const links = [...document.querySelectorAll('link')];
+assert(links.every(link => link.getAttribute('rel') === 'stylesheet'));
 ```
 
 One of your link elements should have the `href` set to `https://fonts.googleapis.com/css?family=Anton|Baskervville|Raleway&display=swap`.
@@ -55,7 +49,7 @@ assert(links.find(link => link.getAttribute('href') === 'https://use.fontawesome
 One of your `link` elements should have an `href` attribute with the value `styles.css`.
 
 ```js
-assert.match(code, /<link[\s\S]*?href=('|"|`)(\.\/)?styles\.css\1/)
+assert.match(code, /<link[\s\S]*?href\s*=\s*('|"|`)(\.\/)?styles\.css\1/)
 ```
 
 Your code should have a `title` element.

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-variables-by-building-a-city-skyline/5d822fd413a79914d39e98cc.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-variables-by-building-a-city-skyline/5d822fd413a79914d39e98cc.md
@@ -51,28 +51,31 @@ const heads = document.querySelectorAll('head');
 assert.equal(heads?.length, 1);
 ```
 
-Your `link` element should be a self-closing element.
+You should have a one a self-closing `link` element.
 
 ```js
-assert(code.match(/<link[\w\W\s]+\/>/i));
+assert(document.querySelectorAll('link').length === 1);
 ```
 
 Your `link` element should be within your `head` element.
 
 ```js
-assert(code.match(/<head>[\w\W\s]*<link[\w\W\s]*\/>[\w\W\s]*<\/head>/i))
+assert.exists(document.querySelector('head > link'));
 ```
 
 Your `link` element should have a `rel` attribute with the value `stylesheet`.
 
 ```js
-assert.match(code, /<link[\s\S]*?rel=('|"|`)stylesheet\1/)
+const link_element = document.querySelector('link');
+const rel = link_element.getAttribute("rel");
+assert.equal(rel, "stylesheet");
 ```
 
 Your `link` element should have an `href` attribute with the value `styles.css`.
 
 ```js
-assert.match(code, /<link[\s\S]*?href=('|"|`)(\.\/)?styles\.css\1/)
+const link = document.querySelector('link');
+assert.equal(link.dataset.href, "styles.css");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60f0286404aefb0562a4fdf9.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60f0286404aefb0562a4fdf9.md
@@ -51,10 +51,10 @@ const heads = document.querySelectorAll('head');
 assert.equal(heads?.length, 1);
 ```
 
-Your `link` element should be a self-closing element.
+You should have a one a self-closing element `link` element.
 
 ```js
-assert(code.match(/<link[\w\W\s]+\/>/i));
+assert(document.querySelectorAll('link').length === 1);
 ```
 
 Your `link` element should be within your `head` element.

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60f0286404aefb0562a4fdf9.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60f0286404aefb0562a4fdf9.md
@@ -51,7 +51,7 @@ const heads = document.querySelectorAll('head');
 assert.equal(heads?.length, 1);
 ```
 
-You should have a one a self-closing element `link` element.
+You should have a one a self-closing `link` element.
 
 ```js
 assert(document.querySelectorAll('link').length === 1);

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-intermediate-css-by-building-a-picasso-painting/60b69a66b6ddb80858c5157a.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-intermediate-css-by-building-a-picasso-painting/60b69a66b6ddb80858c5157a.md
@@ -13,7 +13,7 @@ Add a `link` element with a `rel` of `stylesheet` and an `href` of `https://use.
 
 # --hints--
 
-You should add another `link` element.
+You should have two `link` elements.
 
 ```js
 assert(document.querySelectorAll('link').length === 2);

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-intermediate-css-by-building-a-picasso-painting/60b80da8676fb3227967a731.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-intermediate-css-by-building-a-picasso-painting/60b80da8676fb3227967a731.md
@@ -20,28 +20,31 @@ Your code should have a `link` element.
 assert.match(code, /<link/)
 ```
 
-Your `link` element should be a self-closing element.
+You should have a one a self-closing `link` element.
 
 ```js
-assert(code.match(/<link[\w\W\s]+\/>/i));
+assert(document.querySelectorAll('link').length === 1);
 ```
 
 Your `link` element should be within your `head` element.
 
 ```js
-assert(code.match(/<head>[\w\W\s]*<link[\w\W\s]*\/>[\w\W\s]*<\/head>/i))
+assert.exists(document.querySelector('head > link'));
 ```
 
 Your `link` element should have a `rel` attribute with the value `stylesheet`.
 
 ```js
-assert.match(code, /<link[\s\S]*?rel=('|"|`)stylesheet\1/)
+const link_element = document.querySelector('link');
+const rel = link_element.getAttribute("rel");
+assert.equal(rel, "stylesheet");
 ```
 
 Your `link` element should have an `href` attribute with the value `styles.css`.
 
 ```js
-assert.match(code, /<link[\s\S]*?href=('|"|`)(\.\/)?styles\.css\1/)
+const link = document.querySelector('link');
+assert.equal(link.dataset.href, "styles.css");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-responsive-web-design-by-building-a-piano/612e83ec2eca1e370f830511.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-responsive-web-design-by-building-a-piano/612e83ec2eca1e370f830511.md
@@ -24,28 +24,31 @@ const heads = document.querySelectorAll('head');
 assert.equal(heads?.length, 1);
 ```
 
-Your `link` element should be a self-closing element.
+You should have a one a self-closing `link` element.
 
 ```js
-assert(code.match(/<link[\w\W\s]+\/>/i));
+assert(document.querySelectorAll('link').length === 1);
 ```
 
 Your `link` element should be within your `head` element.
 
 ```js
-assert(code.match(/<head>[\w\W\s]*<link[\w\W\s]*\/>[\w\W\s]*<\/head>/i))
+assert.exists(document.querySelector('head > link'));
 ```
 
 Your `link` element should have a `rel` attribute with the value `stylesheet`.
 
 ```js
-assert.match(code, /<link[\s\S]*?rel=('|"|`)stylesheet\1/)
+const link_element = document.querySelector('link');
+const rel = link_element.getAttribute("rel");
+assert.equal(rel, "stylesheet");
 ```
 
 Your `link` element should have an `href` attribute with the value `styles.css`.
 
 ```js
-assert.match(code, /<link[\s\S]*?href=('|"|`)(\.\/)?styles\.css\1/)
+const link = document.querySelector('link');
+assert.equal(link.dataset.href, "styles.css");
 ```
 
 # --seed--

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-typography-by-building-a-nutrition-label/615f34ecc1091b4fd5a8a484.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-typography-by-building-a-nutrition-label/615f34ecc1091b4fd5a8a484.md
@@ -15,22 +15,23 @@ Also add a `link` element to link your `styles.css` file.
 
 # --hints--
 
-You should have two `link` elements.
+Your code should have two self-closing `link` elements.
 
 ```js
-assert(code.match(/<link/g)?.length === 2);
+assert(document.querySelectorAll('link').length === 2);
 ```
 
 Both of your `link` elements should have the `rel` attribute set to `stylesheet`.
 
 ```js
-assert(code.match(/<link[\s\S]*?rel=('|"|`)stylesheet\1/)?.length === 2);
+const links = [...document.querySelectorAll('link')];
+assert(links.every(link => link.getAttribute('rel') === 'stylesheet'));
 ```
 
 One of your `link` elements should have an `href` attribute set to `./styles.css`.
 
 ```js
-assert(code.match(/<link[\s\S]*?href=('|"|`)(\.\/)?styles\.css\1/g)?.length === 1);
+assert(code.match(/<link[\s\S]*?href\s*=\s*('|"|`)(\.\/)?styles\.css\1/g)?.length === 1);
 ```
 
 One of your `link` elements should have an `href` attribute set to `https://fonts.googleapis.com/css?family=Open+Sans:400,700,800`.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #45215 
Closes #44616

<!-- Feel free to add any additional description of changes below this line -->
I focused on not allowing `<link><link/>` to pass, and allowing `<link attributes>` to pass
![image](https://user-images.githubusercontent.com/88248797/176369245-ecaa3f16-135c-4cbc-a844-f09f41fd85c6.png)

I didn't want to be strict on `link` and not allow `<link></link>` to pass, because `<meta></meta>` do pass. Do you want me to change `meta` tests, as well? or keep everything as is

![image](https://user-images.githubusercontent.com/88248797/176371468-781fe8e3-0838-4dc6-8dfd-5adfd69ba28d.png)