### PR TITLE
feat(client): replace preview icon with a clearer one

### DIFF
--- a/client/src/templates/Challenges/classic/action-row.tsx
+++ b/client/src/templates/Challenges/classic/action-row.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
+import { faWindowRestore } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useTranslation } from 'react-i18next';
 import EditorTabs from './editor-tabs';
@@ -88,7 +88,7 @@ const ActionRow = ({
             onClick={() => togglePane('showPreviewPortal')}
           >
             <span className='sr-only'>{getPreviewBtnsSrText().portal}</span>
-            <FontAwesomeIcon icon={faExternalLinkAlt} />
+            <FontAwesomeIcon icon={faWindowRestore} />
           </button>
         </div>
       </div>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #47923

<!-- Feel free to add any additional description of changes below this line -->
Have changed the preview icon as per this [comment](https://github.com/freeCodeCamp/freeCodeCamp/issues/47923#issuecomment-1286824203). This icon does feel more intuitive to represent a modal.

This is the output - 
![image](https://user-images.githubusercontent.com/54077356/197194254-ce2d545a-7110-40f9-97df-28500bf3299b.png)
