### PR TITLE
fix: update a link URL to www.freecodecamp.org

### DIFF
--- a/curriculum/challenges/english/03-front-end-development-libraries/redux/create-a-redux-store.md
+++ b/curriculum/challenges/english/03-front-end-development-libraries/redux/create-a-redux-store.md
@@ -20,7 +20,7 @@ The Redux `store` is an object which holds and manages application `state`. Ther
 
 Declare a `store` variable and assign it to the `createStore()` method, passing in the `reducer` as an argument.
 
-**Note:** The code in the editor uses ES6 default argument syntax to initialize this state to hold a value of `5`. If you're not familiar with default arguments, you can refer to the <a href="https://learn.freecodecamp.org/javascript-algorithms-and-data-structures/es6/set-default-parameters-for-your-functions" target="_blank" rel="noopener noreferrer nofollow">ES6 section in the Curriculum</a> which covers this topic.
+**Note:** The code in the editor uses ES6 default argument syntax to initialize this state to hold a value of `5`. If you're not familiar with default arguments, you can refer to the <a href="https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/es6/set-default-parameters-for-your-functions" target="_blank" rel="noopener noreferrer nofollow">ES6 section in the Curriculum</a> which covers this topic.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
The link was using `learn.freecodecamp.org` URL. It redirects properly but I thought it's better to update it.
I searched through other files and this should be the only place using this URL.

Affected page: Front End Development Libraries > Redux > Create a Redux Store
https://www.freecodecamp.org/learn/front-end-development-libraries/redux/create-a-redux-store