### PR TITLE
fix: change keyword for code highlighting on forum

### DIFF
--- a/client/src/templates/Challenges/redux/create-question-epic.js
+++ b/client/src/templates/Challenges/redux/create-question-epic.js
@@ -22,7 +22,7 @@ function filesToMarkdown(challengeFiles = {}) {
 
     const fileExtension = challengeFile.ext;
     const fileName = challengeFile.name;
-    const fileType = fileExtension;
+    const fileType = fileExtension === 'js' ? 'javascript' : fileExtension;
     let fileDescription;
 
     if (!moreThanOneFile) {

--- a/client/src/templates/Challenges/redux/create-question-epic.js
+++ b/client/src/templates/Challenges/redux/create-question-epic.js
@@ -19,16 +19,21 @@ function filesToMarkdown(challengeFiles = {}) {
     if (!challengeFile) {
       return fileString;
     }
-    let fileName;
-    const fileType = challengeFile.ext;
+
+    const fileExtension = challengeFile.ext;
+    const fileName = challengeFile.name;
+    const fileType = fileExtension;
+    let fileDescription;
+
     if (!moreThanOneFile) {
-      fileName = '';
-    } else if (fileType === 'html') {
-      fileName = `<!-- file: ${challengeFile.name}.${challengeFile.ext} -->\n`;
+      fileDescription = '';
+    } else if (fileExtension === 'html') {
+      fileDescription = `<!-- file: ${fileName}.${fileExtension} -->\n`;
     } else {
-      fileName = `/* file: ${challengeFile.name}.${challengeFile.ext} */\n`;
+      fileDescription = `/* file: ${fileName}.${fileExtension} */\n`;
     }
-    return `${fileString}\`\`\`${fileType}\n${fileName}${challengeFile.contents}\n\`\`\`\n\n`;
+
+    return `${fileString}\`\`\`${fileType}\n${fileDescription}${challengeFile.contents}\n\`\`\`\n\n`;
   }, '\n');
 }
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

It was kind of irking me to have a `fileName` variable for what is not the file name but the whole comment.

The second commit does the `js` --> `javascript` change for the markdown keyword. It can be removed if we can figure out what's the issue in the forum with JS not being hightlighted correctly if you use only `js`