### PR TITLE
fix(a11y): add tabstop on info panel

### DIFF
--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -104,6 +104,22 @@
   overflow: hidden;
 }
 
+#mobile-layout #mobile-layout-pane-instructions {
+  overflow-y: auto;
+}
+
+#mobile-layout-pane-instructions:focus-visible {
+  outline: 3px solid var(--blue-mid);
+  outline-offset: -2px;
+}
+
+@supports not selector(:focus-visible) {
+  #mobile-layout-pane-instructions:focus {
+    outline: 3px solid var(--blue-mid);
+    outline-offset: -2px;
+  }
+}
+
 #mobile-layout .nav-tabs > li.active > a {
   color: var(--quaternary-color);
   background-color: var(--quaternary-background);

--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -88,6 +88,7 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
             <TabPane
               eventKey={Tab.Instructions}
               title={i18next.t('learn.editor-tabs.info')}
+              tabIndex={0}
             >
               {instructions}
             </TabPane>

--- a/client/src/templates/Challenges/components/side-panel.css
+++ b/client/src/templates/Challenges/components/side-panel.css
@@ -8,7 +8,5 @@
 
 .instructions-panel {
   padding: 0 10px;
-  overflow-y: scroll;
-  height: 100%;
   width: 100%;
 }

--- a/client/src/templates/Challenges/components/side-panel.css
+++ b/client/src/templates/Challenges/components/side-panel.css
@@ -8,5 +8,12 @@
 
 .instructions-panel {
   padding: 0 10px;
+  overflow-y: scroll;
+  height: 100%;
   width: 100%;
+}
+
+#mobile-layout-pane-instructions > .instructions-panel {
+  height: auto;
+  overflow-y: none;
 }

--- a/client/src/templates/Challenges/components/side-panel.tsx
+++ b/client/src/templates/Challenges/components/side-panel.tsx
@@ -71,7 +71,11 @@ export function SidePanel({
   }, [block]);
 
   return (
-    <div className='instructions-panel' ref={instructionsPanelRef}>
+    <div
+      className='instructions-panel'
+      ref={instructionsPanelRef}
+      tabIndex={-1}
+    >
       {challengeTitle}
       {challengeDescription}
       {showToolPanel && <ToolPanel guideUrl={guideUrl} videoUrl={videoUrl} />}

--- a/client/src/templates/Challenges/components/side-panel.tsx
+++ b/client/src/templates/Challenges/components/side-panel.tsx
@@ -71,11 +71,7 @@ export function SidePanel({
   }, [block]);
 
   return (
-    <div
-      className='instructions-panel'
-      ref={instructionsPanelRef}
-      tabIndex={-1}
-    >
+    <div className='instructions-panel' ref={instructionsPanelRef}>
       {challengeTitle}
       {challengeDescription}
       {showToolPanel && <ToolPanel guideUrl={guideUrl} videoUrl={videoUrl} />}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

My previous PR removed the tab stop on the Code panel in the mobile layout because it was unnecessary. This PR adds a tab stop on the Info panel because it is definitely necessary in several situations.

- Some Info panels do not have any focusable elements in them and thus it is currently impossible for a keyboard user to scroll the content of the Info panel when needed. See the [Stand in Line challenge](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-javascript/stand-in-line).
- As suggested by the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/#keyboard-interaction-21), unless the first element in the tab panel is focusable then the tab panel itself should be a tab stop. This will be particularly helpful for screen reader users as it will guarantee they always get dropped into the tab panel at the very beginning of the content.

