### PR TITLE
fix: cypress third-party ignore docs

### DIFF
--- a/.github/workflows/cypress-third-party.yml
+++ b/.github/workflows/cypress-third-party.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   do-everything:


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Was looking in to why Hanaa was seeing Cypress fail on her docs PR. The issue was unrelated, but I figured we should exclude docs from the third party cypress like we do the main cypress.

Save ourselves a runner or two.