### PR TITLE
fix(curriculim): improve hints for Cat Photo App step 46

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5f05a1d8e233dff4a68508d8.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5f05a1d8e233dff4a68508d8.md
@@ -21,7 +21,8 @@ assert(
   indoorInput !== null && 
   indoorInput.id === 'indoor' &&
   indoorInput.nextSibling.nodeValue.replace(/^\s|\s$/g, '').match(/^Indoor$/) &&
-  indoorInput.type === 'radio'
+  indoorInput.type === 'radio' &&
+  code.match(/<label\s*>\s*<input [^>]*id="indoor"[^>]*>\s*Indoor\s*<\/label>/g)
 );
 ```
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5f05a1d8e233dff4a68508d8.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5f05a1d8e233dff4a68508d8.md
@@ -19,7 +19,7 @@ Only the original `Indoor` radio button `input` should have an `id` set to `indo
 assert(document.querySelectorAll('#indoor').length < 2);
 ```
 
-You have accidentally made changes to the `Indoor` radio button. You can restart the step to get the original HTML back if needed.
+You should not make any changes to the `Indoor` radio button. You can restart the step to get the original HTML back if needed.
 
 ```js
 const indoorInput = document.querySelectorAll('#indoor');
@@ -27,7 +27,7 @@ assert(
   indoorInput.length == 1 &&
   indoorInput[0]?.nodeName?.toUpperCase() === 'INPUT' &&
   indoorInput[0]?.type === 'radio' &&
-  code.match(/<label\s*>\s*<input [^>]*(id=["']indoor["'])[^>]*>\s*Indoor\s*<\/label>/)
+  code.match(/<label\s*>\s*<input [^>]*(id=["']?indoor["']?)[^>]*>\s*Indoor\s*<\/label>/)
 );
 ```
 
@@ -55,7 +55,7 @@ Your new `input` should have a `type` attribute with the value `radio`.
 assert(document.querySelector('label input[id="outdoor"][type="radio"]'));
 ```
 
-You should not add any elements other than an `input` nested in a `label`.
+You should not add any new elements other than an `input` nested in a `label`.
 
 ```js
 assert(document.querySelector('label input[id="outdoor"]:only-child'));
@@ -74,7 +74,7 @@ assert(
 The label text for your new radio button must be exactly `Outdoor`. This includes capitalization. 
 
 ```js
-assert(document.querySelector('label > input[id="outdoor"]')?.nextSibling?.nodeValue?.replace(/^\s|\s$/g, '') === 'Outdoor');
+assert(document.querySelector('label > input[id="outdoor"]')?.nextSibling?.nodeValue?.replace(/^\s+|\s+$/g, '') === 'Outdoor');
 ```
 
 Your new radio button and label should be immediately below/after the `Indoor` radio button and label. There should be no other tags between them.

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5f05a1d8e233dff4a68508d8.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5f05a1d8e233dff4a68508d8.md
@@ -13,45 +13,68 @@ Nest another radio button with the option `Outdoor` in a new `label` element. Th
 
 # --hints--
 
-You will need to add a new `label` element in which to nest your new radio button. Make sure it has both an opening and closing tag.
+You have accidentally made changes to the `Indoor` radio button. You may want to restart the step to get the original HTML back.
 
 ```js
+const indoorInput = document.querySelector('label > input#indoor');
 assert(
-  document.querySelectorAll('label').length === 2 &&
-    code.match(/<\/label\>/g).length === 2
+  indoorInput !== null && 
+  indoorInput.id === 'indoor' &&
+  indoorInput.nextSibling.nodeValue.replace(/^\s|\s$/g, '').match(/^Indoor$/) &&
+  indoorInput.type === 'radio'
 );
 ```
 
-The text ` Outdoor` should be located directly to the right of your new `radio` button. Make sure there is a space between the element and the text. You have either omitted the text or have a typo.
+You should add exactly one new `input` element nested in a new `label` element. Make sure your `label` has both an opening and closing tag.
 
 ```js
-const radioButtons = [...$('input')];
+assert(document.querySelectorAll('label input').length === 2);
+```
+
+You should not add any attributes to either opening `label` tag.
+
+```js
+assert(code.match(/<label\s*>/g).length === 2);
+```
+
+Your new `input` should have an `id` attribute with the value `outdoor`. 
+
+```js
+assert(document.querySelector('label input[id="outdoor"]'));
+```
+
+Your new `input` should have a `type` attribute with the value `radio`.
+
+```js
+assert(document.querySelector('label input[id="outdoor"][type="radio"]'));
+```
+
+You should not add any other elements other than an `input` nested in a `label`.
+
+```js
+assert(document.querySelector('label input[id="outdoor"]:only-child'));
+```
+
+There should be no text to the left of your new `input`.
+
+```js
+const outdoorBtn = document.querySelector('label input[id="outdoor"]');
 assert(
-  radioButtons.filter((btn) =>
-    btn.nextSibling.nodeValue.replace(/\s+/g, ' ').match(/ *Outdoor/i)
-  ).length
+    outdoorBtn?.previousSibling?.nodeName !== '#text' ||
+    outdoorBtn?.previousSibling?.nodeValue?.replace(/\s/g, '') === ''
 );
 ```
 
-Your new radio button and associated label should be below the first one. You have them in the wrong order.
+The label text for your new radio button must be exactly `Outdoor`. This includes capitalization. 
 
 ```js
-const collection = [
-  ...document.querySelectorAll('input[type="radio"]')
-].map((node) => node.nextSibling.nodeValue.replace(/\s+/g, ''));
-assert(collection.indexOf('Indoor') < collection.indexOf('Outdoor'));
+assert(document.querySelector('label > input[id="outdoor"]')?.nextSibling?.nodeValue?.replace(/^\s|\s$/g, '') === 'Outdoor');
 ```
 
-Your new radio button should have an `id` attribute. Check that there is a space after the opening tag's name and/or there are spaces before all attribute names.
+Your new radio button and associated label should be immediately below the `Indoor` radio button and label.
 
 ```js
-assert($('input')[1].hasAttribute('id'));
-```
-
-Your new radio button should have an `id` attribute with the value `outdoor`. You have either omitted the value or have a typo. Remember that attribute values should be surrounded with quotation marks.
-
-```js
-assert($('input')[1].id.match(/^outdoor$/));
+assert(code.match(/<\/label>\s*<label\s*>\s*<input [^>]+>\s*Outdoor/i));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5f05a1d8e233dff4a68508d8.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5f05a1d8e233dff4a68508d8.md
@@ -13,16 +13,14 @@ Nest another radio button with the option `Outdoor` in a new `label` element. Th
 
 # --hints--
 
-You have accidentally made changes to the `Indoor` radio button. You may want to restart the step to get the original HTML back.
+You have accidentally made changes to the `Indoor` radio button. You can restart the step to get the original HTML back if needed.
 
 ```js
 const indoorInput = document.querySelector('label > input#indoor');
 assert(
-  indoorInput !== null && 
-  indoorInput.id === 'indoor' &&
-  indoorInput.nextSibling.nodeValue.replace(/^\s|\s$/g, '').match(/^Indoor$/) &&
+  indoorInput && 
   indoorInput.type === 'radio' &&
-  code.match(/<label\s*>\s*<input [^>]*id="indoor"[^>]*>\s*Indoor\s*<\/label>/g)
+  code.match(/<label\s*>\s*<input [^>]*id=["']indoor["'][^>]*>\s*Indoor\s*<\/label>/g)
 );
 ```
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5f05a1d8e233dff4a68508d8.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5f05a1d8e233dff4a68508d8.md
@@ -13,18 +13,25 @@ Nest another radio button with the option `Outdoor` in a new `label` element. Th
 
 # --hints--
 
+Only the original `Indoor` radio button `input` should have an `id` set to `indoor`. You can restart the step to get the original HTML back if needed.
+
+```js
+assert(document.querySelectorAll('#indoor').length < 2);
+```
+
 You have accidentally made changes to the `Indoor` radio button. You can restart the step to get the original HTML back if needed.
 
 ```js
-const indoorInput = document.querySelector('label > input#indoor');
+const indoorInput = document.querySelectorAll('#indoor');
 assert(
-  indoorInput && 
-  indoorInput.type === 'radio' &&
-  code.match(/<label\s*>\s*<input [^>]*id=["']indoor["'][^>]*>\s*Indoor\s*<\/label>/g)
+  indoorInput.length == 1 &&
+  indoorInput[0]?.nodeName?.toUpperCase() === 'INPUT' &&
+  indoorInput[0]?.type === 'radio' &&
+  code.match(/<label\s*>\s*<input [^>]*(id=["']indoor["'])[^>]*>\s*Indoor\s*<\/label>/)
 );
 ```
 
-You should add exactly one new `input` element nested in a new `label` element. Make sure your `label` has both an opening and closing tag.
+You should add exactly one new `input` element nested in a new `label` element. Make sure your new `label` has both an opening and closing tag.
 
 ```js
 assert(document.querySelectorAll('label input').length === 2);
@@ -48,7 +55,7 @@ Your new `input` should have a `type` attribute with the value `radio`.
 assert(document.querySelector('label input[id="outdoor"][type="radio"]'));
 ```
 
-You should not add any other elements other than an `input` nested in a `label`.
+You should not add any elements other than an `input` nested in a `label`.
 
 ```js
 assert(document.querySelector('label input[id="outdoor"]:only-child'));
@@ -70,7 +77,7 @@ The label text for your new radio button must be exactly `Outdoor`. This include
 assert(document.querySelector('label > input[id="outdoor"]')?.nextSibling?.nodeValue?.replace(/^\s|\s$/g, '') === 'Outdoor');
 ```
 
-Your new radio button and associated label should be immediately below the `Indoor` radio button and label.
+Your new radio button and label should be immediately below/after the `Indoor` radio button and label. There should be no other tags between them.
 
 ```js
 assert(code.match(/<\/label>\s*<label\s*>\s*<input [^>]+>\s*Outdoor/i));


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This step is quite popular on the forums and the issue is almost always that they don't capitalize `Outdoor` in the label text. The hint they are currently getting for this error is:

> Hint: Your new radio button and associated label should be below the first one. You have them in the wrong order.

This is confusing since they have added the new radio button below the first one, they just have a simple capitalization error.

So I've reworked the tests to give better hints for the various issues I've seen on the forum (and even some I haven't). For sure, I haven't caught everything. And I did make a few changes (for simplicity's sake), such as not allowing any attributes on the `<label>`s. The current tests do allow attributes on the `<label>`s, so the user could add `for` attributes for these, and they could add them correctly, but the tests don't check these, so they can also pass by adding them incorrectly. I figured it was just better to not allow any.

My approach here is to first check that they didn't change the existing `Indoor` radio button. Then check that they added the new `Outdoor` radio button correctly (just syntax). Then finally check that they adding the new radio button in the correct position.