### PR TITLE
fix(curriculum): fix Fibonacci sequence text

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/sum-all-odd-fibonacci-numbers.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/intermediate-algorithm-scripting/sum-all-odd-fibonacci-numbers.md
@@ -10,7 +10,7 @@ dashedName: sum-all-odd-fibonacci-numbers
 
 Given a positive integer `num`, return the sum of all odd Fibonacci numbers that are less than or equal to `num`.
 
-The first two numbers in the Fibonacci sequence are 1 and 1. Every additional number in the sequence is the sum of the two previous numbers. The first six numbers of the Fibonacci sequence are 1, 1, 2, 3, 5 and 8.
+The first two numbers in the Fibonacci sequence are 0 and 1. Every additional number in the sequence is the sum of the two previous numbers. The first seven numbers of the Fibonacci sequence are 0, 1, 1, 2, 3, 5 and 8.
 
 For example, `sumFibs(10)` should return `10` because all odd Fibonacci numbers less than or equal to `10` are 1, 1, 3, and 5.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #49444 

<!-- Feel free to add any additional description of changes below this line -->
Fixed the text in sum-all-odd-fibonacci-numbers.md file.

The description previously stated:
"The first two numbers in the Fibonacci sequence are 1 and 1."

I changed the text to indicate that the first two numbers are actually 0 and 1:
"The first two numbers in the Fibonacci sequence are 0 and 1."

I also changed the text that previously showed the first six elements of the Fibonacci sequence:
"The first six numbers of the Fibonacci sequence are 1, 1, 2, 3, 5 and 8."

Changed it to show the first seven elements to include the number 0:
"The first seven numbers of the Fibonacci sequence are 0, 1, 1, 2, 3, 5 and 8."

