### PR TITLE
fix(docs): typos in language lead handbook

### DIFF
--- a/docs/language-lead-handbook.md
+++ b/docs/language-lead-handbook.md
@@ -28,7 +28,7 @@ With `link` being the link of the original article.
 
 ## How to update trending articles
 
-> ![TIP]
+> [!TIP]
 > Changing the articles in the footer at least once a month means giving a boost to the linked articles on google results.
 
 There two places in which to change the trending articles.
@@ -120,7 +120,7 @@ The `compliments` array is an array of strings, so for example you would write:
 }
 ```
 
-> ![TIP]
+> [!TIP]
 > You should start with at least a dozen compliments to have some variety when users complete challenges.
 
 The motivational quotes are the quotes that appear at https://freecodecamp.org/learn.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Fixed to typos of the same kind.
Before: 
![image](https://user-images.githubusercontent.com/105294544/178006466-1b791e77-17ba-4999-bca3-579b99318092.png)
After:
![image](https://user-images.githubusercontent.com/105294544/178006589-991edb48-173e-4676-9039-405789db6832.png)

