### PR TITLE
fix: download ram differently

### DIFF
--- a/.github/workflows/node.js-tests-upcoming.yml
+++ b/.github/workflows/node.js-tests-upcoming.yml
@@ -83,5 +83,5 @@ jobs:
 
       - name: Run Tests
         env:
-          NODE_OPTIONS: '--max_old_space_size=6144'
+          NODE_OPTIONS: '--max-old-space-size=6144'
         run: npm test

--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -162,5 +162,5 @@ jobs:
         env:
           CURRICULUM_LOCALE: ${{ matrix.locale }}
           CLIENT_LOCALE: ${{ matrix.locale }}
-          NODE_OPTIONS: '--max_old_space_size=6144'
+          NODE_OPTIONS: '--max-old-space-size=6144'
         run: npm test


### PR DESCRIPTION
Dashes shouldn't be necessary, but you never know.

If https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/3054476975/jobs/4926493493 fails, we can try this.  If not, this can be closed.
