### PR TITLE
feat(client): add page for users blocked by okta

### DIFF
--- a/client/src/pages/blocked.css
+++ b/client/src/pages/blocked.css
@@ -1,0 +1,3 @@
+.blocked-body p {
+  font-family: Lato, sans-serif;
+}

--- a/client/src/pages/blocked.tsx
+++ b/client/src/pages/blocked.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Grid, Col, Row } from '@freecodecamp/react-bootstrap';
+import Helmet from 'react-helmet';
+
+import { Spacer } from '../components/helpers';
+import './blocked.css';
+
+function BlockedPage(): JSX.Element {
+  return (
+    <>
+      <Helmet title={`Access Denied | freeCodeCamp.org`} />
+      <Grid className='text-center'>
+        <Spacer size={2} />
+        <Row>
+          <Col lg={8} lgOffset={2} sm={10} smOffset={1} xs={12}>
+            <h1>We can&apos;t log you in.</h1>
+            <Spacer size={2} />
+            <Col lg={10} lgOffset={1} sm={10} smOffset={1} xs={12}>
+              <div className='text-left blocked-body'>
+                <p>
+                  United States export control and economic sanctions rules
+                  don&apos;t allow us to log in visitors from your region. Sorry
+                  about this. The situation may change in the future.
+                </p>
+                <p>
+                  If you want, you can{' '}
+                  <a href='https://www.okta.com/blocked'>
+                    learn more about these restrictions
+                  </a>
+                  .
+                </p>
+              </div>
+            </Col>
+          </Col>
+        </Row>
+        <Spacer size={2} />
+      </Grid>
+    </>
+  );
+}
+
+BlockedPage.displayName = 'BlockedPage';
+
+export default BlockedPage;


### PR DESCRIPTION
This PR adds the page where we can redirect users that Okta blocks due to [compliance requirements](https://support.okta.com/help/s/article/Important-Customer-Update-to-Okta-IP-Access-Policy?language=en_US). 

Soon, Okta will start returning an error instead of a valid access_token to the API; we will need additional changes on the API to handle it correctly.

#47992 adds the changes to the API to intercept the error and redirect to this page. This PR should be merged & deployed first.

⚠️ **The deployments will have to go out separately.**

There is also a third thing; we will be using https://marketplace.auth0.com/integrations/country-based-access?tab=install to get the Auth0 action/flow working. 

That will be activated later once all deployments are live.