### PR TITLE
refactor(client): space between passed icons and their sibling

### DIFF
--- a/client/src/assets/icons/green-not-completed.tsx
+++ b/client/src/assets/icons/green-not-completed.tsx
@@ -17,9 +17,9 @@ function GreenNotCompleted(props: GreenNotCompletedProps): JSX.Element {
       )}
       <svg
         aria-hidden='true'
-        height='50'
+        height='15'
         viewBox='0 0 200 200'
-        width='50'
+        width='15'
         xmlns='http://www.w3.org/2000/svg'
         {...rest}
       >

--- a/client/src/assets/icons/green-pass.tsx
+++ b/client/src/assets/icons/green-pass.tsx
@@ -14,9 +14,9 @@ function GreenPass(props: GreenPassProps): JSX.Element {
       <svg
         {...(hushScreenReaderText && { 'aria-hidden': true })}
         {...(!hushScreenReaderText && { 'aria-label': t('icons.passed') })}
-        height='50'
+        height='15'
         viewBox='0 0 200 200'
-        width='50'
+        width='15'
         xmlns='http://www.w3.org/2000/svg'
         {...rest}
       >

--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -1,3 +1,8 @@
+:root {
+  --icons-spacing: 10px;
+  --small-icons-spacing: 7px;
+}
+
 html {
   height: 100%;
   font-size: 18px;

--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -1,8 +1,3 @@
-:root {
-  --icons-spacing: 10px;
-  --small-icons-spacing: 7px;
-}
-
 html {
   height: 100%;
   font-size: 18px;

--- a/client/src/templates/Challenges/components/__snapshots__/challenge-title.test.tsx.snap
+++ b/client/src/templates/Challenges/components/__snapshots__/challenge-title.test.tsx.snap
@@ -19,7 +19,6 @@ exports[`<ChallengeTitle/> renders correctly 1`] = `
         style={
           Object {
             "height": "15px",
-            "marginLeft": "7px",
             "width": "15px",
           }
         }

--- a/client/src/templates/Challenges/components/__snapshots__/challenge-title.test.tsx.snap
+++ b/client/src/templates/Challenges/components/__snapshots__/challenge-title.test.tsx.snap
@@ -15,15 +15,9 @@ exports[`<ChallengeTitle/> renders correctly 1`] = `
       </h1>
       <svg
         aria-label="icons.passed"
-        height="50"
-        style={
-          Object {
-            "height": "15px",
-            "width": "15px",
-          }
-        }
+        height="15"
         viewBox="0 0 200 200"
-        width="50"
+        width="15"
         xmlns="http://www.w3.org/2000/svg"
       >
         <g

--- a/client/src/templates/Challenges/components/__snapshots__/completion-modal-body.test.tsx.snap
+++ b/client/src/templates/Challenges/components/__snapshots__/completion-modal-body.test.tsx.snap
@@ -9,9 +9,9 @@ exports[`<CompletionModalBody /> matches snapshot 1`] = `
       aria-label="icons.passed"
       class="completion-success-icon"
       data-testid="fcc-completion-success-icon"
-      height="50"
+      height="15"
       viewBox="0 0 200 200"
-      width="50"
+      width="15"
       xmlns="http://www.w3.org/2000/svg"
     >
       <g

--- a/client/src/templates/Challenges/components/challenge-title.css
+++ b/client/src/templates/Challenges/components/challenge-title.css
@@ -99,7 +99,7 @@
   text-decoration: none;
   min-width: 25px;
   display: flex;
-  gap: var(--small-icons-spacing);
+  gap: 7px;
   align-items: center;
   justify-content: center;
   overflow: hidden;

--- a/client/src/templates/Challenges/components/challenge-title.css
+++ b/client/src/templates/Challenges/components/challenge-title.css
@@ -98,7 +98,8 @@
 .title-text {
   text-decoration: none;
   min-width: 25px;
-  display: inline-block;
+  display: flex;
+  gap: var(--small-icons-spacing);
   align-items: center;
   justify-content: center;
   overflow: hidden;

--- a/client/src/templates/Challenges/components/challenge-title.tsx
+++ b/client/src/templates/Challenges/components/challenge-title.tsx
@@ -31,9 +31,7 @@ function ChallengeTitle({
       <div className='challenge-title'>
         <div className='title-text'>
           <h1>{children}</h1>
-          {isCompleted ? (
-            <GreenPass style={{ height: '15px', width: '15px' }} />
-          ) : null}
+          {isCompleted && <GreenPass />}
         </div>
       </div>
     </div>

--- a/client/src/templates/Challenges/components/challenge-title.tsx
+++ b/client/src/templates/Challenges/components/challenge-title.tsx
@@ -22,7 +22,6 @@ function ChallengeTitle({
         <>
           <Link
             className='title-translation-cta'
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             to={i18next.t('links:help-translate-link-url')}
           >
             {i18next.t('misc.translation-pending')}
@@ -33,9 +32,7 @@ function ChallengeTitle({
         <div className='title-text'>
           <h1>{children}</h1>
           {isCompleted ? (
-            <GreenPass
-              style={{ height: '15px', width: '15px', marginLeft: '7px' }}
-            />
+            <GreenPass style={{ height: '15px', width: '15px' }} />
           ) : null}
         </div>
       </div>

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -58,7 +58,7 @@ interface BlockProps {
   toggleBlock: typeof toggleBlock;
 }
 
-const mapIconStyle = { height: '15px', marginRight: '10px', width: '15px' };
+const mapIconStyle = { height: '15px', marginInline: '10px', width: '15px' };
 
 export class Block extends Component<BlockProps> {
   static displayName: string;

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -58,7 +58,7 @@ interface BlockProps {
   toggleBlock: typeof toggleBlock;
 }
 
-const mapIconStyle = { height: '15px', marginInline: '10px', width: '15px' };
+const mapIconStyle = { height: '15px', width: '15px' };
 
 export class Block extends Component<BlockProps> {
   static displayName: string;

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -58,8 +58,6 @@ interface BlockProps {
   toggleBlock: typeof toggleBlock;
 }
 
-const mapIconStyle = { height: '15px', width: '15px' };
-
 export class Block extends Component<BlockProps> {
   static displayName: string;
   constructor(props: BlockProps) {
@@ -83,9 +81,9 @@ export class Block extends Component<BlockProps> {
 
   renderCheckMark(isCompleted: boolean): JSX.Element {
     return isCompleted ? (
-      <GreenPass hushScreenReaderText style={mapIconStyle} />
+      <GreenPass hushScreenReaderText />
     ) : (
-      <GreenNotCompleted hushScreenReaderText style={mapIconStyle} />
+      <GreenNotCompleted hushScreenReaderText />
     );
   }
 

--- a/client/src/templates/Introduction/components/challenges.tsx
+++ b/client/src/templates/Introduction/components/challenges.tsx
@@ -24,8 +24,6 @@ interface Challenges {
   blockTitle?: string | null;
 }
 
-const mapIconStyle = { height: '15px', width: '15px' };
-
 function Challenges({
   challengesWithCompleted,
   executeGA,
@@ -44,11 +42,7 @@ function Challenges({
     });
 
   const renderCheckMark = (isCompleted: boolean) =>
-    isCompleted ? (
-      <GreenPass style={mapIconStyle} />
-    ) : (
-      <GreenNotCompleted style={mapIconStyle} />
-    );
+    isCompleted ? <GreenPass /> : <GreenNotCompleted />;
 
   const isGridMap = isNewRespCert(superBlock) || isNewJsCert(superBlock);
 

--- a/client/src/templates/Introduction/components/challenges.tsx
+++ b/client/src/templates/Introduction/components/challenges.tsx
@@ -24,7 +24,7 @@ interface Challenges {
   blockTitle?: string | null;
 }
 
-const mapIconStyle = { height: '15px', marginRight: '10px', width: '15px' };
+const mapIconStyle = { height: '15px', width: '15px' };
 
 function Challenges({
   challengesWithCompleted,

--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -89,6 +89,9 @@ a.cert-tag:active {
 }
 
 .course-title {
+  display: flex;
+  gap: var(--icons-spacing);
+  align-items: center;
   font-size: 1.13rem;
   overflow-wrap: break-word;
 }
@@ -117,6 +120,7 @@ a.cert-tag:active {
 .map-title {
   display: flex;
   align-items: center;
+  gap: var(--icons-spacing);
   padding: 18px 0;
   background: transparent;
   border: none;
@@ -137,6 +141,7 @@ button.map-title {
 .map-challenge-wrap > a,
 .map-project-wrap > a {
   display: flex;
+  gap: var(--small-icons-spacing);
 }
 
 .map-project-wrap > a {
@@ -144,7 +149,6 @@ button.map-title {
 }
 
 .map-project-checkmark {
-  margin-right: 7px;
   padding-left: 15px;
 }
 
@@ -212,7 +216,6 @@ button.map-title {
 
 .map-title svg {
   width: 14px;
-  margin-right: 10px;
   flex-shrink: 0;
   fill: var(--color-quaternary) !important;
   stroke: var(--color-quaternary);
@@ -413,6 +416,7 @@ button.map-title {
 .block-header-button-text {
   align-items: center;
   display: flex;
+  gap: var(--icons-spacing);
   flex-direction: row;
   justify-content: space-between;
 }
@@ -426,12 +430,15 @@ button.map-title {
   padding: 25px;
 }
 
+/* this margin is used to center the element. 
+ToDo: find out why, and remove the need for it */
 .block-grid .map-title > svg {
-  margin: 10px;
+  margin-bottom: 4px;
 }
 
 .title-wrapper {
   display: flex;
+  gap: var(--icons-spacing);
   flex-direction: row;
   align-items: center;
   width: 100%;

--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -90,7 +90,6 @@ a.cert-tag:active {
 
 .course-title {
   display: flex;
-  gap: var(--icons-spacing);
   align-items: center;
   font-size: 1.13rem;
   overflow-wrap: break-word;
@@ -120,7 +119,6 @@ a.cert-tag:active {
 .map-title {
   display: flex;
   align-items: center;
-  gap: var(--icons-spacing);
   padding: 18px 0;
   background: transparent;
   border: none;
@@ -141,7 +139,7 @@ button.map-title {
 .map-challenge-wrap > a,
 .map-project-wrap > a {
   display: flex;
-  gap: var(--small-icons-spacing);
+  gap: 7px;
 }
 
 .map-project-wrap > a {
@@ -416,7 +414,6 @@ button.map-title {
 .block-header-button-text {
   align-items: center;
   display: flex;
-  gap: var(--icons-spacing);
   flex-direction: row;
   justify-content: space-between;
 }
@@ -438,10 +435,15 @@ ToDo: find out why, and remove the need for it */
 
 .title-wrapper {
   display: flex;
-  gap: var(--icons-spacing);
   flex-direction: row;
   align-items: center;
   width: 100%;
+}
+.course-title,
+.map-title,
+.block-header-button-text,
+.title-wrapper {
+  gap: 10px;
 }
 
 .block-grid .progress-wrapper {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Ref #48101

<!-- Feel free to add any additional description of changes below this line -->

I have changed this to Inline because its usage don't revolve around this attribute (the newer section), but the legacy section does use it as spacer. 

Instead of refactoring it, I have added this as a quick hack, because these section may be deleted with the legacy section 

Why I didn't add it in RTL layout PR? because I may be missing a point or a section but so far they are looking the same.

![image](https://user-images.githubusercontent.com/88248797/198840723-a4fbcaa6-4ceb-4a76-abaa-16a30d47ce87.png)
