### PR TITLE
fix(curriculum): removed the mention of 6 spaces for easier understanding

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dc23991f86c76b9248c6eb8.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dc23991f86c76b9248c6eb8.md
@@ -31,7 +31,7 @@ assert(
 );
 ```
 
-Your `h2` element should be below the `main` element's opening tag so that the formatting is consistent. Remember, that's 3 indents from the start of the line.
+You should not change the indentation on the line with your `h2` element. Its opening tag should start 6 spaces over from the start of the line. You can restart the step to restore the original indentation.
 
 ```js
 assert(code.toLowerCase().match(/<main\>\s*\n\s{6}<h2>/));
@@ -49,7 +49,7 @@ The comment's text should be `TODO: Add link to cat photos`. Do not change the t
 assert(code.match(/<!--\s*todo:\s+add\s+link\s+to\s+cat\s+photos\.?\s*-->/i));
 ```
 
-Your comment should be below the `h2` element so that the formatting is consistent. Remember, that's 3 indents from the start of the line.
+You should not change the indentation on the line with your comment element. Its opening tag should start 6 spaces over from the start of the line. You can restart the step to restore the original indentation.
 
 ```js
 assert(
@@ -76,7 +76,7 @@ assert(
 );
 ```
 
-Your `p` element should be below the comment so that the formatting is consistent. Remember, that's 3 indents from the start of the line.
+The opening `p` tag should have indentation that matches your `h1` and comment elements. Its opening tag should start 6 spaces over from the start of the line.
 
 ```js
 assert(code.toLowerCase().match(/-->\n\s{6}<p>/));

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dc23991f86c76b9248c6eb8.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dc23991f86c76b9248c6eb8.md
@@ -31,7 +31,7 @@ assert(
 );
 ```
 
-Your `h2` element should be below the `main` element's opening tag and its opening tag should start 6 spaces over from the start of the line.
+Your `h2` element should be below the `main` element's opening tag so that the formatting is consistent. Remember, that's 3 indents from the start of the line.
 
 ```js
 assert(code.toLowerCase().match(/<main\>\s*\n\s{6}<h2>/));
@@ -49,7 +49,7 @@ The comment's text should be `TODO: Add link to cat photos`. Do not change the t
 assert(code.match(/<!--\s*todo:\s+add\s+link\s+to\s+cat\s+photos\.?\s*-->/i));
 ```
 
-Your comment should be below the `h2` element and start 6 spaces over from the start of the line.
+Your comment should be below the `h2` element so that the formatting is consistent. Remember, that's 3 indents from the start of the line.
 
 ```js
 assert(
@@ -76,7 +76,7 @@ assert(
 );
 ```
 
-Your `p` element should be below the comment and its opening tag should start 6 spaces over from the start of the line.
+Your `p` element should be below the comment so that the formatting is consistent. Remember, that's 3 indents from the start of the line.
 
 ```js
 assert(code.toLowerCase().match(/-->\n\s{6}<p>/));


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #47084

<!-- Feel free to add any additional description of changes below this line -->

It was requested in an issue to remove the 6 spaces from being mentioned. I updated that particular line and the other lines saying 6 spaces.

I changed the wording from this:

> Your `p` element should be below the comment and its opening tag should start 6 spaces over from the start of the line.

to this:

> Your `p` element should be below the comment so that the formatting is consistent. Remember, that's 3 indents from the start of the line.

Hopefully, this makes it a little clearer. The other option would be to add mention of the 6 spaces like this:

> Your `p` element should be below the comment so that the formatting is consistent. Remember, that's 3 indents or 6 spaces from the start of the line.

Let me know what you guys think! :)