### PR TITLE
fix: implement the filter method on a prototype test typo

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/implement-the-filter-method-on-a-prototype.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/functional-programming/implement-the-filter-method-on-a-prototype.md
@@ -16,11 +16,11 @@ Write your own `Array.prototype.myFilter()`, which should behave exactly like `A
 
 # --hints--
 
-`[23, 65, 98, 5, 13].myFilter(item => item % 2)` should equal `[23, 65, 5, 13]`.
+`[23, 65, 98, 5, 13].myFilter(item => item % 2 === 1)` should equal `[23, 65, 5, 13]`.
 
 ```js
 const _test_s = [23, 65, 98, 5, 13];
-const _callback = item => item % 2;
+const _callback = item => item % 2 === 1;
 assert(JSON.stringify(_test_s.filter(_callback)) === JSON.stringify(_test_s.myFilter(_callback)));
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
We received an email in the support inbox that solution 2 for this challenge on the forum no longer works: https://forum.freecodecamp.org/t/freecodecamp-challenge-guide-implement-the-filter-method-on-a-prototype/301231

After some digging, it seems like there may have been a typo introduced in this recent PR to improve this and the "Implement `map` on a Prototype" challenges: https://github.com/freeCodeCamp/freeCodeCamp/pull/48483/files

The changes from https://github.com/freeCodeCamp/freeCodeCamp/pull/48483/files did make it so that learners can't just hardcode the value for the array `s`, but it also looks like the `=== 1` condition is missing from the test text and `_callback`.

`=== 1` used to be in the prefilled test case in the seed code, but was recently removed in this PR: https://github.com/freeCodeCamp/freeCodeCamp/pull/48519

If these changes are merged, solution 2 on the forum should work again.