### PR TITLE
fix(a11y): change headings in footer to h2

### DIFF
--- a/client/src/components/Footer/__snapshots__/footer.test.tsx.snap
+++ b/client/src/components/Footer/__snapshots__/footer.test.tsx.snap
@@ -38,11 +38,11 @@ exports[`<Footer /> matches snapshot 1`] = `
       <div
         className="trending-guides"
       >
-        <div
+        <h2
           className="col-header"
         >
           footer.trending-guides
-        </div>
+        </h2>
         <div
           className="trending-guides-row"
         >
@@ -282,11 +282,11 @@ exports[`<Footer /> matches snapshot 1`] = `
     <div
       className="footer-bottom"
     >
-      <div
+      <h2
         className="col-header"
       >
         footer.our-nonprofit
-      </div>
+      </h2>
       <div
         className="footer-divder"
       />

--- a/client/src/components/Footer/footer.css
+++ b/client/src/components/Footer/footer.css
@@ -42,6 +42,8 @@
   font-size: 16px;
   text-align: center;
   padding: 0 15px 15px;
+  margin-bottom: 0;
+  font-family: Lato, sans-serif;
 }
 
 .footer-row {

--- a/client/src/components/Footer/index.tsx
+++ b/client/src/components/Footer/index.tsx
@@ -25,7 +25,7 @@ function Footer(): JSX.Element {
             </p>
           </div>
           <div className='trending-guides'>
-            <div className='col-header'>{t('footer.trending-guides')}</div>
+            <h2 className='col-header'>{t('footer.trending-guides')}</h2>
             <div className='trending-guides-row'>
               <div className='footer-col footer-col-1'>
                 <Link external={false} to={t('trending:article0link')}>
@@ -132,7 +132,7 @@ function Footer(): JSX.Element {
           </div>
         </div>
         <div className='footer-bottom'>
-          <div className='col-header'>{t('footer.our-nonprofit')}</div>
+          <h2 className='col-header'>{t('footer.our-nonprofit')}</h2>
           <div className='footer-divder' />
           <div className='our-nonprofit'>
             <Link external={false} to={t('links:footer.about-url')}>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This is a rather simple one. The bold headings in the footer look like headings and act like headings and thus should be marked up as headings. 

The **Our Nonprofit** heading only appears when the view port is narrow. Is there any way I can convince you to leave it for wide view ports as well? It would be nice for screen reader user navigation to show that heading permanently since there are so many Trending Guides links above the nonprofit links.