### PR TITLE
feat(client): change the layout of lowerjaw hint and test to flex

### DIFF
--- a/client/src/templates/Challenges/classic/editor.css
+++ b/client/src/templates/Challenges/classic/editor.css
@@ -1,3 +1,10 @@
+:root {
+  --test-icon-spacing: 0.5rem;
+  --test-heading-spacing: 0.5rem;
+  --test-heading-margin: 0.5em 0 0;
+  --test-paragraph-margin: 0.45rem 0 0;
+}
+
 .monaco-editor .margin-view-overlays .line-numbers,
 .monaco-editor .margin-view-overlays .myLineDecoration + .line-numbers {
   color: var(--primary-color);
@@ -117,17 +124,16 @@ textarea.inputarea {
 }
 
 .test-feedback p {
-  margin: 0.45rem 0 0;
+  margin: var(--test-paragraph-margin);
   font-family: 'Lato', sans-serif;
 }
 
 .test-feedback h2 {
   font-size: 1rem;
   line-height: 1.5;
-  padding-right: 0.5rem;
   /* using float instead of inline display so screen readers recognize h2 as a block element */
   float: left;
-  margin: 0.5em 0 0;
+  margin: var(--test-heading-margin);
 }
 
 .test-feedback h2:after {
@@ -137,20 +143,21 @@ textarea.inputarea {
 .test-feedback svg {
   height: 1.5rem;
   width: auto;
-  margin-right: 0.5rem;
-  margin-top: 0.5rem;
+  margin-top: var(--test-icon-spacing);
 }
 
 .test-feedback .test-status,
 .test-feedback .hint-status {
   margin-top: 1rem;
   display: flex;
+  gap: var(--test-icon-spacing);
   flex-direction: row;
 }
 
 .test-status-description,
 .hint-description {
   display: flex;
+  gap: var(--test-heading-spacing);
   width: 100%;
 }
 

--- a/client/src/templates/Challenges/classic/editor.css
+++ b/client/src/templates/Challenges/classic/editor.css
@@ -141,14 +141,18 @@ textarea.inputarea {
   margin-top: 0.6rem;
 }
 
-.test-feedback > div {
+.test-feedback .test-status,
+.test-feedback .hint-status {
   margin-top: 1rem;
   display: flex;
+  align-items: center;
   flex-direction: row;
 }
 
 .test-status-description,
 .hint-description {
+  display: flex;
+  align-items: center;
   width: 100%;
 }
 

--- a/client/src/templates/Challenges/classic/editor.css
+++ b/client/src/templates/Challenges/classic/editor.css
@@ -1,10 +1,3 @@
-:root {
-  --test-icon-spacing: 0.5rem;
-  --test-heading-spacing: 0.5rem;
-  --test-heading-margin: 0.5em 0 0;
-  --test-paragraph-margin: 0.45rem 0 0;
-}
-
 .monaco-editor .margin-view-overlays .line-numbers,
 .monaco-editor .margin-view-overlays .myLineDecoration + .line-numbers {
   color: var(--primary-color);
@@ -124,7 +117,7 @@ textarea.inputarea {
 }
 
 .test-feedback p {
-  margin: var(--test-paragraph-margin);
+  margin: 0.45rem 0 0;
   font-family: 'Lato', sans-serif;
 }
 
@@ -133,7 +126,7 @@ textarea.inputarea {
   line-height: 1.5;
   /* using float instead of inline display so screen readers recognize h2 as a block element */
   float: left;
-  margin: var(--test-heading-margin);
+  margin: 0.5em 0 0;
 }
 
 .test-feedback h2:after {
@@ -143,21 +136,21 @@ textarea.inputarea {
 .test-feedback svg {
   height: 1.5rem;
   width: auto;
-  margin-top: var(--test-icon-spacing);
+  margin-top: 0.5rem;
 }
 
 .test-feedback .test-status,
 .test-feedback .hint-status {
   margin-top: 1rem;
   display: flex;
-  gap: var(--test-icon-spacing);
+  gap: 0.5rem;
   flex-direction: row;
 }
 
 .test-status-description,
 .hint-description {
   display: flex;
-  gap: var(--test-heading-spacing);
+  gap: 0.5rem;
   width: 100%;
 }
 
@@ -183,11 +176,11 @@ textarea.inputarea {
 .lower-jaw-icon-bar {
   overflow: hidden;
   display: flex;
+  gap: 10px;
   flex-direction: row;
 }
 .lower-jaw-icon-bar > button {
   line-height: 0;
-  margin-right: 10px;
 }
 
 .lower-jaw-icon-bar > button:focus {

--- a/client/src/templates/Challenges/classic/editor.css
+++ b/client/src/templates/Challenges/classic/editor.css
@@ -117,7 +117,7 @@ textarea.inputarea {
 }
 
 .test-feedback p {
-  margin: 0.5rem 0 0;
+  margin: 0.45rem 0 0;
   font-family: 'Lato', sans-serif;
 }
 
@@ -138,21 +138,19 @@ textarea.inputarea {
   height: 1.5rem;
   width: auto;
   margin-right: 0.5rem;
-  margin-top: 0.6rem;
+  margin-top: 0.5rem;
 }
 
 .test-feedback .test-status,
 .test-feedback .hint-status {
   margin-top: 1rem;
   display: flex;
-  align-items: center;
   flex-direction: row;
 }
 
 .test-status-description,
 .hint-description {
   display: flex;
-  align-items: center;
   width: 100%;
 }
 

--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -149,7 +149,7 @@ const LowerJaw = ({
               <p>{t(sentencePicker())}</p>
             </div>
           </div>
-          <div className='hint-status' aria-hidden={isFeedbackHidden}>
+          <div className='hint-status fade-in' aria-hidden={isFeedbackHidden}>
             <div className='hint-icon' aria-hidden='true'>
               <span>
                 <LightBulb />

--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -149,7 +149,7 @@ const LowerJaw = ({
               <p>{t(sentencePicker())}</p>
             </div>
           </div>
-          <div className='hint-status fade-in' aria-hidden={isFeedbackHidden}>
+          <div className='hint-status' aria-hidden={isFeedbackHidden}>
             <div className='hint-icon' aria-hidden='true'>
               <span>
                 <LightBulb />


### PR DESCRIPTION


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Ref #48101 

<!-- Feel free to add any additional description of changes below this line -->

Because the `h2` and the `p` don't swap because they aren't flex in RTL layout, I had to change the layout to flex.

![image](https://user-images.githubusercontent.com/88248797/198832763-4fd0d307-1b8f-48aa-bec1-26b3aced566b.png)

