### PR TITLE
refactor(client): the instruction inside the editor

### DIFF
--- a/client/src/templates/Challenges/classic/action-row.tsx
+++ b/client/src/templates/Challenges/classic/action-row.tsx
@@ -50,47 +50,45 @@ const ActionRow = ({
   }
 
   return (
-    <div className='action-row'>
-      <div className='tabs-row'>
-        {!isProjectBasedChallenge && (
-          <button
-            aria-expanded={!!showInstructions}
-            onClick={() => togglePane('showInstructions')}
-          >
-            {t('learn.editor-tabs.instructions')}
-          </button>
-        )}
-        <EditorTabs />
-        <div className='panel-display-tabs'>
-          <button
-            aria-expanded={!!showConsole}
-            onClick={() => togglePane('showConsole')}
-          >
-            {t('learn.editor-tabs.console')}
-          </button>
-          {hasNotes && (
-            <button
-              aria-expanded={!!showNotes}
-              onClick={() => togglePane('showNotes')}
-            >
-              {t('learn.editor-tabs.notes')}
-            </button>
-          )}
-          <button
-            aria-expanded={!!showPreviewPane}
-            onClick={() => togglePane('showPreviewPane')}
-          >
-            <span className='sr-only'>{getPreviewBtnsSrText().pane}</span>
-            <span aria-hidden='true'>{t('learn.editor-tabs.preview')}</span>
-          </button>
-          <button
-            aria-expanded={!!showPreviewPortal}
-            onClick={() => togglePane('showPreviewPortal')}
-          >
-            <span className='sr-only'>{getPreviewBtnsSrText().portal}</span>
-            <FontAwesomeIcon icon={faWindowRestore} />
-          </button>
-        </div>
+    <div className='monaco-editor-tabs'>
+      {!isProjectBasedChallenge && (
+        <button
+          aria-expanded={showInstructions}
+          onClick={() => togglePane('showInstructions')}
+        >
+          {t('learn.editor-tabs.instructions')}
+        </button>
+      )}
+      <EditorTabs />
+      <button
+        aria-expanded={showConsole}
+        onClick={() => togglePane('showConsole')}
+      >
+        {t('learn.editor-tabs.console')}
+      </button>
+      {hasNotes && (
+        <button
+          aria-expanded={showNotes}
+          onClick={() => togglePane('showNotes')}
+        >
+          {t('learn.editor-tabs.notes')}
+        </button>
+      )}
+      <div className='preview-buttons-section'>
+        <button
+          aria-expanded={showPreviewPane}
+          onClick={() => togglePane('showPreviewPane')}
+        >
+          <span className='sr-only'>{getPreviewBtnsSrText().pane}</span>
+          <span aria-hidden='true'>{t('learn.editor-tabs.preview')}</span>
+        </button>
+        <button
+          aria-expanded={showPreviewPortal}
+          onClick={() => togglePane('showPreviewPortal')}
+        >
+          <span className='sr-only'>{getPreviewBtnsSrText().portal}</span>
+          <FontAwesomeIcon icon={faWindowRestore} />
+        </button>
       </div>
     </div>
   );

--- a/client/src/templates/Challenges/classic/action-row.tsx
+++ b/client/src/templates/Challenges/classic/action-row.tsx
@@ -61,6 +61,7 @@ const ActionRow = ({
       )}
       <EditorTabs />
       <button
+        className='editor-console-button'
         aria-expanded={showConsole}
         onClick={() => togglePane('showConsole')}
       >

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -17,13 +17,7 @@
   display: none !important;
 }
 
-.action-row {
-  padding: 10px;
-  border-bottom: 1px solid var(--quaternary-background);
-}
-
-.monaco-editor-tabs [aria-expanded='true'],
-.action-row [aria-expanded='true'] {
+.monaco-editor-tabs [aria-expanded='true'] {
   border-color: var(--secondary-color);
   background-color: var(--secondary-color);
   color: var(--secondary-background);
@@ -43,15 +37,20 @@
 }
 
 .monaco-editor-tabs {
+  padding: 10px;
+  border-bottom: 1px solid var(--quaternary-background);
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(7rem, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(7rem, 1fr));
 }
 
 .monaco-editor-tabs button:not(:first-child) {
   border-left: none;
 }
 
-.panel-display-tabs button:first-child,
+.preview-buttons-section {
+  display: inline-flex;
+}
+
 .tabs-row > button:first-child {
   margin: 0 10px 0 0;
 }
@@ -121,11 +120,6 @@
 #mobile-layout .nav-tabs > li.active > a {
   color: var(--quaternary-color);
   background-color: var(--quaternary-background);
-}
-
-#mobile-layout .monaco-editor-tabs {
-  padding: 10px;
-  width: 100%;
 }
 
 /* Focus indicator for tab panel */

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -17,30 +17,23 @@
   display: none !important;
 }
 
+.monaco-editor-tabs {
+  padding: 10px;
+  border-bottom: 1px solid var(--quaternary-background);
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(7rem, 1fr));
+}
+
 .monaco-editor-tabs [aria-expanded='true'] {
   border-color: var(--secondary-color);
   background-color: var(--secondary-color);
   color: var(--secondary-background);
 }
 
-.tabs-row {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-}
-
-.tabs-row button,
 .monaco-editor-tabs button {
   padding: 6px 12px;
   border-width: 2px;
   border-style: solid;
-}
-
-.monaco-editor-tabs {
-  padding: 10px;
-  border-bottom: 1px solid var(--quaternary-background);
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(7rem, 1fr));
 }
 
 .monaco-editor-tabs button:not(:first-child) {
@@ -51,18 +44,12 @@
   display: inline-flex;
 }
 
-.tabs-row > button:first-child {
-  margin: 0 10px 0 0;
-}
-
 .restart-step-tab {
   margin: 0 auto;
 }
 
 #mobile-layout {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
+  display: grid;
 }
 
 #mobile-layout .nav-tabs {
@@ -85,20 +72,9 @@
   color: var(--gray-85);
 }
 
-#mobile-layout .tab-content {
-  display: grid;
-  height: 100vh;
-  height: 100dvh;
-}
-
 #mobile-layout-pane-editor {
   display: flex;
   flex-direction: column;
-}
-
-#mobile-layout .tab-pane {
-  height: 100%;
-  overflow: hidden;
 }
 
 #mobile-layout #mobile-layout-pane-instructions {

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -21,7 +21,7 @@
   padding: 10px;
   border-bottom: 1px solid var(--quaternary-background);
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(7rem, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));
 }
 
 .monaco-editor-tabs [aria-expanded='true'] {
@@ -36,12 +36,15 @@
   border-style: solid;
 }
 
-.monaco-editor-tabs button:not(:first-child) {
-  border-left: none;
-}
-
 .preview-buttons-section {
   display: inline-flex;
+  grid-column-end: -1;
+}
+
+.editor-console-button {
+  width: 6rem;
+  margin-inline-start: 1.5rem;
+  grid-column-end: -2;
 }
 
 .restart-step-tab {

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -43,8 +43,8 @@
 }
 
 .monaco-editor-tabs {
-  display: flex;
-  margin-inline-end: auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(7rem, 1fr));
 }
 
 .monaco-editor-tabs button:not(:first-child) {
@@ -87,11 +87,9 @@
 }
 
 #mobile-layout .tab-content {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  flex-grow: 1;
-  overflow-y: hidden;
+  display: grid;
+  height: 100vh;
+  height: 100dvh;
 }
 
 #mobile-layout-pane-editor {
@@ -128,11 +126,6 @@
 #mobile-layout .monaco-editor-tabs {
   padding: 10px;
   width: 100%;
-}
-
-#mobile-layout .monaco-editor-tabs button {
-  flex: 1;
-  max-width: 50%;
 }
 
 /* Focus indicator for tab panel */

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -53,6 +53,14 @@
 
 #mobile-layout {
   display: grid;
+  min-height: 100vh;
+  min-height: 100dvh;
+  grid-template-rows: 30px 1fr;
+}
+
+#mobile-layout .tab-content {
+  display: grid;
+  grid-template-rows: 1fr auto;
 }
 
 #mobile-layout .nav-tabs {

--- a/client/src/templates/Challenges/classic/editor-tabs.tsx
+++ b/client/src/templates/Challenges/classic/editor-tabs.tsx
@@ -37,7 +37,7 @@ class EditorTabs extends Component<EditorTabsProps> {
   render() {
     const { challengeFiles, toggleVisibleEditor, visibleEditors } = this.props;
     return (
-      <div className='monaco-editor-tabs'>
+      <>
         {/* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call */}
         {sortChallengeFiles(challengeFiles).map(
           (challengeFile: ChallengeFile) => (
@@ -52,7 +52,7 @@ class EditorTabs extends Component<EditorTabsProps> {
             </button>
           )
         )}
-      </div>
+      </>
     );
   }
 }

--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -98,7 +98,11 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
             title={i18next.t('learn.editor-tabs.code')}
             {...editorTabPaneProps}
           >
-            {usesMultifileEditor && <EditorTabs />}
+            {usesMultifileEditor && (
+              <div className='monaco-editor-tabs'>
+                <EditorTabs />
+              </div>
+            )}
             {editor}
           </TabPane>
           <TabPane


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

The instruction are considered part of the mobile-layout, and doesn't follow the editor layout which cased:

- the vertical scrollbar to show.
- the instruction pushing the buttons away from the view

<!-- Feel free to add any additional description of changes below this line -->
