### PR TITLE
feat(tools): revert the quick solution in cypress tests

### DIFF
--- a/cypress/e2e/default/learn/challenges/backend.ts
+++ b/cypress/e2e/default/learn/challenges/backend.ts
@@ -23,15 +23,9 @@ describe('Backend challenge', function () {
 
   it('does not generate unhandled errors on submission', () => {
     cy.visit(locations.index);
-    cy.get(selectors.tag.inputSolution).type('https://example.com');
-
-    // temporary fix until https://github.com/cypress-io/cypress/issues/20562 is fixed
-    cy.contains(`I've completed this challenge`)
-      .click()
-
-      // revert to this when it is
-      // .type('{enter}')
-
+    cy.get(selectors.tag.inputSolution)
+      .type('https://example.com')
+      .type('{enter}')
       .then(() => {
         cy.get(selectors.class.outputText)
           .contains(runningOutput)

--- a/cypress/e2e/default/learn/challenges/codeally.ts
+++ b/cypress/e2e/default/learn/challenges/codeally.ts
@@ -9,13 +9,9 @@ describe('CodeAlly cert challenge', function () {
     });
 
     it('should not allow you to submit a URL', function () {
-      cy.get('input[name="solution"]').type('https://example.com');
-
-      // temporary fix until https://github.com/cypress-io/cypress/issues/20562 is fixed
-      cy.contains(`I've completed this challenge`).click();
-
-      // revert to this when it is
-      // .type('{enter}')
+      cy.get('input[name="solution"]')
+        .type('https://example.com')
+        .type('{enter}');
 
       cy.contains('You must complete the project first.');
     });
@@ -31,13 +27,9 @@ describe('CodeAlly cert challenge', function () {
     });
 
     it('should allow you to submit a URL', function () {
-      cy.get('input[name="solution"]').type('https://example.com');
-
-      // temporary fix until https://github.com/cypress-io/cypress/issues/20562 is fixed
-      cy.contains(`I've completed this challenge`).click();
-
-      // revert to this when it is
-      // .type('{enter}')
+      cy.get('input[name="solution"]')
+        .type('https://example.com')
+        .type('{enter}');
 
       cy.get('.completion-modal-body');
     });

--- a/cypress/e2e/default/settings/username-change.ts
+++ b/cypress/e2e/default/settings/username-change.ts
@@ -43,7 +43,6 @@ describe('Username input field', () => {
       .should('have.class', 'alert alert-info');
   });
 
-  // eslint-disable-next-line
   it('Should be able to click the `Save` button if username is available', () => {
     cy.typeUsername('oliver');
 
@@ -63,7 +62,6 @@ describe('Username input field', () => {
       .should('have.class', 'alert alert-warning');
   });
 
-  // eslint-disable-next-line
   it('Should not be possible to click the `Save` button if username is unavailable', () => {
     cy.typeUsername('twaha');
 
@@ -83,7 +81,6 @@ describe('Username input field', () => {
     cy.get('@usernameForm').contains('Save').should('be.disabled');
   });
 
-  // eslint-disable-next-line max-len
   it('Should not be possible to click the `Save` button if user types their current name', () => {
     cy.typeUsername('developmentuser');
 
@@ -101,7 +98,6 @@ describe('Username input field', () => {
       .should('have.class', 'alert alert-danger');
   });
 
-  // eslint-disable-next-line max-len
   it('Should not be able to click the `Save` button if username includes invalid character', () => {
     cy.typeUsername('Quincy Larson');
 
@@ -134,11 +130,7 @@ describe('Username input field', () => {
     cy.typeUsername('nhcarrigan');
     cy.contains('Username is available');
 
-    // temporary fix until https://github.com/cypress-io/cypress/issues/20562 is fixed
-    cy.contains(`Save`).click();
-
-    // revert to this when it is
-    // cy.get('@usernameInput').type('{enter}', { force: true, release: false });
+    cy.get('@usernameInput').type('{enter}', { force: true, release: false });
 
     cy.contains('We have updated your username to nhcarrigan')
       .should('be.visible')
@@ -156,11 +148,7 @@ describe('Username input field', () => {
     cy.typeUsername('bjorno');
     cy.contains('Username is available');
 
-    // temporary fix until https://github.com/cypress-io/cypress/issues/20562 is fixed
-    cy.contains(`Save`).click();
-
-    // revert to this when it is
-    // cy.get('@usernameInput').type('{enter}', { force: true, release: false });
+    cy.get('@usernameInput').type('{enter}', { force: true, release: false });
 
     cy.contains('We have updated your username to bjorno').within(() => {
       cy.get('button').click();
@@ -175,11 +163,7 @@ describe('Username input field', () => {
     cy.typeUsername('symbol');
     cy.contains('Username is available');
 
-    // temporary fix until https://github.com/cypress-io/cypress/issues/20562 is fixed
-    cy.contains(`Save`).click();
-
-    // revert to this when it is
-    // cy.get('@usernameInput').type('{enter}', { force: true, release: false });
+    cy.get('@usernameInput').type('{enter}', { force: true, release: false });
 
     cy.contains('Account Settings for symbol').should('be.visible');
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

These action were used, because it didn't work before https://github.com/cypress-io/cypress/issues/20562 is merged. 

Btw, I don't know what the tests do, and how to test them. I saw something that can be deleted, and I deleted it

<!-- Feel free to add any additional description of changes below this line -->
