### PR TITLE
Fix curriculum: add hint not to remove text in editor

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5ef9b03c81a63668521804e9.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5ef9b03c81a63668521804e9.md
@@ -12,6 +12,8 @@ Make the text `freeCodeCamp.org` into a link by enclosing it in an anchor (`a`) 
 # --hints--
 
 Your anchor (`a`) element should be nested within the `footer` element. Make sure to add an opening tag and closing tag for the anchor (`a`) element.
+<br/> 
+Don't alter the `No Copyright - ` text.
 
 ```js
 assert($('footer > p > a').length);

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5ef9b03c81a63668521804e9.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5ef9b03c81a63668521804e9.md
@@ -13,7 +13,7 @@ Make the text `freeCodeCamp.org` into a link by enclosing it in an anchor (`a`) 
 
 Your anchor (`a`) element should be nested within the `footer` element. Make sure to add an opening tag and closing tag for the anchor (`a`) element.
 <br/> 
-Don't alter the `No Copyright - ` text.
+Don't alter the `No Copyright - ` text. And don't include it in the `anchor` tags.
 
 ```js
 assert($('footer > p > a').length);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ X ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [ X ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ X ] My pull request targets the `main` branch of freeCodeCamp.
- [ X ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

fix #49020

<!-- Feel free to add any additional description of changes below this line -->

Add hint not to remove the copyright text, as doing so causes the tests not to pass. Adding this as a hint should provide a reason and avoid confusion for those struggling to pass the tests for this reason. But also doesn't unnecessarily bloat the description section for those that don't have this issue. 