### PR TITLE
fix: added extra test to prevent incorrect solution from passing for the Wherefore art thou challenge

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/wherefore-art-thou.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/wherefore-art-thou.md
@@ -97,6 +97,15 @@ assert.deepEqual(
 );
 ```
 
+`whatIsInAName([{"a": 1, "b": 2, "c": 3, "d": 9999}], {"a": 1, "b": 9999, "c": 3})` should return `[]`
+
+```js
+assert.deepEqual(
+  whatIsInAName([{ a: 1, b: 2, c: 3, d: 9999 }], { a: 1, b: 9999, c: 3 }),
+  []
+);
+```
+
 # --seed--
 
 ## --seed-contents--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

[While helping a forum user](https://forum.freecodecamp.org/t/trouble-with-wherefore-art-thou-js-challenge/531352/6) on the [Wherefore art thou](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/wherefore-art-thou)challenge, a solution (see below) which passed all the tests was created. 

```js
function whatIsInAName(collection, source) {

  const arr = [];
  // Only change code below this line
  let sourceKeys = Object.keys(source);
  let sourceValues = Object.values(source);

  collection.forEach((obj) => {
    let checkAllKeys = sourceKeys.every((i) => obj.hasOwnProperty(i));
    let checkAllValues = sourceValues.every((j) => Object.values(obj).includes(j))
    if (checkAllKeys === true && checkAllValues === true) {
      arr.push(obj)
    }
  })
  // Only change code above this line
  return arr;
}
```
After further inspection of the function's code, I realized the user got lucky with the solution because there is no test case where the all the values of the source object are present on one of the collection's objects but the property names do not.
```
whatIsInAName([{"a": 1, "b": 2, "c": 3, "d": 9999}], {"a": 1, "b": 9999, "c": 3})
```
The above call should return `[ ]` but with function above `[{"a": 1, "b": 2, "c": 3, "d": 9999}]` is returned.

This PR adds a new test to make sure a solution like this would not pass.