### PR TITLE
feat: spam automation

### DIFF
--- a/.github/workflows/autoclose.yml
+++ b/.github/workflows/autoclose.yml
@@ -46,6 +46,6 @@ jobs:
                 owner: context.payload.repository.owner.login,
                 repo: context.payload.repository.name,
                 issue_number: context.issue.number,
-                labels: ["invalid"]
+                labels: ["spam"]
               });
             }

--- a/.github/workflows/spam.yml
+++ b/.github/workflows/spam.yml
@@ -5,7 +5,7 @@ on:
       - labeled
 
 jobs:
-  has-translation:
+  is-spam:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/github-script@7dff1a87643417cf3b95bb10b29f4c4bc60d8ebd # tag=v6

--- a/.github/workflows/spam.yml
+++ b/.github/workflows/spam.yml
@@ -1,0 +1,23 @@
+name: GitHub - Spam PR
+on:
+  pull_request_target:
+    types:
+      - labeled
+
+jobs:
+  has-translation:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/github-script@7dff1a87643417cf3b95bb10b29f4c4bc60d8ebd # tag=v6
+        with:
+          github-token: ${{secrets.CAMPERBOT_NO_TRANSLATE}}
+          script: |
+            const isSpam = context.payload.pull_request.labels.find(label => label.name === "spam");
+            if (isSpam) {
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: "We are marking this pull request as spam. Please note that if you are participating in Hacktoberfest, two or more PRs marked as spam will result in your permanent disqualification.\n\nIf you are interested in making quality and genuine contributions to our projects, check out our [contributing guidelines](https://contribute.freecodecamp.org)."
+              })
+            }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This PR does two things:
- Changes the action that auto-closes those spammy .gitignore PRs to use the `spam` label so folks can be disqualified from Hacktoberfest
- Adds a new action that hooks into the label event, and checks if a PR is spam. If so, it comments explaining that the PR is spam and that they should read our contributing guidelines.