### PR TITLE
fix(curriculum): describe different browser behavior (Survey Form)

### DIFF
--- a/curriculum/challenges/english/01-responsive-web-design/responsive-web-design-projects/build-a-survey-form.md
+++ b/curriculum/challenges/english/01-responsive-web-design/responsive-web-design-projects/build-a-survey-form.md
@@ -19,7 +19,7 @@ dashedName: build-a-survey-form
 1. Inside the form element, you are **required** to enter your email in an `input` field that has an `id` of `email`
 1. If you enter an email that is not formatted correctly, you will see an HTML5 validation error
 1. Inside the form, you can enter a number in an `input` field that has an `id` of `number`
-1. If you enter non-numbers in the number input, you will see an HTML5 validation error
+1. If you enter non-numbers in the number input, either an HTML5 validation error will appear or you won't be able to type them (depending on your browser)
 1. If you enter numbers outside the range of the number input, which are defined by the `min` and `max` attributes, you will see an HTML5 validation error
 1. For the name, email, and number input fields, you can see corresponding `label` elements in the form, that describe the purpose of each field with the following ids: `id="name-label"`, `id="email-label"`, and `id="number-label"`
 1. For the name, email, and number input fields, you can see placeholder text that gives a description or instructions for each field

--- a/curriculum/challenges/english/01-responsive-web-design/responsive-web-design-projects/build-a-survey-form.md
+++ b/curriculum/challenges/english/01-responsive-web-design/responsive-web-design-projects/build-a-survey-form.md
@@ -19,7 +19,7 @@ dashedName: build-a-survey-form
 1. Inside the form element, you are **required** to enter your email in an `input` field that has an `id` of `email`
 1. If you enter an email that is not formatted correctly, you will see an HTML5 validation error
 1. Inside the form, you can enter a number in an `input` field that has an `id` of `number`
-1. If you enter non-numbers in the number input, either an HTML5 validation error will appear or you won't be able to type them (depending on your browser)
+1. The number input should not accept non-numbers, either by preventing you from typing them or by showing an HTML5 validation error (depending on your browser).
 1. If you enter numbers outside the range of the number input, which are defined by the `min` and `max` attributes, you will see an HTML5 validation error
 1. For the name, email, and number input fields, you can see corresponding `label` elements in the form, that describe the purpose of each field with the following ids: `id="name-label"`, `id="email-label"`, and `id="number-label"`
 1. For the name, email, and number input fields, you can see placeholder text that gives a description or instructions for each field

--- a/curriculum/challenges/english/14-responsive-web-design-22/build-a-survey-form-project/build-a-survey-form.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/build-a-survey-form-project/build-a-survey-form.md
@@ -19,7 +19,7 @@ dashedName: build-a-survey-form
 1. Inside the form element, you are **required** to enter your email in an `input` field that has an `id` of `email`
 1. If you enter an email that is not formatted correctly, you will see an HTML5 validation error
 1. Inside the form, you can enter a number in an `input` field that has an `id` of `number`
-1. If you enter non-numbers in the number input, you will see an HTML5 validation error
+1. If you enter non-numbers in the number input, either an HTML5 validation error will appear or you won't be able to type them (depending on your browser)
 1. If you enter numbers outside the range of the number input, which are defined by the `min` and `max` attributes, you will see an HTML5 validation error
 1. For the name, email, and number input fields, you can see corresponding `label` elements in the form, that describe the purpose of each field with the following ids: `id="name-label"`, `id="email-label"`, and `id="number-label"`
 1. For the name, email, and number input fields, you can see placeholder text that gives a description or instructions for each field

--- a/curriculum/challenges/english/14-responsive-web-design-22/build-a-survey-form-project/build-a-survey-form.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/build-a-survey-form-project/build-a-survey-form.md
@@ -19,7 +19,7 @@ dashedName: build-a-survey-form
 1. Inside the form element, you are **required** to enter your email in an `input` field that has an `id` of `email`
 1. If you enter an email that is not formatted correctly, you will see an HTML5 validation error
 1. Inside the form, you can enter a number in an `input` field that has an `id` of `number`
-1. If you enter non-numbers in the number input, either an HTML5 validation error will appear or you won't be able to type them (depending on your browser)
+1. The number input should not accept non-numbers, either by preventing you from typing them or by showing an HTML5 validation error (depending on your browser).
 1. If you enter numbers outside the range of the number input, which are defined by the `min` and `max` attributes, you will see an HTML5 validation error
 1. For the name, email, and number input fields, you can see corresponding `label` elements in the form, that describe the purpose of each field with the following ids: `id="name-label"`, `id="email-label"`, and `id="number-label"`
 1. For the name, email, and number input fields, you can see placeholder text that gives a description or instructions for each field


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Affected page: https://www.freecodecamp.org/learn/2022/responsive-web-design/build-a-survey-form-project/build-a-survey-form

There is this user story:
> 8. If you enter non-numbers in the number input, you will see an HTML5 validation error

This is true on Firefox, but on Chrome or Edge you can't type non-number characters into a number field.
You can check this behavior with the "Age" field in the demo project: https://survey-form.freecodecamp.rocks/