### PR TITLE
fix(curriculum): make test a little more lenient for reg form step 36

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fad0a812d9890938524f50.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fad0a812d9890938524f50.md
@@ -22,7 +22,7 @@ assert.isNotEmpty(document.querySelector('fieldset:nth-child(3) > label:nth-chil
 You should give the `placeholder` a value of `I like coding on the beach...`.
 
 ```js
-assert.equal(document.querySelector('fieldset:nth-child(3) > label:nth-child(4) > textarea')?.placeholder, 'I like coding on the beach...');
+assert.match(document.querySelector('fieldset:nth-child(3) > label:nth-child(4) > textarea')?.placeholder, /^I like coding on the beach\.{3,4}$/);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Seeing people accidentally add a fourth dot to the end of the placeholder text. I think this is completely understandable, especially if they are copy/pasting from the instructions. Is there any harm in accepting either 3 or 4 dots?