### PR TITLE
fix(a11y): accessible names for cert buttons/links in Settings

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -508,7 +508,8 @@
     "step": "Step",
     "steps": "Steps",
     "steps-for": "Steps for {{blockTitle}}",
-    "code-example": "{{codeName}} code example"
+    "code-example": "{{codeName}} code example",
+    "opens-new-window": "Opens in new window"
   },
   "flash": {
     "honest-first": "To claim a certification, you must first accept our academic honesty policy",

--- a/client/src/client-only-routes/show-project-links.tsx
+++ b/client/src/client-only-routes/show-project-links.tsx
@@ -82,7 +82,8 @@ const ShowProjectLinks = (props: ShowProjectLinksProps): JSX.Element => {
     return (
       <SolutionDisplayWidget
         completedChallenge={completedProject}
-        dataCy={projectTitle}
+        dataCy={`${projectTitle} solution`}
+        projectTitle={projectTitle}
         displayContext='certification'
         showUserCode={showUserCode}
         showProjectPreview={showProjectPreview}

--- a/client/src/client-only-routes/show-project-links.tsx
+++ b/client/src/client-only-routes/show-project-links.tsx
@@ -82,7 +82,7 @@ const ShowProjectLinks = (props: ShowProjectLinksProps): JSX.Element => {
     return (
       <SolutionDisplayWidget
         completedChallenge={completedProject}
-        dataCy={`${projectTitle} solution`}
+        dataCy={projectTitle}
         displayContext='certification'
         showUserCode={showUserCode}
         showProjectPreview={showProjectPreview}

--- a/client/src/components/profile/components/time-line.test.tsx
+++ b/client/src/components/profile/components/time-line.test.tsx
@@ -57,7 +57,9 @@ describe('<TimeLine />', () => {
   it('Render button when only solution is present', () => {
     // @ts-expect-error
     render(<TimeLine {...propsForOnlySolution} />, store);
-    const showViewButton = screen.getByRole('link', { name: 'buttons.view' });
+    const showViewButton = screen.getByRole('link', {
+      name: 'buttons.view settings.labels.solution-for (aria.opens-new-window)'
+    });
     expect(showViewButton).toHaveAttribute(
       'href',
       'https://github.com/freeCodeCamp/freeCodeCamp'
@@ -84,7 +86,9 @@ describe('<TimeLine />', () => {
     // @ts-expect-error
     render(<TimeLine {...propsForOnlySolution} />, store);
 
-    const viewButtons = screen.getAllByRole('button', { name: 'buttons.view' });
+    const viewButtons = screen.getAllByRole('button', {
+      name: 'buttons.view settings.labels.solution-for'
+    });
     viewButtons.forEach(button => {
       expect(button).toBeInTheDocument();
     });

--- a/client/src/components/profile/components/time-line.tsx
+++ b/client/src/components/profile/components/time-line.tsx
@@ -104,11 +104,11 @@ function TimelineInner({
     completedChallenge: CompletedChallenge
   ): React.ReactNode {
     const { id } = completedChallenge;
-    const challengeTitle = idToNameMap.get(id)?.challengeTitle;
+    const projectTitle = idToNameMap.get(id)?.challengeTitle || '';
     return (
       <SolutionDisplayWidget
         completedChallenge={completedChallenge}
-        dataCy={challengeTitle}
+        projectTitle={projectTitle}
         showUserCode={() => viewSolution(completedChallenge)}
         showProjectPreview={() => viewProject(completedChallenge)}
         displayContext={'timeline'}

--- a/client/src/components/profile/components/time-line.tsx
+++ b/client/src/components/profile/components/time-line.tsx
@@ -103,9 +103,12 @@ function TimelineInner({
   function renderViewButton(
     completedChallenge: CompletedChallenge
   ): React.ReactNode {
+    const { id } = completedChallenge;
+    const challengeTitle = idToNameMap.get(id)?.challengeTitle;
     return (
       <SolutionDisplayWidget
         completedChallenge={completedChallenge}
+        dataCy={challengeTitle}
         showUserCode={() => viewSolution(completedChallenge)}
         showProjectPreview={() => viewProject(completedChallenge)}
         displayContext={'timeline'}

--- a/client/src/components/profile/components/time-line.tsx
+++ b/client/src/components/profile/components/time-line.tsx
@@ -111,7 +111,7 @@ function TimelineInner({
         projectTitle={projectTitle}
         showUserCode={() => viewSolution(completedChallenge)}
         showProjectPreview={() => viewProject(completedChallenge)}
-        displayContext={'timeline'}
+        displayContext='timeline'
       ></SolutionDisplayWidget>
     );
   }

--- a/client/src/components/settings/certification.js
+++ b/client/src/components/settings/certification.js
@@ -285,7 +285,8 @@ export class CertificationSettings extends Component {
               data-cy={`btn-for-${certSlug}`}
               onClick={createClickHandler(certSlug)}
             >
-              {isCert ? t('buttons.show-cert') : t('buttons.claim-cert')}
+              {isCert ? t('buttons.show-cert') : t('buttons.claim-cert')}{' '}
+              <span className='sr-only'>{certName}</span>
             </Button>
           </td>
         </tr>

--- a/client/src/components/settings/certification.js
+++ b/client/src/components/settings/certification.js
@@ -213,6 +213,7 @@ export class CertificationSettings extends Component {
       <SolutionDisplayWidget
         completedChallenge={completedProject}
         dataCy={projectTitle}
+        projectTitle={projectTitle}
         showUserCode={showUserCode}
         showProjectPreview={showProjectPreview}
         displayContext={'settings'}

--- a/client/src/components/settings/certification.js
+++ b/client/src/components/settings/certification.js
@@ -216,7 +216,7 @@ export class CertificationSettings extends Component {
         projectTitle={projectTitle}
         showUserCode={showUserCode}
         showProjectPreview={showProjectPreview}
-        displayContext={'settings'}
+        displayContext='settings'
       ></SolutionDisplayWidget>
     );
   };

--- a/client/src/components/settings/certification.test.tsx
+++ b/client/src/components/settings/certification.test.tsx
@@ -20,7 +20,7 @@ describe('<certification />', () => {
 
     expect(
       screen.getByRole('link', {
-        name: /^buttons.show-cert /
+        name: /^buttons.show-cert\s+\S+/
       })
     ).toHaveAttribute(
       'href',
@@ -33,7 +33,7 @@ describe('<certification />', () => {
     renderWithRedux(<CertificationSettings {...defaultTestProps} />);
 
     const allClaimedCerts = screen.getAllByRole('link', {
-      name: /^buttons.show-cert/
+      name: /^buttons.show-cert\s+\S+/
     });
 
     allClaimedCerts.forEach(cert => {
@@ -49,7 +49,7 @@ describe('<certification />', () => {
     renderWithRedux(<CertificationSettings {...defaultTestProps} />);
 
     const allClaimedCerts = screen.getAllByRole('link', {
-      name: /^buttons.show-cert /
+      name: /^buttons.show-cert\s+\S+/
     });
 
     allClaimedCerts.forEach(cert => {

--- a/client/src/components/settings/certification.test.tsx
+++ b/client/src/components/settings/certification.test.tsx
@@ -20,7 +20,7 @@ describe('<certification />', () => {
 
     expect(
       screen.getByRole('link', {
-        name: 'buttons.show-cert'
+        name: /^buttons.show-cert /
       })
     ).toHaveAttribute(
       'href',
@@ -33,7 +33,7 @@ describe('<certification />', () => {
     renderWithRedux(<CertificationSettings {...defaultTestProps} />);
 
     const allClaimedCerts = screen.getAllByRole('link', {
-      name: 'buttons.show-cert'
+      name: /^buttons.show-cert/
     });
 
     allClaimedCerts.forEach(cert => {
@@ -49,7 +49,7 @@ describe('<certification />', () => {
     renderWithRedux(<CertificationSettings {...defaultTestProps} />);
 
     const allClaimedCerts = screen.getAllByRole('link', {
-      name: 'buttons.show-cert'
+      name: /^buttons.show-cert /
     });
 
     allClaimedCerts.forEach(cert => {
@@ -65,7 +65,7 @@ describe('<certification />', () => {
 
     expect(
       screen.getByRole('link', {
-        name: 'buttons.view'
+        name: 'buttons.view settings.labels.solution-for (aria.opens-new-window)'
       })
     ).toHaveAttribute('href', 'https://github.com/freeCodeCamp/freeCodeCamp');
   });

--- a/client/src/components/solution-display-widget/index.tsx
+++ b/client/src/components/solution-display-widget/index.tsx
@@ -9,6 +9,7 @@ import './solution-display-widget.css';
 interface Props {
   completedChallenge: CompletedChallenge;
   dataCy?: string;
+  projectTitle: string;
   showUserCode: () => void;
   showProjectPreview?: () => void;
   displayContext: 'timeline' | 'settings' | 'certification';
@@ -17,6 +18,7 @@ interface Props {
 export function SolutionDisplayWidget({
   completedChallenge,
   dataCy,
+  projectTitle,
   showUserCode,
   showProjectPreview,
   displayContext
@@ -33,7 +35,7 @@ export function SolutionDisplayWidget({
     <Button block={true} data-cy={dataCy} onClick={showUserCode}>
       {viewText}{' '}
       <span className='sr-only'>
-        {t('settings.labels.solution-for', { projectTitle: dataCy })}
+        {t('settings.labels.solution-for', { projectTitle })}
       </span>
     </Button>
   );
@@ -42,7 +44,7 @@ export function SolutionDisplayWidget({
       <Dropdown.Toggle block={true} bsStyle='primary' className='btn-invert'>
         {viewText}{' '}
         <span className='sr-only'>
-          {t('settings.labels.solution-for', { projectTitle: dataCy })}
+          {t('settings.labels.solution-for', { projectTitle })}
         </span>
       </Dropdown.Toggle>
       <Dropdown.Menu>
@@ -79,7 +81,7 @@ export function SolutionDisplayWidget({
     >
       {viewText}{' '}
       <span className='sr-only'>
-        {t('settings.labels.solution-for', { projectTitle: dataCy })} (
+        {t('settings.labels.solution-for', { projectTitle })} (
         {t('aria.opens-new-window')})
       </span>
       <FontAwesomeIcon icon={faExternalLinkAlt} />
@@ -98,7 +100,7 @@ export function SolutionDisplayWidget({
     >
       {viewText}{' '}
       <span className='sr-only'>
-        {t('settings.labels.solution-for', { projectTitle: dataCy })}
+        {t('settings.labels.solution-for', { projectTitle })}
       </span>
     </Button>
   );
@@ -108,7 +110,7 @@ export function SolutionDisplayWidget({
         <Dropdown.Toggle block={true} bsStyle='primary' className='btn-invert'>
           {viewText}{' '}
           <span className='sr-only'>
-            {t('settings.labels.solution-for', { projectTitle: dataCy })}
+            {t('settings.labels.solution-for', { projectTitle })}
           </span>
         </Dropdown.Toggle>
         <Dropdown.Menu>
@@ -129,7 +131,7 @@ export function SolutionDisplayWidget({
         <Dropdown.Toggle block={true} bsStyle='primary' className='btn-invert'>
           {viewText}{' '}
           <span className='sr-only'>
-            {t('settings.labels.solution-for', { projectTitle: dataCy })}
+            {t('settings.labels.solution-for', { projectTitle })}
           </span>
         </Dropdown.Toggle>
         <Dropdown.Menu>
@@ -168,7 +170,7 @@ export function SolutionDisplayWidget({
     >
       {viewText}{' '}
       <span className='sr-only'>
-        {t('settings.labels.solution-for', { projectTitle: dataCy })} (
+        {t('settings.labels.solution-for', { projectTitle })} (
         {t('aria.opens-new-window')})
       </span>
       <FontAwesomeIcon icon={faExternalLinkAlt} />

--- a/client/src/components/solution-display-widget/index.tsx
+++ b/client/src/components/solution-display-widget/index.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { CompletedChallenge } from '../../redux/prop-types';
 import { getSolutionDisplayType } from '../../utils/solution-display-type';
+import './solution-display-widget.css';
 interface Props {
   completedChallenge: CompletedChallenge;
   dataCy?: string;

--- a/client/src/components/solution-display-widget/index.tsx
+++ b/client/src/components/solution-display-widget/index.tsx
@@ -1,10 +1,6 @@
 import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import {
-  Button,
-  DropdownButton,
-  MenuItem
-} from '@freecodecamp/react-bootstrap';
+import { Button, Dropdown, MenuItem } from '@freecodecamp/react-bootstrap';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { CompletedChallenge } from '../../redux/prop-types';
@@ -29,37 +25,48 @@ export function SolutionDisplayWidget({
   const viewText = t('buttons.view');
   const viewCode = t('buttons.view-code');
   const viewProject = t('buttons.view-project');
-
+  // We need to add a random number for dropdown button id's since there may be
+  // two dropdowns for the same project on the page.
+  const randomIdSuffix = Math.floor(Math.random() * 1_000_000);
   const ShowFilesSolutionForCertification = (
     <Button block={true} data-cy={dataCy} onClick={showUserCode}>
-      {t('buttons.view')}
+      {viewText}{' '}
+      <span className='sr-only'>
+        {t('settings.labels.solution-for', { projectTitle: dataCy })}
+      </span>
     </Button>
   );
   const ShowProjectAndGithubLinkForCertification = (
-    <DropdownButton
-      block={true}
-      bsStyle='primary'
-      className='btn-invert'
-      id={`dropdown-for-${id}`}
-      title={t('buttons.view')}
-    >
-      <MenuItem
-        bsStyle='primary'
-        href={solution ?? ''}
-        rel='noopener noreferrer'
-        target='_blank'
-      >
-        {t('certification.project.solution')}
-      </MenuItem>
-      <MenuItem
-        bsStyle='primary'
-        href={githubLink}
-        rel='noopener noreferrer'
-        target='_blank'
-      >
-        {t('certification.project.source')}
-      </MenuItem>
-    </DropdownButton>
+    <Dropdown id={`dropdown-for-${id}-${randomIdSuffix}`}>
+      <Dropdown.Toggle block={true} bsStyle='primary' className='btn-invert'>
+        {viewText}{' '}
+        <span className='sr-only'>
+          {t('settings.labels.solution-for', { projectTitle: dataCy })}
+        </span>
+      </Dropdown.Toggle>
+      <Dropdown.Menu>
+        <MenuItem
+          bsStyle='primary'
+          href={solution ?? ''}
+          rel='noopener noreferrer'
+          target='_blank'
+        >
+          {t('certification.project.solution')}
+          <span className='sr-only'>({t('aria.opens-new-window')})</span>
+          <FontAwesomeIcon icon={faExternalLinkAlt} />
+        </MenuItem>
+        <MenuItem
+          bsStyle='primary'
+          href={githubLink}
+          rel='noopener noreferrer'
+          target='_blank'
+        >
+          {t('certification.project.source')}
+          <span className='sr-only'>({t('aria.opens-new-window')})</span>
+          <FontAwesomeIcon icon={faExternalLinkAlt} />
+        </MenuItem>
+      </Dropdown.Menu>
+    </Dropdown>
   );
   const ShowProjectLinkForCertification = (
     <Button
@@ -69,7 +76,12 @@ export function SolutionDisplayWidget({
       rel='noopener noreferrer'
       target='_blank'
     >
-      {t('buttons.view')}
+      {viewText}{' '}
+      <span className='sr-only'>
+        {t('settings.labels.solution-for', { projectTitle: dataCy })} (
+        {t('aria.opens-new-window')})
+      </span>
+      <FontAwesomeIcon icon={faExternalLinkAlt} />
     </Button>
   );
   const MissingSolutionComponentForCertification = (
@@ -81,57 +93,67 @@ export function SolutionDisplayWidget({
       bsStyle='primary'
       className='btn-invert'
       data-cy={dataCy}
-      id={`btn-for-${id}`}
       onClick={showUserCode}
     >
-      {viewText} <FontAwesomeIcon icon={faExternalLinkAlt} />
+      {viewText}{' '}
+      <span className='sr-only'>
+        {t('settings.labels.solution-for', { projectTitle: dataCy })}
+      </span>
     </Button>
   );
   const ShowMultifileProjectSolution = (
     <div className='solutions-dropdown'>
-      <DropdownButton
-        block={true}
-        bsStyle='primary'
-        className='btn-invert'
-        id={`dropdown-for-${id}`}
-        title={t('buttons.view')}
-      >
-        <MenuItem bsStyle='primary' onClick={showUserCode}>
-          {viewCode}
-        </MenuItem>
-        <MenuItem bsStyle='primary' onClick={showProjectPreview}>
-          {viewProject}
-        </MenuItem>
-      </DropdownButton>
+      <Dropdown id={`dropdown-for-${id}-${randomIdSuffix}`}>
+        <Dropdown.Toggle block={true} bsStyle='primary' className='btn-invert'>
+          {viewText}{' '}
+          <span className='sr-only'>
+            {t('settings.labels.solution-for', { projectTitle: dataCy })}
+          </span>
+        </Dropdown.Toggle>
+        <Dropdown.Menu>
+          <MenuItem bsStyle='primary' onClick={showUserCode}>
+            {viewCode}
+          </MenuItem>
+          <MenuItem bsStyle='primary' onClick={showProjectPreview}>
+            {viewProject}
+          </MenuItem>
+        </Dropdown.Menu>
+      </Dropdown>
     </div>
   );
 
   const ShowProjectAndGithubLinks = (
     <div className='solutions-dropdown'>
-      <DropdownButton
-        block={true}
-        bsStyle='primary'
-        className='btn-invert'
-        id={`dropdown-for-${id}`}
-        title={viewText}
-      >
-        <MenuItem
-          bsStyle='primary'
-          href={solution}
-          rel='noopener noreferrer'
-          target='_blank'
-        >
-          {t('buttons.frontend')}
-        </MenuItem>
-        <MenuItem
-          bsStyle='primary'
-          href={githubLink}
-          rel='noopener noreferrer'
-          target='_blank'
-        >
-          {t('buttons.backend')}
-        </MenuItem>
-      </DropdownButton>
+      <Dropdown id={`dropdown-for-${id}-${randomIdSuffix}`}>
+        <Dropdown.Toggle block={true} bsStyle='primary' className='btn-invert'>
+          {viewText}{' '}
+          <span className='sr-only'>
+            {t('settings.labels.solution-for', { projectTitle: dataCy })}
+          </span>
+        </Dropdown.Toggle>
+        <Dropdown.Menu>
+          <MenuItem
+            bsStyle='primary'
+            href={solution}
+            rel='noopener noreferrer'
+            target='_blank'
+          >
+            {t('buttons.frontend')}{' '}
+            <span className='sr-only'>({t('aria.opens-new-window')})</span>
+            <FontAwesomeIcon icon={faExternalLinkAlt} />
+          </MenuItem>
+          <MenuItem
+            bsStyle='primary'
+            href={githubLink}
+            rel='noopener noreferrer'
+            target='_blank'
+          >
+            {t('buttons.backend')}{' '}
+            <span className='sr-only'>({t('aria.opens-new-window')})</span>
+            <FontAwesomeIcon icon={faExternalLinkAlt} />
+          </MenuItem>
+        </Dropdown.Menu>
+      </Dropdown>
     </div>
   );
   const ShowProjectLink = (
@@ -140,11 +162,15 @@ export function SolutionDisplayWidget({
       bsStyle='primary'
       className='btn-invert'
       href={solution}
-      id={`btn-for-${id}`}
       rel='noopener noreferrer'
       target='_blank'
     >
-      {viewText} <FontAwesomeIcon icon={faExternalLinkAlt} />
+      {viewText}{' '}
+      <span className='sr-only'>
+        {t('settings.labels.solution-for', { projectTitle: dataCy })} (
+        {t('aria.opens-new-window')})
+      </span>
+      <FontAwesomeIcon icon={faExternalLinkAlt} />
     </Button>
   );
   const MissingSolutionComponent =

--- a/client/src/components/solution-display-widget/solution-display-widget.css
+++ b/client/src/components/solution-display-widget/solution-display-widget.css
@@ -1,0 +1,3 @@
+.solutions-dropdown a[role='menuitem'] {
+  text-decoration: none;
+}

--- a/client/src/templates/Introduction/components/cert-challenge.tsx
+++ b/client/src/templates/Introduction/components/cert-challenge.tsx
@@ -130,7 +130,8 @@ const CertChallenge = ({
         >
           {isCertified && userLoaded
             ? t('buttons.show-cert')
-            : t('buttons.go-to-settings')}
+            : t('buttons.go-to-settings')}{' '}
+          <span className='sr-only'>{title}</span>
         </Button>
       )}
     </div>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Adds proper accessible name to the View buttons/links and Claim/Show Certification buttons on the Settings page. These changes also bleed over into the Profile page and individual Certificates. 

Also adds "Opens in new window" sr-only text for links that open in new window.