### PR TITLE
fix(UI): make possible to reset challenge after tests pass

### DIFF
--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -84,9 +84,7 @@ const LowerJaw = ({
     }
 
     if (!challengeHasBeenCompleted) {
-      setTimeout(() => {
-        setTestBtnariaHidden(false);
-      }, 500);
+      setTestBtnariaHidden(false);
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -10,7 +10,7 @@ import { apiLocation } from '../../../../../config/env.json';
 
 interface LowerJawProps {
   hint?: string;
-  challengeIsCompleted?: boolean;
+  challengeIsCompleted: boolean;
   openHelpModal: () => void;
   tryToExecuteChallenge: () => void;
   tryToSubmitChallenge: () => void;
@@ -83,11 +83,21 @@ const LowerJaw = ({
       }, 500);
     }
 
+    if (!challengeHasBeenCompleted) {
+      setTimeout(() => {
+        setTestBtnariaHidden(false);
+      }, 500);
+    }
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [challengeHasBeenCompleted]);
 
   useEffect(() => {
     if (!challengeHasBeenCompleted && challengeIsCompleted) {
+      setChallengeHasBeenCompleted(challengeIsCompleted);
+    }
+
+    if (challengeHasBeenCompleted && !challengeIsCompleted) {
       setChallengeHasBeenCompleted(challengeIsCompleted);
     }
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #47302

<!-- Feel free to add any additional description of changes below this line -->

Change the behavior of Test button and Submit button in 2022 new challenge editor so the Test button will be coming back (with no deley) after Reset the challenge.

Affected page:
New Responsive Web Design > all courses with step
https://www.freecodecamp.org/learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-16

https://user-images.githubusercontent.com/44451585/185602817-902096e6-8448-45f3-bf1c-9916a8c415b9.mp4