### PR TITLE
feat(client): hide the console when the file is multifile editor

### DIFF
--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -101,13 +101,15 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
             {usesMultifileEditor && <EditorTabs />}
             {editor}
           </TabPane>
-          <TabPane
-            eventKey={Tab.Console}
-            title={i18next.t('learn.editor-tabs.console')}
-            {...editorTabPaneProps}
-          >
-            {testOutput}
-          </TabPane>
+          {usesMultifileEditor && (
+            <TabPane
+              eventKey={Tab.Console}
+              title={i18next.t('learn.editor-tabs.console')}
+              {...editorTabPaneProps}
+            >
+              {testOutput}
+            </TabPane>
+          )}
           {hasNotes && usesMultifileEditor && (
             <TabPane
               eventKey={Tab.Notes}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Console isn't used in the new RWD, and part of the legacy system. Although the new JavaScript certification is coming, it isn't here and we need to create new logic to check if the multifileeditor isn't in JavaScript course, and hides the hints from the markdown file.

 For now I think it's the best to hide it entirely, until needed. to give credit due, I think Ahmad found out the issue in my last meeting with him, I just remembered it while working on refactoring.

![image](https://user-images.githubusercontent.com/88248797/217880054-beb388d2-b943-415b-9821-ab0c19a6aefd.png)


<!-- Feel free to add any additional description of changes below this line -->
