### PR TITLE
fix(client): console height in multi-file editor

### DIFF
--- a/client/src/templates/Challenges/classic/desktop-layout.tsx
+++ b/client/src/templates/Challenges/classic/desktop-layout.tsx
@@ -250,7 +250,10 @@ const DesktopLayout = (props: DesktopLayoutProps): JSX.Element => {
                 <ReflexSplitter propagate={true} {...resizeProps} />
               )}
               {displayPreviewConsole && (
-                <ReflexElement flex={testsPane.flex} {...resizeProps}>
+                <ReflexElement
+                  {...(displayPreviewPane && { flex: testsPane.flex })}
+                  {...resizeProps}
+                >
                   {testOutput}
                 </ReflexElement>
               )}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Noticed this while testing #49228 (after it had been merged). 

Open Survey form in new RWD. Toggle Preview off and Console on so that the console is taking up the entire right pane. Run the tests. Notice that the console output does not take up the entire pane but rather just a percentage of the top of the pane and is scrollable. This PR fixes that.