### PR TITLE
feat(api): validate environment variables before use

### DIFF
--- a/api/db/index.ts
+++ b/api/db/index.ts
@@ -2,7 +2,7 @@ import fastifyPlugin from 'fastify-plugin';
 import fastifyMongo from '@fastify/mongodb';
 import { FastifyInstance } from 'fastify';
 
-import { MONGOHQ_URL } from '../utils/secrets';
+import { MONGOHQ_URL } from '../utils/env';
 
 async function connect(fastify: FastifyInstance) {
   fastify.log.info(`Connecting to Mongodb`);

--- a/api/db/index.ts
+++ b/api/db/index.ts
@@ -2,12 +2,12 @@ import fastifyPlugin from 'fastify-plugin';
 import fastifyMongo from '@fastify/mongodb';
 import { FastifyInstance } from 'fastify';
 
-const URI = process.env.MONGOHQ_URL || 'mongodb://localhost:27017/freecodecamp';
+import { MONGOHQ_URL } from '../utils/secrets';
 
 async function connect(fastify: FastifyInstance) {
-  fastify.log.info(`Connecting to : ${URI}`);
+  fastify.log.info(`Connecting to Mongodb`);
   await fastify.register(fastifyMongo, {
-    url: URI
+    url: MONGOHQ_URL
   });
 }
 

--- a/api/index.ts
+++ b/api/index.ts
@@ -1,5 +1,3 @@
-import { config } from 'dotenv';
-config({ path: '../.env' });
 import fastifyAuth0 from 'fastify-auth0-verify';
 import Fastify from 'fastify';
 import middie from '@fastify/middie';
@@ -8,9 +6,10 @@ import jwtAuthz from './plugins/fastify-jwt-authz';
 import { testRoutes } from './routes/test';
 import { dbConnector } from './db';
 import { auth0Verify, testMiddleware } from './middleware';
+import { AUTH0_AUDIENCE, AUTH0_DOMAIN, NODE_ENV, PORT } from './utils/env';
 
 const fastify = Fastify({
-  logger: { level: process.env.NODE_ENV === 'development' ? 'debug' : 'fatal' }
+  logger: { level: NODE_ENV === 'development' ? 'debug' : 'fatal' }
 });
 
 fastify.get('/', async (_request, _reply) => {
@@ -23,8 +22,8 @@ const start = async () => {
 
   // Auth0 plugin
   void fastify.register(fastifyAuth0, {
-    domain: process.env.AUTH0_DOMAIN,
-    audience: process.env.AUTH0_AUDIENCE
+    domain: AUTH0_DOMAIN,
+    audience: AUTH0_AUDIENCE
   });
   void fastify.register(jwtAuthz);
 
@@ -37,7 +36,7 @@ const start = async () => {
   void fastify.register(testRoutes);
 
   try {
-    const port = Number(process.env.PORT) || 3000;
+    const port = Number(PORT);
     fastify.log.info(`Starting server on port ${port}`);
     await fastify.listen({ port });
   } catch (err) {

--- a/api/utils/env.ts
+++ b/api/utils/env.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert';
+import path from 'node:path';
+import { config } from 'dotenv';
+
+const envPath = path.resolve(__dirname, '../../.env');
+const { error } = config({ path: envPath });
+
+if (error) {
+  console.warn(`
+  ----------------------------------------------------
+  Warning: .env file not found.
+  ----------------------------------------------------
+  Please copy sample.env to .env
+
+  You can ignore this warning if using a different way
+  to setup this environment.
+  ----------------------------------------------------
+  `);
+}
+
+assert.ok(process.env.NODE_ENV);
+assert.ok(process.env.AUTH0_DOMAIN);
+assert.ok(process.env.AUTH0_AUDIENCE);
+if (process.env.NODE_ENV !== 'development') {
+  assert.ok(process.env.PORT);
+}
+
+export const NODE_ENV = process.env.NODE_ENV;
+export const AUTH0_DOMAIN = process.env.AUTH0_DOMAIN;
+export const AUTH0_AUDIENCE = process.env.AUTH0_AUDIENCE;
+export const PORT = process.env.PORT || '3000';

--- a/api/utils/env.ts
+++ b/api/utils/env.ts
@@ -21,10 +21,14 @@ if (error) {
 assert.ok(process.env.NODE_ENV);
 assert.ok(process.env.AUTH0_DOMAIN);
 assert.ok(process.env.AUTH0_AUDIENCE);
+
 if (process.env.NODE_ENV !== 'development') {
   assert.ok(process.env.PORT);
+  assert.ok(process.env.MONGOHQ_URL);
 }
 
+export const MONGOHQ_URL =
+  process.env.MONGOHQ_URL || 'mongodb://localhost:27017/freecodecamp';
 export const NODE_ENV = process.env.NODE_ENV;
 export const AUTH0_DOMAIN = process.env.AUTH0_DOMAIN;
 export const AUTH0_AUDIENCE = process.env.AUTH0_AUDIENCE;

--- a/api/utils/secrets.ts
+++ b/api/utils/secrets.ts
@@ -1,8 +1,0 @@
-import assert from 'node:assert';
-
-import { NODE_ENV } from './env';
-
-if (NODE_ENV !== 'development') assert.ok(process.env.MONGOHQ_URL);
-
-export const MONGOHQ_URL =
-  process.env.MONGOHQ_URL || 'mongodb://localhost:27017/freecodecamp';

--- a/api/utils/secrets.ts
+++ b/api/utils/secrets.ts
@@ -1,0 +1,8 @@
+import assert from 'node:assert';
+
+import { NODE_ENV } from './env';
+
+if (NODE_ENV !== 'development') assert.ok(process.env.MONGOHQ_URL);
+
+export const MONGOHQ_URL =
+  process.env.MONGOHQ_URL || 'mongodb://localhost:27017/freecodecamp';


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This is similar in concept to ensure-env, but a little simpler since there is no need to put the data in a file before the api can consume it.


<!-- Feel free to add any additional description of changes below this line -->
