### PR TITLE
fix(curriculum): use DOM for link element tests

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/619665c9abd72906f3ad30f9.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/619665c9abd72906f3ad30f9.md
@@ -101,7 +101,7 @@ assert.exists(document.querySelector('link'));
 Your `link` element should be within your `head` element.
 
 ```js
-assert.exists(document.querySelector('head > link'));
+assert(code.match(/<head>[\w\W\s]*<link[\w\W\s]*\/?>[\w\W\s]*<\/head>/i));
 ```
 
 Your `link` element should have a `rel` attribute with the value `stylesheet`.

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/619665c9abd72906f3ad30f9.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/619665c9abd72906f3ad30f9.md
@@ -95,25 +95,28 @@ assert.isAtLeast(title?.textContent?.length, 1);
 Your code should have a `link` element.
 
 ```js
-assert(/<link/.test(code))
+assert.exists(document.querySelector('link'));
 ```
 
 Your `link` element should be within your `head` element.
 
 ```js
-assert(code.match(/<head>[\w\W\s]*<link[\w\W\s]*\/>[\w\W\s]*<\/head>/i))
+assert.exists(document.querySelector('head > link'));
 ```
 
 Your `link` element should have a `rel` attribute with the value `stylesheet`.
 
 ```js
-assert.match(code, /<link[\s\S]*?rel=('|"|`)stylesheet\1/)
+const link_element = document.querySelector('link');
+const rel = link_element.getAttribute("rel");
+assert.equal(rel, "stylesheet");
 ```
 
 Your `link` element should have an `href` attribute with the value `styles.css`.
 
 ```js
-assert.match(code, /<link[\s\S]*?href=('|"|`)(\.\/)?styles\.css\1/)
+const link = document.querySelector('link');
+assert.equal(link.dataset.href, "styles.css");
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Switch to DOM queries for the `link` element test, fixing the `/>` requirement for the element.

Note: there currently seems to be a bug with the `head > link` test see issue https://github.com/freeCodeCamp/freeCodeCamp/issues/47207
