### PR TITLE
fix: trust private network proxies

### DIFF
--- a/api-server/src/server/index.js
+++ b/api-server/src/server/index.js
@@ -28,6 +28,8 @@ const app = loopback();
 app.set('state namespace', '__fcc__');
 app.set('port', process.env.API_PORT || 3000);
 app.set('views', path.join(__dirname, 'views'));
+app.set('trust proxy', ['loopback', 'linklocal', 'uniquelocal']);
+
 app.use(loopback.token());
 app.use(
   morgan(reqLogFormat, { stream: { write: msg => log(_.split(msg, '\n')[0]) } })


### PR DESCRIPTION
If the downstream is inside a private network, the api will assume that
client is the first ip it doesn't recognise as being part of the
network.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This makes `req.ip` return the 'real ip', i.e. the address of the requesting client.  As such, express-rate-limit's [default keygen](https://github.com/express-rate-limit/express-rate-limit#keygenerator) will work.

Related https://github.com/freeCodeCamp/freeCodeCamp/pull/49194

<!-- Feel free to add any additional description of changes below this line -->
