### PR TITLE
fix: Fixed typos for 'self closing link element' in multiple files

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f3477cb2e27333b1ab2b955.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f3477cb2e27333b1ab2b955.md
@@ -24,7 +24,7 @@ You should not change your existing `head` element. Make sure you did not delete
 assert($('head').length === 1);
 ```
 
-You should have a one a self-closing `link` element.
+You should have one self-closing `link` element.
 
 ```js
 const link = document.querySelectorAll('link');

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-animation-by-building-a-ferris-wheel/6140c7e645d8e905819f1dd4.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-animation-by-building-a-ferris-wheel/6140c7e645d8e905819f1dd4.md
@@ -139,7 +139,7 @@ Your code should have a `link` element.
 assert.match(code, /<link/)
 ```
 
-You should have a one a self-closing `link` element.
+You should have one self-closing `link` element.
 
 ```js
 assert(document.querySelectorAll('link').length === 1);

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/61696ef7ac756c829f9e4048.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/61696ef7ac756c829f9e4048.md
@@ -13,7 +13,7 @@ Nest a `link` element within the `head`. Give it a `rel` attribute set to `style
 
 # --hints--
 
-You should have a one a self-closing `link` element.
+You should have one self-closing `link` element.
 
 ```js
 assert(document.querySelectorAll('link').length === 1);

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-variables-by-building-a-city-skyline/5d822fd413a79914d39e98cc.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-variables-by-building-a-city-skyline/5d822fd413a79914d39e98cc.md
@@ -63,7 +63,7 @@ const heads = document.querySelectorAll('head');
 assert.equal(heads?.length, 1);
 ```
 
-You should have a one a self-closing `link` element.
+You should have one self-closing `link` element.
 
 ```js
 assert(document.querySelectorAll('link').length === 1);

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60f0286404aefb0562a4fdf9.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60f0286404aefb0562a4fdf9.md
@@ -51,7 +51,7 @@ const heads = document.querySelectorAll('head');
 assert.equal(heads?.length, 1);
 ```
 
-You should have a one a self-closing `link` element.
+You should have one self-closing `link` element.
 
 ```js
 assert(document.querySelectorAll('link').length === 1);

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-intermediate-css-by-building-a-picasso-painting/60b80da8676fb3227967a731.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-intermediate-css-by-building-a-picasso-painting/60b80da8676fb3227967a731.md
@@ -20,7 +20,7 @@ Your code should have a `link` element.
 assert.match(code, /<link/)
 ```
 
-You should have a one a self-closing `link` element.
+You should have one self-closing `link` element.
 
 ```js
 assert(document.querySelectorAll('link').length === 1);

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-responsive-web-design-by-building-a-piano/612e83ec2eca1e370f830511.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-responsive-web-design-by-building-a-piano/612e83ec2eca1e370f830511.md
@@ -24,7 +24,7 @@ const heads = document.querySelectorAll('head');
 assert.equal(heads?.length, 1);
 ```
 
-You should have a one a self-closing `link` element.
+You should have one self-closing `link` element.
 
 ```js
 assert(document.querySelectorAll('link').length === 1);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #46785

<!-- Feel free to add any additional description of changes below this line -->
Fixes typos in files outlined in [issue 46785](https://github.com/freeCodeCamp/freeCodeCamp/issues/46785), relating to _self closing link element_ text in multiple files. 
