### PR TITLE
fix(curriculum): ensure left alignment of output in translations

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/escape-sequences-in-strings.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/escape-sequences-in-strings.md
@@ -19,7 +19,7 @@ Quotes are not the only characters that can be <dfn>escaped</dfn> inside a strin
 
 Assign the following three lines of text into the single variable `myStr` using escape sequences.
 
-```
+<pre>
 FirstLine
     \SecondLine
 ThirdLine

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/escape-sequences-in-strings.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/escape-sequences-in-strings.md
@@ -23,7 +23,7 @@ Assign the following three lines of text into the single variable `myStr` using 
 FirstLine
     \SecondLine
 ThirdLine
-```
+</pre>
 
 You will need to use escape sequences to insert special characters correctly. You will also need to follow the spacing as it looks above, with no spaces between escape sequences or words.
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/escape-sequences-in-strings.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/escape-sequences-in-strings.md
@@ -19,7 +19,11 @@ Quotes are not the only characters that can be <dfn>escaped</dfn> inside a strin
 
 Assign the following three lines of text into the single variable `myStr` using escape sequences.
 
-<blockquote>FirstLine<br>    \SecondLine<br>ThirdLine</blockquote>
+```
+FirstLine
+    \SecondLine
+ThirdLine
+```
 
 You will need to use escape sequences to insert special characters correctly. You will also need to follow the spacing as it looks above, with no spaces between escape sequences or words.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #49515 

<!-- Feel free to add any additional description of changes below this line -->

The *blockquote* were changed to **codeblocks** to ensure Right-to-left format