### PR TITLE
fix: update lower jaw on ctrl enter

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -617,7 +617,7 @@ const Editor = (props: EditorProps): JSX.Element => {
         tryToExecuteChallenge={tryToExecuteChallenge}
         hint={output[1]}
         testsLength={props.tests.length}
-        attemptsNumber={attemptsRef.current}
+        attempts={attemptsRef.current}
         challengeIsCompleted={isChallengeComplete}
         challengeHasErrors={challengeHasErrors()}
         tryToSubmitChallenge={tryToSubmitChallenge}

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -619,7 +619,6 @@ const Editor = (props: EditorProps): JSX.Element => {
         testsLength={props.tests.length}
         attempts={attemptsRef.current}
         challengeIsCompleted={isChallengeComplete}
-        challengeHasErrors={challengeHasErrors()}
         tryToSubmitChallenge={tryToSubmitChallenge}
         isEditorInFocus={isEditorInFocus}
         isSignedIn={props.isSignedIn}
@@ -1073,10 +1072,11 @@ const Editor = (props: EditorProps): JSX.Element => {
     return tests.every(test => test.pass && !test.err);
   }
 
-  function challengeHasErrors() {
-    const tests = testRef.current;
-    return tests.some(test => test.err);
-  }
+  // We need to set initialize the tests, but only once
+  useEffect(() => {
+    initTests(props.initialTests);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // runs every update to the editor and when the challenge is reset
   useEffect(() => {
@@ -1094,11 +1094,6 @@ const Editor = (props: EditorProps): JSX.Element => {
       resetEditorValues();
       focusIfTargetEditor();
     }
-
-    // Once a challenge has been completed, we don't want changes to the content
-    // to reset the tests since the user is already done with the challenge.
-    if (props.initialTests && !challengeIsComplete())
-      initTests(props.initialTests);
 
     if (hasEditableRegion() && editor) {
       if (props.isResetting) {

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -272,11 +272,8 @@ const Editor = (props: EditorProps): JSX.Element => {
   // use a ref, since it will be updated on every render.
   const testRef = useRef<Test[]>([]);
   testRef.current = props.tests;
-
-  // TENATIVE PLAN: create a typical order [html/jsx, css, js], put the
-  // available files into that order.  i.e. if it's just one file it will
-  // automatically be first, but  if there's jsx and js (for some reason) it
-  //  will be [jsx, js].
+  const attemptsRef = useRef<number>(0);
+  attemptsRef.current = props.attempts;
 
   const options: editor.IStandaloneEditorConstructionOptions = {
     fontSize: 18,
@@ -606,7 +603,7 @@ const Editor = (props: EditorProps): JSX.Element => {
   const tryToSubmitChallenge = submitChallengeDebounceRef.current;
 
   function createLowerJaw(outputNode: HTMLElement, callback?: () => void) {
-    const { output, attempts } = props;
+    const { output } = props;
     const isChallengeComplete = challengeIsComplete();
     const isEditorInFocus = document.activeElement?.tagName === 'TEXTAREA';
     ReactDOM.render(
@@ -616,7 +613,7 @@ const Editor = (props: EditorProps): JSX.Element => {
         tryToExecuteChallenge={tryToExecuteChallenge}
         hint={output[1]}
         testsLength={props.tests.length}
-        attemptsNumber={attempts}
+        attemptsNumber={attemptsRef.current}
         challengeIsCompleted={isChallengeComplete}
         challengeHasErrors={challengeHasErrors()}
         tryToSubmitChallenge={tryToSubmitChallenge}

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -629,7 +629,6 @@ const Editor = (props: EditorProps): JSX.Element => {
   }
 
   const updateOutputZone = () => {
-    console.log('updateOutputZone');
     const editor = dataRef.current.editor;
     if (!editor || !dataRef.current.outputNode) return;
 

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -602,10 +602,14 @@ const Editor = (props: EditorProps): JSX.Element => {
 
   const tryToSubmitChallenge = submitChallengeDebounceRef.current;
 
-  function createLowerJaw(outputNode: HTMLElement, callback?: () => void) {
+  function createLowerJaw(
+    outputNode: HTMLDivElement,
+    editor: editor.IStandaloneCodeEditor
+  ) {
     const { output } = props;
     const isChallengeComplete = challengeIsComplete();
     const isEditorInFocus = document.activeElement?.tagName === 'TEXTAREA';
+
     ReactDOM.render(
       <LowerJaw
         openHelpModal={props.openHelpModal}
@@ -619,9 +623,9 @@ const Editor = (props: EditorProps): JSX.Element => {
         tryToSubmitChallenge={tryToSubmitChallenge}
         isEditorInFocus={isEditorInFocus}
         isSignedIn={props.isSignedIn}
+        updateContainer={() => updateOutputViewZone(outputNode, editor)}
       />,
-      outputNode,
-      callback
+      outputNode
     );
   }
 
@@ -630,13 +634,11 @@ const Editor = (props: EditorProps): JSX.Element => {
     if (!editor || !dataRef.current.outputNode) return;
 
     const outputNode = dataRef.current.outputNode;
-    createLowerJaw(outputNode, () => {
-      if (dataRef.current.outputNode) {
-        updateOutputViewZone(outputNode, editor);
-      }
-    });
+    createLowerJaw(outputNode, editor);
   };
 
+  // TODO: there's a potential performance gain to be had by only updating when
+  // the outputViewZone has actually changed.
   const updateOutputViewZone = (
     outputNode: HTMLDivElement,
     editor: editor.IStandaloneCodeEditor

--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -39,10 +39,10 @@ const LowerJaw = ({
 }: LowerJawProps): JSX.Element => {
   const previousHintRef = React.useRef('');
   const [runningTests, setRunningTests] = useState(false);
-  const [testFeedbackheight, setTestFeedbackHeight] = useState(0);
+  const [testFeedbackHeight, setTestFeedbackHeight] = useState(0);
   const [currentAttempts, setCurrentAttempts] = useState(attempts);
   const [isFeedbackHidden, setIsFeedbackHidden] = useState(false);
-  const [testBtnariaHidden, setTestBtnAriaHidden] = useState(false);
+  const [testBtnAriaHidden, setTestBtnAriaHidden] = useState(false);
   const { t } = useTranslation();
   const submitButtonRef = React.createRef<HTMLButtonElement>();
   const testFeedbackRef = React.createRef<HTMLDivElement>();
@@ -223,7 +223,7 @@ const LowerJaw = ({
           <button
             id='test-button'
             className={`btn-block btn ${challengeIsCompleted ? 'sr-only' : ''}`}
-            aria-hidden={testBtnariaHidden}
+            aria-hidden={testBtnAriaHidden}
             onClick={tryToExecuteChallenge}
           >
             {showDesktopButton
@@ -248,7 +248,7 @@ const LowerJaw = ({
     <div className='action-row-container'>
       {renderButtons()}
       <div
-        style={runningTests ? { height: `${testFeedbackheight}px` } : {}}
+        style={runningTests ? { height: `${testFeedbackHeight}px` } : {}}
         className={`test-feedback`}
         id='test-feedback'
         aria-live='assertive'

--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -36,11 +36,11 @@ const LowerJaw = ({
   openResetModal,
   isSignedIn
 }: LowerJawProps): JSX.Element => {
-  const [previousHint, setpreviousHint] = useState('');
+  const [previousHint, setPreviousHint] = useState('');
   const [runningTests, setRunningTests] = useState(false);
-  const [testFeedbackheight, setTestFeedbackheight] = useState(0);
+  const [testFeedbackheight, setTestFeedbackHeight] = useState(0);
   const [isFeedbackHidden, setIsFeedbackHidden] = useState(false);
-  const [testBtnariaHidden, setTestBtnariaHidden] = useState(false);
+  const [testBtnariaHidden, setTestBtnAriaHidden] = useState(false);
   const { t } = useTranslation();
   const submitButtonRef = React.createRef<HTMLButtonElement>();
   const testFeedbackRef = React.createRef<HTMLDivElement>();
@@ -65,7 +65,7 @@ const LowerJaw = ({
   useEffect(() => {
     // only save error hints
     if (challengeHasErrors && hint && previousHint !== hint) {
-      setpreviousHint(hint);
+      setPreviousHint(hint);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [challengeHasErrors, hint]);
@@ -74,11 +74,11 @@ const LowerJaw = ({
     if (challengeIsCompleted && submitButtonRef?.current) {
       submitButtonRef.current.focus();
       setTimeout(() => {
-        setTestBtnariaHidden(true);
+        setTestBtnAriaHidden(true);
       }, 500);
     }
 
-    setTestBtnariaHidden(challengeIsCompleted);
+    setTestBtnAriaHidden(challengeIsCompleted);
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [challengeIsCompleted]);
@@ -86,7 +86,7 @@ const LowerJaw = ({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     if (testFeedbackRef.current) {
-      setTestFeedbackheight(testFeedbackRef.current.clientHeight);
+      setTestFeedbackHeight(testFeedbackRef.current.clientHeight);
     }
   });
 

--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -14,11 +14,10 @@ interface LowerJawProps {
   openHelpModal: () => void;
   tryToExecuteChallenge: () => void;
   tryToSubmitChallenge: () => void;
-  showFeedback?: boolean;
   isEditorInFocus?: boolean;
   challengeHasErrors?: boolean;
   testsLength?: number;
-  attemptsNumber?: number;
+  attemptsNumber: number;
   openResetModal: () => void;
   isSignedIn: boolean;
 }
@@ -36,7 +35,7 @@ const LowerJaw = ({
   openResetModal,
   isSignedIn
 }: LowerJawProps): JSX.Element => {
-  const [previousHint, setPreviousHint] = useState('');
+  const previousHintRef = React.useRef('');
   const [runningTests, setRunningTests] = useState(false);
   const [testFeedbackheight, setTestFeedbackHeight] = useState(0);
   const [isFeedbackHidden, setIsFeedbackHidden] = useState(false);
@@ -61,14 +60,6 @@ const LowerJaw = ({
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [attemptsNumber]);
-
-  useEffect(() => {
-    // only save error hints
-    if (challengeHasErrors && hint && previousHint !== hint) {
-      setPreviousHint(hint);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [challengeHasErrors, hint]);
 
   useEffect(() => {
     if (challengeIsCompleted && submitButtonRef?.current) {
@@ -96,7 +87,12 @@ const LowerJaw = ({
 
     For consistency, use the persisted version if the conditions has been met before.
   */
-  const earliestAvailableHint = hint || previousHint;
+  const earliestAvailableHint = hint || previousHintRef.current;
+
+  // only save error hints
+  if (challengeHasErrors) {
+    previousHintRef.current = earliestAvailableHint;
+  }
 
   const renderTestFeedbackContainer = () => {
     if (attemptsNumber === 0) {
@@ -166,9 +162,7 @@ const LowerJaw = ({
       'learn.sorry-hang-in-there',
       'learn.sorry-dont-giveup'
     ];
-    return attemptsNumber
-      ? sentenceArray[attemptsNumber % sentenceArray.length]
-      : sentenceArray[0];
+    return sentenceArray[attemptsNumber % sentenceArray.length];
   };
 
   const renderContextualActionRow = () => {

--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -20,6 +20,7 @@ interface LowerJawProps {
   attemptsNumber: number;
   openResetModal: () => void;
   isSignedIn: boolean;
+  updateContainer: () => void;
 }
 
 const LowerJaw = ({
@@ -33,7 +34,8 @@ const LowerJaw = ({
   testsLength,
   isEditorInFocus,
   openResetModal,
-  isSignedIn
+  isSignedIn,
+  updateContainer
 }: LowerJawProps): JSX.Element => {
   const previousHintRef = React.useRef('');
   const [runningTests, setRunningTests] = useState(false);
@@ -45,10 +47,9 @@ const LowerJaw = ({
   const testFeedbackRef = React.createRef<HTMLDivElement>();
 
   useEffect(() => {
-    if (attemptsNumber && attemptsNumber > 0) {
+    if (attemptsNumber > 0) {
       //hide the feedback from SR until the "Running tests" are displayed and removed.
       setIsFeedbackHidden(true);
-      //allow the lower jaw height to be picked up by the editor.
       setRunningTests(true);
 
       //display the test feedback contents.
@@ -57,8 +58,6 @@ const LowerJaw = ({
         setIsFeedbackHidden(false);
       }, 300);
     }
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [attemptsNumber]);
 
   useEffect(() => {
@@ -70,15 +69,16 @@ const LowerJaw = ({
     }
 
     setTestBtnAriaHidden(challengeIsCompleted);
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [challengeIsCompleted]);
+  }, [challengeIsCompleted, submitButtonRef]);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     if (testFeedbackRef.current) {
       setTestFeedbackHeight(testFeedbackRef.current.clientHeight);
     }
+    // Every render could change the shape of the jaw, so this effect will let
+    // monaco know it might need to resize
+    updateContainer();
   });
 
   /*

--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -225,6 +225,7 @@ const LowerJaw = ({
           ) : null}
           <button
             id='test-button'
+            data-cy='run-tests-button'
             className={`btn-block btn ${challengeIsCompleted ? 'sr-only' : ''}`}
             aria-hidden={testBtnAriaHidden}
             onClick={tryToExecuteChallenge}
@@ -235,6 +236,7 @@ const LowerJaw = ({
           </button>
           <button
             id='submit-button'
+            data-cy='submit-button'
             aria-hidden={!challengeIsCompleted}
             className='btn-block btn'
             onClick={tryToSubmitChallenge}

--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -40,6 +40,7 @@ const LowerJaw = ({
   const previousHintRef = React.useRef('');
   const [runningTests, setRunningTests] = useState(false);
   const [testFeedbackheight, setTestFeedbackHeight] = useState(0);
+  const [currentAttempts, setCurrentAttempts] = useState(attempts);
   const [isFeedbackHidden, setIsFeedbackHidden] = useState(false);
   const [testBtnariaHidden, setTestBtnAriaHidden] = useState(false);
   const { t } = useTranslation();
@@ -51,6 +52,11 @@ const LowerJaw = ({
       //hide the feedback from SR until the "Running tests" are displayed and removed.
       setIsFeedbackHidden(true);
       setRunningTests(true);
+      //to prevent the changing attempts value from immediately triggering a new
+      //render, the rendered component only depends on currentAttempts. Since
+      //currentAttempts is updated with when the feedback is hidden, the screen
+      //reader should only read out the new message.
+      setCurrentAttempts(attempts);
 
       //display the test feedback contents.
       setTimeout(() => {
@@ -95,7 +101,7 @@ const LowerJaw = ({
   }
 
   const renderTestFeedbackContainer = () => {
-    if (attempts === 0) {
+    if (currentAttempts === 0) {
       return '';
     } else if (runningTests) {
       return <span className='sr-only'>{t('aria.running-tests')}</span>;
@@ -162,12 +168,14 @@ const LowerJaw = ({
       'learn.sorry-hang-in-there',
       'learn.sorry-dont-giveup'
     ];
-    return sentenceArray[attempts % sentenceArray.length];
+    return sentenceArray[currentAttempts % sentenceArray.length];
   };
 
   const renderContextualActionRow = () => {
     const isAttemptsLargerThanTest =
-      attempts && testsLength && (attempts >= testsLength || attempts >= 3);
+      currentAttempts &&
+      testsLength &&
+      (currentAttempts >= testsLength || currentAttempts >= 3);
 
     if (isAttemptsLargerThanTest && !challengeIsCompleted) {
       return (

--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -46,6 +46,8 @@ const LowerJaw = ({
   const testFeedbackRef = React.createRef<HTMLDivElement>();
 
   useEffect(() => {
+    // prevent unnecessary updates:
+    if (attempts === currentAttempts) return;
     // Attempts should only be zero when the step is reset, so we should reset
     // the state here.
     if (attempts === 0) {
@@ -53,8 +55,8 @@ const LowerJaw = ({
       setRunningTests(false);
       setTestBtnAriaHidden(false);
       setIsFeedbackHidden(false);
-    }
-    if (attempts > 0 && hint) {
+      hintRef.current = '';
+    } else if (attempts > 0 && hint) {
       //hide the feedback from SR until the "Running tests" are displayed and removed.
       setIsFeedbackHidden(true);
       setRunningTests(true);
@@ -71,7 +73,7 @@ const LowerJaw = ({
         setIsFeedbackHidden(false);
       }, 300);
     }
-  }, [attempts, hint]);
+  }, [attempts, hint, currentAttempts]);
 
   useEffect(() => {
     if (challengeIsCompleted && submitButtonRef?.current) {
@@ -82,7 +84,11 @@ const LowerJaw = ({
     }
 
     setTestBtnAriaHidden(challengeIsCompleted);
-  }, [challengeIsCompleted, submitButtonRef]);
+    // Since submitButtonRef changes every render, we have to ignore it here or,
+    // once the challenges is completed, every render (including ones triggered
+    // by typing in the editor) will focus the button.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [challengeIsCompleted]);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
@@ -95,9 +101,7 @@ const LowerJaw = ({
   });
 
   const renderTestFeedbackContainer = () => {
-    if (currentAttempts === 0) {
-      return '';
-    } else if (runningTests) {
+    if (runningTests) {
       return <span className='sr-only'>{t('aria.running-tests')}</span>;
     } else if (challengeIsCompleted) {
       const submitKeyboardInstructions = isEditorInFocus ? (
@@ -155,6 +159,8 @@ const LowerJaw = ({
           </div>
         </>
       );
+    } else {
+      return null;
     }
   };
 

--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -76,7 +76,8 @@ const LowerJaw = ({
   }, [attempts, hint, currentAttempts]);
 
   useEffect(() => {
-    if (challengeIsCompleted && submitButtonRef?.current) {
+    if (challengeIsCompleted) {
+      if (!isEditorInFocus) submitButtonRef?.current?.focus();
       setTimeout(() => {
         setTestBtnAriaHidden(true);
       }, 500);

--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -77,7 +77,6 @@ const LowerJaw = ({
 
   useEffect(() => {
     if (challengeIsCompleted && submitButtonRef?.current) {
-      submitButtonRef.current.focus();
       setTimeout(() => {
         setTestBtnAriaHidden(true);
       }, 500);

--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -49,11 +49,8 @@ const LowerJaw = ({
     if (attemptsNumber && attemptsNumber > 0) {
       //hide the feedback from SR until the "Running tests" are displayed and removed.
       setIsFeedbackHidden(true);
-
       //allow the lower jaw height to be picked up by the editor.
-      setTimeout(() => {
-        setRunningTests(true);
-      }, 200);
+      setRunningTests(true);
 
       //display the test feedback contents.
       setTimeout(() => {

--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -17,7 +17,7 @@ interface LowerJawProps {
   isEditorInFocus?: boolean;
   challengeHasErrors?: boolean;
   testsLength?: number;
-  attemptsNumber: number;
+  attempts: number;
   openResetModal: () => void;
   isSignedIn: boolean;
   updateContainer: () => void;
@@ -30,7 +30,7 @@ const LowerJaw = ({
   hint,
   tryToExecuteChallenge,
   tryToSubmitChallenge,
-  attemptsNumber,
+  attempts,
   testsLength,
   isEditorInFocus,
   openResetModal,
@@ -47,7 +47,7 @@ const LowerJaw = ({
   const testFeedbackRef = React.createRef<HTMLDivElement>();
 
   useEffect(() => {
-    if (attemptsNumber > 0) {
+    if (attempts > 0) {
       //hide the feedback from SR until the "Running tests" are displayed and removed.
       setIsFeedbackHidden(true);
       setRunningTests(true);
@@ -58,7 +58,7 @@ const LowerJaw = ({
         setIsFeedbackHidden(false);
       }, 300);
     }
-  }, [attemptsNumber]);
+  }, [attempts]);
 
   useEffect(() => {
     if (challengeIsCompleted && submitButtonRef?.current) {
@@ -95,7 +95,7 @@ const LowerJaw = ({
   }
 
   const renderTestFeedbackContainer = () => {
-    if (attemptsNumber === 0) {
+    if (attempts === 0) {
       return '';
     } else if (runningTests) {
       return <span className='sr-only'>{t('aria.running-tests')}</span>;
@@ -162,14 +162,12 @@ const LowerJaw = ({
       'learn.sorry-hang-in-there',
       'learn.sorry-dont-giveup'
     ];
-    return sentenceArray[attemptsNumber % sentenceArray.length];
+    return sentenceArray[attempts % sentenceArray.length];
   };
 
   const renderContextualActionRow = () => {
     const isAttemptsLargerThanTest =
-      attemptsNumber &&
-      testsLength &&
-      (attemptsNumber >= testsLength || attemptsNumber >= 3);
+      attempts && testsLength && (attempts >= testsLength || attempts >= 3);
 
     if (isAttemptsLargerThanTest && !challengeIsCompleted) {
       return (

--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -46,6 +46,14 @@ const LowerJaw = ({
   const testFeedbackRef = React.createRef<HTMLDivElement>();
 
   useEffect(() => {
+    // Attempts should only be zero when the step is reset, so we should reset
+    // the state here.
+    if (attempts === 0) {
+      setCurrentAttempts(0);
+      setRunningTests(false);
+      setTestBtnAriaHidden(false);
+      setIsFeedbackHidden(false);
+    }
     if (attempts > 0 && hint) {
       //hide the feedback from SR until the "Running tests" are displayed and removed.
       setIsFeedbackHidden(true);

--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -119,7 +119,11 @@ const LowerJaw = ({
       }`;
       return (
         <>
-          <div className='test-status fade-in' aria-hidden={isFeedbackHidden}>
+          <div
+            data-cy='failing-test-feedback'
+            className='test-status fade-in'
+            aria-hidden={isFeedbackHidden}
+          >
             <div className='status-icon' aria-hidden='true'>
               <span>
                 <Fail />

--- a/client/src/templates/Challenges/components/ResetModal.tsx
+++ b/client/src/templates/Challenges/components/ResetModal.tsx
@@ -70,6 +70,7 @@ function ResetModal({ reset, close, isOpen }: ResetModalProps): JSX.Element {
       </Modal.Body>
       <Modal.Footer className='reset-modal-footer'>
         <Button
+          data-cy='reset-modal-confirm'
           block={true}
           bsSize='large'
           bsStyle='danger'

--- a/client/src/templates/Challenges/redux/action-types.js
+++ b/client/src/templates/Challenges/redux/action-types.js
@@ -41,6 +41,7 @@ export const actionTypes = createTypes(
     'resetChallenge',
     'stopResetting',
     'submitChallenge',
+    'resetAttempts',
 
     'setEditorFocusability',
     'toggleVisibleEditor'

--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -17,6 +17,7 @@ export { ns };
 
 const initialState = {
   canFocusEditor: true,
+  attempts: 0,
   visibleEditors: {},
   challengeFiles: [],
   challengeMeta: {
@@ -127,6 +128,7 @@ export const executeChallenge = createAction(actionTypes.executeChallenge);
 export const resetChallenge = createAction(actionTypes.resetChallenge);
 export const stopResetting = createAction(actionTypes.stopResetting);
 export const submitChallenge = createAction(actionTypes.submitChallenge);
+export const resetAttempts = createAction(actionTypes.resetAttempts);
 
 export const setEditorFocusability = createAction(
   actionTypes.setEditorFocusability
@@ -215,6 +217,7 @@ export const challengeDataSelector = state => {
   return challengeData;
 };
 
+export const attemptsSelector = state => state[ns].attempts;
 export const canFocusEditorSelector = state => state[ns].canFocusEditor;
 export const visibleEditorsSelector = state => state[ns].visibleEditors;
 
@@ -308,9 +311,14 @@ export const reducer = handleActions(
           testString
         })),
         consoleOut: [],
-        isResetting: true
+        isResetting: true,
+        attempts: 0
       };
     },
+    [actionTypes.resetAttempts]: state => ({
+      ...state,
+      attempts: 0
+    }),
     [actionTypes.stopResetting]: state => ({
       ...state,
       isResetting: false
@@ -361,7 +369,8 @@ export const reducer = handleActions(
     }),
     [actionTypes.executeChallenge]: state => ({
       ...state,
-      currentTab: 3
+      currentTab: 3,
+      attempts: state.attempts + 1
     }),
     [actionTypes.setEditorFocusability]: (state, { payload }) => ({
       ...state,

--- a/cypress/integration/default/learn/challenges/multifile.js
+++ b/cypress/integration/default/learn/challenges/multifile.js
@@ -2,9 +2,10 @@ import translations from '../../../../../client/i18n/locales/english/translation
 const location =
   '/learn/2022/responsive-web-design/learn-accessibility-by-building-a-quiz/step-2';
 const selectors = {
-  testButton: '#test-button',
+  testButton: '[data-cy=run-tests-button]',
   monacoTabs: '.monaco-editor-tabs',
-  signInButton: '#action-buttons-container a[href$="/signin"]'
+  signInButton: '#action-buttons-container a[href$="/signin"]',
+  submitButton: '[data-cy=submit-button]'
 };
 
 describe('Challenge with multifile editor', () => {
@@ -48,5 +49,13 @@ describe('Challenge with multifile editor', () => {
     cy.get(selectors.signInButton).click();
     cy.go('back');
     cy.get(selectors.signInButton).should('not.exist');
+  });
+
+  it('focuses the submit button after testing a valid solution', () => {
+    cy.visit(location);
+    cy.focused().type('{end}{enter}<meta charset="UTF-8" />');
+    cy.get(selectors.submitButton).should('not.be.focused');
+    cy.get(selectors.testButton).click();
+    cy.get(selectors.submitButton).should('be.focused');
   });
 });

--- a/cypress/integration/default/learn/challenges/multifile.js
+++ b/cypress/integration/default/learn/challenges/multifile.js
@@ -27,6 +27,17 @@ describe('Challenge with multifile editor', () => {
       .contains('Check Your Code');
   });
 
+  it('resets the lower jaw when prompted', () => {
+    cy.get('[data-cy=failing-test-feedback]').should('not.exist');
+
+    cy.contains('Check Your Code').click();
+    cy.get('[data-cy=failing-test-feedback]').should('be.visible');
+    cy.contains('Restart Step').click();
+    cy.get('[data-cy=reset-modal-confirm').click();
+
+    cy.get('[data-cy=failing-test-feedback]').should('not.exist');
+  });
+
   // Page will change after this test. If your test requires page used in previous
   // tests make sure it is above this one
   it('prompts unauthenticated user to sign in to save progress', () => {

--- a/cypress/integration/default/learn/challenges/multifile.js
+++ b/cypress/integration/default/learn/challenges/multifile.js
@@ -41,8 +41,10 @@ describe('Challenge with multifile editor', () => {
   // Page will change after this test. If your test requires page used in previous
   // tests make sure it is above this one
   it('prompts unauthenticated user to sign in to save progress', () => {
+    cy.visit(location);
     cy.focused().type('{end}{enter}<meta charset="UTF-8" />{ctrl+enter}');
     cy.get(selectors.signInButton).contains(translations.learn['sign-in-save']);
+    cy.contains(translations.learn['congratulations']);
     cy.get(selectors.signInButton).click();
     cy.go('back');
     cy.get(selectors.signInButton).should('not.exist');


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Ref: https://github.com/freeCodeCamp/freeCodeCamp/issues/47457

Still in draft because I uncovered a weird (probably) closure-related bug in which `createLowerJaw` gets different props depending on whether it's called from `onDidChangeContent` or `useEffect`.  Long story short, this means the hints + feedback occasionally vanish as you type.  Probably something trivial, but I'm not seeing it right now!

Anyways @bbsmooth could you take a look/listen?  I _think_ I preserved the a11y behaviour we want, but it would be awesome if you could confirm!

Aside from that, I tidied a few things up.  The individual commits should make sense, though.