### PR TITLE
fix(curriculum): change 'markdown' to 'markup' (CatPhotoApp Step 69)

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/62bb4009e3458a128ff57d5d.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/62bb4009e3458a128ff57d5d.md
@@ -13,7 +13,7 @@ You can set browser behavior by adding self-closing `meta` elements in the `head
 <meta attribute="value">
 ```
 
-Tell the browser to parse the markdown into multiple languages by creating a `meta` element as a child of the `head` element. Set its `charset` attribute to `UTF-8`.
+Tell the browser to parse the markup into multiple languages by creating a `meta` element as a child of the `head` element. Set its `charset` attribute to `UTF-8`.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Affected page:
https://www.freecodecamp.org/learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-69

The current instruction seems incorrect.