### PR TITLE
fix: allow user to add one unsaved item at a time

### DIFF
--- a/api-server/src/server/boot/settings.js
+++ b/api-server/src/server/boot/settings.js
@@ -125,7 +125,6 @@ function updateMyPortfolio(...args) {
   ];
   const buildUpdate = body => {
     const portfolio = body?.portfolio?.map(elem => _.pick(elem, portfolioKeys));
-    console.log(JSON.stringify(portfolio));
     return { portfolio };
   };
   const validate = ({ portfolio }) => portfolio?.every(isPortfolioElement);

--- a/api-server/src/server/boot/settings.js
+++ b/api-server/src/server/boot/settings.js
@@ -115,14 +115,24 @@ function updateMyEmail(req, res, next) {
 // }
 
 function updateMyPortfolio(...args) {
-  const portfolioKeys = ['id', 'title', 'description', 'url', 'image'];
+  const portfolioKeys = [
+    'id',
+    'title',
+    'description',
+    'url',
+    'image',
+    'isSaved'
+  ];
   const buildUpdate = body => {
     const portfolio = body?.portfolio?.map(elem => _.pick(elem, portfolioKeys));
+    console.log(JSON.stringify(portfolio));
     return { portfolio };
   };
   const validate = ({ portfolio }) => portfolio?.every(isPortfolioElement);
   const isPortfolioElement = elem =>
-    Object.values(elem).every(val => typeof val == 'string');
+    Object.values(elem).every(
+      val => typeof val == 'string' || typeof val === 'boolean'
+    );
   createUpdateUserProperties(buildUpdate, validate)(...args);
 }
 

--- a/client/src/components/settings/PreventableButton.jsx
+++ b/client/src/components/settings/PreventableButton.jsx
@@ -1,0 +1,25 @@
+import React, { useState, useEffect } from 'react';
+import { Button } from '@freecodecamp/react-bootstrap';
+
+const PreventableButton = ({ handleAdd, t, portfolio }) => {
+  const [isDisabled, setIsDisabled] = useState(false);
+  useEffect(() => {
+    const found = portfolio.find(item => !item.isSaved);
+    return found ? setIsDisabled(true) : setIsDisabled(false);
+  }, [portfolio.length, portfolio]);
+
+  return (
+    <Button
+      disabled={isDisabled}
+      block={true}
+      bsSize='lg'
+      bsStyle='primary'
+      onClick={handleAdd}
+      type='button'
+    >
+      {t('buttons.add-portfolio')}
+    </Button>
+  );
+};
+
+export default PreventableButton;

--- a/client/src/components/settings/portfolio.tsx
+++ b/client/src/components/settings/portfolio.tsx
@@ -5,7 +5,7 @@ import {
   FormControl,
   HelpBlock
 } from '@freecodecamp/react-bootstrap';
-import { findIndex, find, isEqual } from 'lodash-es';
+import { findIndex, find, isEqual, omit } from 'lodash-es';
 import { nanoid } from 'nanoid';
 import React, { Component, FormEvent } from 'react';
 import { TFunction, withTranslation } from 'react-i18next';
@@ -130,7 +130,7 @@ class PortfolioSettings extends Component<PortfolioProps, PortfolioState> {
       return false;
     }
     const edited = find(portfolio, createFindById(id));
-    return isEqual(original, edited);
+    return isEqual(omit(original, ['isSaved']), omit(edited, ['isSaved']));
   };
 
   // TODO: Check if this function is required or not

--- a/client/src/components/settings/portfolio.tsx
+++ b/client/src/components/settings/portfolio.tsx
@@ -95,15 +95,16 @@ class PortfolioSettings extends Component<PortfolioProps, PortfolioState> {
     e.preventDefault();
     const target = e.target as HTMLInputElement;
     const id = target?.id || undefined;
-    if (id) {
-      this.setState(state => ({
-        portfolio: state.portfolio.map(item =>
-          item.id === id ? { ...item, isSaved: true } : item
-        )
-      }));
-    }
     const { updatePortfolio } = this.props;
-    const { portfolio } = this.state;
+    let { portfolio } = this.state;
+    if (id) {
+      portfolio = portfolio.map(item =>
+        item.id === id ? { ...item, isSaved: true } : item
+      );
+      this.setState({
+        portfolio
+      });
+    }
     return updatePortfolio({ portfolio });
   };
 

--- a/client/src/components/settings/portfolio.tsx
+++ b/client/src/components/settings/portfolio.tsx
@@ -16,8 +16,10 @@ import { hasProtocolRE } from '../../utils';
 import { FullWidthRow, ButtonSpacer, Spacer } from '../helpers';
 import BlockSaveButton from '../helpers/form/block-save-button';
 import SectionHeader from './section-header';
+import PreventableButton from './PreventableButton';
 
 type PortfolioValues = {
+  isSaved: boolean;
   id: string;
   description: string;
   image: string;
@@ -26,6 +28,7 @@ type PortfolioValues = {
 };
 
 type PortfolioProps = {
+  isSaved: boolean;
   picture?: string;
   portfolio: PortfolioValues[];
   t: TFunction;
@@ -43,7 +46,8 @@ function createEmptyPortfolio() {
     title: '',
     description: '',
     url: '',
-    image: ''
+    image: '',
+    isSaved: false
   };
 }
 
@@ -89,6 +93,15 @@ class PortfolioSettings extends Component<PortfolioProps, PortfolioState> {
 
   handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    const target = e.target as HTMLInputElement;
+    const id = target?.id || undefined;
+    if (id) {
+      this.setState(state => ({
+        portfolio: state.portfolio.map(item =>
+          item.id === id ? { ...item, isSaved: true } : item
+        )
+      }));
+    }
     const { updatePortfolio } = this.props;
     const { portfolio } = this.state;
     return updatePortfolio({ portfolio });
@@ -213,11 +226,10 @@ class PortfolioSettings extends Component<PortfolioProps, PortfolioState> {
     );
     const { state: descriptionState, message: descriptionMessage } =
       this.getDescriptionValidation(description);
-
     return (
       <div key={id}>
         <FullWidthRow>
-          <form onSubmit={this.handleSubmit}>
+          <form id={id} onSubmit={this.handleSubmit}>
             <FormGroup
               controlId={`${id}-title`}
               validationState={
@@ -325,15 +337,11 @@ class PortfolioSettings extends Component<PortfolioProps, PortfolioState> {
         </FullWidthRow>
         <FullWidthRow>
           <ButtonSpacer />
-          <Button
-            block={true}
-            bsSize='lg'
-            bsStyle='primary'
-            onClick={this.handleAdd}
-            type='button'
-          >
-            {t('buttons.add-portfolio')}
-          </Button>
+          <PreventableButton
+            handleAdd={this.handleAdd}
+            t={t}
+            portfolio={portfolio}
+          />
         </FullWidthRow>
         <Spacer size={2} />
         {portfolio.length ? portfolio.map(this.renderPortfolio) : null}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #46510 

<!-- Feel free to add any additional description of changes below this line -->
Allows for better User Experience, it is confusing to allow him/her to add unlimited unsaved items. User can now have as many saved items as desired, but is required to save an item before adding another. 