### PR TITLE
feat(client): remove inline values in GreenPass component

### DIFF
--- a/client/src/templates/Challenges/classic/editor.css
+++ b/client/src/templates/Challenges/classic/editor.css
@@ -53,6 +53,7 @@ textarea.inputarea {
 
 .challenge-description-header {
   display: flex;
+  gap: 7px;
 }
 
 .description-container h1 {
@@ -61,7 +62,7 @@ textarea.inputarea {
   font-size: 1.1rem;
   font-weight: 700;
   line-height: 1.1;
-  margin: 0 0 0.6rem;
+  margin: 0.1em 0 0.6rem;
 }
 
 .description-highlighter {

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -70,7 +70,6 @@ import LowerJaw from './lower-jaw';
 
 import './editor.css';
 
-// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
 const MonacoEditor = Loadable(() => import('react-monaco-editor'));
 
 interface EditorProps {
@@ -265,7 +264,6 @@ const Editor = (props: EditorProps): JSX.Element => {
     noteIndex: number;
     shouldPlay: boolean | undefined;
   }>({
-    // eslint-disable-next-line no-undefined
     sampler: undefined,
     noteIndex: 0,
     shouldPlay: store.get('fcc-sound') as boolean | undefined
@@ -456,7 +454,6 @@ const Editor = (props: EditorProps): JSX.Element => {
     editor.addAction({
       id: 'execute-challenge',
       label: 'Run tests',
-      /* eslint-disable no-bitwise */
       keybindings: [
         monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
         monaco.KeyMod.WinCtrl | monaco.KeyCode.Enter
@@ -701,14 +698,7 @@ const Editor = (props: EditorProps): JSX.Element => {
       )}</span>`;
       jawHeading.appendChild(challengeTitle);
       const checkmark = ReactDOMServer.renderToStaticMarkup(
-        <GreenPass
-          hushScreenReaderText
-          style={{
-            height: '15px',
-            width: '15px',
-            marginLeft: '7px'
-          }}
-        />
+        <GreenPass hushScreenReaderText />
       );
       const completedChallengeHeader = document.createElement('div');
       completedChallengeHeader.innerHTML = checkmark;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

![image](https://user-images.githubusercontent.com/88248797/201852099-1ca9cff7-b848-4f41-a43d-da62b77cc785.png)

There are inline values for GreenPass in show.tsx, but it's used for codeAlly lay out, so I haven't touched them

<!-- Feel free to add any additional description of changes below this line -->
