### PR TITLE
fix: Colored Markers Step 2 - tighten up tests

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/61695ab9f6ffe951c16d03dd.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/61695ab9f6ffe951c16d03dd.md
@@ -41,7 +41,7 @@ There should only be one `head` element.
 assert(code.match(/<head\s*>/ig).length === 1);
 ```
 
-There should only be one `head` element.
+There should only be one `head` closing tag.
 
 ```js
 assert(code.match(/<\/head\s*>/ig).length === 1);

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/61695ab9f6ffe951c16d03dd.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/61695ab9f6ffe951c16d03dd.md
@@ -35,10 +35,46 @@ You should have a closing `body` tag.
 assert(code.match(/<\/body\s*>/i));
 ```
 
+There should only be one `head` element.
+
+```js
+assert(code.match(/<head\s*>/ig).length === 1);
+```
+
+There should only be one `head` element.
+
+```js
+assert(code.match(/<\/head\s*>/ig).length === 1);
+```
+
+There should only be one `body` element.
+
+```js
+assert(code.match(/<body\s*>/ig).length === 1);
+```
+
+There should only be one `body` element.
+
+```js
+assert(code.match(/<\/body\s*>/ig).length === 1);
+```
+
 Your `head` and `body` elements should be siblings.
 
 ```js
-assert(document.querySelector('head')?.nextElementSibling?.localName === 'body');
+assert(code.match(/<head\s*>\s*<\/head\s*>/i));
+```
+
+Your `head` and `body` elements should be siblings.
+
+```js
+assert(code.match(/<body\s*>\s*<\/body\s*>/i));
+```
+
+Your `body` element should be placed after your `head` element.
+
+```js
+assert(code.match(/<\/head\s*>\s*<body\s*>/i));
 ```
 
 Your `head` element should be within the `html` element.

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/61695ab9f6ffe951c16d03dd.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/61695ab9f6ffe951c16d03dd.md
@@ -47,7 +47,7 @@ There should only be one `head` closing tag.
 assert(code.match(/<\/head\s*>/ig).length === 1);
 ```
 
-There should only be one `body` element.
+There should only be one `body` opening tag.
 
 ```js
 assert(code.match(/<body\s*>/ig).length === 1);

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/61695ab9f6ffe951c16d03dd.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/61695ab9f6ffe951c16d03dd.md
@@ -35,7 +35,7 @@ You should have a closing `body` tag.
 assert(code.match(/<\/body\s*>/i));
 ```
 
-There should only be one `head` element.
+There should only be one `head` opening tag.
 
 ```js
 assert(code.match(/<head\s*>/ig).length === 1);

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/61695ab9f6ffe951c16d03dd.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/61695ab9f6ffe951c16d03dd.md
@@ -53,7 +53,7 @@ There should only be one `body` opening tag.
 assert(code.match(/<body\s*>/ig).length === 1);
 ```
 
-There should only be one `body` element.
+There should only be one `body` closing tag.
 
 ```js
 assert(code.match(/<\/body\s*>/ig).length === 1);

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/61695ab9f6ffe951c16d03dd.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/61695ab9f6ffe951c16d03dd.md
@@ -59,13 +59,13 @@ There should only be one `body` closing tag.
 assert(code.match(/<\/body\s*>/ig).length === 1);
 ```
 
-Your `head` and `body` elements should be siblings.
+Your `head` element should be empty.
 
 ```js
 assert(code.match(/<head\s*>\s*<\/head\s*>/i));
 ```
 
-Your `head` and `body` elements should be siblings.
+Your `body` element should be empty.
 
 ```js
 assert(code.match(/<body\s*>\s*<\/body\s*>/i));


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #46814

<!-- Feel free to add any additional description of changes below this line -->

Apparently modern browser are so good at fixing bad HTML that you can completely mangle the `head` and `body` elements and they will automatically fix them. So we can't query the `document` to verify that the HTML the user entered is actually correct. Instead, it looks like we need a bunch of pattern matching. I may have gone overboard a little? While I was at it I figured why not make sure they only add one `head` element and one `body` element, and in the correct order. If someone has a cleaner way to do this I'm all ears.