### PR TITLE
fix: enable writes to locale files before format

### DIFF
--- a/.github/workflows/crowdin-download.client-ui.yml
+++ b/.github/workflows/crowdin-download.client-ui.yml
@@ -238,11 +238,13 @@ jobs:
           # Uncomment below to debug
           # dryrun_action: true
 
-      # Format JSON
+      ###### Format JSON #####
+      # Crowdin gives the files read-only permissions, so we first have to allow
+      # writes.
       - name: Format JSON
         run: |
-          npm ci
-          npx prettier --write client/i18n/locales/**/*.json
+          chmod 664 client/i18n/locales/**/*.json
+          npx --yes prettier --write client/i18n/locales/**/*.json
 
       # Create Commit
       - name: Commit Changes


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Should stop errors downloading the client translations like this: https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/3182079998/jobs/5187581919

<!-- Feel free to add any additional description of changes below this line -->
