### PR TITLE
refactor(api): shiny new api

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,7 +38,16 @@
     "import/order": "error",
     "import/no-cycle": [2, { "maxDepth": 2 }],
     "react/prop-types": "off",
-    "no-only-tests/no-only-tests": "error"
+    "no-only-tests/no-only-tests": "error",
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_",
+        "caughtErrorsIgnorePattern": "^_"
+      }
+    ]
   },
   "overrides": [
     {

--- a/.gitignore
+++ b/.gitignore
@@ -212,3 +212,6 @@ client/static/curriculum-data
 
 ### UI Components ###
 tools/ui-components/dist
+
+### API ###
+api/**/*.js

--- a/api/db/index.ts
+++ b/api/db/index.ts
@@ -1,0 +1,14 @@
+import fastifyPlugin from 'fastify-plugin';
+import fastifyMongo from '@fastify/mongodb';
+import { FastifyInstance } from 'fastify';
+
+const URI = process.env.MONGOHQ_URL || 'mongodb://localhost:27017/freecodecamp';
+// eslint-disable-next-line @typescript-eslint/require-await
+async function connect(fastify: FastifyInstance) {
+  fastify.log.info(`Connecting to : ${URI}`);
+  void fastify.register(fastifyMongo, {
+    url: URI
+  });
+}
+
+export const dbConnector = fastifyPlugin(connect);

--- a/api/index.ts
+++ b/api/index.ts
@@ -1,0 +1,29 @@
+import { config } from 'dotenv';
+config({ path: '../.env' });
+import Fastify from 'fastify';
+import { testRoutes } from './routes/test';
+import { dbConnector } from './db';
+
+const fastify = Fastify({
+  logger: { level: process.env.NODE_ENV === 'development' ? 'debug' : 'fatal' }
+});
+
+fastify.get('/', async (_request, _reply) => {
+  return { hello: 'world' };
+});
+
+void fastify.register(dbConnector);
+void fastify.register(testRoutes);
+
+const start = async () => {
+  try {
+    const port = Number(process.env.PORT) || 3000;
+    fastify.log.info(`Starting server on port ${port}`);
+    await fastify.listen({ port });
+  } catch (err) {
+    fastify.log.error(err);
+    process.exit(1);
+  }
+};
+
+void start();

--- a/api/middleware/index.ts
+++ b/api/middleware/index.ts
@@ -1,0 +1,3 @@
+export async function auth0Verify() {
+  // Verify user authorization code with Auth0
+}

--- a/api/package.json
+++ b/api/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@freecodecamp/api",
+  "version": "0.0.1",
+  "description": "The freeCodeCamp.org open-source codebase and curriculum",
+  "license": "BSD-3-Clause",
+  "private": true,
+  "engines": {
+    "node": ">=18",
+    "npm": ">=8"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/freeCodeCamp/freeCodeCamp.git"
+  },
+  "bugs": {
+    "url": "https://github.com/freeCodeCamp/freeCodeCamp/issues"
+  },
+  "homepage": "https://github.com/freeCodeCamp/freeCodeCamp#readme",
+  "author": "freeCodeCamp <team@freecodecamp.org>",
+  "main": "none",
+  "scripts": {
+    "build": "tsc index.ts",
+    "start": "NODE_ENV=production node index.js",
+    "develop": "NODE_ENV=development nodemon index.ts"
+  },
+  "dependencies": {
+    "@fastify/mongodb": "6.1.0",
+    "fastify": "4.9.2",
+    "fastify-plugin": "4.3.0"
+  }
+}

--- a/api/routes/auth0.ts
+++ b/api/routes/auth0.ts
@@ -1,0 +1,8 @@
+import { FastifyInstance } from 'fastify';
+
+// eslint-disable-next-line @typescript-eslint/require-await
+export async function auth0Routes(fastify: FastifyInstance) {
+  fastify.get('/oauth/token', async (_request, _reply) => {
+    return { a: 'b' };
+  });
+}

--- a/api/routes/test.ts
+++ b/api/routes/test.ts
@@ -1,0 +1,14 @@
+import { FastifyInstance } from 'fastify';
+
+// eslint-disable-next-line @typescript-eslint/require-await
+export async function testRoutes(fastify: FastifyInstance) {
+  const collection = fastify?.mongo?.db?.collection('user');
+
+  fastify.get('/test', async (_request, _reply) => {
+    if (!collection) {
+      return { error: 'No collection' };
+    }
+    const user = await collection?.findOne({ email: 'bar@bar.com' });
+    return { user };
+  });
+}

--- a/api/utils/index.ts
+++ b/api/utils/index.ts
@@ -1,0 +1,15 @@
+import { randomBytes, createHash } from 'crypto';
+
+export function base64URLEncode(buf: Buffer) {
+  return buf
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
+}
+export const verifier = base64URLEncode(randomBytes(32));
+
+function sha256(buf: Buffer) {
+  return createHash('sha256').update(buf).digest();
+}
+export const challenge = base64URLEncode(sha256(Buffer.from(verifier)));

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "BSD-3-Clause",
       "workspaces": [
+        "api",
         "api-server",
         "client",
         "client/plugins/fcc-source-challenges",
@@ -109,6 +110,20 @@
       },
       "engines": {
         "node": ">=16",
+        "npm": ">=8"
+      }
+    },
+    "api": {
+      "name": "@freecodecamp/api",
+      "version": "0.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@fastify/mongodb": "6.1.0",
+        "fastify": "4.9.2",
+        "fastify-plugin": "4.3.0"
+      },
+      "engines": {
+        "node": ">=18",
         "npm": ">=8"
       }
     },
@@ -882,6 +897,1329 @@
     "node_modules/@ardatan/aggregate-error/node_modules/tslib": {
       "version": "2.0.3",
       "license": "0BSD"
+    },
+    "node_modules/@aws-crypto/ie11-detection": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
+      "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/sha256-js": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
+      "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
+      "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.110.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/abort-controller": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.201.0.tgz",
+      "integrity": "sha512-xJ984k+CKlGjBmvNarzM8Y+b6X4L1Zt0TycQmVBJq7fAr/ju9l13pQIoXR5WlDIW1FkGeVczF5Nu6fN46SCORQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/abort-controller/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/client-cognito-identity": {
+      "version": "3.202.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.202.0.tgz",
+      "integrity": "sha512-PebtNMe214k8ueVtC12SaXHgtfdBpGsbxg81nkGddzesYLhqsBIKlcAyI+ZotrXU50NJ8+rEzxslNleLZ0NI+w==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.202.0",
+        "@aws-sdk/config-resolver": "3.201.0",
+        "@aws-sdk/credential-provider-node": "3.202.0",
+        "@aws-sdk/fetch-http-handler": "3.201.0",
+        "@aws-sdk/hash-node": "3.201.0",
+        "@aws-sdk/invalid-dependency": "3.201.0",
+        "@aws-sdk/middleware-content-length": "3.201.0",
+        "@aws-sdk/middleware-endpoint": "3.201.0",
+        "@aws-sdk/middleware-host-header": "3.201.0",
+        "@aws-sdk/middleware-logger": "3.201.0",
+        "@aws-sdk/middleware-recursion-detection": "3.201.0",
+        "@aws-sdk/middleware-retry": "3.201.0",
+        "@aws-sdk/middleware-serde": "3.201.0",
+        "@aws-sdk/middleware-signing": "3.201.0",
+        "@aws-sdk/middleware-stack": "3.201.0",
+        "@aws-sdk/middleware-user-agent": "3.201.0",
+        "@aws-sdk/node-config-provider": "3.201.0",
+        "@aws-sdk/node-http-handler": "3.201.0",
+        "@aws-sdk/protocol-http": "3.201.0",
+        "@aws-sdk/smithy-client": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "@aws-sdk/url-parser": "3.201.0",
+        "@aws-sdk/util-base64-browser": "3.188.0",
+        "@aws-sdk/util-base64-node": "3.201.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.201.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.201.0",
+        "@aws-sdk/util-defaults-mode-node": "3.201.0",
+        "@aws-sdk/util-endpoints": "3.202.0",
+        "@aws-sdk/util-user-agent-browser": "3.201.0",
+        "@aws-sdk/util-user-agent-node": "3.201.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.202.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.202.0.tgz",
+      "integrity": "sha512-c0impiZUbJeB5AdyZyER81tsqF9bxxaEz6p2LYkTn62NWVXPWEUo/1CHQRj36MUzorz1xiWKIN0NPgK6GBJkPQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.201.0",
+        "@aws-sdk/fetch-http-handler": "3.201.0",
+        "@aws-sdk/hash-node": "3.201.0",
+        "@aws-sdk/invalid-dependency": "3.201.0",
+        "@aws-sdk/middleware-content-length": "3.201.0",
+        "@aws-sdk/middleware-endpoint": "3.201.0",
+        "@aws-sdk/middleware-host-header": "3.201.0",
+        "@aws-sdk/middleware-logger": "3.201.0",
+        "@aws-sdk/middleware-recursion-detection": "3.201.0",
+        "@aws-sdk/middleware-retry": "3.201.0",
+        "@aws-sdk/middleware-serde": "3.201.0",
+        "@aws-sdk/middleware-stack": "3.201.0",
+        "@aws-sdk/middleware-user-agent": "3.201.0",
+        "@aws-sdk/node-config-provider": "3.201.0",
+        "@aws-sdk/node-http-handler": "3.201.0",
+        "@aws-sdk/protocol-http": "3.201.0",
+        "@aws-sdk/smithy-client": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "@aws-sdk/url-parser": "3.201.0",
+        "@aws-sdk/util-base64-browser": "3.188.0",
+        "@aws-sdk/util-base64-node": "3.201.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.201.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.201.0",
+        "@aws-sdk/util-defaults-mode-node": "3.201.0",
+        "@aws-sdk/util-endpoints": "3.202.0",
+        "@aws-sdk/util-user-agent-browser": "3.201.0",
+        "@aws-sdk/util-user-agent-node": "3.201.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.202.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.202.0.tgz",
+      "integrity": "sha512-WGRFzODig8+cZR903q3fa7OAzGigSuzD9AoK+ybefQa7bxSuhT2ous4GNPOJz9WYWvugEPyrJu8vbG35IoF1ZQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.201.0",
+        "@aws-sdk/credential-provider-node": "3.202.0",
+        "@aws-sdk/fetch-http-handler": "3.201.0",
+        "@aws-sdk/hash-node": "3.201.0",
+        "@aws-sdk/invalid-dependency": "3.201.0",
+        "@aws-sdk/middleware-content-length": "3.201.0",
+        "@aws-sdk/middleware-endpoint": "3.201.0",
+        "@aws-sdk/middleware-host-header": "3.201.0",
+        "@aws-sdk/middleware-logger": "3.201.0",
+        "@aws-sdk/middleware-recursion-detection": "3.201.0",
+        "@aws-sdk/middleware-retry": "3.201.0",
+        "@aws-sdk/middleware-sdk-sts": "3.201.0",
+        "@aws-sdk/middleware-serde": "3.201.0",
+        "@aws-sdk/middleware-signing": "3.201.0",
+        "@aws-sdk/middleware-stack": "3.201.0",
+        "@aws-sdk/middleware-user-agent": "3.201.0",
+        "@aws-sdk/node-config-provider": "3.201.0",
+        "@aws-sdk/node-http-handler": "3.201.0",
+        "@aws-sdk/protocol-http": "3.201.0",
+        "@aws-sdk/smithy-client": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "@aws-sdk/url-parser": "3.201.0",
+        "@aws-sdk/util-base64-browser": "3.188.0",
+        "@aws-sdk/util-base64-node": "3.201.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.201.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.201.0",
+        "@aws-sdk/util-defaults-mode-node": "3.201.0",
+        "@aws-sdk/util-endpoints": "3.202.0",
+        "@aws-sdk/util-user-agent-browser": "3.201.0",
+        "@aws-sdk/util-user-agent-node": "3.201.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.201.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/config-resolver": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.201.0.tgz",
+      "integrity": "sha512-6YLIel7OGMGi+r8XC1A54cQJRIpx/NJ4fBALy44zFpQ+fdJUEmw4daUf1LECmAQiPA2Pr/hD0nBtX+wiiTf5/g==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "@aws-sdk/util-config-provider": "3.201.0",
+        "@aws-sdk/util-middleware": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/config-resolver/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.202.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.202.0.tgz",
+      "integrity": "sha512-W/Z4Zf05Yw5ya5SU1UO6xz/OZtxCzMMQmmb71eAHWsh/LIlJ9A3IFsAnAveG7eISTpFjMadT7n6mfsYt/eWgoQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.202.0",
+        "@aws-sdk/property-provider": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.201.0.tgz",
+      "integrity": "sha512-g2MJsowzFhSsIOITUjYp7EzWFeHINjEP526Uf+5z2/p2kxQVwYYWZQK7j+tPE2Bk3MEjGOCmVHbbE7IFj0rNHw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.201.0.tgz",
+      "integrity": "sha512-i8U2k3/L3iUWJJ1GSlwVBMfLQ2OTUT97E8yJi/xz5GavYuPOsUQWQe4fp7WGQivxh+AqybXAGFUCYub6zfUqag==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.201.0",
+        "@aws-sdk/property-provider": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "@aws-sdk/url-parser": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-imds/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.202.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.202.0.tgz",
+      "integrity": "sha512-d0kiYMpGzAq3EBXgEJ1SdeoMXVf3lk6NKHDi/Gy8LB03sZqgc5cY4XFCnY3cqE3DNWWZNR26M4j/KiA0LIjAVA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.201.0",
+        "@aws-sdk/credential-provider-imds": "3.201.0",
+        "@aws-sdk/credential-provider-sso": "3.202.0",
+        "@aws-sdk/credential-provider-web-identity": "3.201.0",
+        "@aws-sdk/property-provider": "3.201.0",
+        "@aws-sdk/shared-ini-file-loader": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.202.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.202.0.tgz",
+      "integrity": "sha512-/uHNs3c1O3oFpH7z9nnpjyg8NKNyRbNxUDIHkuHkNSUUKXpfBisDX6TMbD4VcflGuNdkbT+8spkw5vsE8ox3ig==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.201.0",
+        "@aws-sdk/credential-provider-imds": "3.201.0",
+        "@aws-sdk/credential-provider-ini": "3.202.0",
+        "@aws-sdk/credential-provider-process": "3.201.0",
+        "@aws-sdk/credential-provider-sso": "3.202.0",
+        "@aws-sdk/credential-provider-web-identity": "3.201.0",
+        "@aws-sdk/property-provider": "3.201.0",
+        "@aws-sdk/shared-ini-file-loader": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.201.0.tgz",
+      "integrity": "sha512-jTK3HSZgNj/hVrWb0wuF/cPUWSJYoRI/80fnN55o6QLS8WWIgOI8o2PNeVTAT5OrKioSoN4fgKTeUm3DZy3npQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.201.0",
+        "@aws-sdk/shared-ini-file-loader": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.202.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.202.0.tgz",
+      "integrity": "sha512-EBUY/qKboJwy3qxPHiD/LAnhzga4xR1p++QMoxg2BKgkgwlvGb23lYGr5DSCNhdtJj5o165YZDbGYH+PKn2NVw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.202.0",
+        "@aws-sdk/property-provider": "3.201.0",
+        "@aws-sdk/shared-ini-file-loader": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.201.0.tgz",
+      "integrity": "sha512-U54bqhYaClPVZfswgknhlICp3BAtKXpOgHQCUF8cko5xUgbL4lVgd1rC3lWviGFMQAaTIF3QOXyEouemxr3VXw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/credential-providers": {
+      "version": "3.202.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.202.0.tgz",
+      "integrity": "sha512-CQVSlKh+V4X3tWv+6IJFB8Io89bwErQSP6m7pGynrwH37dr0jg04A5WQQt+l8tRX8NSteVYrAyxebefLnWMTyA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.202.0",
+        "@aws-sdk/client-sso": "3.202.0",
+        "@aws-sdk/client-sts": "3.202.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.202.0",
+        "@aws-sdk/credential-provider-env": "3.201.0",
+        "@aws-sdk/credential-provider-imds": "3.201.0",
+        "@aws-sdk/credential-provider-ini": "3.202.0",
+        "@aws-sdk/credential-provider-node": "3.202.0",
+        "@aws-sdk/credential-provider-process": "3.201.0",
+        "@aws-sdk/credential-provider-sso": "3.202.0",
+        "@aws-sdk/credential-provider-web-identity": "3.201.0",
+        "@aws-sdk/property-provider": "3.201.0",
+        "@aws-sdk/shared-ini-file-loader": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.201.0.tgz",
+      "integrity": "sha512-uiEoH79j6WOpbp4THcpvD9XmD+vPgy+00oyYXjtZqJnv2PM/9b6tGWKTdI+TJW4P/oPv7HP7JmRlkGaTnkIdXw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.201.0",
+        "@aws-sdk/querystring-builder": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "@aws-sdk/util-base64-browser": "3.188.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/fetch-http-handler/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/hash-node": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.201.0.tgz",
+      "integrity": "sha512-WJsMZg5/TMoWnLM+0NuwLwFzHsi89Bi9J1Dt7JdJHXFLoEZV54FEz1PK/Sq5NOldhVljpXQwWOB2dHA2wxFztg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.201.0",
+        "@aws-sdk/util-buffer-from": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/hash-node/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.201.0.tgz",
+      "integrity": "sha512-f/zgntOfIozNyKSaG9dvHjjBaR3y20kYNswMYkSuCM2NIT5LpyHiiq5I11TwaocatUFcDztWpcsv7vHpIgI5Ig==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/invalid-dependency/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/is-array-buffer/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.201.0.tgz",
+      "integrity": "sha512-p4G9AtdrKO8A3Z4RyZiy0isEYwuge7bQRBS7UzcGkcIOhJONq2pcM+gRZYz+NWvfYYNWUg5uODsFQfU8342yKg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-content-length/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/middleware-endpoint": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.201.0.tgz",
+      "integrity": "sha512-F3JlXo5GusbeZR956hA9VxmDxUeg77Xh6o8fveAE2+G4Bjcb1iq9jPNlw6A14vDj3oTKenv2LLnjL2OIfl6hRA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/middleware-serde": "3.201.0",
+        "@aws-sdk/protocol-http": "3.201.0",
+        "@aws-sdk/signature-v4": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "@aws-sdk/url-parser": "3.201.0",
+        "@aws-sdk/util-config-provider": "3.201.0",
+        "@aws-sdk/util-middleware": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.201.0.tgz",
+      "integrity": "sha512-7KNzdV7nFcKAoahvgGAlzsOq9FFDsU5h3w2iPtVdJhz6ZRDH/2v6WFeUCji+UNZip36gFfMPivoO8Y5smb5r/A==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.201.0.tgz",
+      "integrity": "sha512-kYLsa9x3oUJxYU7V5KOO50Kl7b0kk+I4ltkrdarLvvXcVI7ZXmWHzHLT2dkUhj8S0ceVdi0FYHVPJ3GoE8re4A==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.201.0.tgz",
+      "integrity": "sha512-NGOr+n559ZcJLdFoJR8LNGdrOJFIp2BTuWEDYeicNdNb0bETTXrkzcfT1BRhV9CWqCDmjFvjdrzbhS0cw/UUGA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.201.0.tgz",
+      "integrity": "sha512-4jQjSKCpSc4oB1X9nNq4FbIAwQrr+mvmUSmg/oe2Llf42Ak1G9gg3rNTtQdfzA/wNMlL4ZFfF5Br+uz06e1hnQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.201.0",
+        "@aws-sdk/service-error-classification": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "@aws-sdk/util-middleware": "3.201.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-retry/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/middleware-retry/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.201.0.tgz",
+      "integrity": "sha512-clZuXcoN0mAP4JH5C6pW5+0tdF25+fpFJqE7GNRjjH/NYNk6ImVI0Kq2espEWwVBuaS0/chTDK3b+pK8YOWdhw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.201.0",
+        "@aws-sdk/property-provider": "3.201.0",
+        "@aws-sdk/protocol-http": "3.201.0",
+        "@aws-sdk/signature-v4": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.201.0.tgz",
+      "integrity": "sha512-Z7AzIuqEDvsZmp80zeT1oYxsoB8uQZby20Z8kF6/vNoq3sIzaGf/wHeNn0p+Vgo2auGSbZcVUZKoDptQLSLwIQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-serde/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.201.0.tgz",
+      "integrity": "sha512-08ri5+mB28tva9RjVIXFcUP5lRTx+Pj8C2HYqF2GL5H3uAo+h3RQ++fEG1uwUMLf7tCEFivcw6SHA1KmCnB7+w==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.201.0",
+        "@aws-sdk/protocol-http": "3.201.0",
+        "@aws-sdk/signature-v4": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "@aws-sdk/util-middleware": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.201.0.tgz",
+      "integrity": "sha512-lqHYSBP5FBxzA5w5XiYYYpfXabFzleXonqRkqZts1tapNJ4sOd+itiKG8JoNP7LDOwJ8qxNW/a33/gQeh3wkwQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-stack/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.201.0.tgz",
+      "integrity": "sha512-/rYZ93WN1gDJudXis/0382CEoTqRa4qZJA608u2EPWs5aiMocUrm7pjH5XvKm2OYX8K/lyaMSBvL2OTIMzXGaQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.201.0.tgz",
+      "integrity": "sha512-JO0K2qPTYn+pPC7g8rWr1oueg9CqGCkYbINuAuz79vjToOLUQnZT9GiFm7QADe6J6RT1oGEKRQabNaJnp8cFpQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.201.0",
+        "@aws-sdk/shared-ini-file-loader": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-config-provider/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.201.0.tgz",
+      "integrity": "sha512-bWjXBd4WCiQcV4PwY+eFnlz9tZ4UiqfiJteav4MDt8YWkVlsVnR8RutmVSm3KZZjO2tJNSrla0ZWBebkNnI/Xg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.201.0",
+        "@aws-sdk/protocol-http": "3.201.0",
+        "@aws-sdk/querystring-builder": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/property-provider": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.201.0.tgz",
+      "integrity": "sha512-lVMP75VsYHIW04uYbkjA0I8Bb7b+aEj6PBBLdFoA22S0uCeJOD42OSr2Gtg2fToDGO7LQJw/K2D+LMCYKfZ3vQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/property-provider/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/protocol-http": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.201.0.tgz",
+      "integrity": "sha512-RdOc1elWFpj8MogxG87nkhtylw0a+OD7W8WFM+Gw4yJMkl7cwW42VIBFfb0+KCGZfIQltIeSLRvfe3WvVPyo7Q==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/protocol-http/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.201.0.tgz",
+      "integrity": "sha512-FgQnVHpYR19w/HmHEgWpykCn9tdogW0n45Ins6LBCo2aImDf9kBATD4xgN/F2rtogGuLGgu5LIIMHIOj1Tzs/w==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.201.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-builder/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.201.0.tgz",
+      "integrity": "sha512-vS9Ljbqrwi0sIKYxgyZYJUN1AcE291hvuqwty9etgD2w/26SbWiMhjIW/fXJUOZjUvGKkYCpbivJYSzAGAuWfQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-parser/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.201.0.tgz",
+      "integrity": "sha512-Pfcfmurgq8UpM0rXco6FVblcruqN4Mo3TW8/yaXrbctWpmdNT/8v19fffQIIgk94TU8Vf/nPJ7E5DXL7MZr4Fw==",
+      "optional": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.201.0.tgz",
+      "integrity": "sha512-Pbxk0TXep0yI8MnK7Prly6JuBm5Me9AITav8/zPEgTZ3fMhXhQhhiuQcuTCI9GeosSzoiu8VvK53oPtBZZFnXQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/shared-ini-file-loader/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/signature-v4": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.201.0.tgz",
+      "integrity": "sha512-zEHoG1/hzJq169slggkPy1SN9YPWI78Bbe/MvHGYmCmQDspblu60JSBIbAatNqAxAmcWKc2HqpyGKjCkMG94ZA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.201.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/smithy-client": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.201.0.tgz",
+      "integrity": "sha512-cL87Jgxczee8YFkWGWKQ2Ze0vjn4+eCa1kDvEYMCOQvNujTuFgatXLgije5a7nVkSnL9WLoIP7Y7fsBGrKfMnQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/smithy-client/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.201.0.tgz",
+      "integrity": "sha512-RCQj2pQyHD330Jd4c5CHJ87k2ZqC3Mmtl6nhwH1dy3vbnGUpc3q+3yinOKoTAY934kIa7ia32Y/2EjuyHxaj1A==",
+      "optional": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/url-parser": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.201.0.tgz",
+      "integrity": "sha512-V15aqj0tj4Y79VpuIdHUvX4Nvn4hYPB0RAn/qg5CCComIl0doLOirAQtW1MOBOyctdRlD9Uv7d1QdPLzJZMHjQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/url-parser/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-base64-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.188.0.tgz",
+      "integrity": "sha512-qlH+5NZBLiyKziL335BEPedYxX6j+p7KFRWXvDQox9S+s+gLCayednpK+fteOhBenCcR9fUZOVuAPScy1I8qCg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64-browser/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-base64-node": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.201.0.tgz",
+      "integrity": "sha512-ydZqNpB3l5kiicInpPDExPb5xHI7uyVIa1vMupnuIrJ412iNb0F2+K8LlFynzw6fSJShVKnqFcWOYRA96z1iIw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64-node/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-browser/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.201.0.tgz",
+      "integrity": "sha512-q+gwQoLn/DOwirb2hgZJeEwo1D3vLhoD6FfSV42Ecfvtb4jHnWReWMHguujfCubuDgZCrMEvYQzuocS75HHsbA==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-node/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.201.0.tgz",
+      "integrity": "sha512-s6Wjltd9vU+vR3n0pqSPmNDcrrkrVTdV4t7x2zz3nDsFKTI77iVNafDmuaUlOA/bIlpjCJqaWecoVrZmEKeR7A==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-buffer-from/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.201.0.tgz",
+      "integrity": "sha512-cCRJlnRRP8vrLJomzJRBIyiyohsjJKmnIaQ9t0tAhGCywZbyjx6TlpYRZYfVWo+MwdF1Pi8ZScTrFPW0JuBOIQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-config-provider/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.201.0.tgz",
+      "integrity": "sha512-skRMAM+xrV/sDvvtHC81ExEKQEiZFaRrRdUT39fBX1SpGnFTo2wpv7XK+rAW2XopGgnLPytXLQD97Kub79o4zA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-browser/node_modules/bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-browser/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.201.0.tgz",
+      "integrity": "sha512-9N5LXRhxigbkbEcjQ4nNXHuQxp0VFlbc2/5wbcuPjIKX/OROiQI4mYQ6nuSKk7eku5sNFb9FtEHeD/RZo8od6Q==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.201.0",
+        "@aws-sdk/credential-provider-imds": "3.201.0",
+        "@aws-sdk/node-config-provider": "3.201.0",
+        "@aws-sdk/property-provider": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.202.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.202.0.tgz",
+      "integrity": "sha512-sNees5uDp7nfEbvzaA1DAHqoEvEb9ZOkdNH5gcj/FMBETbr00YtsuXsTZogTHQsX/otRTiudZBE3iH7R4SLSAQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-hex-encoding/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.201.0.tgz",
+      "integrity": "sha512-hPJgifWh/rADabLAk1C9xXA2B3O4NUmbU58KgBRgC1HksiiHGFVZObB5fkBH8US/XV2jwORkpSf4OhretXQuKg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-middleware": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.201.0.tgz",
+      "integrity": "sha512-iAitcEZo17IyKn4ku1IBgtomr25esu5OuSRjw5Or4bNOeqXB0w50cItf/9qft8LIhbvBEAUtNAYXvqNzvhTZdQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-middleware/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-uri-escape/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.201.0.tgz",
+      "integrity": "sha512-iL2gyz7GuUVtZcMZpqvfxdFrl9hc28qpagymmJ/w2yhN86YNPHdK8Sx1Yo6VxNGVDCCWGb7tHXf7VP+U4Yv/Lg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.201.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser/node_modules/bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.201.0.tgz",
+      "integrity": "sha512-6lhhvwB3AZSISnYQpDGdlyTrzfYK2P9QYjy7vZEBRd9TSOaggiFICXe03ZvZfVOSeg0EInlMKn1fIHzPUHRuHQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-browser/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-utf8-node": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.201.0.tgz",
+      "integrity": "sha512-A+bJFR/1rHYOJg137E69L1sX0I+LH+xf9ZjMXG9BVO0hSo7yDPoJVpHrzTJyOc3tuRITjIGBv9Qi4TKcoOSi1A==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-node/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "optional": true
     },
     "node_modules/@babel/cli": {
       "version": "7.17.10",
@@ -3300,6 +4638,123 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@fastify/ajv-compiler": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-3.4.0.tgz",
+      "integrity": "sha512-69JnK7Cot+ktn7LD5TikP3b7psBPX55tYpQa8WSumt8r117PCa2zwHnImfBtRWYExreJlI48hr0WZaVrTBGj7w==",
+      "dependencies": {
+        "ajv": "^8.11.0",
+        "ajv-formats": "^2.1.1",
+        "fast-uri": "^2.0.0"
+      }
+    },
+    "node_modules/@fastify/ajv-compiler/node_modules/ajv": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@fastify/ajv-compiler/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/@fastify/deepmerge": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-1.1.0.tgz",
+      "integrity": "sha512-E8Hfdvs1bG6u0N4vN5Nty6JONUfTdOciyD5rn8KnEsLKIenvOVcr210BQR9t34PRkNyjqnMLGk3e0BsaxRdL+g=="
+    },
+    "node_modules/@fastify/error": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-3.0.0.tgz",
+      "integrity": "sha512-dPRyT40GiHRzSCll3/Jn2nPe25+E1VXc9tDwRAIKwFCxd5Np5wzgz1tmooWG3sV0qKgrBibihVoCna2ru4SEFg=="
+    },
+    "node_modules/@fastify/fast-json-stringify-compiler": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-4.1.0.tgz",
+      "integrity": "sha512-cTKBV2J9+u6VaKDhX7HepSfPSzw+F+TSd+k0wzifj4rG+4E5PjSFJCk19P8R6tr/72cuzgGd+mbB3jFT6lvAgw==",
+      "dependencies": {
+        "fast-json-stringify": "^5.0.0"
+      }
+    },
+    "node_modules/@fastify/mongodb": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/mongodb/-/mongodb-6.1.0.tgz",
+      "integrity": "sha512-gnrmUXImqId/0NcV/evEgQ+fOUUCl7EmQcQ/E6sQP+77RoU8gSzEZC/jQxtjjiKs92Z7z4pgwDl8qgITejBDtw==",
+      "dependencies": {
+        "fastify-plugin": "^4.0.0",
+        "mongodb": "^4.0.1"
+      }
+    },
+    "node_modules/@fastify/mongodb/node_modules/bson": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.0.tgz",
+      "integrity": "sha512-VrlEE4vuiO1WTpfof4VmaVolCVYkYTgB9iWgYNOrVlnifpME/06fhFRmONgBhClD5pFC1t9ZWqFUQEQAzY43bA==",
+      "dependencies": {
+        "buffer": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@fastify/mongodb/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/@fastify/mongodb/node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/@fastify/mongodb/node_modules/mongodb": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.11.0.tgz",
+      "integrity": "sha512-9l9n4Nk2BYZzljW3vHah3Z0rfS5npKw6ktnkmFgTcnzaXH1DRm3pDl6VMHu84EVb1lzmSaJC4OzWZqTkB5i2wg==",
+      "dependencies": {
+        "bson": "^4.7.0",
+        "denque": "^2.1.0",
+        "mongodb-connection-string-url": "^2.5.4",
+        "socks": "^2.7.1"
+      },
+      "engines": {
+        "node": ">=12.9.0"
+      },
+      "optionalDependencies": {
+        "@aws-sdk/credential-providers": "^3.186.0",
+        "saslprep": "^1.0.3"
+      }
+    },
     "node_modules/@fortawesome/fontawesome-common-types": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.2.0.tgz",
@@ -3356,6 +4811,10 @@
         "@fortawesome/fontawesome-svg-core": "~1 || ~6",
         "react": ">=16.3"
       }
+    },
+    "node_modules/@freecodecamp/api": {
+      "resolved": "api",
+      "link": true
     },
     "node_modules/@freecodecamp/api-server": {
       "resolved": "api-server",
@@ -14717,6 +16176,11 @@
         "vfile-message": "*"
       }
     },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog=="
+    },
     "node_modules/@types/webpack": {
       "version": "4.41.32",
       "devOptional": true,
@@ -14766,6 +16230,15 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
       }
     },
     "node_modules/@types/ws": {
@@ -15634,6 +17107,11 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/abstract-logging": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="
+    },
     "node_modules/accept-language": {
       "version": "3.0.18",
       "license": "MIT",
@@ -16110,6 +17588,11 @@
       ],
       "license": "MIT"
     },
+    "node_modules/archy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw=="
+    },
     "node_modules/are-we-there-yet": {
       "version": "1.1.7",
       "license": "ISC",
@@ -16466,6 +17949,14 @@
         "node": ">= 4.5.0"
       }
     },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/automation-events": {
       "version": "4.0.10",
       "license": "MIT",
@@ -16522,6 +18013,37 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/avvio": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-8.2.0.tgz",
+      "integrity": "sha512-bbCQdg7bpEv6kGH41RO/3B2/GMMmJSo2iBK+X8AWN9mujtfUipMDfIjsgHCfpnKqoGEQrrmCDKSa5OQ19+fDmg==",
+      "dependencies": {
+        "archy": "^1.0.0",
+        "debug": "^4.0.0",
+        "fastq": "^1.6.1"
+      }
+    },
+    "node_modules/avvio/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/avvio/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/aws-sdk": {
       "version": "2.1041.0",
@@ -25428,6 +26950,11 @@
       "version": "2.1.1",
       "license": "MIT"
     },
+    "node_modules/fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "license": "MIT"
@@ -25456,13 +26983,67 @@
       "version": "2.1.0",
       "license": "MIT"
     },
+    "node_modules/fast-json-stringify": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.4.0.tgz",
+      "integrity": "sha512-PIzon53oX/zEGLrGbu4DpfNcYiV4K4rk+JsVrawRPO/G8cNBEMZ3KlIk2BCGqN+m1KCCA4zt5E7Hh3GG9ojRVA==",
+      "dependencies": {
+        "@fastify/deepmerge": "^1.0.0",
+        "ajv": "^8.10.0",
+        "ajv-formats": "^2.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^2.1.0",
+        "rfdc": "^1.2.0"
+      }
+    },
+    "node_modules/fast-json-stringify/node_modules/ajv": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/fast-json-stringify/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "license": "MIT"
     },
+    "node_modules/fast-querystring": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.0.0.tgz",
+      "integrity": "sha512-3LQi62IhQoDlmt4ULCYmh17vRO2EtS7hTSsG4WwoKWgV7GLMKBOecEh+aiavASnLx8I2y89OD33AGLo0ccRhzA==",
+      "dependencies": {
+        "fast-decode-uri-component": "^1.0.1"
+      }
+    },
+    "node_modules/fast-redact": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.1.2.tgz",
+      "integrity": "sha512-+0em+Iya9fKGfEQGcd62Yv6onjBmmhV1uh86XVfOU8VwAe6kaFdQCWI9s0/Nnugx5Vd9tdbZ7e6gE2tR9dzXdw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-2.1.0.tgz",
+      "integrity": "sha512-qKRta6N7BWEFVlyonVY/V+BMLgFqktCUV0QjT259ekAIlbVrMaFnFLxJ4s/JPl4tou56S1BzPufI60bLe29fHA=="
     },
     "node_modules/fast-url-parser": {
       "version": "1.1.3",
@@ -25477,9 +27058,81 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-xml-parser": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
+      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+      "optional": true,
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
+      }
+    },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.12",
       "license": "MIT"
+    },
+    "node_modules/fastify": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.9.2.tgz",
+      "integrity": "sha512-Mk3hv7ZRet2huMYN6IJ8RGy1TAAC7LJsCEjxLf808zafAADNu43xRzbl7FSEIBxKyhntTM0F626Oc34LUNcUxQ==",
+      "dependencies": {
+        "@fastify/ajv-compiler": "^3.3.1",
+        "@fastify/error": "^3.0.0",
+        "@fastify/fast-json-stringify-compiler": "^4.1.0",
+        "abstract-logging": "^2.0.1",
+        "avvio": "^8.2.0",
+        "find-my-way": "^7.3.0",
+        "light-my-request": "^5.6.1",
+        "pino": "^8.5.0",
+        "process-warning": "^2.0.0",
+        "proxy-addr": "^2.0.7",
+        "rfdc": "^1.3.0",
+        "secure-json-parse": "^2.5.0",
+        "semver": "^7.3.7",
+        "tiny-lru": "^9.0.2"
+      }
+    },
+    "node_modules/fastify-plugin": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-4.3.0.tgz",
+      "integrity": "sha512-M3+i368lV0OYTJ5TfClIoPKEKSOF7112iiPdwgfSR0gN98BjA1Nk+c6oBHtfcVt9KiMxl+EQKHC1QNWo3ZOpYQ=="
+    },
+    "node_modules/fastify/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/fastify/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/fastify/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/fastq": {
       "version": "1.13.0",
@@ -25807,6 +27460,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/find-my-way": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-7.3.1.tgz",
+      "integrity": "sha512-kGvM08SOkqvheLcuQ8GW9t/H901Qb9rZEbcNWbXopzy4jDRoaJpJoObPSKf4MnQLZ20ZTp7rL5MpF6rf+pqmyg==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-querystring": "^1.0.0",
+        "safe-regex2": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/find-up": {
@@ -34175,6 +35841,24 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/light-my-request": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-5.6.1.tgz",
+      "integrity": "sha512-sbJnC1UBRivi9L1kICr3CESb82pNiPNB3TvtdIrZZqW0Qh8uDXvoywMmWKZlihDcmw952CMICCzM+54LDf+E+g==",
+      "dependencies": {
+        "cookie": "^0.5.0",
+        "process-warning": "^2.0.0",
+        "set-cookie-parser": "^2.4.1"
+      }
+    },
+    "node_modules/light-my-request/node_modules/cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.5.tgz",
@@ -38325,6 +40009,46 @@
         }
       }
     },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.5.4.tgz",
+      "integrity": "sha512-SeAxuWs0ez3iI3vvmLk/j2y+zHwigTDKQhtdxTgt5ZCOQQS5+HW4g45/Xw5vzzbn7oQXCNQ24Z40AkJsizEy7w==",
+      "dependencies": {
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/moo": {
       "version": "0.5.1",
       "license": "BSD-3-Clause"
@@ -39717,6 +41441,11 @@
       "version": "1.1.2",
       "license": "MIT"
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.0.tgz",
+      "integrity": "sha512-VuCaZZAjReZ3vUwgOB8LxAosIurDiAW0s13rI1YwmaP++jvcxP77AWoQvenZebpCA2m8WC1/EosPYPMjnRAp/w=="
+    },
     "node_modules/on-finished": {
       "version": "2.3.0",
       "license": "MIT",
@@ -41036,6 +42765,63 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/pino": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.7.0.tgz",
+      "integrity": "sha512-l9sA5uPxmZzwydhMWUcm1gI0YxNnYl8MfSr2h8cwLvOAzQLBLewzF247h/vqHe3/tt6fgtXeG9wdjjoetdI/vA==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "v1.0.0",
+        "pino-std-serializers": "^6.0.0",
+        "process-warning": "^2.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^3.1.0",
+        "thread-stream": "^2.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.0.0.tgz",
+      "integrity": "sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==",
+      "dependencies": {
+        "readable-stream": "^4.0.0",
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-abstract-transport/node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/pino-abstract-transport/node_modules/readable-stream": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.2.0.tgz",
+      "integrity": "sha512-gJrBHsaI3lgBoGMW/jHZsQ/o/TIWiu5ENCJG1BB7fuCKzpFM8GaS2UoBVt9NO+oI+3FcrBNbUkl3ilDe09aY4A==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.0.0.tgz",
+      "integrity": "sha512-mMMOwSKrmyl+Y12Ri2xhH1lbzQxwwpuru9VjyJpgFIH4asSj88F2csdMwN6+M5g1Ll4rmsYghHLQJw81tgZ7LQ=="
     },
     "node_modules/pirates": {
       "version": "4.0.5",
@@ -42371,6 +44157,11 @@
       "version": "2.0.1",
       "license": "MIT"
     },
+    "node_modules/process-warning": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.0.0.tgz",
+      "integrity": "sha512-+MmoAXoUX+VTHAlwns0h+kFUWFs/3FZy+ZuchkgjyOu3oioLAo2LB5aCfKPh2+P9O18i3m43tUEv3YqttSy0Ww=="
+    },
     "node_modules/progress": {
       "version": "2.0.3",
       "license": "MIT",
@@ -42849,6 +44640,11 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
     "node_modules/quick-lru": {
       "version": "5.1.1",
@@ -45265,6 +47061,14 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
     "node_modules/rechoir": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
@@ -46409,7 +48213,6 @@
     },
     "node_modules/rfdc": {
       "version": "1.3.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/rimraf": {
@@ -46677,6 +48480,30 @@
       "license": "MIT",
       "dependencies": {
         "ret": "~0.1.10"
+      }
+    },
+    "node_modules/safe-regex2": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-2.0.0.tgz",
+      "integrity": "sha512-PaUSFsUaNNuKwkBijoAPHAK6/eM6VirvyPWlZ7BAQy4D+hCvh4B6lIG+nPdhbFfIbP+gTGBcrdsOaUs0F+ZBOQ==",
+      "dependencies": {
+        "ret": "~0.2.0"
+      }
+    },
+    "node_modules/safe-regex2/node_modules/ret": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
+      "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.1.tgz",
+      "integrity": "sha512-dVHE6bMtS/bnL2mwualjc6IxEv1F+OCUpA46pKUj6F8uDbUM0jCCulPqRNPSnWwGNKx5etqMjZYdXtrm5KJZGA==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/safer-buffer": {
@@ -47105,6 +48932,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/secure-json-parse": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.5.0.tgz",
+      "integrity": "sha512-ZQruFgZnIWH+WyO9t5rWt4ZEGqCKPwhiw+YbzTwpmT9elgLrLcfuyUiSnwwjUiVy9r4VM3urtbNF1xmEh9IL2w=="
+    },
     "node_modules/select-hose": {
       "version": "2.0.0",
       "license": "MIT"
@@ -47525,6 +49357,11 @@
       "version": "2.0.0",
       "license": "ISC"
     },
+    "node_modules/set-cookie-parser": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.5.1.tgz",
+      "integrity": "sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ=="
+    },
     "node_modules/set-value": {
       "version": "2.0.1",
       "license": "MIT",
@@ -47894,6 +49731,15 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/smee-client": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/smee-client/-/smee-client-1.2.3.tgz",
@@ -48223,6 +50069,32 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/socks": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
+      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+      "dependencies": {
+        "ip": "^2.0.0",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks/node_modules/ip": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
+    },
+    "node_modules/sonic-boom": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.2.0.tgz",
+      "integrity": "sha512-SbbZ+Kqj/XIunvIAgUZRlqd6CGQYq71tRRbXR92Za8J/R3Yh4Av+TWENiSiEgnlwckYLyP0YZQWVfyNC0dzLaA==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-list-map": {
       "version": "2.0.1",
       "license": "MIT"
@@ -48457,6 +50329,14 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
+      "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
@@ -49182,6 +51062,12 @@
       "engines": {
         "node": "^8.1 || >=10.*"
       }
+    },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "optional": true
     },
     "node_modules/strong-error-handler": {
       "version": "3.5.0",
@@ -50373,6 +52259,14 @@
       "version": "0.2.0",
       "license": "MIT"
     },
+    "node_modules/thread-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.2.0.tgz",
+      "integrity": "sha512-rUkv4/fnb4rqy/gGy7VuqK6wE1+1DOCOWy4RMeaV69ZHMP11tQKZvZSip1yTgrKCMZzEMcCL/bKfHvSfDHx+iQ==",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
     "node_modules/throat": {
       "version": "6.0.1",
       "license": "MIT"
@@ -50452,6 +52346,14 @@
     "node_modules/timsort": {
       "version": "0.3.0",
       "license": "MIT"
+    },
+    "node_modules/tiny-lru": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-9.0.3.tgz",
+      "integrity": "sha512-/i9GruRjXsnDgehxvy6iZ4AFNVxngEFbwzirhdulomMNPGPVV3ECMZOWSw0w4sRMZ9Al9m4jy08GPvRxRUGYlw==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/tinydate": {
       "version": "1.3.0",
@@ -55266,6 +57168,1277 @@
         }
       }
     },
+    "@aws-crypto/ie11-detection": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
+      "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
+      "optional": true,
+      "requires": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-crypto/sha256-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/sha256-js": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-crypto/sha256-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-crypto/supports-web-crypto": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
+      "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
+      "optional": true,
+      "requires": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-crypto/util": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
+      "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "^3.110.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-sdk/abort-controller": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.201.0.tgz",
+      "integrity": "sha512-xJ984k+CKlGjBmvNarzM8Y+b6X4L1Zt0TycQmVBJq7fAr/ju9l13pQIoXR5WlDIW1FkGeVczF5Nu6fN46SCORQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/client-cognito-identity": {
+      "version": "3.202.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.202.0.tgz",
+      "integrity": "sha512-PebtNMe214k8ueVtC12SaXHgtfdBpGsbxg81nkGddzesYLhqsBIKlcAyI+ZotrXU50NJ8+rEzxslNleLZ0NI+w==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.202.0",
+        "@aws-sdk/config-resolver": "3.201.0",
+        "@aws-sdk/credential-provider-node": "3.202.0",
+        "@aws-sdk/fetch-http-handler": "3.201.0",
+        "@aws-sdk/hash-node": "3.201.0",
+        "@aws-sdk/invalid-dependency": "3.201.0",
+        "@aws-sdk/middleware-content-length": "3.201.0",
+        "@aws-sdk/middleware-endpoint": "3.201.0",
+        "@aws-sdk/middleware-host-header": "3.201.0",
+        "@aws-sdk/middleware-logger": "3.201.0",
+        "@aws-sdk/middleware-recursion-detection": "3.201.0",
+        "@aws-sdk/middleware-retry": "3.201.0",
+        "@aws-sdk/middleware-serde": "3.201.0",
+        "@aws-sdk/middleware-signing": "3.201.0",
+        "@aws-sdk/middleware-stack": "3.201.0",
+        "@aws-sdk/middleware-user-agent": "3.201.0",
+        "@aws-sdk/node-config-provider": "3.201.0",
+        "@aws-sdk/node-http-handler": "3.201.0",
+        "@aws-sdk/protocol-http": "3.201.0",
+        "@aws-sdk/smithy-client": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "@aws-sdk/url-parser": "3.201.0",
+        "@aws-sdk/util-base64-browser": "3.188.0",
+        "@aws-sdk/util-base64-node": "3.201.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.201.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.201.0",
+        "@aws-sdk/util-defaults-mode-node": "3.201.0",
+        "@aws-sdk/util-endpoints": "3.202.0",
+        "@aws-sdk/util-user-agent-browser": "3.201.0",
+        "@aws-sdk/util-user-agent-node": "3.201.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/client-sso": {
+      "version": "3.202.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.202.0.tgz",
+      "integrity": "sha512-c0impiZUbJeB5AdyZyER81tsqF9bxxaEz6p2LYkTn62NWVXPWEUo/1CHQRj36MUzorz1xiWKIN0NPgK6GBJkPQ==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.201.0",
+        "@aws-sdk/fetch-http-handler": "3.201.0",
+        "@aws-sdk/hash-node": "3.201.0",
+        "@aws-sdk/invalid-dependency": "3.201.0",
+        "@aws-sdk/middleware-content-length": "3.201.0",
+        "@aws-sdk/middleware-endpoint": "3.201.0",
+        "@aws-sdk/middleware-host-header": "3.201.0",
+        "@aws-sdk/middleware-logger": "3.201.0",
+        "@aws-sdk/middleware-recursion-detection": "3.201.0",
+        "@aws-sdk/middleware-retry": "3.201.0",
+        "@aws-sdk/middleware-serde": "3.201.0",
+        "@aws-sdk/middleware-stack": "3.201.0",
+        "@aws-sdk/middleware-user-agent": "3.201.0",
+        "@aws-sdk/node-config-provider": "3.201.0",
+        "@aws-sdk/node-http-handler": "3.201.0",
+        "@aws-sdk/protocol-http": "3.201.0",
+        "@aws-sdk/smithy-client": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "@aws-sdk/url-parser": "3.201.0",
+        "@aws-sdk/util-base64-browser": "3.188.0",
+        "@aws-sdk/util-base64-node": "3.201.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.201.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.201.0",
+        "@aws-sdk/util-defaults-mode-node": "3.201.0",
+        "@aws-sdk/util-endpoints": "3.202.0",
+        "@aws-sdk/util-user-agent-browser": "3.201.0",
+        "@aws-sdk/util-user-agent-node": "3.201.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/client-sts": {
+      "version": "3.202.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.202.0.tgz",
+      "integrity": "sha512-WGRFzODig8+cZR903q3fa7OAzGigSuzD9AoK+ybefQa7bxSuhT2ous4GNPOJz9WYWvugEPyrJu8vbG35IoF1ZQ==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.201.0",
+        "@aws-sdk/credential-provider-node": "3.202.0",
+        "@aws-sdk/fetch-http-handler": "3.201.0",
+        "@aws-sdk/hash-node": "3.201.0",
+        "@aws-sdk/invalid-dependency": "3.201.0",
+        "@aws-sdk/middleware-content-length": "3.201.0",
+        "@aws-sdk/middleware-endpoint": "3.201.0",
+        "@aws-sdk/middleware-host-header": "3.201.0",
+        "@aws-sdk/middleware-logger": "3.201.0",
+        "@aws-sdk/middleware-recursion-detection": "3.201.0",
+        "@aws-sdk/middleware-retry": "3.201.0",
+        "@aws-sdk/middleware-sdk-sts": "3.201.0",
+        "@aws-sdk/middleware-serde": "3.201.0",
+        "@aws-sdk/middleware-signing": "3.201.0",
+        "@aws-sdk/middleware-stack": "3.201.0",
+        "@aws-sdk/middleware-user-agent": "3.201.0",
+        "@aws-sdk/node-config-provider": "3.201.0",
+        "@aws-sdk/node-http-handler": "3.201.0",
+        "@aws-sdk/protocol-http": "3.201.0",
+        "@aws-sdk/smithy-client": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "@aws-sdk/url-parser": "3.201.0",
+        "@aws-sdk/util-base64-browser": "3.188.0",
+        "@aws-sdk/util-base64-node": "3.201.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.201.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.201.0",
+        "@aws-sdk/util-defaults-mode-node": "3.201.0",
+        "@aws-sdk/util-endpoints": "3.202.0",
+        "@aws-sdk/util-user-agent-browser": "3.201.0",
+        "@aws-sdk/util-user-agent-node": "3.201.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.201.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/config-resolver": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.201.0.tgz",
+      "integrity": "sha512-6YLIel7OGMGi+r8XC1A54cQJRIpx/NJ4fBALy44zFpQ+fdJUEmw4daUf1LECmAQiPA2Pr/hD0nBtX+wiiTf5/g==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/signature-v4": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "@aws-sdk/util-config-provider": "3.201.0",
+        "@aws-sdk/util-middleware": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.202.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.202.0.tgz",
+      "integrity": "sha512-W/Z4Zf05Yw5ya5SU1UO6xz/OZtxCzMMQmmb71eAHWsh/LIlJ9A3IFsAnAveG7eISTpFjMadT7n6mfsYt/eWgoQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/client-cognito-identity": "3.202.0",
+        "@aws-sdk/property-provider": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-env": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.201.0.tgz",
+      "integrity": "sha512-g2MJsowzFhSsIOITUjYp7EzWFeHINjEP526Uf+5z2/p2kxQVwYYWZQK7j+tPE2Bk3MEjGOCmVHbbE7IFj0rNHw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-imds": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.201.0.tgz",
+      "integrity": "sha512-i8U2k3/L3iUWJJ1GSlwVBMfLQ2OTUT97E8yJi/xz5GavYuPOsUQWQe4fp7WGQivxh+AqybXAGFUCYub6zfUqag==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.201.0",
+        "@aws-sdk/property-provider": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "@aws-sdk/url-parser": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-ini": {
+      "version": "3.202.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.202.0.tgz",
+      "integrity": "sha512-d0kiYMpGzAq3EBXgEJ1SdeoMXVf3lk6NKHDi/Gy8LB03sZqgc5cY4XFCnY3cqE3DNWWZNR26M4j/KiA0LIjAVA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.201.0",
+        "@aws-sdk/credential-provider-imds": "3.201.0",
+        "@aws-sdk/credential-provider-sso": "3.202.0",
+        "@aws-sdk/credential-provider-web-identity": "3.201.0",
+        "@aws-sdk/property-provider": "3.201.0",
+        "@aws-sdk/shared-ini-file-loader": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-node": {
+      "version": "3.202.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.202.0.tgz",
+      "integrity": "sha512-/uHNs3c1O3oFpH7z9nnpjyg8NKNyRbNxUDIHkuHkNSUUKXpfBisDX6TMbD4VcflGuNdkbT+8spkw5vsE8ox3ig==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.201.0",
+        "@aws-sdk/credential-provider-imds": "3.201.0",
+        "@aws-sdk/credential-provider-ini": "3.202.0",
+        "@aws-sdk/credential-provider-process": "3.201.0",
+        "@aws-sdk/credential-provider-sso": "3.202.0",
+        "@aws-sdk/credential-provider-web-identity": "3.201.0",
+        "@aws-sdk/property-provider": "3.201.0",
+        "@aws-sdk/shared-ini-file-loader": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-process": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.201.0.tgz",
+      "integrity": "sha512-jTK3HSZgNj/hVrWb0wuF/cPUWSJYoRI/80fnN55o6QLS8WWIgOI8o2PNeVTAT5OrKioSoN4fgKTeUm3DZy3npQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.201.0",
+        "@aws-sdk/shared-ini-file-loader": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-sso": {
+      "version": "3.202.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.202.0.tgz",
+      "integrity": "sha512-EBUY/qKboJwy3qxPHiD/LAnhzga4xR1p++QMoxg2BKgkgwlvGb23lYGr5DSCNhdtJj5o165YZDbGYH+PKn2NVw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/client-sso": "3.202.0",
+        "@aws-sdk/property-provider": "3.201.0",
+        "@aws-sdk/shared-ini-file-loader": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-web-identity": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.201.0.tgz",
+      "integrity": "sha512-U54bqhYaClPVZfswgknhlICp3BAtKXpOgHQCUF8cko5xUgbL4lVgd1rC3lWviGFMQAaTIF3QOXyEouemxr3VXw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/credential-providers": {
+      "version": "3.202.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.202.0.tgz",
+      "integrity": "sha512-CQVSlKh+V4X3tWv+6IJFB8Io89bwErQSP6m7pGynrwH37dr0jg04A5WQQt+l8tRX8NSteVYrAyxebefLnWMTyA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/client-cognito-identity": "3.202.0",
+        "@aws-sdk/client-sso": "3.202.0",
+        "@aws-sdk/client-sts": "3.202.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.202.0",
+        "@aws-sdk/credential-provider-env": "3.201.0",
+        "@aws-sdk/credential-provider-imds": "3.201.0",
+        "@aws-sdk/credential-provider-ini": "3.202.0",
+        "@aws-sdk/credential-provider-node": "3.202.0",
+        "@aws-sdk/credential-provider-process": "3.201.0",
+        "@aws-sdk/credential-provider-sso": "3.202.0",
+        "@aws-sdk/credential-provider-web-identity": "3.201.0",
+        "@aws-sdk/property-provider": "3.201.0",
+        "@aws-sdk/shared-ini-file-loader": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/fetch-http-handler": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.201.0.tgz",
+      "integrity": "sha512-uiEoH79j6WOpbp4THcpvD9XmD+vPgy+00oyYXjtZqJnv2PM/9b6tGWKTdI+TJW4P/oPv7HP7JmRlkGaTnkIdXw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.201.0",
+        "@aws-sdk/querystring-builder": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "@aws-sdk/util-base64-browser": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/hash-node": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.201.0.tgz",
+      "integrity": "sha512-WJsMZg5/TMoWnLM+0NuwLwFzHsi89Bi9J1Dt7JdJHXFLoEZV54FEz1PK/Sq5NOldhVljpXQwWOB2dHA2wxFztg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.201.0",
+        "@aws-sdk/util-buffer-from": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/invalid-dependency": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.201.0.tgz",
+      "integrity": "sha512-f/zgntOfIozNyKSaG9dvHjjBaR3y20kYNswMYkSuCM2NIT5LpyHiiq5I11TwaocatUFcDztWpcsv7vHpIgI5Ig==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/is-array-buffer": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-content-length": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.201.0.tgz",
+      "integrity": "sha512-p4G9AtdrKO8A3Z4RyZiy0isEYwuge7bQRBS7UzcGkcIOhJONq2pcM+gRZYz+NWvfYYNWUg5uODsFQfU8342yKg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-endpoint": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.201.0.tgz",
+      "integrity": "sha512-F3JlXo5GusbeZR956hA9VxmDxUeg77Xh6o8fveAE2+G4Bjcb1iq9jPNlw6A14vDj3oTKenv2LLnjL2OIfl6hRA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/middleware-serde": "3.201.0",
+        "@aws-sdk/protocol-http": "3.201.0",
+        "@aws-sdk/signature-v4": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "@aws-sdk/url-parser": "3.201.0",
+        "@aws-sdk/util-config-provider": "3.201.0",
+        "@aws-sdk/util-middleware": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-host-header": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.201.0.tgz",
+      "integrity": "sha512-7KNzdV7nFcKAoahvgGAlzsOq9FFDsU5h3w2iPtVdJhz6ZRDH/2v6WFeUCji+UNZip36gFfMPivoO8Y5smb5r/A==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-logger": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.201.0.tgz",
+      "integrity": "sha512-kYLsa9x3oUJxYU7V5KOO50Kl7b0kk+I4ltkrdarLvvXcVI7ZXmWHzHLT2dkUhj8S0ceVdi0FYHVPJ3GoE8re4A==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-recursion-detection": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.201.0.tgz",
+      "integrity": "sha512-NGOr+n559ZcJLdFoJR8LNGdrOJFIp2BTuWEDYeicNdNb0bETTXrkzcfT1BRhV9CWqCDmjFvjdrzbhS0cw/UUGA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-retry": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.201.0.tgz",
+      "integrity": "sha512-4jQjSKCpSc4oB1X9nNq4FbIAwQrr+mvmUSmg/oe2Llf42Ak1G9gg3rNTtQdfzA/wNMlL4ZFfF5Br+uz06e1hnQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.201.0",
+        "@aws-sdk/service-error-classification": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "@aws-sdk/util-middleware": "3.201.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-sdk-sts": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.201.0.tgz",
+      "integrity": "sha512-clZuXcoN0mAP4JH5C6pW5+0tdF25+fpFJqE7GNRjjH/NYNk6ImVI0Kq2espEWwVBuaS0/chTDK3b+pK8YOWdhw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/middleware-signing": "3.201.0",
+        "@aws-sdk/property-provider": "3.201.0",
+        "@aws-sdk/protocol-http": "3.201.0",
+        "@aws-sdk/signature-v4": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-serde": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.201.0.tgz",
+      "integrity": "sha512-Z7AzIuqEDvsZmp80zeT1oYxsoB8uQZby20Z8kF6/vNoq3sIzaGf/wHeNn0p+Vgo2auGSbZcVUZKoDptQLSLwIQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-signing": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.201.0.tgz",
+      "integrity": "sha512-08ri5+mB28tva9RjVIXFcUP5lRTx+Pj8C2HYqF2GL5H3uAo+h3RQ++fEG1uwUMLf7tCEFivcw6SHA1KmCnB7+w==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.201.0",
+        "@aws-sdk/protocol-http": "3.201.0",
+        "@aws-sdk/signature-v4": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "@aws-sdk/util-middleware": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-stack": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.201.0.tgz",
+      "integrity": "sha512-lqHYSBP5FBxzA5w5XiYYYpfXabFzleXonqRkqZts1tapNJ4sOd+itiKG8JoNP7LDOwJ8qxNW/a33/gQeh3wkwQ==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-user-agent": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.201.0.tgz",
+      "integrity": "sha512-/rYZ93WN1gDJudXis/0382CEoTqRa4qZJA608u2EPWs5aiMocUrm7pjH5XvKm2OYX8K/lyaMSBvL2OTIMzXGaQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/node-config-provider": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.201.0.tgz",
+      "integrity": "sha512-JO0K2qPTYn+pPC7g8rWr1oueg9CqGCkYbINuAuz79vjToOLUQnZT9GiFm7QADe6J6RT1oGEKRQabNaJnp8cFpQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.201.0",
+        "@aws-sdk/shared-ini-file-loader": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/node-http-handler": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.201.0.tgz",
+      "integrity": "sha512-bWjXBd4WCiQcV4PwY+eFnlz9tZ4UiqfiJteav4MDt8YWkVlsVnR8RutmVSm3KZZjO2tJNSrla0ZWBebkNnI/Xg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/abort-controller": "3.201.0",
+        "@aws-sdk/protocol-http": "3.201.0",
+        "@aws-sdk/querystring-builder": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/property-provider": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.201.0.tgz",
+      "integrity": "sha512-lVMP75VsYHIW04uYbkjA0I8Bb7b+aEj6PBBLdFoA22S0uCeJOD42OSr2Gtg2fToDGO7LQJw/K2D+LMCYKfZ3vQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/protocol-http": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.201.0.tgz",
+      "integrity": "sha512-RdOc1elWFpj8MogxG87nkhtylw0a+OD7W8WFM+Gw4yJMkl7cwW42VIBFfb0+KCGZfIQltIeSLRvfe3WvVPyo7Q==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/querystring-builder": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.201.0.tgz",
+      "integrity": "sha512-FgQnVHpYR19w/HmHEgWpykCn9tdogW0n45Ins6LBCo2aImDf9kBATD4xgN/F2rtogGuLGgu5LIIMHIOj1Tzs/w==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.201.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/querystring-parser": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.201.0.tgz",
+      "integrity": "sha512-vS9Ljbqrwi0sIKYxgyZYJUN1AcE291hvuqwty9etgD2w/26SbWiMhjIW/fXJUOZjUvGKkYCpbivJYSzAGAuWfQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/service-error-classification": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.201.0.tgz",
+      "integrity": "sha512-Pfcfmurgq8UpM0rXco6FVblcruqN4Mo3TW8/yaXrbctWpmdNT/8v19fffQIIgk94TU8Vf/nPJ7E5DXL7MZr4Fw==",
+      "optional": true
+    },
+    "@aws-sdk/shared-ini-file-loader": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.201.0.tgz",
+      "integrity": "sha512-Pbxk0TXep0yI8MnK7Prly6JuBm5Me9AITav8/zPEgTZ3fMhXhQhhiuQcuTCI9GeosSzoiu8VvK53oPtBZZFnXQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/signature-v4": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.201.0.tgz",
+      "integrity": "sha512-zEHoG1/hzJq169slggkPy1SN9YPWI78Bbe/MvHGYmCmQDspblu60JSBIbAatNqAxAmcWKc2HqpyGKjCkMG94ZA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.201.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/smithy-client": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.201.0.tgz",
+      "integrity": "sha512-cL87Jgxczee8YFkWGWKQ2Ze0vjn4+eCa1kDvEYMCOQvNujTuFgatXLgije5a7nVkSnL9WLoIP7Y7fsBGrKfMnQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/middleware-stack": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.201.0.tgz",
+      "integrity": "sha512-RCQj2pQyHD330Jd4c5CHJ87k2ZqC3Mmtl6nhwH1dy3vbnGUpc3q+3yinOKoTAY934kIa7ia32Y/2EjuyHxaj1A==",
+      "optional": true
+    },
+    "@aws-sdk/url-parser": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.201.0.tgz",
+      "integrity": "sha512-V15aqj0tj4Y79VpuIdHUvX4Nvn4hYPB0RAn/qg5CCComIl0doLOirAQtW1MOBOyctdRlD9Uv7d1QdPLzJZMHjQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/querystring-parser": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-base64-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.188.0.tgz",
+      "integrity": "sha512-qlH+5NZBLiyKziL335BEPedYxX6j+p7KFRWXvDQox9S+s+gLCayednpK+fteOhBenCcR9fUZOVuAPScy1I8qCg==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-base64-node": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.201.0.tgz",
+      "integrity": "sha512-ydZqNpB3l5kiicInpPDExPb5xHI7uyVIa1vMupnuIrJ412iNb0F2+K8LlFynzw6fSJShVKnqFcWOYRA96z1iIw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-body-length-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-body-length-node": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.201.0.tgz",
+      "integrity": "sha512-q+gwQoLn/DOwirb2hgZJeEwo1D3vLhoD6FfSV42Ecfvtb4jHnWReWMHguujfCubuDgZCrMEvYQzuocS75HHsbA==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-buffer-from": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.201.0.tgz",
+      "integrity": "sha512-s6Wjltd9vU+vR3n0pqSPmNDcrrkrVTdV4t7x2zz3nDsFKTI77iVNafDmuaUlOA/bIlpjCJqaWecoVrZmEKeR7A==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-config-provider": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.201.0.tgz",
+      "integrity": "sha512-cCRJlnRRP8vrLJomzJRBIyiyohsjJKmnIaQ9t0tAhGCywZbyjx6TlpYRZYfVWo+MwdF1Pi8ZScTrFPW0JuBOIQ==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.201.0.tgz",
+      "integrity": "sha512-skRMAM+xrV/sDvvtHC81ExEKQEiZFaRrRdUT39fBX1SpGnFTo2wpv7XK+rAW2XopGgnLPytXLQD97Kub79o4zA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "bowser": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+          "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+          "optional": true
+        },
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-defaults-mode-node": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.201.0.tgz",
+      "integrity": "sha512-9N5LXRhxigbkbEcjQ4nNXHuQxp0VFlbc2/5wbcuPjIKX/OROiQI4mYQ6nuSKk7eku5sNFb9FtEHeD/RZo8od6Q==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/config-resolver": "3.201.0",
+        "@aws-sdk/credential-provider-imds": "3.201.0",
+        "@aws-sdk/node-config-provider": "3.201.0",
+        "@aws-sdk/property-provider": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-endpoints": {
+      "version": "3.202.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.202.0.tgz",
+      "integrity": "sha512-sNees5uDp7nfEbvzaA1DAHqoEvEb9ZOkdNH5gcj/FMBETbr00YtsuXsTZogTHQsX/otRTiudZBE3iH7R4SLSAQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-hex-encoding": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-locate-window": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.201.0.tgz",
+      "integrity": "sha512-hPJgifWh/rADabLAk1C9xXA2B3O4NUmbU58KgBRgC1HksiiHGFVZObB5fkBH8US/XV2jwORkpSf4OhretXQuKg==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-middleware": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.201.0.tgz",
+      "integrity": "sha512-iAitcEZo17IyKn4ku1IBgtomr25esu5OuSRjw5Or4bNOeqXB0w50cItf/9qft8LIhbvBEAUtNAYXvqNzvhTZdQ==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-uri-escape": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-user-agent-browser": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.201.0.tgz",
+      "integrity": "sha512-iL2gyz7GuUVtZcMZpqvfxdFrl9hc28qpagymmJ/w2yhN86YNPHdK8Sx1Yo6VxNGVDCCWGb7tHXf7VP+U4Yv/Lg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.201.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "bowser": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+          "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+          "optional": true
+        },
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-user-agent-node": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.201.0.tgz",
+      "integrity": "sha512-6lhhvwB3AZSISnYQpDGdlyTrzfYK2P9QYjy7vZEBRd9TSOaggiFICXe03ZvZfVOSeg0EInlMKn1fIHzPUHRuHQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.201.0",
+        "@aws-sdk/types": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-utf8-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-utf8-node": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.201.0.tgz",
+      "integrity": "sha512-A+bJFR/1rHYOJg137E69L1sX0I+LH+xf9ZjMXG9BVO0hSo7yDPoJVpHrzTJyOc3tuRITjIGBv9Qi4TKcoOSi1A==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "optional": true
+        }
+      }
+    },
     "@babel/cli": {
       "version": "7.17.10",
       "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.17.10.tgz",
@@ -56817,6 +59990,98 @@
         }
       }
     },
+    "@fastify/ajv-compiler": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-3.4.0.tgz",
+      "integrity": "sha512-69JnK7Cot+ktn7LD5TikP3b7psBPX55tYpQa8WSumt8r117PCa2zwHnImfBtRWYExreJlI48hr0WZaVrTBGj7w==",
+      "requires": {
+        "ajv": "^8.11.0",
+        "ajv-formats": "^2.1.1",
+        "fast-uri": "^2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        }
+      }
+    },
+    "@fastify/deepmerge": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-1.1.0.tgz",
+      "integrity": "sha512-E8Hfdvs1bG6u0N4vN5Nty6JONUfTdOciyD5rn8KnEsLKIenvOVcr210BQR9t34PRkNyjqnMLGk3e0BsaxRdL+g=="
+    },
+    "@fastify/error": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-3.0.0.tgz",
+      "integrity": "sha512-dPRyT40GiHRzSCll3/Jn2nPe25+E1VXc9tDwRAIKwFCxd5Np5wzgz1tmooWG3sV0qKgrBibihVoCna2ru4SEFg=="
+    },
+    "@fastify/fast-json-stringify-compiler": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-4.1.0.tgz",
+      "integrity": "sha512-cTKBV2J9+u6VaKDhX7HepSfPSzw+F+TSd+k0wzifj4rG+4E5PjSFJCk19P8R6tr/72cuzgGd+mbB3jFT6lvAgw==",
+      "requires": {
+        "fast-json-stringify": "^5.0.0"
+      }
+    },
+    "@fastify/mongodb": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/mongodb/-/mongodb-6.1.0.tgz",
+      "integrity": "sha512-gnrmUXImqId/0NcV/evEgQ+fOUUCl7EmQcQ/E6sQP+77RoU8gSzEZC/jQxtjjiKs92Z7z4pgwDl8qgITejBDtw==",
+      "requires": {
+        "fastify-plugin": "^4.0.0",
+        "mongodb": "^4.0.1"
+      },
+      "dependencies": {
+        "bson": {
+          "version": "4.7.0",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.0.tgz",
+          "integrity": "sha512-VrlEE4vuiO1WTpfof4VmaVolCVYkYTgB9iWgYNOrVlnifpME/06fhFRmONgBhClD5pFC1t9ZWqFUQEQAzY43bA==",
+          "requires": {
+            "buffer": "^5.6.0"
+          }
+        },
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        },
+        "denque": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+          "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="
+        },
+        "mongodb": {
+          "version": "4.11.0",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.11.0.tgz",
+          "integrity": "sha512-9l9n4Nk2BYZzljW3vHah3Z0rfS5npKw6ktnkmFgTcnzaXH1DRm3pDl6VMHu84EVb1lzmSaJC4OzWZqTkB5i2wg==",
+          "requires": {
+            "@aws-sdk/credential-providers": "^3.186.0",
+            "bson": "^4.7.0",
+            "denque": "^2.1.0",
+            "mongodb-connection-string-url": "^2.5.4",
+            "saslprep": "^1.0.3",
+            "socks": "^2.7.1"
+          }
+        }
+      }
+    },
     "@fortawesome/fontawesome-common-types": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.2.0.tgz",
@@ -56852,6 +60117,14 @@
       "integrity": "sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==",
       "requires": {
         "prop-types": "^15.8.1"
+      }
+    },
+    "@freecodecamp/api": {
+      "version": "file:api",
+      "requires": {
+        "@fastify/mongodb": "*",
+        "fastify": "4.9.2",
+        "fastify-plugin": "*"
       }
     },
     "@freecodecamp/api-server": {
@@ -65792,6 +69065,11 @@
         "vfile-message": "*"
       }
     },
+    "@types/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog=="
+    },
     "@types/webpack": {
       "version": "4.41.32",
       "devOptional": true,
@@ -65833,6 +69111,15 @@
       "version": "1.0.2",
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@types/whatwg-url": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+      "requires": {
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
       }
     },
     "@types/ws": {
@@ -66453,6 +69740,11 @@
         "event-target-shim": "^5.0.0"
       }
     },
+    "abstract-logging": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="
+    },
     "accept-language": {
       "version": "3.0.18",
       "requires": {
@@ -66760,6 +70052,11 @@
     "arch": {
       "version": "2.2.0"
     },
+    "archy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw=="
+    },
     "are-we-there-yet": {
       "version": "1.1.7",
       "requires": {
@@ -66996,6 +70293,11 @@
     "atob": {
       "version": "2.1.2"
     },
+    "atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
+    },
     "automation-events": {
       "version": "4.0.10",
       "requires": {
@@ -67023,6 +70325,31 @@
     },
     "available-typed-arrays": {
       "version": "1.0.5"
+    },
+    "avvio": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-8.2.0.tgz",
+      "integrity": "sha512-bbCQdg7bpEv6kGH41RO/3B2/GMMmJSo2iBK+X8AWN9mujtfUipMDfIjsgHCfpnKqoGEQrrmCDKSa5OQ19+fDmg==",
+      "requires": {
+        "archy": "^1.0.0",
+        "debug": "^4.0.0",
+        "fastq": "^1.6.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
     },
     "aws-sdk": {
       "version": "2.1041.0",
@@ -73307,6 +76634,11 @@
     "fast-copy": {
       "version": "2.1.1"
     },
+    "fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="
+    },
     "fast-deep-equal": {
       "version": "3.1.3"
     },
@@ -73329,11 +76661,60 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0"
     },
+    "fast-json-stringify": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.4.0.tgz",
+      "integrity": "sha512-PIzon53oX/zEGLrGbu4DpfNcYiV4K4rk+JsVrawRPO/G8cNBEMZ3KlIk2BCGqN+m1KCCA4zt5E7Hh3GG9ojRVA==",
+      "requires": {
+        "@fastify/deepmerge": "^1.0.0",
+        "ajv": "^8.10.0",
+        "ajv-formats": "^2.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^2.1.0",
+        "rfdc": "^1.2.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        }
+      }
+    },
     "fast-levenshtein": {
       "version": "2.0.6"
     },
+    "fast-querystring": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.0.0.tgz",
+      "integrity": "sha512-3LQi62IhQoDlmt4ULCYmh17vRO2EtS7hTSsG4WwoKWgV7GLMKBOecEh+aiavASnLx8I2y89OD33AGLo0ccRhzA==",
+      "requires": {
+        "fast-decode-uri-component": "^1.0.1"
+      }
+    },
+    "fast-redact": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.1.2.tgz",
+      "integrity": "sha512-+0em+Iya9fKGfEQGcd62Yv6onjBmmhV1uh86XVfOU8VwAe6kaFdQCWI9s0/Nnugx5Vd9tdbZ7e6gE2tR9dzXdw=="
+    },
     "fast-safe-stringify": {
       "version": "2.1.1"
+    },
+    "fast-uri": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-2.1.0.tgz",
+      "integrity": "sha512-qKRta6N7BWEFVlyonVY/V+BMLgFqktCUV0QjT259ekAIlbVrMaFnFLxJ4s/JPl4tou56S1BzPufI60bLe29fHA=="
     },
     "fast-url-parser": {
       "version": "1.1.3",
@@ -73348,8 +76729,66 @@
         }
       }
     },
+    "fast-xml-parser": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
+      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+      "optional": true,
+      "requires": {
+        "strnum": "^1.0.5"
+      }
+    },
     "fastest-levenshtein": {
       "version": "1.0.12"
+    },
+    "fastify": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.9.2.tgz",
+      "integrity": "sha512-Mk3hv7ZRet2huMYN6IJ8RGy1TAAC7LJsCEjxLf808zafAADNu43xRzbl7FSEIBxKyhntTM0F626Oc34LUNcUxQ==",
+      "requires": {
+        "@fastify/ajv-compiler": "^3.3.1",
+        "@fastify/error": "^3.0.0",
+        "@fastify/fast-json-stringify-compiler": "^4.1.0",
+        "abstract-logging": "^2.0.1",
+        "avvio": "^8.2.0",
+        "find-my-way": "^7.3.0",
+        "light-my-request": "^5.6.1",
+        "pino": "^8.5.0",
+        "process-warning": "^2.0.0",
+        "proxy-addr": "^2.0.7",
+        "rfdc": "^1.3.0",
+        "secure-json-parse": "^2.5.0",
+        "semver": "^7.3.7",
+        "tiny-lru": "^9.0.2"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
+    "fastify-plugin": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-4.3.0.tgz",
+      "integrity": "sha512-M3+i368lV0OYTJ5TfClIoPKEKSOF7112iiPdwgfSR0gN98BjA1Nk+c6oBHtfcVt9KiMxl+EQKHC1QNWo3ZOpYQ=="
     },
     "fastq": {
       "version": "1.13.0",
@@ -73574,6 +77013,16 @@
             "find-up": "^3.0.0"
           }
         }
+      }
+    },
+    "find-my-way": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-7.3.1.tgz",
+      "integrity": "sha512-kGvM08SOkqvheLcuQ8GW9t/H901Qb9rZEbcNWbXopzy4jDRoaJpJoObPSKf4MnQLZ20ZTp7rL5MpF6rf+pqmyg==",
+      "requires": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-querystring": "^1.0.0",
+        "safe-regex2": "^2.0.0"
       }
     },
     "find-up": {
@@ -78937,6 +82386,23 @@
         "type-check": "~0.4.0"
       }
     },
+    "light-my-request": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-5.6.1.tgz",
+      "integrity": "sha512-sbJnC1UBRivi9L1kICr3CESb82pNiPNB3TvtdIrZZqW0Qh8uDXvoywMmWKZlihDcmw952CMICCzM+54LDf+E+g==",
+      "requires": {
+        "cookie": "^0.5.0",
+        "process-warning": "^2.0.0",
+        "set-cookie-parser": "^2.4.1"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+          "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+        }
+      }
+    },
     "lilconfig": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.5.tgz",
@@ -81671,6 +85137,39 @@
         "saslprep": "^1.0.0"
       }
     },
+    "mongodb-connection-string-url": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.5.4.tgz",
+      "integrity": "sha512-SeAxuWs0ez3iI3vvmLk/j2y+zHwigTDKQhtdxTgt5ZCOQQS5+HW4g45/Xw5vzzbn7oQXCNQ24Z40AkJsizEy7w==",
+      "requires": {
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+          "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+          "requires": {
+            "punycode": "^2.1.1"
+          }
+        },
+        "webidl-conversions": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+          "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
+        },
+        "whatwg-url": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+          "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+          "requires": {
+            "tr46": "^3.0.0",
+            "webidl-conversions": "^7.0.0"
+          }
+        }
+      }
+    },
     "moo": {
       "version": "0.5.1"
     },
@@ -82679,6 +86178,11 @@
     "obuf": {
       "version": "1.1.2"
     },
+    "on-exit-leak-free": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.0.tgz",
+      "integrity": "sha512-VuCaZZAjReZ3vUwgOB8LxAosIurDiAW0s13rI1YwmaP++jvcxP77AWoQvenZebpCA2m8WC1/EosPYPMjnRAp/w=="
+    },
     "on-finished": {
       "version": "2.3.0",
       "requires": {
@@ -83543,6 +87047,56 @@
         "pinkie": "^2.0.0"
       }
     },
+    "pino": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.7.0.tgz",
+      "integrity": "sha512-l9sA5uPxmZzwydhMWUcm1gI0YxNnYl8MfSr2h8cwLvOAzQLBLewzF247h/vqHe3/tt6fgtXeG9wdjjoetdI/vA==",
+      "requires": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "v1.0.0",
+        "pino-std-serializers": "^6.0.0",
+        "process-warning": "^2.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^3.1.0",
+        "thread-stream": "^2.0.0"
+      }
+    },
+    "pino-abstract-transport": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.0.0.tgz",
+      "integrity": "sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==",
+      "requires": {
+        "readable-stream": "^4.0.0",
+        "split2": "^4.0.0"
+      },
+      "dependencies": {
+        "events": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+          "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
+        },
+        "readable-stream": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.2.0.tgz",
+          "integrity": "sha512-gJrBHsaI3lgBoGMW/jHZsQ/o/TIWiu5ENCJG1BB7fuCKzpFM8GaS2UoBVt9NO+oI+3FcrBNbUkl3ilDe09aY4A==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "buffer": "^6.0.3",
+            "events": "^3.3.0",
+            "process": "^0.11.10"
+          }
+        }
+      }
+    },
+    "pino-std-serializers": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.0.0.tgz",
+      "integrity": "sha512-mMMOwSKrmyl+Y12Ri2xhH1lbzQxwwpuru9VjyJpgFIH4asSj88F2csdMwN6+M5g1Ll4rmsYghHLQJw81tgZ7LQ=="
+    },
     "pirates": {
       "version": "4.0.5"
     },
@@ -84249,6 +87803,11 @@
     "process-nextick-args": {
       "version": "2.0.1"
     },
+    "process-warning": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.0.0.tgz",
+      "integrity": "sha512-+MmoAXoUX+VTHAlwns0h+kFUWFs/3FZy+ZuchkgjyOu3oioLAo2LB5aCfKPh2+P9O18i3m43tUEv3YqttSy0Ww=="
+    },
     "progress": {
       "version": "2.0.3"
     },
@@ -84561,6 +88120,11 @@
     },
     "queue-microtask": {
       "version": "1.2.3"
+    },
+    "quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
     "quick-lru": {
       "version": "5.1.1"
@@ -86180,6 +89744,11 @@
         "picomatch": "^2.2.1"
       }
     },
+    "real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="
+    },
     "rechoir": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
@@ -86924,8 +90493,7 @@
       "version": "1.0.4"
     },
     "rfdc": {
-      "version": "1.3.0",
-      "dev": true
+      "version": "1.3.0"
     },
     "rimraf": {
       "version": "3.0.2",
@@ -87101,6 +90669,26 @@
       "requires": {
         "ret": "~0.1.10"
       }
+    },
+    "safe-regex2": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-2.0.0.tgz",
+      "integrity": "sha512-PaUSFsUaNNuKwkBijoAPHAK6/eM6VirvyPWlZ7BAQy4D+hCvh4B6lIG+nPdhbFfIbP+gTGBcrdsOaUs0F+ZBOQ==",
+      "requires": {
+        "ret": "~0.2.0"
+      },
+      "dependencies": {
+        "ret": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
+          "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ=="
+        }
+      }
+    },
+    "safe-stable-stringify": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.1.tgz",
+      "integrity": "sha512-dVHE6bMtS/bnL2mwualjc6IxEv1F+OCUpA46pKUj6F8uDbUM0jCCulPqRNPSnWwGNKx5etqMjZYdXtrm5KJZGA=="
     },
     "safer-buffer": {
       "version": "2.1.2"
@@ -87408,6 +90996,11 @@
         "extend-shallow": "^2.0.1",
         "kind-of": "^6.0.0"
       }
+    },
+    "secure-json-parse": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.5.0.tgz",
+      "integrity": "sha512-ZQruFgZnIWH+WyO9t5rWt4ZEGqCKPwhiw+YbzTwpmT9elgLrLcfuyUiSnwwjUiVy9r4VM3urtbNF1xmEh9IL2w=="
     },
     "select-hose": {
       "version": "2.0.0"
@@ -87719,6 +91312,11 @@
     "set-blocking": {
       "version": "2.0.0"
     },
+    "set-cookie-parser": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.5.1.tgz",
+      "integrity": "sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ=="
+    },
     "set-value": {
       "version": "2.0.1",
       "requires": {
@@ -87960,6 +91558,11 @@
     "slugify": {
       "version": "1.6.3"
     },
+    "smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
+    },
     "smee-client": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/smee-client/-/smee-client-1.2.3.tgz",
@@ -88199,6 +91802,30 @@
         }
       }
     },
+    "socks": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
+      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+      "requires": {
+        "ip": "^2.0.0",
+        "smart-buffer": "^4.2.0"
+      },
+      "dependencies": {
+        "ip": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+          "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
+        }
+      }
+    },
+    "sonic-boom": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.2.0.tgz",
+      "integrity": "sha512-SbbZ+Kqj/XIunvIAgUZRlqd6CGQYq71tRRbXR92Za8J/R3Yh4Av+TWENiSiEgnlwckYLyP0YZQWVfyNC0dzLaA==",
+      "requires": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "source-list-map": {
       "version": "2.0.1"
     },
@@ -88357,6 +91984,11 @@
           }
         }
       }
+    },
+    "split2": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
+      "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ=="
     },
     "sprintf-js": {
       "version": "1.1.2"
@@ -88860,6 +92492,12 @@
         "@types/node": ">=8.1.0",
         "qs": "^6.6.0"
       }
+    },
+    "strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "optional": true
     },
     "strong-error-handler": {
       "version": "3.5.0",
@@ -89628,6 +93266,14 @@
     "text-table": {
       "version": "0.2.0"
     },
+    "thread-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.2.0.tgz",
+      "integrity": "sha512-rUkv4/fnb4rqy/gGy7VuqK6wE1+1DOCOWy4RMeaV69ZHMP11tQKZvZSip1yTgrKCMZzEMcCL/bKfHvSfDHx+iQ==",
+      "requires": {
+        "real-require": "^0.2.0"
+      }
+    },
     "throat": {
       "version": "6.0.1"
     },
@@ -89696,6 +93342,11 @@
     },
     "timsort": {
       "version": "0.3.0"
+    },
+    "tiny-lru": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-9.0.3.tgz",
+      "integrity": "sha512-/i9GruRjXsnDgehxvy6iZ4AFNVxngEFbwzirhdulomMNPGPVV3ECMZOWSw0w4sRMZ9Al9m4jy08GPvRxRUGYlw=="
     },
     "tinydate": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "author": "freeCodeCamp <team@freecodecamp.org>",
   "main": "none",
   "workspaces": [
+    "api",
     "api-server",
     "client",
     "client/plugins/fcc-source-challenges",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "include": [
+    "api",
     "client/i18n/**/*",
     "client/plugins/**/*",
     "client/src/**/*",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

**For Development**

```bash
/api $ npm run develop
```

**For Production**

```bash
/api $ npm run build
/api $ npm run start
```

**Note**

For convenience, no module separation (code splitting) or bundling is done. `tsc` simply converts the TypeScript files into `.js`. During development, `nodemon` uses the `ts-node` peer dep (from root `package.json` [^1]) to execute/watch the scripts.

[^1]: Caveat - `nodemon` will complain if you have not `npm i` in root. Obviously, this can be changed, by including `ts-node` as an actual `peerDependency`, but seeing as `api` is a part of the root workspace 🤷‍♂️ 