### PR TITLE
docs(component-library): Fix typo in table

### DIFF
--- a/docs/how-to-work-on-the-component-library.md
+++ b/docs/how-to-work-on-the-component-library.md
@@ -35,13 +35,13 @@ npm run gen-component MyComponent
 
 The command will generate a new folder inside the `ui-components` directory, with the following files:
 
-| File name                  | Purpose                                                |
-| -------------------------- | ------------------------------------------------------ |
-| `index.ts`                 | It is used for exporting the component and its types.  |
-| `my-component.stories.tsx` | It is used for demoing the component on Storybook.     |
-| `my-component.test.tsx`    | It is a test file.                                     |
-| `my-component.tsx`         | It is where we implement the component.                |
-| `types.ts`                 | Is is where we locate component's interface and types. |
+| File name                  | Purpose                                                    |
+| -------------------------- | ---------------------------------------------------------- |
+| `index.ts`                 | It is used for exporting the component and its types.      |
+| `my-component.stories.tsx` | It is used for demoing the component on Storybook.         |
+| `my-component.test.tsx`    | It is a test file.                                         |
+| `my-component.tsx`         | It is where we implement the component.                    |
+| `types.ts`                 | It is where we locate the component's interface and types. |
 
 Each component is different, but in general a component should:
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

Hi all, I've fixed a typo in the contribution docs for the [component library](https://contribute.freecodecamp.org/#/how-to-work-on-the-component-library?id=implementing-the-component). Thank you!