### PR TITLE
fix(client): prevent word wrap in Chinese & Japanese button text

### DIFF
--- a/client/src/components/profile/components/portfolio.css
+++ b/client/src/components/profile/components/portfolio.css
@@ -39,6 +39,8 @@
   padding-inline: 4rem;
   margin: 1em;
   text-decoration: none;
+  /* prevent line breaks in Chinese/Japanese/Korean */
+  word-break: keep-all;
 }
 
 .portfolio-container a::after {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
This issue is the same as #48530
Affected page: Profile page such as https://www.freecodecamp.org/japanese/sidemt

![image](https://user-images.githubusercontent.com/25644062/222712208-f646a0b7-0a7c-4fac-9024-c57124fec385.png)
