### PR TITLE
Fix: leave external window open and refresh with updated content

### DIFF
--- a/client/src/templates/Challenges/classic/desktop-layout.tsx
+++ b/client/src/templates/Challenges/classic/desktop-layout.tsx
@@ -69,6 +69,12 @@ const reflexProps = {
 };
 
 const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
+  const {
+    showPreviewPane,
+    showPreviewPortal,
+    setReduxShowPreviewPane,
+    setReduxShowPreviewPortal
+  } = props;
   const [showNotes, setShowNotes] = useState(false);
 
   const [showConsole, setShowConsole] = useState(false);
@@ -76,14 +82,14 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
   const togglePane = (pane: string): void => {
     switch (pane) {
       case 'showPreviewPane':
-        if (!props.showPreviewPane && props.showPreviewPortal)
-          props.setReduxShowPreviewPortal(false);
-        props.setReduxShowPreviewPane(!props.showPreviewPane);
+        if (!showPreviewPane && showPreviewPortal)
+          setReduxShowPreviewPortal(false);
+        setReduxShowPreviewPane(!showPreviewPane);
         break;
       case 'showPreviewPortal':
-        if (!props.showPreviewPortal && props.showPreviewPane)
-          props.setReduxShowPreviewPane(false);
-        props.setReduxShowPreviewPortal(!props.showPreviewPortal);
+        if (!showPreviewPortal && showPreviewPane)
+          setReduxShowPreviewPane(false);
+        setReduxShowPreviewPortal(!showPreviewPortal);
         break;
       case 'showConsole':
         setShowConsole(!showConsole);
@@ -97,8 +103,8 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
       default:
         setShowInstuctions(true);
         setShowConsole(false);
-        props.setReduxShowPreviewPane(true);
-        props.setReduxShowPreviewPortal(false);
+        setReduxShowPreviewPane(true);
+        setReduxShowPreviewPortal(false);
         setShowNotes(false);
     }
   };
@@ -127,8 +133,8 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
   const projectBasedChallenge = hasEditableBoundaries;
   const isMultifileCertProject =
     challengeType === challengeTypes.multifileCertProject;
-  const displayPreviewPane = hasPreview && props.showPreviewPane;
-  const displayPreviewPortal = hasPreview && props.showPreviewPortal;
+  const displayPreviewPane = hasPreview && showPreviewPane;
+  const displayPreviewPortal = hasPreview && showPreviewPortal;
   const displayNotes = projectBasedChallenge ? showNotes && hasNotes : false;
   const displayConsole =
     projectBasedChallenge || isMultifileCertProject ? showConsole : true;
@@ -150,8 +156,8 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
           showConsole={showConsole}
           showNotes={showNotes}
           showInstructions={showInstructions}
-          showPreviewPane={props.showPreviewPane}
-          showPreviewPortal={props.showPreviewPortal}
+          showPreviewPane={showPreviewPane}
+          showPreviewPortal={showPreviewPortal}
           togglePane={togglePane}
         />
       )}

--- a/client/src/templates/Challenges/classic/desktop-layout.tsx
+++ b/client/src/templates/Challenges/classic/desktop-layout.tsx
@@ -1,5 +1,7 @@
 import { first } from 'lodash-es';
 import React, { useState, ReactElement } from 'react';
+import { createSelector } from 'reselect';
+import { connect } from 'react-redux';
 import { ReflexContainer, ReflexSplitter, ReflexElement } from 'react-reflex';
 import { sortChallengeFiles } from '../../../../../utils/sort-challengefiles';
 import { challengeTypes } from '../../../../utils/challenge-types';
@@ -9,6 +11,14 @@ import {
   ResizeProps
 } from '../../../redux/prop-types';
 import PreviewPortal from '../components/preview-portal';
+import {
+  setReduxShowPreviewPane,
+  setReduxShowPreviewPortal
+} from '../redux/actions';
+import {
+  showPreviewPortalSelector,
+  showPreviewPaneSelector
+} from '../redux/selectors';
 import ActionRow from './action-row';
 
 type Pane = { flex: number };
@@ -34,7 +44,25 @@ interface DesktopLayoutProps {
   resizeProps: ResizeProps;
   testOutput: ReactElement;
   windowTitle: string;
+  showPreviewPortal: boolean;
+  showPreviewPane: boolean;
+  setReduxShowPreviewPane: (arg: boolean) => void;
+  setReduxShowPreviewPortal: (arg: boolean) => void;
 }
+
+const mapDispatchToProps = {
+  setReduxShowPreviewPane,
+  setReduxShowPreviewPortal
+};
+
+const mapStateToProps = createSelector(
+  showPreviewPortalSelector,
+  showPreviewPaneSelector,
+  (showPreviewPortal: boolean, showPreviewPane: boolean) => ({
+    showPreviewPortal,
+    showPreviewPane
+  })
+);
 
 const reflexProps = {
   propagateDimensions: true
@@ -42,20 +70,20 @@ const reflexProps = {
 
 const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
   const [showNotes, setShowNotes] = useState(false);
-  const [showPreviewPane, setShowPreviewPane] = useState(true);
-  const [showPreviewPortal, setShowPreviewPortal] = useState(false);
+
   const [showConsole, setShowConsole] = useState(false);
   const [showInstructions, setShowInstuctions] = useState(true);
-
   const togglePane = (pane: string): void => {
     switch (pane) {
       case 'showPreviewPane':
-        if (!showPreviewPane && showPreviewPortal) setShowPreviewPortal(false);
-        setShowPreviewPane(!showPreviewPane);
+        if (!props.showPreviewPane && props.showPreviewPortal)
+          props.setReduxShowPreviewPortal(false);
+        props.setReduxShowPreviewPane(!props.showPreviewPane);
         break;
       case 'showPreviewPortal':
-        if (!showPreviewPortal && showPreviewPane) setShowPreviewPane(false);
-        setShowPreviewPortal(!showPreviewPortal);
+        if (!props.showPreviewPortal && props.showPreviewPane)
+          props.setReduxShowPreviewPane(false);
+        props.setReduxShowPreviewPortal(!props.showPreviewPortal);
         break;
       case 'showConsole':
         setShowConsole(!showConsole);
@@ -69,8 +97,8 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
       default:
         setShowInstuctions(true);
         setShowConsole(false);
-        setShowPreviewPane(true);
-        setShowPreviewPortal(false);
+        props.setReduxShowPreviewPane(true);
+        props.setReduxShowPreviewPortal(false);
         setShowNotes(false);
     }
   };
@@ -99,8 +127,8 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
   const projectBasedChallenge = hasEditableBoundaries;
   const isMultifileCertProject =
     challengeType === challengeTypes.multifileCertProject;
-  const displayPreviewPane = hasPreview && showPreviewPane;
-  const displayPreviewPortal = hasPreview && showPreviewPortal;
+  const displayPreviewPane = hasPreview && props.showPreviewPane;
+  const displayPreviewPortal = hasPreview && props.showPreviewPortal;
   const displayNotes = projectBasedChallenge ? showNotes && hasNotes : false;
   const displayConsole =
     projectBasedChallenge || isMultifileCertProject ? showConsole : true;
@@ -122,8 +150,8 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
           showConsole={showConsole}
           showNotes={showNotes}
           showInstructions={showInstructions}
-          showPreviewPane={showPreviewPane}
-          showPreviewPortal={showPreviewPortal}
+          showPreviewPane={props.showPreviewPane}
+          showPreviewPortal={props.showPreviewPortal}
           togglePane={togglePane}
         />
       )}
@@ -192,4 +220,4 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
 
 DesktopLayout.displayName = 'DesktopLayout';
 
-export default DesktopLayout;
+export default connect(mapStateToProps, mapDispatchToProps)(DesktopLayout);

--- a/client/src/templates/Challenges/components/preview-portal.tsx
+++ b/client/src/templates/Challenges/components/preview-portal.tsx
@@ -2,26 +2,40 @@ import { Component, ReactElement } from 'react';
 import ReactDOM from 'react-dom';
 import { TFunction, withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
-import { storePortalDocument, removePortalDocument } from '../redux/actions';
+import { createSelector } from 'reselect';
+import { storeportalWindow, removeportalWindow } from '../redux/actions';
+import {
+  portalWindowSelector,
+  showPreviewPortalSelector
+} from '../redux/selectors';
+
+const mapStateToProps = createSelector(
+  showPreviewPortalSelector,
+  portalWindowSelector,
+  (showPreviewPortal: null, portalWindow: Window | null) => ({
+    showPreviewPortal,
+    portalWindow
+  })
+);
 
 interface PreviewPortalProps {
   children: ReactElement | null;
   togglePane: (pane: string) => void;
   windowTitle: string;
   t: TFunction;
-  storePortalDocument: (document: Document | undefined) => void;
-  removePortalDocument: () => void;
+  storeportalWindow: (window: Window | null) => void;
+  removeportalWindow: () => void;
 }
 
 const mapDispatchToProps = {
-  storePortalDocument,
-  removePortalDocument
+  storeportalWindow,
+  removeportalWindow
 };
 
 class PreviewPortal extends Component<PreviewPortalProps> {
   static displayName = 'PreviewPortal';
   mainWindow: Window;
-  externalWindow: Window | null = null;
+  externalWindow: Window | null;
   containerEl;
   titleEl;
   styleEl;
@@ -72,7 +86,8 @@ class PreviewPortal extends Component<PreviewPortalProps> {
       this.props.togglePane('showPreviewPortal');
     });
 
-    this.props.storePortalDocument(this.externalWindow?.document);
+    console.log('window: ', this.externalWindow);
+    this.props.storeportalWindow(this.externalWindow);
 
     this.mainWindow?.addEventListener('beforeunload', () => {
       this.externalWindow?.close();
@@ -81,7 +96,7 @@ class PreviewPortal extends Component<PreviewPortalProps> {
 
   componentWillUnmount() {
     this.externalWindow?.close();
-    this.props.removePortalDocument();
+    this.props.removeportalWindow();
   }
 
   render() {
@@ -92,6 +107,6 @@ class PreviewPortal extends Component<PreviewPortalProps> {
 PreviewPortal.displayName = 'PreviewPortal';
 
 export default connect(
-  null,
+  mapStateToProps,
   mapDispatchToProps
 )(withTranslation()(PreviewPortal));

--- a/client/src/templates/Challenges/components/preview-portal.tsx
+++ b/client/src/templates/Challenges/components/preview-portal.tsx
@@ -59,17 +59,25 @@ class PreviewPortal extends Component<PreviewPortalProps> {
 
   constructor(props: PreviewPortalProps) {
     super(props);
-
+    const { portalWindow } = this.props;
     this.mainWindow = window;
     this.externalWindow = null;
     this.containerEl = document.createElement('div');
     this.titleEl = document.createElement('title');
     this.styleEl = document.createElement('style');
-    this.existingExternalWindow = this.props.portalWindow;
+    this.existingExternalWindow = portalWindow;
   }
 
   componentDidMount() {
-    const { t, windowTitle } = this.props;
+    const {
+      t,
+      windowTitle,
+      showPreviewPortal,
+      portalDocument,
+      storePortalWindow,
+      storeportalDocument,
+      portalWindow
+    } = this.props;
 
     this.titleEl.innerText = `${t(
       'learn.editor-tabs.preview'
@@ -83,17 +91,16 @@ class PreviewPortal extends Component<PreviewPortalProps> {
       }
     `;
 
-    if (
-      this.props.portalWindow &&
-      this.props.showPreviewPortal &&
-      this.props.portalDocument
-    ) {
-      console.log(this.existingExternalWindow.document);
-      this.existingExternalWindow.document.head.innerHTML = '';
-      this.existingExternalWindow.document.body.innerHTML = '';
-      this.existingExternalWindow?.document.head.appendChild(this.titleEl);
-      this.existingExternalWindow?.document.head.appendChild(this.styleEl);
-      this.existingExternalWindow?.document.body.setAttribute(
+    const processWindowAndDocuments = (
+      title: HTMLElement,
+      style: HTMLElement,
+      containerEl: HTMLElement,
+      externalWindow: Window | null,
+      clientDocument: Document | undefined
+    ) => {
+      externalWindow?.document.head.appendChild(title);
+      externalWindow?.document.head.appendChild(style);
+      externalWindow?.document.body.setAttribute(
         'style',
         `
         margin: 0px;
@@ -101,29 +108,34 @@ class PreviewPortal extends Component<PreviewPortalProps> {
         overflow: hidden;
       `
       );
-      this.existingExternalWindow?.document.body.appendChild(this.containerEl);
-      this.props.storePortalWindow(this.existingExternalWindow);
-      this.props.storeportalDocument(this.existingExternalWindow?.document);
+      externalWindow?.document.body.appendChild(containerEl);
+      storePortalWindow(externalWindow);
+      storeportalDocument(clientDocument);
+    };
+
+    if (portalWindow && showPreviewPortal && portalDocument) {
+      this.existingExternalWindow.document.head.innerHTML = '';
+      this.existingExternalWindow.document.body.innerHTML = '';
+      processWindowAndDocuments(
+        this.titleEl,
+        this.styleEl,
+        this.containerEl,
+        this.existingExternalWindow,
+        this.existingExternalWindow?.document
+      );
     } else {
       this.externalWindow = window.open(
         '',
         '',
         'width=960,height=540,left=100,top=100'
       );
-
-      this.externalWindow?.document.head.appendChild(this.titleEl);
-      this.externalWindow?.document.head.appendChild(this.styleEl);
-      this.externalWindow?.document.body.setAttribute(
-        'style',
-        `
-        margin: 0px;
-        padding: 0px;
-        overflow: hidden;
-      `
+      processWindowAndDocuments(
+        this.titleEl,
+        this.styleEl,
+        this.containerEl,
+        this.externalWindow,
+        this.externalWindow?.document
       );
-      this.externalWindow?.document.body.appendChild(this.containerEl);
-      this.props.storePortalWindow(this.externalWindow);
-      this.props.storeportalDocument(this.externalWindow?.document);
     }
 
     this.externalWindow?.addEventListener('beforeunload', () => {

--- a/client/src/templates/Challenges/redux/action-types.js
+++ b/client/src/templates/Challenges/redux/action-types.js
@@ -36,8 +36,10 @@ export const actionTypes = createTypes(
 
     'previewMounted',
     'projectPreviewMounted',
-    'storeportalWindow',
-    'removeportalWindow',
+    'storeportalDocument',
+    'removeportalDocument',
+    'storePortalWindow',
+
     'challengeMounted',
     'checkChallenge',
     'executeChallenge',

--- a/client/src/templates/Challenges/redux/action-types.js
+++ b/client/src/templates/Challenges/redux/action-types.js
@@ -29,14 +29,15 @@ export const actionTypes = createTypes(
     'storedCodeFound',
     'noStoredCodeFound',
     'saveEditorContent',
-
+    'setReduxShowPreviewPane',
+    'setReduxShowPreviewPortal',
     'closeModal',
     'openModal',
 
     'previewMounted',
     'projectPreviewMounted',
-    'storePortalDocument',
-    'removePortalDocument',
+    'storeportalWindow',
+    'removeportalWindow',
     'challengeMounted',
     'checkChallenge',
     'executeChallenge',

--- a/client/src/templates/Challenges/redux/actions.js
+++ b/client/src/templates/Challenges/redux/actions.js
@@ -58,11 +58,14 @@ export const projectPreviewMounted = createAction(
   actionTypes.projectPreviewMounted
 );
 
-export const storePortalDocument = createAction(
-  actionTypes.storePortalDocument
+export const storeportalWindow = createAction(actionTypes.storeportalWindow);
+export const removeportalWindow = createAction(actionTypes.removeportalWindow);
+
+export const setReduxShowPreviewPortal = createAction(
+  actionTypes.setReduxShowPreviewPortal
 );
-export const removePortalDocument = createAction(
-  actionTypes.removePortalDocument
+export const setReduxShowPreviewPane = createAction(
+  actionTypes.setReduxShowPreviewPane
 );
 
 export const challengeMounted = createAction(actionTypes.challengeMounted);

--- a/client/src/templates/Challenges/redux/actions.js
+++ b/client/src/templates/Challenges/redux/actions.js
@@ -58,9 +58,13 @@ export const projectPreviewMounted = createAction(
   actionTypes.projectPreviewMounted
 );
 
-export const storeportalWindow = createAction(actionTypes.storeportalWindow);
-export const removeportalWindow = createAction(actionTypes.removeportalWindow);
-
+export const storeportalDocument = createAction(
+  actionTypes.storeportalDocument
+);
+export const removeportalDocument = createAction(
+  actionTypes.removeportalDocument
+);
+export const storePortalWindow = createAction(actionTypes.storePortalWindow);
 export const setReduxShowPreviewPortal = createAction(
   actionTypes.setReduxShowPreviewPortal
 );

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -50,7 +50,7 @@ import {
   challengeMetaSelector,
   challengeTestsSelector,
   isBuildEnabledSelector,
-  portalWindowSelector
+  portalDocumentSelector
 } from './selectors';
 
 // How long before bailing out of a preview.
@@ -247,8 +247,10 @@ function* previewChallengeSaga({ flushLogs = true } = {}) {
       if (challengeHasPreview(challengeData)) {
         //????//
         const document = yield getContext('document');
-        const portalWindow = yield select(portalWindowSelector);
-        const finalDocument = portalWindow || document;
+        console.log({ document });
+        const portalDocument = yield select(portalDocumentSelector);
+
+        const finalDocument = portalDocument || document;
 
         yield call(updatePreview, buildData, finalDocument, proxyLogger);
       } else if (isJavaScriptChallenge(challengeData)) {

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -50,7 +50,7 @@ import {
   challengeMetaSelector,
   challengeTestsSelector,
   isBuildEnabledSelector,
-  portalDocumentSelector
+  portalWindowSelector
 } from './selectors';
 
 // How long before bailing out of a preview.
@@ -245,9 +245,10 @@ function* previewChallengeSaga({ flushLogs = true } = {}) {
       });
       // evaluate the user code in the preview frame or in the worker
       if (challengeHasPreview(challengeData)) {
+        //????//
         const document = yield getContext('document');
-        const portalDocument = yield select(portalDocumentSelector);
-        const finalDocument = portalDocument || document;
+        const portalWindow = yield select(portalWindowSelector);
+        const finalDocument = portalWindow || document;
 
         yield call(updatePreview, buildData, finalDocument, proxyLogger);
       } else if (isJavaScriptChallenge(challengeData)) {

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -245,9 +245,7 @@ function* previewChallengeSaga({ flushLogs = true } = {}) {
       });
       // evaluate the user code in the preview frame or in the worker
       if (challengeHasPreview(challengeData)) {
-        //????//
         const document = yield getContext('document');
-        console.log({ document });
         const portalDocument = yield select(portalDocumentSelector);
 
         const finalDocument = portalDocument || document;

--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -41,11 +41,12 @@ const initialState = {
     projectPreview: false,
     shortcuts: false
   },
-  portalWindow: null,
+  portalDocument: false,
   projectFormValues: {},
   successMessage: 'Happy Coding!',
   reduxShowPreviewPortal: false,
-  reduxShowPreviewPane: true
+  reduxShowPreviewPane: true,
+  portalWindow: false
 };
 
 export const epics = [
@@ -180,13 +181,17 @@ export const reducer = handleActions(
       ...state,
       isBuildEnabled: false
     }),
-    [actionTypes.storeportalWindow]: (state, { payload }) => ({
+    [actionTypes.storeportalDocument]: (state, { payload }) => ({
+      ...state,
+      portalDocument: payload
+    }),
+    [actionTypes.storePortalWindow]: (state, { payload }) => ({
       ...state,
       portalWindow: payload
     }),
-    [actionTypes.removeportalWindow]: state => ({
+    [actionTypes.removeportalDocument]: state => ({
       ...state,
-      portalWindow: null
+      portalDocument: null
     }),
     [actionTypes.setReduxShowPreviewPortal]: (state, { payload }) => ({
       ...state,

--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -41,9 +41,11 @@ const initialState = {
     projectPreview: false,
     shortcuts: false
   },
-  portalDocument: false,
+  portalWindow: null,
   projectFormValues: {},
-  successMessage: 'Happy Coding!'
+  successMessage: 'Happy Coding!',
+  reduxShowPreviewPortal: false,
+  reduxShowPreviewPane: true
 };
 
 export const epics = [
@@ -178,13 +180,21 @@ export const reducer = handleActions(
       ...state,
       isBuildEnabled: false
     }),
-    [actionTypes.storePortalDocument]: (state, { payload }) => ({
+    [actionTypes.storeportalWindow]: (state, { payload }) => ({
       ...state,
-      portalDocument: payload
+      portalWindow: payload
     }),
-    [actionTypes.removePortalDocument]: state => ({
+    [actionTypes.removeportalWindow]: state => ({
       ...state,
-      portalDocument: false
+      portalWindow: null
+    }),
+    [actionTypes.setReduxShowPreviewPortal]: (state, { payload }) => ({
+      ...state,
+      reduxShowPreviewPortal: payload
+    }),
+    [actionTypes.setReduxShowPreviewPane]: (state, { payload }) => ({
+      ...state,
+      reduxShowPreviewPane: payload
     }),
     [actionTypes.updateSuccessMessage]: (state, { payload }) => ({
       ...state,

--- a/client/src/templates/Challenges/redux/selectors.js
+++ b/client/src/templates/Challenges/redux/selectors.js
@@ -31,7 +31,7 @@ export const successMessageSelector = state => state[ns].successMessage;
 export const projectFormValuesSelector = state =>
   state[ns].projectFormValues || {};
 
-export const portalDocumentSelector = state => state[ns].portalDocument;
+export const portalWindowSelector = state => state[ns].portalWindow;
 
 export const challengeDataSelector = state => {
   const { challengeType } = challengeMetaSelector(state);
@@ -85,3 +85,6 @@ export const challengeDataSelector = state => {
 export const attemptsSelector = state => state[ns].attempts;
 export const canFocusEditorSelector = state => state[ns].canFocusEditor;
 export const visibleEditorsSelector = state => state[ns].visibleEditors;
+export const showPreviewPortalSelector = state =>
+  state[ns].reduxShowPreviewPortal;
+export const showPreviewPaneSelector = state => state[ns].reduxShowPreviewPane;

--- a/client/src/templates/Challenges/redux/selectors.js
+++ b/client/src/templates/Challenges/redux/selectors.js
@@ -31,6 +31,7 @@ export const successMessageSelector = state => state[ns].successMessage;
 export const projectFormValuesSelector = state =>
   state[ns].projectFormValues || {};
 
+export const portalDocumentSelector = state => state[ns].portalDocument;
 export const portalWindowSelector = state => state[ns].portalWindow;
 
 export const challengeDataSelector = state => {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #48326

<!-- Feel free to add any additional description of changes below this line -->

Tested locally starting with step # 1 of new responsive web development curriculum and it keeps the external window open and refreshes with content of the next challenge.  
