### PR TITLE
fix: collapse rosetta

### DIFF
--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -122,7 +122,8 @@ export class Block extends Component<BlockProps> {
     const isProjectBlock = challenges.some(({ challenge }) => {
       const isJsProject =
         [3, 6, 10, 14, 17].includes(challenge.order) &&
-        challenge.challengeType === 5;
+        challenge.challengeType === 5 &&
+        blockDashedName !== 'rosetta-code';
 
       const isOtherProject =
         challenge.challengeType === 3 ||


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #46006 

<!-- Feel free to add any additional description of changes below this line -->
Is this an approrpiate way to solve this issue?

Sorry, @JordanMooree , it came to mind and I had to try

This is a much smaller fix than what talked in #46339, but I imagine that would also help going forward. It's hacky but it works immediately, and it's not worse than relying on challenge order. (Rosetta Code would pass the `[3, 6, 10, 14, 17].includes(challenge.order)` test)

![image](https://user-images.githubusercontent.com/26656284/176521157-b64ee6a5-9e4d-4b1d-9250-8f36db101e58.png)

