### PR TITLE
fix(ui): preserve monaco tab trap on resize

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -420,7 +420,9 @@ const Editor = (props: EditorProps): JSX.Element => {
       store.set('monacoTabTrapped', trapped);
       ariaAlert(
         `${
-          trapped ? t('editor-alerts.tab-trapped') : t('editor-alerts.tab-free')
+          trapped
+            ? t('learn.editor-alerts.tab-trapped')
+            : t('learn.editor-alerts.tab-free')
         }`
       );
     };

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -374,6 +374,14 @@ const Editor = (props: EditorProps): JSX.Element => {
     }
   };
 
+  const isTabTrapped = () => !!(store.get('monacoTabTrapped') ?? true);
+
+  // Monaco uses the contextKey 'editorTabMovesFocus' to control how it
+  // reacts to the Tab key. Setting it to true allows the user to tab
+  // out of the editor. False keeps it inside the editor and creates a tab.
+  const setMonacoTabTrapped = (trapped: boolean) =>
+    dataRef.current.editor?.createContextKey('editorTabMovesFocus', !trapped);
+
   const editorDidMount = (
     editor: editor.IStandaloneCodeEditor,
     monaco: typeof monacoEditor
@@ -407,14 +415,8 @@ const Editor = (props: EditorProps): JSX.Element => {
       return accessibility;
     };
 
-    const isTabTrapped = () => !!(store.get('monacoTabTrapped') ?? true);
-
     const setTabTrapped = (trapped: boolean) => {
-      // Monaco uses the contextKey 'editorTabMovesFocus' to control how it
-      // reacts to the tab key. Setting this to true allows the user to tab
-      // outside of the editor. If it is false, tab will act inside the editor
-      // (i.e. create spaces).
-      editor.createContextKey('editorTabMovesFocus', !trapped);
+      setMonacoTabTrapped(trapped);
       store.set('monacoTabTrapped', trapped);
       ariaAlert(
         `${
@@ -1058,7 +1060,6 @@ const Editor = (props: EditorProps): JSX.Element => {
           updateEditableRegion(coveringRange, { model });
         }
       };
-
       // If the content has changed, the zones may need moving. Rather than
       // working out if they have to for a particular content change, we simply
       // ask monaco to update regardless.
@@ -1185,6 +1186,11 @@ const Editor = (props: EditorProps): JSX.Element => {
   useEffect(() => {
     const editor = dataRef.current.editor;
     editor?.layout();
+    // layout() resets the monaco tab trapping back to default (true), so we
+    // need to untrap it if the user had it set to false.
+    if (!isTabTrapped()) {
+      setMonacoTabTrapped(false);
+    }
     if (hasEditableRegion()) {
       updateDescriptionZone();
       updateOutputZone();


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

My previous PR #48529 preserved the user's choice for tab key behavior in the editor. But I noticed recently that it would always default back to being trapped in the editor if you either resized the browser window or the editor iframe. This was annoying me and so I fixed it.

Also, I noticed that the screen reader alerts for this setting were not being read correctly, so I fixed that too.

Testing:
- Open any step in the new RWD courses.
- Make sure keyboard focus is in the editor.
- Use the `ctrl + m` toggle to set the tab key behavior so that that keyboard focus will jump to the Check Your Code button when you press Tab while focus is in the editor.
- Resize your browser window (doesn't have to be a lot).
- Put the keyboard focus back in the editor if it's not already there.
- Press the Tab key. Focus should still go to the Check Your Code button.