### PR TITLE
fix(curriculum): add a closing parenthesis

### DIFF
--- a/curriculum/challenges/english/07-scientific-computing-with-python/scientific-computing-with-python-projects/arithmetic-formatter.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/scientific-computing-with-python-projects/arithmetic-formatter.md
@@ -68,7 +68,7 @@ The function will return the correct conversion if the supplied problems are pro
   - Each operand (aka number on each side of the operator) has a max of four digits in width. Otherwise, the error string returned will be:
     `Error: Numbers cannot be more than four digits.`
 - If the user supplied the correct format of problems, the conversion you return will follow these rules:
-  - There should be a single space between the operator and the longest of the two operands, the operator will be on the same line as the second operand, both operands will be in the same order as provided (the first will be the top one and the second will be the bottom.
+  - There should be a single space between the operator and the longest of the two operands, the operator will be on the same line as the second operand, both operands will be in the same order as provided (the first will be the top one and the second will be the bottom).
   - Numbers should be right-aligned.
   - There should be four spaces between each problem.
   - There should be dashes at the bottom of each problem. The dashes should run along the entire length of each problem individually. (The example above shows what this should look like.)


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Added a closing parenthesis to the text of [Arithmetic Formatter of Scientific Computing with Python Projects](https://www.freecodecamp.org/learn/scientific-computing-with-python/scientific-computing-with-python-projects/arithmetic-formatter).

It could also be considered adding a closing parenthesis AFTER period, like bellow:

> the operator will be on the same line as the second operand, both operands will be in the same order as provided (the first will be the top one and the second will be the bottom.)

But the sentence in parentheses seems to relate only a sentence "both operands will be in the same order as provided" so I added one BEFORE period simply.

By only running my local clone and seeing the change in browser, I tested this change
![add_a_closing_parenthesis](https://user-images.githubusercontent.com/44451585/177988685-6869eaa6-567d-4dbe-a591-c93d17fa7f5a.png)
.