### PR TITLE
docs: update link to article

### DIFF
--- a/docs/how-to-setup-wsl.md
+++ b/docs/how-to-setup-wsl.md
@@ -128,7 +128,7 @@ Now that you have installed the pre-requisites, follow [our local setup guide](h
 
 ## Useful Links
 
-- [A WSL2 Dev Setup with Ubuntu 20.04, Node.js, MongoDB, VS Code and Docker](https://devlog.sh/wsl2-dev-setup-with-ubuntu-nodejs-mongodb-and-docker) - an article by Mrugesh Mohapatra (Staff Developer at freeCodeCamp.org)
+- [A WSL2 Dev Setup with Ubuntu 20.04, Node.js, MongoDB, VS Code and Docker](https://hn.mrugesh.dev/wsl2-dev-setup-with-ubuntu-nodejs-mongodb-and-docker) - an article by Mrugesh Mohapatra (Staff Developer at freeCodeCamp.org)
 - Frequently asked questions on:
   - [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/faq)
   - [Docker Desktop for Windows](https://docs.docker.com/docker-for-windows/faqs)


### PR DESCRIPTION
Updating a link to my article I wrote 2 years ago. I considered removing it, but @RandellDawson said it was relevant and helpful. There is domain name change and I did not realize this was still here. Normally we would have written an article on news and swapped it, and I will get to it when I get some time. This should help anyone who is seeing a 404 right now.
