### PR TITLE
fix: confirm modal

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -719,7 +719,7 @@
   },
   "signout": {
     "heading": "Sign out of your account",
-    "p1": "Warning: Signing out will stop your progress being saved.",
+    "p1": "Warning: If you continue, your progress will no longer be saved.",
     "p2": "This action will sign you out of your account on this device and browser session only. Please confirm if you would like to proceed.",
     "certain": "Yes, sign out of my account",
     "nevermind": "Nevermind, I don't want to sign out"

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -719,7 +719,7 @@
   },
   "signout": {
     "heading": "Sign out of your account",
-    "p1": "Warning: Signing out will stop saving your progress.",
+    "p1": "Warning: Signing out will stop your progress being saved.",
     "p2": "This action will sign you out of your account on this device and browser session only. Please confirm if you would like to proceed.",
     "certain": "Yes, sign out of my account",
     "nevermind": "Nevermind, I don't want to sign out"

--- a/client/src/components/Header/components/nav-links.tsx
+++ b/client/src/components/Header/components/nav-links.tsx
@@ -56,7 +56,7 @@ interface NavLinksProps {
   showLanguageMenu: (elementToFocus: HTMLButtonElement) => void;
   hideLanguageMenu: () => void;
   menuButtonRef: React.RefObject<HTMLButtonElement>;
-  openSignoutModal?: () => void;
+  openSignoutModal: () => void;
 }
 
 const mapDispatchToProps = {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Ref: https://github.com/freeCodeCamp/freeCodeCamp/pull/48385

The original wording sounded like "signing out" was a thing that was saving your progress and that it was going to stop.

`openSignoutModal` isn't optional, it's provided by react-redux.

<!-- Feel free to add any additional description of changes below this line -->
