### PR TITLE
docs: fix internal link

### DIFF
--- a/docs/how-to-translate-files.md
+++ b/docs/how-to-translate-files.md
@@ -131,7 +131,7 @@ Our `/learn` interface relies on JSON files loaded into an i18n plugin to genera
 
 The `links.json`, `meta-tags.json`, `motivation.json`, and `trending.json` files contain information that needs to be updated to reflect your language. However, we cannot load these into Crowdin, as the content isn't something that would be a one-to-one translation.
 
-These files will most likely be maintained by your language lead but you are welcome to [read about how to translate them](/language-lead-handbook.md).
+These files will most likely be maintained by your language lead but you are welcome to [read about how to translate them](language-lead-handbook.md).
 
 ### On Crowdin
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Sorry @nhcarrigan, I didn't catch it while your PR was open :(
If we put the slash in front it will go only to the English page. It needs to not have the slash to be relative in the language folder for the translated file.

See https://contribute.freecodecamp.org/#/how-to-work-on-the-docs-theme?id=how-to-create-an-internal-link