### PR TITLE
fix(curriculum): reduce strictness of code formatting

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5ef9b03c81a63668521804e1.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5ef9b03c81a63668521804e1.md
@@ -18,8 +18,10 @@ Both radio buttons should still be located between opening and closing `label` e
 ```js
 const labelChildNodes = [...$('label')].map((node) => [...node.childNodes]);
 assert(
-  labelChildNodes.filter((childNode) => childNode[0].nodeName === 'INPUT')
-    .length === 2
+  labelChildNodes.filter(
+    childNodes =>
+      childNodes.filter(node => node.nodeName === 'INPUT').length === 1
+  ).length === 2
 );
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #46705 

<!-- Feel free to add any additional description of changes below this line -->

Fixes a bug in the Cat Photo App challenge #49, where a space between the `<label>` and `<input>` tags would cause tests to fail.

I used the solution suggested in the thread for issue #46705, but it required a slight modification.  I had to remove one semicolon at the end of the `).length === 2` line, in order for the multiline formatting to be valid.