### PR TITLE
fix: use shx for cross-platform cp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46905,6 +46905,44 @@
       "version": "1.7.3",
       "license": "MIT"
     },
+    "node_modules/shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/shelljs/node_modules/interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/shelljs/node_modules/rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/shortid": {
       "version": "2.2.16",
       "license": "MIT",
@@ -46915,6 +46953,22 @@
     "node_modules/shortid/node_modules/nanoid": {
       "version": "2.1.11",
       "license": "MIT"
+    },
+    "node_modules/shx": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
+      "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.3",
+        "shelljs": "^0.8.5"
+      },
+      "bin": {
+        "shx": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.0.4",
@@ -53787,6 +53841,7 @@
       "devDependencies": {
         "@types/express": "4.17.13",
         "dotenv": "16.0.1",
+        "shx": "0.3.4",
         "typescript": "4.7.4"
       }
     },
@@ -53817,7 +53872,8 @@
       "devDependencies": {
         "@types/codemirror": "5.60.5",
         "cross-env": "7.0.3",
-        "eslint-plugin-react-hooks": "4.6.0"
+        "eslint-plugin-react-hooks": "4.6.0",
+        "shx": "0.3.4"
       }
     },
     "tools/challenge-helper-scripts": {
@@ -56121,6 +56177,7 @@
         "dotenv": "16.0.1",
         "express": "4.18.1",
         "gray-matter": "4.0.3",
+        "shx": "0.3.4",
         "ts-node": "10.8.2",
         "typescript": "4.7.4"
       },
@@ -56147,6 +56204,7 @@
         "react-dom": "16.14.0",
         "react-router-dom": "6.3.0",
         "react-scripts": "5.0.1",
+        "shx": "0.3.4",
         "typescript": "4.7.4"
       }
     },
@@ -86081,6 +86139,34 @@
     "shell-quote": {
       "version": "1.7.3"
     },
+    "shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "dependencies": {
+        "interpret": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+          "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+          "dev": true
+        },
+        "rechoir": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+          "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+          "dev": true,
+          "requires": {
+            "resolve": "^1.1.6"
+          }
+        }
+      }
+    },
     "shortid": {
       "version": "2.2.16",
       "requires": {
@@ -86090,6 +86176,16 @@
         "nanoid": {
           "version": "2.1.11"
         }
+      }
+    },
+    "shx": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
+      "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.3",
+        "shelljs": "^0.8.5"
       }
     },
     "side-channel": {

--- a/tools/challenge-editor/api/package.json
+++ b/tools/challenge-editor/api/package.json
@@ -5,7 +5,7 @@
   "description": "Editor to help with new challenge structure",
   "scripts": {
     "start": "ts-node server.ts",
-    "postinstall": "cp ./sample.env ./.env"
+    "postinstall": "shx cp ./sample.env ./.env"
   },
   "author": "freeCodeCamp",
   "license": "BSD-3-Clause",
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@types/express": "4.17.13",
     "dotenv": "16.0.1",
+    "shx": "0.3.4",
     "typescript": "4.7.4"
   }
 }

--- a/tools/challenge-editor/client/package.json
+++ b/tools/challenge-editor/client/package.json
@@ -19,7 +19,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "postinstall": "cp ./sample.env ./.env"
+    "postinstall": "shx cp ./sample.env ./.env"
   },
   "browserslist": {
     "production": [
@@ -36,6 +36,7 @@
   "devDependencies": {
     "@types/codemirror": "5.60.5",
     "cross-env": "7.0.3",
-    "eslint-plugin-react-hooks": "4.6.0"
+    "eslint-plugin-react-hooks": "4.6.0",
+    "shx": "0.3.4"
   }
 }


### PR DESCRIPTION
My changes in https://github.com/freeCodeCamp/freeCodeCamp/pull/46784 broken Windows (post) installs since cp is not a Windows command.  `shx` addresses that.