### PR TITLE
docs: add how to translate info boxes headers

### DIFF
--- a/docs/language-lead-handbook.md
+++ b/docs/language-lead-handbook.md
@@ -94,6 +94,86 @@ You can convert from one format to the other carefully changing it manually. Or 
 > [!TIP]
 > A new workflow is being worked on, there will be only one place to change in the future.
 
+## How to translate the info boxes headers in the documentation
+
+You can find these boxes all around the documentation:
+
+> [!NOTE]
+> I am a note box
+
+> [!TIP]
+> I am a tip box
+
+> [!WARNING]
+> I am a warning box
+
+> [!ATTENTION]
+> I am an attention box
+
+By default, their headers appear in English even in the translated docs.
+
+You can have the headers translated in the docs in your language by changing the file `docs/index.html`, in this way:
+
+Inside the `script` element there is an object, find the `flexibleAlerts` property, which has this shape:
+
+```js
+flexibleAlerts: {
+  note: {
+    label: {
+      '/': 'Note'
+    }
+  },
+  tip: {
+    label: {
+      '/': 'Tip'
+    }
+  },
+  warning: {
+    label: {
+      '/': 'Warning'
+    }
+  },
+  attention: {
+    label: {
+      '/': 'Attention'
+    }
+  }
+}
+```
+
+Inside the object of the label property, before the `'/'` property, you would add a new property for your language, like `/i18n/<langauge>/`.
+
+For example, adding the translations for Portuguese would appear like this:
+
+```js
+flexibleAlerts: {
+  note: {
+    label: {
+      '/i18n/portuguese/': 'Observação',
+      '/': 'Note'
+    }
+  },
+  tip: {
+    label: {
+      '/i18n/portuguese/': 'Dica',
+      '/': 'Tip'
+    }
+  },
+  warning: {
+    label: {
+      '/i18n/portuguese/': 'Aviso',
+      '/': 'Warning'
+    }
+  },
+  attention: {
+    label: {
+      '/i18n/portuguese/': 'Atenção',
+      '/': 'Attention'
+    }
+  }
+}
+```
+
 ## How to translate the motivational quotes
 
 The motivational quotes can be found in the [curriculum repository](https://github.com/freeCodeCamp/freeCodeCamp/) in the `/client/i18n/locales/<language>/motivation.json` file.

--- a/docs/language-lead-handbook.md
+++ b/docs/language-lead-handbook.md
@@ -141,7 +141,7 @@ flexibleAlerts: {
 }
 ```
 
-Inside the object of the label property, before the `'/'` property, you would add a new property for your language, like `/i18n/<langauge>/`.
+Inside the object of the label property, before the `'/'` property, you would add a new property for your language, like `/i18n/<language>/`.
 
 For example, adding the translations for Portuguese would appear like this:
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #46852 

<!-- Feel free to add any additional description of changes below this line -->

This add how to translate the headers of these boxes in the translated docs:

![image](https://user-images.githubusercontent.com/26656284/179229508-ad7c6737-45d9-4457-807f-77bc18205504.png)
