### PR TITLE
fix(env): resolve localhost to 127.0.0.1

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -1,5 +1,5 @@
 # Database
-MONGOHQ_URL=mongodb://localhost:27017/freecodecamp
+MONGOHQ_URL=mongodb://127.0.0.1:27017/freecodecamp
 
 # Logging
 SENTRY_DSN=dsn_from_sentry_dashboard


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Fixes this on Gitpod:

```bash
Oh noes!! Error seeding local auth user.
MongoNetworkError: failed to connect to server [localhost:27017] on first connect [Error: connect ECONNREFUSED ::1:27017
    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1494:16) {
  name: 'MongoNetworkError'
}]
```

I never get this error locally with Node v18, but [I have read](https://superuser.com/questions/436574/ipv4-vs-ipv6-priority-in-windows-7/436944#436944) some machines are just set to prioritise IPv6 over IPv4. Maybe an actual fix is in there, but, as far as I am aware, this fixes the issue on Gitpod without breaking anything for anyone else.