### PR TITLE
fix(client) broken donate button text alignment in RTL layout

### DIFF
--- a/client/src/components/layouts/rtl-layout.css
+++ b/client/src/components/layouts/rtl-layout.css
@@ -38,15 +38,6 @@ Intro project buttons and headings
 }
 
 /* 
-fix misaligned text in button and in donation 
-*/
-
-[dir='rtl'] .link-btn,
-[dir='rtl'] .faq-item h4 {
-  text-align: right;
-}
-
-/* 
  intro to courses section
 */
 

--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -123,7 +123,7 @@ a.cert-tag:active {
   padding: 18px 0;
   background: transparent;
   border: none;
-  text-align: left;
+  text-align: start;
   width: 100%;
 }
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I have used selectors to sort the alignment issue originally, but they are no longer used.

I should have done this from the start, so if someone changes LTR, it does affect RTL too, and they don't need to worry about deleting or adding selector, because one selector is affecting both layout.

![image](https://user-images.githubusercontent.com/88248797/214269102-64476620-7a04-4b4a-b239-ba07ed79bbf0.png)



<!-- Feel free to add any additional description of changes below this line -->
