### PR TITLE
fix(curriculum): Include paragraph tags in edit region

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5ef9b03c81a63668521804e9.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5ef9b03c81a63668521804e9.md
@@ -106,11 +106,9 @@ assert(pText.match(/^no copyright - freecodecamp.org$/));
       </section>
     </main>
     <footer>
-      <p>
 --fcc-editable-region--
-        No Copyright - freeCodeCamp.org
+      <p>No Copyright - freeCodeCamp.org</p>
 --fcc-editable-region--
-      </p>
     </footer>
   </body>
 </html>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #49020

<!-- Feel free to add any additional description of changes below this line -->

I simply moved the paragraph tags inside the edit region for Step 64 of the Cat Photo App. A few times in the issue, it should help prevent some additional confusion. At minimum, it should help the campers that are adding extra paragraph tags. 
