### PR TITLE
fix(a11y): make console pane output keyboard accessible

### DIFF
--- a/client/src/templates/Challenges/components/output.css
+++ b/client/src/templates/Challenges/components/output.css
@@ -13,3 +13,12 @@ pre.output-text code {
   font-size: 90%;
   padding: 2px 4px;
 }
+
+.output-text:focus {
+  outline: 2px solid var(--blue-mid);
+  outline-offset: -2px;
+}
+
+.output-text:focus:not(:focus-visible) {
+  outline: none;
+}

--- a/client/src/templates/Challenges/components/output.tsx
+++ b/client/src/templates/Challenges/components/output.tsx
@@ -1,6 +1,7 @@
 import { isEmpty } from 'lodash-es';
 import React from 'react';
 import sanitizeHtml from 'sanitize-html';
+import i18next from 'i18next';
 
 import './output.css';
 
@@ -20,6 +21,10 @@ function Output({ defaultOutput, output }: OutputProps): JSX.Element {
     <pre
       className='output-text'
       dangerouslySetInnerHTML={{ __html: message }}
+      role='region'
+      aria-label={i18next.t('learn.editor-tabs.console')}
+      // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+      tabIndex={0}
     />
   );
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes locally on my machine.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

The console pane output has the ability to vertically scroll but not all browsers automatically make this keyboard accessible (looking at you Chrome). So we need to add a `tabindex='0'` to allow all keyboard users access to it. And when we do that we must also give it a role and accessible name. It's also a good idea to put a focus outline around it.