### PR TITLE
feat(client): allow full width component to carry key prop

### DIFF
--- a/client/src/components/helpers/full-width-row.tsx
+++ b/client/src/components/helpers/full-width-row.tsx
@@ -1,22 +1,22 @@
 import { Row, Col } from '@freecodecamp/react-bootstrap';
 import React from 'react';
 
-function FullWidthRow({
-  children,
-  className
-}: {
+interface FullWidthRowProps {
   children?: React.ReactNode;
   className?: string;
-}): JSX.Element {
+  key?: string;
+}
+
+export const FullWidthRow = ({
+  children,
+  className,
+  key
+}: FullWidthRowProps) => {
   return (
-    <Row className={className}>
+    <Row className={className} key={key}>
       <Col sm={8} smOffset={2} xs={12}>
         {children}
       </Col>
     </Row>
   );
-}
-
-FullWidthRow.displayName = 'FullWidthRow';
-
-export default FullWidthRow;
+};

--- a/client/src/components/helpers/full-width-row.tsx
+++ b/client/src/components/helpers/full-width-row.tsx
@@ -2,7 +2,7 @@ import { Row, Col } from '@freecodecamp/react-bootstrap';
 import React from 'react';
 
 interface FullWidthRowProps {
-  children?: React.ReactNode;
+  children: React.ReactNode;
   className?: string;
 }
 

--- a/client/src/components/helpers/full-width-row.tsx
+++ b/client/src/components/helpers/full-width-row.tsx
@@ -4,12 +4,11 @@ import React from 'react';
 interface FullWidthRowProps {
   children?: React.ReactNode;
   className?: string;
-  key?: string;
 }
 
-const FullWidthRow = ({ children, className, key }: FullWidthRowProps) => {
+const FullWidthRow = ({ children, className }: FullWidthRowProps) => {
   return (
-    <Row className={className} key={key}>
+    <Row className={className}>
       <Col sm={8} smOffset={2} xs={12}>
         {children}
       </Col>

--- a/client/src/components/helpers/full-width-row.tsx
+++ b/client/src/components/helpers/full-width-row.tsx
@@ -7,11 +7,7 @@ interface FullWidthRowProps {
   key?: string;
 }
 
-export const FullWidthRow = ({
-  children,
-  className,
-  key
-}: FullWidthRowProps) => {
+const FullWidthRow = ({ children, className, key }: FullWidthRowProps) => {
   return (
     <Row className={className} key={key}>
       <Col sm={8} smOffset={2} xs={12}>
@@ -20,3 +16,7 @@ export const FullWidthRow = ({
     </Row>
   );
 };
+
+FullWidthRow.displayName = 'FullWidthRow';
+
+export default FullWidthRow;

--- a/client/src/components/settings/portfolio.tsx
+++ b/client/src/components/settings/portfolio.tsx
@@ -219,100 +219,96 @@ class PortfolioSettings extends Component<PortfolioProps, PortfolioState> {
     const { state: descriptionState, message: descriptionMessage } =
       this.getDescriptionValidation(description);
     return (
-      <div key={id}>
-        <FullWidthRow>
-          <form onSubmit={e => this.handleSubmit(e, id)}>
-            <FormGroup
-              controlId={`${id}-title`}
-              validationState={
-                pristine || (!pristine && !title) ? null : titleState
-              }
-            >
-              <ControlLabel>{t('settings.labels.title')}</ControlLabel>
-              <FormControl
-                onChange={this.createOnChangeHandler(id, 'title')}
-                required={true}
-                type='text'
-                value={title}
-              />
-              {titleMessage ? <HelpBlock>{titleMessage}</HelpBlock> : null}
-            </FormGroup>
-            <FormGroup
-              controlId={`${id}-url`}
-              validationState={
-                pristine || (!pristine && !url) ? null : urlState
-              }
-            >
-              <ControlLabel>{t('settings.labels.url')}</ControlLabel>
-              <FormControl
-                onChange={this.createOnChangeHandler(id, 'url')}
-                required={true}
-                type='url'
-                value={url}
-              />
-              {urlMessage ? <HelpBlock>{urlMessage}</HelpBlock> : null}
-            </FormGroup>
-            <FormGroup
-              controlId={`${id}-image`}
-              validationState={pristine ? null : imageState}
-            >
-              <ControlLabel>{t('settings.labels.image')}</ControlLabel>
-              <FormControl
-                onChange={this.createOnChangeHandler(id, 'image')}
-                type='url'
-                value={image}
-              />
-              {imageMessage ? <HelpBlock>{imageMessage}</HelpBlock> : null}
-            </FormGroup>
-            <FormGroup
-              controlId={`${id}-description`}
-              validationState={pristine ? null : descriptionState}
-            >
-              <ControlLabel>{t('settings.labels.description')}</ControlLabel>
-              <FormControl
-                componentClass='textarea'
-                onChange={this.createOnChangeHandler(id, 'description')}
-                value={description}
-              />
-              {descriptionMessage ? (
-                <HelpBlock>{descriptionMessage}</HelpBlock>
-              ) : null}
-            </FormGroup>
-            <BlockSaveButton
-              disabled={
-                pristine ||
-                !title ||
-                !isURL(url, {
-                  protocols: ['http', 'https'],
-                  /* eslint-disable camelcase, @typescript-eslint/naming-convention */
-                  require_tld: true,
-                  require_protocol: true
-                  /* eslint-enable camelcase, @typescript-eslint/naming-convention */
-                })
-              }
-            >
-              {t('buttons.save-portfolio')}
-            </BlockSaveButton>
-            <ButtonSpacer />
-            <Button
-              block={true}
-              bsSize='lg'
-              bsStyle='danger'
-              onClick={() => this.handleRemoveItem(id)}
-              type='button'
-            >
-              {t('buttons.remove-portfolio')}
-            </Button>
-          </form>
-          {index + 1 !== arr.length && (
-            <>
-              <Spacer />
-              <hr />
-              <Spacer />
-            </>
-          )}
-        </FullWidthRow>
-      </div>
+      <FullWidthRow key={id}>
+        <form onSubmit={e => this.handleSubmit(e, id)}>
+          <FormGroup
+            controlId={`${id}-title`}
+            validationState={
+              pristine || (!pristine && !title) ? null : titleState
+            }
+          >
+            <ControlLabel>{t('settings.labels.title')}</ControlLabel>
+            <FormControl
+              onChange={this.createOnChangeHandler(id, 'title')}
+              required={true}
+              type='text'
+              value={title}
+            />
+            {titleMessage ? <HelpBlock>{titleMessage}</HelpBlock> : null}
+          </FormGroup>
+          <FormGroup
+            controlId={`${id}-url`}
+            validationState={pristine || (!pristine && !url) ? null : urlState}
+          >
+            <ControlLabel>{t('settings.labels.url')}</ControlLabel>
+            <FormControl
+              onChange={this.createOnChangeHandler(id, 'url')}
+              required={true}
+              type='url'
+              value={url}
+            />
+            {urlMessage ? <HelpBlock>{urlMessage}</HelpBlock> : null}
+          </FormGroup>
+          <FormGroup
+            controlId={`${id}-image`}
+            validationState={pristine ? null : imageState}
+          >
+            <ControlLabel>{t('settings.labels.image')}</ControlLabel>
+            <FormControl
+              onChange={this.createOnChangeHandler(id, 'image')}
+              type='url'
+              value={image}
+            />
+            {imageMessage ? <HelpBlock>{imageMessage}</HelpBlock> : null}
+          </FormGroup>
+          <FormGroup
+            controlId={`${id}-description`}
+            validationState={pristine ? null : descriptionState}
+          >
+            <ControlLabel>{t('settings.labels.description')}</ControlLabel>
+            <FormControl
+              componentClass='textarea'
+              onChange={this.createOnChangeHandler(id, 'description')}
+              value={description}
+            />
+            {descriptionMessage ? (
+              <HelpBlock>{descriptionMessage}</HelpBlock>
+            ) : null}
+          </FormGroup>
+          <BlockSaveButton
+            disabled={
+              pristine ||
+              !title ||
+              !isURL(url, {
+                protocols: ['http', 'https'],
+                /* eslint-disable camelcase, @typescript-eslint/naming-convention */
+                require_tld: true,
+                require_protocol: true
+                /* eslint-enable camelcase, @typescript-eslint/naming-convention */
+              })
+            }
+          >
+            {t('buttons.save-portfolio')}
+          </BlockSaveButton>
+          <ButtonSpacer />
+          <Button
+            block={true}
+            bsSize='lg'
+            bsStyle='danger'
+            onClick={() => this.handleRemoveItem(id)}
+            type='button'
+          >
+            {t('buttons.remove-portfolio')}
+          </Button>
+        </form>
+        {index + 1 !== arr.length && (
+          <>
+            <Spacer />
+            <hr />
+            <Spacer />
+          </>
+        )}
+      </FullWidthRow>
     );
   };
 

--- a/client/src/components/settings/portfolio.tsx
+++ b/client/src/components/settings/portfolio.tsx
@@ -219,7 +219,7 @@ class PortfolioSettings extends Component<PortfolioProps, PortfolioState> {
     const { state: descriptionState, message: descriptionMessage } =
       this.getDescriptionValidation(description);
     return (
-      <FullWidthRow key={id}>
+      <FullWidthRow>
         <form onSubmit={e => this.handleSubmit(e, id)}>
           <FormGroup
             controlId={`${id}-title`}

--- a/client/src/components/settings/portfolio.tsx
+++ b/client/src/components/settings/portfolio.tsx
@@ -219,7 +219,7 @@ class PortfolioSettings extends Component<PortfolioProps, PortfolioState> {
     const { state: descriptionState, message: descriptionMessage } =
       this.getDescriptionValidation(description);
     return (
-      <FullWidthRow>
+      <FullWidthRow key={id}>
         <form onSubmit={e => this.handleSubmit(e, id)}>
           <FormGroup
             controlId={`${id}-title`}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The div element didn't do much, except carrying a key props, so I removed it

![image](https://user-images.githubusercontent.com/88248797/213864536-837ce4cc-5bff-4026-8241-8cba63c7b586.png)

<!-- Feel free to add any additional description of changes below this line -->
