### PR TITLE
fix: challenge with wrong type in es6 block

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/create-a-module-script.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/create-a-module-script.md
@@ -1,7 +1,7 @@
 ---
 id: 5cddbfd622f1a59093ec611d
 title: Create a Module Script
-challengeType: 6
+challengeType: 1
 forumTopicId: 301198
 dashedName: create-a-module-script
 ---


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Continue work in https://github.com/freeCodeCamp/freeCodeCamp/issues/46729

<!-- Feel free to add any additional description of changes below this line -->

There was a challenge in the JavaScript certification that was using challengeType 6 instead of 5, so I missed it in https://github.com/freeCodeCamp/freeCodeCamp/pull/46826
And it doesn't make sense that there is only one challenge in there with type 6