### PR TITLE
fix: Change instructions for Set up a Template Engine challenge to make user implement res.render() 

### DIFF
--- a/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/set-up-a-template-engine.md
+++ b/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/set-up-a-template-engine.md
@@ -22,11 +22,11 @@ A template engine enables you to use static template files (such as those writte
 
 Express needs to know which template engine you are using. We will use the `set` method to assign `pug` as the `view engine` property's value: `app.set('view engine', 'pug')`
 
-Your page will not load until you correctly render the index file in the `views/pug` directory.
+Your page will be blank until you correctly render the index file in the `views/pug` directory.
 
-Change the argument of the `res.render()` declaration in the `/` route to be the file path to the `views/pug` directory. The path can be a relative path (relative to views), or an absolute path, and does not require a file extension.
+To render the `pug` template, you need to use `res.render()` in the `/` route. Pass the file path to the `views/pug` directory as the argument to the method. The path can be a relative path (relative to views), or an absolute path, and does not require a file extension.
 
-If all went as planned, your app home page will stop showing the message "`Pug template is not defined.`" and will now display a message indicating you've successfully rendered the Pug template!
+If all went as planned, your app home page will no longer be blank and will display a message indicating you've successfully rendered the Pug template!
 
 Submit your page when you think you've got it right. If you're running into errors, you can <a href="https://gist.github.com/camperbot/3515cd676ea4dfceab4e322f59a37791" target="_blank" rel="noopener noreferrer nofollow">check out the project completed up to this point</a>.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

This PR is an attempt to address [the issue I pointed out in the merging of PR #47050](https://github.com/freeCodeCamp/freeCodeCamp/pull/47050#issuecomment-1200248050).  I will make a suggested change on https://github.com/freeCodeCamp/boilerplate-advancednode/pull/24 that will correspond to this new instruction, so users do not see error messages in the console when first starting up the project to work on it.