### PR TITLE
feat: Set keyboardShortcuts to true for authUser in seedAuthUser.js

### DIFF
--- a/tools/scripts/seed/seedAuthUser.js
+++ b/tools/scripts/seed/seedAuthUser.js
@@ -85,7 +85,7 @@ const authUser = {
   isDonating: envVariables.includes('--donor'),
   emailAuthLinkTTL: null,
   emailVerifyTTL: null,
-  keyboardShortcuts: false
+  keyboardShortcuts: true
 };
 
 const blankUser = {


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #46923

Solution suggested by @raisedadead in #46923

EDIT: Tested on https://8000-paulabarszc-freecodecam-wkfvuusl44z.ws-eu54.gitpod.io/settings
Option `Enable Keyboard Shortcuts` is now by default switched on:

![preview_keyboard shortcuts](https://user-images.githubusercontent.com/31891675/180074547-abc48e71-e58d-4a74-a0c5-3060d8156cec.jpg)

