### PR TITLE
feat: add search link to help modal

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -286,7 +286,7 @@
     "percent-complete": "{{percent}}% complete",
     "tried-rsa": "If you've already tried the <0>Read-Search-Ask</0> method, then you can ask for help on the freeCodeCamp forum.",
     "rsa": "Read, search, ask",
-    "search-link-text": "<0>Here are forum posts potentially related to this challenge.</0> You should see if one of these posts has a solution to your question before making a new post.",
+    "search-link-text": "<0>Here are forum posts potentially related to this challenge.</0> You should see if one of these posts has a solution to your question <strong>before making a new post</strong>.",
     "reset": "Reset this lesson?",
     "reset-warn": "Are you sure you wish to reset this lesson? The editors and tests will be reset.",
     "reset-warn-2": "This cannot be undone",

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -286,6 +286,7 @@
     "percent-complete": "{{percent}}% complete",
     "tried-rsa": "If you've already tried the <0>Read-Search-Ask</0> method, then you can ask for help on the freeCodeCamp forum.",
     "rsa": "Read, search, ask",
+    "search-link-text": "<0>Here are forum posts potentially related to this challenge.</0> You should see if one of these posts has a solution to your question before making a new post.",
     "reset": "Reset this lesson?",
     "reset-warn": "Are you sure you wish to reset this lesson? The editors and tests will be reset.",
     "reset-warn-2": "This cannot be undone",

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -286,7 +286,7 @@
     "percent-complete": "{{percent}}% complete",
     "tried-rsa": "If you've already tried the <0>Read-Search-Ask</0> method, then you can ask for help on the freeCodeCamp forum.",
     "rsa": "Read, search, ask",
-    "search-link-text": "<0>Here are forum posts potentially related to this challenge.</0> You should see if one of these posts has a solution to your question <strong>before making a new post</strong>.",
+    "rsa-forum": "<strong>Before making a new post</strong> please see if your question has <0>already been answered on the forum</0>.",
     "reset": "Reset this lesson?",
     "reset-warn": "Are you sure you wish to reset this lesson? The editors and tests will be reset.",
     "reset-warn-2": "This cannot be undone",

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -532,7 +532,7 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
             certification={certification}
             superBlock={superBlock}
           />
-          <HelpModal />
+          <HelpModal challengeTitle={title} challengeBlock={blockName} />
           <VideoModal videoUrl={this.getVideoUrl()} />
           <ResetModal />
           <ProjectPreviewModal

--- a/client/src/templates/Challenges/codeally/show.tsx
+++ b/client/src/templates/Challenges/codeally/show.tsx
@@ -368,7 +368,7 @@ class ShowCodeAlly extends Component<ShowCodeAllyProps> {
                 certification={certification}
                 superBlock={superBlock}
               />
-              <HelpModal />
+              <HelpModal challengeTitle={title} challengeBlock={blockName} />
             </Row>
           </Grid>
         </LearnLayout>

--- a/client/src/templates/Challenges/components/help-modal.css
+++ b/client/src/templates/Challenges/components/help-modal.css
@@ -1,3 +1,13 @@
+.help-grid {
+  display: grid;
+  grid-template-columns: auto auto;
+  align-items: center;
+}
+
+.fa-circle-exclamation {
+  font-size: 3rem;
+}
+
 @media screen and (max-width: 767px) {
   .help-modal .btn-lg {
     font-size: 16px;

--- a/client/src/templates/Challenges/components/help-modal.css
+++ b/client/src/templates/Challenges/components/help-modal.css
@@ -1,7 +1,5 @@
-.help-grid {
-  display: grid;
-  grid-template-columns: auto auto;
-  align-items: center;
+.alert > p > strong {
+  color: inherit;
 }
 
 .fa-circle-exclamation {

--- a/client/src/templates/Challenges/components/help-modal.css
+++ b/client/src/templates/Challenges/components/help-modal.css
@@ -4,6 +4,7 @@
 
 .fa-circle-exclamation {
   font-size: 3rem;
+  padding-bottom: 10px;
 }
 
 @media screen and (max-width: 767px) {

--- a/client/src/templates/Challenges/components/help-modal.tsx
+++ b/client/src/templates/Challenges/components/help-modal.tsx
@@ -1,3 +1,5 @@
+import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Button, Modal } from '@freecodecamp/react-bootstrap';
 import React from 'react';
 import { Trans, withTranslation } from 'react-i18next';
@@ -73,18 +75,21 @@ export function HelpModal({
             </a>
           </Trans>
         </h3>
-        <p>
-          <Trans i18nKey='learn.search-link-text'>
-            <a
-              href={generateSearchLink(challengeTitle, challengeBlock)}
-              rel='noopener noreferrer'
-              target='_blank'
-            >
+        <div className='help-grid'>
+          <FontAwesomeIcon icon={faExclamationCircle} />
+          <p>
+            <Trans i18nKey='learn.search-link-text'>
+              <a
+                href={generateSearchLink(challengeTitle, challengeBlock)}
+                rel='noopener noreferrer'
+                target='_blank'
+              >
+                placeholder
+              </a>
               placeholder
-            </a>
-            placeholder
-          </Trans>
-        </p>
+            </Trans>
+          </p>
+        </div>
         <Button
           block={true}
           bsSize='lg'

--- a/client/src/templates/Challenges/components/help-modal.tsx
+++ b/client/src/templates/Challenges/components/help-modal.tsx
@@ -34,7 +34,6 @@ const mapDispatchToProps = (dispatch: Dispatch) =>
 const RSA = forumLocation + '/t/19514';
 
 const generateSearchLink = (title: string, block: string) => {
-  console.table({ title, block });
   const query = /^step\s*\d*$/i.test(title)
     ? encodeURIComponent(`${block} - ${title}`)
     : encodeURIComponent(title);

--- a/client/src/templates/Challenges/components/help-modal.tsx
+++ b/client/src/templates/Challenges/components/help-modal.tsx
@@ -16,6 +16,8 @@ interface HelpModalProps {
   executeGA: (attributes: { type: string; data: string }) => void;
   isOpen?: boolean;
   t: (text: string) => string;
+  challengeTitle: string;
+  challengeBlock: string;
 }
 
 const { forumLocation } = envData;
@@ -31,12 +33,23 @@ const mapDispatchToProps = (dispatch: Dispatch) =>
 
 const RSA = forumLocation + '/t/19514';
 
+const generateSearchLink = (title: string, block: string) => {
+  console.table({ title, block });
+  const query = /^step\s*\d*$/i.test(title)
+    ? encodeURIComponent(`${block} - ${title}`)
+    : encodeURIComponent(title);
+  const search = `${forumLocation}/search?q=${query}`;
+  return search;
+};
+
 export function HelpModal({
   closeHelpModal,
   createQuestion,
   executeGA,
   isOpen,
-  t
+  t,
+  challengeBlock,
+  challengeTitle
 }: HelpModalProps): JSX.Element {
   if (isOpen) {
     executeGA({ type: 'modal', data: '/help-modal' });
@@ -61,6 +74,18 @@ export function HelpModal({
             </a>
           </Trans>
         </h3>
+        <p>
+          <Trans i18nKey='learn.search-link-text'>
+            <a
+              href={generateSearchLink(challengeTitle, challengeBlock)}
+              rel='noopener noreferrer'
+              target='_blank'
+            >
+              placeholder
+            </a>
+            placeholder
+          </Trans>
+        </p>
         <Button
           block={true}
           bsSize='lg'

--- a/client/src/templates/Challenges/components/help-modal.tsx
+++ b/client/src/templates/Challenges/components/help-modal.tsx
@@ -75,10 +75,10 @@ export function HelpModal({
             </a>
           </Trans>
         </h3>
-        <div className='help-grid'>
+        <div className='alert alert-danger'>
           <FontAwesomeIcon icon={faExclamationCircle} />
           <p>
-            <Trans i18nKey='learn.search-link-text'>
+            <Trans i18nKey='learn.rsa-forum'>
               <a
                 href={generateSearchLink(challengeTitle, challengeBlock)}
                 rel='noopener noreferrer'

--- a/client/src/templates/Challenges/projects/backend/Show.tsx
+++ b/client/src/templates/Challenges/projects/backend/Show.tsx
@@ -270,7 +270,7 @@ class BackEnd extends Component<BackEndProps> {
                 certification={certification}
                 superBlock={superBlock}
               />
-              <HelpModal />
+              <HelpModal challengeTitle={title} challengeBlock={blockName} />
             </Row>
           </Grid>
         </LearnLayout>

--- a/client/src/templates/Challenges/projects/frontend/Show.tsx
+++ b/client/src/templates/Challenges/projects/frontend/Show.tsx
@@ -204,7 +204,7 @@ class Project extends Component<ProjectProps> {
                 certification={certification}
                 superBlock={superBlock}
               />
-              <HelpModal />
+              <HelpModal challengeTitle={title} challengeBlock={blockName} />
             </Row>
           </Grid>
         </LearnLayout>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #47375 

<!-- Feel free to add any additional description of changes below this line -->

Thought I'd have a play with this. This adds a link to the search page of the forum with a pre-filled query based on the current challenge. The idea was to encourage searching for a solution to their question without making the experience of asking for help frustrating.