### PR TITLE
fix(curriculum): remove reference to a label element that doesn't exist

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5f0d4ab1b435f13ab6550052.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5f0d4ab1b435f13ab6550052.md
@@ -47,7 +47,7 @@ const foundElems = childrenOf1stFieldset.filter((child) => {
 assert(foundElems.length === 0);
 ```
 
-Both `fieldset` elements should be above the text field and its associated `label` element. They are out of order.
+Both `fieldset` elements should be above the text field. They are out of order.
 
 ```js
 const formChildren = $('form')[0].children;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
The current hint is:
>Both `fieldset` elements should be above the text field and its associated `label` element.

But there is no label element associated with the text field in the code.

Affected page:
https://www.freecodecamp.org/learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-51