### PR TITLE
fix(curriculum): fix the text going against the guidelines In step 20 of building a skyline project

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-flexbox-by-building-a-photo-gallery/6153a3952facd25a83fe8083.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-flexbox-by-building-a-photo-gallery/6153a3952facd25a83fe8083.md
@@ -7,7 +7,7 @@ dashedName: step-20
 
 # --description--
 
-The `::after` pseudo-element creates an element that is the last child of the selected element. We can use it to add an empty element after the last image. If we give it the same `width` as the images it will push the last image to the left when the gallery is in a two-column layout. Right now, it is in the center because we set `justify-content: center` on the flex container.
+The `::after` pseudo-element creates an element that is the last child of the selected element. You can use it to add an empty element after the last image. If you give it the same `width` as the images it will push the last image to the left when the gallery is in a two-column layout. Right now, it is in the center because you set `justify-content: center` on the flex container.
 
 Example:
 


### PR DESCRIPTION
Changing the Text In step 20 of building a Skyline project #47817

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #47816 

<!-- Feel free to add any additional description of changes below this line -->
I update the Text In step 20 of building a skyline project, so it goes not against the challenge document anymore