### PR TITLE
add visual separation in Change language menu UI

### DIFF
--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -157,6 +157,10 @@
   cursor: pointer;
 }
 
+#nav-lang-menu li:first-child {
+  border-bottom: 0.1rem solid var(--gray-45) !important;
+}
+
 button.nav-link:focus {
   color: var(--tertiary-color);
   background-color: var(--tertiary-background);
@@ -208,7 +212,6 @@ button.nav-link[aria-disabled='true'] {
   overflow-y: auto;
   scrollbar-width: auto;
   /* lang menu should always be full height */
-  height: 19.9rem;
 }
 
 /* main menu must be at least as tall as lang menu (when displayed) 
@@ -239,6 +242,10 @@ button.nav-link[aria-disabled='true'] {
 
 .nav-lang-menu .nav-link:hover {
   background-color: var(--gray-10) !important;
+}
+
+.nav-lang-menu li:first-child .nav-link:hover {
+  color: var(--love-dark) !important;
 }
 
 .nav-lang-button {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #47360

<!-- Feel free to add any additional description of changes below this line -->

Updated CSS in the header component for adding visual separation between `Cancel Changes` and `Languages` in the Languages menu on the landing page for better UX. 
Removed the `height` property from class `.nav-lang-menu`  inside the header component to make sure all the languages appear in the menu.