### PR TITLE
docs: update image alt text for accessibility

### DIFF
--- a/docs/how-to-catch-outgoing-emails-locally.md
+++ b/docs/how-to-catch-outgoing-emails-locally.md
@@ -106,15 +106,15 @@ Start [using MailHog](#using-mailhog).
 
 Open a new browser tab or window and navigate to [http://localhost:8025](http://localhost:8025) to open your MailHog inbox when the MailHog installation has completed and MailHog is running. The inbox will appear similar to the screenshot below.
 
-![MailHog Screenshot 1](https://contribute.freecodecamp.org/images/mailhog/1.jpg)
+![The inbox page without incoming messages. The message counter has 0 value.](https://contribute.freecodecamp.org/images/mailhog/1.jpg)
 
 Emails sent by your freeCodeCamp installation will appear as below
 
-![MailHog Screenshot 2](https://contribute.freecodecamp.org/images/mailhog/2.jpg)
+![The inbox page with one incoming message. The message counter has 1 value. The sender is freeCodeCamp and the description is "Your sign in link for your new freeCodeCamp.org account"](https://contribute.freecodecamp.org/images/mailhog/2.jpg)
 
 Two tabs that allow you to view either plain text or source content will be available when you open a given email. Ensure that the plain text tab is selected as below.
 
-![MailHog Screenshot 3](https://contribute.freecodecamp.org/images/mailhog/3.jpg)
+![The Plain text as active tab containing the plain text sent in the body of the message.](https://contribute.freecodecamp.org/images/mailhog/3.jpg)
 
 All links in the email should be clickable and resolve to their URL.
 


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #48723

This PR update the alt text of how-to-catch-outgoing-emails-locally.md documentation page to provide a description of the image for the screen reader.
