### PR TITLE
fix: remove tool panel buttons from mobile layout

### DIFF
--- a/client/src/components/layouts/learn.tsx
+++ b/client/src/components/layouts/learn.tsx
@@ -50,6 +50,8 @@ type LearnLayoutProps = {
   user: User;
   tryToShowDonationModal: () => void;
   children?: React.ReactNode;
+  hasEditableBoundaries?: boolean;
+  usesMultifileEditor?: boolean;
 };
 
 function LearnLayout({
@@ -57,7 +59,9 @@ function LearnLayout({
   fetchState,
   user,
   tryToShowDonationModal,
-  children
+  children,
+  hasEditableBoundaries,
+  usesMultifileEditor
 }: LearnLayoutProps): JSX.Element {
   useEffect(() => {
     tryToShowDonationModal();

--- a/client/src/components/layouts/learn.tsx
+++ b/client/src/components/layouts/learn.tsx
@@ -94,8 +94,6 @@ function LearnLayout({
       >
         {children}
       </main>
-      {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
-      /* @ts-ignore  */}
       <DonateModal />
     </>
   );

--- a/client/src/components/layouts/learn.tsx
+++ b/client/src/components/layouts/learn.tsx
@@ -51,7 +51,6 @@ type LearnLayoutProps = {
   tryToShowDonationModal: () => void;
   children?: React.ReactNode;
   hasEditableBoundaries?: boolean;
-  usesMultifileEditor?: boolean;
 };
 
 function LearnLayout({
@@ -60,8 +59,7 @@ function LearnLayout({
   user,
   tryToShowDonationModal,
   children,
-  hasEditableBoundaries,
-  usesMultifileEditor
+  hasEditableBoundaries
 }: LearnLayoutProps): JSX.Element {
   useEffect(() => {
     tryToShowDonationModal();
@@ -90,7 +88,14 @@ function LearnLayout({
       <Helmet>
         <meta content='noindex' name='robots' />
       </Helmet>
-      <main id='learn-app-wrapper'>{children}</main>
+      <main
+        id='learn-app-wrapper'
+        {...(hasEditableBoundaries && { 'data-has-editable-boundaries': true })}
+      >
+        {children}
+      </main>
+      {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
+      /* @ts-ignore  */}
       <DonateModal />
     </>
   );

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -137,12 +137,10 @@
   flex-direction: column;
 }
 
-[data-uses-multifile-editor='true'][data-has-editable-boundaries='true']
-  #mobile-layout
-  .tab-content {
+[data-has-editable-boundaries='true'] #mobile-layout .tab-content {
   height: calc(
     100vh - var(--header-height, 0px) - var(--flash-message-height, 0px) - 33px
-  ); /* What does 33px represent? */
+  );
 }
 
 #mobile-layout .tab-pane {

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -139,7 +139,7 @@
 
 [data-has-editable-boundaries='true'] #mobile-layout .tab-content {
   height: calc(
-    100vh - var(--header-height, 0px) - var(--flash-message-height, 0px) - 33px
+    100vh - var(--header-height, 0px) - var(--flash-message-height, 0px) - 80px
   );
 }
 

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -137,6 +137,14 @@
   flex-direction: column;
 }
 
+[data-uses-multifile-editor='true'][data-has-editable-boundaries='true']
+  #mobile-layout
+  .tab-content {
+  height: calc(
+    100vh - var(--header-height, 0px) - var(--flash-message-height, 0px) - 33px
+  ); /* What does 33px represent? */
+}
+
 #mobile-layout .tab-pane {
   height: 100%;
   overflow: hidden;

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -138,9 +138,7 @@
 }
 
 [data-has-editable-boundaries='true'] #mobile-layout .tab-content {
-  height: calc(
-    100vh - var(--header-height, 0px) - var(--flash-message-height, 0px) - 80px
-  );
+  padding-block-end: 0;
 }
 
 #mobile-layout .tab-pane {

--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -39,49 +39,55 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
     currentTab: this.props.hasEditableBoundaries ? Tab.Editor : Tab.Instructions
   };
 
+  // The Help, Reset, and Run buttons at the bottom of the Instructions.
+  // These will not exist in the Steps, only in the older challenges.
+  toolPanelGroup = (
+    document.getElementsByClassName(
+      'tool-panel-group-mobile'
+    ) as HTMLCollectionOf<HTMLElement>
+  )[0];
+
   switchTab = (tab: Tab): void => {
     this.setState({
       currentTab: tab
     });
   };
 
-  getToolPanelGroup = () =>
-    (
-      document.getElementsByClassName(
-        'tool-panel-group-mobile'
-      ) as HTMLCollectionOf<HTMLElement>
-    )[0];
-
   // Keep the tool panel visible when mobile address bar and/or keyboard are in view.
   setToolPanelPosition = () => {
-    const toolPanelGroup = this.getToolPanelGroup();
+    if (!this.toolPanelGroup) return;
     // Detect the appearance of the mobile virtual keyboard.
     if (visualViewport?.height && window.innerHeight > visualViewport.height) {
       setTimeout(() => {
         if (visualViewport?.height !== undefined) {
-          toolPanelGroup.style.top =
+          this.toolPanelGroup.style.top =
             String(visualViewport.height - TOOL_PANEL_HEIGHT) + 'px';
         }
       }, 200);
     } else {
       if (visualViewport?.height !== undefined) {
-        toolPanelGroup.style.top =
+        this.toolPanelGroup.style.top =
           String(window.innerHeight - TOOL_PANEL_HEIGHT) + 'px';
       }
     }
   };
 
   componentDidMount(): void {
-    const toolPanelGroup = this.getToolPanelGroup();
-    if (/iPhone|Android.+Mobile/.exec(navigator.userAgent)) {
+    if (
+      this.toolPanelGroup &&
+      /iPhone|Android.+Mobile/.exec(navigator.userAgent)
+    ) {
       visualViewport?.addEventListener('resize', this.setToolPanelPosition);
-      toolPanelGroup.style.top =
+      this.toolPanelGroup.style.top =
         String(window.innerHeight - TOOL_PANEL_HEIGHT) + 'px';
     }
   }
 
   componentWillUnmount(): void {
-    if (/iPhone|Android.+Mobile/.exec(navigator.userAgent)) {
+    if (
+      this.toolPanelGroup &&
+      /iPhone|Android.+Mobile/.exec(navigator.userAgent)
+    ) {
       visualViewport?.removeEventListener('resize', this.setToolPanelPosition);
       document.documentElement.style.height = '100%';
     }

--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -35,17 +35,11 @@ interface MobileLayoutState {
 class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
   static displayName: string;
 
+  #toolPanelGroup!: HTMLElement;
+
   state: MobileLayoutState = {
     currentTab: this.props.hasEditableBoundaries ? Tab.Editor : Tab.Instructions
   };
-
-  // The Help, Reset, and Run buttons at the bottom of the Instructions.
-  // These will not exist in the Steps, only in the older challenges.
-  toolPanelGroup = (
-    document.getElementsByClassName(
-      'tool-panel-group-mobile'
-    ) as HTMLCollectionOf<HTMLElement>
-  )[0];
 
   switchTab = (tab: Tab): void => {
     this.setState({
@@ -55,39 +49,42 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
 
   // Keep the tool panel visible when mobile address bar and/or keyboard are in view.
   setToolPanelPosition = () => {
-    if (!this.toolPanelGroup) return;
+    if (!this.#toolPanelGroup) return;
     // Detect the appearance of the mobile virtual keyboard.
     if (visualViewport?.height && window.innerHeight > visualViewport.height) {
       setTimeout(() => {
         if (visualViewport?.height !== undefined) {
-          this.toolPanelGroup.style.top =
+          this.#toolPanelGroup.style.top =
             String(visualViewport.height - TOOL_PANEL_HEIGHT) + 'px';
         }
       }, 200);
     } else {
       if (visualViewport?.height !== undefined) {
-        this.toolPanelGroup.style.top =
+        this.#toolPanelGroup.style.top =
           String(window.innerHeight - TOOL_PANEL_HEIGHT) + 'px';
       }
     }
   };
 
+  isMobileDeviceWithToolPanel = () =>
+    this.#toolPanelGroup && /iPhone|Android.+Mobile/.exec(navigator.userAgent);
+
   componentDidMount(): void {
-    if (
-      this.toolPanelGroup &&
-      /iPhone|Android.+Mobile/.exec(navigator.userAgent)
-    ) {
+    this.#toolPanelGroup = (
+      document.getElementsByClassName(
+        'tool-panel-group-mobile'
+      ) as HTMLCollectionOf<HTMLElement>
+    )[0];
+
+    if (this.isMobileDeviceWithToolPanel()) {
       visualViewport?.addEventListener('resize', this.setToolPanelPosition);
-      this.toolPanelGroup.style.top =
+      this.#toolPanelGroup.style.top =
         String(window.innerHeight - TOOL_PANEL_HEIGHT) + 'px';
     }
   }
 
   componentWillUnmount(): void {
-    if (
-      this.toolPanelGroup &&
-      /iPhone|Android.+Mobile/.exec(navigator.userAgent)
-    ) {
+    if (this.isMobileDeviceWithToolPanel()) {
       visualViewport?.removeEventListener('resize', this.setToolPanelPosition);
       document.documentElement.style.height = '100%';
     }

--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -166,7 +166,13 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
               {preview}
             </TabPane>
           )}
-          <ToolPanel guideUrl={guideUrl} isMobile={true} videoUrl={videoUrl} />
+          {!hasEditableBoundaries && (
+            <ToolPanel
+              guideUrl={guideUrl}
+              isMobile={true}
+              videoUrl={videoUrl}
+            />
+          )}
         </Tabs>
       </>
     );

--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -115,9 +115,6 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
     // Unlike the desktop layout the mobile version does not have an ActionRow,
     // but still needs a way to switch between the different tabs.
 
-    const showToolPanel =
-      !usesMultifileEditor || (usesMultifileEditor && !hasEditableBoundaries);
-
     return (
       <>
         <Tabs

--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -115,6 +115,9 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
     // Unlike the desktop layout the mobile version does not have an ActionRow,
     // but still needs a way to switch between the different tabs.
 
+    const showToolPanel =
+      !usesMultifileEditor || (usesMultifileEditor && !hasEditableBoundaries);
+
     return (
       <>
         <Tabs

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -420,7 +420,7 @@ function ShowClassic({
       usesMultifileEditor={usesMultifileEditor}
       {...(editorRef && { editorRef: editorRef })}
     >
-      <LearnLayout>
+      <LearnLayout hasEditableBoundaries={hasEditableBoundaries}>
         <Helmet title={windowTitle} />
         <Media maxWidth={MAX_MOBILE_WIDTH}>
           <MobileLayout


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally on my machine.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #47597

<!-- Feel free to add any additional description of changes below this line -->

Removes the tool panel buttons at the bottom of the mobile layout for the Steps since they already have these buttons built into the editor. Not sure if this is the best way to do it? I was originally going to place the new data attributes on the `#mobile-layout` div but that is created using the Tabs component in react-bootstrap and I could not find a way to place them on that div.