### PR TITLE
fix(api): update mobile-auth ratelimit config

### DIFF
--- a/api-server/src/server/middlewares/rate-limit.js
+++ b/api-server/src/server/middlewares/rate-limit.js
@@ -11,6 +11,9 @@ export default function rateLimitMiddleware() {
     max: 10,
     standardHeaders: true,
     legacyHeaders: false,
+    keyGenerator: req => {
+      return req.headers['x-forwarded-for'] || 'localhost';
+    },
     store: new MongoStore({
       collectionName: 'UserRateLimit',
       uri: url,

--- a/api-server/src/server/middlewares/rate-limit.js
+++ b/api-server/src/server/middlewares/rate-limit.js
@@ -12,6 +12,7 @@ export default function rateLimitMiddleware() {
     standardHeaders: true,
     legacyHeaders: false,
     store: new MongoStore({
+      collectionName: 'UserRateLimit',
       uri: url,
       expireTimeMs: 15 * 60 * 1000
     })


### PR DESCRIPTION
This commit will likely be hot-patched over to production. The collection doesn't need to be created ahead of time, but we want something we can recognize later.


The key generator config should use the IP address in the headers to avoid conflicts.