### PR TITLE
feat(tools): validate curriculum PRs

### DIFF
--- a/.github/workflows/i18n-prs.yml
+++ b/.github/workflows/i18n-prs.yml
@@ -1,0 +1,47 @@
+name: i18n - Curriculum PR Validation
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  ci:
+    name: Validate i18n Builds
+    runs-on: ubuntu-latest
+    # run only on PRs that camperbot opens with title that matches the curriculum sync
+    if: |
+      ${{ github.event.pull_request.user.login == "camperbot" && github.event.pull_request.title == "chore(i18n,learn): processed translations" }}
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+
+    steps:
+      - name: Checkout Source Files
+        uses: actions/checkout@v3
+
+      - name: Use Node.js v${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Validate Challenge Files
+        id: validate
+        run: npm run audit-challenges
+
+      - name: Create Comment
+        # Run if the validate challenge files step fails, specifically.
+        if: ${{ steps.validate.conclusion == "failure" }}
+        uses: actions/github-script@7a5c598405937d486b0331594b5da2b14db670da # tag=v6
+        with:
+          github-token: ${{secrets.CAMPERBOT_NO_TRANSLATE}}
+        script: |
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: "Hey @freeCodeCamp/i18n, it looks like we have new English curriculum files that need to be translated."
+          })

--- a/.github/workflows/i18n-prs.yml
+++ b/.github/workflows/i18n-prs.yml
@@ -32,8 +32,8 @@ jobs:
         run: npm run audit-challenges
 
       - name: Create Comment
-        # Run if the validate challenge files step fails, specifically.
-        if: ${{ steps.validate.conclusion == 'failure' }}
+        # Run if the validate challenge files step fails, specifically. Note that we need the failure() call for this step to trigger if the action fails.
+        if: ${{ failure() && steps.validate.conclusion == 'failure' }}
         uses: actions/github-script@7a5c598405937d486b0331594b5da2b14db670da # tag=v6
         with:
           github-token: ${{secrets.CAMPERBOT_NO_TRANSLATE}}
@@ -42,5 +42,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-                body: "Hey @freeCodeCamp/i18n, it looks like we have new English curriculum files that need to be translated."
-              })
+              body: "Hey @freecodecamp/i18n, it looks like we have new English curriculum files that need to be translated."
+            })

--- a/.github/workflows/i18n-prs.yml
+++ b/.github/workflows/i18n-prs.yml
@@ -9,8 +9,7 @@ jobs:
     name: Validate i18n Builds
     runs-on: ubuntu-latest
     # run only on PRs that camperbot opens with title that matches the curriculum sync
-    if: |
-      ${{ github.event.pull_request.user.login == 'camperbot' && github.event.pull_request.title == 'chore(i18n,learn): processed translations' }}
+    if: ${{ github.event.pull_request.user.login == 'camperbot' && contains(github.event.pull_request.title, 'chore(i18n,learn)') }}
     strategy:
       matrix:
         node-version: [16.x]

--- a/.github/workflows/i18n-prs.yml
+++ b/.github/workflows/i18n-prs.yml
@@ -10,8 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     # run only on PRs that camperbot opens with title that matches the curriculum sync
     if: |
-      ${{ github.event.pull_request.user.login == "camperbot" && github.event.pull_request.title == "chore(i18n,learn): processed translations" }}
-
+      ${{ github.event.pull_request.user.login == 'camperbot' && github.event.pull_request.title == 'chore(i18n,learn): processed translations' }}
     strategy:
       matrix:
         node-version: [16.x]
@@ -34,14 +33,14 @@ jobs:
 
       - name: Create Comment
         # Run if the validate challenge files step fails, specifically.
-        if: ${{ steps.validate.conclusion == "failure" }}
+        if: ${{ steps.validate.conclusion == 'failure' }}
         uses: actions/github-script@7a5c598405937d486b0331594b5da2b14db670da # tag=v6
         with:
           github-token: ${{secrets.CAMPERBOT_NO_TRANSLATE}}
-        script: |
-          github.rest.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: "Hey @freeCodeCamp/i18n, it looks like we have new English curriculum files that need to be translated."
-          })
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+                body: "Hey @freeCodeCamp/i18n, it looks like we have new English curriculum files that need to be translated."
+              })


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #46966

<!-- Feel free to add any additional description of changes below this line -->

Okay, this workflow should be similar to the one we run on main, but a separate action so I can scope it conditionally.

This action should only run when the pr author is camperbot AND the pr title ~~is `chore(i18n,learn): processed translations`~~ contains `chore(i18n,learn)` - so it won't run on the other crowdin syncs.

It specifically checks if the validation step fails, and if so, creates the comment. 



