### PR TITLE
fix(curriculum): change a text to match the test

### DIFF
--- a/curriculum/challenges/english/07-scientific-computing-with-python/scientific-computing-with-python-projects/budget-app.md
+++ b/curriculum/challenges/english/07-scientific-computing-with-python/scientific-computing-with-python-projects/budget-app.md
@@ -41,7 +41,7 @@ Besides the `Category` class, create a function (outside of the class) called `c
 
 The chart should show the percentage spent in each category passed in to the function. The percentage spent should be calculated only with withdrawals and not with deposits. Down the left side of the chart should be labels 0 - 100. The "bars" in the bar chart should be made out of the "o" character. The height of each bar should be rounded down to the nearest 10. The horizontal line below the bars should go two spaces past the final bar. Each category name should be written vertically below the bar. There should be a title at the top that says "Percentage spent by category".
 
-This function will be tested with up to four categories.
+This function will be tested with three categories.
 
 Look at the example output below very closely and make sure the spacing of the output matches the example exactly.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Change an instruction text to match the contents of the test. 

Affected page:
[Scientific Computing with Python Projects - Budget App](https://www.freecodecamp.org/learn/scientific-computing-with-python/scientific-computing-with-python-projects/budget-app)

In the test_module.py, test_create_spend_chart passes three categories to the function as list argument, and the number of categories which the function may receive is not restricted to four.

I also considered deleting the sentence and then append "and create_spend_chart" to the text "For development, you can use main.py to test your Category class." in Development to reduce the reading amount. But I thought it will change the instruction flow. 

So I simply replaced "up to four" to "three".

I've tested this change by running my clone locally and seeing the result in my browser like bellow:

![change-a-text-to-match-the-contents-of-the-test](https://user-images.githubusercontent.com/44451585/178937389-578737d9-b440-4c7b-8df5-7edf96ea501e.png)

