### PR TITLE
fix(curriculum): change the instruction text

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60f8604682407e0d017bbf7f.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60f8604682407e0d017bbf7f.md
@@ -7,7 +7,7 @@ dashedName: step-25
 
 # --description--
 
-For the terms and conditions, add an `input` with a `type` of `checkbox` to the third `label` element. Also, as we do not want users to sign up, without having read the terms and conditions, make it `required`.
+For the terms and conditions, add an `input` with a `type` of `checkbox` to the third `label` element. Also, as users should not sign up, without having read the terms and conditions, make it `required`.
 
 # --hints--
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60f8604682407e0d017bbf7f.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60f8604682407e0d017bbf7f.md
@@ -7,7 +7,7 @@ dashedName: step-25
 
 # --description--
 
-For the terms and conditions, add an `input` with a `type` of `checkbox` to the third `label` element. Also, as users should not sign up, without having read the terms and conditions, make it `required`.
+For the terms and conditions, add an `input` with a `type` of `checkbox` to the third `label` element. Make this `input` element `required` because users should not sign up without reading the terms and conditions.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Avoid using word `we` in the instruction text owing to make it conform to [how-to-work-on-coding-challenges document](https://contribute.freecodecamp.org/#/how-to-work-on-coding-challenges?id=challenge-descriptionsinstructions).

Affected page:
New Responsive Web Design > Learn HTML Forms by Building a Registration Form > Step 25
https://www.freecodecamp.org/learn/2022/responsive-web-design/learn-html-forms-by-building-a-registration-form/step-25
