### PR TITLE
fix(UI): make 'Tests' heading translatable

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -277,7 +277,6 @@
     "submit-and-go": "Submit and go to my next challenge",
     "congratulations": "Congratulations, your code passes. Submit your code to continue.",
     "i-completed": "I've completed this challenge",
-    "tests": "Tests",
     "test-output": "Your test output will go here",
     "running-tests": "// running tests",
     "tests-completed": "// tests completed",

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -277,6 +277,7 @@
     "submit-and-go": "Submit and go to my next challenge",
     "congratulations": "Congratulations, your code passes. Submit your code to continue.",
     "i-completed": "I've completed this challenge",
+    "tests": "Tests",
     "test-output": "Your test output will go here",
     "running-tests": "// running tests",
     "tests-completed": "// tests completed",

--- a/client/src/templates/Challenges/components/test-suite.tsx
+++ b/client/src/templates/Challenges/components/test-suite.tsx
@@ -26,7 +26,9 @@ function TestSuite({ tests }: TestSuiteProps): JSX.Element {
 
   return (
     <>
-      <h2 className='challenge-test-suite-heading'>{t('learn.tests')}</h2>
+      <h2 className='challenge-test-suite-heading'>
+        {t('learn.editor-tabs.tests')}
+      </h2>
       <ul className='challenge-test-suite'>
         {testSuiteTests.map(({ err, pass = false, text = '' }, index) => {
           const isInitial = !pass && !err;

--- a/client/src/templates/Challenges/components/test-suite.tsx
+++ b/client/src/templates/Challenges/components/test-suite.tsx
@@ -26,7 +26,7 @@ function TestSuite({ tests }: TestSuiteProps): JSX.Element {
 
   return (
     <>
-      <h2 className='challenge-test-suite-heading'>Tests</h2>
+      <h2 className='challenge-test-suite-heading'>{t('learn.tests')}</h2>
       <ul className='challenge-test-suite'>
         {testSuiteTests.map(({ err, pass = false, text = '' }, index) => {
           const isInitial = !pass && !err;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
This heading was not translated:
![image](https://user-images.githubusercontent.com/25644062/205385577-d054cc39-b52f-4f76-834e-90f1c67b4dea.png)

Affected page:
https://www.freecodecamp.org/japanese/learn/javascript-algorithms-and-data-structures/functional-programming/combine-two-arrays-using-the-concat-method
or any other (not project based) challenges