### PR TITLE
fix: update Basic Node and Express challenge text

### DIFF
--- a/curriculum/challenges/english/05-back-end-development-and-apis/basic-node-and-express/use-body-parser-to-parse-post-requests.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/basic-node-and-express/use-body-parser-to-parse-post-requests.md
@@ -22,11 +22,11 @@ Content-Length: 20
 name=John+Doe&age=25
 ```
 
-As you can see, the body is encoded like the query string. This is the default format used by HTML forms. With Ajax, you can also use JSON to handle data having a more complex structure. There is also another type of encoding: multipart/form-data. This one is used to upload binary files. In this exercise, you will use a urlencoded body. To parse the data coming from POST requests, you have to install the `body-parser` package. This package allows you to use a series of middleware, which can decode data in different formats.
+As you can see, the body is encoded like the query string. This is the default format used by HTML forms. With Ajax, you can also use JSON to handle data having a more complex structure. There is also another type of encoding: multipart/form-data. This one is used to upload binary files. In this exercise, you will use a urlencoded body. To parse the data coming from POST requests, you have to use the `body-parser` package. This package allows you to use a series of middleware, which can decode data in different formats.
 
 # --instructions--
 
-Install the `body-parser` module in your `package.json`. Then, `require` it at the top of the file. Store it in a variable named `bodyParser`. The middleware to handle urlencoded data is returned by `bodyParser.urlencoded({extended: false})`. Pass the function returned by the previous method call to `app.use()`. As usual, the middleware must be mounted before all the routes that depend on it.
+`body-parser` has already been installed, and is in your project's `package.json` file. `require` it at the top of the `myApp.js` file and store it in a variable named `bodyParser`. The middleware to handle urlencoded data is returned by `bodyParser.urlencoded({extended: false})`. Pass the function returned by the previous method call to `app.use()`. As usual, the middleware must be mounted before all the routes that depend on it.
 
 **Note:** `extended` is a configuration option that tells `body-parser` which parsing needs to be used. When `extended=false` it uses the classic encoding `querystring` library. When `extended=true` it uses `qs` library for parsing. 
 

--- a/curriculum/challenges/english/05-back-end-development-and-apis/basic-node-and-express/use-body-parser-to-parse-post-requests.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/basic-node-and-express/use-body-parser-to-parse-post-requests.md
@@ -26,7 +26,7 @@ As you can see, the body is encoded like the query string. This is the default f
 
 # --instructions--
 
-`body-parser` has already been installed, and is in your project's `package.json` file. `require` it at the top of the `myApp.js` file and store it in a variable named `bodyParser`. The middleware to handle urlencoded data is returned by `bodyParser.urlencoded({extended: false})`. Pass the function returned by the previous method call to `app.use()`. As usual, the middleware must be mounted before all the routes that depend on it.
+`body-parser` has already been installed and is in your project's `package.json` file. `require` it at the top of the `myApp.js` file and store it in a variable named `bodyParser`. The middleware to handle URL encoded data is returned by `bodyParser.urlencoded({extended: false})`. Pass the function returned by the previous method call to `app.use()`. As usual, the middleware must be mounted before all the routes that depend on it.
 
 **Note:** `extended` is a configuration option that tells `body-parser` which parsing needs to be used. When `extended=false` it uses the classic encoding `querystring` library. When `extended=true` it uses `qs` library for parsing. 
 

--- a/curriculum/challenges/english/05-back-end-development-and-apis/basic-node-and-express/use-body-parser-to-parse-post-requests.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/basic-node-and-express/use-body-parser-to-parse-post-requests.md
@@ -22,7 +22,7 @@ Content-Length: 20
 name=John+Doe&age=25
 ```
 
-As you can see, the body is encoded like the query string. This is the default format used by HTML forms. With Ajax, you can also use JSON to handle data having a more complex structure. There is also another type of encoding: multipart/form-data. This one is used to upload binary files. In this exercise, you will use a urlencoded body. To parse the data coming from POST requests, you have to use the `body-parser` package. This package allows you to use a series of middleware, which can decode data in different formats.
+As you can see, the body is encoded like the query string. This is the default format used by HTML forms. With Ajax, you can also use JSON to handle data having a more complex structure. There is also another type of encoding: multipart/form-data. This one is used to upload binary files. In this exercise, you will use a URL encoded body. To parse the data coming from POST requests, you must use the `body-parser` package. This package allows you to use a series of middleware, which can decode data in different formats.
 
 # --instructions--
 

--- a/curriculum/challenges/english/05-back-end-development-and-apis/basic-node-and-express/use-the-.env-file.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/basic-node-and-express/use-the-.env-file.md
@@ -22,7 +22,7 @@ Then, in the `/json` GET route handler you created in the last challenge, transf
 
 **Note:** If you are using Replit, you cannot create a `.env` file. Instead, use the built-in <dfn>SECRETS</dfn> tab to add the variable.
 
-If you are working locally, you will need the `dotenv` package. It loads environment variables from your `.env` file into `process.env`. The `dotenv` package has already been installed, and is in your project's `package.json`file. At the top of your `myApp.js` file, import and load the variables with `require('dotenv').config()`.
+If you are working locally, you will need the `dotenv` package. It loads environment variables from your `.env` file into `process.env`. The `dotenv` package has already been installed, and is in your project's `package.json` file. At the top of your `myApp.js` file, import and load the variables with `require('dotenv').config()`.
 
 # --hints--
 

--- a/curriculum/challenges/english/05-back-end-development-and-apis/basic-node-and-express/use-the-.env-file.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/basic-node-and-express/use-the-.env-file.md
@@ -22,7 +22,7 @@ Then, in the `/json` GET route handler you created in the last challenge, transf
 
 **Note:** If you are using Replit, you cannot create a `.env` file. Instead, use the built-in <dfn>SECRETS</dfn> tab to add the variable.
 
-If you are working locally, you will need the `dotenv` package. It loads environment variables from your `.env` file into `process.env`. Install it with `npm install dotenv`. Then, at the top of your `myApp.js` file, import and load the variables with `require('dotenv').config()`.
+If you are working locally, you will need the `dotenv` package. It loads environment variables from your `.env` file into `process.env`. The `dotenv` package has already been installed, and is in your project's `package.json`file. At the top of your `myApp.js` file, import and load the variables with `require('dotenv').config()`.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to https://github.com/freeCodeCamp/freeCodeCamp/issues/46910

<!-- Feel free to add any additional description of changes below this line -->
This updates the challenge text for a couple of challenges where learners should no longer have to install `body-parser` or `dotenv` themselves.

As mentioned in https://github.com/freeCodeCamp/boilerplate-express/pull/98, if it's decided that we should't preinstall the `dotenv` package for local development, I can remove the commit that updates the challenge text here.