### PR TITLE
fix(curriculum): soften regex test ad-node

### DIFF
--- a/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/implementation-of-social-authentication-iii.md
+++ b/curriculum/challenges/english/06-quality-assurance/advanced-node-and-express/implementation-of-social-authentication-iii.md
@@ -61,7 +61,7 @@ async (getUserInput) => {
   );
   assert.match(
     data,
-    /GitHubStrategy[^]*return cb/gi,
+    /GitHubStrategy[^]*cb/gi,
     'Strategy should return the callback function "cb"'
   );
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

As mentioned on this forum post: https://forum.freecodecamp.org/t/does-not-pass-the-test-quality-assurance-course-advanced-node-and-express-implementation-of-social-authentication-iii/589424

The test causes valid code to fail:

```js
() => cb
```

These tests are already so lenient; I do not see the harm in softening this one as well.