### PR TITLE
chore: add lint for json files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -41,6 +41,10 @@
   },
   "overrides": [
     {
+      "files": ["**/*.json"],
+      "extends": ["plugin:json/recommended"]
+    },
+    {
       "files": ["**/*.ts?(x)"],
       "parser": "@typescript-eslint/parser",
       "parserOptions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,6 +78,7 @@
         "eslint-config-prettier": "8.5.0",
         "eslint-plugin-import": "2.26.0",
         "eslint-plugin-jest-dom": "3.9.4",
+        "eslint-plugin-json": "3.1.0",
         "eslint-plugin-jsx-a11y": "6.6.1",
         "eslint-plugin-no-only-tests": "2.6.0",
         "eslint-plugin-prefer-object-spread": "1.2.1",
@@ -23891,6 +23892,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/eslint-plugin-json": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-json/-/eslint-plugin-json-3.1.0.tgz",
+      "integrity": "sha512-MrlG2ynFEHe7wDGwbUuFPsaT2b1uhuEFhJ+W1f1u+1C2EkXmTYJp4B1aAdQQ8M+CC3t//N/oRKiIVw14L2HR1g==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "vscode-json-languageservice": "^4.1.6"
+      },
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
     "node_modules/eslint-plugin-jsx-a11y": {
       "version": "6.6.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.6.1.tgz",
@@ -33582,6 +33596,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
     },
     "node_modules/jsonfile": {
       "version": "6.1.0",
@@ -51748,6 +51768,43 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/vscode-json-languageservice": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.2.1.tgz",
+      "integrity": "sha512-xGmv9QIWs2H8obGbWg+sIPI/3/pFgj/5OWBhNzs00BkYQ9UaB2F6JJaGB/2/YOZJ3BvLXQTC4Q7muqU25QgAhA==",
+      "dev": true,
+      "dependencies": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-languageserver-textdocument": "^1.0.3",
+        "vscode-languageserver-types": "^3.16.0",
+        "vscode-nls": "^5.0.0",
+        "vscode-uri": "^3.0.3"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.7.tgz",
+      "integrity": "sha512-bFJH7UQxlXT8kKeyiyu41r22jCZXG8kuuVVA33OEJn1diWOZK5n8zBSPZFHVBOu8kXZ6h0LIRhf5UnCo61J4Hg==",
+      "dev": true
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
+      "integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA==",
+      "dev": true
+    },
+    "node_modules/vscode-nls": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.2.0.tgz",
+      "integrity": "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng==",
+      "dev": true
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.6.tgz",
+      "integrity": "sha512-fmL7V1eiDBFRRnu+gfRWTzyPpNIHJTc4mWnFkwBUmO9U3KPgJAmTx7oxi2bl/Rh6HLdU7+4C9wlj0k2E4AdKFQ==",
+      "dev": true
     },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
@@ -71968,6 +72025,16 @@
         }
       }
     },
+    "eslint-plugin-json": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-json/-/eslint-plugin-json-3.1.0.tgz",
+      "integrity": "sha512-MrlG2ynFEHe7wDGwbUuFPsaT2b1uhuEFhJ+W1f1u+1C2EkXmTYJp4B1aAdQQ8M+CC3t//N/oRKiIVw14L2HR1g==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.21",
+        "vscode-json-languageservice": "^4.1.6"
+      }
+    },
     "eslint-plugin-jsx-a11y": {
       "version": "6.6.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.6.1.tgz",
@@ -78062,6 +78129,12 @@
     },
     "json5": {
       "version": "2.2.1"
+    },
+    "jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
     },
     "jsonfile": {
       "version": "6.1.0",
@@ -90003,6 +90076,43 @@
     },
     "void-elements": {
       "version": "3.1.0"
+    },
+    "vscode-json-languageservice": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.2.1.tgz",
+      "integrity": "sha512-xGmv9QIWs2H8obGbWg+sIPI/3/pFgj/5OWBhNzs00BkYQ9UaB2F6JJaGB/2/YOZJ3BvLXQTC4Q7muqU25QgAhA==",
+      "dev": true,
+      "requires": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-languageserver-textdocument": "^1.0.3",
+        "vscode-languageserver-types": "^3.16.0",
+        "vscode-nls": "^5.0.0",
+        "vscode-uri": "^3.0.3"
+      }
+    },
+    "vscode-languageserver-textdocument": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.7.tgz",
+      "integrity": "sha512-bFJH7UQxlXT8kKeyiyu41r22jCZXG8kuuVVA33OEJn1diWOZK5n8zBSPZFHVBOu8kXZ6h0LIRhf5UnCo61J4Hg==",
+      "dev": true
+    },
+    "vscode-languageserver-types": {
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
+      "integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA==",
+      "dev": true
+    },
+    "vscode-nls": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.2.0.tgz",
+      "integrity": "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng==",
+      "dev": true
+    },
+    "vscode-uri": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.6.tgz",
+      "integrity": "sha512-fmL7V1eiDBFRRnu+gfRWTzyPpNIHJTc4mWnFkwBUmO9U3KPgJAmTx7oxi2bl/Rh6HLdU7+4C9wlj0k2E4AdKFQ==",
+      "dev": true
     },
     "w3c-hr-time": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
     "eslint-config-prettier": "8.5.0",
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-jest-dom": "3.9.4",
+    "eslint-plugin-json": "3.1.0",
     "eslint-plugin-jsx-a11y": "6.6.1",
     "eslint-plugin-no-only-tests": "2.6.0",
     "eslint-plugin-prefer-object-spread": "1.2.1",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This fails locally because of:

```bash
/home/shauh/freeCodeCamp/client/i18n/locales/german/motivation.json
  42:27  error  Trailing comma  json/*

/home/shauh/freeCodeCamp/client/src/templates/Challenges/rechallenge/transformers.js
  14:22  error  Unable to resolve path to module '../../../../../config/client/sass-compile.json'  import/no-unresolved

/home/shauh/freeCodeCamp/client/src/templates/Challenges/utils/build.ts
   1:29  error  Unable to resolve path to module '../../../../../config/client/frame-runner.json'    import/no-unresolved
   2:31  error  Unable to resolve path to module '../../../../../config/client/test-evaluator.json'  import/no-unresolved
  56:7   error  Unsafe assignment of an `any` value                                                  @typescript-eslint/no-unsafe-assignment
  57:7   error  Unsafe assignment of an `any` value                                                  @typescript-eslint/no-unsafe-assignment
  61:17  error  Invalid type "any" of template literal expression                                    @typescript-eslint/restrict-template-expressions

/home/shauh/freeCodeCamp/curriculum-server/source-curriculum.ts
  3:24  error  Unable to resolve path to module '../config/curriculum.json'  import/no-unresolved

/home/shauh/freeCodeCamp/tsconfig-base.json
  19:4  error  Comment not allowed  json/*
  20:4  error  Comment not allowed  json/*

✖ 10 problems (10 errors, 0 warnings)
```
_ignore the german/motivations.json_ warning now