### PR TITLE
fix(server): default to log `fcc` namespaces, unless env set

### DIFF
--- a/api-server/package.json
+++ b/api-server/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "babel-dev-server": "babel-node --inspect=0.0.0.0 ./src/server/index.js",
     "build": "babel src --out-dir lib --ignore '/**/*.test.js' --copy-files --no-copy-ignored",
-    "develop": "cross-env DEBUG=fcc* node src/development-start.js",
+    "develop": "node src/development-start.js",
     "start": "cross-env DEBUG=fcc* node lib/production-start.js"
   },
   "resolutions": {

--- a/api-server/src/development-start.js
+++ b/api-server/src/development-start.js
@@ -34,7 +34,7 @@ nodemon({
   watch: path.resolve(__dirname, './server'),
   spawn: true,
   env: {
-    DEBUG: 'fcc*'
+    DEBUG: `fcc*,${process.env.DEBUG}`
   }
 });
 

--- a/api-server/src/server/index.js
+++ b/api-server/src/server/index.js
@@ -74,7 +74,8 @@ app.start = _.once(function () {
       app.get('port'),
       app.get('env')
     );
-    log(`connecting to db at ${db.settings.url}`);
+    const severedDbURI = db.settings.url.replace(/(?<=\/\/).+?(?=@)/, '***');
+    log(`connecting to db at ${severedDbURI}`);
   });
 
   process.on('SIGINT', () => {

--- a/api-server/src/server/index.js
+++ b/api-server/src/server/index.js
@@ -14,10 +14,6 @@ const { setupPassport } = require('./component-passport');
 const log = createDebugger('fcc:server');
 const reqLogFormat = ':date[iso] :status :method :response-time ms - :url';
 
-// force logger to always output
-// this may be brittle
-log.enabled = true;
-
 if (sentry.dsn === 'dsn_from_sentry_dashboard') {
   log('Sentry reporting disabled unless DSN is provided.');
 } else {
@@ -74,8 +70,7 @@ app.start = _.once(function () {
       app.get('port'),
       app.get('env')
     );
-    const severedDbURI = db.settings.url.replace(/(?<=\/\/).+?(?=@)/, '***');
-    log(`connecting to db at ${severedDbURI}`);
+    log(`connecting to db at ${db.settings.url}`);
   });
 
   process.on('SIGINT', () => {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

We have/had this set in far too many places. Anyway, now i can set `DEBUG=-fcc:server` in `.env` and not see those logs