### PR TITLE
Fix(curriculum) accessibility issue with labels in registration form course

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60f852f645b5310a8264f555.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60f852f645b5310a8264f555.md
@@ -42,10 +42,10 @@ assert.exists(document.querySelector('fieldset:nth-child(2)')?.querySelector('la
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
       <fieldset>
-        <label>Enter Your First Name: <input type="text" required /></label>
-        <label>Enter Your Last Name: <input type="text" required /></label>
-        <label>Enter Your Email: <input type="email" required /></label>
-        <label>Create a New Password: <input type="password" pattern="[a-z0-5]{8,}" required /></label>
+        <label for="first-name">Enter Your First Name: <input id="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
 --fcc-editable-region--
       <fieldset>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60f85a62fb30c80bcea0cedb.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60f85a62fb30c80bcea0cedb.md
@@ -49,10 +49,10 @@ assert.equal(document.querySelectorAll('fieldset:nth-child(2) input[type="radio"
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
       <fieldset>
-        <label>Enter Your First Name: <input type="text" required /></label>
-        <label>Enter Your Last Name: <input type="text" required /></label>
-        <label>Enter Your Email: <input type="email" required /></label>
-        <label>Create a New Password: <input type="password" pattern="[a-z0-5]{8,}" required /></label>
+        <label for="first-name">Enter Your First Name: <input id="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
 --fcc-editable-region--
       <fieldset>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60f8604682407e0d017bbf7f.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60f8604682407e0d017bbf7f.md
@@ -46,10 +46,10 @@ assert.equal(document.querySelector('fieldset:nth-child(2) label:nth-child(3) in
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
       <fieldset>
-        <label>Enter Your First Name: <input type="text" required /></label>
-        <label>Enter Your Last Name: <input type="text" required /></label>
-        <label>Enter Your Email: <input type="email" required /></label>
-        <label>Create a New Password: <input type="password" pattern="[a-z0-5]{8,}" required /></label>
+        <label for="first-name">Enter Your First Name: <input id="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
 --fcc-editable-region--
       <fieldset>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60f8618d191b940d62038513.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60f8618d191b940d62038513.md
@@ -70,10 +70,10 @@ assert.equal(document.querySelector('fieldset:nth-child(2) > label:nth-child(3)'
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
       <fieldset>
-        <label>Enter Your First Name: <input type="text" required /></label>
-        <label>Enter Your Last Name: <input type="text" required /></label>
-        <label>Enter Your Email: <input type="email" required /></label>
-        <label>Create a New Password: <input type="password" pattern="[a-z0-5]{8,}" required /></label>
+        <label for="first-name">Enter Your First Name: <input id="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
 --fcc-editable-region--
       <fieldset>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fab4a123ce4b04526b082b.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fab4a123ce4b04526b082b.md
@@ -48,10 +48,10 @@ assert.isEmpty(document.querySelector('fieldset:nth-child(2) label:nth-child(3) 
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
       <fieldset>
-        <label>Enter Your First Name: <input type="text" required /></label>
-        <label>Enter Your Last Name: <input type="text" required /></label>
-        <label>Enter Your Email: <input type="email" required /></label>
-        <label>Create a New Password: <input type="password" pattern="[a-z0-5]{8,}" required /></label>
+        <label for="first-name">Enter Your First Name: <input id="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
 --fcc-editable-region--
       <fieldset>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fab8367d35de04e5cb7929.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fab8367d35de04e5cb7929.md
@@ -50,10 +50,10 @@ assert.equal(document.querySelector('fieldset:nth-child(2) > label:nth-child(3) 
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
       <fieldset>
-        <label>Enter Your First Name: <input type="text" required /></label>
-        <label>Enter Your Last Name: <input type="text" required /></label>
-        <label>Enter Your Email: <input type="email" required /></label>
-        <label>Create a New Password: <input type="password" pattern="[a-z0-5]{8,}" required /></label>
+        <label for="first-name">Enter Your First Name: <input id="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
 --fcc-editable-region--
       <fieldset>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fab9f17fa294054b74228c.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fab9f17fa294054b74228c.md
@@ -48,18 +48,27 @@ assert.equal(document.querySelector('fieldset:nth-child(3) > label > input')?.ty
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
       <fieldset>
-        <label>Enter Your First Name: <input type="text" required /></label>
-        <label>Enter Your Last Name: <input type="text" required /></label>
-        <label>Enter Your Email: <input type="email" required /></label>
-        <label>Create a New Password: <input type="password" pattern="[a-z0-5]{8,}" required /></label>
+        <label for="first-name">Enter Your First Name: <input id="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
       <fieldset>
+<<<<<<< HEAD
+        <label for="personal-account"><input id="personal-account" type="radio" name="account-type" /> Personal Account</label>
+        <label for="business-account"><input id="business-account" type="radio" name="account-type" /> Business Account</label>
+        <label for="terms-and-conditions">
+          <input id="terms-and-conditions" type="checkbox" required /> I accept the
+				    <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
+			  </label>
+=======
         <label><input type="radio" name="account-type" /> Personal Account</label>
         <label><input type="radio" name="account-type" /> Business Account</label>
         <label>
           <input type="checkbox" required /> I accept the
             <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
       </fieldset>
 --fcc-editable-region--
       <fieldset>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fabf0dd4959805dbae09e6.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fabf0dd4959805dbae09e6.md
@@ -62,17 +62,26 @@ assert.equal(document.querySelector('fieldset:nth-child(3) > label:nth-child(2) 
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
       <fieldset>
-        <label>Enter Your First Name: <input type="text" required /></label>
-        <label>Enter Your Last Name: <input type="text" required /></label>
-        <label>Enter Your Email: <input type="email" required /></label>
-        <label>Create a New Password: <input type="password" pattern="[a-z0-5]{8,}" required /></label>
+        <label for="first-name">Enter Your First Name: <input id="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
       <fieldset>
+<<<<<<< HEAD
+        <label for="personal-account"><input id="personal-account" type="radio" name="account-type" /> Personal Account</label>
+        <label for="business-account"><input id="business-account" type="radio" name="account-type" /> Business Account</label>
+        <label for="terms-and-conditions">
+          <input id="terms-and-conditions" type="checkbox" required /> I accept the
+				    <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
+			  </label>
+=======
         <label><input type="radio" name="account-type" /> Personal Account</label>
         <label><input type="radio" name="account-type" /> Business Account</label>
         <label>
           <input type="checkbox" required /> I accept the <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
       </fieldset>
 --fcc-editable-region--
       <fieldset>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fac4095512d3066053d73c.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fac4095512d3066053d73c.md
@@ -42,17 +42,26 @@ assert.equal(document.querySelectorAll('fieldset:nth-child(3) > select > option'
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
       <fieldset>
-        <label>Enter Your First Name: <input type="text" required /></label>
-        <label>Enter Your Last Name: <input type="text" required /></label>
-        <label>Enter Your Email: <input type="email" required /></label>
-        <label>Create a New Password: <input type="password" pattern="[a-z0-5]{8,}" required /></label>
+        <label for="first-name">Enter Your First Name: <input id="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
       <fieldset>
+<<<<<<< HEAD
+        <label for="personal-account"><input id="personal-account" type="radio" name="account-type" /> Personal Account</label>
+        <label for="business-account"><input id="business-account" type="radio" name="account-type" /> Business Account</label>
+        <label for="terms-and-conditions">
+          <input id="terms-and-conditions" type="checkbox" required /> I accept the
+				    <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
+			  </label>
+=======
         <label><input type="radio" name="account-type" /> Personal Account</label>
         <label><input type="radio" name="account-type" /> Business Account</label>
         <label>
           <input type="checkbox" required /> I accept the <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
       </fieldset>
 --fcc-editable-region--
       <fieldset>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fac56271087806def55b33.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fac56271087806def55b33.md
@@ -52,17 +52,26 @@ assert.equal(document.querySelectorAll('fieldset > label > select > option')?.le
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
       <fieldset>
-        <label>Enter Your First Name: <input type="text" required /></label>
-        <label>Enter Your Last Name: <input type="text" required /></label>
-        <label>Enter Your Email: <input type="email" required /></label>
-        <label>Create a New Password: <input type="password" pattern="[a-z0-5]{8,}" required /></label>
+        <label for="first-name">Enter Your First Name: <input id="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
       <fieldset>
+<<<<<<< HEAD
+        <label for="personal-account"><input id="personal-account" type="radio" name="account-type" /> Personal Account</label>
+        <label for="business-account"><input id="business-account" type="radio" name="account-type" /> Business Account</label>
+        <label for="terms-and-conditions">
+          <input id="terms-and-conditions" type="checkbox" required /> I accept the
+				    <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
+			  </label>
+=======
         <label><input type="radio" name="account-type" /> Personal Account</label>
         <label><input type="radio" name="account-type" /> Business Account</label>
         <label>
           <input type="checkbox" required /> I accept the <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
       </fieldset>
 --fcc-editable-region--
       <fieldset>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fac8d7fdfaee0796934f20.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fac8d7fdfaee0796934f20.md
@@ -66,17 +66,26 @@ assert.equal(document.querySelectorAll('fieldset:nth-child(3) > label:nth-child(
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
       <fieldset>
-        <label>Enter Your First Name: <input type="text" required /></label>
-        <label>Enter Your Last Name: <input type="text" required /></label>
-        <label>Enter Your Email: <input type="email" required /></label>
-        <label>Create a New Password: <input type="password" pattern="[a-z0-5]{8,}" required /></label>
+        <label for="first-name">Enter Your First Name: <input id="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
       <fieldset>
+<<<<<<< HEAD
+        <label for="personal-account"><input id="personal-account" type="radio" name="account-type" /> Personal Account</label>
+        <label for="business-account"><input id="business-account" type="radio" name="account-type" /> Business Account</label>
+        <label for="terms-and-conditions">
+          <input id="terms-and-conditions" type="checkbox" required /> I accept the
+				    <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
+			  </label>
+=======
         <label><input type="radio" name="account-type" /> Personal Account</label>
         <label><input type="radio" name="account-type" /> Business Account</label>
         <label>
           <input type="checkbox" required /> I accept the <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
       </fieldset>
 --fcc-editable-region--
       <fieldset>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60faca286cb48b07f6482970.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60faca286cb48b07f6482970.md
@@ -60,17 +60,26 @@ assert.equal(document.querySelectorAll('fieldset:nth-child(3) > label:nth-child(
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
       <fieldset>
-        <label>Enter Your First Name: <input type="text" required /></label>
-        <label>Enter Your Last Name: <input type="text" required /></label>
-        <label>Enter Your Email: <input type="email" required /></label>
-        <label>Create a New Password: <input type="password" pattern="[a-z0-5]{8,}" required /></label>
+        <label for="first-name">Enter Your First Name: <input id="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
       <fieldset>
+<<<<<<< HEAD
+        <label for="personal-account"><input id="personal-account" type="radio" name="account-type" /> Personal Account</label>
+        <label for="business-account"><input id="business-account" type="radio" name="account-type" /> Business Account</label>
+        <label for="terms-and-conditions">
+          <input id="terms-and-conditions" type="checkbox" required /> I accept the
+				    <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
+			  </label>
+=======
         <label><input type="radio" name="account-type" /> Personal Account</label>
         <label><input type="radio" name="account-type" /> Business Account</label>
         <label>
           <input type="checkbox" required /> I accept the <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
       </fieldset>
 --fcc-editable-region--
       <fieldset>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60facde2d0dc61085b41063f.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60facde2d0dc61085b41063f.md
@@ -54,17 +54,26 @@ assert.match(code, /<textarea\s*>[\s\S]*<\/textarea\s*>/);
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
       <fieldset>
-        <label>Enter Your First Name: <input type="text" required /></label>
-        <label>Enter Your Last Name: <input type="text" required /></label>
-        <label>Enter Your Email: <input type="email" required /></label>
-        <label>Create a New Password: <input type="password" pattern="[a-z0-5]{8,}" required /></label>
+        <label for="first-name">Enter Your First Name: <input id="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
       <fieldset>
+<<<<<<< HEAD
+        <label for="personal-account"><input id="personal-account" type="radio" name="account-type" /> Personal Account</label>
+        <label for="business-account"><input id="business-account" type="radio" name="account-type" /> Business Account</label>
+        <label for="terms-and-conditions">
+          <input id="terms-and-conditions" type="checkbox" required /> I accept the
+				    <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
+			  </label>
+=======
         <label><input type="radio" name="account-type" /> Personal Account</label>
         <label><input type="radio" name="account-type" /> Business Account</label>
         <label>
           <input type="checkbox" required /> I accept the <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
       </fieldset>
 --fcc-editable-region--
       <fieldset>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60facf914c7b9b08d7510c2c.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60facf914c7b9b08d7510c2c.md
@@ -42,17 +42,26 @@ assert.equal(document.querySelector('fieldset:nth-child(3) > label:nth-child(4) 
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
       <fieldset>
-        <label>Enter Your First Name: <input type="text" required /></label>
-        <label>Enter Your Last Name: <input type="text" required /></label>
-        <label>Enter Your Email: <input type="email" required /></label>
-        <label>Create a New Password: <input type="password" pattern="[a-z0-5]{8,}" required /></label>
+        <label for="first-name">Enter Your First Name: <input id="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
       <fieldset>
+<<<<<<< HEAD
+        <label for="personal-account"><input id="personal-account" type="radio" name="account-type" /> Personal Account</label>
+        <label for="business-account"><input id="business-account" type="radio" name="account-type" /> Business Account</label>
+        <label for="terms-and-conditions">
+          <input id="terms-and-conditions" type="checkbox" required /> I accept the
+				    <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
+			  </label>
+=======
         <label><input type="radio" name="account-type" /> Personal Account</label>
         <label><input type="radio" name="account-type" /> Business Account</label>
         <label>
           <input type="checkbox" required /> I accept the <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
       </fieldset>
 --fcc-editable-region--
       <fieldset>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fad0a812d9890938524f50.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fad0a812d9890938524f50.md
@@ -42,17 +42,26 @@ assert.equal(document.querySelector('fieldset:nth-child(3) > label:nth-child(4) 
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
       <fieldset>
-        <label>Enter Your First Name: <input type="text" required /></label>
-        <label>Enter Your Last Name: <input type="text" required /></label>
-        <label>Enter Your Email: <input type="email" required /></label>
-        <label>Create a New Password: <input type="password" pattern="[a-z0-5]{8,}" required /></label>
+        <label for="first-name">Enter Your First Name: <input id="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
       <fieldset>
+<<<<<<< HEAD
+        <label for="personal-account"><input id="personal-account" type="radio" name="account-type" /> Personal Account</label>
+        <label for="business-account"><input id="business-account" type="radio" name="account-type" /> Business Account</label>
+        <label for="terms-and-conditions">
+          <input id="terms-and-conditions" type="checkbox" required /> I accept the
+				    <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
+			  </label>
+=======
         <label><input type="radio" name="account-type" /> Personal Account</label>
         <label><input type="radio" name="account-type" /> Business Account</label>
         <label>
           <input type="checkbox" required /> I accept the <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
       </fieldset>
 --fcc-editable-region--
       <fieldset>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fad1cafcde010995e15306.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fad1cafcde010995e15306.md
@@ -102,13 +102,26 @@ You should not give any of the `fieldset` elements a `name` attribute.
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
 --fcc-editable-region--
-      <fieldset>
-        <label>Enter Your First Name: <input type="text" required /></label>
-        <label>Enter Your Last Name: <input type="text" required /></label>
-        <label>Enter Your Email: <input type="email" required /></label>
-        <label>Create a New Password: <input type="password" pattern="[a-z0-5]{8,}" required /></label>
+        <fieldset>
+        <label for="first-name">Enter Your First Name: <input id="first-name" name="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" name="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" name="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" name="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
       <fieldset>
+<<<<<<< HEAD
+        <label for="personal-account"><input id="personal-account" type="radio" name="account-type" /> Personal Account</label>
+        <label for="business-account"><input id="business-account" type="radio" name="account-type" /> Business Account</label>
+        <label for="terms-and-conditions" name="terms-and-conditions">
+          <input id="terms-and-conditions" type="checkbox" required name="terms-and-conditions" /> I accept the
+				    <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
+			  </label>
+      </fieldset>
+      <fieldset>
+        <label for="profile-picture">Upload a profile picture: <input id="profile-picture" type="file"/></label>
+        <label for="age">Input your age (years): <input id="age" type="number" min="13" max="120" />
+			  </label>
+=======
         <label><input type="radio" name="account-type" /> Personal Account</label>
         <label><input type="radio" name="account-type" /> Business Account</label>
         <label>
@@ -119,8 +132,9 @@ You should not give any of the `fieldset` elements a `name` attribute.
         <label>Upload a profile picture: <input type="file" /></label>
         <label>Input your age (years): <input type="number" min="13" max="120" />
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
         <label>How did you hear about us?
-          <select>
+          <select name="referrer">
             <option value="">(select one)</option>
             <option value="1">freeCodeCamp News</option>
             <option value="2">freeCodeCamp YouTube Channel</option>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fad6dfcc0d930a59becf12.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fad6dfcc0d930a59becf12.md
@@ -48,12 +48,25 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('body')?.fontSize, '16px')
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
       <fieldset>
-        <label>Enter Your First Name: <input type="text" name="first-name" required /></label>
-        <label>Enter Your Last Name: <input type="text" name="last-name" required /></label>
-        <label>Enter Your Email: <input type="email" name="email" required /></label>
-        <label>Create a New Password: <input type="password" name="password" pattern="[a-z0-5]{8,}" required /></label>
+        <label for="first-name">Enter Your First Name: <input id="first-name" name="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" name="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" name="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" name="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
       <fieldset>
+<<<<<<< HEAD
+        <label for="personal-account"><input id="personal-account" type="radio" name="account-type" /> Personal Account</label>
+        <label for="business-account"><input id="business-account" type="radio" name="account-type" /> Business Account</label>
+        <label for="terms-and-conditions" name="terms-and-conditions">
+          <input id="terms-and-conditions" type="checkbox" required name="terms-and-conditions" /> I accept the
+				    <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
+			  </label>
+      </fieldset>
+      <fieldset>
+        <label for="profile-picture">Upload a profile picture: <input id="profile-picture" type="file" name="file" /></label>
+        <label for="age">Input your age (years): <input id="age" type="number" name="age" min="13" max="120" />
+			  </label>
+=======
         <label><input type="radio" name="account-type" /> Personal Account</label>
         <label><input type="radio" name="account-type" /> Business Account</label>
         <label>
@@ -64,6 +77,7 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('body')?.fontSize, '16px')
         <label>Upload a profile picture: <input type="file" name="file" /></label>
         <label>Input your age (years): <input type="number" name="age" min="13" max="120" />
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
         <label>How did you hear about us?
           <select name="referrer">
             <option value="">(select one)</option>
@@ -74,8 +88,13 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('body')?.fontSize, '16px')
           </select>
         </label>
         <label>Provide a bio:
+<<<<<<< HEAD
+				  <textarea name="bio" rows="3" cols="30" placeholder="I like coding on the beach..."></textarea>
+			  </label>
+=======
           <textarea name="bio" rows="3" cols="30" placeholder="I like coding on the beach..."></textarea>
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
       </fieldset>
       <input type="submit" value="Submit" />
     </form>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fad8e6148f310bba7890b1.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fad8e6148f310bba7890b1.md
@@ -46,12 +46,25 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('h1, p')?.textAlign, 'cent
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
       <fieldset>
-        <label>Enter Your First Name: <input type="text" name="first-name" required /></label>
-        <label>Enter Your Last Name: <input type="text" name="last-name" required /></label>
-        <label>Enter Your Email: <input type="email" name="email" required /></label>
-        <label>Create a New Password: <input type="password" name="password" pattern="[a-z0-5]{8,}" required /></label>
+        <label for="first-name">Enter Your First Name: <input id="first-name" name="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" name="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" name="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" name="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
       <fieldset>
+<<<<<<< HEAD
+        <label for="personal-account"><input id="personal-account" type="radio" name="account-type" /> Personal Account</label>
+        <label for="business-account"><input id="business-account" type="radio" name="account-type" /> Business Account</label>
+        <label for="terms-and-conditions" name="terms-and-conditions">
+          <input id="terms-and-conditions" type="checkbox" required name="terms-and-conditions" /> I accept the
+				    <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
+			  </label>
+      </fieldset>
+      <fieldset>
+        <label for="profile-picture">Upload a profile picture: <input id="profile-picture" type="file" name="file" /></label>
+        <label for="age">Input your age (years): <input id="age" type="number" name="age" min="13" max="120" />
+			  </label>
+=======
         <label><input type="radio" name="account-type" /> Personal Account</label>
         <label><input type="radio" name="account-type" /> Business Account</label>
         <label>
@@ -62,6 +75,7 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('h1, p')?.textAlign, 'cent
         <label>Upload a profile picture: <input type="file" name="file" /></label>
         <label>Input your age (years): <input type="number" name="age" min="13" max="120" />
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
         <label>How did you hear about us?
           <select name="referrer">
             <option value="">(select one)</option>
@@ -72,8 +86,13 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('h1, p')?.textAlign, 'cent
           </select>
         </label>
         <label>Provide a bio:
+<<<<<<< HEAD
+				  <textarea name="bio" rows="3" cols="30" placeholder="I like coding on the beach..."></textarea>
+			  </label>
+=======
           <textarea name="bio" rows="3" cols="30" placeholder="I like coding on the beach..."></textarea>
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
       </fieldset>
       <input type="submit" value="Submit" />
     </form>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fad99e09f9d30c1657e790.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fad99e09f9d30c1657e790.md
@@ -58,12 +58,25 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('form')?.width, '60vw');
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
       <fieldset>
-        <label>Enter Your First Name: <input type="text" name="first-name" required /></label>
-        <label>Enter Your Last Name: <input type="text" name="last-name" required /></label>
-        <label>Enter Your Email: <input type="email" name="email" required /></label>
-        <label>Create a New Password: <input type="password" name="password" pattern="[a-z0-5]{8,}" required /></label>
+        <label for="first-name">Enter Your First Name: <input id="first-name" name="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" name="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" name="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" name="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
       <fieldset>
+<<<<<<< HEAD
+        <label for="personal-account"><input id="personal-account" type="radio" name="account-type" /> Personal Account</label>
+        <label for="business-account"><input id="business-account" type="radio" name="account-type" /> Business Account</label>
+        <label for="terms-and-conditions" name="terms-and-conditions">
+          <input id="terms-and-conditions" type="checkbox" required name="terms-and-conditions" /> I accept the
+				    <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
+			  </label>
+      </fieldset>
+      <fieldset>
+        <label for="profile-picture">Upload a profile picture: <input id="profile-picture" type="file" name="file" /></label>
+        <label for="age">Input your age (years): <input id="age" type="number" name="age" min="13" max="120" />
+			  </label>
+=======
         <label><input type="radio" name="account-type" /> Personal Account</label>
         <label><input type="radio" name="account-type" /> Business Account</label>
         <label>
@@ -74,6 +87,7 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('form')?.width, '60vw');
         <label>Upload a profile picture: <input type="file" name="file" /></label>
         <label>Input your age (years): <input type="number" name="age" min="13" max="120" />
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
         <label>How did you hear about us?
           <select name="referrer">
             <option value="">(select one)</option>
@@ -84,8 +98,13 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('form')?.width, '60vw');
           </select>
         </label>
         <label>Provide a bio:
+<<<<<<< HEAD
+				  <textarea name="bio" rows="3" cols="30" placeholder="I like coding on the beach..."></textarea>
+			  </label>
+=======
           <textarea name="bio" rows="3" cols="30" placeholder="I like coding on the beach..."></textarea>
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
       </fieldset>
       <input type="submit" value="Submit" />
     </form>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fadb18058e950c73925279.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fadb18058e950c73925279.md
@@ -52,12 +52,25 @@ assert.equal(fieldset?.paddingRight, '0px');
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
       <fieldset>
-        <label>Enter Your First Name: <input type="text" name="first-name" required /></label>
-        <label>Enter Your Last Name: <input type="text" name="last-name" required /></label>
-        <label>Enter Your Email: <input type="email" name="email" required /></label>
-        <label>Create a New Password: <input type="password" name="password" pattern="[a-z0-5]{8,}" required /></label>
+        <label for="first-name">Enter Your First Name: <input id="first-name" name="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" name="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" name="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" name="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
       <fieldset>
+<<<<<<< HEAD
+        <label for="personal-account"><input id="personal-account" type="radio" name="account-type" /> Personal Account</label>
+        <label for="business-account"><input id="business-account" type="radio" name="account-type" /> Business Account</label>
+        <label for="terms-and-conditions" name="terms-and-conditions">
+          <input id="terms-and-conditions" type="checkbox" required name="terms-and-conditions" /> I accept the
+				    <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
+			  </label>
+      </fieldset>
+      <fieldset>
+        <label for="profile-picture">Upload a profile picture: <input id="profile-picture" type="file" name="file" /></label>
+        <label for="age">Input your age (years): <input id="age" type="number" name="age" min="13" max="120" />
+			  </label>
+=======
         <label><input type="radio" name="account-type" /> Personal Account</label>
         <label><input type="radio" name="account-type" /> Business Account</label>
         <label>
@@ -68,6 +81,7 @@ assert.equal(fieldset?.paddingRight, '0px');
         <label>Upload a profile picture: <input type="file" name="file" /></label>
         <label>Input your age (years): <input type="number" name="age" min="13" max="120" />
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
         <label>How did you hear about us?
           <select name="referrer">
             <option value="">(select one)</option>
@@ -78,8 +92,13 @@ assert.equal(fieldset?.paddingRight, '0px');
           </select>
         </label>
         <label>Provide a bio:
+<<<<<<< HEAD
+				  <textarea name="bio" rows="3" cols="30" placeholder="I like coding on the beach..."></textarea>
+			  </label>
+=======
           <textarea name="bio" rows="3" cols="30" placeholder="I like coding on the beach..."></textarea>
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
       </fieldset>
       <input type="submit" value="Submit" />
     </form>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fadce90f85c50d0bb0dd4f.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fadce90f85c50d0bb0dd4f.md
@@ -34,12 +34,25 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('fieldset')?.borderBottom,
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
       <fieldset>
-        <label>Enter Your First Name: <input type="text" name="first-name" required /></label>
-        <label>Enter Your Last Name: <input type="text" name="last-name" required /></label>
-        <label>Enter Your Email: <input type="email" name="email" required /></label>
-        <label>Create a New Password: <input type="password" name="password" pattern="[a-z0-5]{8,}" required /></label>
+        <label for="first-name">Enter Your First Name: <input id="first-name" name="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" name="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" name="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" name="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
       <fieldset>
+<<<<<<< HEAD
+        <label for="personal-account"><input id="personal-account" type="radio" name="account-type" /> Personal Account</label>
+        <label for="business-account"><input id="business-account" type="radio" name="account-type" /> Business Account</label>
+        <label for="terms-and-conditions" name="terms-and-conditions">
+          <input id="terms-and-conditions" type="checkbox" required name="terms-and-conditions" /> I accept the
+				    <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
+			  </label>
+      </fieldset>
+      <fieldset>
+        <label for="profile-picture">Upload a profile picture: <input id="profile-picture" type="file" name="file" /></label>
+        <label for="age">Input your age (years): <input id="age" type="number" name="age" min="13" max="120" />
+			  </label>
+=======
         <label><input type="radio" name="account-type" /> Personal Account</label>
         <label><input type="radio" name="account-type" /> Business Account</label>
         <label>
@@ -50,6 +63,7 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('fieldset')?.borderBottom,
         <label>Upload a profile picture: <input type="file" name="file" /></label>
         <label>Input your age (years): <input type="number" name="age" min="13" max="120" />
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
         <label>How did you hear about us?
           <select name="referrer">
             <option value="">(select one)</option>
@@ -60,8 +74,13 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('fieldset')?.borderBottom,
           </select>
         </label>
         <label>Provide a bio:
+<<<<<<< HEAD
+				  <textarea name="bio" rows="3" cols="30" placeholder="I like coding on the beach..."></textarea>
+			  </label>
+=======
           <textarea name="bio" rows="3" cols="30" placeholder="I like coding on the beach..."></textarea>
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
       </fieldset>
       <input type="submit" value="Submit" />
     </form>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fadd972e6ffe0d6858fa2d.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fadd972e6ffe0d6858fa2d.md
@@ -73,12 +73,25 @@ assert.equal(selFunc(['input, textarea, select', 'input, select, textarea', 'sel
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
       <fieldset>
-        <label>Enter Your First Name: <input type="text" name="first-name" required /></label>
-        <label>Enter Your Last Name: <input type="text" name="last-name" required /></label>
-        <label>Enter Your Email: <input type="email" name="email" required /></label>
-        <label>Create a New Password: <input type="password" name="password" pattern="[a-z0-5]{8,}" required /></label>
+        <label for="first-name">Enter Your First Name: <input id="first-name" name="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" name="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" name="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" name="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
       <fieldset>
+<<<<<<< HEAD
+        <label for="personal-account"><input id="personal-account" type="radio" name="account-type" /> Personal Account</label>
+        <label for="business-account"><input id="business-account" type="radio" name="account-type" /> Business Account</label>
+        <label for="terms-and-conditions" name="terms-and-conditions">
+          <input id="terms-and-conditions" type="checkbox" required name="terms-and-conditions" /> I accept the
+				    <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
+			  </label>
+      </fieldset>
+      <fieldset>
+        <label for="profile-picture">Upload a profile picture: <input id="profile-picture" type="file" name="file" /></label>
+        <label for="age">Input your age (years): <input id="age" type="number" name="age" min="13" max="120" />
+			  </label>
+=======
         <label><input type="radio" name="account-type" /> Personal Account</label>
         <label><input type="radio" name="account-type" /> Business Account</label>
         <label>
@@ -89,6 +102,7 @@ assert.equal(selFunc(['input, textarea, select', 'input, select, textarea', 'sel
         <label>Upload a profile picture: <input type="file" name="file" /></label>
         <label>Input your age (years): <input type="number" name="age" min="13" max="120" />
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
         <label>How did you hear about us?
           <select name="referrer">
             <option value="">(select one)</option>
@@ -99,8 +113,13 @@ assert.equal(selFunc(['input, textarea, select', 'input, select, textarea', 'sel
           </select>
         </label>
         <label>Provide a bio:
+<<<<<<< HEAD
+				  <textarea name="bio" rows="3" cols="30" placeholder="I like coding on the beach..."></textarea>
+			  </label>
+=======
           <textarea name="bio" rows="3" cols="30" placeholder="I like coding on the beach..."></textarea>
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
       </fieldset>
       <input type="submit" value="Submit" />
     </form>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fadfa2b540b70dcfa8b771.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fadfa2b540b70dcfa8b771.md
@@ -48,13 +48,27 @@ assert(document.querySelectorAll('fieldset:nth-child(2) input')?.[2]?.classList?
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
       <fieldset>
-        <label>Enter Your First Name: <input type="text" name="first-name" required /></label>
-        <label>Enter Your Last Name: <input type="text" name="last-name" required /></label>
-        <label>Enter Your Email: <input type="email" name="email" required /></label>
-        <label>Create a New Password: <input type="password" name="password" pattern="[a-z0-5]{8,}" required /></label>
+        <label for="first-name">Enter Your First Name: <input id="first-name" name="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" name="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" name="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" name="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
 --fcc-editable-region--
       <fieldset>
+<<<<<<< HEAD
+        <label for="personal-account"><input id="personal-account" type="radio" name="account-type" /> Personal Account</label>
+        <label for="business-account"><input id="business-account" type="radio" name="account-type" /> Business Account</label>
+        <label for="terms-and-conditions" name="terms-and-conditions">
+          <input id="terms-and-conditions" type="checkbox" required name="terms-and-conditions" /> I accept the
+				    <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
+			  </label>
+      </fieldset>
+--fcc-editable-region--
+      <fieldset>
+        <label for="profile-picture">Upload a profile picture: <input id="profile-picture" type="file" name="file" /></label>
+        <label for="age">Input your age (years): <input id="age" type="number" name="age" min="13" max="120" />
+			  </label>
+=======
         <label><input type="radio" name="account-type" /> Personal Account</label>
         <label><input type="radio" name="account-type" /> Business Account</label>
         <label>
@@ -66,6 +80,7 @@ assert(document.querySelectorAll('fieldset:nth-child(2) input')?.[2]?.classList?
         <label>Upload a profile picture: <input type="file" name="file" /></label>
         <label>Input your age (years): <input type="number" name="age" min="13" max="120" />
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
         <label>How did you hear about us?
           <select name="referrer">
             <option value="">(select one)</option>
@@ -76,8 +91,13 @@ assert(document.querySelectorAll('fieldset:nth-child(2) input')?.[2]?.classList?
           </select>
         </label>
         <label>Provide a bio:
+<<<<<<< HEAD
+				  <textarea name="bio" rows="3" cols="30" placeholder="I like coding on the beach..."></textarea>
+			  </label>
+=======
           <textarea name="bio" rows="3" cols="30" placeholder="I like coding on the beach..."></textarea>
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
       </fieldset>
       <input type="submit" value="Submit" />
     </form>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fc219d333e37046f474a6e.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fc219d333e37046f474a6e.md
@@ -40,17 +40,26 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('.inline')?.width, 'unset'
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
       <fieldset>
-        <label>Enter Your First Name: <input type="text" name="first-name" required /></label>
-        <label>Enter Your Last Name: <input type="text" name="last-name" required /></label>
-        <label>Enter Your Email: <input type="email" name="email" required /></label>
-        <label>Create a New Password: <input type="password" name="password" pattern="[a-z0-5]{8,}" required /></label>
+        <label for="first-name">Enter Your First Name: <input id="first-name" name="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" name="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" name="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" name="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
       <fieldset>
+<<<<<<< HEAD
+        <label for="personal-account"><input id="personal-account" type="radio" name="account-type" class="inline" /> Personal Account</label>
+        <label for="business-account"><input id="business-account" type="radio" name="account-type" class="inline" /> Business Account</label>
+        <label for="terms-and-conditions" name="terms-and-conditions">
+          <input id="terms-and-conditions" type="checkbox" required name="terms-and-conditions" class="inline" /> I accept the
+				    <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
+			  </label>
+=======
         <label><input type="radio" name="account-type" class="inline" /> Personal Account</label>
         <label><input type="radio" name="account-type" class="inline" /> Business Account</label>
         <label>
           <input type="checkbox" name="terms" class="inline" required /> I accept the <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
       </fieldset>
       <fieldset>
         <label>Upload a profile picture: <input type="file" name="file" /></label>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fc22d1e64d1b04cdd4e602.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fc22d1e64d1b04cdd4e602.md
@@ -52,17 +52,26 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('.inline')?.marginLeft, '0
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
       <fieldset>
-        <label>Enter Your First Name: <input type="text" name="first-name" required /></label>
-        <label>Enter Your Last Name: <input type="text" name="last-name" required /></label>
-        <label>Enter Your Email: <input type="email" name="email" required /></label>
-        <label>Create a New Password: <input type="password" name="password" pattern="[a-z0-5]{8,}" required /></label>
+        <label for="first-name">Enter Your First Name: <input id="first-name" name="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" name="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" name="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" name="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
       <fieldset>
+<<<<<<< HEAD
+        <label for="personal-account"><input id="personal-account" type="radio" name="account-type" class="inline" /> Personal Account</label>
+        <label for="business-account"><input id="business-account" type="radio" name="account-type" class="inline" /> Business Account</label>
+        <label for="terms-and-conditions" name="terms-and-conditions">
+          <input id="terms-and-conditions" type="checkbox" required name="terms-and-conditions" class="inline" /> I accept the
+				    <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
+			  </label>
+=======
         <label><input type="radio" name="account-type" class="inline" /> Personal Account</label>
         <label><input type="radio" name="account-type" class="inline" /> Business Account</label>
         <label>
           <input type="checkbox" name="terms" class="inline" required /> I accept the <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
       </fieldset>
       <fieldset>
         <label>Upload a profile picture: <input type="file" name="file" /></label>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fc236dc04532052926fdac.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fc236dc04532052926fdac.md
@@ -36,17 +36,26 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('.inline')?.verticalAlign,
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
       <fieldset>
-        <label>Enter Your First Name: <input type="text" name="first-name" required /></label>
-        <label>Enter Your Last Name: <input type="text" name="last-name" required /></label>
-        <label>Enter Your Email: <input type="email" name="email" required /></label>
-        <label>Create a New Password: <input type="password" name="password" pattern="[a-z0-5]{8,}" required /></label>
+        <label for="first-name">Enter Your First Name: <input id="first-name" name="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" name="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" name="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" name="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
       <fieldset>
+<<<<<<< HEAD
+        <label for="personal-account"><input id="personal-account" type="radio" name="account-type" class="inline" /> Personal Account</label>
+        <label for="business-account"><input id="business-account" type="radio" name="account-type" class="inline" /> Business Account</label>
+        <label for="terms-and-conditions" name="terms-and-conditions">
+          <input id="terms-and-conditions" type="checkbox" required name="terms-and-conditions" class="inline" /> I accept the
+				    <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
+			  </label>
+=======
         <label><input type="radio" name="account-type" class="inline" /> Personal Account</label>
         <label><input type="radio" name="account-type" class="inline" /> Business Account</label>
         <label>
           <input type="checkbox" name="terms" class="inline" required /> I accept the <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
       </fieldset>
       <fieldset>
         <label>Upload a profile picture: <input type="file" name="file" /></label>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60ffe1bc30415f042faea936.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60ffe1bc30415f042faea936.md
@@ -51,17 +51,26 @@ assert.equal(selFunc(['input, textarea', 'textarea, input'].find(selFunc))?.bord
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
       <fieldset>
-        <label>Enter Your First Name: <input type="text" name="first-name" required /></label>
-        <label>Enter Your Last Name: <input type="text" name="last-name" required /></label>
-        <label>Enter Your Email: <input type="email" name="email" required /></label>
-        <label>Create a New Password: <input type="password" name="password" pattern="[a-z0-5]{8,}" required /></label>
+        <label for="first-name">Enter Your First Name: <input id="first-name" name="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" name="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" name="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" name="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
       <fieldset>
+<<<<<<< HEAD
+        <label for="personal-account"><input id="personal-account" type="radio" name="account-type" class="inline" /> Personal Account</label>
+        <label for="business-account"><input id="business-account" type="radio" name="account-type" class="inline" /> Business Account</label>
+        <label for="terms-and-conditions" name="terms-and-conditions">
+          <input id="terms-and-conditions" type="checkbox" required name="terms-and-conditions" class="inline" /> I accept the
+				    <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
+			  </label>
+=======
         <label><input type="radio" name="account-type" class="inline" /> Personal Account</label>
         <label><input type="radio" name="account-type" class="inline" /> Business Account</label>
         <label>
           <input type="checkbox" name="terms" class="inline" required /> I accept the <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
       </fieldset>
       <fieldset>
         <label>Upload a profile picture: <input type="file" name="file" /></label>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60ffe3936796ac04959285a9.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60ffe3936796ac04959285a9.md
@@ -44,17 +44,26 @@ assert.equal(selFunc(['input, textarea', 'textarea, input'].find(selFunc))?.minH
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
       <fieldset>
-        <label>Enter Your First Name: <input type="text" name="first-name" required /></label>
-        <label>Enter Your Last Name: <input type="text" name="last-name" required /></label>
-        <label>Enter Your Email: <input type="email" name="email" required /></label>
-        <label>Create a New Password: <input type="password" name="password" pattern="[a-z0-5]{8,}" required /></label>
+        <label for="first-name">Enter Your First Name: <input id="first-name" name="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" name="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" name="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" name="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
       <fieldset>
+<<<<<<< HEAD
+        <label for="personal-account"><input id="personal-account" type="radio" name="account-type" class="inline" /> Personal Account</label>
+        <label for="business-account"><input id="business-account" type="radio" name="account-type" class="inline" /> Business Account</label>
+        <label for="terms-and-conditions" name="terms-and-conditions">
+          <input id="terms-and-conditions" type="checkbox" required name="terms-and-conditions" class="inline" /> I accept the
+				    <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
+			  </label>
+=======
         <label><input type="radio" name="account-type" class="inline" /> Personal Account</label>
         <label><input type="radio" name="account-type" class="inline" /> Business Account</label>
         <label>
           <input type="checkbox" name="terms" class="inline" required /> I accept the <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
       </fieldset>
       <fieldset>
         <label>Upload a profile picture: <input type="file" name="file" /></label>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60ffe4f4ec18cd04dc470c56.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60ffe4f4ec18cd04dc470c56.md
@@ -48,17 +48,26 @@ assert.isEmpty(new __helpers.CSSHelp(document).getStyle('input, textarea')?.minH
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
       <fieldset>
-        <label>Enter Your First Name: <input type="text" name="first-name" required /></label>
-        <label>Enter Your Last Name: <input type="text" name="last-name" required /></label>
-        <label>Enter Your Email: <input type="email" name="email" required /></label>
-        <label>Create a New Password: <input type="password" name="password" pattern="[a-z0-5]{8,}" required /></label>
+        <label for="first-name">Enter Your First Name: <input id="first-name" name="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" name="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" name="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" name="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
       <fieldset>
+<<<<<<< HEAD
+        <label for="personal-account"><input id="personal-account" type="radio" name="account-type" class="inline" /> Personal Account</label>
+        <label for="business-account"><input id="business-account" type="radio" name="account-type" class="inline" /> Business Account</label>
+        <label for="terms-and-conditions" name="terms-and-conditions">
+          <input id="terms-and-conditions" type="checkbox" required name="terms-and-conditions" class="inline" /> I accept the
+				    <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
+			  </label>
+=======
         <label><input type="radio" name="account-type" class="inline" /> Personal Account</label>
         <label><input type="radio" name="account-type" class="inline" /> Business Account</label>
         <label>
           <input type="checkbox" name="terms" class="inline" required /> I accept the <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
       </fieldset>
       <fieldset>
         <label>Upload a profile picture: <input type="file" name="file" /></label>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60ffe69ee377c6055e192a46.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60ffe69ee377c6055e192a46.md
@@ -54,17 +54,26 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('input[type="submit"]')?.w
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
       <fieldset>
-        <label>Enter Your First Name: <input type="text" name="first-name" required /></label>
-        <label>Enter Your Last Name: <input type="text" name="last-name" required /></label>
-        <label>Enter Your Email: <input type="email" name="email" required /></label>
-        <label>Create a New Password: <input type="password" name="password" pattern="[a-z0-5]{8,}" required /></label>
+        <label for="first-name">Enter Your First Name: <input id="first-name" name="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" name="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" name="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" name="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
       <fieldset>
+<<<<<<< HEAD
+        <label for="personal-account"><input id="personal-account" type="radio" name="account-type" class="inline" /> Personal Account</label>
+        <label for="business-account"><input id="business-account" type="radio" name="account-type" class="inline" /> Business Account</label>
+        <label for="terms-and-conditions" name="terms-and-conditions">
+          <input id="terms-and-conditions" type="checkbox" required name="terms-and-conditions" class="inline" /> I accept the
+				    <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
+			  </label>
+=======
         <label><input type="radio" name="account-type" class="inline" /> Personal Account</label>
         <label><input type="radio" name="account-type" class="inline" /> Business Account</label>
         <label>
           <input type="checkbox" name="terms" class="inline" required /> I accept the <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
       </fieldset>
       <fieldset>
         <label>Upload a profile picture: <input type="file" name="file" /></label>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60ffe7d8aae62c05bcc9e7eb.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60ffe7d8aae62c05bcc9e7eb.md
@@ -43,17 +43,26 @@ assert.isEmpty(new __helpers.CSSHelp(document).getStyle('input[type="submit"]')?
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
       <fieldset>
-        <label>Enter Your First Name: <input type="text" name="first-name" required /></label>
-        <label>Enter Your Last Name: <input type="text" name="last-name" required /></label>
-        <label>Enter Your Email: <input type="email" name="email" required /></label>
-        <label>Create a New Password: <input type="password" name="password" pattern="[a-z0-5]{8,}" required /></label>
+        <label for="first-name">Enter Your First Name: <input id="first-name" name="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" name="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" name="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" name="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
       <fieldset>
+<<<<<<< HEAD
+        <label for="personal-account"><input id="personal-account" type="radio" name="account-type" class="inline" /> Personal Account</label>
+        <label for="business-account"><input id="business-account" type="radio" name="account-type" class="inline" /> Business Account</label>
+        <label for="terms-and-conditions" name="terms-and-conditions">
+          <input id="terms-and-conditions" type="checkbox" required name="terms-and-conditions" class="inline" /> I accept the
+				    <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
+			  </label>
+=======
         <label><input type="radio" name="account-type" class="inline" /> Personal Account</label>
         <label><input type="radio" name="account-type" class="inline" /> Business Account</label>
         <label>
           <input type="checkbox" name="terms" class="inline" required /> I accept the <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
       </fieldset>
       <fieldset>
         <label>Upload a profile picture: <input type="file" name="file" /></label>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60ffe8a5ceb0e90618db06d9.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60ffe8a5ceb0e90618db06d9.md
@@ -40,17 +40,26 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('input[type="submit"]')?.f
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
       <fieldset>
-        <label>Enter Your First Name: <input type="text" name="first-name" required /></label>
-        <label>Enter Your Last Name: <input type="text" name="last-name" required /></label>
-        <label>Enter Your Email: <input type="email" name="email" required /></label>
-        <label>Create a New Password: <input type="password" name="password" pattern="[a-z0-5]{8,}" required /></label>
+        <label for="first-name">Enter Your First Name: <input id="first-name" name="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" name="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" name="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" name="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
       <fieldset>
+<<<<<<< HEAD
+        <label for="personal-account"><input id="personal-account" type="radio" name="account-type" class="inline" /> Personal Account</label>
+        <label for="business-account"><input id="business-account" type="radio" name="account-type" class="inline" /> Business Account</label>
+        <label for="terms-and-conditions" name="terms-and-conditions">
+          <input id="terms-and-conditions" type="checkbox" required name="terms-and-conditions" class="inline" /> I accept the
+				    <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
+			  </label>
+=======
         <label><input type="radio" name="account-type" class="inline" /> Personal Account</label>
         <label><input type="radio" name="account-type" class="inline" /> Business Account</label>
         <label>
           <input type="checkbox" name="terms" class="inline" required /> I accept the <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
       </fieldset>
       <fieldset>
         <label>Upload a profile picture: <input type="file" name="file" /></label>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60ffe947a868ec068f7850f6.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60ffe947a868ec068f7850f6.md
@@ -40,17 +40,26 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('input[type="submit"]')?.b
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
       <fieldset>
-        <label>Enter Your First Name: <input type="text" name="first-name" required /></label>
-        <label>Enter Your Last Name: <input type="text" name="last-name" required /></label>
-        <label>Enter Your Email: <input type="email" name="email" required /></label>
-        <label>Create a New Password: <input type="password" name="password" pattern="[a-z0-5]{8,}" required /></label>
+        <label for="first-name">Enter Your First Name: <input id="first-name" name="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" name="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" name="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" name="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
       <fieldset>
+<<<<<<< HEAD
+        <label for="personal-account"><input id="personal-account" type="radio" name="account-type" class="inline" /> Personal Account</label>
+        <label for="business-account"><input id="business-account" type="radio" name="account-type" class="inline" /> Business Account</label>
+        <label for="terms-and-conditions" name="terms-and-conditions">
+          <input id="terms-and-conditions" type="checkbox" required name="terms-and-conditions" class="inline" /> I accept the
+				    <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
+			  </label>
+=======
         <label><input type="radio" name="account-type" class="inline" /> Personal Account</label>
         <label><input type="radio" name="account-type" class="inline" /> Business Account</label>
         <label>
           <input type="checkbox" name="terms" class="inline" required /> I accept the <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
       </fieldset>
       <fieldset>
         <label>Upload a profile picture: <input type="file" name="file" /></label>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60ffe9cb47809106eda2f2c9.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60ffe9cb47809106eda2f2c9.md
@@ -43,17 +43,26 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('input[type="submit"]')?.m
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
       <fieldset>
-        <label>Enter Your First Name: <input type="text" name="first-name" required /></label>
-        <label>Enter Your Last Name: <input type="text" name="last-name" required /></label>
-        <label>Enter Your Email: <input type="email" name="email" required /></label>
-        <label>Create a New Password: <input type="password" name="password" pattern="[a-z0-5]{8,}" required /></label>
+        <label for="first-name">Enter Your First Name: <input id="first-name" name="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" name="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" name="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" name="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
       <fieldset>
+<<<<<<< HEAD
+        <label for="personal-account"><input id="personal-account" type="radio" name="account-type" class="inline" /> Personal Account</label>
+        <label for="business-account"><input id="business-account" type="radio" name="account-type" class="inline" /> Business Account</label>
+        <label for="terms-and-conditions" name="terms-and-conditions">
+          <input id="terms-and-conditions" type="checkbox" required name="terms-and-conditions" class="inline" /> I accept the
+				    <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
+			  </label>
+=======
         <label><input type="radio" name="account-type" class="inline" /> Personal Account</label>
         <label><input type="radio" name="account-type" class="inline" /> Business Account</label>
         <label>
           <input type="checkbox" name="terms" class="inline" required /> I accept the <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
       </fieldset>
       <fieldset>
         <label>Upload a profile picture: <input type="file" name="file" /></label>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60ffec2825da1007509ddd06.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60ffec2825da1007509ddd06.md
@@ -42,17 +42,26 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('input[type="file"]')?.pad
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
       <fieldset>
-        <label>Enter Your First Name: <input type="text" name="first-name" required /></label>
-        <label>Enter Your Last Name: <input type="text" name="last-name" required /></label>
-        <label>Enter Your Email: <input type="email" name="email" required /></label>
-        <label>Create a New Password: <input type="password" name="password" pattern="[a-z0-5]{8,}" required /></label>
+        <label for="first-name">Enter Your First Name: <input id="first-name" name="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" name="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" name="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" name="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
       <fieldset>
+<<<<<<< HEAD
+        <label for="personal-account"><input id="personal-account" type="radio" name="account-type" class="inline" /> Personal Account</label>
+        <label for="business-account"><input id="business-account" type="radio" name="account-type" class="inline" /> Business Account</label>
+        <label for="terms-and-conditions" name="terms-and-conditions">
+          <input id="terms-and-conditions" type="checkbox" required name="terms-and-conditions" class="inline" /> I accept the
+				    <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
+			  </label>
+=======
         <label><input type="radio" name="account-type" class="inline" /> Personal Account</label>
         <label><input type="radio" name="account-type" class="inline" /> Business Account</label>
         <label>
           <input type="checkbox" name="terms" class="inline" required /> I accept the <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
       </fieldset>
       <fieldset>
         <label>Upload a profile picture: <input type="file" name="file" /></label>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60ffecefac971607ae73c60f.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60ffecefac971607ae73c60f.md
@@ -40,17 +40,26 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('form')?.paddingBottom, '2
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
       <fieldset>
-        <label>Enter Your First Name: <input type="text" name="first-name" required /></label>
-        <label>Enter Your Last Name: <input type="text" name="last-name" required /></label>
-        <label>Enter Your Email: <input type="email" name="email" required /></label>
-        <label>Create a New Password: <input type="password" name="password" pattern="[a-z0-5]{8,}" required /></label>
+        <label for="first-name">Enter Your First Name: <input id="first-name" name="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" name="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" name="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" name="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
       <fieldset>
+<<<<<<< HEAD
+        <label for="personal-account"><input id="personal-account" type="radio" name="account-type" class="inline" /> Personal Account</label>
+        <label for="business-account"><input id="business-account" type="radio" name="account-type" class="inline" /> Business Account</label>
+        <label for="terms-and-conditions" name="terms-and-conditions">
+          <input id="terms-and-conditions" type="checkbox" required name="terms-and-conditions" class="inline" /> I accept the
+				    <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
+			  </label>
+=======
         <label><input type="radio" name="account-type" class="inline" /> Personal Account</label>
         <label><input type="radio" name="account-type" class="inline" /> Business Account</label>
         <label>
           <input type="checkbox" name="terms" class="inline" required /> I accept the <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
       </fieldset>
       <fieldset>
         <label>Upload a profile picture: <input type="file" name="file" /></label>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60ffefd6479a3d084fb77cbc.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60ffefd6479a3d084fb77cbc.md
@@ -42,17 +42,26 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('a')?.color, 'rgb(223, 223
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
       <fieldset>
-        <label>Enter Your First Name: <input type="text" name="first-name" required /></label>
-        <label>Enter Your Last Name: <input type="text" name="last-name" required /></label>
-        <label>Enter Your Email: <input type="email" name="email" required /></label>
-        <label>Create a New Password: <input type="password" name="password" pattern="[a-z0-5]{8,}" required /></label>
+        <label for="first-name">Enter Your First Name: <input id="first-name" name="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" name="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" name="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" name="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
       <fieldset>
+<<<<<<< HEAD
+        <label for="personal-account"><input id="personal-account" type="radio" name="account-type" class="inline" /> Personal Account</label>
+        <label for="business-account"><input id="business-account" type="radio" name="account-type" class="inline" /> Business Account</label>
+        <label for="terms-and-conditions" name="terms-and-conditions">
+          <input id="terms-and-conditions" type="checkbox" required name="terms-and-conditions" class="inline" /> I accept the
+				    <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
+			  </label>
+=======
         <label><input type="radio" name="account-type" class="inline" /> Personal Account</label>
         <label><input type="radio" name="account-type" class="inline" /> Business Account</label>
         <label>
           <input type="checkbox" name="terms" class="inline" required /> I accept the <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
         </label>
+>>>>>>> 39b5842b79db5e82ce58b3c0c3e2c43452dde180
       </fieldset>
       <fieldset>
         <label>Upload a profile picture: <input type="file" name="file" /></label>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/62b30924c5e4ef0daba23b5e.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/62b30924c5e4ef0daba23b5e.md
@@ -47,22 +47,23 @@ assert(borderBottom === 'none' || borderBottom === 'medium none');
     <p>Please fill out this form with the required information</p>
     <form action='https://register-demo.freecodecamp.org'>
       <fieldset>
-        <label>Enter Your First Name: <input type="text" name="first-name" required /></label>
-        <label>Enter Your Last Name: <input type="text" name="last-name" required /></label>
-        <label>Enter Your Email: <input type="email" name="email" required /></label>
-        <label>Create a New Password: <input type="password" name="password" pattern="[a-z0-5]{8,}" required /></label>
+        <label for="first-name">Enter Your First Name: <input id="first-name" name="first-name" type="text" required /></label>
+        <label for="last-name">Enter Your Last Name: <input id="last-name" name="last-name" type="text" required /></label>
+        <label for="email">Enter Your Email: <input id="email" name="email" type="email" required /></label>
+        <label for="new-password">Create a New Password: <input id="new-password" name="new-password" type="password" pattern="[a-z0-5]{8,}" required /></label>
       </fieldset>
       <fieldset>
-        <label><input type="radio" name="account-type" /> Personal Account</label>
-        <label><input type="radio" name="account-type" /> Business Account</label>
-        <label>
-          <input type="checkbox" name="terms" required /> I accept the <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
-        </label>
+        <label for="personal-account"><input id="personal-account" type="radio" name="account-type" /> Personal Account</label>
+        <label for="business-account"><input id="business-account" type="radio" name="account-type" /> Business Account</label>
+        <label for="terms-and-conditions" name="terms-and-conditions">
+          <input id="terms-and-conditions" type="checkbox" required name="terms-and-conditions" /> I accept the
+				    <a href="https://www.freecodecamp.org/news/terms-of-service/">terms and conditions</a>
+			  </label>
       </fieldset>
       <fieldset>
-        <label>Upload a profile picture: <input type="file" name="file" /></label>
-        <label>Input your age (years): <input type="number" name="age" min="13" max="120" />
-        </label>
+        <label for="profile-picture">Upload a profile picture: <input id="profile-picture" type="file" name="file" /></label>
+        <label for="age">Input your age (years): <input id="age" type="number" name="age" min="13" max="120" />
+			  </label>
         <label>How did you hear about us?
           <select name="referrer">
             <option value="">(select one)</option>
@@ -73,8 +74,8 @@ assert(borderBottom === 'none' || borderBottom === 'medium none');
           </select>
         </label>
         <label>Provide a bio:
-          <textarea name="bio" rows="3" cols="30" placeholder="I like coding on the beach..."></textarea>
-        </label>
+				  <textarea name="bio" rows="3" cols="30" placeholder="I like coding on the beach..."></textarea>
+			  </label>
       </fieldset>
       <input type="submit" value="Submit" />
     </form>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #47064

<!-- Feel free to add any additional description of changes below this line -->
Adjusted all steps starting from when labels are first introduced to incorporate accessibility formatting.
