### PR TITLE
fix(UI): restore keyboard accessibility

### DIFF
--- a/client/src/components/Header/components/nav-links.tsx
+++ b/client/src/components/Header/components/nav-links.tsx
@@ -35,7 +35,9 @@ import LanguageGlobe from '../../../assets/icons/language-globe';
 
 const { clientLocale, radioLocation, apiLocation } = envData;
 
-const locales = availableLangs.client;
+const locales = availableLangs.client.filter(
+  lang => !hiddenLangs.includes(lang)
+);
 
 export interface NavLinksProps {
   displayMenu?: boolean;
@@ -428,29 +430,27 @@ export class NavLinks extends Component<NavLinksProps, {}> {
                   {t('buttons.cancel-change')}
                 </button>
               </li>
-              {locales
-                .filter(lang => !hiddenLangs.includes(lang))
-                .map((lang, index) => (
-                  <li key={'lang-' + lang} role='none'>
-                    <button
-                      {...(clientLocale === lang && { 'aria-current': true })}
-                      className='nav-link nav-lang-menu-option'
-                      data-value={lang}
-                      {...(LangCodes[lang] && {
-                        lang: LangCodes[lang] as string
-                      })}
-                      onClick={this.handleLanguageChange}
-                      onKeyDown={this.handleLanguageMenuKeyDown}
-                      {...(index === locales.length - 2 && {
-                        ref: this.lastLangOptionRef
-                      })}
-                      role='menuitem'
-                      tabIndex='-1'
-                    >
-                      {LangNames[lang]}
-                    </button>
-                  </li>
-                ))}
+              {locales.map((lang, index) => (
+                <li key={'lang-' + lang} role='none'>
+                  <button
+                    {...(clientLocale === lang && { 'aria-current': true })}
+                    className='nav-link nav-lang-menu-option'
+                    data-value={lang}
+                    {...(LangCodes[lang] && {
+                      lang: LangCodes[lang] as string
+                    })}
+                    onClick={this.handleLanguageChange}
+                    onKeyDown={this.handleLanguageMenuKeyDown}
+                    {...(index === locales.length - 1 && {
+                      ref: this.lastLangOptionRef
+                    })}
+                    role='menuitem'
+                    tabIndex='-1'
+                  >
+                    {LangNames[lang]}
+                  </button>
+                </li>
+              ))}
             </ul>
           </div>
         </li>

--- a/client/src/components/Header/components/nav-links.tsx
+++ b/client/src/components/Header/components/nav-links.tsx
@@ -441,7 +441,7 @@ export class NavLinks extends Component<NavLinksProps, {}> {
                       })}
                       onClick={this.handleLanguageChange}
                       onKeyDown={this.handleLanguageMenuKeyDown}
-                      {...(index === locales.length - 1 && {
+                      {...(index === locales.length - 2 && {
                         ref: this.lastLangOptionRef
                       })}
                       role='menuitem'


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Restore keyboard accessibility in language list of menu. 

Now fcc code base has `german` in `availableLangs` of `/config/i18n/all-lang` but it has been hided and there is no button element for the language therefore the one can not be referenced. This causes malfunction of keyboard accessibility feature.
So in `nav-links.tsx`, the index, which is referencing "日本語" button set in `lastLangOptionRef`, was fixed. 

Affected page:
https://www.freecodecamp.org/
https://www.freecodecamp.org/learn  etc...

I've test the fixed code locally based on the list of [this comment](https://github.com/freeCodeCamp/freeCodeCamp/pull/46644#issuecomment-1210022946).
