### PR TITLE
Fixed Spanglish instructions to only Spanish

### DIFF
--- a/curriculum/challenges/espanol/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148da157cc0bd0d06df5c0a.md
+++ b/curriculum/challenges/espanol/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148da157cc0bd0d06df5c0a.md
@@ -7,7 +7,7 @@ dashedName: step-57
 
 # --description--
 
-To align the input boxes with each other, create a new ruleset that targets all `input` and `label` elements within an `.info` element and set the `display` property to `inline-block`.
+Para alinear los cuadros de entrada entre sí, crea un nuevo conjunto de selectores que apunte a todos los elementos `input` y `label` que se encuentren dentro de un elemento `.info` y establece la propiedad de `display` a `inline-block`.
 
 Alinea también el texto del elemento `label` a la derecha.
 


### PR DESCRIPTION
The previous instructions mixed two languages when its intended to be only in Spanish.

Previous: 

Paso 57

To align the input boxes with each other, create a new ruleset that targets all input and label elements within an .info element and set the display property to inline-block.

Alinea también el texto del elemento label a la derecha.

New: 

Para alinear los cuadros de entrada entre sí, crea un nuevo conjunto de selectores que apunte a todos los elementos `input` y `label` que se encuentren dentro de un elemento `.info` y establece la propiedad de `display` a `inline-block`.

Alinea también el texto del elemento `label` a la derecha.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
