### PR TITLE
fix(client): move console in multi-file editor

### DIFF
--- a/client/src/templates/Challenges/classic/desktop-layout.tsx
+++ b/client/src/templates/Challenges/classic/desktop-layout.tsx
@@ -174,27 +174,26 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
           </ReflexElement>
         )}
 
-        {displayPreviewPane && (
-          <ReflexSplitter propagate={true} {...resizeProps} />
-        )}
-        {displayPreviewPane && (
-          <ReflexElement flex={previewPane.flex} {...resizeProps}>
-            <ReflexContainer orientation='horizontal'>
-              <ReflexElement flex={previewPane.flex} {...resizeProps}>
-                {preview}
-              </ReflexElement>
-              {displayConsole && (
-                <ReflexSplitter propagate={true} {...resizeProps} />
-              )}
-              {displayConsole && (
-                <ReflexElement flex={testsPane.flex} {...resizeProps}>
+        {(projectBasedChallenge || isMultifileCertProject) &&
+          (displayPreviewPane || displayConsole) && (
+            <ReflexSplitter propagate={true} {...resizeProps} />
+          )}
+        {(projectBasedChallenge || isMultifileCertProject) &&
+          (displayPreviewPane || displayConsole) && (
+            <ReflexElement flex={previewPane.flex} {...resizeProps}>
+              <ReflexContainer orientation='horizontal'>
+                {displayPreviewPane && <ReflexElement>{preview}</ReflexElement>}
+                {displayPreviewPane && displayConsole && (
                   <ReflexSplitter propagate={true} {...resizeProps} />
-                  {testOutput}
-                </ReflexElement>
-              )}
-            </ReflexContainer>
-          </ReflexElement>
-        )}
+                )}
+                {displayConsole && (
+                  <ReflexElement flex={testsPane.flex} {...resizeProps}>
+                    {testOutput}
+                  </ReflexElement>
+                )}
+              </ReflexContainer>
+            </ReflexElement>
+          )}
       </ReflexContainer>
       {displayPreviewPortal && (
         <PreviewPortal togglePane={togglePane} windowTitle={windowTitle}>

--- a/client/src/templates/Challenges/classic/desktop-layout.tsx
+++ b/client/src/templates/Challenges/classic/desktop-layout.tsx
@@ -102,13 +102,8 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
   const displayPreviewPane = hasPreview && showPreviewPane;
   const displayPreviewPortal = hasPreview && showPreviewPortal;
   const displayNotes = projectBasedChallenge ? showNotes && hasNotes : false;
-  const displayEditorConsole = !(
-    projectBasedChallenge || isMultifileCertProject
-  )
-    ? true
-    : false;
-  const displayPreviewConsole =
-    (projectBasedChallenge || isMultifileCertProject) && showConsole;
+  const displayConsole =
+    projectBasedChallenge || isMultifileCertProject ? showConsole : true;
   const {
     codePane,
     editorPane,
@@ -155,18 +150,20 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
               >
                 {editor}
               </ReflexElement>
-              {displayEditorConsole && (
-                <ReflexSplitter propagate={true} {...resizeProps} />
-              )}
-              {displayEditorConsole && (
-                <ReflexElement
-                  flex={testsPane.flex}
-                  {...reflexProps}
-                  {...resizeProps}
-                >
-                  {testOutput}
-                </ReflexElement>
-              )}
+              {!(projectBasedChallenge || isMultifileCertProject) &&
+                displayConsole && (
+                  <ReflexSplitter propagate={true} {...resizeProps} />
+                )}
+              {!(projectBasedChallenge || isMultifileCertProject) &&
+                displayConsole && (
+                  <ReflexElement
+                    flex={testsPane.flex}
+                    {...reflexProps}
+                    {...resizeProps}
+                  >
+                    {testOutput}
+                  </ReflexElement>
+                )}
             </ReflexContainer>
           )}
         </ReflexElement>
@@ -186,10 +183,10 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
               <ReflexElement flex={previewPane.flex} {...resizeProps}>
                 {preview}
               </ReflexElement>
-              {displayPreviewConsole && (
+              {displayConsole && (
                 <ReflexSplitter propagate={true} {...resizeProps} />
               )}
-              {displayPreviewConsole && (
+              {displayConsole && (
                 <ReflexElement flex={testsPane.flex} {...resizeProps}>
                   <ReflexSplitter propagate={true} {...resizeProps} />
                   {testOutput}

--- a/client/src/templates/Challenges/classic/desktop-layout.tsx
+++ b/client/src/templates/Challenges/classic/desktop-layout.tsx
@@ -102,8 +102,13 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
   const displayPreviewPane = hasPreview && showPreviewPane;
   const displayPreviewPortal = hasPreview && showPreviewPortal;
   const displayNotes = projectBasedChallenge ? showNotes && hasNotes : false;
-  const displayConsole =
-    projectBasedChallenge || isMultifileCertProject ? showConsole : true;
+  const displayEditorConsole = !(
+    projectBasedChallenge || isMultifileCertProject
+  )
+    ? true
+    : false;
+  const displayPreviewConsole =
+    (projectBasedChallenge || isMultifileCertProject) && showConsole;
   const {
     codePane,
     editorPane,
@@ -150,10 +155,10 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
               >
                 {editor}
               </ReflexElement>
-              {displayConsole && (
+              {displayEditorConsole && (
                 <ReflexSplitter propagate={true} {...resizeProps} />
               )}
-              {displayConsole && (
+              {displayEditorConsole && (
                 <ReflexElement
                   flex={testsPane.flex}
                   {...reflexProps}
@@ -177,7 +182,20 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
         )}
         {displayPreviewPane && (
           <ReflexElement flex={previewPane.flex} {...resizeProps}>
-            {preview}
+            <ReflexContainer orientation='horizontal'>
+              <ReflexElement flex={previewPane.flex} {...resizeProps}>
+                {preview}
+              </ReflexElement>
+              {displayPreviewConsole && (
+                <ReflexSplitter propagate={true} {...resizeProps} />
+              )}
+              {displayPreviewConsole && (
+                <ReflexElement flex={testsPane.flex} {...resizeProps}>
+                  <ReflexSplitter propagate={true} {...resizeProps} />
+                  {testOutput}
+                </ReflexElement>
+              )}
+            </ReflexContainer>
           </ReflexElement>
         )}
       </ReflexContainer>

--- a/client/src/templates/Challenges/classic/desktop-layout.tsx
+++ b/client/src/templates/Challenges/classic/desktop-layout.tsx
@@ -102,8 +102,13 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
   const displayPreviewPane = hasPreview && showPreviewPane;
   const displayPreviewPortal = hasPreview && showPreviewPortal;
   const displayNotes = projectBasedChallenge ? showNotes && hasNotes : false;
-  const displayConsole =
-    projectBasedChallenge || isMultifileCertProject ? showConsole : true;
+  const displayEditorConsole = !(
+    projectBasedChallenge || isMultifileCertProject
+  )
+    ? true
+    : false;
+  const displayPreviewConsole =
+    (projectBasedChallenge || isMultifileCertProject) && showConsole;
   const {
     codePane,
     editorPane,
@@ -150,20 +155,18 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
               >
                 {editor}
               </ReflexElement>
-              {!(projectBasedChallenge || isMultifileCertProject) &&
-                displayConsole && (
-                  <ReflexSplitter propagate={true} {...resizeProps} />
-                )}
-              {!(projectBasedChallenge || isMultifileCertProject) &&
-                displayConsole && (
-                  <ReflexElement
-                    flex={testsPane.flex}
-                    {...reflexProps}
-                    {...resizeProps}
-                  >
-                    {testOutput}
-                  </ReflexElement>
-                )}
+              {displayEditorConsole && (
+                <ReflexSplitter propagate={true} {...resizeProps} />
+              )}
+              {displayEditorConsole && (
+                <ReflexElement
+                  flex={testsPane.flex}
+                  {...reflexProps}
+                  {...resizeProps}
+                >
+                  {testOutput}
+                </ReflexElement>
+              )}
             </ReflexContainer>
           )}
         </ReflexElement>
@@ -174,26 +177,24 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
           </ReflexElement>
         )}
 
-        {(projectBasedChallenge || isMultifileCertProject) &&
-          (displayPreviewPane || displayConsole) && (
-            <ReflexSplitter propagate={true} {...resizeProps} />
-          )}
-        {(projectBasedChallenge || isMultifileCertProject) &&
-          (displayPreviewPane || displayConsole) && (
-            <ReflexElement flex={previewPane.flex} {...resizeProps}>
-              <ReflexContainer orientation='horizontal'>
-                {displayPreviewPane && <ReflexElement>{preview}</ReflexElement>}
-                {displayPreviewPane && displayConsole && (
-                  <ReflexSplitter propagate={true} {...resizeProps} />
-                )}
-                {displayConsole && (
-                  <ReflexElement flex={testsPane.flex} {...resizeProps}>
-                    {testOutput}
-                  </ReflexElement>
-                )}
-              </ReflexContainer>
-            </ReflexElement>
-          )}
+        {(displayPreviewPane || displayPreviewConsole) && (
+          <ReflexSplitter propagate={true} {...resizeProps} />
+        )}
+        {(displayPreviewPane || displayPreviewConsole) && (
+          <ReflexElement flex={previewPane.flex} {...resizeProps}>
+            <ReflexContainer orientation='horizontal'>
+              {displayPreviewPane && <ReflexElement>{preview}</ReflexElement>}
+              {displayPreviewPane && displayPreviewConsole && (
+                <ReflexSplitter propagate={true} {...resizeProps} />
+              )}
+              {displayPreviewConsole && (
+                <ReflexElement flex={testsPane.flex} {...resizeProps}>
+                  {testOutput}
+                </ReflexElement>
+              )}
+            </ReflexContainer>
+          </ReflexElement>
+        )}
       </ReflexContainer>
       {displayPreviewPortal && (
         <PreviewPortal togglePane={togglePane} windowTitle={windowTitle}>

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -142,7 +142,7 @@ const BASE_LAYOUT = {
   codePane: { flex: 1 },
   editorPane: { flex: 1 },
   instructionPane: { flex: 1 },
-  previewPane: { flex: 1 },
+  previewPane: { flex: 0.7 },
   notesPane: { flex: 0.7 },
   testsPane: { flex: 0.3 }
 };

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -142,7 +142,7 @@ const BASE_LAYOUT = {
   codePane: { flex: 1 },
   editorPane: { flex: 1 },
   instructionPane: { flex: 1 },
-  previewPane: { flex: 0.7 },
+  previewPane: { flex: 1 },
   notesPane: { flex: 0.7 },
   testsPane: { flex: 0.3 }
 };


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
One of the main suggestions we got from volunteers who gave early feedback on the JS RPG is that the console would be easier to use on the right side of the screen. The changes here move the console to the right preview pane.

When the preview is open it appears below the preview:

![image](https://user-images.githubusercontent.com/2051070/216257364-f3fd73c2-e8f0-4eb9-a7b9-de53914e8353.png)

And when the preview is closed and the console button is clicked, it opens up where the preview would normally be, and takes up all of the vertical space in that pane:

![image](https://user-images.githubusercontent.com/2051070/216257485-ceba6452-70d6-410b-beb2-b857f268b92d.png)

We can also implement Tom's suggestion of adding a pop-out button for the console and having the console open by default for the new JS challenges in future PRs.