### PR TITLE
fix(component-library): add color variables to css build

### DIFF
--- a/tools/ui-components/src/base.css
+++ b/tools/ui-components/src/base.css
@@ -1,3 +1,5 @@
+@import './colors.css';
+
 @tailwind base;
 
 @layer base {


### PR DESCRIPTION
This pr imports the colors.css file into the base.css so the color variables are included in the build 

For testing, go to  ./tools/ui-components/ and `npm run build:css' on the main branch.
- view the ./dist/base.css and the color variables should not be included in the file.
- Do the same tasks on this branch and compare the base.css (the variables are added)


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
