### PR TITLE
fix: update hint and test for cat photo app challenge

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dfa22d1b521be39a3de7be0.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dfa22d1b521be39a3de7be0.md
@@ -23,13 +23,21 @@ Your anchor (`a`) element should be nested within the `p` element.
 assert($('p > a').length);
 ```
 
+The link's href value should be `https://freecatphotoapp.com`. You have either omitted the href value or have a typo.
+
+```js
+const nestedAnchor = $('p > a')[0];
+assert(
+  nestedAnchor.getAttribute('href') === 'https://freecatphotoapp.com'
+);
+```
+
 The link's text should be `cat photos`. You have either omitted the text or have a typo.
 
 ```js
 const nestedAnchor = $('p > a')[0];
 assert(
-  nestedAnchor.getAttribute('href') === 'https://freecatphotoapp.com' &&
-    nestedAnchor.innerText.toLowerCase().replace(/\s+/g, ' ') === 'cat photos'
+  nestedAnchor.innerText.toLowerCase().replace(/\s+/g, ' ') === 'cat photos'
 );
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

I want to change this. When users write code or move code, when the anchor's href value is wrong, it will point at the link text is wrong. But there is no hint to tell the user that the href value is incorrect or missing.

### before change: 
![Screen Shot 2022-07-05 at 4 16 40 PM](https://user-images.githubusercontent.com/9701609/177418045-398305c5-bbaa-4854-ac95-8b7af68de189.png)

### after change: 

![Screen Shot 2022-07-05 at 4 20 39 PM](https://user-images.githubusercontent.com/9701609/177418520-9037a008-c6a4-448f-a8b1-0c348ca551d1.png)


But I am not sure what the href's hint message needs to be!  

> The link's href value should be `https://freecatphotoapp.com`. You have either omitted the href value or have a typo.



