### PR TITLE
fix(curriculum): changed wording of step 11 and 12 for easier understanding

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/616d4a84b756d9c4b8255093.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/616d4a84b756d9c4b8255093.md
@@ -7,7 +7,7 @@ dashedName: step-11
 
 # --description--
 
-It's time to add some color to the page. Remember that one way to add color to an element is to use a <dfn>color keyword</dfn> like `black`, `cyan`, or `yellow`.
+It's time to add some color to the marker. Remember that one way to add color to an element is to use a <dfn>color keyword</dfn> like `black`, `cyan`, or `yellow`.
 
 As a reminder, here's how to target the class `freecodecamp`:
 
@@ -18,6 +18,8 @@ As a reminder, here's how to target the class `freecodecamp`:
 ```
 
 Create a new CSS rule that targets the class `marker`, and set its `background-color` property to `red`.
+
+**Note:** You will not see any changes after adding the CSS.
 
 # --hints--
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/616d50b93ba424d6282c99cf.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-colors-by-building-a-set-of-colored-markers/616d50b93ba424d6282c99cf.md
@@ -7,9 +7,9 @@ dashedName: step-12
 
 # --description--
 
-Notice that your marker doesn't seem to have any color. The background color was actually applied, but since the marker `div` element is empty, it doesn't have any height by default.
+The background color was applied, but since the marker `div` element is empty, it doesn't have any height by default.
 
-In your `.marker` CSS rule, set the `width` property to `200px` and the `height` property to `25px`.
+In your `.marker` CSS rule, set the `height` property to `25px` and the `width` property to `200px`
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #47102 

<!-- Feel free to add any additional description of changes below this line -->

I agree that taking out the first sentence of step 12 makes sense because we reference it in the previous step, however, if we think it might be beneficial to repeat it again in case someone doesn't read the last sentence of the last step, I can add that line back in.
