### PR TITLE
chore(client): remove exports for unused types

### DIFF
--- a/client/src/components/Header/components/Login.tsx
+++ b/client/src/components/Header/components/Login.tsx
@@ -15,7 +15,7 @@ const mapStateToProps = createSelector(isSignedInSelector, isSignedIn => ({
   isSignedIn
 }));
 
-export interface LoginProps {
+interface LoginProps {
   block?: boolean;
   children?: ReactNode;
   'data-test-label'?: string;

--- a/client/src/components/Header/components/auth-or-profile.tsx
+++ b/client/src/components/Header/components/auth-or-profile.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { Link, AvatarRenderer } from '../../helpers';
 import Login from './Login';
 
-export interface AuthOrProfileProps {
+interface AuthOrProfileProps {
   user?: Record<string, unknown>;
 }
 const AuthOrProfile = ({ user }: AuthOrProfileProps): JSX.Element => {

--- a/client/src/components/Header/components/menu-button.tsx
+++ b/client/src/components/Header/components/menu-button.tsx
@@ -2,7 +2,7 @@ import React, { RefObject } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBars } from '@fortawesome/free-solid-svg-icons';
-export interface MenuButtonProps {
+interface MenuButtonProps {
   className?: string;
   displayMenu?: boolean;
   innerRef?: RefObject<HTMLButtonElement>;

--- a/client/src/components/Header/components/nav-links.tsx
+++ b/client/src/components/Header/components/nav-links.tsx
@@ -42,7 +42,7 @@ interface NavlinkStates {
   arg: Record<string, unknown>;
 }
 
-export interface NavLinksProps {
+interface NavLinksProps {
   displayMenu: boolean;
   isLanguageMenuDisplayed: boolean;
   fetchState: { pending: boolean };

--- a/client/src/components/Header/components/universal-nav.tsx
+++ b/client/src/components/Header/components/universal-nav.tsx
@@ -22,7 +22,7 @@ const SearchBarOptimized = Loadable(
 
 const MAX_MOBILE_WIDTH = 980;
 
-export interface UniversalNavProps {
+interface UniversalNavProps {
   displayMenu?: boolean;
   isLanguageMenuDisplayed?: boolean;
   fetchState?: { pending: boolean };

--- a/client/src/components/Header/index.tsx
+++ b/client/src/components/Header/index.tsx
@@ -9,7 +9,7 @@ import UniversalNav from './components/universal-nav';
 
 import './header.css';
 
-export interface HeaderProps {
+interface HeaderProps {
   fetchState: { pending: boolean };
   user: Record<string, any>;
 }

--- a/client/src/components/formHelpers/form-validators.tsx
+++ b/client/src/components/formHelpers/form-validators.tsx
@@ -23,7 +23,7 @@ export const localhostValidator = (value: string): React.ReactElement | null =>
 export const httpValidator = (value: string): React.ReactElement | null =>
   httpRegex.test(value) ? <Trans>validation.http-url</Trans> : null;
 
-export type Validator = (value: string) => React.ReactElement | null;
+type Validator = (value: string) => React.ReactElement | null;
 export function composeValidators(...validators: (Validator | null)[]) {
   return (value: string): ReturnType<Validator> | null =>
     validators.reduce(

--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -215,14 +215,6 @@ export type AllChallengeNode = {
   ];
 };
 
-type AllMarkdownRemark = {
-  edges: [
-    {
-      node: MarkdownRemark;
-    }
-  ];
-};
-
 export type ResizeProps = {
   onStopResize: (arg0: HandlerProps) => void;
   onResize: () => void;

--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -119,7 +119,7 @@ export type MarkdownRemark = {
 
 type Question = { text: string; answers: string[]; solution: number };
 type Fields = { slug: string; blockName: string; tests: Test[] };
-export type Required = {
+type Required = {
   link: string;
   raw: boolean;
   src: string;
@@ -215,7 +215,7 @@ export type AllChallengeNode = {
   ];
 };
 
-export type AllMarkdownRemark = {
+type AllMarkdownRemark = {
   edges: [
     {
       node: MarkdownRemark;
@@ -243,7 +243,7 @@ export type ChallengeTest = {
   testString: string;
 };
 
-export type CertTest = {
+type CertTest = {
   id: string;
   title: string;
 };
@@ -295,7 +295,7 @@ export type ProfileUI = {
   showTimeLine: boolean;
 };
 
-export type ClaimedCertifications = {
+type ClaimedCertifications = {
   is2018DataVisCert: boolean;
   isApisMicroservicesCert: boolean;
   isBackEndCert: boolean;
@@ -315,7 +315,7 @@ export type ClaimedCertifications = {
   isMachineLearningPyCertV7: boolean;
 };
 
-export type SavedChallenges = SavedChallenge[];
+type SavedChallenges = SavedChallenge[];
 
 export type SavedChallenge = {
   id: string;
@@ -367,7 +367,7 @@ export type Portfolio = {
   description?: string;
 };
 
-export type FileKeyChallenge = {
+type FileKeyChallenge = {
   contents: string;
   ext: Ext;
   head: string;

--- a/client/src/redux/types.ts
+++ b/client/src/redux/types.ts
@@ -35,14 +35,14 @@ export interface FlashState {
   message: { id: string } & FlashMessageArg;
 }
 
-export interface DefaultFetchState {
+interface DefaultFetchState {
   pending: boolean;
   complete: boolean;
   errored: boolean;
   error: null | string;
 }
 
-export interface DefaultDonationFormState {
+interface DefaultDonationFormState {
   redirecting: boolean;
   processing: boolean;
   success: boolean;


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

Addresses one of the tasks in #47971. This PR removes the exports for types that are not used outside of the file they are declared in, along with any types that aren't used in the file they're declared in

The following types listed in #47971 have not been removed as they are used in the test suite:
- `HandledError` in `client/src/utils/handled-error.ts`
- `FormProps` in `client/src/components/formHelpers/form.tsx`