### PR TITLE
fix: do not display breadcrumbs with iframe

### DIFF
--- a/client/src/templates/Challenges/codeally/show.tsx
+++ b/client/src/templates/Challenges/codeally/show.tsx
@@ -230,6 +230,9 @@ class ShowCodeAlly extends Component<ShowCodeAllyProps> {
       challenge => challenge.id === challengeId
     );
 
+    const breadcrumbs = document.querySelector('.breadcrumbs-demo');
+    showCodeAlly && breadcrumbs?.remove();
+
     return showCodeAlly ? (
       <LearnLayout>
         <Helmet title={`${blockName}: ${title} | freeCodeCamp.org`} />


### PR DESCRIPTION
Signed-off-by: Prince Mendiratta <prince.mendi@gmail.com>

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #47980

<!-- Feel free to add any additional description of changes below this line -->

The breadcrumbs would be hidden after the user initialises the CodeAlly iframe for the first time.

## Screenshots

They are displayed normally on the default course details page.
![image](https://user-images.githubusercontent.com/54077356/195195894-67dbaf7b-2f6b-4ee7-b46a-cb07b0660c65.png)


After clicking on the 'Start the course' button,
![image](https://user-images.githubusercontent.com/54077356/195195992-49d52ded-9276-4ff1-a0a3-e2004f5cc601.png)


And finally the code editor,
![image](https://user-images.githubusercontent.com/54077356/195196086-b6bdd4bf-f2fc-45d9-948d-b643911b7a86.png)
