### PR TITLE
fix(e2e): reduce load on the CI

### DIFF
--- a/.github/workflows/cypress-third-party.yml
+++ b/.github/workflows/cypress-third-party.yml
@@ -2,13 +2,13 @@ name: CI - Cypress (e2e) 3rd party donation tests
 on:
   push:
     branches:
-      - main
+      - 'prod-*'
     paths-ignore:
       - 'docs/**'
 
 jobs:
   do-everything:
-    name: Build
+    name: Build & Test
     runs-on: ubuntu-20.04
     services:
       mongodb:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -64,11 +64,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        browsers: [chrome, firefox, electron]
+        browsers: [chrome, firefox]
         node-version: [16.x]
-        include:
-          - browsers: electron
-            spec: cypress/e2e/default/learn/challenges/projects.js
+
     services:
       mongodb:
         image: mongo:4


### PR DESCRIPTION
This removed the electon config which is taking considerably long and is a hack to run one test. You are welcome to re-introduce a proper way to test those specs instead. I do not see any reason to spend an hour worth of CI time on one test. Also I am moving the third-party stuff because they are dependent on external factors and hence flaky by design. We should run them as a sanity check only, before we push to prod-*
