### PR TITLE
feat(client): add growthbook

### DIFF
--- a/client/gatsby-browser.js
+++ b/client/gatsby-browser.js
@@ -8,6 +8,7 @@ import i18n from './i18n/config';
 import AppMountNotifier from './src/components/app-mount-notifier';
 import { createStore } from './src/redux/createStore';
 import layoutSelector from './utils/gatsby/layout-selector';
+import GrowthBookProvider from './src/components/growth-book/growth-book-wrapper';
 
 const store = createStore();
 
@@ -15,7 +16,9 @@ export const wrapRootElement = ({ element }) => {
   return (
     <Provider store={store}>
       <I18nextProvider i18n={i18n}>
-        <AppMountNotifier render={() => element} />
+        <GrowthBookProvider>
+          <AppMountNotifier render={() => element} />
+        </GrowthBookProvider>
       </I18nextProvider>
     </Provider>
   );

--- a/client/gatsby-ssr.js
+++ b/client/gatsby-ssr.js
@@ -7,13 +7,16 @@ import i18n from './i18n/config';
 import { createStore } from './src/redux/createStore';
 import layoutSelector from './utils/gatsby/layout-selector';
 import { getheadTagComponents, getPostBodyComponents } from './utils/tags';
+import GrowthBookProvider from './src/components/growth-book/growth-book-wrapper';
 
 const store = createStore();
 
 export const wrapRootElement = ({ element }) => {
   return (
     <Provider store={store}>
-      <I18nextProvider i18n={i18n}>{element}</I18nextProvider>
+      <I18nextProvider i18n={i18n}>
+        <GrowthBookProvider>{element}</GrowthBookProvider>
+      </I18nextProvider>
     </Provider>
   );
 };

--- a/client/package.json
+++ b/client/package.json
@@ -48,6 +48,7 @@
     "@freecodecamp/react-bootstrap": "0.32.3",
     "@freecodecamp/react-calendar-heatmap": "1.0.0",
     "@freecodecamp/strip-comments": "3.0.1",
+    "@growthbook/growthbook-react": "0.9.1",
     "@loadable/component": "5.15.2",
     "@reach/router": "1.3.4",
     "@sentry/gatsby": "6.19.7",

--- a/client/src/components/Intro/index.tsx
+++ b/client/src/components/Intro/index.tsx
@@ -6,6 +6,7 @@ import { Link, Spacer, Loader } from '../helpers';
 import IntroDescription from './components/IntroDescription';
 
 import './intro.css';
+import ResearchBannerx from './research-banner';
 
 interface IntroProps {
   complete?: boolean;
@@ -55,6 +56,7 @@ const Intro = ({
             </span>
           </blockquote>
         </div>
+        <ResearchBannerx />
         {completedChallengeCount && slug && completedChallengeCount < 15 ? (
           <div className='intro-description'>
             <Spacer />

--- a/client/src/components/Intro/research-banner.tsx
+++ b/client/src/components/Intro/research-banner.tsx
@@ -9,10 +9,11 @@ const ResearchBannerx = (): JSX.Element | null => {
       <p>
         <b>Launching Oct 19</b>: freeCodeCamp is teaming up with researchers
         from Stanford and UPenn to study how to help people build strong coding
-        habits.{' '}
+        habits.
       </p>
       <p style={{ marginBottom: 20, marginTop: 14 }}>
-        Would you like to get involved? You’ll get free coaching from experts.{' '}
+        Would you like to get involved? You’ll get free coaching from our
+        scientists.
       </p>
       <div style={{ display: 'flex', justifyContent: 'center' }}>
         <Button

--- a/client/src/components/Intro/research-banner.tsx
+++ b/client/src/components/Intro/research-banner.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Alert } from '@freecodecamp/react-bootstrap';
+import { Alert, Button } from '@freecodecamp/react-bootstrap';
 import { useFeature } from '@growthbook/growthbook-react';
 
 const ResearchBannerx = (): JSX.Element | null => {
@@ -7,20 +7,20 @@ const ResearchBannerx = (): JSX.Element | null => {
   return feature.on ? (
     <Alert>
       <p>
-        freeCodeCamp is collaborating with Stanford and the University of
-        Pennsylvania to study how people learn to code and build positive
+        <b>Launching Oct 19</b>: freeCodeCamp is teaming up with researchers
+        from Stanford and UPenn to study how to help people build strong coding
         habits.{' '}
       </p>
-      <p style={{ marginBottom: 10, marginTop: 10 }}>
+      <p style={{ marginBottom: 20, marginTop: 14 }}>
         Would you like to get involved? You’ll get free coaching from experts.{' '}
       </p>
-      <p>
-        You can{' '}
-        <a href={'https://wharton.qualtrics.com/jfe/form/SV_57rJfXROkQDDU2y'}>
-          learn more about HabitLab’s first beta cohort here
-        </a>
-        .
-      </p>
+      <div style={{ display: 'flex', justifyContent: 'center' }}>
+        <Button
+          href={'https://wharton.qualtrics.com/jfe/form/SV_57rJfXROkQDDU2y'}
+        >
+          Learn about HabitLab
+        </Button>
+      </div>
     </Alert>
   ) : null;
 };

--- a/client/src/components/Intro/research-banner.tsx
+++ b/client/src/components/Intro/research-banner.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Alert } from '@freecodecamp/react-bootstrap';
 import { useFeature } from '@growthbook/growthbook-react';
 
-const ResearchBannerx = (): JSX.Element | '' => {
+const ResearchBannerx = (): JSX.Element | null => {
   const feature = useFeature('show-research-recruitment-alert');
   return feature.on ? (
     <Alert>
@@ -22,9 +22,7 @@ const ResearchBannerx = (): JSX.Element | '' => {
         .
       </p>
     </Alert>
-  ) : (
-    ''
-  );
+  ) : null;
 };
 
 ResearchBannerx.displayName = 'ResearchBannerx';

--- a/client/src/components/Intro/research-banner.tsx
+++ b/client/src/components/Intro/research-banner.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Alert } from '@freecodecamp/react-bootstrap';
 import { useFeature } from '@growthbook/growthbook-react';
 
-const ResearchBannerx = (): JSX.Element | string => {
+const ResearchBannerx = (): JSX.Element | '' => {
   const feature = useFeature('show-research-recruitment-alert');
   return feature.on ? (
     <Alert>

--- a/client/src/components/Intro/research-banner.tsx
+++ b/client/src/components/Intro/research-banner.tsx
@@ -2,9 +2,29 @@ import React from 'react';
 import { Alert } from '@freecodecamp/react-bootstrap';
 import { useFeature } from '@growthbook/growthbook-react';
 
-const ResearchBannerx = (): JSX.Element => {
-  const feature = useFeature('show-h1');
-  return feature.on ? <Alert>hello</Alert> : <Alert>Mello</Alert>;
+const ResearchBannerx = (): JSX.Element | string => {
+  const feature = useFeature('show-research-recruitment-alert');
+  return feature.on ? (
+    <Alert>
+      <p>
+        freeCodeCamp is collaborating with Stanford and the University of
+        Pennsylvania to study how people learn to code and build positive
+        habits.{' '}
+      </p>
+      <p style={{ marginBottom: 10, marginTop: 10 }}>
+        Would you like to get involved? You’ll get free coaching from experts.{' '}
+      </p>
+      <p>
+        You can{' '}
+        <a href={'https://wharton.qualtrics.com/jfe/form/SV_57rJfXROkQDDU2y'}>
+          learn more about HabitLab’s first beta cohort here
+        </a>
+        .
+      </p>
+    </Alert>
+  ) : (
+    ''
+  );
 };
 
 ResearchBannerx.displayName = 'ResearchBannerx';

--- a/client/src/components/Intro/research-banner.tsx
+++ b/client/src/components/Intro/research-banner.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Alert } from '@freecodecamp/react-bootstrap';
+import { useFeature } from '@growthbook/growthbook-react';
+
+const ResearchBannerx = (): JSX.Element => {
+  const feature = useFeature('show-h1');
+  return feature.on ? <Alert>hello</Alert> : <Alert>Mello</Alert>;
+};
+
+ResearchBannerx.displayName = 'ResearchBannerx';
+
+export default ResearchBannerx;

--- a/client/src/components/growth-book/growth-book-wrapper.tsx
+++ b/client/src/components/growth-book/growth-book-wrapper.tsx
@@ -1,0 +1,70 @@
+import React, { ReactNode, useEffect } from 'react';
+import { GrowthBook, GrowthBookProvider } from '@growthbook/growthbook-react';
+
+const growthbook = new GrowthBook({
+  trackingCallback: (experiment, result) => {
+    console.log({
+      experimentId: experiment.key,
+      variationId: result.variationId
+    });
+  }
+});
+
+import { connect } from 'react-redux';
+
+import { createSelector } from 'reselect';
+
+import { isSignedInSelector } from '../../redux/selectors';
+
+const mapStateToProps = createSelector(isSignedInSelector, isSignedIn => ({
+  isSignedIn
+}));
+
+type StateProps = ReturnType<typeof mapStateToProps>;
+
+interface GrowthBookWrapper extends StateProps {
+  children: ReactNode;
+}
+
+// interface GrowthBookResponse {
+//   status: number;
+//   features: object;
+//   dateUpdated: string;
+// }
+
+const GrowthBookWrapper = ({ children, isSignedIn }: GrowthBookWrapper) => {
+  useEffect(() => {
+    // Load feature definitions from API
+    // In production, we recommend putting a CDN in front of the API endpoint
+    void fetch(
+      'https://api.gb.freecodecamp.org/api/features/key_prod_740cf9417e8af5aa'
+    )
+      .then(res => res.json())
+      .then(json => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+        growthbook.setFeatures(json.features);
+      });
+
+    // TODO: replace with real targeting attributes
+    growthbook.setAttributes({
+      id: 'foo',
+      deviceId: 'foo',
+      company: 'foo',
+      signedin: true,
+      employee: true,
+      country: 'foo',
+      browser: 'foo',
+      url: 'foo',
+      local: 'foo',
+      startdate: 123,
+      challengeCompleted: 123
+    });
+  }, []);
+  console.log(isSignedIn);
+
+  return (
+    <GrowthBookProvider growthbook={growthbook}>{children}</GrowthBookProvider>
+  );
+};
+
+export default connect(mapStateToProps)(GrowthBookWrapper);

--- a/client/src/components/growth-book/growth-book-wrapper.tsx
+++ b/client/src/components/growth-book/growth-book-wrapper.tsx
@@ -11,7 +11,10 @@ import { isSignedInSelector, userSelector } from '../../redux/selectors';
 import envData from '../../../../config/env.json';
 import { User } from '../../redux/prop-types';
 
-const { clientLocale, growthbookUri } = envData;
+const { clientLocale, growthbookUri } = envData as {
+  clientLocale: string;
+  growthbookUri: string | null;
+};
 
 const growthbook = new GrowthBook();
 
@@ -27,8 +30,6 @@ const mapStateToProps = createSelector(
 type StateProps = ReturnType<typeof mapStateToProps>;
 interface GrowthBookWrapper extends StateProps {
   children: ReactNode;
-  user: User;
-  isSignedIn: boolean;
 }
 
 const GrowthBookWrapper = ({

--- a/client/src/components/growth-book/growth-book-wrapper.tsx
+++ b/client/src/components/growth-book/growth-book-wrapper.tsx
@@ -1,18 +1,13 @@
-/* eslint-disable @typescript-eslint/no-unsafe-argument */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-
 import React, { ReactNode, useEffect } from 'react';
 import sha1 from 'sha-1';
-import { GrowthBook, GrowthBookProvider } from '@growthbook/growthbook-react';
-
+import {
+  FeatureDefinition,
+  GrowthBook,
+  GrowthBookProvider
+} from '@growthbook/growthbook-react';
 import { connect } from 'react-redux';
-
 import { createSelector } from 'reselect';
-
 import { isSignedInSelector, userSelector } from '../../redux/selectors';
-
 import envData from '../../../../config/env.json';
 import {
   prodGrowthbookKey,
@@ -20,20 +15,14 @@ import {
 } from '../../../../config/growthbook-settings';
 import { User } from '../../redux/prop-types';
 
-const {
-  deploymentEnv,
-  clientLocale
-}: { deploymentEnv: 'staging' | 'live'; clientLocale: string } = envData as {
-  deploymentEnv: 'staging' | 'live';
-  clientLocale: string;
-};
+const { deploymentEnv, clientLocale } = envData;
 
 const growthbook = new GrowthBook();
 
 const mapStateToProps = createSelector(
   isSignedInSelector,
   userSelector,
-  (isSignedIn, user) => ({
+  (isSignedIn, user: User) => ({
     isSignedIn,
     user
   })
@@ -59,11 +48,14 @@ const GrowthBookWrapper = ({
 
       const apiEndPoint = `https://api.gb.freecodecamp.org/api/features/${growthBookKey}`;
 
-      void fetch(apiEndPoint)
-        .then(res => res.json())
-        .then(json => {
-          growthbook.setFeatures(json.features);
-        });
+      void (async () => {
+        const res = await fetch(apiEndPoint);
+        const data = (await res.json()) as {
+          features: Record<string, FeatureDefinition>;
+        };
+        growthbook.setFeatures(data.features);
+      })();
+
       growthbook.setAttributes({
         id: sha1(user.email),
         staff: true,

--- a/client/src/components/growth-book/growth-book-wrapper.tsx
+++ b/client/src/components/growth-book/growth-book-wrapper.tsx
@@ -31,25 +31,24 @@ interface GrowthBookWrapper extends StateProps {
   isSignedIn: boolean;
 }
 
-void (async () => {
-  const res = await fetch(growthbookUri);
-  const data = (await res.json()) as {
-    features: Record<string, FeatureDefinition>;
-  };
-  growthbook.setFeatures(data.features);
-})();
-
 const GrowthBookWrapper = ({
   children,
   isSignedIn,
   user
 }: GrowthBookWrapper) => {
+  void (async () => {
+    const res = await fetch(growthbookUri);
+    const data = (await res.json()) as {
+      features: Record<string, FeatureDefinition>;
+    };
+    growthbook.setFeatures(data.features);
+  })();
   useEffect(() => {
     if (isSignedIn) {
       const { joinDate, completedChallenges } = user;
       growthbook.setAttributes({
         id: sha1(user.email),
-        staff: true,
+        staff: user.email.includes('@freecodecamp'),
         clientLocal: clientLocale,
         joinDateUnix: Date.parse(joinDate),
         completedChallengesLength: completedChallenges.length

--- a/client/src/components/growth-book/growth-book-wrapper.tsx
+++ b/client/src/components/growth-book/growth-book-wrapper.tsx
@@ -36,13 +36,15 @@ const GrowthBookWrapper = ({
   isSignedIn,
   user
 }: GrowthBookWrapper) => {
-  void (async () => {
-    const res = await fetch(growthbookUri);
-    const data = (await res.json()) as {
-      features: Record<string, FeatureDefinition>;
-    };
-    growthbook.setFeatures(data.features);
-  })();
+  if (growthbookUri) {
+    void (async () => {
+      const res = await fetch(growthbookUri);
+      const data = (await res.json()) as {
+        features: Record<string, FeatureDefinition>;
+      };
+      growthbook.setFeatures(data.features);
+    })();
+  }
   useEffect(() => {
     if (isSignedIn) {
       const { joinDate, completedChallenges } = user;

--- a/client/src/components/growth-book/growth-book-wrapper.tsx
+++ b/client/src/components/growth-book/growth-book-wrapper.tsx
@@ -14,18 +14,17 @@ import { createSelector } from 'reselect';
 import { isSignedInSelector, userSelector } from '../../redux/selectors';
 
 import envData from '../../../../config/env.json';
-import {
-  prodGrowthbookKey,
-  devGrowthbookKey
-} from '../../../../config/growthbook-settings';
 import { User } from '../../redux/prop-types';
 
 const {
-  deploymentEnv,
-  clientLocale
-}: { deploymentEnv: 'staging' | 'live'; clientLocale: string } = envData as {
-  deploymentEnv: 'staging' | 'live';
+  clientLocale,
+  growthbookUri
+}: {
   clientLocale: string;
+  growthbookUri: string;
+} = envData as {
+  clientLocale: string;
+  growthbookUri: string;
 };
 
 const growthbook = new GrowthBook();
@@ -51,19 +50,16 @@ const GrowthBookWrapper = ({
   isSignedIn,
   user
 }: GrowthBookWrapper) => {
+  void fetch(growthbookUri)
+    .then(res => res.json())
+    .then(json => {
+      growthbook.setFeatures(json.features);
+    });
+
   useEffect(() => {
     if (isSignedIn) {
       const { joinDate, completedChallenges } = user;
-      const growthBookKey =
-        deploymentEnv === 'staging' ? devGrowthbookKey : prodGrowthbookKey;
 
-      const apiEndPoint = `https://api.gb.freecodecamp.org/api/features/${growthBookKey}`;
-
-      void fetch(apiEndPoint)
-        .then(res => res.json())
-        .then(json => {
-          growthbook.setFeatures(json.features);
-        });
       growthbook.setAttributes({
         id: sha1(user.email),
         staff: true,

--- a/config/growthbook-settings.js
+++ b/config/growthbook-settings.js
@@ -1,0 +1,2 @@
+exports.prodGrowthbookKey = 'key_prod_740cf9417e8af5aa';
+exports.devGrowthbookKey = 'key_deve_0e0abaa3a8cd17b5';

--- a/config/growthbook-settings.js
+++ b/config/growthbook-settings.js
@@ -1,2 +1,0 @@
-exports.prodGrowthbookKey = 'key_prod_740cf9417e8af5aa';
-exports.devGrowthbookKey = 'key_deve_0e0abaa3a8cd17b5';

--- a/config/read-env.js
+++ b/config/read-env.js
@@ -33,7 +33,8 @@ const {
   DEPLOYMENT_ENV: deploymentEnv,
   SENTRY_CLIENT_DSN: sentryClientDSN,
   SHOW_UPCOMING_CHANGES: showUpcomingChanges,
-  SHOW_NEW_CURRICULUM: showNewCurriculum
+  SHOW_NEW_CURRICULUM: showNewCurriculum,
+  GROWTHBOOK_URI: growthbookUri
 } = process.env;
 
 const locations = {
@@ -77,5 +78,9 @@ module.exports = Object.assign(locations, {
       ? null
       : sentryClientDSN,
   showUpcomingChanges: showUpcomingChanges === 'true',
-  showNewCurriculum: showNewCurriculum === 'true'
+  showNewCurriculum: showNewCurriculum === 'true',
+  growthbookUri:
+    !growthbookUri || growthbookUri === 'api_URI_from_Growthbook_dashboard'
+      ? null
+      : growthbookUri
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -443,6 +443,7 @@
         "@freecodecamp/react-bootstrap": "0.32.3",
         "@freecodecamp/react-calendar-heatmap": "1.0.0",
         "@freecodecamp/strip-comments": "3.0.1",
+        "@growthbook/growthbook-react": "0.9.1",
         "@loadable/component": "5.15.2",
         "@reach/router": "1.3.4",
         "@sentry/gatsby": "6.19.7",
@@ -3797,6 +3798,28 @@
     "node_modules/@graphql-tools/wrap/node_modules/tslib": {
       "version": "2.2.0",
       "license": "0BSD"
+    },
+    "node_modules/@growthbook/growthbook": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@growthbook/growthbook/-/growthbook-0.18.1.tgz",
+      "integrity": "sha512-hNNh515lleAUzTch+ezYYVHBteYTIAF1Xxh6+dLJk+BjbhPXUo6X9qNcryIN1b/IMLVnO1ZfE5zbAzVGEQai2w==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@growthbook/growthbook-react": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@growthbook/growthbook-react/-/growthbook-react-0.9.1.tgz",
+      "integrity": "sha512-b4yaMkcIeYQ+j5wND+wsGHbeV33QJoG6vQc4r/7qTDKmq3QhAyMNuLvfy/bYQ/nWnh5TmZArzQ6IRUGTWKfOGg==",
+      "dependencies": {
+        "@growthbook/growthbook": "^0.18.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0-0 || ^17.0.0-0 || ^18.0.0-0"
+      }
     },
     "node_modules/@hapi/address": {
       "version": "2.1.4",
@@ -56887,6 +56910,7 @@
         "@freecodecamp/react-bootstrap": "0.32.3",
         "@freecodecamp/react-calendar-heatmap": "1.0.0",
         "@freecodecamp/strip-comments": "3.0.1",
+        "@growthbook/growthbook-react": "*",
         "@loadable/component": "5.15.2",
         "@reach/router": "1.3.4",
         "@sentry/gatsby": "6.19.7",
@@ -57491,6 +57515,19 @@
         "tslib": {
           "version": "2.2.0"
         }
+      }
+    },
+    "@growthbook/growthbook": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@growthbook/growthbook/-/growthbook-0.18.1.tgz",
+      "integrity": "sha512-hNNh515lleAUzTch+ezYYVHBteYTIAF1Xxh6+dLJk+BjbhPXUo6X9qNcryIN1b/IMLVnO1ZfE5zbAzVGEQai2w=="
+    },
+    "@growthbook/growthbook-react": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@growthbook/growthbook-react/-/growthbook-react-0.9.1.tgz",
+      "integrity": "sha512-b4yaMkcIeYQ+j5wND+wsGHbeV33QJoG6vQc4r/7qTDKmq3QhAyMNuLvfy/bYQ/nWnh5TmZArzQ6IRUGTWKfOGg==",
+      "requires": {
+        "@growthbook/growthbook": "^0.18.1"
       }
     },
     "@hapi/address": {

--- a/sample.env
+++ b/sample.env
@@ -78,3 +78,6 @@ CODESEE=false
 
 # Webhook proxy url from smee.io for PayPal
 WEBHOOK_PROXY_URL=
+
+# Analytics
+GROWTHBOOK_URI=api_URI_from_Growthbook_dashboard

--- a/tools/scripts/build/ensure-env.ts
+++ b/tools/scripts/build/ensure-env.ts
@@ -52,12 +52,14 @@ if (FREECODECAMP_NODE_ENV !== 'development') {
   const searchKeys = ['algoliaAppId', 'algoliaAPIKey'];
   const donationKeys = ['stripePublicKey', 'paypalClientId', 'patreonClientId'];
   const loggingKeys = ['sentryClientDSN'];
+  const abTestingKeys = ['growthbookUri'];
 
   const expectedVariables = locationKeys.concat(
     deploymentKeys,
     searchKeys,
     donationKeys,
-    loggingKeys
+    loggingKeys,
+    abTestingKeys
   );
   const actualVariables = Object.keys(env as Record<string, unknown>);
   if (expectedVariables.length !== actualVariables.length) {


### PR DESCRIPTION
This pr adds the Growthbook CLI to our client.
It basically pulls the feature rules and decides if it should show a feature or not based on the provided attributes.

You should see an alert component if you have signed in with a  freecodecamp email locally. (or just change the user's email from the db locally) or simply set `staff: user.email.includes('@freecodecamp')` to true.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
