### PR TITLE
fix(curriculum): fitting an instruction text to fcc document

### DIFF
--- a/curriculum/challenges/english/07-scientific-computing-with-python/scientific-computing-with-python-projects/probability-calculator.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/scientific-computing-with-python-projects/probability-calculator.md
@@ -37,7 +37,7 @@ Next, create an `experiment` function in `prob_calculator.py` (not inside the `H
 
 The `experiment` function should return a probability.
 
-For example, assuming that you want to determine the probability of getting at least 2 red balls and 1 green ball when you draw 5 balls from a hat containing 6 black, 4 red, and 3 green. To do this, you will perform `N` experiments, count how many times `M` you get at least 2 red balls and 1 green ball, and estimate the probability as `M/N`. Each experiment consists of starting with a hat containing the specified balls, drawing a number of balls, and checking if you got the balls you were attempting to draw.
+For example, if you want to determine the probability of getting at least two red balls and one green ball when you draw five balls from a hat containing six black, four red, and three green. To do this, you will perform `N` experiments, count how many times `M` you get at least two red balls and one green ball, and estimate the probability as `M/N`. Each experiment consists of starting with a hat containing the specified balls, drawing several balls, and checking if you got the balls you were attempting to draw.
 
 Here is how you would call the `experiment` function based on the example above with 2000 experiments:
 

--- a/curriculum/challenges/english/07-scientific-computing-with-python/scientific-computing-with-python-projects/probability-calculator.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/scientific-computing-with-python-projects/probability-calculator.md
@@ -37,7 +37,7 @@ Next, create an `experiment` function in `prob_calculator.py` (not inside the `H
 
 The `experiment` function should return a probability.
 
-For example, let's say that you want to determine the probability of getting at least 2 red balls and 1 green ball when you draw 5 balls from a hat containing 6 black, 4 red, and 3 green. To do this, we perform `N` experiments, count how many times `M` we get at least 2 red balls and 1 green ball, and estimate the probability as `M/N`. Each experiment consists of starting with a hat containing the specified balls, drawing a number of balls, and checking if we got the balls we were attempting to draw.
+For example, assuming that you want to determine the probability of getting at least 2 red balls and 1 green ball when you draw 5 balls from a hat containing 6 black, 4 red, and 3 green. To do this, you will perform `N` experiments, count how many times `M` you get at least 2 red balls and 1 green ball, and estimate the probability as `M/N`. Each experiment consists of starting with a hat containing the specified balls, drawing a number of balls, and checking if you got the balls you were attempting to draw.
 
 Here is how you would call the `experiment` function based on the example above with 2000 experiments:
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Change an instruction text and fitting it to [how-to-work-on-coding-challenges document](https://contribute.freecodecamp.org/#/how-to-work-on-coding-challenges?id=challenge-descriptionsinstructions).

Affected page:
[Scientific Computing with Python Projects - Probability Calculator](
https://www.freecodecamp.org/learn/scientific-computing-with-python/scientific-computing-with-python-projects/probability-calculator)

I'm not native english speaker, so I carefully chose ["assuming"](https://www.ldoceonline.com/dictionary/assume) instead of ["suppose"](https://www.ldoceonline.com/dictionary/suppose).

I've tested this change by running my clone locally and seeing the result in my browser like bellow:

![fitting-an-instruction-text-to-fcc-document](https://user-images.githubusercontent.com/44451585/178391559-8065fd88-6420-43a6-be4a-85fbf35f00dc.png)

