### PR TITLE
chore(UI): move new RWD to top in Japanese

### DIFF
--- a/config/superblock-order.ts
+++ b/config/superblock-order.ts
@@ -392,7 +392,7 @@ export const superBlockOrder: SuperBlockOrder = {
   },
   [Languages.Japanese]: {
     [CurriculumMaps.Landing]: [
-      SuperBlocks.RespWebDesign,
+      SuperBlocks.RespWebDesignNew,
       SuperBlocks.JsAlgoDataStruct,
       SuperBlocks.FrontEndDevLibs,
       SuperBlocks.DataVis,
@@ -407,6 +407,7 @@ export const superBlockOrder: SuperBlockOrder = {
     [CurriculumMaps.Learn]: {
       [TranslationStates.Audited]: {
         [SuperBlockStates.Current]: [
+          SuperBlocks.RespWebDesignNew,
           SuperBlocks.RespWebDesign,
           SuperBlocks.JsAlgoDataStruct,
           SuperBlocks.FrontEndDevLibs,
@@ -425,7 +426,7 @@ export const superBlockOrder: SuperBlockOrder = {
         [SuperBlockStates.Legacy]: []
       },
       [TranslationStates.NotAudited]: {
-        [SuperBlockStates.Current]: [SuperBlocks.RespWebDesignNew],
+        [SuperBlockStates.Current]: [],
         [SuperBlockStates.New]: [],
         [SuperBlockStates.Upcoming]: [SuperBlocks.JsAlgoDataStructNew],
         [SuperBlockStates.Legacy]: []


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
I left the legacy RWD just below the new one to avoid campers get upset thinking their progress for the legacy cert got lost. We can move it to the bottom later.

![image](https://user-images.githubusercontent.com/25644062/204029794-5cac48d3-3bdf-4f8d-891f-006825b47e8b.png)
