### PR TITLE
fix: make ctrl+enter work on mac

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -431,7 +431,10 @@ const Editor = (props: EditorProps): JSX.Element => {
       id: 'execute-challenge',
       label: 'Run tests',
       /* eslint-disable no-bitwise */
-      keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter],
+      keybindings: [
+        monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
+        monaco.KeyMod.WinCtrl | monaco.KeyCode.Enter
+      ],
       run: () => {
         if (props.usesMultifileEditor && !isFinalProject(props.challengeType)) {
           if (challengeIsComplete()) {
@@ -456,7 +459,10 @@ const Editor = (props: EditorProps): JSX.Element => {
     editor.addAction({
       id: 'save-editor-content',
       label: 'Save editor content',
-      keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_S],
+      keybindings: [
+        monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_S,
+        monaco.KeyMod.WinCtrl | monaco.KeyCode.KEY_S
+      ],
       run:
         props.challengeType === challengeTypes.multifileCertProject &&
         props.isSignedIn
@@ -468,7 +474,10 @@ const Editor = (props: EditorProps): JSX.Element => {
     editor.addAction({
       id: 'toggle-accessibility',
       label: 'Toggle Accessibility Mode',
-      keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_E],
+      keybindings: [
+        monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_E,
+        monaco.KeyMod.WinCtrl | monaco.KeyCode.KEY_E
+      ],
       run: () => {
         const currentAccessibility = storedAccessibilityMode();
 


### PR DESCRIPTION
Makes ctrl+enter or cmd+enter work on mac when the editor is focused. The original issue was that the "check code" button says ctrl+enter, but that didn't work on mac. I also added the same option to use ctrl+enter for saving code and toggling accessibility - the other two places that code was used. Not sure if we wanted to include those or not.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #46423

<!-- Feel free to add any additional description of changes below this line -->
