### PR TITLE
fix(curriculum): set overflow to hidden in penguin practice project

### DIFF
--- a/curriculum/challenges/arabic/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/61968e9243a4090cc805531c.md
+++ b/curriculum/challenges/arabic/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/61968e9243a4090cc805531c.md
@@ -11,10 +11,10 @@ dashedName: step-5
 
 # --hints--
 
-يجب عليك إعطاء `body` خاصية `overflow` بقيمة `clip`.
+يجب عليك إعطاء `body` خاصية `overflow` بقيمة `hidden`.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('body')?.overflow, 'clip');
+assert.equal(new __helpers.CSSHelp(document).getStyle('body')?.overflow, 'hidden');
 ```
 
 # --seed--

--- a/curriculum/challenges/chinese-traditional/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/61968e9243a4090cc805531c.md
+++ b/curriculum/challenges/chinese-traditional/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/61968e9243a4090cc805531c.md
@@ -11,10 +11,10 @@ dashedName: step-5
 
 # --hints--
 
-應該給 `body` 的 `overflow` 設置爲 `clip`。
+應該給 `body` 的 `overflow` 設置爲 `hidden`。
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('body')?.overflow, 'clip');
+assert.equal(new __helpers.CSSHelp(document).getStyle('body')?.overflow, 'hidden');
 ```
 
 # --seed--

--- a/curriculum/challenges/chinese/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/61968e9243a4090cc805531c.md
+++ b/curriculum/challenges/chinese/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/61968e9243a4090cc805531c.md
@@ -11,10 +11,10 @@ dashedName: step-5
 
 # --hints--
 
-应该给 `body` 的 `overflow` 设置为 `clip`。
+应该给 `body` 的 `overflow` 设置为 `hidden`。
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('body')?.overflow, 'clip');
+assert.equal(new __helpers.CSSHelp(document).getStyle('body')?.overflow, 'hidden');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/61968e9243a4090cc805531c.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/61968e9243a4090cc805531c.md
@@ -11,10 +11,10 @@ Remove both the horizontal and vertical scrollbars, and prevent programmatic scr
 
 # --hints--
 
-You should give `body` an `overflow` of `clip`.
+You should give `body` an `overflow` of `hidden`.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('body')?.overflow, 'clip');
+assert.equal(new __helpers.CSSHelp(document).getStyle('body')?.overflow, 'hidden');
 ```
 
 # --seed--

--- a/curriculum/challenges/espanol/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/61968e9243a4090cc805531c.md
+++ b/curriculum/challenges/espanol/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/61968e9243a4090cc805531c.md
@@ -11,10 +11,10 @@ Remove both the horizontal and vertical scrollbars, and prevent programmatic scr
 
 # --hints--
 
-You should give `body` an `overflow` of `clip`.
+You should give `body` an `overflow` of `hidden`.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('body')?.overflow, 'clip');
+assert.equal(new __helpers.CSSHelp(document).getStyle('body')?.overflow, 'hidden');
 ```
 
 # --seed--

--- a/curriculum/challenges/german/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/61968e9243a4090cc805531c.md
+++ b/curriculum/challenges/german/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/61968e9243a4090cc805531c.md
@@ -11,10 +11,10 @@ Remove both the horizontal and vertical scrollbars, and prevent programmatic scr
 
 # --hints--
 
-You should give `body` an `overflow` of `clip`.
+You should give `body` an `overflow` of `hidden`.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('body')?.overflow, 'clip');
+assert.equal(new __helpers.CSSHelp(document).getStyle('body')?.overflow, 'hidden');
 ```
 
 # --seed--

--- a/curriculum/challenges/italian/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/61968e9243a4090cc805531c.md
+++ b/curriculum/challenges/italian/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/61968e9243a4090cc805531c.md
@@ -11,10 +11,10 @@ Rimuovi sia le barre di scorrimento orizzontali che verticali e previeni lo scor
 
 # --hints--
 
-Dovresti dare all'elemento `body` una proprietà `overflow` con il valore `clip`.
+Dovresti dare all'elemento `body` una proprietà `overflow` con il valore `hidden`.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('body')?.overflow, 'clip');
+assert.equal(new __helpers.CSSHelp(document).getStyle('body')?.overflow, 'hidden');
 ```
 
 # --seed--

--- a/curriculum/challenges/japanese/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/61968e9243a4090cc805531c.md
+++ b/curriculum/challenges/japanese/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/61968e9243a4090cc805531c.md
@@ -11,10 +11,10 @@ Remove both the horizontal and vertical scrollbars, and prevent programmatic scr
 
 # --hints--
 
-You should give `body` an `overflow` of `clip`.
+You should give `body` an `overflow` of `hidden`.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('body')?.overflow, 'clip');
+assert.equal(new __helpers.CSSHelp(document).getStyle('body')?.overflow, 'hidden');
 ```
 
 # --seed--

--- a/curriculum/challenges/portuguese/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/61968e9243a4090cc805531c.md
+++ b/curriculum/challenges/portuguese/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/61968e9243a4090cc805531c.md
@@ -11,10 +11,10 @@ Remova as barras de rolagem horizontal e vertical e impeça rolagem programátic
 
 # --hints--
 
-Você deve dar `overflow` de `clip` ao `body`.
+Você deve dar `overflow` de `hidden` ao `body`.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('body')?.overflow, 'clip');
+assert.equal(new __helpers.CSSHelp(document).getStyle('body')?.overflow, 'hidden');
 ```
 
 # --seed--

--- a/curriculum/challenges/ukrainian/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/61968e9243a4090cc805531c.md
+++ b/curriculum/challenges/ukrainian/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/61968e9243a4090cc805531c.md
@@ -11,10 +11,10 @@ dashedName: step-5
 
 # --hints--
 
-Ви повинні надати `body` властивість `overflow` зі значенням `clip`.
+Ви повинні надати `body` властивість `overflow` зі значенням `hidden`.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('body')?.overflow, 'clip');
+assert.equal(new __helpers.CSSHelp(document).getStyle('body')?.overflow, 'hidden');
 ```
 
 # --seed--


### PR DESCRIPTION
Signed-off-by: Prince Mendiratta <prince.mendi@gmail.com>

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #47513 

<!-- Feel free to add any additional description of changes below this line -->
Have made changes to use the `hidden` property of overflow instead of `clip` as per this [comment](https://github.com/freeCodeCamp/freeCodeCamp/pull/47515#issuecomment-1248616586).
