### PR TITLE
feat: more aggressive autoclose on .gitignore

### DIFF
--- a/.github/workflows/autoclose.yml
+++ b/.github/workflows/autoclose.yml
@@ -14,11 +14,11 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const patches = [
-              "@@ -63,7 +63,6 @@ $RECYCLE.BIN/\n # Icon must end with two \\r\n Icon\n \n-\n # Thumbnails\n ._*\n ",
-              "@@ -63,7 +63,6 @@ $RECYCLE.BIN/\n # Icon must end with two \\r\n Icon\n \n-\n # Thumbnails\n ._*\n \n@@ -165,7 +164,6 @@ config/curriculum.json\n config/i18n/all-langs.js\n config/certification-settings.js\n \n-\n ### vim ###\n # Swap\n [._]*.s[a-v][a-z]",
-              "@@ -165,7 +165,6 @@ config/curriculum.json\n config/i18n/all-langs.js\n config/certification-settings.js\n \n-\n ### vim ###\n # Swap\n [._]*.s[a-v][a-z]"
-            ];
+            const isMod = await github.rest.teams.getMembershipForUserInOrg({
+              org: "freeCodeCamp",
+              team_slug: "moderators",
+              username: context.payload.pull_request.user.login
+            }).catch(() => ({status: 404}));
             const files = await github.rest.pulls.listFiles({
               owner: context.payload.repository.owner.login,
               repo: context.payload.repository.name,
@@ -27,7 +27,7 @@ jobs:
             if (
               files.data.length === 1 &&
               files.data[0].filename === ".gitignore" &&
-              patches.includes(files.data[0].patch)
+              isMod.status !== 200
             ) {
               core.setFailed("Invalid PR detected.");
               github.rest.issues.createComment({

--- a/.github/workflows/autoclose.yml
+++ b/.github/workflows/autoclose.yml
@@ -28,11 +28,14 @@ jobs:
             });
             const issues = await github.paginate(opts);
 
+            // iterate through issues
             for (const issue of issues) {
+              // if the issue is this one, keep looking
               if (issue.number === context.issue.number) {
                 continue;
               }
 
+              // if the issue is actually a PR, they're not a first timer
               if (issue.pull_request) {
                 return // Creator is already a contributor.
               }

--- a/.github/workflows/autoclose.yml
+++ b/.github/workflows/autoclose.yml
@@ -14,38 +14,45 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const isMod = await github.rest.teams.getMembershipForUserInOrg({
-              org: "freeCodeCamp",
-              team_slug: "moderators",
-              username: context.payload.pull_request.user.login
-            }).catch(() => ({status: 404}));
-            const files = await github.rest.pulls.listFiles({
+            if (
+              files.data.length !== 1 || 
+              files.data[0].filename !== ".gitignore"
+            ) {
+              return;
+            }
+            const creator = context.payload.sender.login
+            const opts = github.rest.issues.listForRepo.endpoint.merge({
+              ...context.issue,
+              creator,
+              state: 'all'
+            })
+            const issues = await github.paginate(opts)
+
+            for (const issue of issues) {
+              if (issue.number === context.issue.number) {
+                continue
+              }
+
+              if (issue.pull_request) {
+                return // Creator is already a contributor.
+              }
+            }
+            core.setFailed("Invalid PR detected.");
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "Thank you for opening this pull request.\n\nThis is a standard message notifying you that we've reviewed your pull request and have decided not to merge it. We would welcome future pull requests from you.\n\nThank you and happy coding.",
+            });
+            await github.rest.pulls.update({
               owner: context.payload.repository.owner.login,
               repo: context.payload.repository.name,
               pull_number: context.payload.pull_request.number,
+              state: "closed"
             });
-            if (
-              files.data.length === 1 &&
-              files.data[0].filename === ".gitignore" &&
-              isMod.status !== 200
-            ) {
-              core.setFailed("Invalid PR detected.");
-              github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: "Thank you for opening this pull request.\n\nThis is a standard message notifying you that we've reviewed your pull request and have decided not to merge it. We would welcome future pull requests from you.\n\nThank you and happy coding.",
-              });
-              await github.rest.pulls.update({
-                owner: context.payload.repository.owner.login,
-                repo: context.payload.repository.name,
-                pull_number: context.payload.pull_request.number,
-                state: "closed"
-              });
-              await github.rest.issues.addLabels({
-                owner: context.payload.repository.owner.login,
-                repo: context.payload.repository.name,
-                issue_number: context.issue.number,
-                labels: ["spam"]
-              });
-            }
+            await github.rest.issues.addLabels({
+              owner: context.payload.repository.owner.login,
+              repo: context.payload.repository.name,
+              issue_number: context.issue.number,
+              labels: ["spam"]
+            });

--- a/.github/workflows/autoclose.yml
+++ b/.github/workflows/autoclose.yml
@@ -15,22 +15,22 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             if (
-              files.data.length !== 1 || 
+              files.data.length !== 1 ||
               files.data[0].filename !== ".gitignore"
             ) {
               return;
             }
-            const creator = context.payload.sender.login
+            const creator = context.payload.sender.login;
             const opts = github.rest.issues.listForRepo.endpoint.merge({
               ...context.issue,
               creator,
               state: 'all'
-            })
-            const issues = await github.paginate(opts)
+            });
+            const issues = await github.paginate(opts);
 
             for (const issue of issues) {
               if (issue.number === context.issue.number) {
-                continue
+                continue;
               }
 
               if (issue.pull_request) {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Changes the `.gitignore` logic to auto-close any PR to that file (if it is the only file) unless it comes from a member of the mod team.