### PR TITLE
fix(curriculum): pass tests with x and y overflows

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/61968e9243a4090cc805531c.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/61968e9243a4090cc805531c.md
@@ -14,7 +14,10 @@ Remove both the horizontal and vertical scrollbars, and prevent programmatic scr
 You should give `body` an `overflow` of `clip`.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('body')?.overflow, 'clip');
+const bodyStyle = new __helpers.CSSHelp(document).getStyle('body')
+const overflow = bodyStyle?.overflow || (bodyStyle?.overflowX && bodyStyle?.overflowY)
+
+assert.equal(overflow, 'clip');
 ```
 
 # --seed--


### PR DESCRIPTION
It's not necessary, but may help the test pass on iPads

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This is a bit of a wild hunch but it may close

Close https://github.com/freeCodeCamp/freeCodeCamp/issues/47513

<!-- Feel free to add any additional description of changes below this line -->
