### PR TITLE
fix(client): set fcc-sound value in local storage after user data is fetched

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -122,7 +122,6 @@
     "sha-1": "1.0.0",
     "store": "2.0.12",
     "stream-browserify": "3.0.0",
-    "tone": "14.7.77",
     "typescript": "4.8.4",
     "util": "0.12.4",
     "uuid": "8.3.2",

--- a/client/package.json
+++ b/client/package.json
@@ -122,6 +122,7 @@
     "sha-1": "1.0.0",
     "store": "2.0.12",
     "stream-browserify": "3.0.0",
+    "tone": "^14.7.77",
     "typescript": "4.8.4",
     "util": "0.12.4",
     "uuid": "8.3.2",

--- a/client/src/redux/fetch-user-saga.js
+++ b/client/src/redux/fetch-user-saga.js
@@ -19,6 +19,13 @@ function* fetchSessionUser() {
       data: { user = {}, result = '', sessionMeta = {} }
     } = yield call(getSessionUser);
     const appUser = user[result] || {};
+
+    const [userId] = Object.keys(user);
+
+    const sound = user[userId].sound;
+
+    localStorage.setItem('fcc-sound', sound);
+
     yield put(
       fetchUserComplete({ user: appUser, username: result, sessionMeta })
     );

--- a/client/src/redux/fetch-user-saga.js
+++ b/client/src/redux/fetch-user-saga.js
@@ -1,5 +1,5 @@
 import { call, put, takeEvery } from 'redux-saga/effects';
-
+import store from 'store';
 import { getSessionUser, getUserProfile } from '../utils/ajax';
 import {
   fetchProfileForUserComplete,
@@ -24,7 +24,7 @@ function* fetchSessionUser() {
 
     const sound = user[userId].sound;
 
-    localStorage.setItem('fcc-sound', sound);
+    store.set('fcc-sound', sound);
 
     yield put(
       fetchUserComplete({ user: appUser, username: result, sessionMeta })

--- a/client/src/utils/tone/index.ts
+++ b/client/src/utils/tone/index.ts
@@ -1,4 +1,5 @@
 import store from 'store';
+import * as Tone from 'tone';
 import { FlashMessages } from '../../components/Flash/redux/flash-messages';
 import { Themes } from '../../components/settings/theme';
 
@@ -62,20 +63,14 @@ type ToneStates = keyof typeof toneUrls;
 export async function playTone(state: ToneStates): Promise<void> {
   const playSound = !!store.get('fcc-sound');
   if (playSound && toneUrls[state]) {
-    const tone = await import('tone');
-
-    if (tone.context.state !== 'running') {
-      tone.context.resume().catch(err => {
-        console.error('Error resuming audio context', err);
-      });
-    }
-    const player = new tone.Player(toneUrls[state]).toDestination();
+    const player = new Tone.Player(toneUrls[state]).toDestination();
 
     const storedVolume = (store.get('soundVolume') as number) ?? 50;
     const calculateDecibel = -60 * (1 - storedVolume / 100);
 
     player.volume.value = calculateDecibel;
 
-    player.autostart = true;
+    await Tone.loaded();
+    player.start();
   }
 }

--- a/client/src/utils/tone/index.ts
+++ b/client/src/utils/tone/index.ts
@@ -66,7 +66,7 @@ export async function playTone(state: ToneStates): Promise<void> {
 
     const storedVolume = (store.get('soundVolume') as number) ?? 50;
 
-    // volume range [0-1], 0 -> muted, 100 -> loudest
+    // volume range [0-1], 0 -> muted, 1 -> loudest
     const volume = storedVolume / 100;
 
     audio.volume = volume;

--- a/client/src/utils/tone/index.ts
+++ b/client/src/utils/tone/index.ts
@@ -1,5 +1,4 @@
 import store from 'store';
-import * as Tone from 'tone';
 import { FlashMessages } from '../../components/Flash/redux/flash-messages';
 import { Themes } from '../../components/settings/theme';
 
@@ -63,14 +62,15 @@ type ToneStates = keyof typeof toneUrls;
 export async function playTone(state: ToneStates): Promise<void> {
   const playSound = !!store.get('fcc-sound');
   if (playSound && toneUrls[state]) {
-    const player = new Tone.Player(toneUrls[state]).toDestination();
+    const audio = new Audio(toneUrls[state]);
 
     const storedVolume = (store.get('soundVolume') as number) ?? 50;
-    const calculateDecibel = -60 * (1 - storedVolume / 100);
 
-    player.volume.value = calculateDecibel;
+    // volume range [0-1], 0 -> muted, 100 -> loudest
+    const volume = storedVolume / 100;
 
-    await Tone.loaded();
-    player.start();
+    audio.volume = volume;
+
+    await audio.play();
   }
 }

--- a/client/src/utils/tone/index.ts
+++ b/client/src/utils/tone/index.ts
@@ -62,15 +62,16 @@ type ToneStates = keyof typeof toneUrls;
 export async function playTone(state: ToneStates): Promise<void> {
   const playSound = !!store.get('fcc-sound');
   if (playSound && toneUrls[state]) {
-    const audio = new Audio(toneUrls[state]);
+    const Tone = await import('tone');
+
+    const player = new Tone.Player(toneUrls[state]).toDestination();
 
     const storedVolume = (store.get('soundVolume') as number) ?? 50;
+    const calculateDecibel = -60 * (1 - storedVolume / 100);
 
-    // volume range [0-1], 0 -> muted, 1 -> loudest
-    const volume = storedVolume / 100;
+    player.volume.value = calculateDecibel;
 
-    audio.volume = volume;
-
-    await audio.play();
+    await Tone.loaded();
+    player.start();
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -518,6 +518,7 @@
         "sha-1": "1.0.0",
         "store": "2.0.12",
         "stream-browserify": "3.0.0",
+        "tone": "^14.7.77",
         "typescript": "4.8.4",
         "util": "0.12.4",
         "uuid": "8.3.2",
@@ -2836,11 +2837,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
-      "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
+      "version": "7.20.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
+      "integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.10"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -16310,6 +16311,23 @@
       "engines": {
         "node": ">= 4.5.0"
       }
+    },
+    "node_modules/automation-events": {
+      "version": "4.0.22",
+      "resolved": "https://registry.npmjs.org/automation-events/-/automation-events-4.0.22.tgz",
+      "integrity": "sha512-npbme6c94VOnW8pvns60ioIi1+9lUZEMC6feTJoAkINnKSEHda5dKwMRmzoh4Y8zjQVXMUNcO6LcQkH4SXyvWA==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.4",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=12.20.1"
+      }
+    },
+    "node_modules/automation-events/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/autoprefixer": {
       "version": "10.4.12",
@@ -45147,8 +45165,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.9",
-      "license": "MIT"
+      "version": "0.13.10",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
+      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.0",
@@ -48332,6 +48351,21 @@
       "version": "1.2.0",
       "license": "MIT"
     },
+    "node_modules/standardized-audio-context": {
+      "version": "25.3.33",
+      "resolved": "https://registry.npmjs.org/standardized-audio-context/-/standardized-audio-context-25.3.33.tgz",
+      "integrity": "sha512-9BzVo8NDemOMENPKiwdE65uJJ6ae00jmafT2ZzZ0j+1WVhYZXfmykDgcP4h8eRAPC7r+mFedJfbdr7DMANJRkw==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.4",
+        "automation-events": "^4.0.22",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/standardized-audio-context/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+    },
     "node_modules/start-server-and-test": {
       "version": "1.14.0",
       "dev": true,
@@ -50384,6 +50418,20 @@
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
       }
+    },
+    "node_modules/tone": {
+      "version": "14.7.77",
+      "resolved": "https://registry.npmjs.org/tone/-/tone-14.7.77.tgz",
+      "integrity": "sha512-tCfK73IkLHyzoKUvGq47gyDyxiKLFvKiVCOobynGgBB9Dl0NkxTM2p+eRJXyCYrjJwy9Y0XCMqD3uOYsYt2Fdg==",
+      "dependencies": {
+        "standardized-audio-context": "^25.1.8",
+        "tslib": "^2.0.1"
+      }
+    },
+    "node_modules/tone/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/toposort": {
       "version": "2.0.2",
@@ -56190,11 +56238,11 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
-      "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
+      "version": "7.20.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
+      "integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
       "requires": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.10"
       }
     },
     "@babel/runtime-corejs3": {
@@ -57002,6 +57050,7 @@
         "sha-1": "1.0.0",
         "store": "2.0.12",
         "stream-browserify": "3.0.0",
+        "tone": "*",
         "ts-node": "10.9.1",
         "typescript": "4.8.4",
         "util": "0.12.4",
@@ -66523,6 +66572,22 @@
     },
     "atob": {
       "version": "2.1.2"
+    },
+    "automation-events": {
+      "version": "4.0.22",
+      "resolved": "https://registry.npmjs.org/automation-events/-/automation-events-4.0.22.tgz",
+      "integrity": "sha512-npbme6c94VOnW8pvns60ioIi1+9lUZEMC6feTJoAkINnKSEHda5dKwMRmzoh4Y8zjQVXMUNcO6LcQkH4SXyvWA==",
+      "requires": {
+        "@babel/runtime": "^7.19.4",
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
+      }
     },
     "autoprefixer": {
       "version": "10.4.12",
@@ -85698,7 +85763,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.9"
+      "version": "0.13.10",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
+      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw=="
     },
     "regenerator-transform": {
       "version": "0.15.0",
@@ -87857,6 +87924,23 @@
     "stackframe": {
       "version": "1.2.0"
     },
+    "standardized-audio-context": {
+      "version": "25.3.33",
+      "resolved": "https://registry.npmjs.org/standardized-audio-context/-/standardized-audio-context-25.3.33.tgz",
+      "integrity": "sha512-9BzVo8NDemOMENPKiwdE65uJJ6ae00jmafT2ZzZ0j+1WVhYZXfmykDgcP4h8eRAPC7r+mFedJfbdr7DMANJRkw==",
+      "requires": {
+        "@babel/runtime": "^7.19.4",
+        "automation-events": "^4.0.22",
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
+      }
+    },
     "start-server-and-test": {
       "version": "1.14.0",
       "dev": true,
@@ -89224,6 +89308,22 @@
       "requires": {
         "@tokenizer/token": "^0.3.0",
         "ieee754": "^1.2.1"
+      }
+    },
+    "tone": {
+      "version": "14.7.77",
+      "resolved": "https://registry.npmjs.org/tone/-/tone-14.7.77.tgz",
+      "integrity": "sha512-tCfK73IkLHyzoKUvGq47gyDyxiKLFvKiVCOobynGgBB9Dl0NkxTM2p+eRJXyCYrjJwy9Y0XCMqD3uOYsYt2Fdg==",
+      "requires": {
+        "standardized-audio-context": "^25.1.8",
+        "tslib": "^2.0.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
       }
     },
     "toposort": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -518,7 +518,6 @@
         "sha-1": "1.0.0",
         "store": "2.0.12",
         "stream-browserify": "3.0.0",
-        "tone": "14.7.77",
         "typescript": "4.8.4",
         "util": "0.12.4",
         "uuid": "8.3.2",
@@ -16311,21 +16310,6 @@
       "engines": {
         "node": ">= 4.5.0"
       }
-    },
-    "node_modules/automation-events": {
-      "version": "4.0.10",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.16.3",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=12.20.1"
-      }
-    },
-    "node_modules/automation-events/node_modules/tslib": {
-      "version": "2.3.1",
-      "license": "0BSD"
     },
     "node_modules/autoprefixer": {
       "version": "10.4.12",
@@ -48348,19 +48332,6 @@
       "version": "1.2.0",
       "license": "MIT"
     },
-    "node_modules/standardized-audio-context": {
-      "version": "25.3.16",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.16.3",
-        "automation-events": "^4.0.10",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/standardized-audio-context/node_modules/tslib": {
-      "version": "2.3.1",
-      "license": "0BSD"
-    },
     "node_modules/start-server-and-test": {
       "version": "1.14.0",
       "dev": true,
@@ -50413,18 +50384,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
       }
-    },
-    "node_modules/tone": {
-      "version": "14.7.77",
-      "license": "MIT",
-      "dependencies": {
-        "standardized-audio-context": "^25.1.8",
-        "tslib": "^2.0.1"
-      }
-    },
-    "node_modules/tone/node_modules/tslib": {
-      "version": "2.3.1",
-      "license": "0BSD"
     },
     "node_modules/toposort": {
       "version": "2.0.2",
@@ -57043,7 +57002,6 @@
         "sha-1": "1.0.0",
         "store": "2.0.12",
         "stream-browserify": "3.0.0",
-        "tone": "14.7.77",
         "ts-node": "10.9.1",
         "typescript": "4.8.4",
         "util": "0.12.4",
@@ -66565,18 +66523,6 @@
     },
     "atob": {
       "version": "2.1.2"
-    },
-    "automation-events": {
-      "version": "4.0.10",
-      "requires": {
-        "@babel/runtime": "^7.16.3",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.3.1"
-        }
-      }
     },
     "autoprefixer": {
       "version": "10.4.12",
@@ -87911,19 +87857,6 @@
     "stackframe": {
       "version": "1.2.0"
     },
-    "standardized-audio-context": {
-      "version": "25.3.16",
-      "requires": {
-        "@babel/runtime": "^7.16.3",
-        "automation-events": "^4.0.10",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.3.1"
-        }
-      }
-    },
     "start-server-and-test": {
       "version": "1.14.0",
       "dev": true,
@@ -89291,18 +89224,6 @@
       "requires": {
         "@tokenizer/token": "^0.3.0",
         "ieee754": "^1.2.1"
-      }
-    },
-    "tone": {
-      "version": "14.7.77",
-      "requires": {
-        "standardized-audio-context": "^25.1.8",
-        "tslib": "^2.0.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.3.1"
-        }
       }
     },
     "toposort": {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #46372
Closes #48107 

<!-- Feel free to add any additional description of changes below this line -->
This is first method of solving issue
After user has logged in successfully I'm setting `fcc-sound` value in local storage after user data is fetched in `fetchSessionUser`.
As `playTone` grabs `fcc-sound` value from local storage to play audio