### PR TITLE
fix(curriculum): add word nesting & comments to nutrition-label-step-43

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-typography-by-building-a-nutrition-label/615f6b2d164f81809efd9bdc.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-typography-by-building-a-nutrition-label/615f6b2d164f81809efd9bdc.md
@@ -7,7 +7,7 @@ dashedName: step-43
 
 # --description--
 
-After your last `.divider` element, create a `p` element and give it the text `Total Fat 8g 10%`. Wrap `Total Fat` in a `span` element with the `class` set to `bold`. Wrap `10%` in another `span` element with the `class` set to `bold`. Finally, nest these two `span` elements in an additional `span` element for alignment.
+After your last `.divider` element, create a `p` element and give it the text `Total Fat 8g 10%`. Wrap `Total Fat` in a `span` element with the `class` set to `bold`. Wrap `10%` in another `span` element with the `class` set to `bold`. Finally, nest the `Total Fat` `span` element and the text `8g` in an additional `span` element for alignment.
 
 # --hints--
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-typography-by-building-a-nutrition-label/615f6b2d164f81809efd9bdc.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-typography-by-building-a-nutrition-label/615f6b2d164f81809efd9bdc.md
@@ -95,9 +95,9 @@ assert(document.querySelector('.daily-value.small-text')?.lastElementChild?.inne
     <div class="daily-value small-text">
       <p class="bold right">% Daily Value *</p>
       <div class="divider"></div>
-      <!-- Code goes below here-->
+      <!--Add your code below this line-->
       
-      <!-- Code goes above here-->
+      <!--Add your code above this line-->
     </div>
     --fcc-editable-region--
   </div>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-typography-by-building-a-nutrition-label/615f6b2d164f81809efd9bdc.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-typography-by-building-a-nutrition-label/615f6b2d164f81809efd9bdc.md
@@ -7,7 +7,7 @@ dashedName: step-43
 
 # --description--
 
-After your last `.divider` element, create a `p` element and give it the text `Total Fat 8g 10%`. Wrap `Total Fat` in a `span` element with the `class` set to `bold`. Wrap `10%` in another `span` element with the `class` set to `bold`. Finally wrap both the `span` element `Total Fat` and the text `8g` with a `span`, so that they are nested together inside a `span` element.
+After your last `.divider` element, create a `p` element and give it the text `Total Fat 8g 10%`. Wrap `Total Fat` in a `span` element with the `class` set to `bold`. Wrap `10%` in another `span` element with the `class` set to `bold`. Finally, nest these two `span` elements in an additional `span` element for alignment.
 
 # --hints--
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-typography-by-building-a-nutrition-label/615f6b2d164f81809efd9bdc.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-typography-by-building-a-nutrition-label/615f6b2d164f81809efd9bdc.md
@@ -7,7 +7,7 @@ dashedName: step-43
 
 # --description--
 
-After your last `.divider` element, create a `p` element and give it the text `Total Fat 8g 10%`. Wrap `Total Fat` in a `span` element with the `class` set to `bold`. Wrap `10%` in another `span` element with the `class` set to `bold`. Also wrap the words `Total Fat 8g` in an additional `span` element for alignment.
+After your last `.divider` element, create a `p` element and give it the text `Total Fat 8g 10%`. Wrap `Total Fat` in a `span` element with the `class` set to `bold`. Wrap `10%` in another `span` element with the `class` set to `bold`. Finally wrap both the `span` element `Total Fat` and the text `8g` with a `span`, so that they are nested together inside a `span` element.
 
 # --hints--
 
@@ -95,6 +95,9 @@ assert(document.querySelector('.daily-value.small-text')?.lastElementChild?.inne
     <div class="daily-value small-text">
       <p class="bold right">% Daily Value *</p>
       <div class="divider"></div>
+      <!-- Code goes below here-->
+      
+      <!-- Code goes above here-->
     </div>
     --fcc-editable-region--
   </div>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-typography-by-building-a-nutrition-label/615f6b2d164f81809efd9bdc.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-typography-by-building-a-nutrition-label/615f6b2d164f81809efd9bdc.md
@@ -95,9 +95,6 @@ assert(document.querySelector('.daily-value.small-text')?.lastElementChild?.inne
     <div class="daily-value small-text">
       <p class="bold right">% Daily Value *</p>
       <div class="divider"></div>
-      <!--Add your code below this line-->
-      
-      <!--Add your code above this line-->
     </div>
     --fcc-editable-region--
   </div>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-typography-by-building-a-nutrition-label/615f7de4487b64919bb4aa5e.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-typography-by-building-a-nutrition-label/615f7de4487b64919bb4aa5e.md
@@ -7,7 +7,7 @@ dashedName: step-53
 
 # --description--
 
-After your last `.divider`, create a new `p` element with the text `Cholesterol 0mg 0%`. Wrap the text `Cholesterol` in a `span` element, and give that `span` element the `class` attribute set to `bold`. Wrap the text `0%` in another `span` element, with the `class` set to `bold`. Also wrap `Cholesterol 0mg` in an additional `span` element for the alignment.
+After your last `.divider`, create a new `p` element with the text `Cholesterol 0mg 0%`. Wrap the text `Cholesterol` in a `span` element, and give that `span` element the `class` attribute set to `bold`. Wrap the text `0%` in another `span` element, with the `class` set to `bold`. Finally, nest the `Cholesterol` and `0mg` span elements inside an additional span element for alignment.
 
 # --hints--
 


### PR DESCRIPTION
Add comments to code to clear up confusion about where user's should actually be writing their code, as this has been the cause of problems and frustration for some. Also improve the description to incorporate the use of the phrasing 'nesting' in a clear and understandable manner as per suggestions in issue #49017

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ X ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [ X ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ X ] My pull request targets the `main` branch of freeCodeCamp.
- [  X ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

fix #49017

<!-- Feel free to add any additional description of changes below this line -->

Improve the description to incorporate the use of the phrasing 'nesting' in a clear and understandable manner as per suggestions in issue #49017. Also, added comments to code to clear up confusion about where user's should actually be writing their code, as this has been the cause of problems and frustration for some.