### PR TITLE
fix(docs): Fixed Typo in language lead handbook

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/applied-accessibility/add-an-accessible-date-picker.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-accessibility/add-an-accessible-date-picker.md
@@ -9,7 +9,7 @@ dashedName: add-an-accessible-date-picker
 
 # --description--
 
-Forms often includ the `input` field, which can be used to create several different form controls. The `type` attribute on this element indicates what kind of `input` element will be created.
+Forms often include the `input` field, which can be used to create several different form controls. The `type` attribute on this element indicates what kind of `input` element will be created.
 
 You may have noticed the `text` and `submit` input types in prior challenges, and HTML5 introduced an option to specify a `date` field. Depending on browser support, a date picker shows up in the `input` field when it's in focus, which makes filling in a form easier for all users.
 

--- a/curriculum/challenges/english/01-responsive-web-design/applied-accessibility/add-an-accessible-date-picker.md
+++ b/curriculum/challenges/english/01-responsive-web-design/applied-accessibility/add-an-accessible-date-picker.md
@@ -9,7 +9,7 @@ dashedName: add-an-accessible-date-picker
 
 # --description--
 
-Forms often include the `input` field, which can be used to create several different form controls. The `type` attribute on this element indicates what kind of `input` element will be created.
+Forms often includ the `input` field, which can be used to create several different form controls. The `type` attribute on this element indicates what kind of `input` element will be created.
 
 You may have noticed the `text` and `submit` input types in prior challenges, and HTML5 introduced an option to specify a `date` field. Depending on browser support, a date picker shows up in the `input` field when it's in focus, which makes filling in a form easier for all users.
 

--- a/docs/language-lead-handbook.md
+++ b/docs/language-lead-handbook.md
@@ -266,7 +266,7 @@ Then there are three steps to complete:
 
 ![pre-translate existing translations](./images/crowdin/pre-translate3.png)
 
-When you have finished settings this, press the Pre-Translate button, and wait. It will alert you once it has finished. It will take more or less time depending on how many untranslated strings are present in the files you have choosen.
+When you have finished setting this, press the Pre-Translate button and wait. It will alert you once it has finished. The time it takes depends on how many untranslated strings are in the chosen files.
 
 ## How to update Crowdin Glossary
 

--- a/docs/language-lead-handbook.md
+++ b/docs/language-lead-handbook.md
@@ -31,7 +31,7 @@ With `link` being the link of the original article.
 > [!TIP]
 > Changing the articles in the footer at least once a month means giving a boost to the linked articles on google results.
 
-There two places in which to change the trending articles.
+There are two places in which to change the trending articles.
 
 - [The curriculum repository](https://github.com/freeCodeCamp/freeCodeCamp/)
 - [The CDN repository](https://github.com/freeCodeCamp/cdn)
@@ -266,7 +266,7 @@ Then there are three steps to complete:
 
 ![pre-translate existing translations](./images/crowdin/pre-translate3.png)
 
-When you have finished settngs this, press the Pre-Translate button, and wait. It will alert you once it has finished. It will take more or less time depending on how many untranslated strings are present in the files you have choosen.
+When you have finished settings this, press the Pre-Translate button, and wait. It will alert you once it has finished. It will take more or less time depending on how many untranslated strings are present in the files you have choosen.
 
 ## How to update Crowdin Glossary
 


### PR DESCRIPTION
Checklist:

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.


Closes #46977

The issue was to fix two typos first one at line 34 where `there two places` should have been `there are two places` and second one at line 269 where the word `settngs` was misspelled. 

This PR fixes both the typos.

![image](https://user-images.githubusercontent.com/87017414/180305526-d75341cb-39a3-4e62-ac02-9cf76877ca04.png)

![image](https://user-images.githubusercontent.com/87017414/180305049-e3ceffa2-7ecb-4d9e-adda-4d04d29ef5cc.png)




