### PR TITLE
fix(curriculum): remove target attribute seed code [cat-photo-app step-13]

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/62dabe2ef403a12d5d295273.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/62dabe2ef403a12d5d295273.md
@@ -74,7 +74,7 @@ assert(
       <h2>Cat Photos</h2>
       <!-- TODO: Add link to cat photos -->
 --fcc-editable-region--
-      <p>See more <a target="_blank" href="https://freecatphotoapp.com">cat photos</a> in our gallery.</p>
+      <p>See more <a href="https://freecatphotoapp.com">cat photos</a> in our gallery.</p>
       <a href="https://freecatphotoapp.com">link to cat pictures</a>
 --fcc-editable-region--
       <img src="https://cdn.freecodecamp.org/curriculum/cat-photo-app/relaxing-cat.jpg" alt="A cute orange cat lying on its back.">


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

In step 12 campers need to wrap text around a link, but they don't need to add `target` attribute.

here is the link

![image](https://user-images.githubusercontent.com/88248797/219934207-9ed56b28-3ce9-4c87-8950-60bae1ca300f.png)

http://freecodecamp.org/learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-12

But in step 13 `target` attribute exist in the seed code

![image](https://user-images.githubusercontent.com/88248797/219934167-51f90649-2ac9-4261-8bdd-18f504d98f24.png)

here is the link

http://freecodecamp.org/learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-13

<!-- Feel free to add any additional description of changes below this line -->
