### PR TITLE
fix: allow users to submit after editing

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -1084,7 +1084,10 @@ const Editor = (props: EditorProps): JSX.Element => {
       focusIfTargetEditor();
     }
 
-    if (props.initialTests) initTests(props.initialTests);
+    // Once a challenge has been completed, we don't want changes to the content
+    // to reset the tests since the user is already done with the challenge.
+    if (props.initialTests && !challengeIsComplete())
+      initTests(props.initialTests);
 
     if (hasEditableRegion() && editor) {
       if (props.isResetting) {


### PR DESCRIPTION
If a user runs the tests and they pass, the multifile editor will show a
submit button.  If the user then edited the page, it would no longer be
possible to submit.

This ensures the redux store keeps the original, passing, tests and lets
the user submit

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/46933

<!-- Feel free to add any additional description of changes below this line -->
