### PR TITLE
fix(curriculum): add missing instructions for lang attribute

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-animation-by-building-a-ferris-wheel/6140c7e645d8e905819f1dd4.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-animation-by-building-a-ferris-wheel/6140c7e645d8e905819f1dd4.md
@@ -7,7 +7,7 @@ dashedName: step-1
 
 # --description--
 
-Begin with the standard boilerplate. Add your `DOCTYPE` declaration, your `html` element, your `head` and `body` elements.
+Begin with the standard boilerplate. Add your `DOCTYPE` declaration, your `html` element, your `head` and `body` elements. Give the `html` element a `lang` attribute with `en` as its value.
 
 Add your `meta` element for the correct `charset`, your `title` element, and a `link` element for the `./styles.css` file.
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-animation-by-building-a-ferris-wheel/6140c7e645d8e905819f1dd4.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-animation-by-building-a-ferris-wheel/6140c7e645d8e905819f1dd4.md
@@ -7,7 +7,7 @@ dashedName: step-1
 
 # --description--
 
-Begin with the standard boilerplate. Add your `DOCTYPE` declaration, your `html` element, your `head` and `body` elements. Give the `html` element a `lang` attribute with `en` as its value.
+Begin with the standard boilerplate. Add your `DOCTYPE` declaration, your `html` element with the language set to English, your `head` and `body` elements.
 
 Add your `meta` element for the correct `charset`, your `title` element, and a `link` element for the `./styles.css` file.
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-grid-by-building-a-magazine/61437d575fb98f57fa8f7f36.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-grid-by-building-a-magazine/61437d575fb98f57fa8f7f36.md
@@ -7,7 +7,7 @@ dashedName: step-1
 
 # --description--
 
-Begin with your standard HTML boilerplate. Add a `DOCTYPE` declaration, an `html` element, a `head` element, and a `body` element. Give the `html` element a `lang` attribute with `en` as its value.
+Begin with your standard HTML boilerplate. Add a `DOCTYPE` declaration, an `html` element specifying this page is in English, a `head` element, and a `body` element.
 
 Add a `<meta>` tag with the appropriate `charset` and a `<meta>` tag for mobile responsiveness within the `head` element.
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-grid-by-building-a-magazine/61437d575fb98f57fa8f7f36.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-grid-by-building-a-magazine/61437d575fb98f57fa8f7f36.md
@@ -7,7 +7,7 @@ dashedName: step-1
 
 # --description--
 
-Begin with your standard HTML boilerplate. Add a `DOCTYPE` declaration, an `html` element, a `head` element, and a `body` element.
+Begin with your standard HTML boilerplate. Add a `DOCTYPE` declaration, an `html` element, a `head` element, and a `body` element. Give the `html` element a `lang` attribute with `en` as its value.
 
 Add a `<meta>` tag with the appropriate `charset` and a `<meta>` tag for mobile responsiveness within the `head` element.
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/619665c9abd72906f3ad30f9.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/619665c9abd72906f3ad30f9.md
@@ -9,7 +9,7 @@ dashedName: step-1
 
 You will be building a happy Flappy Penguin, and further exploring CSS transforms and animations in the process.
 
-Begin with your basic HTML boilerplate. Include the `DOCTYPE` declaration, `html` element, the appropriate `meta` tags, a `head`, `body`, and `title` element. Also, link your stylesheet to the page.
+Begin with your basic HTML boilerplate. Include the `DOCTYPE` declaration, `html` element with a `lang` attribute of `en`, the appropriate `meta` tags, a `head`, `body`, and `title` element. Also, link your stylesheet to the page.
 
 # --hints--
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/619665c9abd72906f3ad30f9.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/619665c9abd72906f3ad30f9.md
@@ -9,7 +9,7 @@ dashedName: step-1
 
 You will be building a happy Flappy Penguin, and further exploring CSS transforms and animations in the process.
 
-Begin with your basic HTML boilerplate. Include the `DOCTYPE` declaration, `html` element with a `lang` attribute of `en`, the appropriate `meta` tags, a `head`, `body`, and `title` element. Also, link your stylesheet to the page.
+Begin with your basic HTML boilerplate. Include the `DOCTYPE` declaration, `html` element with a language set to English, the appropriate `meta` tags, a `head`, `body`, and `title` element. Also, link your stylesheet to the page.
 
 # --hints--
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-variables-by-building-a-city-skyline/5d822fd413a79914d39e98ca.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-variables-by-building-a-city-skyline/5d822fd413a79914d39e98ca.md
@@ -7,7 +7,7 @@ dashedName: step-2
 
 # --description--
 
-Add opening and closing `html` tags below the `DOCTYPE` so you have a place to start putting some code. Be sure to set the language.
+Add opening and closing `html` tags below the `DOCTYPE` so you have a place to start putting some code. Be sure to set the language to `en`.
 
 # --hints--
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-variables-by-building-a-city-skyline/5d822fd413a79914d39e98ca.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-variables-by-building-a-city-skyline/5d822fd413a79914d39e98ca.md
@@ -7,7 +7,7 @@ dashedName: step-2
 
 # --description--
 
-Add opening and closing `html` tags below the `DOCTYPE` so you have a place to start putting some code. Be sure to set the language to `en`.
+Add opening and closing `html` tags below the `DOCTYPE` so you have a place to start putting some code. Be sure to set the language to English.
 
 # --hints--
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-more-about-css-pseudo-selectors-by-building-a-balance-sheet/61fd5a93fd62bb35968adeab.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-more-about-css-pseudo-selectors-by-building-a-balance-sheet/61fd5a93fd62bb35968adeab.md
@@ -7,7 +7,7 @@ dashedName: step-1
 
 # --description--
 
-Set up your HTML with the `DOCTYPE`, `html`, `head`, and `body` elements. Give the `html` element a `lang` attribute with `en` as its value.
+Set up your HTML with the `DOCTYPE`, `html` indicating this document is in English, `head`, and `body` elements.
 
 Give your `head` element the appropriate `meta` elements for the `charset` and `viewport`, a `title` element with an appropriate title, and a `link` element for your stylesheet.
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-more-about-css-pseudo-selectors-by-building-a-balance-sheet/61fd5a93fd62bb35968adeab.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-more-about-css-pseudo-selectors-by-building-a-balance-sheet/61fd5a93fd62bb35968adeab.md
@@ -7,7 +7,9 @@ dashedName: step-1
 
 # --description--
 
-Set up your HTML with the `DOCTYPE`, `html`, `head`, and `body` elements. Give your `head` element the appropriate `meta` elements for the `charset` and `viewport`, a `title` element with an appropriate title, and a `link` element for your stylesheet.
+Set up your HTML with the `DOCTYPE`, `html`, `head`, and `body` elements. Give the `html` element a `lang` attribute with `en` as its value.
+
+Give your `head` element the appropriate `meta` elements for the `charset` and `viewport`, a `title` element with an appropriate title, and a `link` element for your stylesheet.
 
 # --hints--
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-responsive-web-design-by-building-a-piano/612e6afc009b450a437940a1.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-responsive-web-design-by-building-a-piano/612e6afc009b450a437940a1.md
@@ -9,7 +9,7 @@ dashedName: step-1
 
 Begin with the basic HTML structure. Add a `DOCTYPE` declaration and `html`, `head`, `body`, and `title` elements.
 
-Give the `html` element a `lang` attribute with `en` as its value. Set the `title` to `Piano`.
+Set the language of this page to English. Set the `title` to `Piano`.
 
 # --hints--
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-responsive-web-design-by-building-a-piano/612e6afc009b450a437940a1.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-responsive-web-design-by-building-a-piano/612e6afc009b450a437940a1.md
@@ -7,7 +7,9 @@ dashedName: step-1
 
 # --description--
 
-Begin with the basic HTML structure. Add a `DOCTYPE` declaration and `html`, `head`, `body`, and `title` elements. Set the `title` to `Piano`.
+Begin with the basic HTML structure. Add a `DOCTYPE` declaration and `html`, `head`, `body`, and `title` elements.
+
+Give the `html` element a `lang` attribute with `en` as its value. Set the `title` to `Piano`.
 
 # --hints--
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-the-css-box-model-by-building-a-rothko-painting/60a3e3396c7b40068ad6996a.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-the-css-box-model-by-building-a-rothko-painting/60a3e3396c7b40068ad6996a.md
@@ -9,7 +9,7 @@ dashedName: step-1
 
 By now, you should be familiar with the basic elements an HTML page should have.
 
-Set up your code with a `DOCTYPE` declaration, an `html` element, a `head` element, and a `body` element.
+Set up your code with a `DOCTYPE` declaration, an `html` element, a `head` element, and a `body` element. Give the `html` element a `lang` attribute with `en` as its value.
 
 # --hints--
 
@@ -19,10 +19,10 @@ Your code should have a `<!DOCTYPE html>` declaration.
 assert(code.match(/<!DOCTYPE html>/i));
 ```
 
-Your code should have an `html` element.
+You should have an opening `<html>` tag with a `lang` attribute of `en`.
 
 ```js
-assert(document.querySelectorAll('html').length === 1);
+assert(code.match(/<html\s+lang\s*=\s*('|")en\1\s*>/gi));
 ```
 
 Your code should have a `head` element within the `html` element.

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-the-css-box-model-by-building-a-rothko-painting/60a3e3396c7b40068ad6996a.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-the-css-box-model-by-building-a-rothko-painting/60a3e3396c7b40068ad6996a.md
@@ -9,7 +9,7 @@ dashedName: step-1
 
 By now, you should be familiar with the basic elements an HTML page should have.
 
-Set up your code with a `DOCTYPE` declaration, an `html` element, a `head` element, and a `body` element. Give the `html` element a `lang` attribute with `en` as its value.
+Set up your code with a `DOCTYPE` declaration, an `html` element with the language set to English, a `head` element, and a `body` element.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

The tests to check if `lang="en"` attribute is set were added to all projects in #46540 but the instructions to do so were missing in some projects:
- Balance sheet
- Piano
- City skyline
- Magazine
- Ferris Wheel
- Penguin
- Rothko Painting (test was missing too, but the `lang="en"` was in the seed code of the next step)

I thought it's better to clarify them since the project itself is still in English but the instruction will be translated into different languages.
