### PR TITLE
feat(client): warn endpoint url submission

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -596,7 +596,8 @@
     "editor-url": "Remember to submit the Live App URL.",
     "http-url": "An unsecure (http) URL cannot be used.",
     "own-work-url": "Remember to submit your own work.",
-    "publicly-visible-url": "Remember to submit a publicly visible app URL."
+    "publicly-visible-url": "Remember to submit a publicly visible app URL.",
+    "endpoint-url": "You probably do not mean to submit a URL including an endpoint."
   },
   "certification": {
     "executive": "Executive Director, freeCodeCamp.org",

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -597,7 +597,7 @@
     "http-url": "An unsecure (http) URL cannot be used.",
     "own-work-url": "Remember to submit your own work.",
     "publicly-visible-url": "Remember to submit a publicly visible app URL.",
-    "endpoint-url": "You probably want to submit the root path i.e. https://example.com, not https://example.com/path"
+    "path-url": "You probably want to submit the root path i.e. https://example.com, not https://example.com/path"
   },
   "certification": {
     "executive": "Executive Director, freeCodeCamp.org",

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -597,7 +597,7 @@
     "http-url": "An unsecure (http) URL cannot be used.",
     "own-work-url": "Remember to submit your own work.",
     "publicly-visible-url": "Remember to submit a publicly visible app URL.",
-    "endpoint-url": "You probably do not mean to submit a URL including an endpoint."
+    "endpoint-url": "You probably want to submit the root path i.e. https://example.com, not https://example.com/path"
   },
   "certification": {
     "executive": "Executive Director, freeCodeCamp.org",

--- a/client/src/components/formHelpers/form-fields.tsx
+++ b/client/src/components/formHelpers/form-fields.tsx
@@ -16,7 +16,7 @@ import {
   composeValidators,
   fCCValidator,
   httpValidator,
-  endpointValidator
+  pathValidator
 } from './form-validators';
 
 export type FormOptions = {
@@ -64,7 +64,7 @@ function FormFields(props: FormFieldsProps): JSX.Element {
       fCCValidator,
       httpValidator,
       isLocalLinkAllowed ? null : localhostValidator,
-      endpointValidator
+      pathValidator
     )(value);
     const message: string = (error ||
       validationError ||

--- a/client/src/components/formHelpers/form-fields.tsx
+++ b/client/src/components/formHelpers/form-fields.tsx
@@ -15,7 +15,8 @@ import {
   localhostValidator,
   composeValidators,
   fCCValidator,
-  httpValidator
+  httpValidator,
+  endpointValidator
 } from './form-validators';
 
 export type FormOptions = {
@@ -62,7 +63,8 @@ function FormFields(props: FormFieldsProps): JSX.Element {
       name === 'githubLink' || isEditorLinkAllowed ? null : editorValidator,
       fCCValidator,
       httpValidator,
-      isLocalLinkAllowed ? null : localhostValidator
+      isLocalLinkAllowed ? null : localhostValidator,
+      endpointValidator
     )(value);
     const message: string = (error ||
       validationError ||

--- a/client/src/components/formHelpers/form-validators.tsx
+++ b/client/src/components/formHelpers/form-validators.tsx
@@ -9,7 +9,7 @@ const fCCRegex =
 const localhostRegex = /localhost:/;
 const httpRegex = /http(?!s|([^s]+?localhost))/;
 
-function hasEndpoint(urlString: string): boolean {
+function isPathRoot(urlString: string): boolean {
   try {
     return new URL(urlString).pathname !== '/';
   } catch {
@@ -31,8 +31,8 @@ export const localhostValidator = (value: string): React.ReactElement | null =>
 export const httpValidator = (value: string): React.ReactElement | null =>
   httpRegex.test(value) ? <Trans>validation.http-url</Trans> : null;
 
-export const endpointValidator = (value: string): React.ReactElement | null =>
-  hasEndpoint(value) ? <Trans>validation.endpoint-url</Trans> : null;
+export const pathValidator = (value: string): React.ReactElement | null =>
+  isPathRoot(value) ? <Trans>validation.path-url</Trans> : null;
 
 type Validator = (value: string) => React.ReactElement | null;
 export function composeValidators(...validators: (Validator | null)[]) {

--- a/client/src/components/formHelpers/form-validators.tsx
+++ b/client/src/components/formHelpers/form-validators.tsx
@@ -9,6 +9,18 @@ const fCCRegex =
 const localhostRegex = /localhost:/;
 const httpRegex = /http(?!s|([^s]+?localhost))/;
 
+function hasEndpoint(urlString: string): boolean {
+  try {
+    const url = new URL(urlString);
+    if (url.pathname && url.pathname !== '/') {
+      return true;
+    }
+  } catch (_e) {
+    return false;
+  }
+  return false;
+}
+
 export const editorValidator = (value: string): React.ReactElement | null =>
   editorRegex.test(value) ? <Trans>validation.editor-url</Trans> : null;
 
@@ -22,6 +34,9 @@ export const localhostValidator = (value: string): React.ReactElement | null =>
 
 export const httpValidator = (value: string): React.ReactElement | null =>
   httpRegex.test(value) ? <Trans>validation.http-url</Trans> : null;
+
+export const endpointValidator = (value: string): React.ReactElement | null =>
+  hasEndpoint(value) ? <Trans>validation.endpoint-url</Trans> : null;
 
 type Validator = (value: string) => React.ReactElement | null;
 export function composeValidators(...validators: (Validator | null)[]) {

--- a/client/src/components/formHelpers/form-validators.tsx
+++ b/client/src/components/formHelpers/form-validators.tsx
@@ -11,14 +11,10 @@ const httpRegex = /http(?!s|([^s]+?localhost))/;
 
 function hasEndpoint(urlString: string): boolean {
   try {
-    const url = new URL(urlString);
-    if (url.pathname && url.pathname !== '/') {
-      return true;
-    }
-  } catch (_e) {
+    return new URL(urlString).pathname !== '/';
+  } catch {
     return false;
   }
-  return false;
 }
 
 export const editorValidator = (value: string): React.ReactElement | null =>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Feature internally discussed:
- Campers have been known to submit URLs like: `https://camper.replit.com/json`
  - This fails tests
- We should still allow endpoints, because some (me) host multiple projects on a single domain

Currently, this just adds a warning (form is **always** submit-able):
<img width="475" alt="image" src="https://user-images.githubusercontent.com/51722130/222207084-9a42a2e4-0eaf-4886-a817-a8a4398fd3b2.png">


_I always forget: should all language translations be updated or not?_