### PR TITLE
fix(a11y): enhance accessibility of prismjs code examples

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -503,7 +503,8 @@
     "open-preview-in-new-window": "Open the preview in a new window and focus it",
     "step": "Step",
     "steps": "Steps",
-    "steps-for": "Steps for {{blockTitle}}"
+    "steps-for": "Steps for {{blockTitle}}",
+    "code-example": "{{codeName}} code example"
   },
   "flash": {
     "honest-first": "To claim a certification, you must first accept our academic honesty policy",

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -7,7 +7,7 @@ import type {
   editor
   // eslint-disable-next-line import/no-duplicates
 } from 'monaco-editor/esm/vs/editor/editor.api';
-import { highlightAllUnder } from 'prismjs';
+import Prism from 'prismjs';
 import React, {
   useEffect,
   Suspense,
@@ -66,6 +66,7 @@ import {
   isChallengeCompletedSelector
 } from '../redux/selectors';
 import GreenPass from '../../../assets/icons/green-pass';
+import { enhancePrismAccessibility } from '../utils/index';
 import LowerJaw from './lower-jaw';
 
 import './editor.css';
@@ -725,7 +726,8 @@ const Editor = (props: EditorProps): JSX.Element => {
     descContainer.appendChild(jawHeading);
     descContainer.appendChild(desc);
     desc.innerHTML = description;
-    highlightAllUnder(desc);
+    Prism.hooks.add('complete', enhancePrismAccessibility);
+    Prism.highlightAllUnder(desc);
 
     domNode.style.userSelect = 'text';
 

--- a/client/src/templates/Challenges/components/prism-formatted.tsx
+++ b/client/src/templates/Challenges/components/prism-formatted.tsx
@@ -1,5 +1,6 @@
 import Prism from 'prismjs';
 import React, { useRef, useEffect } from 'react';
+import { enhancePrismAccessibility } from '../utils';
 
 interface PrismFormattedProps {
   className?: string;
@@ -12,6 +13,7 @@ function PrismFormatted({ className, text }: PrismFormattedProps): JSX.Element {
   useEffect(() => {
     // Just in case 'current' has not been created, though it should have been.
     if (instructionsRef.current) {
+      Prism.hooks.add('complete', enhancePrismAccessibility);
       Prism.highlightAllUnder(instructionsRef.current);
     }
   }, []);

--- a/client/src/templates/Challenges/utils/index.ts
+++ b/client/src/templates/Challenges/utils/index.ts
@@ -1,3 +1,4 @@
+import i18next from 'i18next';
 import envData from '../../../../../config/env.json';
 
 const { forumLocation } = envData;
@@ -30,4 +31,38 @@ export function transformEditorLink(url: string): string {
       /(\/\/)(?<projectname>[^.]+)\.glitch\.me\/?/,
       '//glitch.com/edit/#!/$<projectname>'
     );
+}
+
+export function enhancePrismAccessibility(
+  prismEnv: Prism.hooks.ElementHighlightedEnvironment
+) {
+  const langs: { [key: string]: string } = {
+    js: 'JavaScript',
+    javascript: 'JavaScript',
+    css: 'CSS',
+    html: 'HTML',
+    python: 'python',
+    py: 'python',
+    xml: 'XML',
+    jsx: 'JSX',
+    scss: 'SCSS',
+    sql: 'SQL',
+    http: 'HTTP',
+    json: 'JSON',
+    pug: 'pug'
+  };
+  const parent = prismEnv?.element?.parentElement;
+  if (parent && parent.nodeName === 'PRE' && parent.tabIndex === 0) {
+    parent.setAttribute('role', 'region');
+    const codeType = prismEnv.element?.className
+      .replace(/language-(.*)/, '$1')
+      .toLowerCase();
+    const codeName = langs[codeType] || '';
+    parent.setAttribute(
+      'aria-label',
+      i18next.t('aria.code-example', {
+        codeName
+      })
+    );
+  }
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Finally getting around to implementing the second option in my rejected [PR 44983](https://github.com/freeCodeCamp/freeCodeCamp/pull/44983). PrismJS adds a `tabindex=0` to the `pre` element wrapping the code (which is great for keyboard accessibility). But any interactive element also needs to have a role and accessible name, and this PR adds those two attributes to the `pre` element. 

I have customized the accessible name so that it will announce the type of code to screen reader users. But I'm noticing that there are a few code types (`markdown`, `markup`, and `md`) that are being used to display regular text instead of actual code. For these three, the accessible name will just be the generic 'code example'. 