### PR TITLE
refactor(client): clear selector type error in editor cypress test

### DIFF
--- a/cypress/e2e/default/learn/common-components/editor.ts
+++ b/cypress/e2e/default/learn/common-components/editor.ts
@@ -1,4 +1,4 @@
-const selectors = {
+const editorElement = {
   editor: '.monaco-editor'
 };
 
@@ -7,7 +7,7 @@ describe('Editor Shortcuts', () => {
     cy.visit(
       'learn/responsive-web-design/basic-html-and-html5/say-hello-to-html-elements'
     );
-    cy.get(selectors.editor, { timeout: 15000 })
+    cy.get(editorElement.editor, { timeout: 15000 })
       .first()
       .click()
       .focused()
@@ -19,7 +19,7 @@ describe('Editor Shortcuts', () => {
     cy.visit(
       'learn/responsive-web-design/basic-html-and-html5/say-hello-to-html-elements'
     );
-    cy.get(selectors.editor, { timeout: 15000 })
+    cy.get(editorElement.editor, { timeout: 15000 })
       .first()
       .click()
       .focused()


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Editor had type error in it, which indicated that we shouldn't use selector

<!-- Feel free to add any additional description of changes below this line -->
