### PR TITLE
fix: add test to validate result format has space between count value and text - Counting Cards challenge

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/counting-cards.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/counting-cards.md
@@ -26,6 +26,40 @@ Do NOT include quotes (single or double) in the output.
 
 # --hints--
 
+Your function should return a value for count and the text (`Bet` or `Hold`) with one space character between them.
+
+```js
+assert(//
+  (function () {
+    count = 0;
+    cc(2);
+    cc(2);
+    let out = cc(10);
+    const hasSpace = /-?\d+ Bet/.test('' + out);
+    return hasSpace;
+  })()
+);
+```
+
+Cards Sequence 3, 2, A, 10, K should return the string `-1 Hold`
+
+```js
+assert(
+  (function () {
+    count = 0;
+    cc(3);
+    cc(2);
+    cc('A');
+    cc(10);
+    var out = cc('K');
+    if (out === '-1 Hold') {
+      return true;
+    }
+    return false;
+  })()
+);
+```
+
 Cards Sequence 2, 3, 4, 5, 6 should return the string `5 Bet`
 
 ```js


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

I can not tell you how many times I have seen a question on the forum concerning the [Counting Cards challenge](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-javascript/counting-cards) where a user's function has the correct logic that returns the correct count and displays the corresponding `Bet` or `Hold` but for some reason the user concatenates the two without the space between specified in the instructions.  I have added a new test that appears first in the list to make sure the user is thinking more about the format.

I am definitely open to change the hint text to make it clearer if need be but I believe the test is needed and could reduce the number of questions concerning the format of the return value.