### PR TITLE
chore(ci): remove headless from cypress config

### DIFF
--- a/.github/workflows/e2e-mobile.yml
+++ b/.github/workflows/e2e-mobile.yml
@@ -65,7 +65,7 @@ jobs:
           wait-on-timeout: 1200
           config: retries=1,screenshotOnRunFailure=false,video=false,baseUrl=http://localhost:3000/mobile/mobile-app/generated-tests/
           browser: chrome
-          headless: true
+
           spec: cypress/integration/mobile-learn/test-challenges.js
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}

--- a/.github/workflows/e2e-third-party.yml
+++ b/.github/workflows/e2e-third-party.yml
@@ -65,5 +65,5 @@ jobs:
           wait-on-timeout: 1200
           config: baseUrl=http://localhost:8000
           browser: chrome
-          headless: true
+
           spec: cypress/e2e/third-party/*.js

--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -136,5 +136,5 @@ jobs:
           wait-on-timeout: 1200
           config: baseUrl=http://localhost:8000
           browser: ${{ matrix.browsers }}
-          headless: true
+
           spec: ${{ matrix.spec }}


### PR DESCRIPTION
Updates the workflows to remove the deprecated config. More details: https://github.com/cypress-io/github-action#headed 
