### PR TITLE
fix(tests): adjust `test:full-output` to typescriptify

### DIFF
--- a/curriculum/package.json
+++ b/curriculum/package.json
@@ -26,7 +26,7 @@
     "lint": "ts-node --project ../tsconfig.json lint-localized",
     "update-step-titles": "cross-env CALLING_DIR=$INIT_CWD ts-node --project ../tsconfig.json ../tools/challenge-helper-scripts/update-step-titles",
     "test": "ts-node ../node_modules/mocha/bin/mocha --delay --exit --reporter progress --bail",
-    "test:full-output": "cross-env FULL_OUTPUT=true mocha --delay --reporter progress"
+    "test:full-output": "cross-env FULL_OUTPUT=true ts-node ../node_modules/mocha/bin/mocha --delay --reporter progress"
   },
   "devDependencies": {
     "@babel/core": "7.18.5",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Without this, the following error appears:

```bash
Error: Cannot find module './frame'
Require stack:
- /home/shauh/freeCodeCamp/client/src/templates/Challenges/utils/build.js
- /home/shauh/freeCodeCamp/curriculum/test/test-challenges.js
```