### PR TITLE
fix: update i18n keys

### DIFF
--- a/client/i18n/locales/chinese-traditional/links.json
+++ b/client/i18n/locales/chinese-traditional/links.json
@@ -13,7 +13,10 @@
     "copyright-url": "https://www.freecodecamp.org/news/copyright-policy/"
   },
   "donate": {
-    "other-ways-url": "https://chinese.freecodecamp.org/news/how-to-donate-to-free-code-camp/"
+    "other-ways-url": "https://chinese.freecodecamp.org/news/how-to-donate-to-free-code-camp/",
+    "download-irs-url": "https://s3.amazonaws.com/freecodecamp/Free+Code+Camp+Inc+IRS+Determination+Letter.pdf",
+    "download-990-url": "https://freecodecamp.s3.amazonaws.com/freeCodeCamp+2019+f990.pdf",
+    "one-time-url": "https://paypal.me/freecodecamp"
   },
   "nav": {
     "forum": "https://chinese.freecodecamp.org/forum/",
@@ -23,6 +26,6 @@
     "HTML-CSS": "front-end",
     "JavaScript": "front-end",
     "Python": "curriculum",
-    "Relational Databases": "curriculum"
+    "Backend Development": "curriculum"
   }
 }

--- a/client/i18n/locales/chinese-traditional/links.json
+++ b/client/i18n/locales/chinese-traditional/links.json
@@ -1,5 +1,5 @@
 {
-  "help-translate-url": "https://contribute.freecodecamp.org/#/i18n/chinese/how-to-translate-files",
+  "help-translate-link-url": "https://contribute.freecodecamp.org/#/i18n/chinese/how-to-translate-files",
   "top-contributors": "https://www.freecodecamp.org/news/freecodecamp-top-contributors/",
   "footer": {
     "about-url": "https://chinese.freecodecamp.org/news/about/",

--- a/client/i18n/locales/chinese-traditional/links.json
+++ b/client/i18n/locales/chinese-traditional/links.json
@@ -23,9 +23,9 @@
     "news": "https://chinese.freecodecamp.org/news/"
   },
   "help": {
-    "HTML-CSS": "front-end",
-    "JavaScript": "front-end",
-    "Python": "curriculum",
-    "Backend Development": "curriculum"
+    "HTML-CSS": "chinese/html-css",
+    "JavaScript": "chinese/javascript",
+    "Python": "chinese/python",
+    "Backend Development": "chinese/programming-help"
   }
 }

--- a/client/i18n/locales/chinese/links.json
+++ b/client/i18n/locales/chinese/links.json
@@ -13,7 +13,10 @@
     "copyright-url": "https://www.freecodecamp.org/news/copyright-policy/"
   },
   "donate": {
-    "other-ways-url": "https://chinese.freecodecamp.org/news/how-to-donate-to-free-code-camp/"
+    "other-ways-url": "https://chinese.freecodecamp.org/news/how-to-donate-to-free-code-camp/",
+    "download-irs-url": "https://s3.amazonaws.com/freecodecamp/Free+Code+Camp+Inc+IRS+Determination+Letter.pdf",
+    "download-990-url": "https://freecodecamp.s3.amazonaws.com/freeCodeCamp+2019+f990.pdf",
+    "one-time-url": "https://paypal.me/freecodecamp"
   },
   "nav": {
     "forum": "https://chinese.freecodecamp.org/forum/",
@@ -23,6 +26,6 @@
     "HTML-CSS": "front-end",
     "JavaScript": "front-end",
     "Python": "curriculum",
-    "Relational Databases": "curriculum"
+    "Backend Development": "curriculum"
   }
 }

--- a/client/i18n/locales/chinese/links.json
+++ b/client/i18n/locales/chinese/links.json
@@ -1,5 +1,5 @@
 {
-  "help-translate-url": "https://contribute.freecodecamp.org/#/i18n/chinese/how-to-translate-files",
+  "help-translate-link-url": "https://contribute.freecodecamp.org/#/i18n/chinese/how-to-translate-files",
   "top-contributors": "https://www.freecodecamp.org/news/freecodecamp-top-contributors/",
   "footer": {
     "about-url": "https://chinese.freecodecamp.org/news/about/",

--- a/client/i18n/locales/chinese/links.json
+++ b/client/i18n/locales/chinese/links.json
@@ -23,9 +23,9 @@
     "news": "https://chinese.freecodecamp.org/news/"
   },
   "help": {
-    "HTML-CSS": "front-end",
-    "JavaScript": "front-end",
-    "Python": "curriculum",
-    "Backend Development": "curriculum"
+    "HTML-CSS": "chinese/html-css",
+    "JavaScript": "chinese/javascript",
+    "Python": "chinese/python",
+    "Backend Development": "chinese/programming-help"
   }
 }

--- a/client/i18n/locales/espanol/links.json
+++ b/client/i18n/locales/espanol/links.json
@@ -13,7 +13,10 @@
     "copyright-url": "https://www.freecodecamp.org/news/copyright-policy/"
   },
   "donate": {
-    "other-ways-url": "https://www.freecodecamp.org/news/how-to-donate-to-free-code-camp"
+    "other-ways-url": "https://www.freecodecamp.org/news/how-to-donate-to-free-code-camp",
+    "download-irs-url": "https://s3.amazonaws.com/freecodecamp/Free+Code+Camp+Inc+IRS+Determination+Letter.pdf",
+    "download-990-url": "https://freecodecamp.s3.amazonaws.com/freeCodeCamp+2019+f990.pdf",
+    "one-time-url": "https://paypal.me/freecodecamp"
   },
   "nav": {
     "forum": "https://forum.freecodecamp.org/c/espanol/",
@@ -23,6 +26,6 @@
     "HTML-CSS": "Espanol/HTML-CSS",
     "JavaScript": "Espanol/JavaScript",
     "Python": "Espanol/Python",
-    "Relational Databases": "Espanol/Relational Databases"
+    "Backend Development": "Espanol/Relational Databases"
   }
 }

--- a/client/i18n/locales/espanol/links.json
+++ b/client/i18n/locales/espanol/links.json
@@ -26,6 +26,6 @@
     "HTML-CSS": "Espanol/HTML-CSS",
     "JavaScript": "Espanol/JavaScript",
     "Python": "Espanol/Python",
-    "Backend Development": "Espanol/Relational Databases"
+    "Backend Development": "espanol/ayuda-de-programacion"
   }
 }

--- a/client/i18n/locales/italian/links.json
+++ b/client/i18n/locales/italian/links.json
@@ -13,7 +13,10 @@
     "copyright-url": "https://www.freecodecamp.org/news/copyright-policy/"
   },
   "donate": {
-    "other-ways-url": "https://www.freecodecamp.org/news/how-to-donate-to-free-code-camp"
+    "other-ways-url": "https://www.freecodecamp.org/news/how-to-donate-to-free-code-camp",
+    "download-irs-url": "https://s3.amazonaws.com/freecodecamp/Free+Code+Camp+Inc+IRS+Determination+Letter.pdf",
+    "download-990-url": "https://freecodecamp.s3.amazonaws.com/freeCodeCamp+2019+f990.pdf",
+    "one-time-url": "https://paypal.me/freecodecamp"
   },
   "nav": {
     "forum": "https://forum.freecodecamp.org/c/italiano/",
@@ -23,6 +26,6 @@
     "HTML-CSS": "Italiano/HTML-CSS",
     "JavaScript": "Italiano/JavaScript",
     "Python": "Italiano/Python",
-    "Relational Databases": "Italiano/Relational Databases"
+    "Backend Development": "Italiano/Relational Databases"
   }
 }

--- a/client/i18n/locales/italian/links.json
+++ b/client/i18n/locales/italian/links.json
@@ -26,6 +26,6 @@
     "HTML-CSS": "Italiano/HTML-CSS",
     "JavaScript": "Italiano/JavaScript",
     "Python": "Italiano/Python",
-    "Backend Development": "Italiano/Relational Databases"
+    "Backend Development": "italiano/aiuto-programmazione"
   }
 }

--- a/client/i18n/locales/japanese/links.json
+++ b/client/i18n/locales/japanese/links.json
@@ -26,6 +26,6 @@
     "HTML-CSS": "Japanese/HTML-CSS",
     "JavaScript": "Japanese/JavaScript",
     "Python": "Japanese/Python",
-    "Relational Databases": "Japanese/Relational Databases"
+    "Backend Development": "Japanese/Relational Databases"
   }
 }

--- a/client/i18n/locales/japanese/links.json
+++ b/client/i18n/locales/japanese/links.json
@@ -26,6 +26,6 @@
     "HTML-CSS": "Japanese/HTML-CSS",
     "JavaScript": "Japanese/JavaScript",
     "Python": "Japanese/Python",
-    "Backend Development": "Japanese/Relational Databases"
+    "Backend Development": "Japanese/programming-help"
   }
 }

--- a/client/i18n/locales/portuguese/links.json
+++ b/client/i18n/locales/portuguese/links.json
@@ -26,6 +26,6 @@
     "HTML-CSS": "Portugues/HTML-CSS",
     "JavaScript": "Portugues/JavaScript",
     "Python": "Portugues/Python",
-    "Backend Development": "Portugues/Relational Databases"
+    "Backend Development": "Portugues/ajuda-em-programacao"
   }
 }

--- a/client/i18n/locales/portuguese/links.json
+++ b/client/i18n/locales/portuguese/links.json
@@ -13,7 +13,10 @@
     "copyright-url": "https://www.freecodecamp.org/news/copyright-policy/"
   },
   "donate": {
-    "other-ways-url": "https://www.freecodecamp.org/news/how-to-donate-to-free-code-camp"
+    "other-ways-url": "https://www.freecodecamp.org/news/how-to-donate-to-free-code-camp",
+    "download-irs-url": "https://s3.amazonaws.com/freecodecamp/Free+Code+Camp+Inc+IRS+Determination+Letter.pdf",
+    "download-990-url": "https://freecodecamp.s3.amazonaws.com/freeCodeCamp+2019+f990.pdf",
+    "one-time-url": "https://paypal.me/freecodecamp"
   },
   "nav": {
     "forum": "https://forum.freecodecamp.org/c/portugues/",
@@ -23,6 +26,6 @@
     "HTML-CSS": "Portugues/HTML-CSS",
     "JavaScript": "Portugues/JavaScript",
     "Python": "Portugues/Python",
-    "Relational Databases": "Portugues/Relational Databases"
+    "Backend Development": "Portugues/Relational Databases"
   }
 }

--- a/client/i18n/locales/ukrainian/links.json
+++ b/client/i18n/locales/ukrainian/links.json
@@ -26,6 +26,6 @@
     "HTML-CSS": "HTML-CSS",
     "JavaScript": "JavaScript",
     "Python": "Python",
-    "Backend Development": "Relational Databases"
+    "Backend Development": "Backend Development"
   }
 }

--- a/client/i18n/locales/ukrainian/links.json
+++ b/client/i18n/locales/ukrainian/links.json
@@ -13,7 +13,10 @@
     "copyright-url": "https://www.freecodecamp.org/news/copyright-policy/"
   },
   "donate": {
-    "other-ways-url": "https://www.freecodecamp.org/news/how-to-donate-to-free-code-camp"
+    "other-ways-url": "https://www.freecodecamp.org/news/how-to-donate-to-free-code-camp",
+    "download-irs-url": "https://s3.amazonaws.com/freecodecamp/Free+Code+Camp+Inc+IRS+Determination+Letter.pdf",
+    "download-990-url": "https://freecodecamp.s3.amazonaws.com/freeCodeCamp+2019+f990.pdf",
+    "one-time-url": "https://paypal.me/freecodecamp"
   },
   "nav": {
     "forum": "https://forum.freecodecamp.org/",
@@ -23,6 +26,6 @@
     "HTML-CSS": "HTML-CSS",
     "JavaScript": "JavaScript",
     "Python": "Python",
-    "Relational Databases": "Relational Databases"
+    "Backend Development": "Relational Databases"
   }
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

During the Chinese contributor meeting, it was brought to my attention that the "Help Us Translate" CTA wasn't pointing to the Chinese docs. After a bit of investigating, I saw that the key name never got updated in the two Chinese `links.json` files.

While I was in there, I synced the keys that were missing or not updated in all languages' `links.json` files.

Finally, I went ahead and brought the forum category links up-to-date, so they reflect actual categories and subcategories we have.