### PR TITLE
fix(i18n,client): translate view certificate button

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -11,6 +11,7 @@
     "view": "View",
     "view-code": "View Code",
     "view-project": "View Project",
+    "view-cert-title": "View {{certTitle}}",
     "show-cert": "Show Certification",
     "claim-cert": "Claim Certification",
     "save-progress": "Save Progress",

--- a/client/src/components/profile/components/certifications.tsx
+++ b/client/src/components/profile/components/certifications.tsx
@@ -55,7 +55,9 @@ function CertButton({ username, cert }: CertButtonProps): JSX.Element {
             to={`/certification/${username}/${cert.certSlug}`}
             data-cy='claimed-certification'
           >
-            View {t(`certification.title.${cert.certSlug}`)}
+            {t('buttons.view-cert-title', {
+              certTitle: t(`certification.title.${cert.certSlug}`)
+            })}
           </Link>
         </Col>
       </Row>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

Make the word "View" translatable.
These are the buttons on the profile page: https://www.freecodecamp.org/japanese/sidemt

Current:
<!-- Feel free to add any additional description of changes below this line -->
![スクリーンショット 2023-01-07 022412](https://user-images.githubusercontent.com/25644062/211066792-55cf65b4-958f-42a8-a24a-58c7b613473e.png)

Fix (note that the order of the words is different in Japanese):
![スクリーンショット 2023-01-07 023509](https://user-images.githubusercontent.com/25644062/211066863-8258500c-a16f-4792-8a4a-20a3965ef6dc.png)
