### PR TITLE
fix(curriculum): fix the instruction and the test to match the hint (CatPhotoApp Step3)

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dc17d3bf86c76b9248c6eb4.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dc17d3bf86c76b9248c6eb4.md
@@ -9,7 +9,7 @@ dashedName: step-3
 
 The `p` element is used to create a paragraph of text on websites. Create a `p` element below your `h2` element and give it the following text:
 
-`Click here to view more cat photos`
+`Click here to view more cat photos.`
 
 # --hints--
 
@@ -31,7 +31,7 @@ Your `p` element's text should be `Click here to view more cat photos.` You have
 const extraSpacesRemoved = document
   .querySelector('p')
   .innerText.replace(/\s+/g, ' ');
-assert(extraSpacesRemoved.match(/click here to view more cat photos\.?$/i));
+assert(extraSpacesRemoved.match(/click here to view more cat photos\.$/i));
 ```
 
 Your `p` element should be below the `h2` element. You have them in the wrong order.

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dc17d3bf86c76b9248c6eb4.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dc17d3bf86c76b9248c6eb4.md
@@ -31,7 +31,7 @@ Your `p` element's text should be `Click here to view more cat photos.` You have
 const extraSpacesRemoved = document
   .querySelector('p')
   .innerText.replace(/\s+/g, ' ');
-assert(extraSpacesRemoved.match(/click here to view more cat photos\.$/i));
+assert(extraSpacesRemoved.match(/click here to view more cat photos\.?$/i));
 ```
 
 Your `p` element should be below the `h2` element. You have them in the wrong order.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
The description says the text should be `Click here to view more cat photos` (without `.`) but the hint says it should be `Click here to view more cat photos.` (with `.`)

The current test passes either way, but I think it's better to stick to the text with `.` to avoid confusion. (The seed code in the next step has it.)

Affected page: (New) Responsive Web Design > Learn HTML by Building a Cat Photo App > Step 3
https://www.freecodecamp.org/learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-3