### PR TITLE
fix: pass expected object to isAudited

### DIFF
--- a/utils/is-audited.js
+++ b/utils/is-audited.js
@@ -4,7 +4,7 @@ function isAuditedCert(language, superblock) {
   if (!language || !superblock)
     throw Error('Both arguments must be provided for auditing');
 
-  const auditedSuperBlocks = getAuditedSuperBlocks(language);
+  const auditedSuperBlocks = getAuditedSuperBlocks({ language });
   return auditedSuperBlocks.includes(superblock);
 }
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

I was looking in to the failing tests on #49294 and finally found this. It looks like `getAuditedSuperblocks` was updated to expect an object with a `language` property, but `isAuditedCert` was still passing the language directly.

This meant all of the tests were running on the English superblock order, which was throwing the error in the above PR. I'm not entirely sure how nothing broke until now, but this *should* fix it?