### PR TITLE
Updated FAQ with Grammar Changes

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -92,7 +92,7 @@ Here are some recommended paths for some of our platforms:
   to see if they are valid and (ideally) try to propose solutions for these
   issues to be picked up by others (or yourself).
 
-Altogether, be respectful to others. We are humans all around the world. With
+Altogether, be respectful to others. We are humans from all around the world. With
 that in mind, please also consider using encouraging or supportive language and
 be mindful of cross-cultural communication.
 
@@ -119,6 +119,6 @@ Thanks in advance for being polite and patient. Remember – this community is r
 
 ### Additional Assistance
 
-If you have queries about the stack, architecture of the codebase, translations, or anything else feel free to reach out to our staff team [on the forum](https://forum.freecodecamp.org/g/team).
+If you have queries about the stack, architecture of the codebase, translations, or anything else, feel free to reach out to our staff team [on the forum](https://forum.freecodecamp.org/g/team).
 
 **You can email our developer staff at: `dev[at]freecodecamp.org`**


### PR DESCRIPTION
In line 95, `we are humans all around the world` has been changed to `we are humans from all around the world` In line 122, added a `,` after anything else to separate the sentences

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!-- Feel free to add any additional description of changes below this line -->
