### PR TITLE
fix: Typo in Quality Assurance Project

### DIFF
--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/american-british-translator.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-projects/american-british-translator.md
@@ -69,7 +69,7 @@ Write the following tests in `tests/2_functional-tests.js`:
 
 # --hints--
 
-I can provide my own project, not the example URL.
+You should provide your own project, not the example URL.
 
 ```js
 (getUserInput) => {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #48715 

<!-- Feel free to add any additional description of changes below this line -->

The line that says:

> I can provide my own project, not the example URL.

is changed to:

> You should provide your own project, not the example URL.