### PR TITLE
fix(UI): prevent Chinese & Japanese headings in lower jaw getting wrapped

### DIFF
--- a/client/src/templates/Challenges/classic/editor.css
+++ b/client/src/templates/Challenges/classic/editor.css
@@ -127,6 +127,8 @@ textarea.inputarea {
   /* using float instead of inline display so screen readers recognize h2 as a block element */
   float: left;
   margin: 0.5em 0 0;
+  /* prevent line breaks in Chinese/Japanese/Korean */
+  word-break: keep-all;
 }
 
 .test-feedback h2:after {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
![japanese_h2](https://user-images.githubusercontent.com/25644062/202378991-a2236839-aa8f-4008-bc55-c60dcdfafb82.png)

The issue seems to be introduced in #48322 and is happening only in Chinese and Japanese. This is due to language characteristics of Chinese/Japanese/Korean.