### PR TITLE
fix(client): provide return types for get-completion-percentage

### DIFF
--- a/client/src/templates/Challenges/redux/selectors.js
+++ b/client/src/templates/Challenges/redux/selectors.js
@@ -94,30 +94,25 @@ export const challengeDataSelector = state => {
 export const currentBlockIdsSelector = state => {
   const { block, certification, challengeType } = challengeMetaSelector(state);
   const allChallengesInfo = allChallengesInfoSelector(state);
-  const currentBlockIds = getCurrentBlockIds(
+
+  return getCurrentBlockIds(
     allChallengesInfo,
     block,
     certification,
     challengeType
   );
-
-  if (!currentBlockIds) {
-    return [];
-  }
-
-  return currentBlockIds;
 };
 
 export const completedChallengesInBlockSelector = state => {
   const completedChallengesIds = completedChallengesIdsSelector(state);
   const currentBlockIds = currentBlockIdsSelector(state);
   const { id } = challengeMetaSelector(state);
-  const completedChallengesInBlock = getCompletedChallengesInBlock(
+
+  return getCompletedChallengesInBlock(
     completedChallengesIds,
     currentBlockIds,
     id
   );
-  return completedChallengesInBlock;
 };
 
 export const completedPercentageSelector = state => {

--- a/client/src/utils/get-completion-percentage.ts
+++ b/client/src/utils/get-completion-percentage.ts
@@ -23,7 +23,7 @@ export function getCompletedChallengesInBlock(
   completedChallengesIds: string[],
   currentBlockIds: string[],
   currentChallengeId: string
-) {
+): number {
   const oldCompletionCount = completedChallengesIds.filter(challengeId =>
     currentBlockIds.includes(challengeId)
   ).length;
@@ -39,13 +39,14 @@ export const getCurrentBlockIds = (
   block: string,
   certification: string,
   challengeType: number
-) => {
+): string[] => {
   const { challengeEdges, certificateNodes } = allChallengesInfo;
-  const currentCertificateIds = certificateNodes
-    .filter(
-      node => dasherize(node.challenge.certification) === certification
-    )[0]
-    ?.challenge.tests.map(test => test.id);
+  const currentCertificateIds =
+    certificateNodes
+      .filter(
+        node => dasherize(node.challenge.certification) === certification
+      )[0]
+      ?.challenge.tests.map(test => test.id) ?? [];
   const currentBlockIds = challengeEdges
     .filter(edge => edge.node.challenge.block === block)
     .map(edge => edge.node.challenge.id);


### PR DESCRIPTION
I also moved the undefined check closer to the source, so it's clearer
what is missing

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Ref: https://github.com/freeCodeCamp/freeCodeCamp/pull/49293

<!-- Feel free to add any additional description of changes below this line -->
