### PR TITLE
chore: make too many lockfiles error more explicit

### DIFF
--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           if [ $(find . -name 'package-lock.json' | grep -vc -e 'node_modules') -gt 1 ]
           then
-            echo 'Error: found too many lockfiles in the repository'
+            echo -e 'Error: found too many lockfiles in the repository.\nWe use npm workspaces to manage packages so all dependencies should be added to the root package-lock.json'
             exit 1
           fi
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This change should make it more obvious when your only context is the error itself.

<!-- Feel free to add any additional description of changes below this line -->
