### PR TITLE
fix(curriculum): change step tests to use expected/found values

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5efc4f528d6a74d05e68af74.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5efc4f528d6a74d05e68af74.md
@@ -19,10 +19,10 @@ You should make sure the checkbox is still present.
 assert($('input[type="checkbox"]')[0]);
 ```
 
-Your checkbox should still have an `id` attribute with the value `loving`. You may have removed the attribute or changed its value.
+Your checkbox should still have an `id` attribute with the value `loving`.  Expected `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
-assert($('input[type="checkbox"]')[0].id === 'loving');
+assert.equal($('input[type="checkbox"]')[0].id, 'loving');
 ```
 
 The text ` Loving` should no longer be located directly to the right of your checkbox. It should be wrapped in a `label` element. Make sure there is a space between the two elements.
@@ -59,11 +59,11 @@ const labelElem = $('input[type="checkbox"]')[0].nextElementSibling;
 assert(labelElem.hasAttribute('for'));
 ```
 
-The new `label` element should have a `for` attribute with the value `loving`. You have either omitted the value or have a typo. Remember that attribute values should be surrounded with quotation marks.
+The new `label` element should have a `for` attribute with the value `loving`.  Expected `--fcc-expected--`, but found `--fcc-actual--`.
 
 ```js
 const labelElem = $('input[type="checkbox"]')[0].nextElementSibling;
-assert(labelElem.getAttribute('for').match(/^loving$/));
+assert.equal(labelElem.getAttribute('for'), 'loving');
 ```
 
 The text `Loving` should be nested within the new `label` element. You have either omitted the text or have a typo.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Maybe Closes #47601

<!-- Feel free to add any additional description of changes below this line -->

This is a tentative approach in fixing the confusion there is with people adding the word capitalized as value for the attributes.