### PR TITLE
fix: update github actions trigger configs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,13 +1,15 @@
 name: CI - Run CodeQL Analysis
 on:
   push:
-    branches: [main]
     paths-ignore:
       - 'docs/**'
+    branches:
+      - 'main'
   pull_request:
-    branches: [main]
     paths-ignore:
       - 'docs/**'
+    branches:
+      - 'main'
 
 permissions:
   contents: read

--- a/.github/workflows/e2e-mobile.yml
+++ b/.github/workflows/e2e-mobile.yml
@@ -4,11 +4,14 @@ on:
   # push:
   #   paths-ignore:
   #     - 'docs/**'
-  #   branches-ignore:
-  #     - 'renovate/**'
+  #   branches:
+  #     - 'main'
   # pull_request:
   #   paths-ignore:
   #     - 'docs/**'
+  #   branches:
+  #     - 'main'
+  #     - 'next-**'
 
 jobs:
   mobile-test:

--- a/.github/workflows/e2e-third-party.yml
+++ b/.github/workflows/e2e-third-party.yml
@@ -5,7 +5,7 @@ name: CI - E2E - 3rd party donation tests
 on:
   push:
     branches:
-      - 'prod-*'
+      - 'prod-**'
     paths-ignore:
       - 'docs/**'
 

--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -3,14 +3,14 @@ on:
   push:
     paths-ignore:
       - 'docs/**'
-    branches-ignore:
-      - 'renovate/**'
-      - 'next-api'
+    branches:
+      - 'main'
   pull_request:
     paths-ignore:
       - 'docs/**'
-    branches-ignore:
-      - 'next-api'
+    branches:
+      - 'main'
+      - 'next-**'
 
 jobs:
   build-client:

--- a/.github/workflows/node.js-tests-upcoming.yml
+++ b/.github/workflows/node.js-tests-upcoming.yml
@@ -2,14 +2,20 @@ name: CI - Node.js Test Upcoming
 env:
   NODE_OPTIONS: '--max_old_space_size=6144'
 on:
+  # Run on push events, but only for the below branches
   push:
     branches:
-      # Treat the below branches as special case for working on workflows
-      - actions-**
-      - upcoming-**
+      - 'main'
+      - 'prod-**'
+  # Run on pull requests, but only for the below targets
+  pull_request:
+    branches:
+      - 'main'
+      - 'next-**'
   schedule:
     # run this Action every 14 days
     - cron: '0 * */14 * *'
+  # Run on demand
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -1,14 +1,21 @@
 name: CI - Node.js Test Current
 env:
   NODE_OPTIONS: '--max_old_space_size=6144'
+
 on:
+  # Run on push events, but only for the below branches
   push:
-    branches-ignore:
-      - 'renovate/**'
-      - 'next-api'
+    branches:
+      - 'main'
+      - 'prod-**'
+  # Run on pull requests, but only for the below targets
   pull_request:
-    branches-ignore:
-      - 'next-api'
+    branches:
+      - 'main'
+      - 'next-**'
+  # Run on Merge Queue
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read


### PR DESCRIPTION
Here the aim is to make sure that our GitHub workflows (especially the ones that we use for testing, etc.) are triggered only when: 

- A PR opened targeting one of our primary work branches, like `main` or `next-**`(for feature dev, etc.).
- A commit (including a PR merge) is merged into one of the branches like `main` or `prod-**`.

This covers all scenarios where we do checks. For example, we do not need to run workflows when pushing to a `renovate/**` branch, which will overlap with PR that targets `main`, and so on.