### PR TITLE
fix(docs): button padding in mobile device

### DIFF
--- a/docs/_theme.css
+++ b/docs/_theme.css
@@ -173,6 +173,11 @@ section.cover.show ~ .sidebar-toggle {
     width: 100%;
     margin: 0.2rem 0;
   }
+  
+  section.cover .cover-main > p:last-child a:last-child {
+    padding-left: 0;
+    padding-right: 0;
+  }
 }
 
 /****** Sidebar ******/

--- a/docs/_theme.css
+++ b/docs/_theme.css
@@ -173,10 +173,14 @@ section.cover.show ~ .sidebar-toggle {
     width: 100%;
     margin: 0.2rem 0;
   }
-  
+}
+
+@media (max-width: 400px) {
   section.cover .cover-main > p:last-child a:last-child {
     padding-left: 0;
     padding-right: 0;
+    margin-right: 0;
+    margin-left: 0;
   }
 }
 


### PR DESCRIPTION
Checklist:
- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #48848 

Added left and right padding as 0 (which overwrites `section.cover .cover-main > p:last-child a` from `vue.css:558`) in the buttton for mobile layout.

<img width="374" alt="Screenshot 2023-01-13 at 7 18 57 PM" src="https://user-images.githubusercontent.com/46367738/212335281-53186c4b-31c7-45c9-9349-40b699396941.png">
