### PR TITLE
fix(curriculum): Changed Mongoose version to avoid warnings in boilerplate's Node console when working on Mongoose challenges

### DIFF
--- a/curriculum/challenges/english/05-back-end-development-and-apis/mongodb-and-mongoose/install-and-set-up-mongoose.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/mongodb-and-mongoose/install-and-set-up-mongoose.md
@@ -45,7 +45,7 @@ mongoose.connect(<Your URI>, { useNewUrlParser: true, useUnifiedTopology: true }
       assert.match(
         packJson.dependencies.mongoose,
         /^\^5\.11\.15/,
-        'Wrong version of "mongoose". It should be ~5.11.15'
+        'Wrong version of "mongoose". It should be ^5.11.15'
       );
     },
     (xhr) => {

--- a/curriculum/challenges/english/05-back-end-development-and-apis/mongodb-and-mongoose/install-and-set-up-mongoose.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/mongodb-and-mongoose/install-and-set-up-mongoose.md
@@ -22,7 +22,7 @@ Follow <a href='https://www.freecodecamp.org/news/get-started-with-mongodb-atlas
 
 # --instructions--
 
-`mongodb@~3.6.0` and `mongoose@~5.4.0` have been added to your project’s `package.json` file. First, require mongoose as `mongoose` in `myApp.js`. Next, create a `.env` file and add a `MONGO_URI` variable to it. Its value should be your MongoDB Atlas database URI. Be sure to surround the URI with single or double quotes, and remember that you can't use spaces around the `=` in environment variables. For example, `MONGO_URI='VALUE'`.
+`mongoose@^5.11.15` has been added to your project’s `package.json` file. First, require mongoose as `mongoose` in `myApp.js`. Next, create a `.env` file and add a `MONGO_URI` variable to it. Its value should be your MongoDB Atlas database URI. Be sure to surround the URI with single or double quotes, and remember that you can't use spaces around the `=` in environment variables. For example, `MONGO_URI='VALUE'`.
 
 **Note:** If you are using Replit, you cannot create a `.env` file. Instead, use the built-in <dfn>SECRETS</dfn> tab to add the variable. <em>Do not</em> surround the values with quotes when using the <em>SECRETS</em> tab.
 
@@ -34,27 +34,7 @@ mongoose.connect(<Your URI>, { useNewUrlParser: true, useUnifiedTopology: true }
 
 # --hints--
 
-"mongodb version ~3.6.0" dependency should be in package.json
-
-```js
-(getUserInput) =>
-  $.get(getUserInput('url') + '/_api/file/package.json').then(
-    (data) => {
-      var packJson = JSON.parse(data);
-      assert.property(packJson.dependencies, 'mongodb')
-      assert.match(
-        packJson.dependencies.mongodb,
-        /^\~3\.6\.0/,
-        'Wrong version of "mongodb". It should be ~3.6.0'
-      );
-    },
-    (xhr) => {
-      throw new Error(xhr.responseText);
-    }
-  );
-```
-
-"mongoose version ~5.4.0" dependency should be in package.json
+"mongoose version ^5.11.15" dependency should be in package.json
 
 ```js
 (getUserInput) =>
@@ -64,8 +44,8 @@ mongoose.connect(<Your URI>, { useNewUrlParser: true, useUnifiedTopology: true }
       assert.property(packJson.dependencies, 'mongoose');
       assert.match(
         packJson.dependencies.mongoose,
-        /^\~5\.4\.0/,
-        'Wrong version of "mongoose". It should be ~5.4.0'
+        /^\^5\.11\.15/,
+        'Wrong version of "mongoose". It should be ~5.11.15'
       );
     },
     (xhr) => {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

As mentioned [in this PR's comments](https://github.com/freeCodeCamp/boilerplate-mongomongoose/pull/36#issuecomment-1202987911), I found simply removing `mongodb` and changing `mongoose` version to `^5.11.15` gets rid of all the warning messages in the Node console and does not affect any of the challenges in the MongoDB and Mongoose section challenges.  See [related boilerplate PR](https://github.com/freeCodeCamp/boilerplate-mongomongoose/pull/48) where I change the `package.json` to remove `mongodb` and change the `mongoose` version to `^5.11.15`.

This PR updates the instructions and tests to work with the changes in the corresponding boilerplate PR (mentioned above).
