### PR TITLE
fix: spacing issue in RTL layout

### DIFF
--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -83,7 +83,6 @@
   justify-content: flex-end;
   width: 100vw;
   height: auto;
-  margin: 0 0 0 -12px;
   padding: 0;
   list-style: none;
   max-width: 15rem;

--- a/client/src/components/layouts/rtl-layout.css
+++ b/client/src/components/layouts/rtl-layout.css
@@ -207,3 +207,9 @@ sections that need to stay left to right
 [dir='rtl'] [name='payment-method'] {
   font-family: 'NotoSansArabic';
 }
+
+@media (min-width: 980px) {
+  [dir='rtl'] .donate-page-wrapper > .row {
+    display: flex;
+  }
+}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Pointed out by: Tom

I have used flexbox in the donation page to add a quick hack for the spacing issue and fix the layout being LTR

here how it looks 

![image](https://user-images.githubusercontent.com/88248797/209087371-9374f315-fdd2-40ba-b0db-aee2ba157215.png)

---

I have removed magic values in the menu, here how it looks.

![image](https://user-images.githubusercontent.com/88248797/209087504-63557b92-6d1d-4d55-afac-921ee279d78a.png)

<!-- Feel free to add any additional description of changes below this line -->
