### PR TITLE
fix(client): prevent navigating on failed submissions

### DIFF
--- a/client/src/templates/Challenges/redux/completion-epic.js
+++ b/client/src/templates/Challenges/redux/completion-epic.js
@@ -7,6 +7,7 @@ import {
   retry,
   catchError,
   concat,
+  tap,
   filter,
   finalize
 } from 'rxjs/operators';
@@ -142,7 +143,11 @@ function submitBackendChallenge(type, state) {
         endpoint: '/backend-challenge-completed',
         payload: challengeInfo
       };
-      return postChallenge(update, username);
+      try {
+        return postChallenge(update, username);
+      } catch(err) {
+        return err;
+      }
     }
   }
   return empty();

--- a/client/src/templates/Challenges/redux/completion-epic.js
+++ b/client/src/templates/Challenges/redux/completion-epic.js
@@ -7,7 +7,6 @@ import {
   retry,
   catchError,
   concat,
-  tap,
   filter,
   finalize
 } from 'rxjs/operators';
@@ -145,7 +144,7 @@ function submitBackendChallenge(type, state) {
       };
       try {
         return postChallenge(update, username);
-      } catch(err) {
+      } catch (err) {
         return err;
       }
     }

--- a/client/src/templates/Challenges/redux/completion-epic.js
+++ b/client/src/templates/Challenges/redux/completion-epic.js
@@ -163,7 +163,6 @@ export default function completionEpic(action$, state$) {
       const state = state$.value;
       const meta = challengeMetaSelector(state);
       const { nextChallengePath, challengeType, superBlock } = meta;
-      const closeChallengeModal = of(closeModal('completion'));
 
       let submitter = () => of({ type: 'no-user-signed-in' });
       if (

--- a/client/src/templates/Challenges/redux/completion-epic.js
+++ b/client/src/templates/Challenges/redux/completion-epic.js
@@ -2,14 +2,7 @@ import { navigate } from 'gatsby';
 import { omit } from 'lodash-es';
 import { ofType } from 'redux-observable';
 import { of, empty } from 'rxjs';
-import {
-  switchMap,
-  retry,
-  catchError,
-  concat,
-  finalize,
-  tap
-} from 'rxjs/operators';
+import { switchMap, retry, catchError, concat, map } from 'rxjs/operators';
 
 import { challengeTypes, submitTypes } from '../../../../utils/challenge-types';
 import {
@@ -181,17 +174,15 @@ export default function completionEpic(action$, state$) {
       const pathToNavigateTo = () => {
         return findPathToNavigateTo(nextChallengePath, superBlock);
       };
-      let result = false;
+
       return submitter(type, state).pipe(
-        tap(res => {
-          result = res.type !== submitActionTypes.updateFailed;
-        }),
-        concat(of(closeModal('completion'))),
-        finalize(async () => {
-          if (result) {
-            navigate(pathToNavigateTo());
+        map(res => {
+          if (res.type !== submitActionTypes.updateFailed) {
+            setTimeout(() => navigate(pathToNavigateTo()), 1);
           }
-        })
+          return res;
+        }),
+        concat(of(closeModal('completion')))
       );
     })
   );

--- a/client/src/templates/Challenges/redux/completion-epic.js
+++ b/client/src/templates/Challenges/redux/completion-epic.js
@@ -2,7 +2,7 @@ import { navigate } from 'gatsby';
 import { omit } from 'lodash-es';
 import { ofType } from 'redux-observable';
 import { of, empty } from 'rxjs';
-import { switchMap, retry, catchError, concat, map } from 'rxjs/operators';
+import { switchMap, retry, catchError, concat, tap } from 'rxjs/operators';
 
 import { challengeTypes, submitTypes } from '../../../../utils/challenge-types';
 import {
@@ -176,11 +176,10 @@ export default function completionEpic(action$, state$) {
       };
 
       return submitter(type, state).pipe(
-        map(res => {
+        tap(res => {
           if (res.type !== submitActionTypes.updateFailed) {
-            setTimeout(() => navigate(pathToNavigateTo()), 1);
+            navigate(pathToNavigateTo());
           }
-          return res;
         }),
         concat(of(closeModal('completion')))
       );

--- a/client/src/templates/Challenges/redux/completion-epic.js
+++ b/client/src/templates/Challenges/redux/completion-epic.js
@@ -178,8 +178,8 @@ export default function completionEpic(action$, state$) {
         submitter = submitters[submitTypes[challengeType]];
       }
 
-      const pathToNavigateTo = async () => {
-        return await findPathToNavigateTo(nextChallengePath, superBlock);
+      const pathToNavigateTo = () => {
+        return findPathToNavigateTo(nextChallengePath, superBlock);
       };
       let result = false;
       return submitter(type, state).pipe(
@@ -189,14 +189,14 @@ export default function completionEpic(action$, state$) {
         concat(closeChallengeModal),
 
         finalize(async () => {
-          result && navigate(await pathToNavigateTo());
+          result && navigate(pathToNavigateTo());
         })
       );
     })
   );
 }
 
-async function findPathToNavigateTo(nextChallengePath, superBlock) {
+function findPathToNavigateTo(nextChallengePath, superBlock) {
   if (nextChallengePath.includes(superBlock)) {
     return nextChallengePath;
   } else {

--- a/client/src/templates/Challenges/redux/completion-epic.js
+++ b/client/src/templates/Challenges/redux/completion-epic.js
@@ -186,6 +186,7 @@ export default function completionEpic(action$, state$) {
         tap(res => {
           result = res.type !== submitActionTypes.updateFailed;
         }),
+        concat(of(closeModal('completion'))),
         finalize(async () => {
           if (result) {
             navigate(pathToNavigateTo());

--- a/client/src/templates/Challenges/redux/completion-epic.js
+++ b/client/src/templates/Challenges/redux/completion-epic.js
@@ -23,6 +23,7 @@ import {
 import postUpdate$ from '../utils/post-update';
 import { mapFilesToChallengeFiles } from '../../../utils/ajax';
 import { standardizeRequestBody } from '../../../utils/challenge-request-helpers';
+import { actionTypes as submitActionTypes } from '../../../redux/action-types';
 import { actionTypes } from './action-types';
 import {
   projectFormValuesSelector,
@@ -184,12 +185,12 @@ export default function completionEpic(action$, state$) {
       let result = false;
       return submitter(type, state).pipe(
         tap(res => {
-          result = res.type !== 'app.updateFailed';
+          result = res.type !== submitActionTypes.updateFailed;
         }),
-        concat(closeChallengeModal),
-
         finalize(async () => {
-          result && navigate(pathToNavigateTo());
+          if (result) {
+            navigate(pathToNavigateTo());
+          }
         })
       );
     })

--- a/client/src/utils/ajax.ts
+++ b/client/src/utils/ajax.ts
@@ -81,8 +81,9 @@ async function request<T>(
   };
 
   const response = await fetch(`${base}${path}`, options);
-  if (!response.ok)
-    throw new Error((response as any)?.error?.message || 'some error happen');
+  if (!response.ok) {
+    throw new Error(response.statusText);
+  }
   return combineDataWithResponse(response);
 }
 

--- a/client/src/utils/ajax.ts
+++ b/client/src/utils/ajax.ts
@@ -81,7 +81,8 @@ async function request<T>(
   };
 
   const response = await fetch(`${base}${path}`, options);
-  if (!response.ok) throw new Error((response as any)?.error?.message || 'some error happen')
+  if (!response.ok)
+    throw new Error((response as any)?.error?.message || 'some error happen');
   return combineDataWithResponse(response);
 }
 

--- a/client/src/utils/ajax.ts
+++ b/client/src/utils/ajax.ts
@@ -81,6 +81,7 @@ async function request<T>(
   };
 
   const response = await fetch(`${base}${path}`, options);
+  if (!response.ok) throw new Error((response as any)?.error?.message || 'some error happen')
   return combineDataWithResponse(response);
 }
 

--- a/client/src/utils/ajax.ts
+++ b/client/src/utils/ajax.ts
@@ -81,6 +81,9 @@ async function request<T>(
   };
 
   const response = await fetch(`${base}${path}`, options);
+  if (!response.ok) {
+    throw new Error(response.statusText);
+  }
   return combineDataWithResponse(response);
 }
 

--- a/client/src/utils/ajax.ts
+++ b/client/src/utils/ajax.ts
@@ -81,9 +81,6 @@ async function request<T>(
   };
 
   const response = await fetch(`${base}${path}`, options);
-  if (!response.ok) {
-    throw new Error(response.statusText);
-  }
   return combineDataWithResponse(response);
 }
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to #37615
info about this PR:
my goal was to prevent navigation to next challenge after user pressed 'submit' button on 'success' modal, and API failed.
i used to mimic api failure by modifying `/backend-challenge-completed` request
to return error:

```
      const updatePromise = new Promise((resolve, reject) => {
        return reject("my Name is Jovanny Georgio")
      });
```

<!-- Feel free to add any additional description of changes below this line -->
