### PR TITLE
fix(curriculum) : Fixed A Typo in Step 20 of Building a Skyline Project 

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-flexbox-by-building-a-photo-gallery/6153a3952facd25a83fe8083.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-flexbox-by-building-a-photo-gallery/6153a3952facd25a83fe8083.md
@@ -7,7 +7,7 @@ dashedName: step-20
 
 # --description--
 
-The `::after` pseudo-element creates an element that is the last child of the selected element. We can use it to add an empty element after the last image. If we give it the same `width` as the images it will push the last image to the left when the gallery is in a two-column layout. Right now, it is in the center because we set `justify-content: center` on the flex container.
+The `::after` pseudo-element creates an element that is the last child of the selected element. We can use it to add an empty element after the last image. If you give it the same `width` as the images it will push the last image to the left when the gallery is in a two-column layout. Right now, it is in the center because you set `justify-content: center` on the flex container.
 
 Example:
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-flexbox-by-building-a-photo-gallery/6153a3952facd25a83fe8083.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-flexbox-by-building-a-photo-gallery/6153a3952facd25a83fe8083.md
@@ -7,7 +7,7 @@ dashedName: step-20
 
 # --description--
 
-The `::after` pseudo-element creates an element that is the last child of the selected element. We can use it to add an empty element after the last image. If you give it the same `width` as the images it will push the last image to the left when the gallery is in a two-column layout. Right now, it is in the center because you set `justify-content: center` on the flex container.
+The `::after` pseudo-element creates an element that is the last child of the selected element. We can use it to add an empty element after the last image. If we give it the same `width` as the images it will push the last image to the left when the gallery is in a two-column layout. Right now, it is in the center because we set `justify-content: center` on the flex container.
 
 Example:
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #47816

<!-- Feel free to add any additional description of changes below this line -->

The Step 20 of freeCodeCamp's had a typo issue, that is fixed in this pull request. I have update the code changing "we" at two places to a "you" to prevent it from going against the challenge document.
Affected Page :  [Affected Page](https://www.freecodecamp.org/learn/2022/responsive-web-design/learn-css-flexbox-by-building-a-photo-gallery/step-20) 
