### PR TITLE
docs: Add note to local setup for WSL users to skip mongodb creation step.

### DIFF
--- a/docs/how-to-setup-freecodecamp-locally.md
+++ b/docs/how-to-setup-freecodecamp-locally.md
@@ -214,6 +214,7 @@ Before you can run the application locally, you will need to start the MongoDB s
 > Unless you have MongoDB running in a setup different than the default, the URL stored as the `MONGOHQ_URL` value in the `.env` file should work fine. If you are using a custom configuration, modify this value as needed.
 >
 > If you followed along with the [Windows 10 via WSL2 Setup Guide](how-to-setup-wsl.md), then you should be able to skip this step if the MongoDB server from that guide is already running. You can confirm this by checking that you can reach `http://localhost:27017` on your local machine.
+
 Start the MongoDB server in a separate terminal:
 
   <!-- tabs:start -->

--- a/docs/how-to-setup-freecodecamp-locally.md
+++ b/docs/how-to-setup-freecodecamp-locally.md
@@ -213,6 +213,9 @@ Before you can run the application locally, you will need to start the MongoDB s
 > [!NOTE]
 > Unless you have MongoDB running in a setup different than the default, the URL stored as the `MONGOHQ_URL` value in the `.env` file should work fine. If you are using a custom configuration, modify this value as needed.
 
+> [!NOTE]
+> If you followed along with the [Windows 10 via WSL2 Setup Guide](how-to-setup-wsl.md), then you should be able to skip this step if the MongoDB server from that guide is already running. You can confirm this by checking that you can reach `http://localhost:27017` on your local machine.
+
 Start the MongoDB server in a separate terminal:
 
   <!-- tabs:start -->

--- a/docs/how-to-setup-freecodecamp-locally.md
+++ b/docs/how-to-setup-freecodecamp-locally.md
@@ -212,10 +212,8 @@ Before you can run the application locally, you will need to start the MongoDB s
 
 > [!NOTE]
 > Unless you have MongoDB running in a setup different than the default, the URL stored as the `MONGOHQ_URL` value in the `.env` file should work fine. If you are using a custom configuration, modify this value as needed.
-
-> [!NOTE]
+>
 > If you followed along with the [Windows 10 via WSL2 Setup Guide](how-to-setup-wsl.md), then you should be able to skip this step if the MongoDB server from that guide is already running. You can confirm this by checking that you can reach `http://localhost:27017` on your local machine.
-
 Start the MongoDB server in a separate terminal:
 
   <!-- tabs:start -->


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #47493

This change adds the following note to how-to-setup-freecodecamp-locally.md since users who follow the WSL setup guide already have a MongoDB instance setup by the time they get to the MongoDB creation step.

> [!NOTE]
> If you followed along with the [Windows 10 via WSL2 Setup Guide](how-to-setup-wsl.md), then you should be able to skip this step if the MongoDB server from that guide is already running. You can confirm this by checking that you can reach `http://localhost:27017` on your local machine.

![screenshot-freecodecamp](https://user-images.githubusercontent.com/6621379/193112939-694e6ce5-5275-4260-9f78-ca197c584769.png)
