### PR TITLE
fix(lint): stop tripping over docs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,3 +7,4 @@ config/i18n.js
 config/certification-settings.js
 config/superblock-order.js
 web/**
+docs/**/*.md

--- a/.prettierignore
+++ b/.prettierignore
@@ -9,7 +9,6 @@ config/i18n.js
 config/certification-settings.js
 config/superblock-order.js
 config/superblock-order.test.js
-docs/i18n
 utils/block-nameify.js
 utils/block-nameify.test.js
 utils/slugs.js
@@ -18,3 +17,4 @@ utils/index.js
 **/package-lock.json
 web/.next
 curriculum-server/data/curriculum.json
+docs/**/*.md


### PR DESCRIPTION
I always found the CI tripping over linting rules for markdown in the docs. They need to be lax for the docs than the curriculum because we allow editing docs on GitHub.
