### PR TITLE
fix(client): pre code having extra spaces when code elements are stacked

### DIFF
--- a/client/src/components/layouts/rtl-layout.css
+++ b/client/src/components/layouts/rtl-layout.css
@@ -131,6 +131,12 @@ sections that need to stay left to right
   unicode-bidi: isolate;
 }
 
+/* bootstrap display block breaks the code elements when they are stacked on top of each other to sort this, we remove it for display: grid  */
+
+[dir='rtl'] pre[class*='language-']:has(code) {
+  display: grid;
+}
+
 [dir='rtl'] .description-container,
 [dir='rtl'] .action-row-container,
 [dir='rtl']


### PR DESCRIPTION
Co-authored-by: hbar1st <hanaab@gmail.com>

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The new looks

![image](https://user-images.githubusercontent.com/88248797/218253232-224097a3-1888-434c-a1ce-9ac2eaa9a315.png)

The old looks

![image](https://user-images.githubusercontent.com/88248797/218253348-80bbd2af-4d3c-4813-81fd-740530fca7c0.png)


<!-- Feel free to add any additional description of changes below this line -->
