### PR TITLE
fix: sudo enable writes to locale files

### DIFF
--- a/.github/workflows/crowdin-download.client-ui.yml
+++ b/.github/workflows/crowdin-download.client-ui.yml
@@ -243,7 +243,7 @@ jobs:
       # writes.
       - name: Format JSON
         run: |
-          chmod 664 client/i18n/locales/**/*.json
+          sudo chmod 664 client/i18n/locales/**/*.json
           npx --yes prettier --write client/i18n/locales/**/*.json
 
       # Create Commit


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Trying https://github.com/freeCodeCamp/freeCodeCamp/pull/47823 again, but with [admin privileges](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#administrative-privileges) because https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/3183332114/jobs/5190420283 shows that chmod did not have permission.

<!-- Feel free to add any additional description of changes below this line -->
