### PR TITLE
fix: validate upcoming changes better

### DIFF
--- a/curriculum/challenges/_meta/build-a-caesars-cipher-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-caesars-cipher-project/meta.json
@@ -1,6 +1,6 @@
 {
     "name": "Build a Caesars Cipher Project",
-    "isUpcomingChange": false,
+    "isUpcomingChange": true,
     "usesMultifileEditor": false,
     "order": 17,
     "time": "30 hours",
@@ -13,4 +13,3 @@
       "Build a Caesars Cipher"
     ]
     ]}
-  

--- a/curriculum/challenges/_meta/build-a-cash-register-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-cash-register-project/meta.json
@@ -1,6 +1,6 @@
 {
     "name": "Build a Cash Register Project",
-    "isUpcomingChange": false,
+    "isUpcomingChange": true,
     "usesMultifileEditor": false,
     "order": 14,
     "time": "30 hours",
@@ -13,4 +13,3 @@
             "Build a Cash Register"
           ]
     ]}
-  

--- a/curriculum/challenges/_meta/build-a-palindrome-checker-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-palindrome-checker-project/meta.json
@@ -1,6 +1,6 @@
 {
     "name": "Build a Palindrome Checker Project",
-    "isUpcomingChange": false,
+    "isUpcomingChange": true,
     "usesMultifileEditor": false,
     "order": 3,
     "time": "30 hours",
@@ -13,4 +13,3 @@
             "Build a Palindrome Checker"
           ]
     ]}
-  

--- a/curriculum/challenges/_meta/build-a-roman-numeral-converter-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-roman-numeral-converter-project/meta.json
@@ -1,6 +1,6 @@
 {
     "name": "Build a Roman Numeral Converter Project",
-    "isUpcomingChange": false,
+    "isUpcomingChange": true,
     "usesMultifileEditor": false,
     "order": 6,
     "time": "30 hours",
@@ -13,4 +13,3 @@
             "Build a Roman Numeral Converter"
           ]
     ]}
-  

--- a/curriculum/challenges/_meta/build-a-telephone-number-validator-project/meta.json
+++ b/curriculum/challenges/_meta/build-a-telephone-number-validator-project/meta.json
@@ -1,6 +1,6 @@
 {
     "name": "Build a Telephone Number Validator Project",
-    "isUpcomingChange": false,
+    "isUpcomingChange": true,
     "usesMultifileEditor": false,
     "order": 10,
     "time": "30 hours",
@@ -13,4 +13,3 @@
             "Build a Telephone Number Validator"
           ]
     ]}
-  

--- a/curriculum/getChallenges.js
+++ b/curriculum/getChallenges.js
@@ -219,14 +219,6 @@ async function buildChallenges({ path: filePath }, curriculum, lang) {
   }
   const { meta } = challengeBlock;
   const isCert = path.extname(filePath) === '.yml';
-  // TODO: there's probably a better way, but this makes sure we don't build any
-  // of the new curriculum when we don't want it.
-  if (
-    !showUpcomingChanges &&
-    meta?.superBlock === '2022/javascript-algorithms-and-data-structures'
-  ) {
-    return;
-  }
   const createChallenge = generateChallengeCreator(CHALLENGES_DIR, lang);
   const challenge = isCert
     ? await createCertification(CHALLENGES_DIR, filePath, lang)

--- a/curriculum/getChallenges.js
+++ b/curriculum/getChallenges.js
@@ -1,9 +1,8 @@
 const fs = require('fs');
 const path = require('path');
 const util = require('util');
-const assert = require('assert');
 const yaml = require('js-yaml');
-const { findIndex, isEmpty } = require('lodash');
+const { findIndex } = require('lodash');
 const readDirP = require('readdirp');
 const { helpCategoryMap } = require('../client/utils/challenge-types');
 const { showUpcomingChanges } = require('../config/env.json');
@@ -151,9 +150,6 @@ exports.getChallengesForLang = async function getChallengesForLang(lang) {
     { type: 'directories', depth: 0 },
     buildSuperBlocks
   );
-  Object.entries(curriculum).forEach(([name, superBlock]) => {
-    assert(!isEmpty(superBlock.blocks), `superblock ${name} has no blocks`);
-  });
   const cb = (file, curriculum) => buildChallenges(file, curriculum, lang);
   // fill the scaffold with the challenges
   return walk(
@@ -166,11 +162,15 @@ exports.getChallengesForLang = async function getChallengesForLang(lang) {
 
 async function buildBlocks({ basename: blockName }, curriculum, superBlock) {
   const metaPath = path.resolve(META_DIR, `${blockName}/meta.json`);
+  const isCertification = !fs.existsSync(metaPath);
+  if (isCertification && superBlock !== 'certifications')
+    throw Error(
+      `superblock ${superBlock} is missing meta.json for ${blockName}`
+    );
 
-  if (fs.existsSync(metaPath)) {
-    // try to read the file, if the meta path does not exist it should be a certification.
-    // As they do not have meta files.
-
+  if (isCertification) {
+    curriculum['certifications'].blocks[blockName] = { challenges: [] };
+  } else {
     const blockMeta = JSON.parse(fs.readFileSync(metaPath));
 
     const { isUpcomingChange } = blockMeta;
@@ -186,8 +186,6 @@ async function buildBlocks({ basename: blockName }, curriculum, superBlock) {
       const blockInfo = { meta: blockMeta, challenges: [] };
       curriculum[superBlock].blocks[blockName] = blockInfo;
     }
-  } else {
-    curriculum['certifications'].blocks[blockName] = { challenges: [] };
   }
 }
 


### PR DESCRIPTION
- fix: mark new JS projects as upcoming changes
- fix: verify all non-cert superblocks have metas
- fix: remove special handling of new JS challenges

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

While working on https://github.com/freeCodeCamp/freeCodeCamp/pull/49202 with @Sembauke I realised that the new JS curriculum was being handled as a special case. Also, requiring all superblocks to have blocks is too strong of a constraint because we do not add blocks to the curriculum object for upcoming changes.

<!-- Feel free to add any additional description of changes below this line -->
