### PR TITLE
fix(curriculum): move editable region to expose selector

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f35e5c44359872a137bd98f.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f35e5c44359872a137bd98f.md
@@ -70,13 +70,13 @@ assert(bodyBackground === `url("https://cdn.freecodecamp.org/curriculum/css-cafe
 ```
 
 ```css
-body {
 --fcc-editable-region--
+body {
   /*
   background-color: burlywood;
   */
---fcc-editable-region--
 }
+--fcc-editable-region--
 
 h1, h2, p {
   text-align: center;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Lately I am seeing a few forum posts per day in which people write
```css
body {
body {

}
}
```

this should make more obvious that the body selector is already there