### PR TITLE
fix: update CODEOWNERS so pnpm-lock is not owned

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,7 +17,7 @@
 
 *.md
 package.json
-package-lock.json
+pnpm-lock.yaml
 
 # -------------------------------------------------
 # All files in the root are owned by dev team
@@ -28,7 +28,7 @@ package-lock.json
 # --- Owned by none (negate rule above) ---
 
 /package.json
-/package-lock.json
+/pnpm-lock.yaml
 
 # -------------------------------------------------
 # Files that need attention from Staff


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Ref: https://github.com/freeCodeCamp/freeCodeCamp/pull/49584, this should not have asked for a review from the dev team.

<!-- Feel free to add any additional description of changes below this line -->
