### PR TITLE
fix: only allow display flex in media query build project landing page project

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/build-a-product-landing-page-project/build-a-product-landing-page.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/build-a-product-landing-page-project/build-a-product-landing-page.md
@@ -251,15 +251,21 @@ const cssCheck = new __helpers.CSSHelp(document).getCSSRules('media')
 assert(cssCheck.length > 0 || htmlSourceAttr.length > 0);
 ```
 
-Your Product Landing Page should use CSS Flexbox at least once.
+Your media query should contain a `display` property with the value set to `flex` or `inline-flex`
 
 ```js
 const stylesheet = new __helpers.CSSHelp(document).getStyleSheet()
-const cssRules = new __helpers.CSSHelp(document).styleSheetToCssRulesArray(stylesheet)
-const usesFlex = cssRules.find(rule => {
-  return rule.style?.display === 'flex' || rule.style?.display === 'inline-flex'
-})
-assert(usesFlex)
+const cssCheck = new __helpers.CSSHelp(document).getCSSRules('media')
+const checkArr = [];
+for(let i = 0; i < cssCheck.length; i++){
+  for(let j = 0; j < cssCheck[i].cssRules.length; j++){
+    if(cssCheck[i].cssRules[j].style.display == 'flex' || cssCheck[i].cssRules[j].style.display == 'inline-flex'){
+      checkArr.push(true);
+    }
+  }
+}
+
+assert(checkArr.length > 0);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/14-responsive-web-design-22/build-a-product-landing-page-project/build-a-product-landing-page.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/build-a-product-landing-page-project/build-a-product-landing-page.md
@@ -466,6 +466,7 @@ footer {
 }
 @media (max-width: 350px) {
   #video {
+    display: flex;
     width: 300;
     height: 200;
   }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This gives people the freedom to still add `display: flex` but adding it to the mediaquery mandatory. 

Closes #46887

<!-- Feel free to add any additional description of changes below this line -->
