### PR TITLE
refactor: s/all-langs/i18n/g

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,6 +3,6 @@ client/static/**
 client/public/**
 api-server/src/public/**
 api-server/lib/**
-config/i18n/all-langs.js
+config/i18n.js
 config/certification-settings.js
 web/**

--- a/.gitignore
+++ b/.gitignore
@@ -162,7 +162,7 @@ config/client/sass-compile.json
 config/client/frame-runner.json
 config/client/test-evaluator.json
 config/curriculum.json
-config/i18n/all-langs.js
+config/i18n.js
 config/certification-settings.js
 
 ### Generated utils files ###

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,7 +5,7 @@ client/static
 curriculum/challenges/_meta/*/*
 curriculum/challenges/**/*
 config/**/*.json
-config/i18n/all-langs.js
+config/i18n.js
 config/certification-settings.js
 docs/i18n
 utils/block-nameify.js

--- a/api-server/src/server/component-passport.js
+++ b/api-server/src/server/component-passport.js
@@ -2,7 +2,7 @@ import { PassportConfigurator } from '@freecodecamp/loopback-component-passport'
 import dedent from 'dedent';
 import passport from 'passport';
 
-import { availableLangs } from '../../../config/i18n/all-langs';
+import { availableLangs } from '../../../config/i18n';
 import { jwtSecret } from '../../../config/secrets';
 import passportProviders from './passport-providers';
 import { setAccessTokenToResponse } from './utils/getSetAccessToken';

--- a/api-server/src/server/utils/redirection.js
+++ b/api-server/src/server/utils/redirection.js
@@ -3,7 +3,7 @@ const { allowedOrigins } = require('../../../../config/cors-settings');
 // homeLocation is being used as a fallback here. If the one provided by the
 // client is invalid we default to this.
 const { homeLocation } = require('../../../../config/env.json');
-const { availableLangs } = require('../../../../config/i18n/all-langs');
+const { availableLangs } = require('../../../../config/i18n');
 
 function getReturnTo(encryptedParams, secret, _homeLocation = homeLocation) {
   let params;

--- a/client/i18n/config.js
+++ b/client/i18n/config.js
@@ -4,7 +4,7 @@ import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 
 const envData = require('../../config/env.json');
-const { i18nextCodes } = require('../../config/i18n/all-langs');
+const { i18nextCodes } = require('../../config/i18n');
 
 const { clientLocale } = envData;
 

--- a/client/i18n/locales.test.ts
+++ b/client/i18n/locales.test.ts
@@ -1,10 +1,6 @@
 import fs from 'fs';
 import { setup } from 'jest-json-schema-extended';
-import {
-  availableLangs,
-  LangNames,
-  LangCodes
-} from '../../config/i18n/all-langs';
+import { availableLangs, LangNames, LangCodes } from '../../config/i18n';
 
 setup();
 

--- a/client/i18n/schema-validation.ts
+++ b/client/i18n/schema-validation.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { readFile } from 'fs/promises';
-import { availableLangs } from '../../config/i18n/all-langs';
+import { availableLangs } from '../../config/i18n';
 import introSchema from './locales/english/intro.json';
 import linksSchema from './locales/english/links.json';
 import metaTagsSchema from './locales/english/meta-tags.json';

--- a/client/src/client-only-routes/show-certification.tsx
+++ b/client/src/client-only-routes/show-certification.tsx
@@ -7,7 +7,7 @@ import { bindActionCreators, Dispatch } from 'redux';
 import { createSelector } from 'reselect';
 
 import envData from '../../../config/env.json';
-import { getLangCode } from '../../../config/i18n/all-langs';
+import { getLangCode } from '../../../config/i18n';
 import FreeCodeCampLogo from '../assets/icons/FreeCodeCamp-logo';
 import DonateForm from '../components/Donation/donate-form';
 

--- a/client/src/components/Header/components/nav-links.tsx
+++ b/client/src/components/Header/components/nav-links.tsx
@@ -17,7 +17,7 @@ import {
   LangNames,
   LangCodes,
   hiddenLangs
-} from '../../../../../config/i18n/all-langs';
+} from '../../../../../config/i18n';
 import { hardGoTo as navigate } from '../../../redux/actions';
 import { updateMyTheme } from '../../../redux/settings/actions';
 import createLanguageRedirect from '../../create-language-redirect';

--- a/client/src/components/app-mount-notifier.test.tsx
+++ b/client/src/components/app-mount-notifier.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { I18nextProvider } from 'react-i18next';
 import { Provider } from 'react-redux';
 
-import { i18nextCodes } from '../../../config/i18n/all-langs';
+import { i18nextCodes } from '../../../config/i18n';
 import i18nTestConfig from '../../i18n/config-for-tests';
 import { createStore } from '../redux/createStore';
 import AppMountNotifier from './app-mount-notifier';

--- a/client/src/components/profile/components/camper.tsx
+++ b/client/src/components/profile/components/camper.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { TFunction, useTranslation } from 'react-i18next';
 
 import envData from '../../../../../config/env.json';
-import { getLangCode } from '../../../../../config/i18n/all-langs';
+import { getLangCode } from '../../../../../config/i18n';
 import { AvatarRenderer } from '../../helpers';
 import Link from '../../helpers/link';
 import SocialIcons from './social-icons';

--- a/client/src/components/profile/components/heat-map.tsx
+++ b/client/src/components/profile/components/heat-map.tsx
@@ -16,7 +16,7 @@ import './heatmap.css';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import envData from '../../../../../config/env.json';
-import { getLangCode } from '../../../../../config/i18n/all-langs';
+import { getLangCode } from '../../../../../config/i18n';
 import { User } from '../../../redux/prop-types';
 import FullWidthRow from '../../helpers/full-width-row';
 import Spacer from '../../helpers/spacer';

--- a/client/src/components/profile/components/time-line.tsx
+++ b/client/src/components/profile/components/time-line.tsx
@@ -7,7 +7,7 @@ import { TFunction, withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 
 import envData from '../../../../../config/env.json';
-import { getLangCode } from '../../../../../config/i18n/all-langs';
+import { getLangCode } from '../../../../../config/i18n';
 import {
   getCertIds,
   getPathFromID,

--- a/config/i18n.ts
+++ b/config/i18n.ts
@@ -1,5 +1,5 @@
 // ---------------------------------------------------------------------------
-import { SuperBlocks } from '../certification-settings';
+import { SuperBlocks } from './certification-settings';
 /*
  * List of languages with localizations enabled for builds.
  *

--- a/curriculum/getChallenges.js
+++ b/curriculum/getChallenges.js
@@ -8,7 +8,7 @@ const readDirP = require('readdirp');
 const { helpCategoryMap } = require('../client/utils/challenge-types');
 const { showUpcomingChanges } = require('../config/env.json');
 const { curriculum: curriculumLangs } =
-  require('../config/i18n/all-langs').availableLangs;
+  require('../config/i18n').availableLangs;
 const { parseMD } = require('../tools/challenge-parser/parser');
 /* eslint-disable max-len */
 const {

--- a/curriculum/utils.js
+++ b/curriculum/utils.js
@@ -4,7 +4,7 @@ require('dotenv').config({ path: path.resolve(__dirname, '../.env') });
 const {
   availableLangs,
   languagesWithAuditedBetaReleases
-} = require('../config/i18n/all-langs');
+} = require('../config/i18n');
 const curriculumLangs = availableLangs.curriculum;
 
 exports.testedLang = function testedLang() {

--- a/curriculum/utils.test.ts
+++ b/curriculum/utils.test.ts
@@ -5,7 +5,7 @@ import fs from 'fs';
 import path from 'path';
 import { config } from 'dotenv';
 import { SuperBlocks } from '../config/certification-settings';
-import { languagesWithAuditedBetaReleases } from '../config/i18n/all-langs';
+import { languagesWithAuditedBetaReleases } from '../config/i18n';
 import { getSuperOrder, getSuperBlockFromDir } from './utils';
 
 config({ path: path.resolve(__dirname, '../.env') });

--- a/cypress/e2e/default/learn/header/universal-navigation.js
+++ b/cypress/e2e/default/learn/header/universal-navigation.js
@@ -2,7 +2,7 @@ import {
   availableLangs,
   hiddenLangs,
   LangNames
-} from '../../../../../config/i18n/all-langs';
+} from '../../../../../config/i18n';
 import envData from '../../../../../config/env.json';
 
 const { clientLocale } = envData;

--- a/tools/challenge-auditor/index.ts
+++ b/tools/challenge-auditor/index.ts
@@ -7,7 +7,7 @@ import { config } from 'dotenv';
 const envPath = resolve(__dirname, '../../.env');
 config({ path: envPath });
 
-import { availableLangs, auditedCerts } from '../../config/i18n/all-langs';
+import { availableLangs, auditedCerts } from '../../config/i18n';
 import { getChallengesForLang } from '../../curriculum/getChallenges';
 import { SuperBlocks } from '../../config/certification-settings';
 import { ChallengeNode } from '../../client/src/redux/prop-types';

--- a/tools/scripts/build/ensure-env.ts
+++ b/tools/scripts/build/ensure-env.ts
@@ -2,7 +2,7 @@ import { spawn } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 
-import { availableLangs } from '../../../config/i18n/all-langs';
+import { availableLangs } from '../../../config/i18n';
 import env from '../../../config/read-env';
 
 const globalConfigPath = path.resolve(__dirname, '../../../config');
@@ -14,7 +14,7 @@ function checkClientLocale() {
   if (!availableLangs.client.includes(process.env.CLIENT_LOCALE)) {
     throw Error(`
 
-      CLIENT_LOCALE, ${process.env.CLIENT_LOCALE}, is not an available language in config/i18n/all-langs.ts
+      CLIENT_LOCALE, ${process.env.CLIENT_LOCALE}, is not an available language in config/i18n.ts
 
       `);
   }
@@ -26,7 +26,7 @@ function checkCurriculumLocale() {
   if (!availableLangs.curriculum.includes(process.env.CURRICULUM_LOCALE)) {
     throw Error(`
 
-      CURRICULUM_LOCALE, ${process.env.CURRICULUM_LOCALE}, is not an available language in config/i18n/all-langs.ts
+      CURRICULUM_LOCALE, ${process.env.CURRICULUM_LOCALE}, is not an available language in config/i18n.ts
 
       `);
   }

--- a/utils/is-audited.js
+++ b/utils/is-audited.js
@@ -9,7 +9,7 @@
 // translated, but when they are they can be included by adding 'certificates'
 // to the arrays below
 
-const { auditedCerts } = require('../config/i18n/all-langs');
+const { auditedCerts } = require('../config/i18n');
 
 function isAuditedCert(lang, cert) {
   if (!lang || !cert)


### PR DESCRIPTION
This renames the config file for localization to be more relateable. When the file was created originally the idea was to keep configs in mutliple files co-located in the folder, but I think the memo was missed and it's best we keep it all in a single file achieving the same results.
