### PR TITLE
fix(client) : Added reset & help button texts

### DIFF
--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -194,8 +194,10 @@ const LowerJaw = ({
             aria-label={t('buttons.reset-step')}
             data-cy='reset-code-button'
             onClick={openResetModal}
+            style={{display: 'flex' , justifyContent: 'center' , alignItems : 'center'}}
           >
             <Reset />
+            <div style={{paddingLeft: '.3rem'}}>Reset</div>
           </button>
 
           {isAttemptsLargerThanTest && !challengeIsCompleted ? (
@@ -206,8 +208,10 @@ const LowerJaw = ({
               aria-label={t('buttons.get-help')}
               data-cy='get-help-button'
               onClick={openHelpModal}
+            style={{display: 'flex' , justifyContent: 'center' , alignItems : 'center'}}
             >
               <Help />
+            <div style={{paddingLeft: '.3rem'}}>Help</div>
             </button>
           ) : null}
         </div>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the 49297 below with the issue number.-->

Closes #49297

<!-- Feel free to add any additional description of changes below this line -->
* Added reset and help text in the buttons.
* Button looks like this as discussed [here](https://forum.freecodecamp.org/t/new-help-button-not-obvious/571552/6): 
![free5](https://user-images.githubusercontent.com/103327712/218166022-c5306890-d784-4e38-8863-aa0dc9d815a9.png)
