### PR TITLE
refactor: better error logging

### DIFF
--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -70,29 +70,25 @@ const commentExtractors = {
 
 const { flatten, isEmpty, cloneDeep, isEqual } = lodash;
 
-// rethrow unhandled rejections to make sure the tests exit with -1
+// rethrow unhandled rejections to make sure the tests exit with non-zero code
 process.on('unhandledRejection', err => handleRejection(err));
 // If an uncaught exception gets here, then mocha is in an unexpected state. All
 // we can do is log the exception and exit with a non-zero code.
 process.on('uncaughtException', err => {
-  console.error('Uncaught exception:', err.message);
-  console.error(err.stack);
-  // eslint-disable-next-line no-process-exit
+  console.error('Uncaught exception:');
+  console.error(err);
   process.exit(1);
 });
 
+// some errors *may* not be reported, since cleanup is triggered by the first
+// error and that starts shutting down the browser and the server.
 const handleRejection = err => {
   // setting the error code because node does not (yet) exit with a non-zero
   // code on unhandled exceptions.
   process.exitCode = 1;
   cleanup();
-  if (process.env.FULL_OUTPUT === 'true') {
-    // some errors *may* not be reported, since cleanup is triggered by the
-    // first error and that starts shutting down the browser and the server.
-    console.error(err);
-  } else {
-    throw err;
-  }
+  console.error(err);
+  if (process.env.FULL_OUTPUT !== 'true') process.exit();
 };
 
 const dom = new jsdom.JSDOM('');

--- a/tools/challenge-parser/translation-parser/index.js
+++ b/tools/challenge-parser/translation-parser/index.js
@@ -100,7 +100,11 @@ function translateGeneric(
       updateCounts(commentCounts, dict[comment][lang]);
       text = text.replace(match, `${before}${dict[comment][lang]}${after}`);
     } else if (comment.trim()) {
-      throw `${comment} does not appear in the comment dictionary`;
+      throw `The comment
+${comment}
+does not appear in the comment dictionary.
+When updating or adding a comment it must have the same text in the English challenges and the comment dictionary.
+`;
     }
   }
 


### PR DESCRIPTION
- refactor: log full error, not .message and .stack
- refactor: improve missing comments error message

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This was motivated by the cryptic errors created when there was a mismatch between the comments in challenges and the comments in the dictionary. For example: https://github.com/freeCodeCamp/freeCodeCamp/pull/48799

<!-- Feel free to add any additional description of changes below this line -->
