### PR TITLE
fix(client): add loader to default layouts

### DIFF
--- a/client/src/components/layouts/default.tsx
+++ b/client/src/components/layouts/default.tsx
@@ -34,6 +34,7 @@ import SignoutModal from '../signout-modal';
 import Footer from '../Footer';
 import Header from '../Header';
 import OfflineWarning from '../OfflineWarning';
+import { Loader } from '../helpers';
 
 // preload common fonts
 import './fonts.css';
@@ -154,6 +155,10 @@ class DefaultLayout extends Component<DefaultLayoutProps> {
     } = this.props;
 
     const useSystemTheme = fetchState.complete && isSignedIn === false;
+
+    if (fetchState.pending) {
+      return <Loader fullScreen={true} />;
+    }
 
     return (
       <div className='page-wrapper'>


### PR DESCRIPTION
Currently there is a abrupt transition between full page loads and reloads on any given page. This is mainly because the default layout shows the header and the footer while waiting to fill in the rest of the body. The network latency between the API then adds to the problem showing a akward transition where the footer is shown up top for a short while before being pushed down. 

This PR should address this by adding the loaded back which got removed somehow in the past.

You can test this PR by simulating a delay in the API requests.
