### PR TITLE
feat(tools): sentry apm and other telemetry (#49385)

### DIFF
--- a/api-server/package.json
+++ b/api-server/package.json
@@ -29,7 +29,8 @@
   },
   "dependencies": {
     "@freecodecamp/loopback-component-passport": "1.2.0",
-    "@sentry/node": "6.19.7",
+    "@sentry/node": "7.37.1",
+    "@sentry/tracing": "7.37.1",
     "accepts": "1.3.8",
     "axios": "0.23.0",
     "bad-words": "3.0.4",

--- a/api-server/src/server/index.js
+++ b/api-server/src/server/index.js
@@ -2,6 +2,7 @@ const path = require('path');
 require('dotenv').config({ path: path.resolve(__dirname, '../../../.env') });
 
 const Sentry = require('@sentry/node');
+const Tracing = require('@sentry/tracing');
 const createDebugger = require('debug');
 const _ = require('lodash');
 const loopback = require('loopback');
@@ -13,15 +14,6 @@ const { setupPassport } = require('./component-passport');
 
 const log = createDebugger('fcc:server');
 const reqLogFormat = ':date[iso] :status :method :response-time ms - :url';
-
-if (sentry.dsn === 'dsn_from_sentry_dashboard') {
-  log('Sentry reporting disabled unless DSN is provided.');
-} else {
-  Sentry.init({
-    dsn: sentry.dsn
-  });
-  log('Sentry initialized');
-}
 
 const app = loopback();
 
@@ -62,6 +54,7 @@ db.on(
   'connected',
   _.once(() => log('db connected'))
 );
+
 app.start = _.once(function () {
   const server = app.listen(app.get('port'), function () {
     app.emit('started');
@@ -88,6 +81,31 @@ app.start = _.once(function () {
     });
   });
 });
+
+if (sentry.dsn === 'dsn_from_sentry_dashboard') {
+  log('Sentry reporting disabled unless DSN is provided.');
+} else {
+  Sentry.init({
+    dsn: sentry.dsn,
+    integrations: [
+      new Sentry.Integrations.Http({ tracing: true }),
+      new Tracing.Integrations.Express({
+        app
+      })
+    ],
+    // Capture 20% of transactions to avoid
+    // overwhelming Sentry and remain within
+    // the usage quota
+    tracesSampleRate: 0.2
+  });
+  log('Sentry initialized');
+}
+
+// RequestHandler creates a separate execution context using domains, so that every
+// transaction/span/breadcrumb is attached to its own Hub instance
+app.use(Sentry.Handlers.requestHandler());
+// TracingHandler creates a trace for every incoming request
+app.use(Sentry.Handlers.tracingHandler());
 
 module.exports = app;
 

--- a/api-server/src/server/index.js
+++ b/api-server/src/server/index.js
@@ -101,12 +101,6 @@ if (sentry.dsn === 'dsn_from_sentry_dashboard') {
   log('Sentry initialized');
 }
 
-// RequestHandler creates a separate execution context using domains, so that every
-// transaction/span/breadcrumb is attached to its own Hub instance
-app.use(Sentry.Handlers.requestHandler());
-// TracingHandler creates a trace for every incoming request
-app.use(Sentry.Handlers.tracingHandler());
-
 module.exports = app;
 
 if (require.main === module) {

--- a/api-server/src/server/middleware.json
+++ b/api-server/src/server/middleware.json
@@ -1,6 +1,7 @@
 {
   "initial:before": {
-    "./middlewares/sentry-request-handler": {}
+    "./middlewares/sentry-request-handler": {},
+    "./middlewares/sentry-tracing-handler": {}
   },
   "initial": {
     "compression": {},

--- a/api-server/src/server/middlewares/sentry-tracing-handler.js
+++ b/api-server/src/server/middlewares/sentry-tracing-handler.js
@@ -1,0 +1,8 @@
+import { Handlers } from '@sentry/node';
+import { sentry } from '../../../../config/secrets';
+
+export default function sentryRequestHandler() {
+  return sentry.dsn === 'dsn_from_sentry_dashboard'
+    ? (req, res, next) => next()
+    : Handlers.tracingHandler();
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -114,7 +114,8 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@freecodecamp/loopback-component-passport": "1.2.0",
-        "@sentry/node": "6.19.7",
+        "@sentry/node": "7.37.1",
+        "@sentry/tracing": "7.37.1",
         "accepts": "1.3.8",
         "axios": "0.23.0",
         "bad-words": "3.0.4",
@@ -5275,20 +5276,53 @@
       }
     },
     "node_modules/@sentry/node": {
-      "version": "6.19.7",
-      "license": "BSD-3-Clause",
+      "version": "7.37.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.37.1.tgz",
+      "integrity": "sha512-nGerngIo5JwinJgl7m0SaL/xI+YRBlhb53gbkuLSAAcnoitBFzbp7LjywsqYFTWuWDIyk7O2t124GNxtolBAgA==",
       "dependencies": {
-        "@sentry/core": "6.19.7",
-        "@sentry/hub": "6.19.7",
-        "@sentry/types": "6.19.7",
-        "@sentry/utils": "6.19.7",
+        "@sentry/core": "7.37.1",
+        "@sentry/types": "7.37.1",
+        "@sentry/utils": "7.37.1",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
         "tslib": "^1.9.3"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@sentry/core": {
+      "version": "7.37.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.37.1.tgz",
+      "integrity": "sha512-eS5hoFDjAOl7POZg6K77J0oiypiqR1782oVSB49UkjK+D8tCZzZ5PxPMv0b/O0310p7x4oZ3WGRJaWEN3vY4KQ==",
+      "dependencies": {
+        "@sentry/types": "7.37.1",
+        "@sentry/utils": "7.37.1",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@sentry/types": {
+      "version": "7.37.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.37.1.tgz",
+      "integrity": "sha512-c2HWyWSgVA0V4+DSW2qVb0yjftrb1X/q2CzCom+ayjGHO72qyWC+9Tc+7ZfotU1mapRjqUWBgkXkbGmao8N8Ug==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@sentry/utils": {
+      "version": "7.37.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.37.1.tgz",
+      "integrity": "sha512-/4mJOyDsfysx+5TXyJgSI+Ihw2/0EVJbrHjCyXPDXW5ADwbtU8VdBZ0unOmF0hk4QfftqwM9cyEu3BN4iBJsEA==",
+      "dependencies": {
+        "@sentry/types": "7.37.1",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/react": {
@@ -5307,6 +5341,53 @@
       },
       "peerDependencies": {
         "react": "15.x || 16.x || 17.x || 18.x"
+      }
+    },
+    "node_modules/@sentry/tracing": {
+      "version": "7.37.1",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.37.1.tgz",
+      "integrity": "sha512-3mQG2XtMCGqDkgfzhKpRJAIfRaokNAOF8WafgAmFmZQwEDsRAFjZ3pLoO+KiBUeQE5E5et7HyWBOl9rqHCkWnQ==",
+      "dependencies": {
+        "@sentry/core": "7.37.1",
+        "@sentry/types": "7.37.1",
+        "@sentry/utils": "7.37.1",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/tracing/node_modules/@sentry/core": {
+      "version": "7.37.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.37.1.tgz",
+      "integrity": "sha512-eS5hoFDjAOl7POZg6K77J0oiypiqR1782oVSB49UkjK+D8tCZzZ5PxPMv0b/O0310p7x4oZ3WGRJaWEN3vY4KQ==",
+      "dependencies": {
+        "@sentry/types": "7.37.1",
+        "@sentry/utils": "7.37.1",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/tracing/node_modules/@sentry/types": {
+      "version": "7.37.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.37.1.tgz",
+      "integrity": "sha512-c2HWyWSgVA0V4+DSW2qVb0yjftrb1X/q2CzCom+ayjGHO72qyWC+9Tc+7ZfotU1mapRjqUWBgkXkbGmao8N8Ug==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/tracing/node_modules/@sentry/utils": {
+      "version": "7.37.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.37.1.tgz",
+      "integrity": "sha512-/4mJOyDsfysx+5TXyJgSI+Ihw2/0EVJbrHjCyXPDXW5ADwbtU8VdBZ0unOmF0hk4QfftqwM9cyEu3BN4iBJsEA==",
+      "dependencies": {
+        "@sentry/types": "7.37.1",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/types": {
@@ -55680,7 +55761,8 @@
         "@babel/preset-env": "7.18.0",
         "@babel/register": "7.17.7",
         "@freecodecamp/loopback-component-passport": "1.2.0",
-        "@sentry/node": "6.19.7",
+        "@sentry/node": "7.37.1",
+        "@sentry/tracing": "7.37.1",
         "accepts": "1.3.8",
         "axios": "0.23.0",
         "babel-core": "7.0.0-bridge.0",
@@ -57665,16 +57747,43 @@
       }
     },
     "@sentry/node": {
-      "version": "6.19.7",
+      "version": "7.37.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.37.1.tgz",
+      "integrity": "sha512-nGerngIo5JwinJgl7m0SaL/xI+YRBlhb53gbkuLSAAcnoitBFzbp7LjywsqYFTWuWDIyk7O2t124GNxtolBAgA==",
       "requires": {
-        "@sentry/core": "6.19.7",
-        "@sentry/hub": "6.19.7",
-        "@sentry/types": "6.19.7",
-        "@sentry/utils": "6.19.7",
+        "@sentry/core": "7.37.1",
+        "@sentry/types": "7.37.1",
+        "@sentry/utils": "7.37.1",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@sentry/core": {
+          "version": "7.37.1",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.37.1.tgz",
+          "integrity": "sha512-eS5hoFDjAOl7POZg6K77J0oiypiqR1782oVSB49UkjK+D8tCZzZ5PxPMv0b/O0310p7x4oZ3WGRJaWEN3vY4KQ==",
+          "requires": {
+            "@sentry/types": "7.37.1",
+            "@sentry/utils": "7.37.1",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/types": {
+          "version": "7.37.1",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.37.1.tgz",
+          "integrity": "sha512-c2HWyWSgVA0V4+DSW2qVb0yjftrb1X/q2CzCom+ayjGHO72qyWC+9Tc+7ZfotU1mapRjqUWBgkXkbGmao8N8Ug=="
+        },
+        "@sentry/utils": {
+          "version": "7.37.1",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.37.1.tgz",
+          "integrity": "sha512-/4mJOyDsfysx+5TXyJgSI+Ihw2/0EVJbrHjCyXPDXW5ADwbtU8VdBZ0unOmF0hk4QfftqwM9cyEu3BN4iBJsEA==",
+          "requires": {
+            "@sentry/types": "7.37.1",
+            "tslib": "^1.9.3"
+          }
+        }
       }
     },
     "@sentry/react": {
@@ -57686,6 +57795,43 @@
         "@sentry/utils": "6.19.7",
         "hoist-non-react-statics": "^3.3.2",
         "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/tracing": {
+      "version": "7.37.1",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.37.1.tgz",
+      "integrity": "sha512-3mQG2XtMCGqDkgfzhKpRJAIfRaokNAOF8WafgAmFmZQwEDsRAFjZ3pLoO+KiBUeQE5E5et7HyWBOl9rqHCkWnQ==",
+      "requires": {
+        "@sentry/core": "7.37.1",
+        "@sentry/types": "7.37.1",
+        "@sentry/utils": "7.37.1",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@sentry/core": {
+          "version": "7.37.1",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.37.1.tgz",
+          "integrity": "sha512-eS5hoFDjAOl7POZg6K77J0oiypiqR1782oVSB49UkjK+D8tCZzZ5PxPMv0b/O0310p7x4oZ3WGRJaWEN3vY4KQ==",
+          "requires": {
+            "@sentry/types": "7.37.1",
+            "@sentry/utils": "7.37.1",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/types": {
+          "version": "7.37.1",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.37.1.tgz",
+          "integrity": "sha512-c2HWyWSgVA0V4+DSW2qVb0yjftrb1X/q2CzCom+ayjGHO72qyWC+9Tc+7ZfotU1mapRjqUWBgkXkbGmao8N8Ug=="
+        },
+        "@sentry/utils": {
+          "version": "7.37.1",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.37.1.tgz",
+          "integrity": "sha512-/4mJOyDsfysx+5TXyJgSI+Ihw2/0EVJbrHjCyXPDXW5ADwbtU8VdBZ0unOmF0hk4QfftqwM9cyEu3BN4iBJsEA==",
+          "requires": {
+            "@sentry/types": "7.37.1",
+            "tslib": "^1.9.3"
+          }
+        }
       }
     },
     "@sentry/types": {


### PR DESCRIPTION
The previous attempt was initializing things too early. This gives loopback a chance to complete all the setup + all the magic config we do to overload the login method.

Anyways this should now delay the init right before the `app.start` utility.