### PR TITLE
fix(client): preserve scroll position of preview iframe

### DIFF
--- a/client/src/templates/Challenges/components/preview.tsx
+++ b/client/src/templates/Challenges/components/preview.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { mainPreviewId, setPreviewScrollPosition } from '../utils/frame';
+import { mainPreviewId, scrollManager } from '../utils/frame';
 
 import './preview.css';
 
@@ -31,7 +31,7 @@ function Preview({
 
   useEffect(() => {
     return () => {
-      setPreviewScrollPosition(0);
+      scrollManager.setPreviewScrollPosition(0);
     };
   }, []);
 

--- a/client/src/templates/Challenges/components/preview.tsx
+++ b/client/src/templates/Challenges/components/preview.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { mainPreviewId } from '../utils/frame';
+import { mainPreviewId, setPreviewScrollPosition } from '../utils/frame';
 
 import './preview.css';
 
@@ -28,6 +28,12 @@ function Preview({
   useEffect(() => {
     setIframeStatus(disableIframe);
   }, [disableIframe]);
+
+  useEffect(() => {
+    return () => {
+      setPreviewScrollPosition(0);
+    };
+  }, []);
 
   const id = previewId ?? mainPreviewId;
 

--- a/client/src/templates/Challenges/utils/frame.ts
+++ b/client/src/templates/Challenges/utils/frame.ts
@@ -268,14 +268,13 @@ const writeContentToFrame = (frameContext: Context) => {
     frameContext.document
   );
 
-  const iframe = document.getElementById(
-    frameContext.element.id
-  ) as HTMLIFrameElement;
-
-  registerScrollEventListner(iframe);
+  registerScrollEventListner(frameContext.element);
 
   if (getPreviewScrollPosition()) {
-    restorePreviewScrollPosition(iframe, getPreviewScrollPosition());
+    restorePreviewScrollPosition(
+      frameContext.element,
+      getPreviewScrollPosition()
+    );
   }
   return frameContext;
 };
@@ -286,7 +285,7 @@ export const setPreviewScrollPosition = (position: number) =>
   (previewScrollPosition = position);
 
 const registerScrollEventListner = (iframe: HTMLIFrameElement) => {
-  iframe?.contentDocument?.addEventListener('scroll', event => {
+  iframe.contentDocument?.addEventListener('scroll', event => {
     const target = event.target as Document;
     setPreviewScrollPosition(target.body.scrollTop);
   });

--- a/client/src/templates/Challenges/utils/frame.ts
+++ b/client/src/templates/Challenges/utils/frame.ts
@@ -267,7 +267,37 @@ const writeContentToFrame = (frameContext: Context) => {
     createHeader(frameContext.element.id) + frameContext.build,
     frameContext.document
   );
+
+  const iframe = document.getElementById(
+    frameContext.element.id
+  ) as HTMLIFrameElement;
+
+  registerScrollEventListner(iframe);
+
+  if (getPreviewScrollPosition()) {
+    restorePreviewScrollPosition(iframe, getPreviewScrollPosition());
+  }
   return frameContext;
+};
+
+let previewScrollPosition = 0;
+export const getPreviewScrollPosition = () => previewScrollPosition;
+export const setPreviewScrollPosition = (position: number) =>
+  (previewScrollPosition = position);
+
+const registerScrollEventListner = (iframe: HTMLIFrameElement) => {
+  iframe?.contentDocument?.addEventListener('scroll', event => {
+    const target = event.target as Document;
+    setPreviewScrollPosition(target.body.scrollTop);
+  });
+};
+
+const restorePreviewScrollPosition = (
+  iframe: HTMLIFrameElement,
+  position: number
+) => {
+  if (iframe.contentDocument?.body)
+    iframe.contentDocument.body.scrollTop = position;
 };
 
 export const createMainPreviewFramer = (

--- a/client/src/templates/Challenges/utils/frame.ts
+++ b/client/src/templates/Challenges/utils/frame.ts
@@ -34,10 +34,6 @@ export interface TestRunnerConfig {
   removeComments?: boolean;
 }
 
-export type IframeEvent<T> = Event & {
-  target: T;
-};
-
 export type ProxyLogger = (msg: string) => void;
 
 type InitFrame = (

--- a/client/src/templates/Challenges/utils/frame.ts
+++ b/client/src/templates/Challenges/utils/frame.ts
@@ -34,6 +34,10 @@ export interface TestRunnerConfig {
   removeComments?: boolean;
 }
 
+export type IframeEvent<T> = Event & {
+  target: T;
+};
+
 export type ProxyLogger = (msg: string) => void;
 
 type InitFrame = (
@@ -285,18 +289,24 @@ export const setPreviewScrollPosition = (position: number) =>
   (previewScrollPosition = position);
 
 const registerScrollEventListner = (iframe: HTMLIFrameElement) => {
-  iframe.contentDocument?.addEventListener('scroll', event => {
-    const target = event.target as Document;
-    setPreviewScrollPosition(target.body.scrollTop);
-  });
+  iframe.contentDocument?.addEventListener(
+    'scroll',
+    (event: IframeEvent<Document>) => {
+      const { target } = event;
+      if (target.body.scrollTop) {
+        setPreviewScrollPosition(target.body.scrollTop);
+      }
+    }
+  );
 };
 
 const restorePreviewScrollPosition = (
   iframe: HTMLIFrameElement,
   position: number
 ) => {
-  if (iframe.contentDocument?.body)
+  if (iframe.contentDocument?.body) {
     iframe.contentDocument.body.scrollTop = position;
+  }
 };
 
 export const createMainPreviewFramer = (

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["WebWorker", "DOM", "DOM.Iterable"],
+    "lib": ["WebWorker", "DOM", "DOM.Iterable", "ES2022"],
     "target": "es2020",
     "module": "es2020",
     "moduleResolution": "node",

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["WebWorker", "DOM", "DOM.Iterable", "ES2022"],
+    "lib": ["WebWorker", "DOM", "DOM.Iterable"],
     "target": "es2020",
     "module": "es2020",
     "moduleResolution": "node",


### PR DESCRIPTION
Checklist:
- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Possibly Closes #46061

**Difficulties**:
I tried using hooks and refs in order to achieve this but there were some unexpected behavior and difficulties. Using hooks didn't work for the initial render (mount) but only worked for the later re-renders (after some change in the content) - this could be due to the fact that the document contents are loaded later in the iframe.

The implementation in this PR was only the way (hack) with which I was able to achieve the expected behavior.

**Improvements**:
I believe this is not the best way to implement it but I couldn't find any. Hooks could be the best option but that didn't work.
Also, the scroll position could be stored in the store as state but I didn't dive deep into the store part.

**Result**:

[Screencast from 10-06-2022 06:46:41 PM.webm](https://user-images.githubusercontent.com/52366632/194320301-0fd40321-ef47-481c-8685-b93b8a48ea52.webm)

CC @moT01 @Sembauke @DerrykBoyd