### PR TITLE
fix: adjust grid map css

### DIFF
--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -251,7 +251,7 @@ button.map-title {
 
 .map-challenges-grid .map-challenge-title a {
   width: 3.4rem;
-  height: 2.75rem;
+  height: 3.4rem;
   min-width: 24px;
   min-height: 24px;
   padding: 0;
@@ -269,6 +269,7 @@ button.map-title {
 .map-challenges-grid {
   display: flex;
   flex-wrap: wrap;
+  justify-content: space-evenly;
   margin-top: 1rem;
 }
 .map-challenge-title-grid {

--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -267,10 +267,12 @@ button.map-title {
 }
 
 .map-challenges-grid {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-evenly;
-  margin-top: 1rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, 3.4rem);
+  grid-gap: 3px;
+  justify-content: space-between;
+  margin: 0 auto;
+  width: calc(100% - 50px);
 }
 .map-challenge-title-grid {
   flex: 0 1 60px;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #47158 

<!-- Feel free to add any additional description of changes below this line -->

Makes the grid items square, and spaces them evenly.

Before: 

<img width="581" alt="image" src="https://user-images.githubusercontent.com/63889819/182931636-c070fcc9-495f-479c-8211-43af68d84caf.png">

After: 

<img width="591" alt="image" src="https://user-images.githubusercontent.com/63889819/182931535-655b2702-12c4-417a-b2fb-0f5712d4151d.png">
