### PR TITLE
fix(curriculum): change descriptions of id from properties to attributes

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/62ff8b9dab5ac88e4d3d43a3.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/62ff8b9dab5ac88e4d3d43a3.md
@@ -9,7 +9,7 @@ dashedName: step-17
 
 Following accessibility best practices, link the `input` elements and the `label` elements together using the `for` attribute.
 
-Use these values for the respective `id` attributes: `first-name`, `last-name`, `email`, `new-password`
+Use `first-name`, `last-name`, `email`,  and `new-password` as values for the respective `id` attributes.
 
 # --hints--
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/62ff8b9dab5ac88e4d3d43a3.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/62ff8b9dab5ac88e4d3d43a3.md
@@ -9,7 +9,7 @@ dashedName: step-17
 
 Following accessibility best practices, link the `input` elements and the `label` elements together using the `for` attribute.
 
-Use these values for the respective `id` properties: `first-name`, `last-name`, `email`, `new-password`
+Use these values for the respective `id` attributes: `first-name`, `last-name`, `email`, `new-password`
 
 # --hints--
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/62ff8e998d3e7eae14d6ae3b.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/62ff8e998d3e7eae14d6ae3b.md
@@ -9,7 +9,7 @@ dashedName: step-28
 
 Follow accessibility best practices by linking the `input` elements and the `label` elements in the second `fieldset`.
 
-Use these values for the respective `id` properties: `personal-account`, `business-account`, `terms-and-conditions`
+Use these values for the respective `id` attributes: `personal-account`, `business-account`, `terms-and-conditions`
 
 # --hints--
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/62ff8e998d3e7eae14d6ae3b.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/62ff8e998d3e7eae14d6ae3b.md
@@ -9,7 +9,7 @@ dashedName: step-28
 
 Follow accessibility best practices by linking the `input` elements and the `label` elements in the second `fieldset`.
 
-Use these values for the respective `id` attributes: `personal-account`, `business-account`, `terms-and-conditions`
+Use `personal-account`, `business-account`, and `terms-and-conditions` as values for the respective `id` attributes.
 
 # --hints--
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/62ff919a7b5612c0670923a5.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/62ff919a7b5612c0670923a5.md
@@ -9,7 +9,7 @@ dashedName: step-37
 
 Link the applicable form elements and their `label` elements together.
 
-Use these values for the respective `id` attributes: `profile-picture`, `age`, `referrer`, `bio`
+Use `profile-picture`, `age`, `referrer`, and `bio` as values for the respective `id` attributes.
 
 # --hints--
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/62ff919a7b5612c0670923a5.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/62ff919a7b5612c0670923a5.md
@@ -9,7 +9,7 @@ dashedName: step-37
 
 Link the applicable form elements and their `label` elements together.
 
-Use these values for the respective `id` properties: `profile-picture`, `age`, `referrer`, `bio`
+Use these values for the respective `id` attributes: `profile-picture`, `age`, `referrer`, `bio`
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #47423

The text in 3 challenges in the Responsive Web Design curriculum incorrectly referred to `ids` as "properties" rather than "attributes". This PR fixes this error :)
