### PR TITLE
fix(i18n): configure search Japanese publication

### DIFF
--- a/client/src/utils/algolia-locale-setup.ts
+++ b/client/src/utils/algolia-locale-setup.ts
@@ -35,7 +35,7 @@ const algoliaIndices = {
     searchPage: 'https://www.freecodecamp.org/news/search/'
   },
   japanese: {
-    name: 'news',
+    name: 'news-ja',
     searchPage: 'https://www.freecodecamp.org/japanese/news/search/'
   }
 };


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Currently the search box on Japanese /learn is searching for the English publication. I want to configure it to search in the Japanese publication.

I haven't tested this myself since I didn't have the Algolia app ID and key. I appreciate it if someone could test it.
If you search for `freeCodeCamp` then you should see results like this (I took this screenshot on Japanese /news):
![image](https://user-images.githubusercontent.com/25644062/178815966-35f8203d-301c-4d57-bd7c-02c533422a0a.png)