### PR TITLE
fix(curriculum): corrected grammar in line 12 of the description section of learn HTML forms.md

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fad1cafcde010995e15306.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fad1cafcde010995e15306.md
@@ -9,7 +9,7 @@ dashedName: step-36
 
 With form submissions, it is useful, and good practice, to provide each submittable element with a `name` attribute. This attribute is used to identify the element in the form submission.
 
-Go ahead, and give each submittable element a unique `name` attribute of your choosing. _Except for the two `radio` inputs._
+Give each submittable element a unique name attribute of your choosing, except for the two radio inputs.
 
 # --hints--
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fad1cafcde010995e15306.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fad1cafcde010995e15306.md
@@ -9,7 +9,7 @@ dashedName: step-36
 
 With form submissions, it is useful, and good practice, to provide each submittable element with a `name` attribute. This attribute is used to identify the element in the form submission.
 
-Give each submittable element a unique name attribute of your choosing, except for the two radio inputs.
+Give each submittable element a unique `name` attribute of your choosing, except for the two `radio` inputs.
 
 # --hints--
 


### PR DESCRIPTION
Hello, 
In the description, the line "Go ahead, and give each submittable element a unique name attribute of your choosing. Except for the two radio inputs", 
the phase 
"Except for the two radio inputs' is not a complete sentence. 
To make it more Grammarly correct and complete, I change it to a new sentence. 
Please have a look.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #46854

<!-- Feel free to add any additional description of changes below this line -->

