### PR TITLE
feat(client): refactor universal nav missing types

### DIFF
--- a/client/src/components/Header/components/menu-button.tsx
+++ b/client/src/components/Header/components/menu-button.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBars } from '@fortawesome/free-solid-svg-icons';
 import { User } from '../../../redux/prop-types';
+
 interface MenuButtonProps {
   className?: string;
   displayMenu?: boolean;

--- a/client/src/components/Header/components/menu-button.tsx
+++ b/client/src/components/Header/components/menu-button.tsx
@@ -2,12 +2,14 @@ import React, { RefObject } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBars } from '@fortawesome/free-solid-svg-icons';
+import { User } from '../../../redux/prop-types';
 interface MenuButtonProps {
   className?: string;
   displayMenu?: boolean;
   innerRef?: RefObject<HTMLButtonElement>;
   showMenu: () => void;
   hideMenu: () => void;
+  user?: User;
 }
 
 const MenuButton = ({

--- a/client/src/components/Header/components/nav-links.tsx
+++ b/client/src/components/Header/components/nav-links.tsx
@@ -24,6 +24,7 @@ import createLanguageRedirect from '../../create-language-redirect';
 import { Link } from '../../helpers';
 import { Themes } from '../../settings/theme';
 import LanguageGlobe from '../../../assets/icons/language-globe';
+import { User } from '../../../redux/prop-types';
 
 interface NavigationLocationApi {
   clientLocale: string;
@@ -48,13 +49,10 @@ interface NavLinksProps {
   fetchState: { pending: boolean };
   i18n: Record<string, unknown>;
   t: TFunction;
+  showMenu: () => void;
   hideMenu: () => void;
   toggleNightMode: (theme: Themes) => void;
-  user?: {
-    isDonating: boolean;
-    username: string;
-    theme: Themes;
-  };
+  user?: User;
   navigate?: (location: string) => void;
   showLanguageMenu: (elementToFocus: HTMLButtonElement) => void;
   hideLanguageMenu: () => void;

--- a/client/src/components/Header/components/universal-nav.tsx
+++ b/client/src/components/Header/components/universal-nav.tsx
@@ -1,14 +1,10 @@
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-/* eslint-disable react/prop-types */
-// @ts-nocheck
 import Loadable from '@loadable/component';
-import React, { Ref } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import Media from 'react-responsive';
 import { isLanding } from '../../../utils/path-parsers';
 import { Link, SkeletonSprite } from '../../helpers';
+import { User } from '../../../redux/prop-types';
 import MenuButton from './menu-button';
 import NavLinks from './nav-links';
 import NavLogo from './nav-logo';
@@ -23,16 +19,16 @@ const SearchBarOptimized = Loadable(
 const MAX_MOBILE_WIDTH = 980;
 
 interface UniversalNavProps {
-  displayMenu?: boolean;
-  isLanguageMenuDisplayed?: boolean;
-  fetchState?: { pending: boolean };
-  menuButtonRef?: Ref<HTMLButtonElement> | undefined;
-  searchBarRef?: unknown;
-  showMenu?: () => void;
-  hideMenu?: () => void;
-  showLanguageMenu?: (elementToFocus: HTMLButtonElement) => void;
-  hideLanguageMenu?: () => void;
-  user?: Record<string, unknown>;
+  displayMenu: boolean;
+  isLanguageMenuDisplayed: boolean;
+  fetchState: { pending: boolean };
+  menuButtonRef: React.RefObject<HTMLButtonElement>;
+  searchBarRef?: React.RefObject<HTMLDivElement>;
+  showMenu: () => void;
+  hideMenu: () => void;
+  showLanguageMenu: (elementToFocus: HTMLButtonElement) => void;
+  hideLanguageMenu: () => void;
+  user?: User;
 }
 export const UniversalNav = ({
   displayMenu,

--- a/client/src/components/Header/index.tsx
+++ b/client/src/components/Header/index.tsx
@@ -4,6 +4,7 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import React from 'react';
 import Helmet from 'react-helmet';
+import { User } from '../../redux/prop-types';
 
 import UniversalNav from './components/universal-nav';
 
@@ -11,7 +12,7 @@ import './header.css';
 
 interface HeaderProps {
   fetchState: { pending: boolean };
-  user: Record<string, any>;
+  user: User;
 }
 export class Header extends React.Component<
   HeaderProps,

--- a/client/src/components/helpers/link.tsx
+++ b/client/src/components/helpers/link.tsx
@@ -9,6 +9,7 @@ interface LinkProps {
   state?: Record<string, unknown>;
   to: string;
   onClick?: () => void;
+  id: string;
 }
 
 const Link = ({

--- a/client/src/components/helpers/link.tsx
+++ b/client/src/components/helpers/link.tsx
@@ -9,7 +9,6 @@ interface LinkProps {
   state?: Record<string, unknown>;
   to: string;
   onClick?: () => void;
-  id?: string;
 }
 
 const Link = ({

--- a/client/src/components/helpers/link.tsx
+++ b/client/src/components/helpers/link.tsx
@@ -9,7 +9,7 @@ interface LinkProps {
   state?: Record<string, unknown>;
   to: string;
   onClick?: () => void;
-  id: string;
+  id?: string;
 }
 
 const Link = ({

--- a/client/src/components/helpers/link.tsx
+++ b/client/src/components/helpers/link.tsx
@@ -1,14 +1,11 @@
-import { Link as GatsbyLink } from 'gatsby';
+import { GatsbyLinkProps, Link as GatsbyLink } from 'gatsby';
 import React from 'react';
 
-interface LinkProps {
+interface LinkProps extends Omit<GatsbyLinkProps<string>, 'ref'> {
   children?: React.ReactNode;
-  className?: string;
   external?: boolean;
   sameTab?: boolean;
-  state?: Record<string, unknown>;
   to: string;
-  onClick?: () => void;
 }
 
 const Link = ({

--- a/client/src/components/helpers/link.tsx
+++ b/client/src/components/helpers/link.tsx
@@ -1,11 +1,14 @@
-import { GatsbyLinkProps, Link as GatsbyLink } from 'gatsby';
+import { Link as GatsbyLink } from 'gatsby';
 import React from 'react';
 
-interface LinkProps extends Omit<GatsbyLinkProps<string>, 'ref'> {
+interface LinkProps {
   children?: React.ReactNode;
+  className?: string;
   external?: boolean;
   sameTab?: boolean;
+  state?: Record<string, unknown>;
   to: string;
+  onClick?: () => void;
 }
 
 const Link = ({

--- a/client/src/components/helpers/link.tsx
+++ b/client/src/components/helpers/link.tsx
@@ -1,7 +1,7 @@
 import { GatsbyLinkProps, Link as GatsbyLink } from 'gatsby';
 import React from 'react';
 
-interface LinkProps extends Omit<GatsbyLinkProps<string>, 'ref'> {
+interface LinkProps extends Omit<GatsbyLinkProps<Record<string, unknown>>, 'ref'> {
   children?: React.ReactNode;
   external?: boolean;
   sameTab?: boolean;

--- a/client/src/components/helpers/link.tsx
+++ b/client/src/components/helpers/link.tsx
@@ -1,7 +1,8 @@
 import { GatsbyLinkProps, Link as GatsbyLink } from 'gatsby';
 import React from 'react';
 
-interface LinkProps extends Omit<GatsbyLinkProps<Record<string, unknown>>, 'ref'> {
+interface LinkProps
+  extends Omit<GatsbyLinkProps<Record<string, unknown>>, 'ref'> {
   children?: React.ReactNode;
   external?: boolean;
   sameTab?: boolean;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

ref #48101

While adding the styles to universal-nav component, I needed to add type safety back to the file.

You may be wondering, how is this related? shhh, just accept static analysis

<!-- Feel free to add any additional description of changes below this line -->

Edit: I forgot about auto assignment, I wouldn't have said the line above if I remembered :rofl:

To be serious, while working on [this](https://github.com/freeCodeCamp/freeCodeCamp/compare/main...Sboonny:freeCodeCamp:Arabic-curriculum-subtree), I just added types to make my life easier 
