### PR TITLE
feat(client): refactor the buttons leading to the certifcations intro

### DIFF
--- a/client/src/components/Map/__snapshots__/map.test.tsx.snap
+++ b/client/src/components/Map/__snapshots__/map.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`<Map /> snapshot: Map 1`] = `
           href="/learn/super-block-one/"
         >
           <div
-            style="display: flex; justify-content: space-between; align-items: center;"
+            style="display: flex; justify-content: space-between; align-items: center; gap: 15px;"
           >
             <svg
               aria-hidden="true"
@@ -55,7 +55,7 @@ exports[`<Map /> snapshot: Map 1`] = `
           href="/learn/super-block-four/"
         >
           <div
-            style="display: flex; justify-content: space-between; align-items: center;"
+            style="display: flex; justify-content: space-between; align-items: center; gap: 15px;"
           >
             <svg
               aria-hidden="true"
@@ -95,7 +95,7 @@ exports[`<Map /> snapshot: Map 1`] = `
           href="/learn/super-block-one/"
         >
           <div
-            style="display: flex; justify-content: space-between; align-items: center;"
+            style="display: flex; justify-content: space-between; align-items: center; gap: 15px;"
           >
             <svg
               aria-hidden="true"
@@ -135,7 +135,7 @@ exports[`<Map /> snapshot: Map 1`] = `
           href="/learn/super-block-one/"
         >
           <div
-            style="display: flex; justify-content: space-between; align-items: center;"
+            style="display: flex; justify-content: space-between; align-items: center; gap: 15px;"
           >
             <svg
               aria-hidden="true"
@@ -175,7 +175,7 @@ exports[`<Map /> snapshot: Map 1`] = `
           href="/learn/super-block-one/"
         >
           <div
-            style="display: flex; justify-content: space-between; align-items: center;"
+            style="display: flex; justify-content: space-between; align-items: center; gap: 15px;"
           >
             <svg
               aria-hidden="true"
@@ -215,7 +215,7 @@ exports[`<Map /> snapshot: Map 1`] = `
           href="/learn/super-block-one/"
         >
           <div
-            style="display: flex; justify-content: space-between; align-items: center;"
+            style="display: flex; justify-content: space-between; align-items: center; gap: 15px;"
           >
             <svg
               aria-hidden="true"
@@ -255,7 +255,7 @@ exports[`<Map /> snapshot: Map 1`] = `
           href="/learn/super-block-two/"
         >
           <div
-            style="display: flex; justify-content: space-between; align-items: center;"
+            style="display: flex; justify-content: space-between; align-items: center; gap: 15px;"
           >
             <svg
               aria-hidden="true"
@@ -295,7 +295,7 @@ exports[`<Map /> snapshot: Map 1`] = `
           href="/learn/super-block-two/"
         >
           <div
-            style="display: flex; justify-content: space-between; align-items: center;"
+            style="display: flex; justify-content: space-between; align-items: center; gap: 15px;"
           >
             <svg
               aria-hidden="true"
@@ -335,7 +335,7 @@ exports[`<Map /> snapshot: Map 1`] = `
           href="/learn/super-block-two/"
         >
           <div
-            style="display: flex; justify-content: space-between; align-items: center;"
+            style="display: flex; justify-content: space-between; align-items: center; gap: 15px;"
           >
             <svg
               aria-hidden="true"
@@ -375,7 +375,7 @@ exports[`<Map /> snapshot: Map 1`] = `
           href="/learn/super-block-two/"
         >
           <div
-            style="display: flex; justify-content: space-between; align-items: center;"
+            style="display: flex; justify-content: space-between; align-items: center; gap: 15px;"
           >
             <svg
               aria-hidden="true"
@@ -415,7 +415,7 @@ exports[`<Map /> snapshot: Map 1`] = `
           href="/learn/super-block-three/"
         >
           <div
-            style="display: flex; justify-content: space-between; align-items: center;"
+            style="display: flex; justify-content: space-between; align-items: center; gap: 15px;"
           >
             <svg
               aria-hidden="true"
@@ -455,7 +455,7 @@ exports[`<Map /> snapshot: Map 1`] = `
           href="/learn/super-block-three/"
         >
           <div
-            style="display: flex; justify-content: space-between; align-items: center;"
+            style="display: flex; justify-content: space-between; align-items: center; gap: 15px;"
           >
             <svg
               aria-hidden="true"
@@ -495,7 +495,7 @@ exports[`<Map /> snapshot: Map 1`] = `
           href="/learn/super-block-three/"
         >
           <div
-            style="display: flex; justify-content: space-between; align-items: center;"
+            style="display: flex; justify-content: space-between; align-items: center; gap: 15px;"
           >
             <svg
               aria-hidden="true"

--- a/client/src/components/Map/index.tsx
+++ b/client/src/components/Map/index.tsx
@@ -37,7 +37,8 @@ function createSuperBlockTitle(superBlock: SuperBlocks) {
 const linkSpacingStyle = {
   display: 'flex',
   justifyContent: 'space-between',
-  alignItems: 'center'
+  alignItems: 'center',
+  gap: '15px'
 };
 
 function renderLandingMap(nodes: ChallengeNode[]) {

--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -345,7 +345,7 @@ fieldset[disabled] .btn-primary.focus {
 .map-icon {
   width: 35px;
   max-height: 45px;
-  margin-right: 20px;
+  margin-inline: 5px;
 }
 
 .cert-header-icon {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Ref #48101

<!-- Feel free to add any additional description of changes below this line -->

I was going to change this in RTL layout PR, but I notices that it can be changed in different PR. so here it's 

The aim is to add gap, which will be reversed with the flexbox, instead of manipulating the margin values, so if in the future someone change the spacing in the button, it won't affect the RTL layout