### PR TITLE
fix(curriculum): add code block to input element in cat photo app step 36

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5ef9b03c81a63668521804d8.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5ef9b03c81a63668521804d8.md
@@ -30,7 +30,7 @@ Your `form` element's opening tag should only have an `action` attribute. Remove
 assert([...document.querySelector('form').attributes].length < 2);
 ```
 
-You should create an input element. Check the syntax.
+You should create an `input` element. Check the syntax.
 
 ```js
 assert(document.querySelector('input'));


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #46840

<!-- Feel free to add any additional description of changes below this line -->

Add code block to input element.

Affected page:

https://www.freecodecamp.org/learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-36

The issue was originally reported in a Crowdin comment:

https://freecodecamp.crowdin.com/translate/690087755819f2f67b26dbee3be0eb53/33756/en-ja/132?filter=basic&value=3

I've tested this change by running my clone locally and then check the hint message like below:

![add-code-block-to-input-element](https://user-images.githubusercontent.com/44451585/178146188-75c218fa-6d2d-47d3-9d9b-dccdf652af09.png)

