### PR TITLE
fix(client): use translated cert name for Legacy Full Stack Certification

### DIFF
--- a/client/src/components/settings/certification.js
+++ b/client/src/components/settings/certification.js
@@ -347,7 +347,7 @@ export class CertificationSettings extends Component {
         <div>
           <p>
             {t('settings.claim-legacy', {
-              cert: 'Legacy Full Stack Certification'
+              cert: t('certification.title.Legacy Full Stack Certification')
             })}
           </p>
           <ul>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

---

<!-- Feel free to add any additional description of changes below this line -->
Use translated certification name in the Legacy Full Stack Certification section in the settings.

**Affected page:**
https://www.freecodecamp.org/japanese/settings (and other languages)

**Current state:**
![image](https://user-images.githubusercontent.com/25644062/214804171-f9df04fe-6ba7-47ba-8093-834b2ae0cf8f.png)

**Fix:**
![image](https://user-images.githubusercontent.com/25644062/214804478-cb245581-8af8-4b52-80f2-61de74abb3e9.png)
