### PR TITLE
fix(a11y): remove tab stop on code panel

### DIFF
--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -94,7 +94,6 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
           )}
           <TabPane
             eventKey={Tab.Editor}
-            tabIndex='0'
             title={i18next.t('learn.editor-tabs.code')}
             {...editorTabPaneProps}
           >


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

I am recommending that we remove the tab stop on the Code panel in the mobile layout. This tab stop violates [WCAG SC 2.4.7](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html) because it does not have a visible focus indicator when it is focused. And it is completely non-functional for keyboard users because it does not allow them to interact with the content in the Code panel or even scroll the panel. It is basically an unnecessary tab stop that provides no benefits to keyboard users and adds an unnecessary stop in the tabbing order.

Further, having a tab stop on the panel is not always required. The ARIA Authoring Practices Guide suggests the following [keyboard interaction for the Tab key](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/#keyboard-interaction-21):

> When the tab list contains the focus, [the Tab key] moves focus to the next element in the page tab sequence outside the tablist, which is the tabpanel **unless the first element containing meaningful content inside the tabpanel is focusable**.

To apply this to our Code panel, in the Steps, the first element in the Code panel is an editor toggle button and thus tabbing from the Code tab into the Code panel should put focus on that button. In the older challenges, the only element in the Code panel is the editor and thus tabbing from the Code tab into the Code panel should put focus on the editor.

