### PR TITLE
feat(client): pull percentage challenge data from redux

### DIFF
--- a/client/src/components/layouts/default.tsx
+++ b/client/src/components/layouts/default.tsx
@@ -4,6 +4,7 @@ import { TFunction, withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
 import { createSelector } from 'reselect';
+import { useStaticQuery, graphql } from 'gatsby';
 
 import latoBoldURL from '../../../static/fonts/lato/Lato-Bold.woff';
 import latoLightURL from '../../../static/fonts/lato/Lato-Light.woff';
@@ -16,7 +17,8 @@ import { isBrowser } from '../../../utils';
 import {
   fetchUser,
   onlineStatusChange,
-  serverStatusChange
+  serverStatusChange,
+  loadAllChallengesInfo
 } from '../../redux/actions';
 import {
   isSignedInSelector,
@@ -26,7 +28,12 @@ import {
   userFetchStateSelector
 } from '../../redux/selectors';
 
-import { UserFetchState, User } from '../../redux/prop-types';
+import {
+  UserFetchState,
+  User,
+  AllChallengeNode,
+  CertificateNode
+} from '../../redux/prop-types';
 import BreadCrumb from '../../templates/Challenges/components/bread-crumb';
 import Flash from '../Flash';
 import { flashMessageSelector, removeFlashMessage } from '../Flash/redux';
@@ -77,7 +84,8 @@ const mapDispatchToProps = (dispatch: Dispatch) =>
       fetchUser,
       removeFlashMessage,
       onlineStatusChange,
-      serverStatusChange
+      serverStatusChange,
+      loadAllChallengesInfo
     },
     dispatch
   );
@@ -117,10 +125,13 @@ function DefaultLayout({
   t,
   theme = Themes.Default,
   user,
-  fetchUser
+  fetchUser,
+  loadAllChallengesInfo
 }: DefaultLayoutProps): JSX.Element {
+  const { challengeEdges, certificateNodes } = useGetAllBlockIds();
   useEffect(() => {
     // componentDidMount
+    loadAllChallengesInfo({ challengeEdges, certificateNodes });
     if (!isSignedIn) {
       fetchUser();
     }
@@ -236,6 +247,49 @@ function DefaultLayout({
     );
   }
 }
+
+const useGetAllBlockIds = () => {
+  const {
+    allChallengeNode: { edges: challengeEdges },
+    allCertificateNode: { nodes: certificateNodes }
+  }: {
+    allChallengeNode: AllChallengeNode;
+    allCertificateNode: { nodes: CertificateNode[] };
+  } = useStaticQuery(graphql`
+    query getBlockNod {
+      allChallengeNode(
+        sort: {
+          fields: [
+            challenge___superOrder
+            challenge___order
+            challenge___challengeOrder
+          ]
+        }
+      ) {
+        edges {
+          node {
+            challenge {
+              block
+              id
+            }
+          }
+        }
+      }
+      allCertificateNode {
+        nodes {
+          challenge {
+            certification
+            tests {
+              id
+            }
+          }
+        }
+      }
+    }
+  `);
+
+  return { challengeEdges, certificateNodes };
+};
 
 DefaultLayout.displayName = 'DefaultLayout';
 

--- a/client/src/components/layouts/default.tsx
+++ b/client/src/components/layouts/default.tsx
@@ -18,7 +18,7 @@ import {
   fetchUser,
   onlineStatusChange,
   serverStatusChange,
-  loadAllChallengesInfo
+  updateAllChallengesInfo
 } from '../../redux/actions';
 import {
   isSignedInSelector,
@@ -85,7 +85,7 @@ const mapDispatchToProps = (dispatch: Dispatch) =>
       removeFlashMessage,
       onlineStatusChange,
       serverStatusChange,
-      loadAllChallengesInfo
+      updateAllChallengesInfo
     },
     dispatch
   );
@@ -126,12 +126,12 @@ function DefaultLayout({
   theme = Themes.Default,
   user,
   fetchUser,
-  loadAllChallengesInfo
+  updateAllChallengesInfo
 }: DefaultLayoutProps): JSX.Element {
   const { challengeEdges, certificateNodes } = useGetAllBlockIds();
   useEffect(() => {
     // componentDidMount
-    loadAllChallengesInfo({ challengeEdges, certificateNodes });
+    updateAllChallengesInfo({ challengeEdges, certificateNodes });
     if (!isSignedIn) {
       fetchUser();
     }

--- a/client/src/components/layouts/default.tsx
+++ b/client/src/components/layouts/default.tsx
@@ -248,6 +248,7 @@ function DefaultLayout({
   }
 }
 
+// TODO: get challenge nodes directly rather than wrapped in edges
 const useGetAllBlockIds = () => {
   const {
     allChallengeNode: { edges: challengeEdges },
@@ -256,7 +257,7 @@ const useGetAllBlockIds = () => {
     allChallengeNode: AllChallengeNode;
     allCertificateNode: { nodes: CertificateNode[] };
   } = useStaticQuery(graphql`
-    query getBlockNod {
+    query getBlockNode {
       allChallengeNode(
         sort: {
           fields: [

--- a/client/src/redux/action-types.js
+++ b/client/src/redux/action-types.js
@@ -27,7 +27,7 @@ export const actionTypes = createTypes(
     'updateDonationFormState',
     'updateUserToken',
     'postChargeProcessing',
-    'loadAllChallengesInfo',
+    'updateAllChallengesInfo',
     ...createAsyncTypes('fetchUser'),
     ...createAsyncTypes('postCharge'),
     ...createAsyncTypes('fetchProfileForUser'),

--- a/client/src/redux/action-types.js
+++ b/client/src/redux/action-types.js
@@ -27,6 +27,7 @@ export const actionTypes = createTypes(
     'updateDonationFormState',
     'updateUserToken',
     'postChargeProcessing',
+    'loadAllChallengesInfo',
     ...createAsyncTypes('fetchUser'),
     ...createAsyncTypes('postCharge'),
     ...createAsyncTypes('fetchProfileForUser'),

--- a/client/src/redux/actions.js
+++ b/client/src/redux/actions.js
@@ -53,8 +53,8 @@ export const fetchUser = createAction(actionTypes.fetchUser);
 export const fetchUserComplete = createAction(actionTypes.fetchUserComplete);
 export const fetchUserError = createAction(actionTypes.fetchUserError);
 
-export const loadAllChallengesInfo = createAction(
-  actionTypes.loadAllChallengesInfo
+export const updateAllChallengesInfo = createAction(
+  actionTypes.updateAllChallengesInfo
 );
 
 export const postCharge = createAction(actionTypes.postCharge);

--- a/client/src/redux/actions.js
+++ b/client/src/redux/actions.js
@@ -53,6 +53,10 @@ export const fetchUser = createAction(actionTypes.fetchUser);
 export const fetchUserComplete = createAction(actionTypes.fetchUserComplete);
 export const fetchUserError = createAction(actionTypes.fetchUserError);
 
+export const loadAllChallengesInfo = createAction(
+  actionTypes.loadAllChallengesInfo
+);
+
 export const postCharge = createAction(actionTypes.postCharge);
 export const postChargeProcessing = createAction(
   actionTypes.postChargeProcessing

--- a/client/src/redux/index.js
+++ b/client/src/redux/index.js
@@ -56,7 +56,10 @@ const initialState = {
   userFetchState: {
     ...defaultFetchState
   },
-  allChallengesInfo: {},
+  allChallengesInfo: {
+    challengeEdges: [],
+    certificateNodes: [],
+  },
   userProfileFetchState: {
     ...defaultFetchState
   },

--- a/client/src/redux/index.js
+++ b/client/src/redux/index.js
@@ -56,6 +56,7 @@ const initialState = {
   userFetchState: {
     ...defaultFetchState
   },
+  allChallengesInfo: {},
   userProfileFetchState: {
     ...defaultFetchState
   },
@@ -153,7 +154,10 @@ export const reducer = handleActions(
       ...state,
       donationFormState: { ...defaultDonationFormState, error: payload }
     }),
-
+    [actionTypes.loadAllChallengesInfo]: (state, { payload }) => ({
+      ...state,
+      allChallengesInfo: { ...payload }
+    }),
     [actionTypes.fetchUser]: state => ({
       ...state,
       userFetchState: { ...defaultFetchState }

--- a/client/src/redux/index.js
+++ b/client/src/redux/index.js
@@ -58,7 +58,7 @@ const initialState = {
   },
   allChallengesInfo: {
     challengeEdges: [],
-    certificateNodes: [],
+    certificateNodes: []
   },
   userProfileFetchState: {
     ...defaultFetchState
@@ -157,7 +157,7 @@ export const reducer = handleActions(
       ...state,
       donationFormState: { ...defaultDonationFormState, error: payload }
     }),
-    [actionTypes.loadAllChallengesInfo]: (state, { payload }) => ({
+    [actionTypes.updateAllChallengesInfo]: (state, { payload }) => ({
       ...state,
       allChallengesInfo: { ...payload }
     }),

--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -142,6 +142,19 @@ export type ChallengeNode = {
   };
 };
 
+export type CertificateNode = {
+  challenge: {
+    // TODO: use enum
+    certification: string;
+    tests: { id: string }[];
+  };
+};
+
+export type AllChallengesInfo = {
+  challengeEdges: { node: ChallengeNode }[];
+  certificateNodes: CertificateNode[];
+};
+
 export type AllChallengeNode = {
   edges: [
     {

--- a/client/src/redux/selectors.js
+++ b/client/src/redux/selectors.js
@@ -202,6 +202,8 @@ export const certificatesByNameSelector = username => state => {
 };
 
 export const userFetchStateSelector = state => state[MainApp].userFetchState;
+export const allChallengesInfoSelector = state =>
+  state[MainApp].allChallengesInfo;
 export const userProfileFetchStateSelector = state =>
   state[MainApp].userProfileFetchState;
 export const usernameSelector = state => state[MainApp].appUsername;


### PR DESCRIPTION
This pr attempts to move the data that is required for calculating block completion percentage and showing the donation block.

Here are the things to test for this pr:
1) check if performance of landing page changes (chrome audit/ lighthouse)
2) check if percentage calculation is correct on the completion modal.(NA for new RWD)
3) check if the donation block pop up at the end of block(NA for new RWD)

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related: https://github.com/freeCodeCamp/freeCodeCamp/pull/46811
<!-- Feel free to add any additional description of changes below this line -->
