### PR TITLE
fix(client): Added labels to fields on profile page (name, location, etc) and formatted fields so that they better align.

### DIFF
--- a/client/src/components/profile/__snapshots__/profile.test.tsx.snap
+++ b/client/src/components/profile/__snapshots__/profile.test.tsx.snap
@@ -262,17 +262,33 @@ exports[`<Profile/> renders correctly 1`] = `
         </div>
       </div>
       <br />
-      <h2
-        class="text-center username"
+      <div
+        class="row"
       >
-        @
-        string
-      </h2>
-      
-      
-      
-      
-      <br />
+        <h2
+          class="text-center username"
+        >
+          @
+          string
+        </h2>
+      </div>
+      <div
+        class="row"
+      >
+        <div
+          class="col-lg-5 col-lg-offset-4"
+        >
+          
+          
+          
+        </div>
+      </div>
+      <div
+        class="row"
+      >
+        
+        <br />
+      </div>
     </div>
     <div
       class="spacer"

--- a/client/src/components/profile/components/camper.tsx
+++ b/client/src/components/profile/components/camper.tsx
@@ -96,38 +96,85 @@ function Camper({
         website={website}
       />
       <br />
-      <h2 className='text-center username'>@{username}</h2>
-      {name && <p className='text-center name'>{name}</p>}
-      {location && <p className='text-center location'>{location}</p>}
-      {isDonating && (
-        <p className='text-center supporter'>
-          <FontAwesomeIcon icon={faHeart} /> {t('profile.supporter')}
-        </p>
-      )}
-      {about && <p className='bio text-center'>{about}</p>}
-      {joinDate && (
-        <p className='bio text-center'>
-          <FontAwesomeIcon icon={faCalendar} /> {parseDate(joinDate, t)}
-        </p>
-      )}
-      {yearsTopContributor.filter(Boolean).length > 0 && (
-        <div>
-          <br />
-          <p className='text-center yearsTopContributor'>
-            <FontAwesomeIcon icon={faAward} />{' '}
-            <Link to={t('links:top-contributors')}>
-              {t('profile.contributor')}
-            </Link>
-          </p>
-          <p className='text-center'>{joinArray(yearsTopContributor, t)}</p>
-        </div>
-      )}
-      <br />
-      {typeof points === 'number' ? (
-        <p className='text-center points'>
-          {t('profile.total-points', { count: points })}
-        </p>
-      ) : null}
+      <Row>
+        <h2 className='text-center username'>@{username}</h2>
+      </Row>
+      <Row>
+        <Col lg={5} lgOffset={4}>
+          {name && (
+            <>
+              <Col lg={4} xs={6}>
+                <p className='text-right name'>
+                  <strong>{t('settings.labels.name')}:</strong>
+                </p>
+              </Col>
+              <Col lg={8} xs={6}>
+                <p className='text-left name'>{name}</p>
+              </Col>
+            </>
+          )}
+          {location && (
+            <>
+              <Col lg={4} xs={6}>
+                <p className='text-right location'>
+                  <strong>{t('settings.labels.location')}:</strong>
+                </p>
+              </Col>
+              <Col lg={8} xs={6}>
+                <p className='text-left location'>{location}</p>
+              </Col>
+            </>
+          )}
+          {isDonating && (
+            <Col>
+              <p className='text-center supporter'>
+                <FontAwesomeIcon icon={faHeart} /> {t('profile.supporter')}
+              </p>
+            </Col>
+          )}
+          {about && (
+            <>
+              <Col lg={4} xs={6}>
+                <p className='text-right bio'>
+                  <strong>{t('settings.labels.about')}:</strong>
+                </p>
+              </Col>
+              <Col lg={8} xs={6}>
+                <p className='text-left bio'>{about}</p>
+              </Col>
+            </>
+          )}
+        </Col>
+      </Row>
+      <Row>
+        {joinDate && (
+          <Col>
+            <p className='bio text-center'>
+              <FontAwesomeIcon icon={faCalendar} /> {parseDate(joinDate, t)}
+            </p>
+          </Col>
+        )}
+        {yearsTopContributor.filter(Boolean).length > 0 && (
+          <div>
+            <br />
+            <p className='text-center yearsTopContributor'>
+              <FontAwesomeIcon icon={faAward} />{' '}
+              <Link to={t('links:top-contributors')}>
+                {t('profile.contributor')}
+              </Link>
+            </p>
+            <p className='text-center'>{joinArray(yearsTopContributor, t)}</p>
+          </div>
+        )}
+        <br />
+        {typeof points === 'number' ? (
+          <Col>
+            <p className='text-center points'>
+              {t('profile.total-points', { count: points })}
+            </p>
+          </Col>
+        ) : null}
+      </Row>
     </div>
   );
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x ] My pull request targets the `main` branch of freeCodeCamp.
- [ x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #47847

<!-- Feel free to add any additional description of changes below this line -->
Profile page as it currently appears in freecodecamp.org:
![image](https://user-images.githubusercontent.com/6621379/194912995-7857280d-564e-482c-a562-d3fd365d2c47.png)

Profile page after changes (using developmentuser account, but same profile info):
![image](https://user-images.githubusercontent.com/6621379/194913094-cfd68004-4af9-4c95-a29e-224979c87c44.png)

