### PR TITLE
chore: add best practices for styling a component in codebase

### DIFF
--- a/docs/codebase-best-practices.md
+++ b/docs/codebase-best-practices.md
@@ -2,11 +2,13 @@
 
 ## Styling a component
 
-We recommend using our [design style guide](https://design-style-guide.freecodecamp.org/) in styling components, you will find the colors mentioned in it in our [variable.css](/client/src/components/layouts/variables.css) file, and will find the fonts in [fonts.css](/client/src/components/layouts/fonts.css) file.
+We recommend styling components using our [design style guide](https://design-style-guide.freecodecamp.org/). 
 
-We are against adding new variables to [variable.css](/client/src/components/layouts/variables.css), because the new colors have to account for contrast, color blindness, and cluttering the devtools which affects negatively the developing experiences and add concerns for accessibility.
+The colors are defined in [`variable.css`](/client/src/components/layouts/variables.css), and the fonts are in [`fonts.css`](/client/src/components/layouts/fonts.css).
 
-Use `!important` for accessibility concerns only after leaving a comment describing the issue, so it won't be removed by mistake in future refactoring.
+We are strongly opinionated about adding new variables/tokens to the colors. After careful research, the colors have been chosen to respect the freeCodeCamp brand identity, developer experience, and accessibility.
+
+The `!important` keyword may be used to override values in some cases (for ex.: accessibility concerns). You should add a comment describing the issue, so it doesn't get removed in future refactoring.
 
 ### RTL support
 

--- a/docs/codebase-best-practices.md
+++ b/docs/codebase-best-practices.md
@@ -10,11 +10,11 @@ Use `!important` for accessibility concerns only after leaving a comment describ
 
 ### RTL support
 
-We are striving to support RTL layout in the codebase, for this you need be mindful of how to style the component in your PR. Here are a quick role of thumbs to follow:
+We are striving to support right-to-left (RTL) layout in the codebase for languages that are read in this direction. For this you need be mindful of how to style components. Here are a quick role of thumbs to follow:
 
-- Don't use float properties: Although it may seem best to have the component in the "perfect position", you will be climbing mountains to reach that perfect positioning in responsive layout, and you will need to reach higher heights to have it supported in RTL. 
-- - Use flexbox and Grid layouts instead, as they have RTL support already built in them, and it will be easier to maintain and review
-- Don't define the direction while using `margin` and `padding`: it may seem harmless to use `padding-right` and `margin-left`, but these directions aren't mirrored when the layout change to RTL, and adding counter values for them in the RTL file makes maintaining the codebase harder.
+- Don't use `float` properties: Although it may seem best to have the component in the "perfect position", you will be climbing mountains to reach that perfect positioning in responsive layout, and you will need to reach higher heights to have it supported in RTL. 
+- - Use flexbox and Grid layouts instead, as they have RTL support already built-in, and those will be easier to maintain and review
+- Don't define the direction while using `margin` and `padding`: it may seem harmless to use `padding-right` and `margin-left`, but these directions aren't mirrored when the layout changes to RTL, and adding counter values for them in the RTL file makes maintaining the codebase harder.
 - - Use logical properties for them: You can add the same spacing by using `padding-inline-end` and `margin-inline-start`, and you won't need to worry about RTL layout, as they follow where the line start and ends, and you won't need to add any extra values in the RTL files, so people won't need to remember to change the same values in two files.
 - Don't use `!important` in `font-family`: RTL layout is using different font from the LTR layout, when you add `!important` in the `font-family` property it affects the RTL layout too, which causes a UI bug.
 

--- a/docs/codebase-best-practices.md
+++ b/docs/codebase-best-practices.md
@@ -1,5 +1,23 @@
 # Codebase Best Practices
 
+## Styling a component
+
+Be mindful of adding new colors to the codebase, as you will have to account for contrast and color blindness. Because of this we always use already determined variables in [variable.css](/client/src/components/layouts/variables.css).
+
+We are against adding new variables to [variable.css](/client/src/components/layouts/variables.css), because we have to account for contrast, color blindness 🙂, and cluttering the devtools which affects negatively the devtools experiences and add concerns for accessiblity.
+
+Use `!important` for accessibilty concers only after leaving a comment describing the issue, so it won't be removed by mistake in future refactoring.
+
+### RTL support
+
+We are striving to support RTL layout in the codebase, for this you need to mindful of how to style the component in your PR. Here are a quick roles of thumbs to follow:
+
+- Don't use float properties: Although it may seems best to have the component in the "perfect position", you will be climbing mountians to reach that perfect positioning in responsive layout, and you will need to reach higher heights to have it supported in RTL. 
+- - Use flexbox and Grid layouts when possible instead, as they have RTL support already built in them, and it will be easier to maintain and review
+- Don't define the direction while using `margin` and `padding`: it may seems harmless to use `padding-right` and `margin-left`, but these directions aren't mirrored when the layout change to RTL, and adding counter values for them in the RTL file makes maintaining the codebase harder.
+- - Use logical properties for them: You can add the same spacing by using `padding-inline-end` and `margin-inline-start`, and you won't need to worry about RTL layout, as they follow where the line start and ends, and you won't need to add any extra values in the RTL files, so people won't need to remember to change the same values in two files.
+- Don't use `!important` in `font-family`: RTL layout is using different font from the LTR layout, when you add `!important` in the `font-family` property it affects the RTL layout too, which causes a UI bug.
+
 ## General JavaScript
 
 In most cases, our [linter](how-to-setup-freecodecamp-locally.md#follow-these-steps-to-get-your-development-environment-ready) will warn of any formatting which goes against this codebase's preferred practice.

--- a/docs/codebase-best-practices.md
+++ b/docs/codebase-best-practices.md
@@ -2,19 +2,19 @@
 
 ## Styling a component
 
-Be mindful of adding new colors to the codebase, as you will have to account for contrast and color blindness. Because of this we always use already determined variables in [variable.css](/client/src/components/layouts/variables.css).
+Be mindful of adding new colors to the codebase, as you will have to account for contrast and color blindness. Because of this, we always use already determined variables in [variable.css](/client/src/components/layouts/variables.css).
 
-We are against adding new variables to [variable.css](/client/src/components/layouts/variables.css), because we have to account for contrast, color blindness 🙂, and cluttering the devtools which affects negatively the devtools experiences and add concerns for accessiblity.
+We are against adding new variables to [variable.css](/client/src/components/layouts/variables.css), because we have to account for contrast, color blindness 🙂, and cluttering the devtools which affects negatively the devtools experiences and add concerns for accessibility.
 
-Use `!important` for accessibilty concers only after leaving a comment describing the issue, so it won't be removed by mistake in future refactoring.
+Use `!important` for accessibility concerns only after leaving a comment describing the issue, so it won't be removed by mistake in future refactoring.
 
 ### RTL support
 
-We are striving to support RTL layout in the codebase, for this you need to mindful of how to style the component in your PR. Here are a quick roles of thumbs to follow:
+We are striving to support RTL layout in the codebase, for this you need be mindful of how to style the component in your PR. Here are a quick role of thumbs to follow:
 
-- Don't use float properties: Although it may seems best to have the component in the "perfect position", you will be climbing mountians to reach that perfect positioning in responsive layout, and you will need to reach higher heights to have it supported in RTL. 
-- - Use flexbox and Grid layouts when possible instead, as they have RTL support already built in them, and it will be easier to maintain and review
-- Don't define the direction while using `margin` and `padding`: it may seems harmless to use `padding-right` and `margin-left`, but these directions aren't mirrored when the layout change to RTL, and adding counter values for them in the RTL file makes maintaining the codebase harder.
+- Don't use float properties: Although it may seem best to have the component in the "perfect position", you will be climbing mountains to reach that perfect positioning in responsive layout, and you will need to reach higher heights to have it supported in RTL. 
+- - Use flexbox and Grid layouts instead, as they have RTL support already built in them, and it will be easier to maintain and review
+- Don't define the direction while using `margin` and `padding`: it may seem harmless to use `padding-right` and `margin-left`, but these directions aren't mirrored when the layout change to RTL, and adding counter values for them in the RTL file makes maintaining the codebase harder.
 - - Use logical properties for them: You can add the same spacing by using `padding-inline-end` and `margin-inline-start`, and you won't need to worry about RTL layout, as they follow where the line start and ends, and you won't need to add any extra values in the RTL files, so people won't need to remember to change the same values in two files.
 - Don't use `!important` in `font-family`: RTL layout is using different font from the LTR layout, when you add `!important` in the `font-family` property it affects the RTL layout too, which causes a UI bug.
 

--- a/docs/codebase-best-practices.md
+++ b/docs/codebase-best-practices.md
@@ -15,7 +15,7 @@ The `!important` keyword may be used to override values in some cases (for ex.: 
 We are striving to support right-to-left (RTL) layout in the codebase for languages that are read in this direction. For this you need be mindful of how to style components. Here are a quick role of thumbs to follow:
 
 - Don't use `float` properties: Although it may seem best to have the component in the "perfect position", you will be climbing mountains to reach that perfect positioning in responsive layout, and you will need to reach higher heights to have it supported in RTL. 
-- - Use flexbox and Grid layouts instead, as they have RTL support already built-in, and those will be easier to maintain and review
+- - Use Flexbox and Grid layouts instead, as they have RTL support already built-in, and those will be easier to maintain and review.
 - Don't define the direction while using `margin` and `padding`: it may seem harmless to use `padding-right` and `margin-left`, but these directions aren't mirrored when the layout changes to RTL, and adding counter values for them in the RTL file makes maintaining the codebase harder.
 - - Use logical properties for them: You can add the same spacing by using `padding-inline-end` and `margin-inline-start`, and you won't need to worry about RTL layout, as they follow where the line start and ends, and you won't need to add any extra values in the RTL files, so people won't need to remember to change the same values in two files.
 - Don't use `!important` in `font-family`: RTL layout is using different font from the LTR layout, when you add `!important` in the `font-family` property it affects the RTL layout too, which causes a UI bug.

--- a/docs/codebase-best-practices.md
+++ b/docs/codebase-best-practices.md
@@ -2,9 +2,9 @@
 
 ## Styling a component
 
-Be mindful of adding new colors to the codebase, as you will have to account for contrast and color blindness. Because of this, we always use already determined variables in [variable.css](/client/src/components/layouts/variables.css).
+We recommend using our [design style guide](https://design-style-guide.freecodecamp.org/) in styling components, you will find the colors mentioned in it in our [variable.css](/client/src/components/layouts/variables.css) file, and will find the fonts in [fonts.css](/client/src/components/layouts/fonts.css) file.
 
-We are against adding new variables to [variable.css](/client/src/components/layouts/variables.css), because we have to account for contrast, color blindness 🙂, and cluttering the devtools which affects negatively the devtools experiences and add concerns for accessibility.
+We are against adding new variables to [variable.css](/client/src/components/layouts/variables.css), because the new colors have to account for contrast, color blindness, and cluttering the devtools which affects negatively the developing experiences and add concerns for accessibility.
 
 Use `!important` for accessibility concerns only after leaving a comment describing the issue, so it won't be removed by mistake in future refactoring.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

While reviewing a PR, I needed to add 10+ suggestions to account for RTL support, having guidelines for styling a component in our docs will reduce the needed effort in the review process and will make it easier to link a documentation instead of adding 10 suggestions.

These are RTL issues, I found in reviewing process, so we may need to add more later. 

I have tried to add some of what Ahmad told me in his previous review process to make it easier for other campers too, and I can stop keeping them in my mind and check the docs when I am adding a new component to the code base.

BTW, I mean the client folder when I am mentioning code base

Edit: I haven't thought much about wordings, because I haven't asked Ahmad if we want to mention this, in general.

<!-- Feel free to add any additional description of changes below this line -->
