### PR TITLE
docs(setup): Edited WSL setup and Local Setup sections

### DIFF
--- a/docs/how-to-setup-freecodecamp-locally.md
+++ b/docs/how-to-setup-freecodecamp-locally.md
@@ -81,9 +81,9 @@ Some community members also develop on Windows 10 natively with Git for Windows 
 
 | Prerequisite                                                                                  | Version | Notes                                                                                       |
 | --------------------------------------------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------- |
-| [Node.js](http://nodejs.org)                                                                  | `16.x`  | We use the "Active LTS" version, See [LTS Schedule](https://nodejs.org/en/about/releases/). |
+| [Node.js](http://nodejs.org)                                                                  | `18.x`  | We use the "Active LTS" version, See [LTS Schedule](https://nodejs.org/en/about/releases/). |
 | npm (comes bundled with Node)                                                                 | `8.x`   | We use the version bundled with Node.js Active LTS.                                         |
-| [MongoDB Community Server](https://docs.mongodb.com/manual/administration/install-community/) | `4.2.x` | -                                                                                           |
+| [MongoDB Community Server](https://docs.mongodb.com/manual/administration/install-community/) | `4.2.x` | There is no official installion/support for Ubuntu 22.04, we recommend you install with docker with the version mentioned in [Installing Docker](https://contribute.freecodecamp.org/#/how-to-setup-wsl?id=installing-docker-desktop)                                                                                          |
 
 > [!ATTENTION]
 > If you have a different version, please install the recommended version. We can only support installation issues for recommended versions. See [troubleshooting](#troubleshooting) for details.

--- a/docs/how-to-setup-freecodecamp-locally.md
+++ b/docs/how-to-setup-freecodecamp-locally.md
@@ -238,6 +238,8 @@ Before you can run the application locally, you will need to start the MongoDB s
 > Unless you have MongoDB running in a setup different than the default, the URL stored as the `MONGOHQ_URL` value in the `.env` file should work fine. If you are using a custom configuration, modify this value as needed.
 >
 > If you followed along with the [Windows 10 via WSL2 Setup Guide](how-to-setup-wsl.md), then you should be able to skip this step if the MongoDB server from that guide is already running. You can confirm this by checking that you can reach `http://localhost:27017` on your local machine.
+>
+>If you are using gitpod you may skip starting mongo as it should already be running
 
 Start the MongoDB server in a separate terminal:
 
@@ -281,6 +283,13 @@ npm run develop
 This single command will fire up all the services, including the API server and the client applications available for you to work on.
 
 Once ready, open a web browser and **visit <http://localhost:8000>**. If the app loads, sign in. Congratulations – you're all set! You now have a copy of freeCodeCamp's entire learning platform running on your local machine.
+
+> [!NOTE]
+> If you are using gitpod you will have to run the following command on your terminal to get your gitpod localhost url.
+> ```console
+gp url 8000
+
+
 
 The API serves endpoints at `http://localhost:3000`. The Gatsby app serves the client application at `http://localhost:8000`
 

--- a/docs/how-to-setup-wsl.md
+++ b/docs/how-to-setup-wsl.md
@@ -42,7 +42,7 @@ Follow the instructions on the [official documentation](https://docs.microsoft.c
      NAME                   STATE           VERSION
    * Ubuntu-20.04           Running         2
    ```
-   
+
 ## Set up Git
 
 Git comes pre-installed with Ubuntu 18.04, verify your Git version with `git --version`.
@@ -108,6 +108,18 @@ Once you have configured Docker Desktop to work with WSL2, follow these steps to
 
 We recommend you install the LTS release for Node.js with a node version manager - [nvm](https://github.com/nvm-sh/nvm#installing-and-updating).
 
+In your terminal, run the nvm installer like this:
+
+> [!NOTE]
+> We recommend updating to the latest stable releases of the software listed above, also known as Long Term Support (LTS) releases. However, some npm packages may not be compatible with newer versions of node. NVM can allow you to use npm packages with the compatible versions of node. Check your current node version before upgrading incase you need it later to work on a project outside of freeCodeCamp and notice compatibility issues
+
+```console
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
+
+# or
+
+wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
+```
 Once installed use these commands to install and use the Node.js version as needed
 
 ```console

--- a/docs/how-to-setup-wsl.md
+++ b/docs/how-to-setup-wsl.md
@@ -30,7 +30,19 @@ Follow the instructions on the [official documentation](https://docs.microsoft.c
    # cleanup
    sudo apt autoremove -y
    ```
+3. Check WSL and Linux distribution installation
 
+   ```console
+   wsl --list --verbose
+   ```
+   Your output should display your linux distro and version of WSL if installed correctly
+
+   ```output
+   ~
+     NAME                   STATE           VERSION
+   * Ubuntu-20.04           Running         2
+   ```
+   
 ## Set up Git
 
 Git comes pre-installed with Ubuntu 18.04, verify your Git version with `git --version`.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

On the local setup page I edited the perquisites table. I put the current LTS version of node. I also added a comment about mongodb issues with Ubuntu version 22.04. Because I had issues with this myself. While i was able to get it working locally without having to use docker. I do not recommend my workaround which involved downgrading "Libssl". But your use of docker with WSL will work just fine for those on Linux using version 22.04 since they can run a mongo on an earlier version of Linux in a container.

I added the install script for NVM so users don't have to go to documentation just to install with something that is a one liner in terminal. Also added a comment about checking their current node version since some packages might give them issues for their personal projects once they are done with their contributions assuming they are on older versions of node.

Although there is a link to the gitpod documentation. I thought it would be useful to put in a note box how to get the localhost url for those using gitpod so that they do not have to read the documentation to find the one liner that can help them get what they need.