### PR TITLE
fix(client): Improve alert component

### DIFF
--- a/client/src/components/Flash/flash.css
+++ b/client/src/components/Flash/flash.css
@@ -5,7 +5,6 @@
   margin-bottom: 0px;
   padding-top: 3px;
   padding-bottom: 3px;
-  position: fixed;
   width: 100%;
   z-index: 150;
 }

--- a/client/src/components/Flash/flash.css
+++ b/client/src/components/Flash/flash.css
@@ -6,6 +6,7 @@
   padding-top: 3px;
   padding-bottom: 3px;
   width: 100%;
+  position: relative;
   z-index: 150;
 }
 

--- a/client/src/components/Flash/index.tsx
+++ b/client/src/components/Flash/index.tsx
@@ -33,27 +33,19 @@ function Flash({ flashMessage, removeFlashMessage }: FlashProps): JSX.Element {
   }
 
   return (
-    <>
-      <TransitionGroup>
-        <CSSTransition classNames='flash-message' key={id} timeout={500}>
-          <Alert
-            bsStyle={type}
-            className='flash-message'
-            closeLabel={t('buttons.close')}
-            onDismiss={handleClose}
-          >
-            {t(message, variables)}
-          </Alert>
-        </CSSTransition>
-      </TransitionGroup>
-      {flashMessage && (
-        <div
-          style={{
-            height: `${flashMessageHeight}px`
-          }}
-        />
-      )}
-    </>
+    <TransitionGroup>
+      <CSSTransition classNames='flash-message' key={id} timeout={500}>
+        <Alert
+          bsStyle={type}
+          className='flash-message'
+          closeLabel={t('buttons.close')}
+          onDismiss={handleClose}
+          test={123}
+        >
+          {t(message, variables)}
+        </Alert>
+      </CSSTransition>
+    </TransitionGroup>
   );
 }
 

--- a/client/src/components/Flash/index.tsx
+++ b/client/src/components/Flash/index.tsx
@@ -1,5 +1,5 @@
 import { Alert } from '@freecodecamp/react-bootstrap';
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { TransitionGroup, CSSTransition } from 'react-transition-group';
 import { FlashState } from '../../redux/types';
@@ -15,20 +15,8 @@ type FlashProps = {
 function Flash({ flashMessage, removeFlashMessage }: FlashProps): JSX.Element {
   const { type, message, id, variables } = flashMessage;
   const { t } = useTranslation();
-  const [flashMessageHeight, setFlashMessageHeight] = useState(0);
-
-  useEffect(() => {
-    const flashMessageElem: HTMLElement | null =
-      document.querySelector('.flash-message');
-    setFlashMessageHeight(flashMessageElem?.offsetHeight || 0);
-    document.documentElement.style.setProperty(
-      '--flash-message-height',
-      `${flashMessageHeight}px`
-    );
-  }, [flashMessageHeight]);
 
   function handleClose() {
-    document.documentElement.style.setProperty('--flash-message-height', '0px');
     removeFlashMessage();
   }
 
@@ -40,7 +28,6 @@ function Flash({ flashMessage, removeFlashMessage }: FlashProps): JSX.Element {
           className='flash-message'
           closeLabel={t('buttons.close')}
           onDismiss={handleClose}
-          test={123}
         >
           {t(message, variables)}
         </Alert>

--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -644,6 +644,10 @@ blockquote .small {
   border-color: #31708f;
 }
 
+.alert-dismissable .close {
+  top: 0;
+}
+
 .annual-donation-alert {
   background: linear-gradient(
       -10deg,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

While working on https://github.com/freeCodeCamp/freeCodeCamp/issues/47464 I noticed some issues with the alert component. This PR improves it in two ways:
- Fixes a small visual bug where the close button was not vertically align
- simplifies and improves the maintainability of the component by removing the fixed positioning. It's possible that some point in the past this was necessary but given how things are set up now it is not necessary. It was bad because it forced us to have to manually have a spacer component (since the fixed positioning made the alert component be removed from the normal flow of the page) which could easily be inaccurate if the height of the other component changed (future styling changes, or maybe text just overflows to more rows)

Before:
![Screen Shot 2022-12-28 at 9 12 33 AM](https://user-images.githubusercontent.com/20331238/209840683-01b604c5-fbaa-4e0e-803a-a9a76141044e.png)

After:
![Screen Shot 2022-12-28 at 9 13 55 AM](https://user-images.githubusercontent.com/20331238/209840824-d620e0ab-2809-4a69-b672-6591810a8751.png)

The screenshots are zoomed in so that the difference can be seen more clearly
