### PR TITLE
fix(i18n): download english trending for fallback

### DIFF
--- a/tools/scripts/build/download-trending.ts
+++ b/tools/scripts/build/download-trending.ts
@@ -47,4 +47,4 @@ const download = async (clientLocale: string) => {
 void download(clientLocale);
 // TODO: remove the need to fallback to english once we're confident it's
 // unnecessary (client/i18n/config.js will need all references to 'en' removing)
-void download('english');
+if (clientLocale !== 'english') void download('english');

--- a/tools/scripts/build/download-trending.ts
+++ b/tools/scripts/build/download-trending.ts
@@ -9,7 +9,7 @@ const { clientLocale } = envData;
 const createCdnUrl = (lang: string) =>
   `https://cdn.freecodecamp.org/universal/trending/${lang}.yaml`;
 
-const download = async () => {
+const download = async (clientLocale: string) => {
   const url = createCdnUrl(clientLocale);
   const res = await fetch(url);
   if (!res.ok) {
@@ -44,4 +44,7 @@ const download = async () => {
   }
 };
 
-void download();
+void download(clientLocale);
+// TODO: remove the need to fallback to english once we're confident it's
+// unnecessary (client/i18n/config.js will need all references to 'en' removing)
+void download('english');


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Once we're 100% sure that the trending data will be available for all languages, we can remove the fallback, but for now this seems like the prudent approach.

<!-- Feel free to add any additional description of changes below this line -->
