### PR TITLE
fix(api): write variable names in correct manner

### DIFF
--- a/api-server/src/server/utils/donation.test.js
+++ b/api-server/src/server/utils/donation.test.js
@@ -79,12 +79,12 @@ describe('donation', () => {
         Authorization: `Bearer ${mockAccessToken}`
       }
     };
-    const successVerificationResponce = {
+    const successVerificationResponse = {
       data: {
         verification_status: 'SUCCESS'
       }
     };
-    const failedVerificationResponce = {
+    const failedVerificationResponse = {
       data: {
         verification_status: 'FAILED'
       }
@@ -92,7 +92,7 @@ describe('donation', () => {
 
     it('calls paypal for Webhook verification', async () => {
       axios.post.mockImplementationOnce(() =>
-        Promise.resolve(successVerificationResponce)
+        Promise.resolve(successVerificationResponse)
       );
 
       await expect(
@@ -112,7 +112,7 @@ describe('donation', () => {
     });
     it('throws error if verification not successful', async () => {
       axios.post.mockImplementationOnce(() =>
-        Promise.resolve(failedVerificationResponce)
+        Promise.resolve(failedVerificationResponse)
       );
 
       await expect(


### PR DESCRIPTION
In order to fix typos in [api-server/src/server/utils/donation.test.js](https://github.com/freeCodeCamp/freeCodeCamp/pull/47883/files#diff-2c85ffa590d1712add482e77de3a9ad5441ad67e8066bbb850ca0cbc68ae2e1e)
`successVerificationResponce` and `failedVerificationResponce`
have been renamed as 
`successVerificationResponse` and `failedVerificationResponse` respectively.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
-->
<!-- Feel free to add any additional description of changes below this line -->
