### PR TITLE
refactor(client): searchbar - remove float values

### DIFF
--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -11,6 +11,7 @@
   color: var(--gray-00);
   width: 100%;
   padding: 0 15px;
+  top: 0;
 }
 
 .universal-nav a {
@@ -73,12 +74,15 @@
 
 .nav-list {
   display: none;
+  position: absolute;
   background-color: var(--theme-color);
+  top: calc(var(--header-height) * 2);
+  right: 0;
   flex-wrap: wrap;
   justify-content: flex-end;
   width: 100vw;
   height: auto;
-  margin: 0;
+  margin: 0 0 0 -12px;
   padding: 0;
   list-style: none;
   max-width: 15rem;
@@ -200,6 +204,7 @@ button.nav-link[aria-disabled='true'] {
   color: var(--gray-90);
   background-color: var(--gray-80);
   width: 100%;
+  position: absolute;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -208,6 +213,7 @@ button.nav-link[aria-disabled='true'] {
   border: 2px solid var(--gray-90);
   border-top: 0;
   border-bottom: 0;
+  top: 0;
   overflow-y: auto;
   scrollbar-width: auto;
 
@@ -437,6 +443,12 @@ button.nav-link[aria-disabled='true'] {
   justify-content: center;
 }
 
+.universal-nav-right .fcc_searchBar {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
 .universal-nav-right .fcc_searchBar .ais-SearchBox-form {
   width: 100vw;
   height: var(--search-box-form);
@@ -508,11 +520,15 @@ button.nav-link[aria-disabled='true'] {
 
   .fcc_searchBar .ais-SearchBox-form {
     display: flex;
+    top: var(--header-height);
     max-width: calc(100vw - 350px);
   }
 
   #universal-nav-logo {
     display: flex;
+    position: absolute;
+    left: 17px;
+    top: 0;
   }
 
   .expand-nav {
@@ -523,6 +539,7 @@ button.nav-link[aria-disabled='true'] {
 @media (max-width: 600px) {
   .nav-list {
     min-width: 100%;
+    top: calc(var(--header-height) * 2);
     margin-top: 0;
   }
 
@@ -580,11 +597,15 @@ button.nav-link[aria-disabled='true'] {
   .nav-link-sign-in {
     display: flex;
   }
+  #universal-nav-logo {
+    left: 8px;
+  }
 }
 
 @media (max-width: 300px) {
   #universal-nav-logo {
     max-width: none;
+    left: -170px;
   }
   #universal-nav-logo svg {
     display: block;

--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -484,12 +484,6 @@ button.nav-link[aria-disabled='true'] {
   width: calc(100vw - 17rem);
 }
 
-.universal-nav-right .fcc_searchBar .ais-SearchBox-submit {
-  top: unset;
-  margin-top: 19px;
-  left: 18px;
-}
-
 .ais-SearchBox-input:focus {
   outline: 3px solid var(--blue-mid);
 }

--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -445,14 +445,13 @@ button.nav-link[aria-disabled='true'] {
 
 .universal-nav-right .fcc_searchBar {
   position: absolute;
-  top: 0;
+  top: var(--header-height);
   left: 0;
 }
 
 .universal-nav-right .fcc_searchBar .ais-SearchBox-form {
   width: 100vw;
   max-width: unset;
-  height: var(--search-box-form);
   padding: 0 15px;
 }
 
@@ -475,7 +474,7 @@ button.nav-link[aria-disabled='true'] {
 }
 
 .universal-nav-right .ais-SearchBox-input {
-  width: calc(100vw - 19rem);
+  width: calc(100vw - 17rem);
 }
 
 .universal-nav-right .fcc_searchBar .ais-Hits {
@@ -522,7 +521,6 @@ button.nav-link[aria-disabled='true'] {
   .fcc_searchBar .ais-SearchBox-form {
     display: flex;
     justify-content: flex-end;
-    top: var(--header-height);
     max-width: calc(100vw - 350px);
   }
 
@@ -547,7 +545,6 @@ button.nav-link[aria-disabled='true'] {
 
   .fcc_searchBar,
   .fcc_searchBar div {
-    z-index: -1;
     width: 100%;
   }
 

--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -41,6 +41,7 @@
   display: flex;
   justify-content: flex-end;
   align-items: center;
+  gap: 10px;
   flex: 1 0 33%;
   height: var(--header-height);
 }
@@ -332,7 +333,6 @@ button.nav-link[aria-disabled='true'] {
   background-color: var(--theme-color);
   cursor: pointer;
   max-height: calc(var(--header-height) - 8px);
-  margin-right: 10px;
   display: flex;
   align-items: center;
 }
@@ -543,6 +543,7 @@ button.nav-link[aria-disabled='true'] {
 
   .fcc_searchBar,
   .fcc_searchBar div {
+    z-index: -1;
     width: 100%;
   }
 

--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -452,9 +452,7 @@ button.nav-link[aria-disabled='true'] {
 .universal-nav-right .fcc_searchBar .ais-SearchBox-form {
   width: 100vw;
   height: var(--search-box-form);
-  max-width: unset;
   padding: 0 15px;
-  left: 0;
 }
 
 /* In mobile layout, prevent search input from hanging around if the 
@@ -522,9 +520,7 @@ button.nav-link[aria-disabled='true'] {
 
   .fcc_searchBar .ais-SearchBox-form {
     display: flex;
-    position: absolute;
     top: var(--header-height);
-    left: 15px;
     max-width: calc(100vw - 350px);
   }
 
@@ -554,6 +550,7 @@ button.nav-link[aria-disabled='true'] {
 
   .universal-nav-right .fcc_searchBar .ais-SearchBox-form {
     width: 100%;
+    max-width: 100%;
   }
 
   .display-menu {

--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -11,7 +11,6 @@
   color: var(--gray-00);
   width: 100%;
   padding: 0 15px;
-  top: 0;
 }
 
 .universal-nav a {
@@ -74,15 +73,12 @@
 
 .nav-list {
   display: none;
-  position: absolute;
   background-color: var(--theme-color);
-  top: calc(var(--header-height) * 2);
-  right: 0;
   flex-wrap: wrap;
   justify-content: flex-end;
   width: 100vw;
   height: auto;
-  margin: 0 0 0 -12px;
+  margin: 0;
   padding: 0;
   list-style: none;
   max-width: 15rem;
@@ -204,7 +200,6 @@ button.nav-link[aria-disabled='true'] {
   color: var(--gray-90);
   background-color: var(--gray-80);
   width: 100%;
-  position: absolute;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -213,7 +208,6 @@ button.nav-link[aria-disabled='true'] {
   border: 2px solid var(--gray-90);
   border-top: 0;
   border-bottom: 0;
-  top: 0;
   overflow-y: auto;
   scrollbar-width: auto;
 
@@ -443,12 +437,6 @@ button.nav-link[aria-disabled='true'] {
   justify-content: center;
 }
 
-.universal-nav-right .fcc_searchBar {
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-
 .universal-nav-right .fcc_searchBar .ais-SearchBox-form {
   width: 100vw;
   height: var(--search-box-form);
@@ -520,15 +508,11 @@ button.nav-link[aria-disabled='true'] {
 
   .fcc_searchBar .ais-SearchBox-form {
     display: flex;
-    top: var(--header-height);
     max-width: calc(100vw - 350px);
   }
 
   #universal-nav-logo {
     display: flex;
-    position: absolute;
-    left: 17px;
-    top: 0;
   }
 
   .expand-nav {
@@ -539,7 +523,6 @@ button.nav-link[aria-disabled='true'] {
 @media (max-width: 600px) {
   .nav-list {
     min-width: 100%;
-    top: calc(var(--header-height) * 2);
     margin-top: 0;
   }
 
@@ -597,15 +580,11 @@ button.nav-link[aria-disabled='true'] {
   .nav-link-sign-in {
     display: flex;
   }
-  #universal-nav-logo {
-    left: 8px;
-  }
 }
 
 @media (max-width: 300px) {
   #universal-nav-logo {
     max-width: none;
-    left: -170px;
   }
   #universal-nav-logo svg {
     display: block;

--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -477,7 +477,6 @@ button.nav-link[aria-disabled='true'] {
 
 .universal-nav-right .ais-SearchBox-input {
   width: calc(100vw - 17rem);
-  padding-left: 27px;
 }
 
 .universal-nav-right .fcc_searchBar .ais-Hits {

--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -451,6 +451,7 @@ button.nav-link[aria-disabled='true'] {
 
 .universal-nav-right .fcc_searchBar .ais-SearchBox-form {
   width: 100vw;
+  max-width: unset;
   height: var(--search-box-form);
   padding: 0 15px;
 }
@@ -474,11 +475,7 @@ button.nav-link[aria-disabled='true'] {
 }
 
 .universal-nav-right .ais-SearchBox-input {
-  width: calc(100vw - 17rem);
-}
-
-.universal-nav-right .fcc_searchBar .ais-Hits {
-  width: calc(100vw - 17rem);
+  width: calc(100vw - 19rem);
 }
 
 .ais-SearchBox-input:focus {
@@ -520,6 +517,7 @@ button.nav-link[aria-disabled='true'] {
 
   .fcc_searchBar .ais-SearchBox-form {
     display: flex;
+    justify-content: flex-end;
     top: var(--header-height);
     max-width: calc(100vw - 350px);
   }
@@ -550,7 +548,6 @@ button.nav-link[aria-disabled='true'] {
 
   .universal-nav-right .fcc_searchBar .ais-SearchBox-form {
     width: 100%;
-    max-width: 100%;
   }
 
   .display-menu {

--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -478,6 +478,10 @@ button.nav-link[aria-disabled='true'] {
   width: calc(100vw - 19rem);
 }
 
+.universal-nav-right .fcc_searchBar .ais-Hits {
+  width: calc(100vw - 17rem);
+}
+
 .ais-SearchBox-input:focus {
   outline: 3px solid var(--blue-mid);
 }

--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -4,25 +4,6 @@ html {
   -webkit-font-smoothing: antialiased;
 }
 
-[dir='rtl'] .nav-list {
-  right: 0;
-}
-
-.fcc_searchBar .ais-SearchBox-input,
-.fcc_searchBar .ais-Hits {
-  padding-inline-start: 1.5em;
-}
-@media (max-width: 980px) {
-  [dir='rtl'] #universal-nav-logo {
-    left: inherit;
-    right: 17px;
-  }
-  [dir='rtl'] .ais-SearchBox-submit {
-    left: inherit;
-    right: 0.55em;
-  }
-}
-
 body {
   height: 100%;
   font-family: 'Hack-ZeroSlash', monospace;

--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -4,6 +4,25 @@ html {
   -webkit-font-smoothing: antialiased;
 }
 
+[dir='rtl'] .nav-list {
+  right: 0;
+}
+
+.fcc_searchBar .ais-SearchBox-input,
+.fcc_searchBar .ais-Hits {
+  padding-inline-start: 1.5em;
+}
+@media (max-width: 980px) {
+  [dir='rtl'] #universal-nav-logo {
+    left: inherit;
+    right: 17px;
+  }
+  [dir='rtl'] .ais-SearchBox-submit {
+    left: inherit;
+    right: 0.55em;
+  }
+}
+
 body {
   height: 100%;
   font-family: 'Hack-ZeroSlash', monospace;

--- a/client/src/components/search/searchBar/searchbar-base.css
+++ b/client/src/components/search/searchBar/searchbar-base.css
@@ -617,10 +617,13 @@ a[class^='ais-'] {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  position: absolute;
   z-index: 100;
   width: 20px;
   height: 20px;
+}
+.ais-SearchBox-reset,
+.ais-SearchBox-loadingIndicator {
+  position: absolute;
   top: 50%;
   right: 0.3rem;
   -webkit-transform: translateY(-50%);
@@ -629,7 +632,6 @@ a[class^='ais-'] {
 .ais-SearchBox-reset {
   right: 0.3rem;
 }
-.ais-SearchBox-submitIcon,
 .ais-SearchBox-resetIcon,
 .ais-SearchBox-loadingIcon {
   position: absolute;

--- a/client/src/components/search/searchBar/searchbar-base.css
+++ b/client/src/components/search/searchBar/searchbar-base.css
@@ -632,6 +632,9 @@ a[class^='ais-'] {
 .ais-SearchBox-reset {
   right: 0.3rem;
 }
+.ais-SearchBox-submit {
+  position: absolute;
+}
 .ais-SearchBox-resetIcon,
 .ais-SearchBox-loadingIcon {
   position: absolute;
@@ -685,4 +688,10 @@ a[class^='ais-'] {
 }
 strong.ais-Highlight-highlighted {
   background-color: transparent;
+}
+
+@media (min-width: 981px) {
+  .ais-SearchBox-submit {
+    left: 0;
+  }
 }

--- a/client/src/components/search/searchBar/searchbar-base.css
+++ b/client/src/components/search/searchBar/searchbar-base.css
@@ -24,8 +24,7 @@
 .ais-Menu-showMore,
 .ais-RangeInput-submit,
 .ais-RefinementList-showMore,
-.ais-SearchBox-submit,
-.ais-SearchBox-reset {
+.ais-SearchBox-submit {
   padding: 0;
   overflow: visible;
   font: inherit;
@@ -48,8 +47,7 @@
 .ais-Menu-showMore::-moz-focus-inner,
 .ais-RangeInput-submit::-moz-focus-inner,
 .ais-RefinementList-showMore::-moz-focus-inner,
-.ais-SearchBox-submit::-moz-focus-inner,
-.ais-SearchBox-reset::-moz-focus-inner {
+.ais-SearchBox-submit::-moz-focus-inner {
   padding: 0;
   border: 0;
 }
@@ -62,8 +60,7 @@
 .ais-Menu-showMore[disabled],
 .ais-RangeInput-submit[disabled],
 .ais-RefinementList-showMore[disabled],
-.ais-SearchBox-submit[disabled],
-.ais-SearchBox-reset[disabled] {
+.ais-SearchBox-submit[disabled] {
   cursor: default;
 }
 .ais-Breadcrumb-list,
@@ -611,26 +608,13 @@ a[class^='ais-'] {
 .ais-SearchBox-input:-moz-placeholder {
   color: var(--gray-15);
 }
-.ais-SearchBox-submit,
-.ais-SearchBox-reset,
-.ais-SearchBox-loadingIndicator {
+.ais-SearchBox-submit {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
   z-index: 100;
   width: 20px;
   height: 20px;
-}
-.ais-SearchBox-reset,
-.ais-SearchBox-loadingIndicator {
-  position: absolute;
-  top: 50%;
-  right: 0.3rem;
-  -webkit-transform: translateY(-50%);
-  transform: translateY(-50%);
-}
-.ais-SearchBox-reset {
-  right: 0.3rem;
 }
 .ais-SearchBox-submit {
   position: absolute;
@@ -644,8 +628,7 @@ a[class^='ais-'] {
   transform: translateX(-50%) translateY(-50%);
 }
 .ais-SearchBox-submitIcon path,
-.ais-SearchBox-resetIcon path,
-.ais-SearchBox-loadingIndicator {
+.ais-SearchBox-resetIcon path {
   fill: var(--gray-15);
 }
 .ais-SearchBox-submitIcon {

--- a/client/src/components/search/searchBar/searchbar-base.css
+++ b/client/src/components/search/searchBar/searchbar-base.css
@@ -689,9 +689,3 @@ a[class^='ais-'] {
 strong.ais-Highlight-highlighted {
   background-color: transparent;
 }
-
-@media (min-width: 981px) {
-  .ais-SearchBox-submit {
-    left: 0;
-  }
-}

--- a/client/src/components/search/searchBar/searchbar.css
+++ b/client/src/components/search/searchBar/searchbar.css
@@ -31,6 +31,7 @@
 
 .fcc_searchBar .ais-SearchBox-input,
 .fcc_searchBar .ais-Hits {
+  padding-inline-start: 1.5em;
   z-index: 100;
   background-color: var(--gray-75);
   color: var(--gray-00);

--- a/client/src/components/search/searchBar/searchbar.css
+++ b/client/src/components/search/searchBar/searchbar.css
@@ -15,7 +15,7 @@
 }
 
 .ais-SearchBox-input {
-  padding: 0 10px 0 10px;
+  padding: 0 10px;
   font-size: 18px;
   display: inline-block;
   margin-top: 6px;
@@ -25,8 +25,10 @@
 .ais-SearchBox-submit {
   margin-top: 6px;
   height: 26px;
+  width: 26px;
   background-color: var(--gray-75);
-  padding-left: 3px;
+  padding-inline: 3px;
+  border-radius: 0px 15px 0px 15px / 0px 10px 0px 10px;
 }
 
 .fcc_searchBar .ais-SearchBox-input,
@@ -46,6 +48,7 @@
   margin-bottom: 0;
   display: flex;
   flex-direction: row-reverse;
+  gap: 0.25em;
   position: absolute;
   top: var(--header-height);
   right: 5px;

--- a/client/src/components/search/searchBar/searchbar.css
+++ b/client/src/components/search/searchBar/searchbar.css
@@ -28,6 +28,7 @@
   width: 26px;
   background-color: var(--gray-75);
   padding-inline: 3px;
+  border-radius: 0px 15px 0px 15px / 0px 10px 0px 10px;
 }
 
 .fcc_searchBar .ais-SearchBox-input,
@@ -38,7 +39,9 @@
 }
 
 .fcc_searchBar .ais-Hits {
+  top: 70px;
   width: calc(100vw - 350px);
+  left: 15px;
 }
 
 /* hits */
@@ -127,6 +130,8 @@ and arrow keys */
   display: flex;
   flex-direction: row-reverse;
   gap: 0.25em;
+  top: var(--header-height);
+  right: 15px;
 }
 
 @media (min-width: 981px) {
@@ -139,10 +144,15 @@ and arrow keys */
     max-width: 520px;
   }
   .fcc_searchBar .ais-Hits {
+    top: auto;
     width: calc(100% - 20px);
     max-width: 500px;
+    left: 10px;
   }
   .fcc_searchBar .ais-SearchBox-form {
     display: flex;
+    position: static;
+    top: auto;
+    right: 15px;
   }
 }

--- a/client/src/components/search/searchBar/searchbar.css
+++ b/client/src/components/search/searchBar/searchbar.css
@@ -44,16 +44,6 @@
   left: 15px;
 }
 
-.fcc_searchBar .ais-SearchBox-form {
-  margin-bottom: 0;
-  display: flex;
-  flex-direction: row-reverse;
-  gap: 0.25em;
-  position: absolute;
-  top: var(--header-height);
-  right: 5px;
-}
-
 /* hits */
 .fcc_searchBar .ais-Highlight-highlighted {
   background-color: transparent;
@@ -136,13 +126,15 @@ and arrow keys */
 }
 
 .fcc_searchBar .ais-SearchBox-form {
+  margin-bottom: 0;
   display: flex;
-  position: absolute;
+  flex-direction: row-reverse;
+  gap: 0.25em;
   top: var(--header-height);
   right: 15px;
 }
 
-@media (min-width: 980px) {
+@media (min-width: 981px) {
   .ais-SearchBox-input {
     width: 100%;
     max-width: 500px;

--- a/client/src/components/search/searchBar/searchbar.css
+++ b/client/src/components/search/searchBar/searchbar.css
@@ -31,15 +31,16 @@
 
 .fcc_searchBar .ais-SearchBox-input,
 .fcc_searchBar .ais-Hits {
-  padding-inline-start: 1.5em;
   z-index: 100;
   background-color: var(--gray-75);
   color: var(--gray-00);
 }
 
+.fcc_searchBar .ais-SearchBox-input {
+  padding-inline-start: 1.5em;
+}
+
 .fcc_searchBar .ais-Hits {
-  top: 70px;
-  width: calc(100vw - 350px);
   left: 15px;
 }
 
@@ -129,7 +130,6 @@ and arrow keys */
   display: flex;
   flex-direction: row-reverse;
   gap: 0.25em;
-  top: var(--header-height);
 }
 
 @media (min-width: 981px) {
@@ -143,12 +143,13 @@ and arrow keys */
   }
   .fcc_searchBar .ais-Hits {
     top: auto;
-    width: calc(100% - 20px);
+    width: 100%;
     max-width: 500px;
-    left: 10px;
+    left: 0px;
   }
   .fcc_searchBar .ais-SearchBox-form {
     display: flex;
+    justify-content: flex-end;
     top: auto;
   }
 }

--- a/client/src/components/search/searchBar/searchbar.css
+++ b/client/src/components/search/searchBar/searchbar.css
@@ -1,6 +1,5 @@
 .fcc_searchBar {
   flex-grow: 1;
-  padding: 0 10px;
   max-height: 33px;
   font-family: 'Lato', sans-serif;
 }
@@ -28,7 +27,6 @@
   width: 26px;
   background-color: var(--gray-75);
   padding-inline: 3px;
-  border-radius: 0px 15px 0px 15px / 0px 10px 0px 10px;
 }
 
 .fcc_searchBar .ais-SearchBox-input,
@@ -131,7 +129,6 @@ and arrow keys */
   flex-direction: row-reverse;
   gap: 0.25em;
   top: var(--header-height);
-  right: 15px;
 }
 
 @media (min-width: 981px) {
@@ -151,8 +148,6 @@ and arrow keys */
   }
   .fcc_searchBar .ais-SearchBox-form {
     display: flex;
-    position: static;
     top: auto;
-    right: 15px;
   }
 }

--- a/client/src/components/search/searchBar/searchbar.css
+++ b/client/src/components/search/searchBar/searchbar.css
@@ -9,7 +9,8 @@
   color: var(--gray-00);
 }
 
-.ais-SearchBox-reset {
+.ais-SearchBox-reset,
+.ais-SearchBox-loadingIndicator {
   display: none;
 }
 

--- a/client/src/components/search/searchBar/searchbar.css
+++ b/client/src/components/search/searchBar/searchbar.css
@@ -28,7 +28,6 @@
   width: 26px;
   background-color: var(--gray-75);
   padding-inline: 3px;
-  border-radius: 0px 15px 0px 15px / 0px 10px 0px 10px;
 }
 
 .fcc_searchBar .ais-SearchBox-input,
@@ -39,9 +38,7 @@
 }
 
 .fcc_searchBar .ais-Hits {
-  top: 70px;
   width: calc(100vw - 350px);
-  left: 15px;
 }
 
 /* hits */
@@ -130,8 +127,6 @@ and arrow keys */
   display: flex;
   flex-direction: row-reverse;
   gap: 0.25em;
-  top: var(--header-height);
-  right: 15px;
 }
 
 @media (min-width: 981px) {
@@ -144,15 +139,10 @@ and arrow keys */
     max-width: 520px;
   }
   .fcc_searchBar .ais-Hits {
-    top: auto;
     width: calc(100% - 20px);
     max-width: 500px;
-    left: 10px;
   }
   .fcc_searchBar .ais-SearchBox-form {
     display: flex;
-    position: static;
-    top: auto;
-    right: 15px;
   }
 }

--- a/client/src/components/search/searchBar/searchbar.css
+++ b/client/src/components/search/searchBar/searchbar.css
@@ -15,7 +15,7 @@
 }
 
 .ais-SearchBox-input {
-  padding: 0 10px 0 30px;
+  padding: 0 10px 0 10px;
   font-size: 18px;
   display: inline-block;
   margin-top: 6px;
@@ -23,8 +23,10 @@
 }
 
 .ais-SearchBox-submit {
-  left: 0.3rem;
-  top: 59.5%;
+  margin-top: 6px;
+  height: 26px;
+  background-color: var(--gray-75);
+  padding-left: 3px;
 }
 
 .fcc_searchBar .ais-SearchBox-input,
@@ -43,6 +45,7 @@
 .fcc_searchBar .ais-SearchBox-form {
   margin-bottom: 0;
   display: flex;
+  flex-direction: row-reverse;
   position: absolute;
   top: var(--header-height);
   right: 5px;
@@ -156,8 +159,5 @@ and arrow keys */
     position: static;
     top: auto;
     right: 15px;
-  }
-  .ais-SearchBox-submit {
-    left: 0.85rem;
   }
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Ref #48101

As usual can't fix it? remove it 😅. it was hard to account for float and move around the code base picking certain float values to account for RTL. so I removed the float and focused on flexbox.

I have pushed this, because it can act as backup. I don't know if this is needed, and we are losing outlining both search and the button, which may hurt accessibility somehow? idk. so I have to think of way to sort this out 🤔 

<!-- Feel free to add any additional description of changes below this line -->
