### PR TITLE
fix(docs): Add German language link inside certifications

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@ Certifications are already live in some major world languages like below:
 - [Portuguese (Português)](https://www.freecodecamp.org/portuguese/learn)
 - [Ukrainian (Українська)](https://www.freecodecamp.org/ukrainian/learn)
 - [Japanese (日本語)](https://www.freecodecamp.org/japanese/learn)
+- [German (Deutsch)](https://www.freecodecamp.org/german/learn)
 
 We encourage you to read the [announcement here](https://www.freecodecamp.org/news/help-translate-freecodecamp-language/) and share it with your friends to get them excited about this.
 


### PR DESCRIPTION
Added German language link in live certifications section.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #48607 

<!-- Feel free to add any additional description of changes below this line -->
