### PR TITLE
fix(docs): run docsify on different port

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "develop": "npm-run-all build:curriculum -p develop:*",
     "develop:client": "npm run build:curriculum && cd ./client && npm run develop",
     "develop:server": "npm run predevelop && cd ./api-server && npm run develop",
-    "docs:serve": "docsify serve ./docs -o --port 3200",
+    "docs:serve": "docsify serve ./docs -o --port 3400",
     "e2e": "npm run e2e:dev:run",
     "e2e:dev:run": "start-test develop ':3000/status/ping|8000' cypress:dev:run",
     "e2e:dev:watch": "start-test develop ':3000/status/ping|8000' cypress:dev:watch",


### PR DESCRIPTION
Docs and challenge editor were opening on the same port

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #47663 

<!-- Feel free to add any additional description of changes below this line -->
