### PR TITLE
fix(UI): anchor the tool panel buttons at the bottom

### DIFF
--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -87,11 +87,11 @@
 }
 
 #mobile-layout .tab-content {
-  position: relative;
   display: flex;
   flex-direction: column;
   flex-grow: 1;
   overflow-y: hidden;
+  padding-block-end: 37px;
 }
 
 #mobile-layout-pane-editor {

--- a/client/src/templates/Challenges/classic/editor.css
+++ b/client/src/templates/Challenges/classic/editor.css
@@ -12,6 +12,10 @@
   contain: none !important;
 }
 
+.editor-upper-jaw {
+  pointer-events: none;
+}
+
 .vs .monaco-scrollable-element > .scrollbar > .slider {
   z-index: 11;
 }

--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -68,7 +68,7 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
         });
       } else {
         document.documentElement.style.height =
-          String(window.innerHeight - 1) + 'px';
+          String(window.innerHeight) + 'px';
 
         toolPanelGroup.style.position = '';
         toolPanelGroup.style.bottom = '';
@@ -83,8 +83,7 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
       window.addEventListener('resize', this.setToolPanelPosition);
       visualViewport?.addEventListener('resize', this.setToolPanelPosition);
 
-      document.documentElement.style.height =
-        String(window.innerHeight - 1) + 'px';
+      document.documentElement.style.height = String(window.innerHeight) + 'px';
       document.documentElement.style.overflow = 'hidden';
     }
   }

--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -57,14 +57,18 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
     )[0];
 
     if (navigator.userAgent.match(/iPhone|Android.+Mobile/)) {
-      if (window.innerHeight > (visualViewport?.height as number)) {
+      if (
+        visualViewport?.height &&
+        window.innerHeight > visualViewport.height
+      ) {
         setTimeout(() => {
           window.scrollTo(0, 0);
 
           toolPanelGroup.style.position = 'absolute';
-          toolPanelGroup.style.bottom =
-            String(window.innerHeight - (visualViewport?.height as number)) +
-            'px';
+          if (visualViewport?.height !== undefined) {
+            toolPanelGroup.style.bottom =
+              String(window.innerHeight - visualViewport.height) + 'px';
+          }
         }, 200);
 
         window.addEventListener('touchmove', this.avoidWindowScrolling, {

--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -1,7 +1,7 @@
 import { TabPane, Tabs } from '@freecodecamp/react-bootstrap';
 import i18next from 'i18next';
 import React, { Component, ReactElement } from 'react';
-
+import { TOOL_PANEL_HEIGHT } from '../../../../../config/misc';
 import ToolPanel from '../components/tool-panel';
 import EditorTabs from './editor-tabs';
 
@@ -45,67 +45,44 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
     });
   };
 
-  avoidWindowScrolling = (event: Event) => {
-    event.preventDefault();
-  };
-
-  setToolPanelPosition = () => {
-    const toolPanelGroup = (
+  getToolPanelGroup = () =>
+    (
       document.getElementsByClassName(
         'tool-panel-group-mobile'
       ) as HTMLCollectionOf<HTMLElement>
     )[0];
-    const toolPanelHeight = 37;
 
-    // The former of the if statements is for avoiding a TypeScript error and the latter to detect the appearance of the virtual keyboard on iPhone.
+  // Keep the tool panel visible when mobile address bar and/or keyboard are in view.
+  setToolPanelPosition = () => {
+    const toolPanelGroup = this.getToolPanelGroup();
+    // Detect the appearance of the mobile virtual keyboard.
     if (visualViewport?.height && window.innerHeight > visualViewport.height) {
       setTimeout(() => {
-        window.scrollTo(0, 0);
-
         if (visualViewport?.height !== undefined) {
           toolPanelGroup.style.top =
-            String(visualViewport.height - toolPanelHeight) + 'px';
+            String(visualViewport.height - TOOL_PANEL_HEIGHT) + 'px';
         }
       }, 200);
-
-      window.addEventListener('touchmove', this.avoidWindowScrolling, {
-        passive: false
-      });
     } else {
-      document.documentElement.style.height = String(window.innerHeight) + 'px';
-
       if (visualViewport?.height !== undefined) {
         toolPanelGroup.style.top =
-          String(window.innerHeight - toolPanelHeight) + 'px';
+          String(window.innerHeight - TOOL_PANEL_HEIGHT) + 'px';
       }
-
-      window.removeEventListener('touchmove', this.avoidWindowScrolling);
     }
   };
 
   componentDidMount() {
-    const toolPanelGroup = (
-      document.getElementsByClassName(
-        'tool-panel-group-mobile'
-      ) as HTMLCollectionOf<HTMLElement>
-    )[0];
-    const toolPanelHeight = 37;
-
+    const toolPanelGroup = this.getToolPanelGroup();
     if (navigator.userAgent.match(/iPhone|Android.+Mobile/)) {
       visualViewport?.addEventListener('resize', this.setToolPanelPosition);
-
-      document.documentElement.style.height = String(window.innerHeight) + 'px';
       toolPanelGroup.style.top =
-        String(window.innerHeight - toolPanelHeight) + 'px';
+        String(window.innerHeight - TOOL_PANEL_HEIGHT) + 'px';
     }
   }
 
   componentWillUnmount() {
     if (navigator.userAgent.match(/iPhone|Android.+Mobile/)) {
       visualViewport?.removeEventListener('resize', this.setToolPanelPosition);
-
-      window.removeEventListener('touchmove', this.avoidWindowScrolling);
-
       document.documentElement.style.height = '100%';
     }
   }

--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -45,6 +45,42 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
     });
   };
 
+  avoidWindowfloating = (event: Event) => {
+    event.preventDefault();
+  };
+
+  setHtmlHeight = () => {
+    const vh = String(
+      Math.min(window.innerHeight - 1, visualViewport?.height as number)
+    );
+    document.documentElement.style.height = vh + 'px';
+
+    if (
+      navigator.userAgent.match(/iPhone|Android.+Mobile/) &&
+      window.innerHeight - 1 > (visualViewport?.height as number)
+    ) {
+      window.addEventListener('touchmove', this.avoidWindowfloating, {
+        passive: false
+      });
+    } else {
+      window.removeEventListener('touchmove', this.avoidWindowfloating);
+    }
+  };
+
+  componentDidMount() {
+    window.addEventListener('resize', this.setHtmlHeight);
+    visualViewport?.addEventListener('resize', this.setHtmlHeight);
+    this.setHtmlHeight();
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.setHtmlHeight);
+    visualViewport?.removeEventListener('resize', this.setHtmlHeight);
+
+    window.removeEventListener('touchmove', this.avoidWindowfloating);
+    document.documentElement.style.height = '100%';
+  }
+
   handleKeyDown = (): void => this.props.updateUsingKeyboardInTablist(true);
 
   handleClick = (): void => this.props.updateUsingKeyboardInTablist(false);

--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -73,7 +73,7 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
 
   componentDidMount(): void {
     const toolPanelGroup = this.getToolPanelGroup();
-    if (navigator.userAgent.includes('iPhone' || 'Android.+Mobile')) {
+    if (/iPhone|Android.+Mobile/.exec(navigator.userAgent)) {
       visualViewport?.addEventListener('resize', this.setToolPanelPosition);
       toolPanelGroup.style.top =
         String(window.innerHeight - TOOL_PANEL_HEIGHT) + 'px';
@@ -81,7 +81,7 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
   }
 
   componentWillUnmount(): void {
-    if (navigator.userAgent.includes('iPhone' || 'Android.+Mobile')) {
+    if (/iPhone|Android.+Mobile/.exec(navigator.userAgent)) {
       visualViewport?.removeEventListener('resize', this.setToolPanelPosition);
       document.documentElement.style.height = '100%';
     }

--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -55,56 +55,58 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
         'tool-panel-group-mobile'
       ) as HTMLCollectionOf<HTMLElement>
     )[0];
+    const toolPanelHeight = 37;
 
-    if (navigator.userAgent.match(/iPhone|Android.+Mobile/)) {
-      if (
-        visualViewport?.height &&
-        window.innerHeight > visualViewport.height
-      ) {
-        setTimeout(() => {
-          window.scrollTo(0, 0);
+    // The former of the if statements is for avoiding a TypeScript error and the latter to detect the appearance of the virtual keyboard on iPhone.
+    if (visualViewport?.height && window.innerHeight > visualViewport.height) {
+      setTimeout(() => {
+        window.scrollTo(0, 0);
 
-          toolPanelGroup.style.position = 'absolute';
-          if (visualViewport?.height !== undefined) {
-            toolPanelGroup.style.bottom =
-              String(window.innerHeight - visualViewport.height) + 'px';
-          }
-        }, 200);
+        if (visualViewport?.height !== undefined) {
+          toolPanelGroup.style.top =
+            String(visualViewport.height - toolPanelHeight) + 'px';
+        }
+      }, 200);
 
-        window.addEventListener('touchmove', this.avoidWindowScrolling, {
-          passive: false
-        });
-      } else {
-        document.documentElement.style.height =
-          String(window.innerHeight) + 'px';
+      window.addEventListener('touchmove', this.avoidWindowScrolling, {
+        passive: false
+      });
+    } else {
+      document.documentElement.style.height = String(window.innerHeight) + 'px';
 
-        toolPanelGroup.style.position = '';
-        toolPanelGroup.style.bottom = '';
-
-        window.removeEventListener('touchmove', this.avoidWindowScrolling);
+      if (visualViewport?.height !== undefined) {
+        toolPanelGroup.style.top =
+          String(window.innerHeight - toolPanelHeight) + 'px';
       }
+
+      window.removeEventListener('touchmove', this.avoidWindowScrolling);
     }
   };
 
   componentDidMount() {
+    const toolPanelGroup = (
+      document.getElementsByClassName(
+        'tool-panel-group-mobile'
+      ) as HTMLCollectionOf<HTMLElement>
+    )[0];
+    const toolPanelHeight = 37;
+
     if (navigator.userAgent.match(/iPhone|Android.+Mobile/)) {
-      window.addEventListener('resize', this.setToolPanelPosition);
       visualViewport?.addEventListener('resize', this.setToolPanelPosition);
 
       document.documentElement.style.height = String(window.innerHeight) + 'px';
-      document.documentElement.style.overflow = 'hidden';
+      toolPanelGroup.style.top =
+        String(window.innerHeight - toolPanelHeight) + 'px';
     }
   }
 
   componentWillUnmount() {
     if (navigator.userAgent.match(/iPhone|Android.+Mobile/)) {
-      window.removeEventListener('resize', this.setToolPanelPosition);
       visualViewport?.removeEventListener('resize', this.setToolPanelPosition);
 
       window.removeEventListener('touchmove', this.avoidWindowScrolling);
 
       document.documentElement.style.height = '100%';
-      document.documentElement.style.overflow = 'scroll';
     }
   }
 

--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -71,17 +71,17 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
     }
   };
 
-  componentDidMount() {
+  componentDidMount(): void {
     const toolPanelGroup = this.getToolPanelGroup();
-    if (navigator.userAgent.match(/iPhone|Android.+Mobile/)) {
+    if (navigator.userAgent.includes('iPhone' || 'Android.+Mobile')) {
       visualViewport?.addEventListener('resize', this.setToolPanelPosition);
       toolPanelGroup.style.top =
         String(window.innerHeight - TOOL_PANEL_HEIGHT) + 'px';
     }
   }
 
-  componentWillUnmount() {
-    if (navigator.userAgent.match(/iPhone|Android.+Mobile/)) {
+  componentWillUnmount(): void {
+    if (navigator.userAgent.includes('iPhone' || 'Android.+Mobile')) {
       visualViewport?.removeEventListener('resize', this.setToolPanelPosition);
       document.documentElement.style.height = '100%';
     }

--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -57,7 +57,7 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
     )[0];
 
     if (navigator.userAgent.match(/iPhone|Android.+Mobile/)) {
-      if (window.innerHeight - 1 > (visualViewport?.height as number)) {
+      if (window.innerHeight > (visualViewport?.height as number)) {
         toolPanelGroup.style.position = 'absolute';
         toolPanelGroup.style.bottom =
           String(window.innerHeight - (visualViewport?.height as number)) +

--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -58,10 +58,14 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
 
     if (navigator.userAgent.match(/iPhone|Android.+Mobile/)) {
       if (window.innerHeight > (visualViewport?.height as number)) {
-        toolPanelGroup.style.position = 'absolute';
-        toolPanelGroup.style.bottom =
-          String(window.innerHeight - (visualViewport?.height as number)) +
-          'px';
+        setTimeout(() => {
+          window.scrollTo(0, 0);
+
+          toolPanelGroup.style.position = 'absolute';
+          toolPanelGroup.style.bottom =
+            String(window.innerHeight - (visualViewport?.height as number)) +
+            'px';
+        }, 200);
 
         window.addEventListener('touchmove', this.avoidWindowScrolling, {
           passive: false

--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -45,40 +45,60 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
     });
   };
 
-  avoidWindowfloating = (event: Event) => {
+  avoidWindowScrolling = (event: Event) => {
     event.preventDefault();
   };
 
-  setHtmlHeight = () => {
-    const vh = String(
-      Math.min(window.innerHeight - 1, visualViewport?.height as number)
-    );
-    document.documentElement.style.height = vh + 'px';
+  setToolPanelPosition = () => {
+    const toolPanelGroup = (
+      document.getElementsByClassName(
+        'tool-panel-group-mobile'
+      ) as HTMLCollectionOf<HTMLElement>
+    )[0];
 
-    if (
-      navigator.userAgent.match(/iPhone|Android.+Mobile/) &&
-      window.innerHeight - 1 > (visualViewport?.height as number)
-    ) {
-      window.addEventListener('touchmove', this.avoidWindowfloating, {
-        passive: false
-      });
-    } else {
-      window.removeEventListener('touchmove', this.avoidWindowfloating);
+    if (navigator.userAgent.match(/iPhone|Android.+Mobile/)) {
+      if (window.innerHeight - 1 > (visualViewport?.height as number)) {
+        toolPanelGroup.style.position = 'absolute';
+        toolPanelGroup.style.bottom =
+          String(window.innerHeight - (visualViewport?.height as number)) +
+          'px';
+
+        window.addEventListener('touchmove', this.avoidWindowScrolling, {
+          passive: false
+        });
+      } else {
+        document.documentElement.style.height =
+          String(window.innerHeight - 1) + 'px';
+
+        toolPanelGroup.style.position = '';
+        toolPanelGroup.style.bottom = '';
+
+        window.removeEventListener('touchmove', this.avoidWindowScrolling);
+      }
     }
   };
 
   componentDidMount() {
-    window.addEventListener('resize', this.setHtmlHeight);
-    visualViewport?.addEventListener('resize', this.setHtmlHeight);
-    this.setHtmlHeight();
+    if (navigator.userAgent.match(/iPhone|Android.+Mobile/)) {
+      window.addEventListener('resize', this.setToolPanelPosition);
+      visualViewport?.addEventListener('resize', this.setToolPanelPosition);
+
+      document.documentElement.style.height =
+        String(window.innerHeight - 1) + 'px';
+      document.documentElement.style.overflow = 'hidden';
+    }
   }
 
   componentWillUnmount() {
-    window.removeEventListener('resize', this.setHtmlHeight);
-    visualViewport?.removeEventListener('resize', this.setHtmlHeight);
+    if (navigator.userAgent.match(/iPhone|Android.+Mobile/)) {
+      window.removeEventListener('resize', this.setToolPanelPosition);
+      visualViewport?.removeEventListener('resize', this.setToolPanelPosition);
 
-    window.removeEventListener('touchmove', this.avoidWindowfloating);
-    document.documentElement.style.height = '100%';
+      window.removeEventListener('touchmove', this.avoidWindowScrolling);
+
+      document.documentElement.style.height = '100%';
+      document.documentElement.style.overflow = 'scroll';
+    }
   }
 
   handleKeyDown = (): void => this.props.updateUsingKeyboardInTablist(true);

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -263,7 +263,7 @@ function ShowClassic({
 
     store.set(REFLEX_LAYOUT, layout);
   };
-  
+
   const setHtmlHeight = () => {
     const vh = String(window.innerHeight - 1);
     document.documentElement.style.height = vh + 'px';
@@ -292,7 +292,6 @@ function ShowClassic({
     document.addEventListener('touchmove', handleContentWidgetEvents, true);
     document.addEventListener('touchend', handleContentWidgetEvents, true);
 
-    
     window.addEventListener('resize', setHtmlHeight);
     setHtmlHeight();
 
@@ -320,7 +319,7 @@ function ShowClassic({
         true
       );
       document.removeEventListener('touchend', handleContentWidgetEvents, true);
-      window.removeEventListener('resize',setHtmlHeight);
+      window.removeEventListener('resize', setHtmlHeight);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -263,6 +263,11 @@ function ShowClassic({
 
     store.set(REFLEX_LAYOUT, layout);
   };
+  
+  const setHtmlHeight = () => {
+    const vh = String(window.innerHeight - 1);
+    document.documentElement.style.height = vh + 'px';
+  };
   const onResize = () => {
     setResizing(true);
   };
@@ -286,6 +291,10 @@ function ShowClassic({
     document.addEventListener('touchstart', handleContentWidgetEvents, true);
     document.addEventListener('touchmove', handleContentWidgetEvents, true);
     document.addEventListener('touchend', handleContentWidgetEvents, true);
+
+    
+    window.addEventListener('resize', setHtmlHeight);
+    setHtmlHeight();
 
     return () => {
       createFiles([]);
@@ -311,6 +320,7 @@ function ShowClassic({
         true
       );
       document.removeEventListener('touchend', handleContentWidgetEvents, true);
+      window.removeEventListener('resize',setHtmlHeight);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/client/src/templates/Challenges/components/side-panel.css
+++ b/client/src/templates/Challenges/components/side-panel.css
@@ -7,6 +7,7 @@
 }
 
 .instructions-panel {
+  position: relative;
   padding: 0 10px;
   overflow-y: scroll;
   height: 100%;

--- a/client/src/templates/Challenges/components/tool-panel.css
+++ b/client/src/templates/Challenges/components/tool-panel.css
@@ -13,12 +13,15 @@
   flex-direction: row-reverse;
   width: 100%;
   background-color: var(--tertiary-background);
+  position: absolute;
+  bottom: 0;
 }
 
 .tool-panel-group-mobile > .btn-block,
 .tool-panel-group-mobile > .dropdown > .btn-block {
   margin: 0 2px 0 0;
   padding: 5px 0;
+  height: 37px;
 }
 
 .tool-panel-group .btn-group {

--- a/client/src/templates/Challenges/components/tool-panel.css
+++ b/client/src/templates/Challenges/components/tool-panel.css
@@ -11,6 +11,8 @@
 .tool-panel-group-mobile {
   display: flex;
   flex-direction: row-reverse;
+  width: 100%;
+  background-color: var(--tertiary-background);
 }
 
 .tool-panel-group-mobile > .btn-block,

--- a/config/misc.ts
+++ b/config/misc.ts
@@ -1,4 +1,5 @@
 export const defaultUserImage = 'https://freecodecamp.com/sample-image.png';
 export const MAX_MOBILE_WIDTH = 767;
+export const TOOL_PANEL_HEIGHT = 37;
 export const SEARCH_EXPOSED_WIDTH = 980;
 export const DONATE_NAV_EXPOSED_WIDTH = 600;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
This PR was opened to anchor the tool panel buttons at the bottom of viewport in mobile device in the Challenges/Steps.

The original issue was described in [this comment](https://github.com/freeCodeCamp/freeCodeCamp/pull/48231#issuecomment-1304376040), and this PR makes tool panel buttons anchored at the bottom of viewport not only when any challenges is opened but also when viewport height is changed by swiping down/up on mobile device, as shown in the image below.

![android_issue_fixed_image](https://user-images.githubusercontent.com/44451585/203762160-e4184d57-09bc-42c3-968f-db5628bd3a40.png)

Affected pages are:

1. [Legacy Responsive Web Design](https://www.freecodecamp.org/learn/responsive-web-design/basic-html-and-html5/say-hello-to-html-elements)
1. [(New) Responsive Web Design](https://www.freecodecamp.org/learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-2)
1. [JavaScript Algorithms and Data Structures](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-javascript/comment-your-javascript-code)
1. [Front End Development Libraries](https://www.freecodecamp.org/learn/front-end-development-libraries/bootstrap/create-a-block-element-bootstrap-button)
1. [Data Visualization](https://www.freecodecamp.org/learn/data-visualization/data-visualization-with-d3/add-document-elements-with-d3)
1. [Coding Interview Prep](https://www.freecodecamp.org/learn/coding-interview-prep/algorithms/find-the-symmetric-difference)

The code was tested on android studio emulator (Pixel 6 PRO/android OS 11.0/Chrome) and mobile simulator extention of Chrome and Firefox PC browser locally, but not tested in real mobile device because I don't have the one which can preview the fixed fCC curriculum (I actually need help).
And also the test have done in Chrome, Firefox, Edge, and Brave PC browsers with windows 11 PC.