### PR TITLE
fix: clarify instructions for reg form step 26

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fab8367d35de04e5cb7929.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fab8367d35de04e5cb7929.md
@@ -7,7 +7,7 @@ dashedName: step-26
 
 # --description--
 
-To finish this `fieldset` off, link the text `terms and conditions` to the following location:
+To finish this `fieldset` off, link the text `terms and conditions` in the third `label` to the following location:
 
 ```md
 https://www.freecodecamp.org/news/terms-of-service/


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

I ran into this same issue twice today and several times in the past. People are creating a link below the `label` with the words "terms and conditions" instead of linking the words in the `label` itself. Just a few extra words to hopefully make it clearer so they get it right the first time.