### PR TITLE
fix(curriculum): change the instruction text in step 31

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fabf0dd4959805dbae09e6.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fabf0dd4959805dbae09e6.md
@@ -9,7 +9,7 @@ dashedName: step-31
 
 Add another `label` after the first, with the text `Input your age (years): `. Then, nest an `input` with the `type` of `number`.
 
-As we do not want users under the age of 13 to register, add a `min` attribute to the `input` with a value of `13`. Also, we can probably assume users over the age of 120 will not register; add a `max` attribute with a value of `120`.
+Next, Add a `min` attribute to the `input` with a value of `13` because users under the age of 13 should not register. Also, It can be probably assumed that users over the age of 120 will not register; add a `max` attribute with a value of `120`.
 
 Now, if someone tries to submit the form with values outside of the range, a warning will appear, and the form will not submit. Give it a try.
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fabf0dd4959805dbae09e6.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fabf0dd4959805dbae09e6.md
@@ -9,7 +9,7 @@ dashedName: step-31
 
 Add another `label` after the first, with the text `Input your age (years): `. Then, nest an `input` with the `type` of `number`.
 
-Next, Add a `min` attribute to the `input` with a value of `13` because users under the age of 13 should not register. Also, it can be probably assumed that users over the age of 120 will not register; add a `max` attribute with a value of `120`.
+Next, add a `min` attribute to the `input` with a value of `13` because users under the age of 13 should not register. Also, it can be probably assumed that users over the age of 120 will not register; add a `max` attribute with a value of `120`.
 
 Now, if someone tries to submit the form with values outside of the range, a warning will appear, and the form will not submit. Give it a try.
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fabf0dd4959805dbae09e6.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fabf0dd4959805dbae09e6.md
@@ -9,7 +9,7 @@ dashedName: step-31
 
 Add another `label` after the first, with the text `Input your age (years): `. Then, nest an `input` with the `type` of `number`.
 
-Next, add a `min` attribute to the `input` with a value of `13` because users under the age of 13 should not register. Also, it can be probably assumed that users over the age of 120 will not register; add a `max` attribute with a value of `120`.
+Next, add a `min` attribute to the `input` with a value of `13` because users under the age of 13 should not register. Also, users probably will not be over the age of 120; add a `max` attribute with a value of `120`.
 
 Now, if someone tries to submit the form with values outside of the range, a warning will appear, and the form will not submit. Give it a try.
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fabf0dd4959805dbae09e6.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fabf0dd4959805dbae09e6.md
@@ -9,7 +9,7 @@ dashedName: step-31
 
 Add another `label` after the first, with the text `Input your age (years): `. Then, nest an `input` with the `type` of `number`.
 
-Next, Add a `min` attribute to the `input` with a value of `13` because users under the age of 13 should not register. Also, It can be probably assumed that users over the age of 120 will not register; add a `max` attribute with a value of `120`.
+Next, Add a `min` attribute to the `input` with a value of `13` because users under the age of 13 should not register. Also, it can be probably assumed that users over the age of 120 will not register; add a `max` attribute with a value of `120`.
 
 Now, if someone tries to submit the form with values outside of the range, a warning will appear, and the form will not submit. Give it a try.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Avoid using word we in the instruction text owing to make it conform to [how-to-work-on-coding-challenges document](https://contribute.freecodecamp.org/#/how-to-work-on-coding-challenges?id=challenge-descriptionsinstructions).

Since I'm not native English speaker, If any one could check and provide some advice if this is natural for instruction text, that would be a great help.

Affected page:
New Responsive Web Design > Learn HTML Forms by Building a Registration Form > Step 31
https://www.freecodecamp.org/learn/2022/responsive-web-design/learn-html-forms-by-building-a-registration-form/step-31
