### PR TITLE
feat(client): move the block donation modal logic to an epic.

### DIFF
--- a/client/src/components/Donation/donation-modal.tsx
+++ b/client/src/components/Donation/donation-modal.tsx
@@ -23,10 +23,12 @@ import { playTone } from '../../utils/tone';
 import { Spacer } from '../helpers';
 import DonateForm from './donate-form';
 
+type RecentlyClaimedBlock = null | { block: string; superBlock: string };
+
 const mapStateToProps = createSelector(
   isDonationModalOpenSelector,
   recentlyClaimedBlockSelector,
-  (show: boolean, recentlyClaimedBlock: string) => ({
+  (show: boolean, recentlyClaimedBlock: RecentlyClaimedBlock) => ({
     show,
     recentlyClaimedBlock
   })
@@ -46,7 +48,7 @@ type DonateModalProps = {
   closeDonationModal: typeof closeDonationModal;
   executeGA: typeof executeGA;
   location?: WindowLocation;
-  recentlyClaimedBlock: string;
+  recentlyClaimedBlock: RecentlyClaimedBlock;
   show: boolean;
 };
 
@@ -70,13 +72,13 @@ function DonateModal({
       executeGA({
         event: 'donationview',
         action: `Displayed ${
-          recentlyClaimedBlock ? 'Block' : 'Progress'
+          recentlyClaimedBlock !== null ? 'Block' : 'Progress'
         } Donation Modal`
       });
     }
   }, [show, recentlyClaimedBlock, executeGA]);
 
-  const getDonationText = () => {
+  const getCommonDonationText = () => {
     const donationDuration = modalDefaultDonation.donationDuration;
     switch (donationDuration) {
       case 'one-time':
@@ -95,32 +97,28 @@ function DonateModal({
     }
   };
 
-  const blockDonationText = (
+  const donationText = (
     <div className=' text-center block-modal-text'>
       <div className='donation-icon-container'>
-        <Cup className='donation-icon' />
-      </div>
-      <Row>
-        {!closeLabel && (
-          <Col sm={10} smOffset={1} xs={12}>
-            <b>{t('donate.nicely-done', { block: recentlyClaimedBlock })}</b>
-            <br />
-            {getDonationText()}
-          </Col>
+        {recentlyClaimedBlock !== null ? (
+          <Cup className='donation-icon' />
+        ) : (
+          <Heart className='donation-icon' />
         )}
-      </Row>
-    </div>
-  );
-
-  const progressDonationText = (
-    <div className='text-center progress-modal-text'>
-      <div className='donation-icon-container'>
-        <Heart className='donation-icon' />
       </div>
       <Row>
         {!closeLabel && (
           <Col sm={10} smOffset={1} xs={12}>
-            {getDonationText()}
+            {recentlyClaimedBlock !== null && (
+              <b>
+                {t('donate.nicely-done', {
+                  block: t(
+                    `intro:${recentlyClaimedBlock.superBlock}.blocks.${recentlyClaimedBlock.block}.title`
+                  )
+                })}
+              </b>
+            )}
+            {getCommonDonationText()}
           </Col>
         )}
       </Row>
@@ -135,7 +133,7 @@ function DonateModal({
       show={show}
     >
       <Modal.Body>
-        {recentlyClaimedBlock ? blockDonationText : progressDonationText}
+        {donationText}
         <Spacer />
         <Row>
           <Col xs={12}>

--- a/client/src/templates/Challenges/components/completion-modal.test.tsx
+++ b/client/src/templates/Challenges/components/completion-modal.test.tsx
@@ -1,4 +1,4 @@
-import { getCompletedPercent } from './completion-modal';
+import { getCompletedPercentage } from '../../../utils/get-completion-percentage';
 
 jest.mock('../../../analytics');
 
@@ -8,16 +8,16 @@ const completedChallengesIds = ['1', '3', '5'],
   fakeCompletedChallengesIds = ['1', '3', '5', '7', '8'];
 
 describe('<CompletionModal />', () => {
-  describe('getCompletedPercent', () => {
+  describe('getCompletedPercentage', () => {
     it('returns 25 if one out of four challenges are complete', () => {
-      expect(getCompletedPercent([], currentBlockIds, currentBlockIds[1])).toBe(
-        25
-      );
+      expect(
+        getCompletedPercentage([], currentBlockIds, currentBlockIds[1])
+      ).toBe(25);
     });
 
     it('returns 75 if three out of four challenges are complete', () => {
       expect(
-        getCompletedPercent(
+        getCompletedPercentage(
           completedChallengesIds,
           currentBlockIds,
           completedChallengesIds[0]
@@ -27,13 +27,13 @@ describe('<CompletionModal />', () => {
 
     it('returns 100 if all challenges have been completed', () => {
       expect(
-        getCompletedPercent(completedChallengesIds, currentBlockIds, id)
+        getCompletedPercentage(completedChallengesIds, currentBlockIds, id)
       ).toBe(100);
     });
 
     it('returns 100 if more challenges have been complete than exist', () => {
       expect(
-        getCompletedPercent(fakeCompletedChallengesIds, currentBlockIds, id)
+        getCompletedPercentage(fakeCompletedChallengesIds, currentBlockIds, id)
       ).toBe(100);
     });
   });

--- a/client/src/templates/Challenges/redux/selectors.js
+++ b/client/src/templates/Challenges/redux/selectors.js
@@ -1,12 +1,21 @@
 import { challengeTypes } from '../../../../utils/challenge-types';
-import { completedChallengesSelector } from '../../../redux/selectors';
+import {
+  completedChallengesSelector,
+  allChallengesInfoSelector,
+  isSignedInSelector
+} from '../../../redux/selectors';
+import {
+  getCurrentBlockIds,
+  getCompletedChallengesInBlock,
+  getCompletedPercentage
+} from '../../../utils/get-completion-percentage';
 import { ns } from './action-types';
 
 export const challengeFilesSelector = state => state[ns].challengeFiles;
 export const challengeMetaSelector = state => state[ns].challengeMeta;
 export const challengeTestsSelector = state => state[ns].challengeTests;
 export const consoleOutputSelector = state => state[ns].consoleOut;
-export const completedChallengesIds = state =>
+export const completedChallengesIdsSelector = state =>
   completedChallengesSelector(state).map(node => node.id);
 export const isChallengeCompletedSelector = state => {
   const completedChallenges = completedChallengesSelector(state);
@@ -80,6 +89,53 @@ export const challengeDataSelector = state => {
     };
   }
   return challengeData;
+};
+
+export const currentBlockIdsSelector = state => {
+  const { block, certification, challengeType } = challengeMetaSelector(state);
+  const allChallengesInfo = allChallengesInfoSelector(state);
+  const currentBlockIds = getCurrentBlockIds(
+    allChallengesInfo,
+    block,
+    certification,
+    challengeType
+  );
+
+  return currentBlockIds;
+};
+
+export const completedChallengesInBlockSelector = state => {
+  const completedChallengesIds = completedChallengesIdsSelector(state);
+  const currentBlockIds = currentBlockIdsSelector(state);
+  const { id } = challengeMetaSelector(state);
+  const completedChallengesInBlock = getCompletedChallengesInBlock(
+    completedChallengesIds,
+    currentBlockIds,
+    id
+  );
+  return completedChallengesInBlock;
+};
+
+export const completedPercentageSelector = state => {
+  const isSignedIn = isSignedInSelector(state);
+  if (isSignedIn) {
+    const completedChallengesIds = completedChallengesIdsSelector(state);
+    const { id } = challengeMetaSelector(state);
+    const currentBlockIds = currentBlockIdsSelector(state);
+    const completedPercentage = getCompletedPercentage(
+      completedChallengesIds,
+      currentBlockIds,
+      id
+    );
+    return completedPercentage;
+  } else return 0;
+};
+
+export const isBlockNewlyCompletedSelector = state => {
+  const completedPercentage = completedPercentageSelector(state);
+  const completedChallengesIds = completedChallengesIdsSelector(state);
+  const { id } = challengeMetaSelector(state);
+  return completedPercentage === 100 && !completedChallengesIds.includes(id);
 };
 
 export const attemptsSelector = state => state[ns].attempts;

--- a/client/src/utils/get-completion-percentage.ts
+++ b/client/src/utils/get-completion-percentage.ts
@@ -1,0 +1,56 @@
+import { AllChallengesInfo } from '../redux/prop-types';
+import { dasherize } from '../../../utils/slugs';
+import { isFinalProject } from '../../utils/challenge-types';
+
+export function getCompletedPercentage(
+  completedChallengesIds: string[] = [],
+  currentBlockIds: string[] = [],
+  currentChallengeId: string
+): number {
+  const completedChallengesInBlock = getCompletedChallengesInBlock(
+    completedChallengesIds,
+    currentBlockIds,
+    currentChallengeId
+  );
+  const completedPercent = Math.round(
+    (completedChallengesInBlock / currentBlockIds.length) * 100
+  );
+
+  return completedPercent > 100 ? 100 : completedPercent;
+}
+
+export function getCompletedChallengesInBlock(
+  completedChallengesIds: string[],
+  currentBlockIds: string[],
+  currentChallengeId: string
+) {
+  const oldCompletionCount = completedChallengesIds.filter(challengeId =>
+    currentBlockIds.includes(challengeId)
+  ).length;
+
+  const isAlreadyCompleted =
+    completedChallengesIds.includes(currentChallengeId);
+
+  return isAlreadyCompleted ? oldCompletionCount : oldCompletionCount + 1;
+}
+
+export const getCurrentBlockIds = (
+  allChallengesInfo: AllChallengesInfo,
+  block: string,
+  certification: string,
+  challengeType: number
+) => {
+  const { challengeEdges, certificateNodes } = allChallengesInfo;
+  const currentCertificateIds = certificateNodes
+    .filter(
+      node => dasherize(node.challenge.certification) === certification
+    )[0]
+    ?.challenge.tests.map(test => test.id);
+  const currentBlockIds = challengeEdges
+    .filter(edge => edge.node.challenge.block === block)
+    .map(edge => edge.node.challenge.id);
+
+  return isFinalProject(challengeType)
+    ? currentCertificateIds
+    : currentBlockIds;
+};


### PR DESCRIPTION
This pr moves the percent calculations from the completion modal to selectors and move the block donation logic to an epic. 

To test this pr, try completing a few blocks and see if you get the block donation modal. 🙌

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

ref: #46811
<!-- Feel free to add any additional description of changes below this line -->
