### PR TITLE
fix: use Preview icon for show code buttons in setting

### DIFF
--- a/client/src/components/solution-display-widget/index.tsx
+++ b/client/src/components/solution-display-widget/index.tsx
@@ -1,4 +1,7 @@
-import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
+import {
+  faExternalLinkAlt,
+  faWindowRestore
+} from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   Button,
@@ -84,7 +87,7 @@ export function SolutionDisplayWidget({
       id={`btn-for-${id}`}
       onClick={showUserCode}
     >
-      {viewText} <FontAwesomeIcon icon={faExternalLinkAlt} />
+      {viewText} <FontAwesomeIcon icon={faWindowRestore} />
     </Button>
   );
   const ShowMultifileProjectSolution = (


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->
image of the old setting

![image](https://user-images.githubusercontent.com/88248797/208017533-21839e61-7c37-4a35-adee-ba09db7a06fe.png)


In setting page, we are using externalIcon for preview the code buttons, this aims to use the correct icon for the buttons.
<!-- Feel free to add any additional description of changes below this line -->
