### PR TITLE
feat: remove playwright webkit

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -8,7 +8,6 @@ module.exports = defineConfig({
     projectId: 'ke77ns',
     retries: 4,
     chromeWebSecurity: false,
-    experimentalWebKitSupport: true,
     specPattern: 'cypress/e2e/**/*.js',
     setupNodeEvents(on, config) {
       config.env = config.env || {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,7 +96,6 @@
         "mock-fs": "5.1.4",
         "npm-run-all": "4.1.5",
         "ora": "5.4.1",
-        "playwright-webkit": "1.27.1",
         "prettier": "2.7.1",
         "prismjs": "1.29.0",
         "process": "0.11.10",
@@ -40945,34 +40944,6 @@
     "node_modules/platform": {
       "version": "1.3.6",
       "license": "MIT"
-    },
-    "node_modules/playwright-core": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.27.1.tgz",
-      "integrity": "sha512-9EmeXDncC2Pmp/z+teoVYlvmPWUC6ejSSYZUln7YaP89Z6lpAaiaAnqroUt/BoLo8tn7WYShcfaCh+xofZa44Q==",
-      "dev": true,
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/playwright-webkit": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/playwright-webkit/-/playwright-webkit-1.27.1.tgz",
-      "integrity": "sha512-2HM93FdGJxBfvw2wS8z4ntSwCleLbEPj+JN2/RdkS0HanrSKQc9WK+OiJNM3mwMn7IMZzEuRuf4UjnvO7C0MHQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "playwright-core": "1.27.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=14"
-      }
     },
     "node_modules/pnp-webpack-plugin": {
       "version": "1.6.4",
@@ -83169,21 +83140,6 @@
     },
     "platform": {
       "version": "1.3.6"
-    },
-    "playwright-core": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.27.1.tgz",
-      "integrity": "sha512-9EmeXDncC2Pmp/z+teoVYlvmPWUC6ejSSYZUln7YaP89Z6lpAaiaAnqroUt/BoLo8tn7WYShcfaCh+xofZa44Q==",
-      "dev": true
-    },
-    "playwright-webkit": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/playwright-webkit/-/playwright-webkit-1.27.1.tgz",
-      "integrity": "sha512-2HM93FdGJxBfvw2wS8z4ntSwCleLbEPj+JN2/RdkS0HanrSKQc9WK+OiJNM3mwMn7IMZzEuRuf4UjnvO7C0MHQ==",
-      "dev": true,
-      "requires": {
-        "playwright-core": "1.27.1"
-      }
     },
     "pnp-webpack-plugin": {
       "version": "1.6.4",

--- a/package.json
+++ b/package.json
@@ -179,7 +179,6 @@
     "mock-fs": "5.1.4",
     "npm-run-all": "4.1.5",
     "ora": "5.4.1",
-    "playwright-webkit": "1.27.1",
     "prettier": "2.7.1",
     "prismjs": "1.29.0",
     "process": "0.11.10",


### PR DESCRIPTION
playwright-webkit can't be installed on older versions of OSX or Ubuntu - my mac OS included. So when I try to install dependencies, I get an error and can't run the repo locally without uninstalling or downgrading this. Since we aren't using it at the moment, I think we can, and probably should, just remove it. If we need to add it back at some point, there are probably some alternative solutions we can come up with.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
