### PR TITLE
fix: only fetch growthbookUri in browser contexts

### DIFF
--- a/client/src/components/growth-book/growth-book-wrapper.tsx
+++ b/client/src/components/growth-book/growth-book-wrapper.tsx
@@ -38,19 +38,8 @@ const GrowthBookWrapper = ({
   user
 }: GrowthBookWrapper) => {
   useEffect(() => {
-    async function initGrowthBook() {
+    async function setGrowthBookFeatures() {
       if (!growthbookUri) return;
-
-      if (isSignedIn) {
-        const { joinDate, completedChallenges } = user;
-        growthbook.setAttributes({
-          id: sha1(user.email),
-          staff: user.email.includes('@freecodecamp'),
-          clientLocal: clientLocale,
-          joinDateUnix: Date.parse(joinDate),
-          completedChallengesLength: completedChallenges.length
-        });
-      }
 
       try {
         const res = await fetch(growthbookUri);
@@ -64,9 +53,20 @@ const GrowthBookWrapper = ({
       }
     }
 
-    void initGrowthBook();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isSignedIn, growthbookUri]);
+    void setGrowthBookFeatures();
+  }, []);
+
+  useEffect(() => {
+    if (isSignedIn) {
+      growthbook.setAttributes({
+        id: sha1(user.email),
+        staff: user.email.includes('@freecodecamp'),
+        clientLocal: clientLocale,
+        joinDateUnix: Date.parse(user.joinDate),
+        completedChallengesLength: user.completedChallenges.length
+      });
+    }
+  }, [isSignedIn, user.email, user.joinDate, user.completedChallenges]);
 
   return (
     <GrowthBookProvider growthbook={growthbook}>{children}</GrowthBookProvider>

--- a/client/src/components/growth-book/growth-book-wrapper.tsx
+++ b/client/src/components/growth-book/growth-book-wrapper.tsx
@@ -52,11 +52,16 @@ const GrowthBookWrapper = ({
         });
       }
 
-      const res = await fetch(growthbookUri);
-      const data = (await res.json()) as {
-        features: Record<string, FeatureDefinition>;
-      };
-      growthbook.setFeatures(data.features);
+      try {
+        const res = await fetch(growthbookUri);
+        const data = (await res.json()) as {
+          features: Record<string, FeatureDefinition>;
+        };
+        growthbook.setFeatures(data.features);
+      } catch (e) {
+        // TODO: report to sentry when it's enabled
+        console.error(e);
+      }
     }
 
     void initGrowthBook();

--- a/client/src/components/growth-book/growth-book-wrapper.tsx
+++ b/client/src/components/growth-book/growth-book-wrapper.tsx
@@ -37,28 +37,31 @@ const GrowthBookWrapper = ({
   isSignedIn,
   user
 }: GrowthBookWrapper) => {
-  if (growthbookUri) {
-    void (async () => {
+  useEffect(() => {
+    async function initGrowthBook() {
+      if (!growthbookUri) return;
+
+      if (isSignedIn) {
+        const { joinDate, completedChallenges } = user;
+        growthbook.setAttributes({
+          id: sha1(user.email),
+          staff: user.email.includes('@freecodecamp'),
+          clientLocal: clientLocale,
+          joinDateUnix: Date.parse(joinDate),
+          completedChallengesLength: completedChallenges.length
+        });
+      }
+
       const res = await fetch(growthbookUri);
       const data = (await res.json()) as {
         features: Record<string, FeatureDefinition>;
       };
       growthbook.setFeatures(data.features);
-    })();
-  }
-  useEffect(() => {
-    if (isSignedIn) {
-      const { joinDate, completedChallenges } = user;
-      growthbook.setAttributes({
-        id: sha1(user.email),
-        staff: user.email.includes('@freecodecamp'),
-        clientLocal: clientLocale,
-        joinDateUnix: Date.parse(joinDate),
-        completedChallengesLength: completedChallenges.length
-      });
     }
+
+    void initGrowthBook();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isSignedIn]);
+  }, [isSignedIn, growthbookUri]);
 
   return (
     <GrowthBookProvider growthbook={growthbook}>{children}</GrowthBookProvider>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This should stop the build from failing in CD.

The reason it passed in CI is that we don't provide a growthbookUri env var, so fetch was not called during the build process.

<!-- Feel free to add any additional description of changes below this line -->
