### PR TITLE
feat(client): clean extra CSS properties

### DIFF
--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -563,10 +563,6 @@ pre {
   margin-bottom: 0;
 }
 
-.solution-viewer {
-  border-color: var(--primary-color);
-}
-
 .has-success .help-block,
 .has-success .control-label,
 .has-success .radio,

--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -450,10 +450,6 @@ hr {
   border-top: 1px solid var(--quaternary-background);
 }
 
-.panel-default {
-  background: var(--secondary-background);
-}
-
 .btn-primary:active,
 .btn-primary.active,
 .open > .dropdown-toggle.btn-primary,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This property was affecting view buttons in JavaScript Algorithms and Data Structures

with and without the property, it looked like this 

![image](https://user-images.githubusercontent.com/88248797/223426000-5abd15d7-dc17-4dbc-ba90-e7f9df435c20.png)


It isn't needed because there is another property that do the same thing https://github.com/Sboonny/freeCodeCamp/blob/471b0da0cfe88b34249c80ebb603501bcb958c8b/client/src/components/layouts/global.css#L608-L610
<!-- Feel free to add any additional description of changes below this line -->
