### PR TITLE
refactor: clean up types and tsconfig

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -56,6 +56,7 @@
       "parserOptions": {
         "project": [
           "./tsconfig.json",
+          "./api/tsconfig.json",
           "./config/tsconfig.json",
           "./tools/ui-components/tsconfig.json",
           "./utils/tsconfig.json",

--- a/api/index.ts
+++ b/api/index.ts
@@ -18,9 +18,6 @@ const start = async () => {
   // NOTE: Awaited to ensure `.use` is registered on `fastify`
   await fastify.register(middie);
 
-  // @ts-expect-error Types are not exported from Fastify,
-  // and TypeScript is not smart enough to realise types
-  // defined within this module have the same signature
   void fastify.use('/test', testMiddleware);
 
   void fastify.register(dbConnector);

--- a/api/middleware/index.ts
+++ b/api/middleware/index.ts
@@ -1,16 +1,20 @@
-import { NextFunction } from '../utils';
+import type { NextFunction, NextHandleFunction } from '@fastify/middie';
 
 export async function auth0Verify() {
   // Verify user authorization code with Auth0
 }
 
+type MiddieRequest = Parameters<NextHandleFunction>[0];
+type MiddieResponse = Parameters<NextHandleFunction>[1];
+
 export function testMiddleware(
-  req: Request,
-  _res: Response,
+  req: MiddieRequest,
+  res: MiddieResponse,
   next: NextFunction
 ) {
-  //
   console.log('Test middleware running');
   console.log(req.headers);
+  console.log(req.query);
+  res.setHeader('X-Test-Header', 'test');
   next();
 }

--- a/api/package.json
+++ b/api/package.json
@@ -4,7 +4,7 @@
     "url": "https://github.com/freeCodeCamp/freeCodeCamp/issues"
   },
   "dependencies": {
-    "@fastify/middie": "8.0.0",
+    "@fastify/middie": "8.1",
     "@fastify/mongodb": "6.1.0",
     "fastify": "4.9.2",
     "fastify-plugin": "4.3.0"

--- a/api/package.json
+++ b/api/package.json
@@ -32,7 +32,7 @@
     "url": "git+https://github.com/freeCodeCamp/freeCodeCamp.git"
   },
   "scripts": {
-    "build": "tsc index.ts",
+    "build": "tsc",
     "develop": "nodemon index.ts",
     "start": "NODE_ENV=production node index.js",
     "test": "NODE_OPTIONS='--test-only' ts-node **/*.test.ts"

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "CommonJS",
+    "allowJs": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  }
+}

--- a/api/utils/index.ts
+++ b/api/utils/index.ts
@@ -13,7 +13,3 @@ function sha256(buf: Buffer) {
   return createHash('sha256').update(buf).digest();
 }
 export const challenge = base64URLEncode(sha256(Buffer.from(verifier)));
-
-// This is used for Fastify middleware, but is not exported from Fastify itself.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type NextFunction = (err?: any) => void;

--- a/package-lock.json
+++ b/package-lock.json
@@ -117,7 +117,7 @@
       "version": "0.0.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@fastify/middie": "8.0.0",
+        "@fastify/middie": "8.1",
         "@fastify/mongodb": "6.1.0",
         "fastify": "4.9.2",
         "fastify-plugin": "4.3.0"
@@ -4494,19 +4494,14 @@
       }
     },
     "node_modules/@fastify/middie": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@fastify/middie/-/middie-8.0.0.tgz",
-      "integrity": "sha512-SsZUzJwRV2IBhko8TNI5gGzUdUp2Xd0XCrU+pBTfsMN8LYGsksDI/Hb3qcUZ2/Kfg6ecbFEeRO4nZmHeFCDpHQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/middie/-/middie-8.1.0.tgz",
+      "integrity": "sha512-VvUCLfKx2j6KSnh8puT8QW7d5YNzi2fD/4HcFvRQ3a7sHlCo+qtfX2fqzFvNqnMVbNft7GX1JL5if/riUiXsyg==",
       "dependencies": {
-        "fastify-plugin": "^3.0.0",
+        "fastify-plugin": "^4.0.0",
         "path-to-regexp": "^6.1.0",
         "reusify": "^1.0.4"
       }
-    },
-    "node_modules/@fastify/middie/node_modules/fastify-plugin": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-3.0.1.tgz",
-      "integrity": "sha512-qKcDXmuZadJqdTm6vlCqioEbyewF60b/0LOFCcYN1B6BIZGlYJumWWOYs70SFYLDAH4YqdE1cxH/RKMG7rFxgA=="
     },
     "node_modules/@fastify/middie/node_modules/path-to-regexp": {
       "version": "6.2.1",
@@ -14710,7 +14705,8 @@
     },
     "node_modules/@types/connect": {
       "version": "3.4.35",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -57996,20 +57992,15 @@
       }
     },
     "@fastify/middie": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@fastify/middie/-/middie-8.0.0.tgz",
-      "integrity": "sha512-SsZUzJwRV2IBhko8TNI5gGzUdUp2Xd0XCrU+pBTfsMN8LYGsksDI/Hb3qcUZ2/Kfg6ecbFEeRO4nZmHeFCDpHQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/middie/-/middie-8.1.0.tgz",
+      "integrity": "sha512-VvUCLfKx2j6KSnh8puT8QW7d5YNzi2fD/4HcFvRQ3a7sHlCo+qtfX2fqzFvNqnMVbNft7GX1JL5if/riUiXsyg==",
       "requires": {
-        "fastify-plugin": "^3.0.0",
+        "fastify-plugin": "^4.0.0",
         "path-to-regexp": "^6.1.0",
         "reusify": "^1.0.4"
       },
       "dependencies": {
-        "fastify-plugin": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-3.0.1.tgz",
-          "integrity": "sha512-qKcDXmuZadJqdTm6vlCqioEbyewF60b/0LOFCcYN1B6BIZGlYJumWWOYs70SFYLDAH4YqdE1cxH/RKMG7rFxgA=="
-        },
         "path-to-regexp": {
           "version": "6.2.1",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
@@ -58079,7 +58070,7 @@
     "@freecodecamp/api": {
       "version": "file:api",
       "requires": {
-        "@fastify/middie": "8.0.0",
+        "@fastify/middie": "8.1",
         "@fastify/mongodb": "6.1.0",
         "fastify": "4.9.2",
         "fastify-plugin": "4.3.0"
@@ -65296,6 +65287,8 @@
     },
     "@types/connect": {
       "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
       "requires": {
         "@types/node": "*"
       }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "include": [
-    "api",
     "client/i18n/**/*",
     "client/plugins/**/*",
     "client/src/**/*",


### PR DESCRIPTION
The type error stemmed from the use of web api types when we need a few different server specific types (from `http` and `connect`). I created a new tsconfig without those types to prevent that.

Using `Parameters` to get the req/res types is a little ugly, but I couldn't think of a nicer way.