### PR TITLE
refactor(client): stop the homepage image from changing the layout

### DIFF
--- a/client/src/components/landing/components/campers-image.tsx
+++ b/client/src/components/landing/components/campers-image.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import Media from 'react-responsive';
 import wideImg from '../../../assets/images/landing/wide-image.png';
-import { Spacer, LazyImage } from '../../helpers';
+import { LazyImage } from '../../helpers';
 
 const LARGE_SCREEN_SIZE = 1200;
 
@@ -11,31 +11,32 @@ interface CampersImageProps {
 }
 
 const donateImageSize = {
-  spacerSize: 0,
   height: 345,
   width: 585
 };
 
 const landingImageSize = {
-  spacerSize: 2,
+  marginTop: '60px',
   height: 442,
   width: 750
 };
 function CampersImage({ pageName }: CampersImageProps): JSX.Element {
   const { t } = useTranslation();
 
-  const { spacerSize } =
-    pageName === 'donate' ? donateImageSize : landingImageSize;
+  const figureSize = pageName === 'donate' ? donateImageSize : landingImageSize;
 
   return (
     <Media minWidth={LARGE_SCREEN_SIZE}>
-      <Spacer size={spacerSize} />
-      <LazyImage
-        alt={t('landing.hero-img-description')}
-        className='landing-page-image'
-        src={wideImg}
-      />
-      <p className='text-center caption'>{t('landing.hero-img-description')}</p>
+      <figure style={figureSize}>
+        <LazyImage
+          alt={t('landing.hero-img-description')}
+          className='landing-page-image'
+          src={wideImg}
+        />
+        <figcaption className='caption'>
+          {t('landing.hero-img-description')}
+        </figcaption>
+      </figure>
     </Media>
   );
 }

--- a/client/src/components/landing/landing.css
+++ b/client/src/components/landing/landing.css
@@ -31,9 +31,10 @@
   font-family: 'Lato', sans-serif;
 }
 
-p.caption {
+figcaption.caption {
   margin: 10px 0 0;
-  font-size: 0.8rem;
+  font-weight: 600;
+  text-align: center;
   color: var(--quaternary-color);
 }
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

After removing the react lazy loader, the image didn't have a container that set the size for it beforehand. here is the PR https://github.com/freeCodeCamp/freeCodeCamp/pull/49468

This give it a container and make the text more readable, it was hard for me to even notice 🤣, I was surprised that there were paragraphs there 
<!-- Feel free to add any additional description of changes below this line -->

Slow 3G

[rec-tab (10).webm](https://user-images.githubusercontent.com/88248797/220732989-03e930ae-c745-49dd-a8c6-84c7f86fe7d8.webm)

