### PR TITLE
refactor(client): clear extra div around the delete and reset panel

### DIFF
--- a/client/src/components/settings/danger-zone.tsx
+++ b/client/src/components/settings/danger-zone.tsx
@@ -12,11 +12,11 @@ import ResetModal from './reset-modal';
 
 import './danger-zone.css';
 
-type DangerZoneProps = {
+interface DangerZoneProps {
   deleteAccount: () => void;
   resetProgress: () => void;
   t: TFunction;
-};
+}
 
 const mapStateToProps = () => ({});
 const mapDispatchToProps = (dispatch: Dispatch) =>
@@ -42,50 +42,48 @@ function DangerZone({ deleteAccount, resetProgress, t }: DangerZoneProps) {
   }
 
   return (
-    <div className='danger-zone text-center'>
-      <FullWidthRow>
-        <Panel bsStyle='danger'>
-          <Panel.Heading>{t('settings.danger.heading')}</Panel.Heading>
+    <FullWidthRow className='danger-zone text-center'>
+      <Panel bsStyle='danger'>
+        <Panel.Heading>{t('settings.danger.heading')}</Panel.Heading>
+        <Spacer />
+        <p>{t('settings.danger.be-careful')}</p>
+        <FullWidthRow>
+          <Button
+            block={true}
+            bsSize='lg'
+            bsStyle='danger'
+            className='btn-danger'
+            onClick={toggleResetModal}
+            type='button'
+          >
+            {t('settings.danger.reset')}
+          </Button>
+          <ButtonSpacer />
+          <Button
+            block={true}
+            bsSize='lg'
+            bsStyle='danger'
+            className='btn-danger'
+            onClick={toggleDeleteModal}
+            type='button'
+          >
+            {t('settings.danger.delete')}
+          </Button>
           <Spacer />
-          <p>{t('settings.danger.be-careful')}</p>
-          <FullWidthRow>
-            <Button
-              block={true}
-              bsSize='lg'
-              bsStyle='danger'
-              className='btn-danger'
-              onClick={toggleResetModal}
-              type='button'
-            >
-              {t('settings.danger.reset')}
-            </Button>
-            <ButtonSpacer />
-            <Button
-              block={true}
-              bsSize='lg'
-              bsStyle='danger'
-              className='btn-danger'
-              onClick={toggleDeleteModal}
-              type='button'
-            >
-              {t('settings.danger.delete')}
-            </Button>
-            <Spacer />
-          </FullWidthRow>
-        </Panel>
+        </FullWidthRow>
+      </Panel>
 
-        <ResetModal
-          onHide={toggleResetModal}
-          reset={resetProgress}
-          show={reset}
-        />
-        <DeleteModal
-          delete={deleteAccount}
-          onHide={toggleDeleteModal}
-          show={delete_}
-        />
-      </FullWidthRow>
-    </div>
+      <ResetModal
+        onHide={toggleResetModal}
+        reset={resetProgress}
+        show={reset}
+      />
+      <DeleteModal
+        delete={deleteAccount}
+        onHide={toggleDeleteModal}
+        show={delete_}
+      />
+    </FullWidthRow>
   );
 }
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

`div` element was used to carry the classNames, moved them to `FullWidthRow`

![image](https://user-images.githubusercontent.com/88248797/213864702-90889809-da98-4051-ab6e-1fd257cfc2a0.png)

<!-- Feel free to add any additional description of changes below this line -->
