### PR TITLE
fix(client): default `challengeFiles` to array

### DIFF
--- a/client/src/templates/Challenges/redux/create-question-epic.js
+++ b/client/src/templates/Challenges/redux/create-question-epic.js
@@ -14,8 +14,8 @@ import {
 
 const { forumLocation } = envData;
 
-function filesToMarkdown(challengeFiles = {}) {
-  const moreThanOneFile = Object.keys(challengeFiles)?.length > 1;
+function filesToMarkdown(challengeFiles = []) {
+  const moreThanOneFile = challengeFiles?.length > 1;
   return challengeFiles.reduce((fileString, challengeFile) => {
     if (!challengeFile) {
       return fileString;

--- a/client/src/templates/Challenges/redux/create-question-epic.js
+++ b/client/src/templates/Challenges/redux/create-question-epic.js
@@ -15,7 +15,7 @@ import {
 const { forumLocation } = envData;
 
 function filesToMarkdown(challengeFiles = {}) {
-  const moreThanOneFile = challengeFiles?.length > 1;
+  const moreThanOneFile = Object.keys(challengeFiles)?.length > 1;
   return challengeFiles.reduce((fileString, challengeFile) => {
     if (!challengeFile) {
       return fileString;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<s>Object don't have length, so this is always `undefined > 1`, which will never be true. I think it can be removed but I don't know what it does, and it's JavaScript so I am not risking it.</s>

it was array that defined as object 🤷, and I couldn't crash the site even in take home projects, so I don't know how this changed anything.

<!-- Feel free to add any additional description of changes below this line -->
