### PR TITLE
Issue #49297 Help Button is now Obvious 

### DIFF
--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -194,8 +194,10 @@ const LowerJaw = ({
             aria-label={t('buttons.reset-step')}
             data-cy='reset-code-button'
             onClick={openResetModal}
+            style={{display: 'flex' , justifyContent: 'center' , alignItems : 'center'}}
           >
             <Reset />
+            <div style={{paddingLeft: '.3rem'}}>Help</div>
           </button>
 
           {isAttemptsLargerThanTest && !challengeIsCompleted ? (
@@ -206,8 +208,10 @@ const LowerJaw = ({
               aria-label={t('buttons.get-help')}
               data-cy='get-help-button'
               onClick={openHelpModal}
+              style={{display: 'flex' , justifyContent: 'center' , alignItems : 'center'}}
             >
               <Help />
+              <div style={{paddingLeft: '.3rem'}}>Help</div>
             </button>
           ) : null}
         </div>


### PR DESCRIPTION
* Added more information in the Reset and Help buttons.
* Used the design recommended in the issue: https://forum.freecodecamp.org/t/new-help-button-not-obvious/571552/7.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the #49297below with the issue number.-->

Closes #49297

<!-- Feel free to add any additional description of changes below this line -->
* Added texts inside the Reset and Help buttons along with the SVG.
* The code output for Reset and Help buttons : 

![free3](https://user-images.githubusercontent.com/103327712/217737015-b1ee1f79-c891-4ed3-b1f5-5f14509aa4e6.png)

* No merge conflicts in this PR until now.