### PR TITLE
Fix 2 Typos in curriculum section

### DIFF
--- a/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/24-game.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/24-game.md
@@ -51,7 +51,7 @@ assert(isValidSolution_(solve24(testCases_[0])));
 assert(isValidSolution_(solve24(testCases_[1])));
 ```
 
-`solve24("6789")` should return `(6*8)/(9-7)`. `(8*6)/(9-7)`, or a similar valid string
+`solve24("6789")` should return `(6*8)/(9-7)`, `(8*6)/(9-7)`, or a similar valid string
 
 ```js
 assert(isValidSolution_(solve24(testCases_[2])));

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dfa22d1b521be39a3de7be0.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dfa22d1b521be39a3de7be0.md
@@ -20,7 +20,7 @@ You should nest a new anchor (`a`) element within the `p` element.
 assert($('p > a').length);
 ```
 
-The link's href value should be `https://freecatphotoapp.com`. You have either omitted the href value or have a typo.
+The link's `href` value should be `https://freecatphotoapp.com`. You have either omitted the `href` value or have a typo.
 
 ```js
 const nestedAnchor = $('p > a')[0];


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #47689

<!-- Feel free to add any additional description of changes below this line -->

fixed to typos in the curriculum section.