### PR TITLE
feat: disable find hotkey in editor

### DIFF
--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -11,10 +11,6 @@
   top: -999em;
 }
 
-.monaco-editor .editor-widget {
-  display: none !important;
-}
-
 .monaco-menu .monaco-action-bar.vertical .action-item:nth-last-child(n + 5),
 .monaco-menu .monaco-action-bar.vertical .action-item:last-child,
 .monaco-menu .monaco-action-bar.vertical .action-label.separator {

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -446,6 +446,12 @@ const Editor = (props: EditorProps): JSX.Element => {
         newLine.run();
       }
     );
+    // @ts-ignore
+    editor._standaloneKeybindingService.addDynamicKeybinding(
+      '-actions.find',
+      null,
+      () => {}
+    );
     /* eslint-enable */
     editor.addAction({
       id: 'execute-challenge',


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Ref #48170

<!-- Feel free to add any additional description of changes below this line -->
Have disabled the Ctrl+F hotkey for using the editor's built in find functionality. Using Ctrl+F will result in the user interacting directly with the browser's default search/find function. The browser's search functionality works well with the editor and does not result in issues.

Do note that since the find functionality has been disabled, I have commented out the CSS that was being used to hide the find function's panel, as mentioned in this [comment](https://github.com/freeCodeCamp/freeCodeCamp/issues/48170#issuecomment-1287148182).

Another thing to note is that find functionality will only work on the currently displayed content on the editor, this might make searching within code harder. But, assuming that the functionality already was disabled, this shouldn't be much of an issue.