### PR TITLE
feat: simplify client logic

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -40,7 +40,10 @@ import {
 } from '../../../redux/prop-types';
 import { editorToneOptions } from '../../../utils/tone/editor-config';
 import { editorNotes } from '../../../utils/tone/editor-notes';
-import { challengeTypes, isProject } from '../../../../utils/challenge-types';
+import {
+  challengeTypes,
+  isFinalProject
+} from '../../../../utils/challenge-types';
 import {
   canFocusEditorSelector,
   challengeMetaSelector,
@@ -430,7 +433,7 @@ const Editor = (props: EditorProps): JSX.Element => {
       /* eslint-disable no-bitwise */
       keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter],
       run: () => {
-        if (props.usesMultifileEditor && !isProject(props.challengeType)) {
+        if (props.usesMultifileEditor && !isFinalProject(props.challengeType)) {
           if (challengeIsComplete()) {
             tryToSubmitChallenge();
           } else {

--- a/client/src/templates/Challenges/components/Hotkeys.tsx
+++ b/client/src/templates/Challenges/components/Hotkeys.tsx
@@ -15,7 +15,7 @@ import {
   openModal
 } from '../redux';
 import './hotkeys.css';
-import { isProject } from '../../../../utils/challenge-types';
+import { isFinalProject } from '../../../../utils/challenge-types';
 
 const mapStateToProps = createSelector(
   canFocusEditorSelector,
@@ -102,7 +102,7 @@ function Hotkeys({
       if (
         usesMultifileEditor &&
         typeof challengeType == 'number' &&
-        !isProject(challengeType)
+        !isFinalProject(challengeType)
       ) {
         if (testsArePassing) {
           submitChallenge();

--- a/client/src/templates/Challenges/components/completion-modal.tsx
+++ b/client/src/templates/Challenges/components/completion-modal.tsx
@@ -10,7 +10,7 @@ import { Dispatch } from 'redux';
 import { createSelector } from 'reselect';
 
 import { dasherize } from '../../../../../utils/slugs';
-import { isProject } from '../../../../utils/challenge-types';
+import { isFinalProject } from '../../../../utils/challenge-types';
 import Login from '../../../components/Header/components/Login';
 import {
   isSignedInSelector,
@@ -358,7 +358,7 @@ const CompletionModal = (props: CompletionModalsProps) => {
     props.block || '',
     props.certification || '',
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-    { isCertificationBlock: isProject(props.challengeType) }
+    { isCertificationBlock: isFinalProject(props.challengeType) }
   );
   return <CompletionModalInner currentBlockIds={currentBlockIds} {...props} />;
 };

--- a/client/src/templates/Challenges/components/completion-modal.tsx
+++ b/client/src/templates/Challenges/components/completion-modal.tsx
@@ -284,7 +284,7 @@ export class CompletionModalInner extends Component<
 }
 
 interface Options {
-  isCertificationBlock: boolean;
+  isFinalProjectBlock: boolean;
 }
 
 interface CertificateNode {
@@ -348,9 +348,7 @@ const useCurrentBlockIds = (
     .filter(edge => edge.node.challenge.block === block)
     .map(edge => edge.node.challenge.id);
 
-  return options?.isCertificationBlock
-    ? currentCertificateIds
-    : currentBlockIds;
+  return options?.isFinalProjectBlock ? currentCertificateIds : currentBlockIds;
 };
 
 const CompletionModal = (props: CompletionModalsProps) => {

--- a/client/src/templates/Challenges/components/completion-modal.tsx
+++ b/client/src/templates/Challenges/components/completion-modal.tsx
@@ -358,7 +358,7 @@ const CompletionModal = (props: CompletionModalsProps) => {
     props.block || '',
     props.certification || '',
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-    { isCertificationBlock: isFinalProject(props.challengeType) }
+    { isFinalProjectBlock: isFinalProject(props.challengeType) }
   );
   return <CompletionModalInner currentBlockIds={currentBlockIds} {...props} />;
 };

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -18,7 +18,10 @@ import { ChallengeNode, CompletedChallenge } from '../../../redux/prop-types';
 import { playTone } from '../../../utils/tone';
 import { makeExpandedBlockSelector, toggleBlock } from '../redux';
 import { isNewJsCert, isNewRespCert } from '../../../utils/is-a-cert';
-import { isFinalProject } from '../../../../utils/challenge-types';
+import {
+  isCodeAllyPractice,
+  isFinalProject
+} from '../../../../utils/challenge-types';
 import Challenges from './challenges';
 import '../intro.css';
 
@@ -123,7 +126,11 @@ export class Block extends Component<BlockProps> {
     const isProjectBlock = challenges.some(({ challenge }) => {
       const isTakeHomeProject = blockDashedName === 'take-home-projects';
 
-      return isFinalProject(challenge.challengeType) && !isTakeHomeProject;
+      return (
+        isFinalProject(challenge.challengeType) &&
+        !isTakeHomeProject &&
+        isCodeAllyPractice(challenge.challengeType)
+      );
     });
 
     const blockIntroObj: { title?: string; intro: string[] } = t(

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -120,10 +120,7 @@ export class Block extends Component<BlockProps> {
     });
 
     const isProjectBlock = challenges.some(({ challenge }) => {
-      const isJsProject =
-        [3, 6, 10, 14, 17].includes(challenge.order) &&
-        challenge.challengeType === 5 &&
-        blockDashedName !== 'rosetta-code';
+      const isJsProject = challenge.challengeType === 5;
 
       const isOtherProject =
         challenge.challengeType === 3 ||
@@ -135,10 +132,7 @@ export class Block extends Component<BlockProps> {
 
       const isTakeHomeProject = blockDashedName === 'take-home-projects';
 
-      return (
-        (isJsProject && !isTakeHomeProject) ||
-        (isOtherProject && !isTakeHomeProject)
-      );
+      return isJsProject || (isOtherProject && !isTakeHomeProject);
     });
 
     const blockIntroObj: { title?: string; intro: string[] } = t(

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -120,9 +120,11 @@ export class Block extends Component<BlockProps> {
       return { ...challenge, isCompleted };
     });
 
-    const isProjectBlock = challenges.some(({ challenge }) =>
-      isProject(challenge.challengeType)
-    );
+    const isProjectBlock = challenges.some(({ challenge }) => {
+      const isTakeHomeProject = blockDashedName === 'take-home-projects';
+
+      return isProject(challenge.challengeType) && !isTakeHomeProject;
+    });
 
     const blockIntroObj: { title?: string; intro: string[] } = t(
       `intro:${superBlock}.blocks.${blockDashedName}`

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -18,7 +18,7 @@ import { ChallengeNode, CompletedChallenge } from '../../../redux/prop-types';
 import { playTone } from '../../../utils/tone';
 import { makeExpandedBlockSelector, toggleBlock } from '../redux';
 import { isNewJsCert, isNewRespCert } from '../../../utils/is-a-cert';
-import { isProject } from '../../../../utils/challenge-types';
+import { isFinalProject } from '../../../../utils/challenge-types';
 import Challenges from './challenges';
 import '../intro.css';
 
@@ -123,7 +123,7 @@ export class Block extends Component<BlockProps> {
     const isProjectBlock = challenges.some(({ challenge }) => {
       const isTakeHomeProject = blockDashedName === 'take-home-projects';
 
-      return isProject(challenge.challengeType) && !isTakeHomeProject;
+      return isFinalProject(challenge.challengeType) && !isTakeHomeProject;
     });
 
     const blockIntroObj: { title?: string; intro: string[] } = t(

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -18,6 +18,7 @@ import { ChallengeNode, CompletedChallenge } from '../../../redux/prop-types';
 import { playTone } from '../../../utils/tone';
 import { makeExpandedBlockSelector, toggleBlock } from '../redux';
 import { isNewJsCert, isNewRespCert } from '../../../utils/is-a-cert';
+import { isProject } from '../../../../utils/challenge-types';
 import Challenges from './challenges';
 import '../intro.css';
 
@@ -119,21 +120,9 @@ export class Block extends Component<BlockProps> {
       return { ...challenge, isCompleted };
     });
 
-    const isProjectBlock = challenges.some(({ challenge }) => {
-      const isJsProject = challenge.challengeType === 5;
-
-      const isOtherProject =
-        challenge.challengeType === 3 ||
-        challenge.challengeType === 4 ||
-        challenge.challengeType === 10 ||
-        challenge.challengeType === 12 ||
-        challenge.challengeType === 13 ||
-        challenge.challengeType === 14;
-
-      const isTakeHomeProject = blockDashedName === 'take-home-projects';
-
-      return isJsProject || (isOtherProject && !isTakeHomeProject);
-    });
+    const isProjectBlock = challenges.some(({ challenge }) =>
+      isProject(challenge.challengeType)
+    );
 
     const blockIntroObj: { title?: string; intro: string[] } = t(
       `intro:${superBlock}.blocks.${blockDashedName}`

--- a/client/utils/challenge-types.js
+++ b/client/utils/challenge-types.js
@@ -54,6 +54,12 @@ exports.isFinalProject = challengeType => {
   );
 };
 
+exports.isCodeAllyPractice = challengeType => {
+  if (typeof challengeType !== 'number')
+    throw Error('challengeType must be a number');
+  return challengeType === codeAllyPractice;
+};
+
 // turn challengeType to file ext
 exports.pathsMap = {
   [html]: 'html',

--- a/client/utils/challenge-types.js
+++ b/client/utils/challenge-types.js
@@ -47,7 +47,9 @@ exports.isProject = challengeType => {
   return (
     challengeType === frontEndProject ||
     challengeType === backEndProject ||
+    challengeType === jsProject ||
     challengeType === pythonProject ||
+    challengeType === codeAllyPractice ||
     challengeType === codeAllyCert ||
     challengeType === multifileCertProject
   );

--- a/client/utils/challenge-types.js
+++ b/client/utils/challenge-types.js
@@ -41,7 +41,7 @@ exports.challengeTypes = {
   multifileCertProject
 };
 
-exports.isProject = challengeType => {
+exports.isFinalProject = challengeType => {
   if (typeof challengeType !== 'number')
     throw Error('challengeType must be a number');
   return (

--- a/client/utils/challenge-types.js
+++ b/client/utils/challenge-types.js
@@ -49,7 +49,6 @@ exports.isFinalProject = challengeType => {
     challengeType === backEndProject ||
     challengeType === jsProject ||
     challengeType === pythonProject ||
-    challengeType === codeAllyPractice ||
     challengeType === codeAllyCert ||
     challengeType === multifileCertProject
   );


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Continue work for #46729 

<!-- Feel free to add any additional description of changes below this line -->

`isJsProject` now can rely only on the challenge type. Challenge order was for the new JavaScript curriculum, but was kinda hacky.

And in the return there is no need to check for take home projects, as there is none that is of challenge type 5. (Take Home Projects are of type 3 and 4)