### PR TITLE
fix(client): add message to loader

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -463,7 +463,8 @@
     "iframe-preview": "{{title}} preview",
     "iframe-alert": "Normally this link would bring you to another website! It works. This is a link to: {{externalLink}}",
     "iframe-form-submit-alert": "Normally this form would be submitted! It works. This will be submitted to: {{externalLink}}",
-    "document-notfound": "document not found"
+    "document-notfound": "document not found",
+    "slow-load-msg": "Looks like this is taking longer than usual, please try refreshing the page."
   },
   "icons": {
     "gold-cup": "Gold Cup",

--- a/client/src/components/helpers/__snapshots__/loader.test.tsx.snap
+++ b/client/src/components/helpers/__snapshots__/loader.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`<Loader /> matches the fullScreen render snapshot 1`] = `
   <p
     class="text-center"
   >
-    Looks like this is taking longer than usual, please try refreshing the page.
+    misc.slow-load-msg
   </p>
 </div>
 `;

--- a/client/src/components/helpers/__snapshots__/loader.test.tsx.snap
+++ b/client/src/components/helpers/__snapshots__/loader.test.tsx.snap
@@ -14,6 +14,12 @@ exports[`<Loader /> matches the fullScreen render snapshot 1`] = `
     <div />
     <div />
   </div>
+  <br />
+  <p
+    class="text-center"
+  >
+    Looks like this is taking longer than usual, please try refreshing the page.
+  </p>
 </div>
 `;
 

--- a/client/src/components/helpers/loader.css
+++ b/client/src/components/helpers/loader.css
@@ -2,6 +2,7 @@
   height: 100%;
   width: 100%;
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
 }

--- a/client/src/components/helpers/loader.css
+++ b/client/src/components/helpers/loader.css
@@ -5,6 +5,7 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  gap: 1em;
 }
 
 .fcc-loader .sk-spinner,

--- a/client/src/components/helpers/loader.tsx
+++ b/client/src/components/helpers/loader.tsx
@@ -5,31 +5,29 @@ import './loader.css';
 
 interface LoaderProps {
   fullScreen?: boolean;
-  delayedLoaderTimer?: number;
-  delayedMessageTimer?: number;
+  loaderDelay?: number;
+  messageDelay?: number;
 }
 function Loader({
   fullScreen,
-  delayedLoaderTimer,
-  delayedMessageTimer
+  loaderDelay,
+  messageDelay
 }: LoaderProps): JSX.Element {
-  const [showSpinner, setShowSpinner] = useState(!delayedLoaderTimer);
-  const [showMessage, setShowMessage] = useState(!delayedMessageTimer);
+  const [showSpinner, setShowSpinner] = useState(!loaderDelay);
+  const [showMessage, setShowMessage] = useState(!messageDelay);
   useEffect(() => {
-    let timerId: ReturnType<typeof setTimeout>;
-    if (!showSpinner) {
-      timerId = setTimeout(() => setShowSpinner(true), delayedLoaderTimer);
+    if (loaderDelay) {
+      const timerId = setTimeout(() => setShowSpinner(true), loaderDelay);
+      return () => clearTimeout(timerId);
     }
-    return () => clearTimeout(timerId);
-  }, [setShowSpinner, showSpinner, delayedLoaderTimer]);
+  }, [loaderDelay]);
 
   useEffect(() => {
-    let timerId: ReturnType<typeof setTimeout>;
-    if (!showMessage) {
-      timerId = setTimeout(() => setShowMessage(true), delayedMessageTimer);
+    if (messageDelay) {
+      const timerId = setTimeout(() => setShowMessage(true), messageDelay);
+      return () => clearTimeout(timerId);
     }
-    return () => clearTimeout(timerId);
-  }, [setShowMessage, showMessage, delayedMessageTimer]);
+  }, [messageDelay]);
 
   return (
     <div

--- a/client/src/components/helpers/loader.tsx
+++ b/client/src/components/helpers/loader.tsx
@@ -5,23 +5,47 @@ import './loader.css';
 
 interface LoaderProps {
   fullScreen?: boolean;
-  timeout?: number;
+  delayedLoaderTimer?: number;
+  delayedMessageTimer?: number;
 }
-function Loader({ fullScreen, timeout }: LoaderProps): JSX.Element {
-  const [showSpinner, setShowSpinner] = useState(!timeout);
+function Loader({
+  fullScreen,
+  delayedLoaderTimer,
+  delayedMessageTimer
+}: LoaderProps): JSX.Element {
+  const [showSpinner, setShowSpinner] = useState(!delayedLoaderTimer);
+  const [showMessage, setShowMessage] = useState(!delayedMessageTimer);
   useEffect(() => {
     let timerId: ReturnType<typeof setTimeout>;
     if (!showSpinner) {
-      timerId = setTimeout(() => setShowSpinner(true), timeout);
+      timerId = setTimeout(() => setShowSpinner(true), delayedLoaderTimer);
     }
     return () => clearTimeout(timerId);
-  }, [setShowSpinner, showSpinner, timeout]);
+  }, [setShowSpinner, showSpinner, delayedLoaderTimer]);
+
+  useEffect(() => {
+    let timerId: ReturnType<typeof setTimeout>;
+    if (!showMessage) {
+      timerId = setTimeout(() => setShowMessage(true), delayedMessageTimer);
+    }
+    return () => clearTimeout(timerId);
+  }, [setShowMessage, showMessage, delayedMessageTimer]);
+
   return (
     <div
       className={`fcc-loader ${fullScreen ? 'full-screen-wrapper' : ''}`}
       data-testid='fcc-loader'
     >
       {showSpinner && <Spinner name='line-scale-pulse-out' />}
+      {showMessage && fullScreen && (
+        <>
+          <br />
+          <p className='text-center'>
+            Looks like this is taking longer than usual, please try refreshing
+            the page.
+          </p>
+        </>
+      )}
     </div>
   );
 }

--- a/client/src/components/helpers/loader.tsx
+++ b/client/src/components/helpers/loader.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import Spinner from 'react-spinkit';
 
 import './loader.css';
@@ -13,6 +14,8 @@ function Loader({
   loaderDelay,
   messageDelay
 }: LoaderProps): JSX.Element {
+  const { t } = useTranslation();
+
   const [showSpinner, setShowSpinner] = useState(!loaderDelay);
   const [showMessage, setShowMessage] = useState(!messageDelay);
   useEffect(() => {
@@ -38,10 +41,7 @@ function Loader({
       {showMessage && fullScreen && (
         <>
           <br />
-          <p className='text-center'>
-            Looks like this is taking longer than usual, please try refreshing
-            the page.
-          </p>
+          <p className='text-center'>{t('misc.slow-load-msg')}</p>
         </>
       )}
     </div>

--- a/client/src/components/layouts/default.tsx
+++ b/client/src/components/layouts/default.tsx
@@ -157,7 +157,7 @@ class DefaultLayout extends Component<DefaultLayoutProps> {
     const useSystemTheme = fetchState.complete && isSignedIn === false;
 
     if (fetchState.pending) {
-      return <Loader fullScreen={true} />;
+      return <Loader fullScreen={true} delayedMessageTimer={5000} />;
     }
 
     return (

--- a/client/src/components/layouts/default.tsx
+++ b/client/src/components/layouts/default.tsx
@@ -157,7 +157,7 @@ class DefaultLayout extends Component<DefaultLayoutProps> {
     const useSystemTheme = fetchState.complete && isSignedIn === false;
 
     if (fetchState.pending) {
-      return <Loader fullScreen={true} delayedMessageTimer={5000} />;
+      return <Loader fullScreen={true} messageDelay={5000} />;
     }
 
     return (

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -1206,7 +1206,7 @@ const Editor = (props: EditorProps): JSX.Element => {
   const { theme } = props;
   const editorTheme = theme === Themes.Night ? 'vs-dark-custom' : 'vs-custom';
   return (
-    <Suspense fallback={<Loader timeout={600} />}>
+    <Suspense fallback={<Loader delayedLoaderTimer={600} />}>
       <span className='notranslate'>
         <MonacoEditor
           editorDidMount={editorDidMount}

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -1206,7 +1206,7 @@ const Editor = (props: EditorProps): JSX.Element => {
   const { theme } = props;
   const editorTheme = theme === Themes.Night ? 'vs-dark-custom' : 'vs-custom';
   return (
-    <Suspense fallback={<Loader delayedLoaderTimer={600} />}>
+    <Suspense fallback={<Loader loaderDelay={600} />}>
       <span className='notranslate'>
         <MonacoEditor
           editorDidMount={editorDidMount}

--- a/client/src/utils/ajax.ts
+++ b/client/src/utils/ajax.ts
@@ -14,6 +14,8 @@ const { apiLocation } = envData;
 
 const base = apiLocation;
 
+const delay = (ms: number) => new Promise(res => setTimeout(res, ms));
+
 const defaultOptions: RequestInit = {
   credentials: 'include'
 };
@@ -34,8 +36,13 @@ export interface ResponseWithData<T> {
 // TODO: Might want to handle flash messages as close to the request as possible
 // to make use of the Response object (message, status, etc)
 async function get<T>(path: string): Promise<ResponseWithData<T>> {
-  const response = await fetch(`${base}${path}`, defaultOptions);
+  // Check local storage for a token called 'debugdelay'
+  const debugdelay = localStorage.getItem('debug_delay');
+  if (debugdelay) {
+    await delay(Number(debugdelay));
+  }
 
+  const response = await fetch(`${base}${path}`, defaultOptions);
   return combineDataWithResponse(response);
 }
 

--- a/client/src/utils/ajax.ts
+++ b/client/src/utils/ajax.ts
@@ -14,8 +14,6 @@ const { apiLocation } = envData;
 
 const base = apiLocation;
 
-const delay = (ms: number) => new Promise(res => setTimeout(res, ms));
-
 const defaultOptions: RequestInit = {
   credentials: 'include'
 };
@@ -36,13 +34,8 @@ export interface ResponseWithData<T> {
 // TODO: Might want to handle flash messages as close to the request as possible
 // to make use of the Response object (message, status, etc)
 async function get<T>(path: string): Promise<ResponseWithData<T>> {
-  // Check local storage for a token called 'debugdelay'
-  const debugdelay = localStorage.getItem('debug_delay');
-  if (debugdelay) {
-    await delay(Number(debugdelay));
-  }
-
   const response = await fetch(`${base}${path}`, defaultOptions);
+
   return combineDataWithResponse(response);
 }
 


### PR DESCRIPTION
More context in the dev chat but essentially, this PR implements the below (see video):

https://user-images.githubusercontent.com/1884376/210758644-3d64c168-e3d2-4900-aff2-752a553abd92.mp4

To test this yourself, create a localStorage key like so in you browser console:

```
// Add a 15 sec latency
localStorage.setItem('debug_delay', 15000)
```

The key will add an artificial delay and show the loader and the message after 5 seconds. Once you are happy with the review we can drop the debug commit before merge