### PR TITLE
Change in wording for 2nd test of Chain Middleware to Create a Time Server challenge

### DIFF
--- a/curriculum/challenges/english/05-back-end-development-and-apis/basic-node-and-express/chain-middleware-to-create-a-time-server.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/basic-node-and-express/chain-middleware-to-create-a-time-server.md
@@ -49,7 +49,7 @@ The /now endpoint should have mounted middleware
   );
 ```
 
-The /now endpoint should return a time that is +/- 20 secs from now
+The /now endpoint should return the current time.
 
 ```js
 (getUserInput) =>


### PR DESCRIPTION
Slight change in wording for 2nd test of Chain Middleware to Create a Time Server challenge.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [ x ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ x ] My pull request targets the `main` branch of freeCodeCamp.
- [ x ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #46941

<!-- Feel free to add any additional description of changes below this line -->
