### PR TITLE
feat(client): remove bloating CSS from RTL file

### DIFF
--- a/client/src/components/layouts/rtl-layout.css
+++ b/client/src/components/layouts/rtl-layout.css
@@ -7,30 +7,12 @@ Increase the spacing in paragraphs
 }
 
 /* 
-breadcrumbs section
-*/
-
-[dir='rtl'] .challenge-title-breadcrumbs ol {
-  padding-right: 0;
-}
-
-/* 
 Intro project buttons and headings 
 */
 
 [dir='rtl'] .monaco-editor-tabs {
-  margin-right: 0;
-}
-
-[dir='rtl'] .panel-display-tabs button:first-child,
-.tabs-row > button:first-child {
-  margin-right: 0;
-  margin-left: 10px;
-}
-
-[dir='rtl'] .map-ui .superblock-link .map-icon {
-  margin-right: 5px;
-  margin-left: 20px;
+  /* need to remove the margin because the editor is reversed */
+  margin-inline-end: 0;
 }
 
 [dir='rtl'] .map-ui .superblock-link > svg {
@@ -52,17 +34,6 @@ fix misaligned text in button and in donation
 
 [dir='rtl'] .link-btn.btn-lg > svg {
   transform: rotate(180deg);
-}
-
-[dir='rtl'] .block-grid .map-title > svg:last-child,
-[dir='rtl'] .map-title .course-title:last-of-type {
-  margin-right: auto;
-  margin-left: 0;
-}
-
-[dir='rtl'] .map-title .course-title:first-of-type {
-  margin-right: 0.35em;
-  margin-left: auto;
 }
 
 /* 
@@ -135,10 +106,6 @@ New RWD project challenge
 
 [dir='rtl'] .tabs-row {
   gap: 10px;
-}
-
-[dir='rtl'] .panel-display-tabs {
-  margin-left: auto;
 }
 
 [dir='rtl'] .monaco-editor-tabs button:not(:first-child) {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Other than 
![image](https://user-images.githubusercontent.com/88248797/214267287-774bfc50-e29c-445d-b552-751b15727ba3.png)

Nothing should be changed, it changed because the original layout changed to use flex and gap, while it was margin first.

---

There are no need for these values anymore, so I removed them

<!-- Feel free to add any additional description of changes below this line -->
