### PR TITLE
feat(client): remove the panel component

### DIFF
--- a/client/src/client-only-routes/show-unsubscribed.tsx
+++ b/client/src/client-only-routes/show-unsubscribed.tsx
@@ -2,10 +2,10 @@ import { Button } from '@freecodecamp/react-bootstrap';
 import React from 'react';
 import Helmet from 'react-helmet';
 import { useTranslation } from 'react-i18next';
-import './test.css';
-import envData from '../../../config/env.json';
+import { apiLocation } from '../../../config/env.json';
 
-const { apiLocation } = envData;
+import './test.css';
+// Panel-test1
 
 function ShowUnsubscribed({
   unsubscribeId

--- a/client/src/client-only-routes/show-unsubscribed.tsx
+++ b/client/src/client-only-routes/show-unsubscribed.tsx
@@ -1,11 +1,9 @@
-import { Grid, Panel, Button } from '@freecodecamp/react-bootstrap';
+import { Button } from '@freecodecamp/react-bootstrap';
 import React from 'react';
 import Helmet from 'react-helmet';
 import { useTranslation } from 'react-i18next';
-
+import './test.css';
 import envData from '../../../config/env.json';
-import { Spacer } from '../components/helpers';
-import FullWidthRow from '../components/helpers/full-width-row';
 
 const { apiLocation } = envData;
 
@@ -20,31 +18,22 @@ function ShowUnsubscribed({
       <Helmet>
         <title>{t('metaTags:youre-unsubscribed')} | freeCodeCamp.org</title>
       </Helmet>
-      <Grid>
-        <main>
-          <FullWidthRow>
-            <Spacer size={2} />
-            <Panel bsStyle='primary' className='text-center'>
-              <Spacer />
-              <h2>{t('misc.unsubscribed')}</h2>
-              <p>{t('misc.keep-coding')}</p>
-            </Panel>
-          </FullWidthRow>
-          {unsubscribeId ? (
-            <FullWidthRow>
-              <Button
-                block={true}
-                bsSize='lg'
-                bsStyle='primary'
-                href={`${apiLocation}/resubscribe/${unsubscribeId}`}
-              >
-                {t('buttons.resubscribe')}
-              </Button>
-            </FullWidthRow>
-          ) : null}
-          <Spacer size={2} />
-        </main>
-      </Grid>
+      <main className='test'>
+        <section className='panel'>
+          <h2>{t('misc.unsubscribed')}</h2>
+          <p>{t('misc.keep-coding')}</p>
+        </section>
+        {unsubscribeId && (
+          <Button
+            block={true}
+            bsSize='lg'
+            bsStyle='primary'
+            href={`${apiLocation}/resubscribe/${unsubscribeId}`}
+          >
+            {t('buttons.resubscribe')}
+          </Button>
+        )}
+      </main>
     </>
   );
 }

--- a/client/src/client-only-routes/test.css
+++ b/client/src/client-only-routes/test.css
@@ -1,0 +1,11 @@
+.test {
+  display: grid;
+  place-content: center;
+  height: 50vh;
+  text-align: center;
+}
+
+.panel {
+  box-shadow: 1px 0.5px 2px var(--primary-color);
+  padding: 2em 6em;
+}

--- a/client/src/client-only-routes/test.css
+++ b/client/src/client-only-routes/test.css
@@ -1,11 +1,16 @@
 .test {
   display: grid;
   place-content: center;
-  height: 50vh;
   text-align: center;
+  padding-bottom: 60px;
+  padding-inline: 15px;
 }
 
 .panel {
-  box-shadow: 1px 0.5px 2px var(--primary-color);
-  padding: 2em 6em;
+  /* box-shadow: 1px 0.5px 2px var(--primary-color); */
+  margin-block: 60px 25px;
+  max-width: 768px;
+  width: 93vw;
+  border: 1px solid var(--primary-color);
+  padding-top: 30px;
 }

--- a/client/src/components/settings/honesty.tsx
+++ b/client/src/components/settings/honesty.tsx
@@ -15,6 +15,7 @@ type HonestyProps = {
 
 const Honesty = ({ isHonest, updateIsHonest }: HonestyProps): JSX.Element => {
   const { t } = useTranslation();
+  //  panel-Test2
   const button = isHonest ? (
     <Button
       block={true}
@@ -22,7 +23,7 @@ const Honesty = ({ isHonest, updateIsHonest }: HonestyProps): JSX.Element => {
       className='disabled-agreed'
       disabled={true}
     >
-      <p>{t('buttons.accepted-honesty')}</p>
+      {t('buttons.accepted-honesty')}
     </Button>
   ) : (
     <Button


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Ref #48790

I will try to keep the style consistent, and not change anything. This will be refactoring the pages that use that component, here is the initial plan.

- in the area that it used as border, I will swap it with `div` or `section`.
- in the area that it used as `Panel`, I will swap it with new Component called `Panel`.
- clear useless component on the way.


<!-- Feel free to add any additional description of changes below this line -->

![image](https://user-images.githubusercontent.com/88248797/211325246-d88b47c6-ddd6-445d-b42a-dab15bdc945f.png)
