### PR TITLE
fix(tools): challenge editor - input text color

### DIFF
--- a/tools/challenge-editor/client/src/components/tools/Tools.css
+++ b/tools/challenge-editor/client/src/components/tools/Tools.css
@@ -9,4 +9,5 @@ input {
   border: 2px solid var(--content);
   padding: 6px 12px;
   margin-left: 10px;
+  color: white;
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
The input text color in the block tools page of challenge editor tool was black on dark blue which made it hard to read so I changed it to white.