### PR TITLE
feat(api): remove unused eslint errors in the codebase

### DIFF
--- a/api-server/src/server/boot_tests/challenge.test.js
+++ b/api-server/src/server/boot_tests/challenge.test.js
@@ -51,7 +51,6 @@ describe('boot/challenge', () => {
       expect(result).toHaveProperty('updateData.$push.completedChallenges');
     });
 
-    // eslint-disable-next-line max-len
     it('preserves file contents if the completed challenge is a JS Project', () => {
       const jsChallengeId = 'aa2e6f85cab2ab736c9a9b24';
       const completedChallenge = {
@@ -96,7 +95,6 @@ describe('boot/challenge', () => {
       );
     });
 
-    // eslint-disable-next-line max-len
     it('does not attempt to update progressTimestamps for a previously completed challenge', () => {
       const completedChallengeId = 'aaa48de84e1ecc7c742e1124';
       const completedChallenge = {
@@ -116,7 +114,6 @@ describe('boot/challenge', () => {
       expect(hasProgressTimestamps).toBe(false);
     });
 
-    // eslint-disable-next-line max-len
     it('provides a progressTimestamps update for new challenge completion', () => {
       expect.assertions(2);
       const { updateData } = buildUserUpdate(
@@ -167,7 +164,6 @@ describe('boot/challenge', () => {
       });
     }, 10000);
 
-    // eslint-disable-next-line max-len
     it('returns the first challenge url if the provided id does not relate to a challenge', async () => {
       const challengeUrlResolver = await createChallengeUrlResolver(
         mockAllChallenges,
@@ -332,7 +328,6 @@ describe('boot/challenge', () => {
       expect(res.redirect).toHaveBeenCalledWith(mockLearnUrl);
     });
 
-    // eslint-disable-next-line max-len
     it('redirects to the url provided by the challengeUrlResolver', async () => {
       const challengeUrlResolver = await createChallengeUrlResolver(
         mockAllChallenges,
@@ -356,7 +351,6 @@ describe('boot/challenge', () => {
       expect(res.redirect).toHaveBeenCalledWith(expectedUrl);
     });
 
-    // eslint-disable-next-line max-len
     it('redirects to the first challenge for users without a currentChallengeId', async () => {
       const challengeUrlResolver = await createChallengeUrlResolver(
         mockAllChallenges,

--- a/api-server/src/server/boot_tests/fixtures.js
+++ b/api-server/src/server/boot_tests/fixtures.js
@@ -58,7 +58,6 @@ export const mockCompletedChallenges = [
     files: [
       {
         contents:
-          // eslint-disable-next-line max-len
           "function palindrome(str) {\n  const clean = str.replace(/[\\W_]/g, '').toLowerCase()\n  const revStr = clean.split('').reverse().join('');\n  return clean === revStr;\n}\n\n\n\npalindrome(\"eye\");\n",
         ext: 'js',
         path: 'index.js',

--- a/api-server/src/server/index.js
+++ b/api-server/src/server/index.js
@@ -87,7 +87,6 @@ app.start = _.once(function () {
       log('DB connection closed');
       // exit process
       // this may close kept alive sockets
-      // eslint-disable-next-line no-process-exit
       process.exit(0);
     });
   });

--- a/api-server/src/server/middlewares/csurf.js
+++ b/api-server/src/server/middlewares/csurf.js
@@ -13,7 +13,6 @@ export default function getCsurf() {
   return function csrf(req, res, next) {
     const { path } = req;
     if (
-      // eslint-disable-next-line max-len
       /^\/hooks\/update-paypal$|^\/donate\/charge-stripe$|^\/coderoad-challenge-completed$/.test(
         path
       )

--- a/api-server/src/server/middlewares/request-authorization.test.js
+++ b/api-server/src/server/middlewares/request-authorization.test.js
@@ -120,7 +120,6 @@ describe('request-authorization', () => {
         const invalidJWT = jwt.sign({ accessToken }, invalidJWTSecret);
         const req = mockReq({
           path: '/some-path/that-needs/auth',
-          // eslint-disable-next-line camelcase
           cookie: { jwt_access_token: invalidJWT }
         });
         const res = mockRes();
@@ -140,7 +139,6 @@ describe('request-authorization', () => {
         );
         const req = mockReq({
           path: '/some-path/that-needs/auth',
-          // eslint-disable-next-line camelcase
           cookie: { jwt_access_token: invalidJWT }
         });
         const res = mockRes();
@@ -157,7 +155,6 @@ describe('request-authorization', () => {
         const validJWT = jwt.sign({ accessToken }, validJWTSecret);
         const req = mockReq({
           path: '/some-path/that-needs/auth',
-          // eslint-disable-next-line camelcase
           cookie: { jwt_access_token: validJWT }
         });
         const res = mockRes();

--- a/api-server/src/server/rss/lybsyn.js
+++ b/api-server/src/server/rss/lybsyn.js
@@ -31,7 +31,6 @@ export function getLybsynFeed() {
               'item_body_short'
             ])
           )
-          /* eslint-disable camelcase */
           .map(
             ({ full_item_url, item_title, release_date, item_body_short }) => ({
               title: item_title,

--- a/api-server/src/server/utils/__mocks__/donation.js
+++ b/api-server/src/server/utils/__mocks__/donation.js
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 export const mockCancellationHook = {
   headers: {
     host: 'a47fb0f4.ngrok.io',

--- a/api-server/src/server/utils/donation.js
+++ b/api-server/src/server/utils/donation.js
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import axios from 'axios';
 import debug from 'debug';
 import isEmail from 'validator/lib/isEmail';

--- a/api-server/src/server/utils/donation.test.js
+++ b/api-server/src/server/utils/donation.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import axios from 'axios';
 import keys from '../../../../config/secrets';
 import {

--- a/api-server/src/server/utils/get-curriculum.js
+++ b/api-server/src/server/utils/get-curriculum.js
@@ -6,7 +6,6 @@ import { flatten } from 'lodash';
 // via the user object, then we should *not* store this so it can be garbage
 // collected.
 
-// eslint-disable-next-line import/no-unresolved
 import curriculum from '../../../../config/curriculum.json';
 
 export function getChallenges() {

--- a/api-server/src/server/utils/getSetAccessToken.test.js
+++ b/api-server/src/server/utils/getSetAccessToken.test.js
@@ -30,7 +30,6 @@ describe('getSetAccessToken', () => {
     describe('cookies', () => {
       it('returns `invalid token` error for malformed tokens', () => {
         const invalidJWT = jwt.sign({ accessToken }, invalidJWTSecret);
-        // eslint-disable-next-line camelcase
         const req = mockReq({ cookie: { jwt_access_token: invalidJWT } });
         const result = getAccessTokenFromRequest(req, validJWTSecret);
 
@@ -42,7 +41,6 @@ describe('getSetAccessToken', () => {
           { accessToken: { ...accessToken, created: theBeginningOfTime } },
           validJWTSecret
         );
-        // eslint-disable-next-line camelcase
         const req = mockReq({ cookie: { jwt_access_token: invalidJWT } });
         const result = getAccessTokenFromRequest(req, validJWTSecret);
 
@@ -52,7 +50,6 @@ describe('getSetAccessToken', () => {
       it('returns a valid access token with no errors ', () => {
         expect.assertions(2);
         const validJWT = jwt.sign({ accessToken }, validJWTSecret);
-        // eslint-disable-next-line camelcase
         const req = mockReq({ cookie: { jwt_access_token: validJWT } });
         const result = getAccessTokenFromRequest(req, validJWTSecret);
 
@@ -88,7 +85,6 @@ describe('getSetAccessToken', () => {
   });
 
   describe('removeCookies', () => {
-    // eslint-disable-next-line max-len
     it('removes four cookies set in the lifetime of an authenticated session', () => {
       // expect.assertions(4);
       const req = mockReq();

--- a/client/src/__mocks__/gatsby.ts
+++ b/client/src/__mocks__/gatsby.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 import React from 'react';
 import { GatsbyLinkProps } from 'gatsby';
 const gatsby: NodeModule = jest.requireActual('gatsby');

--- a/client/src/client-only-routes/show-project-links.tsx
+++ b/client/src/client-only-routes/show-project-links.tsx
@@ -144,7 +144,6 @@ const ShowProjectLinks = (props: ShowProjectLinksProps): JSX.Element => {
   const challengeData: CompletedChallenge | null = completedChallenge
     ? {
         ...completedChallenge,
-        // // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         challengeFiles:
           completedChallenge?.challengeFiles?.map(regeneratePathAndHistory) ??
           null

--- a/client/src/client/workers/test-evaluator.ts
+++ b/client/src/client/workers/test-evaluator.ts
@@ -98,7 +98,6 @@ ctx.onmessage = async (e: TestEvaluatorEvent) => {
     // This can be reassigned by the eval inside the try block, so it should be declared as a let
     // eslint-disable-next-line prefer-const
     let __userCodeWasExecuted = false;
-    /* eslint-disable no-eval */
     try {
       // Logging is proxyed after the build to catch console.log messages
       // generated during testing.

--- a/client/src/components/Donation/paypal-button-script-loader.tsx
+++ b/client/src/components/Donation/paypal-button-script-loader.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 
@@ -114,7 +113,6 @@ export class PayPalButtonScriptLoader extends Component<
       prevProps.style.height !== this.props.style.height ||
       prevProps.isMinimalForm !== this.props.isMinimalForm
     ) {
-      // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ isSdkLoaded: false });
       this.loadScript(this.state.isSubscription, true);
     }

--- a/client/src/components/Header/components/universal-nav.tsx
+++ b/client/src/components/Header/components/universal-nav.tsx
@@ -1,7 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-/* eslint-disable react/prop-types */
 // @ts-nocheck
 import Loadable from '@loadable/component';
 import React, { Ref } from 'react';

--- a/client/src/components/Header/header.test.tsx
+++ b/client/src/components/Header/header.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 

--- a/client/src/components/create-redirect.ts
+++ b/client/src/components/create-redirect.ts
@@ -1,4 +1,3 @@
-/* eslint-disable react/display-name */
 import { navigate } from 'gatsby';
 
 const createRedirect =

--- a/client/src/components/helpers/image-loader.tsx
+++ b/client/src/components/helpers/image-loader.tsx
@@ -37,7 +37,6 @@ const ImageLoader = ({
       offsetVertical={offsetVertical}
       width={width}
     >
-      {/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */}
       <img
         alt={alt}
         className={fullClassName}

--- a/client/src/components/profile/profile.tsx
+++ b/client/src/components/profile/profile.tsx
@@ -61,7 +61,6 @@ function renderProfile(user: ProfileProps['user']): JSX.Element {
       showPortfolio = false,
       showTimeLine = false
     },
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     calendar,
     completedChallenges,
     githubProfile,
@@ -96,7 +95,6 @@ function renderProfile(user: ProfileProps['user']): JSX.Element {
         website={website}
         yearsTopContributor={yearsTopContributor}
       />
-      {/* eslint-disable-next-line @typescript-eslint/no-unsafe-assignment */}
       {showHeatMap ? <HeatMap calendar={calendar} /> : null}
       {showCerts ? <Certifications username={username} /> : null}
       {showPortfolio ? <Portfolio portfolio={portfolio} /> : null}

--- a/client/src/components/settings/about.tsx
+++ b/client/src/components/settings/about.tsx
@@ -78,7 +78,6 @@ class AboutSettings extends Component<AboutProps, AboutState> {
       picture === formValues.picture &&
       about === formValues.about
     ) {
-      // eslint-disable-next-line react/no-did-update-set-state
       return this.setState({
         originalValues: {
           name,

--- a/client/src/components/settings/internet.tsx
+++ b/client/src/components/settings/internet.tsx
@@ -66,7 +66,6 @@ class InternetSettings extends Component<InternetProps, InternetState> {
       twitter !== originalValues.twitter ||
       website !== originalValues.website
     ) {
-      // eslint-disable-next-line react/no-did-update-set-state
       return this.setState({
         originalValues: { githubProfile, linkedin, twitter, website }
       });

--- a/client/src/components/settings/user-token.tsx
+++ b/client/src/components/settings/user-token.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { Button, Panel } from '@freecodecamp/react-bootstrap';
 import React, { Component } from 'react';
 import { TFunction, withTranslation } from 'react-i18next';

--- a/client/src/components/settings/username.tsx
+++ b/client/src/components/settings/username.tsx
@@ -96,7 +96,6 @@ class UsernameSettings extends Component<UsernameProps, UsernameState> {
     const { username } = this.props;
     const { formValue } = this.state;
     if (prevUsername !== username && prevFormValue === formValue) {
-      // eslint-disable-next-line react/no-did-update-set-state
       return this.setState({
         isFormPristine: username === formValue,
         submitClicked: false,

--- a/client/src/pages/404.tsx
+++ b/client/src/pages/404.tsx
@@ -2,10 +2,8 @@ import { Router } from '@reach/router';
 import { withPrefix } from 'gatsby';
 import React from 'react';
 
-/* eslint-disable max-len */
 import ShowProfileOrFourOhFour from '../client-only-routes/show-profile-or-four-oh-four';
 import FourOhFour from '../components/FourOhFour';
-/* eslint-enable max-len */
 
 function FourOhFourPage(): JSX.Element {
   return (

--- a/client/src/redux/ga-saga.js
+++ b/client/src/redux/ga-saga.js
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import { all, call, select, takeEvery } from 'redux-saga/effects';
 
 import { aBTestConfig } from '../../../config/donation-settings';

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -70,7 +70,6 @@ import LowerJaw from './lower-jaw';
 
 import './editor.css';
 
-// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
 const MonacoEditor = Loadable(() => import('react-monaco-editor'));
 
 interface EditorProps {

--- a/client/src/templates/Challenges/codeally/show.tsx
+++ b/client/src/templates/Challenges/codeally/show.tsx
@@ -240,7 +240,6 @@ class ShowCodeAlly extends Component<ShowCodeAllyProps> {
           className='codeally-frame'
           data-cy='codeally-frame'
           name={`codeAlly${Date.now()}`}
-          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
           sandbox='allow-modals allow-forms allow-popups allow-scripts allow-same-origin'
           src={`https://codeally.io/embed/?repoUrl=${url}&${goBackTo}&${envVariables}&${tempToken}&${date}`}
           title='Editor'

--- a/client/src/templates/Challenges/projects/backend/Show.tsx
+++ b/client/src/templates/Challenges/projects/backend/Show.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 

--- a/client/src/templates/Challenges/rechallenge/transformers.js
+++ b/client/src/templates/Challenges/rechallenge/transformers.js
@@ -46,11 +46,9 @@ let presetsJS, presetsJSX;
 
 async function loadBabel() {
   if (Babel) return;
-  /* eslint-disable no-inline-comments */
   Babel = await import(
     /* webpackChunkName: "@babel/standalone" */ '@babel/standalone'
   );
-  /* eslint-enable no-inline-comments */
   Babel.registerPlugin(
     'loopProtection',
     protect(protectTimeout, loopProtectCB)
@@ -62,12 +60,10 @@ async function loadBabel() {
 }
 
 async function loadPresetEnv() {
-  /* eslint-disable no-inline-comments */
   if (!presetEnv)
     presetEnv = await import(
       /* webpackChunkName: "@babel/preset-env" */ '@babel/preset-env'
     );
-  /* eslint-enable no-inline-comments */
 
   presetsJS = {
     presets: [presetEnv]
@@ -75,7 +71,6 @@ async function loadPresetEnv() {
 }
 
 async function loadPresetReact() {
-  /* eslint-disable no-inline-comments */
   if (!presetReact)
     presetReact = await import(
       /* webpackChunkName: "@babel/preset-react" */ '@babel/preset-react'
@@ -84,7 +79,6 @@ async function loadPresetReact() {
     presetEnv = await import(
       /* webpackChunkName: "@babel/preset-env" */ '@babel/preset-env'
     );
-  /* eslint-enable no-inline-comments */
   presetsJSX = {
     presets: [presetEnv, presetReact]
   };

--- a/client/src/templates/Challenges/utils/worker-executor.test.js
+++ b/client/src/templates/Challenges/utils/worker-executor.test.js
@@ -169,10 +169,8 @@ it('Worker executor should emit LOG events', async () => {
     postMessage: function (data) {
       setImmediate(() => {
         for (let i = 0; i < 3; i++) {
-          // eslint-disable-next-line no-unused-expressions
           this.onmessage && this.onmessage({ data: { type: 'LOG', data: i } });
         }
-        // eslint-disable-next-line no-unused-expressions
         this.onmessage && this.onmessage({ data: `${data} processed` });
         setImmediate(
           () =>

--- a/curriculum/getChallenges.acceptance.test.js
+++ b/curriculum/getChallenges.acceptance.test.js
@@ -7,11 +7,9 @@
 // const { parseMarkdown } = require('../tools/challenge-parser');
 // const { parseTranslation } = require('./getChallenges');
 
-// /* eslint-disable max-len */
 // const {
 //   SIMPLE_TRANSLATION
 // } = require('../tools/challenge-parser/translation-parser/__mocks__/mock-comments');
-// /* eslint-enable max-len */
 
 describe('translation parser', () => {
   it('should pass', () => {

--- a/curriculum/utils.test.ts
+++ b/curriculum/utils.test.ts
@@ -1,5 +1,4 @@
 // utils are not typed (yet), so we have to disable some checks
-/* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 import fs from 'fs';
 import path from 'path';

--- a/cypress/e2e/default/ShowCertification.js
+++ b/cypress/e2e/default/ShowCertification.js
@@ -15,7 +15,6 @@ describe('A certification,', function () {
         .should('have.attr', 'href')
         .and(
           'match',
-          // eslint-disable-next-line max-len
           /https:\/\/www\.linkedin\.com\/profile\/add\?startTask=CERTIFICATION_NAME&name=Responsive Web Design&organizationId=4831032&issueYear=\d\d\d\d&issueMonth=\d\d?&certUrl=https:\/\/freecodecamp\.org\/certification\/certifieduser\/responsive-web-design/
         );
     });

--- a/cypress/e2e/default/legacy/redirects/challenges.js
+++ b/cypress/e2e/default/legacy/redirects/challenges.js
@@ -2,12 +2,10 @@ const locations = {
   chalSuper: '/challenges/responsive-web-design/',
   chalBlock: '/challenges/responsive-web-design/basic-html-and-html5',
   chalChallenge:
-    // eslint-disable-next-line max-len
     '/challenges/responsive-web-design/basic-html-and-html5/say-hello-to-html-elements',
   learnSuper: '/learn/responsive-web-design/',
   learnBlock: '/learn/responsive-web-design/basic-html-and-html5/',
   learnChallenge:
-    // eslint-disable-next-line max-len
     '/learn/responsive-web-design/basic-html-and-html5/say-hello-to-html-elements'
 };
 
@@ -42,7 +40,6 @@ describe('challenges/superblock/block/challenge redirect', function () {
 
     cy.title().should(
       'eq',
-      // eslint-disable-next-line max-len
       'Basic HTML and HTML5: Say Hello to HTML Elements | freeCodeCamp.org'
     );
     cy.location().should(loc => {

--- a/cypress/e2e/default/settings/username-change.js
+++ b/cypress/e2e/default/settings/username-change.js
@@ -43,7 +43,6 @@ describe('Username input field', () => {
       .should('have.class', 'alert alert-info');
   });
 
-  // eslint-disable-next-line
   it('Should be able to click the `Save` button if username is available', () => {
     cy.typeUsername('oliver');
 
@@ -63,7 +62,6 @@ describe('Username input field', () => {
       .should('have.class', 'alert alert-warning');
   });
 
-  // eslint-disable-next-line
   it('Should not be possible to click the `Save` button if username is unavailable', () => {
     cy.typeUsername('twaha');
 
@@ -83,7 +81,6 @@ describe('Username input field', () => {
     cy.get('@usernameForm').contains('Save').should('be.disabled');
   });
 
-  // eslint-disable-next-line max-len
   it('Should not be possible to click the `Save` button if user types their current name', () => {
     cy.typeUsername('developmentuser');
 
@@ -101,7 +98,6 @@ describe('Username input field', () => {
       .should('have.class', 'alert alert-danger');
   });
 
-  // eslint-disable-next-line max-len
   it('Should not be able to click the `Save` button if username includes invalid character', () => {
     cy.typeUsername('Quincy Larson');
 

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -10,7 +10,6 @@
 
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
-/* eslint-disable no-unused-vars */
 
 const { execSync } = require('child_process');
 const { existsSync } = require('fs');


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

While adding RTL layout, I found enlist which weren't used, so I removed them.

This doesn't change code, so I don't think it will harm anything to remove them. not like my previous `make sign out harder` pr


This isn't all of them, because the server stop working after so many eslint error removed 🤣, restarting typescript and eslint servers didn't help as well.