### PR TITLE
fix(curriculum): remove duplicate test from CatPhotoApp Step 23

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dfb6a35eacea3f48c6300b4.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dfb6a35eacea3f48c6300b4.md
@@ -15,16 +15,6 @@ After the image nested in the `figure` element, add a `figcaption` element with 
 
 # --hints--
 
-The Lasagna `img` element should be nested in the `figure` element.
-
-```js
-assert(
-  document.querySelector('figure > img') &&
-    document.querySelector('figure > img').getAttribute('src').toLowerCase() ===
-      'https://cdn.freecodecamp.org/curriculum/cat-photo-app/lasagna.jpg'
-);
-```
-
 Your `figcaption` element should have an opening tag. Opening tags have the following syntax: `<elementName>`.
 
 ```js


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

The first and the 5th tests are the same (The lasagna `img` element should be nested in the `figure` element.) Can we remove one of them?

Affected page:
https://www.freecodecamp.org/learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-23