### PR TITLE
fix(UI) Modified the certifications map to display in grid layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,57 @@ Our full-stack web development and machine learning curriculum is completely fre
 
 ## Table of Contents
 
-- [Certifications](#certifications)
 - [The Learning Platform](#the-learning-platform)
 - [Reporting Bugs and Issues](#reporting-bugs-and-issues)
 - [Reporting Security Issues and Responsible Disclosure](#reporting-security-issues-and-responsible-disclosure)
 - [Contributing](#contributing)
 - [Platform, Build and Deployment Status](#platform-build-and-deployment-status)
 - [License](#license)
+- [Certifications](#certifications)
+
+### The Learning Platform
+
+This code is running live at [freeCodeCamp.org](https://www.freecodecamp.org).
+
+Our community also has:
+
+- A [forum](https://forum.freecodecamp.org) where you can usually get programming help or project feedback within hours.
+- A [YouTube channel](https://youtube.com/freecodecamp) with free courses on Python, SQL, Android, and a wide variety of other technologies.
+- A [technical publication](https://www.freecodecamp.org/news) with thousands of programming tutorials and articles about mathematics and computer science.
+- A [Discord server](https://discord.gg/Z7Fm39aNtZ) where you can hang out and talk with developers and people who are learning to code.
+
+> #### [Join the community here](https://www.freecodecamp.org/signin).
+
+### Reporting Bugs and Issues
+
+If you think you've found a bug, first read the [how to report a bug](https://forum.freecodecamp.org/t/how-to-report-a-bug/19543) article and follow its instructions.
+
+If you're confident it's a new bug and have confirmed that someone else is facing the same issue, go ahead and create a new GitHub issue. Be sure to include as much information as possible so we can reproduce the bug.
+
+### Reporting Security Issues and Responsible Disclosure
+
+We appreciate responsible disclosure of vulnerabilities that might impact the integrity of our platforms and users.
+
+> #### [Read our security policy and follow these steps to report a vulnerability](https://contribute.freecodecamp.org/#/security).
+
+### Contributing
+
+The freeCodeCamp.org community is possible thanks to thousands of kind volunteers like you. We welcome all contributions to the community and are excited to welcome you aboard.
+
+> #### [Please follow these steps to contribute](https://contribute.freecodecamp.org).
+
+### Platform, Build, and Deployment Status
+
+The general platform status for all our applications is available at [`status.freecodecamp.org`](https://status.freecodecamp.org). The build and deployment status for the code is available in [our DevOps Guide](https://contribute.freecodecamp.org/#/devops).
+
+### License
+
+Copyright © 2022 freeCodeCamp.org
+
+The content of this repository is bound by the following licenses:
+
+- The computer software is licensed under the [BSD-3-Clause](LICENSE.md) license.
+- The learning resources in the [`/curriculum`](/curriculum) directory including their subdirectories thereon are licensed under the [CC-BY-SA-4.0](/curriculum/LICENSE.md) license.
 
 ### Certifications
 
@@ -152,47 +196,3 @@ We also have 4 legacy certifications dating back to our 2015 curriculum, which a
 - Legacy Data Visualization Certification
 - Legacy Back End Development Certification
 - Legacy Information Security and Quality Assurance Certification
-
-### The Learning Platform
-
-This code is running live at [freeCodeCamp.org](https://www.freecodecamp.org).
-
-Our community also has:
-
-- A [forum](https://forum.freecodecamp.org) where you can usually get programming help or project feedback within hours.
-- A [YouTube channel](https://youtube.com/freecodecamp) with free courses on Python, SQL, Android, and a wide variety of other technologies.
-- A [technical publication](https://www.freecodecamp.org/news) with thousands of programming tutorials and articles about mathematics and computer science.
-- A [Discord server](https://discord.gg/Z7Fm39aNtZ) where you can hang out and talk with developers and people who are learning to code.
-
-> #### [Join the community here](https://www.freecodecamp.org/signin).
-
-### Reporting Bugs and Issues
-
-If you think you've found a bug, first read the [how to report a bug](https://forum.freecodecamp.org/t/how-to-report-a-bug/19543) article and follow its instructions.
-
-If you're confident it's a new bug and have confirmed that someone else is facing the same issue, go ahead and create a new GitHub issue. Be sure to include as much information as possible so we can reproduce the bug.
-
-### Reporting Security Issues and Responsible Disclosure
-
-We appreciate responsible disclosure of vulnerabilities that might impact the integrity of our platforms and users.
-
-> #### [Read our security policy and follow these steps to report a vulnerability](https://contribute.freecodecamp.org/#/security).
-
-### Contributing
-
-The freeCodeCamp.org community is possible thanks to thousands of kind volunteers like you. We welcome all contributions to the community and are excited to welcome you aboard.
-
-> #### [Please follow these steps to contribute](https://contribute.freecodecamp.org).
-
-### Platform, Build, and Deployment Status
-
-The general platform status for all our applications is available at [`status.freecodecamp.org`](https://status.freecodecamp.org). The build and deployment status for the code is available in [our DevOps Guide](https://contribute.freecodecamp.org/#/devops).
-
-### License
-
-Copyright © 2022 freeCodeCamp.org
-
-The content of this repository is bound by the following licenses:
-
-- The computer software is licensed under the [BSD-3-Clause](LICENSE.md) license.
-- The learning resources in the [`/curriculum`](/curriculum) directory including their subdirectories thereon are licensed under the [CC-BY-SA-4.0](/curriculum/LICENSE.md) license.

--- a/client/src/components/Map/index.tsx
+++ b/client/src/components/Map/index.tsx
@@ -36,7 +36,11 @@ function createSuperBlockTitle(superBlock: SuperBlocks) {
 
 const linkSpacingStyle = {
   display: 'flex',
-  justifyContent: 'space-between',
+  flexDirection: 'column' as const,
+  textAlign: 'center' as const,
+  width: '300px',
+  height: '200px',
+  justifyContent: 'space-around',
   alignItems: 'center'
 };
 

--- a/client/src/components/Map/map.css
+++ b/client/src/components/Map/map.css
@@ -6,6 +6,15 @@
   list-style: none;
   color: var(--secondary-color);
   padding: 0;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  /* width: 100%; */
+}
+
+.map-ui > ul > li {
+  margin: 5px;
+  text-align: center;
 }
 
 @media (max-width: 640px) {

--- a/client/src/components/landing/components/certifications.tsx
+++ b/client/src/components/landing/components/certifications.tsx
@@ -16,7 +16,7 @@ const Certifications = ({
 
   return (
     <Row className='certification-section'>
-      <Col md={8} mdOffset={2} sm={10} smOffset={1} xs={12}>
+      <Col md={8} mdOffset={4} sm={10} smOffset={1} xs={12}>
         <h1 className='big-heading'>{t('landing.certification-heading')}</h1>
         <Map forLanding={true} />
         <Spacer />

--- a/client/src/components/landing/landing.css
+++ b/client/src/components/landing/landing.css
@@ -185,6 +185,7 @@ p.caption {
 .certification-section,
 .testimonials {
   padding: 4vw 0;
+  width: 1000px;
 }
 
 .map-ui .btn {

--- a/docs/how-to-setup-freecodecamp-locally.md
+++ b/docs/how-to-setup-freecodecamp-locally.md
@@ -166,6 +166,21 @@ And as always, feel free to ask questions on the ['Contributors' category on our
 >
 > [Skip to making changes](#making-changes-locally).
 
+## Running with Docker
+If you have [configured Docker Desktop](how-to-setup-wsl.md), you can launch the application in individual docker containers.
+
+Build the images using the provided dockerfiles.
+```console
+docker build docker/api/Dockerfile api
+docker build docker/web/Dockerfile client
+```
+
+Run the containers using the images built.
+```console
+docker run -it api
+docker run -it client
+```
+
 ### Configuring dependencies
 
 #### Step 1: Set up the environment variable file


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
This pull requests intends to implement a grid layout on the /learn endpoint as opposed to the single column list style layout currently deployed.