### PR TITLE
docs: update devops documents for client

### DIFF
--- a/docs/devops.md
+++ b/docs/devops.md
@@ -564,8 +564,8 @@ Provisioning VMs with the Code
 
    ```console
    npm i -g npm@8
-   npm i -g pm2
-   npm install -g serve
+   npm i -g pm2@4
+   npm install -g serve@13
    pm2 install pm2-logrotate
    pm2 startup
    ```
@@ -583,11 +583,11 @@ Provisioning VMs with the Code
    > Todo: This setup needs to move to S3 or Azure Blob storage
 
    ```console
-   echo "serve -c ../../serve.json www -p 50505" >> client-start-primary.sh
+   echo "serve -c '../serve.json' -p 50505 www" > client-start-primary.sh
    chmod +x client-start-primary.sh
    pm2 delete client-primary
    pm2 start  ./client-start-primary.sh --name client-primary
-   echo "serve -c ../../serve.json www -p 52525" >> client-start-secondary.sh
+   echo "serve -c '../serve.json' -p 52525 www" > client-start-secondary.sh
    chmod +x client-start-secondary.sh
    pm2 delete client-secondary
    pm2 start  ./client-start-secondary.sh --name client-secondary

--- a/docs/devops.md
+++ b/docs/devops.md
@@ -583,11 +583,11 @@ Provisioning VMs with the Code
    > Todo: This setup needs to move to S3 or Azure Blob storage
 
    ```console
-   echo "serve -c '../serve.json' -p 50505 www" > client-start-primary.sh
+   echo "serve -c ../serve.json -p 50505 www" > client-start-primary.sh
    chmod +x client-start-primary.sh
    pm2 delete client-primary
    pm2 start  ./client-start-primary.sh --name client-primary
-   echo "serve -c '../serve.json' -p 52525 www" > client-start-secondary.sh
+   echo "serve -c ../serve.json -p 52525 www" > client-start-secondary.sh
    chmod +x client-start-secondary.sh
    pm2 delete client-secondary
    pm2 start  ./client-start-secondary.sh --name client-secondary


### PR DESCRIPTION
The `serve`-CLI looks for the `serve.json` config file in the default folder that it is serving. This should update the correct relative linking, and lock the versions for both `serve` and `pm2` that we know is working for us.

All this should be irrelevant once we jump ship with the cloud-native approach.