### PR TITLE
feat(.eslintrc): ignore no-unused-vars on underscore

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,7 +38,16 @@
     "import/order": "error",
     "import/no-cycle": [2, { "maxDepth": 2 }],
     "react/prop-types": "off",
-    "no-only-tests/no-only-tests": "error"
+    "no-only-tests/no-only-tests": "error",
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_",
+        "caughtErrorsIgnorePattern": "^_"
+      }
+    ]
   },
   "overrides": [
     {

--- a/api-server/src/server/middlewares/error-handlers.js
+++ b/api-server/src/server/middlewares/error-handlers.js
@@ -24,8 +24,7 @@ const isDev = process.env.FREECODECAMP_NODE_ENV !== 'production';
 
 export default function prodErrorHandler() {
   // error handling in production.
-  // eslint-disable-next-line no-unused-vars
-  return function (err, req, res, next) {
+  return function (err, req, res, _next) {
     // response for when req.body is bigger than body-parser's size limit
     if (err?.type === 'entity.too.large') {
       return res.status('413').send('Request payload is too large');

--- a/client/src/__mocks__/gatsby.ts
+++ b/client/src/__mocks__/gatsby.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 import React from 'react';
 import { GatsbyLinkProps } from 'gatsby';
 const gatsby: NodeModule = jest.requireActual('gatsby');

--- a/client/src/client/frame-runner.ts
+++ b/client/src/client/frame-runner.ts
@@ -34,7 +34,6 @@ export interface InitTestFrameArg {
 
 async function initTestFrame(e: InitTestFrameArg = { code: {} }) {
   const code = (e.code.contents || '').slice();
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const __file = (id?: string) => {
     if (id && e.code.original) {
       return e.code.original[id];
@@ -45,7 +44,6 @@ async function initTestFrame(e: InitTestFrameArg = { code: {} }) {
   const editableContents = (e.code.editableContents || '').slice();
   // __testEditable allows test authors to run tests against a transitory dom
   // element built using only the code in the editable region.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const __testEditable = (cb: () => () => unknown) => {
     const div = document.createElement('div');
     div.id = 'editable-only';


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Adds rule to ignore eslint's `no-unused-vars` warning, if variable starts with `_`.

_this has bugged me for a bit_