### PR TITLE
chore: drop setup-node and use caching

### DIFF
--- a/.github/workflows/crowdin-download.client-ui.yml
+++ b/.github/workflows/crowdin-download.client-ui.yml
@@ -15,6 +15,10 @@ jobs:
   i18n-download-client-ui-translations:
     name: Client
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        node-version: [default, 19.x]
+      fail-fast: true
 
     steps:
       - name: Checkout Source Files

--- a/.github/workflows/crowdin-download.curriculum.yml
+++ b/.github/workflows/crowdin-download.curriculum.yml
@@ -278,15 +278,14 @@ jobs:
           version: 7
 
       - name: Get pnpm store directory
-        id: pnpm-cache
         shell: bash
         run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - uses: actions/cache@v3
         name: Setup pnpm cache
         with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-

--- a/.github/workflows/crowdin-download.curriculum.yml
+++ b/.github/workflows/crowdin-download.curriculum.yml
@@ -282,6 +282,12 @@ jobs:
         with:
           version: 7
 
+      - name: Override node version
+        shell: bash
+        if: ${{ matrix.node-version != 'default' }}
+        run: |
+          echo "use-node-version=${{ matrix.node-version }}" >> .npmrc
+
       - name: Get pnpm store directory
         shell: bash
         run: |

--- a/.github/workflows/crowdin-download.curriculum.yml
+++ b/.github/workflows/crowdin-download.curriculum.yml
@@ -15,6 +15,11 @@ jobs:
   i18n-download-curriculum-translations:
     name: Curriculum
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        # allowed values: default and full node versions (e.g. 18.14.2)
+        node-version: [default, 19.7.0]
+      fail-fast: true
 
     steps:
       - name: Checkout Source Files

--- a/.github/workflows/crowdin-download.curriculum.yml
+++ b/.github/workflows/crowdin-download.curriculum.yml
@@ -15,10 +15,6 @@ jobs:
   i18n-download-curriculum-translations:
     name: Curriculum
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        node-version: [18.x]
-      fail-fast: true
 
     steps:
       - name: Checkout Source Files
@@ -280,11 +276,6 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 7
-
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
-        with:
-          node-version: ${{ matrix.node-version }}
 
       - name: Set Environment variables
         run: |

--- a/.github/workflows/crowdin-download.curriculum.yml
+++ b/.github/workflows/crowdin-download.curriculum.yml
@@ -277,6 +277,20 @@ jobs:
         with:
           version: 7
 
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
       - name: Set Environment variables
         run: |
           cp sample.env .env

--- a/.github/workflows/crowdin-download.curriculum.yml
+++ b/.github/workflows/crowdin-download.curriculum.yml
@@ -281,7 +281,7 @@ jobs:
         id: pnpm-cache
         shell: bash
         run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache

--- a/.github/workflows/crowdin-download.curriculum.yml
+++ b/.github/workflows/crowdin-download.curriculum.yml
@@ -311,6 +311,8 @@ jobs:
         run: |
           echo pnpm version $(pnpm -v)
           pnpm install
+          pnpm node -v
+          cat .npmrc
           pnpm run create:config
           pnpm run build:curriculum
           pnpm run build:server

--- a/.github/workflows/crowdin-download.docs.yml
+++ b/.github/workflows/crowdin-download.docs.yml
@@ -15,7 +15,11 @@ jobs:
   i18n-download-docs-translations:
     name: Docs
     runs-on: ubuntu-20.04
-
+    strategy:
+      matrix:
+        # allowed values: default and full node versions (e.g. 18.14.2)
+        node-version: [default, 19.7.0]
+      fail-fast: true
     steps:
       - name: Checkout Source Files
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3

--- a/.github/workflows/crowdin-upload.client-ui.yml
+++ b/.github/workflows/crowdin-upload.client-ui.yml
@@ -15,6 +15,11 @@ jobs:
   i18n-upload-client-ui-files:
     name: Client
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        # allowed values: default and full node versions (e.g. 18.14.2)
+        node-version: [default, 19.7.0]
+      fail-fast: true
 
     steps:
       - name: Checkout Source Files

--- a/.github/workflows/crowdin-upload.curriculum.yml
+++ b/.github/workflows/crowdin-upload.curriculum.yml
@@ -15,6 +15,11 @@ jobs:
   i18n-upload-curriculum-files:
     name: Learn
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        # allowed values: default and full node versions (e.g. 18.14.2)
+        node-version: [default, 19.7.0]
+      fail-fast: true
 
     steps:
       - name: Checkout Source Files

--- a/.github/workflows/crowdin-upload.docs.yml
+++ b/.github/workflows/crowdin-upload.docs.yml
@@ -15,6 +15,11 @@ jobs:
   i18n-upload-docs-files:
     name: Docs
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        # allowed values: default and full node versions (e.g. 18.14.2)
+        node-version: [default, 19.7.0]
+      fail-fast: true
 
     steps:
       - name: Checkout Source Files

--- a/.github/workflows/e2e-mobile.yml
+++ b/.github/workflows/e2e-mobile.yml
@@ -34,15 +34,14 @@ jobs:
           version: 7
 
       - name: Get pnpm store directory
-        id: pnpm-cache
         shell: bash
         run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - uses: actions/cache@v3
         name: Setup pnpm cache
         with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-

--- a/.github/workflows/e2e-mobile.yml
+++ b/.github/workflows/e2e-mobile.yml
@@ -37,7 +37,7 @@ jobs:
         id: pnpm-cache
         shell: bash
         run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache

--- a/.github/workflows/e2e-mobile.yml
+++ b/.github/workflows/e2e-mobile.yml
@@ -17,6 +17,11 @@ jobs:
   mobile-test:
     name: Test curriculum for mobile app
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        # allowed values: default and full node versions (e.g. 18.14.2)
+        node-version: [default, 19.7.0]
+      fail-fast: true
 
     steps:
       - name: Checkout Source Files

--- a/.github/workflows/e2e-mobile.yml
+++ b/.github/workflows/e2e-mobile.yml
@@ -72,6 +72,8 @@ jobs:
       - name: Install and Build
         run: |
           pnpm install
+          pnpm node -v
+          cat .npmrc
           pnpm run create:config
           pnpm run build:curriculum
 

--- a/.github/workflows/e2e-mobile.yml
+++ b/.github/workflows/e2e-mobile.yml
@@ -38,6 +38,12 @@ jobs:
         with:
           version: 7
 
+      - name: Override node version
+        shell: bash
+        if: ${{ matrix.node-version != 'default' }}
+        run: |
+          echo "use-node-version=${{ matrix.node-version }}" >> .npmrc
+
       - name: Get pnpm store directory
         shell: bash
         run: |

--- a/.github/workflows/e2e-mobile.yml
+++ b/.github/workflows/e2e-mobile.yml
@@ -17,9 +17,6 @@ jobs:
   mobile-test:
     name: Test curriculum for mobile app
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        node-version: [18.x]
 
     steps:
       - name: Checkout Source Files
@@ -35,11 +32,6 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 7
-
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
-        with:
-          node-version: ${{ matrix.node-version }}
 
       - name: Setup Flutter 3.3.x
         uses: subosito/flutter-action@dbf1fa04f4d2e52c33185153d06cdb5443aa189d # tag=v2

--- a/.github/workflows/e2e-mobile.yml
+++ b/.github/workflows/e2e-mobile.yml
@@ -33,6 +33,20 @@ jobs:
         with:
           version: 7
 
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
       - name: Setup Flutter 3.3.x
         uses: subosito/flutter-action@dbf1fa04f4d2e52c33185153d06cdb5443aa189d # tag=v2
         with:

--- a/.github/workflows/e2e-third-party.yml
+++ b/.github/workflows/e2e-third-party.yml
@@ -40,15 +40,14 @@ jobs:
           version: 7
 
       - name: Get pnpm store directory
-        id: pnpm-cache
         shell: bash
         run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - uses: actions/cache@v3
         name: Setup pnpm cache
         with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-

--- a/.github/workflows/e2e-third-party.yml
+++ b/.github/workflows/e2e-third-party.yml
@@ -75,6 +75,8 @@ jobs:
       - name: Install and Build
         run: |
           pnpm install
+          pnpm node -v
+          cat .npmrc
           pnpm run build
       - name: Seed Database
         run: pnpm run seed

--- a/.github/workflows/e2e-third-party.yml
+++ b/.github/workflows/e2e-third-party.yml
@@ -39,6 +39,20 @@ jobs:
         with:
           version: 7
 
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
       - name: Set freeCodeCamp Environment Variables
         run: |
           sed '/STRIPE/d; /PAYPAL/d;' sample.env > .env

--- a/.github/workflows/e2e-third-party.yml
+++ b/.github/workflows/e2e-third-party.yml
@@ -13,6 +13,12 @@ jobs:
   do-everything:
     name: Build & Test
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        # allowed values: default and full node versions (e.g. 18.14.2)
+        node-version: [default, 19.7.0]
+      fail-fast: true
+
     services:
       mongodb:
         image: mongo:4.4

--- a/.github/workflows/e2e-third-party.yml
+++ b/.github/workflows/e2e-third-party.yml
@@ -43,7 +43,7 @@ jobs:
         id: pnpm-cache
         shell: bash
         run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache

--- a/.github/workflows/e2e-third-party.yml
+++ b/.github/workflows/e2e-third-party.yml
@@ -13,9 +13,6 @@ jobs:
   do-everything:
     name: Build & Test
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        node-version: [18.x]
     services:
       mongodb:
         image: mongo:4.4
@@ -41,11 +38,6 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 7
-
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
-        with:
-          node-version: ${{ matrix.node-version }}
 
       - name: Set freeCodeCamp Environment Variables
         run: |

--- a/.github/workflows/e2e-third-party.yml
+++ b/.github/workflows/e2e-third-party.yml
@@ -45,6 +45,12 @@ jobs:
         with:
           version: 7
 
+      - name: Override node version
+        shell: bash
+        if: ${{ matrix.node-version != 'default' }}
+        run: |
+          echo "use-node-version=${{ matrix.node-version }}" >> .npmrc
+
       - name: Get pnpm store directory
         shell: bash
         run: |

--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -37,6 +37,12 @@ jobs:
         with:
           version: 7
 
+      - name: Override node version
+        shell: bash
+        if: ${{ matrix.node-version != 'default' }}
+        run: |
+          echo "use-node-version=${{ matrix.node-version }}" >> .npmrc
+
       - name: Get pnpm store directory
         shell: bash
         run: |
@@ -135,6 +141,12 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 7
+
+      - name: Override node version
+        shell: bash
+        if: ${{ matrix.node-version != 'default' }}
+        run: |
+          echo "use-node-version=${{ matrix.node-version }}" >> .npmrc
 
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -35,7 +35,7 @@ jobs:
         id: pnpm-cache
         shell: bash
         run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache
@@ -133,7 +133,7 @@ jobs:
         id: pnpm-cache
         shell: bash
         run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache

--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -31,6 +31,20 @@ jobs:
         with:
           version: 7
 
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
       - name: Set freeCodeCamp Environment Variables
         run: cp sample.env .env
 
@@ -114,6 +128,20 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 7
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
 
       - name: Set freeCodeCamp Environment Variables
         run: cp sample.env .env

--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -32,15 +32,14 @@ jobs:
           version: 7
 
       - name: Get pnpm store directory
-        id: pnpm-cache
         shell: bash
         run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - uses: actions/cache@v3
         name: Setup pnpm cache
         with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
@@ -130,15 +129,14 @@ jobs:
           version: 7
 
       - name: Get pnpm store directory
-        id: pnpm-cache
         shell: bash
         run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - uses: actions/cache@v3
         name: Setup pnpm cache
         with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-

--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -62,6 +62,8 @@ jobs:
       - name: Install and Build
         run: |
           pnpm install
+          pnpm node -v
+          cat .npmrc
           pnpm run build
 
       - name: Move serve.json to Public Folder
@@ -167,6 +169,8 @@ jobs:
       - name: Install and Build
         run: |
           pnpm install
+          pnpm node -v
+          cat .npmrc
           pnpm run create:config
           pnpm run build:curriculum
           pnpm run build:server

--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -16,10 +16,6 @@ jobs:
   build-client:
     name: Build
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        node-version: [18.x]
-
     steps:
       - name: Checkout Source Files
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
@@ -34,11 +30,6 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 7
-
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
-        with:
-          node-version: ${{ matrix.node-version }}
 
       - name: Set freeCodeCamp Environment Variables
         run: cp sample.env .env
@@ -75,7 +66,6 @@ jobs:
       fail-fast: false
       matrix:
         browsers: [chrome, firefox, electron]
-        node-version: [18.x]
         include:
           - browsers: electron
             spec: cypress/e2e/default/learn/challenges/projects.js
@@ -124,11 +114,6 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 7
-
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
-        with:
-          node-version: ${{ matrix.node-version }}
 
       - name: Set freeCodeCamp Environment Variables
         run: cp sample.env .env

--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -16,6 +16,12 @@ jobs:
   build-client:
     name: Build
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        # allowed values: default and full node versions (e.g. 18.14.2)
+        node-version: [default, 19.7.0]
+      fail-fast: true
+
     steps:
       - name: Checkout Source Files
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
@@ -78,6 +84,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # allowed values: default and full node versions (e.g. 18.14.2)
+        node-version: [default, 19.7.0]
         browsers: [chrome, firefox, electron]
         include:
           - browsers: electron

--- a/.github/workflows/i18n-validate-builds.yml
+++ b/.github/workflows/i18n-validate-builds.yml
@@ -8,9 +8,6 @@ jobs:
   ci:
     name: Validate i18n Builds
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        node-version: [18.x]
 
     steps:
       - name: Checkout Source Files
@@ -19,10 +16,6 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 7
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
-        with:
-          node-version: ${{ matrix.node-version }}
 
       - name: Set freeCodeCamp Environment Variables
         run: cp sample.env .env

--- a/.github/workflows/i18n-validate-builds.yml
+++ b/.github/workflows/i18n-validate-builds.yml
@@ -21,7 +21,7 @@ jobs:
         id: pnpm-cache
         shell: bash
         run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache

--- a/.github/workflows/i18n-validate-builds.yml
+++ b/.github/workflows/i18n-validate-builds.yml
@@ -17,6 +17,20 @@ jobs:
         with:
           version: 7
 
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
       - name: Set freeCodeCamp Environment Variables
         run: cp sample.env .env
 

--- a/.github/workflows/i18n-validate-builds.yml
+++ b/.github/workflows/i18n-validate-builds.yml
@@ -22,6 +22,12 @@ jobs:
         with:
           version: 7
 
+      - name: Override node version
+        shell: bash
+        if: ${{ matrix.node-version != 'default' }}
+        run: |
+          echo "use-node-version=${{ matrix.node-version }}" >> .npmrc
+
       - name: Get pnpm store directory
         shell: bash
         run: |

--- a/.github/workflows/i18n-validate-builds.yml
+++ b/.github/workflows/i18n-validate-builds.yml
@@ -8,6 +8,11 @@ jobs:
   ci:
     name: Validate i18n Builds
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        # allowed values: default and full node versions (e.g. 18.14.2)
+        node-version: [default, 19.7.0]
+      fail-fast: true
 
     steps:
       - name: Checkout Source Files

--- a/.github/workflows/i18n-validate-builds.yml
+++ b/.github/workflows/i18n-validate-builds.yml
@@ -18,15 +18,14 @@ jobs:
           version: 7
 
       - name: Get pnpm store directory
-        id: pnpm-cache
         shell: bash
         run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - uses: actions/cache@v3
         name: Setup pnpm cache
         with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-

--- a/.github/workflows/i18n-validate-prs.yml
+++ b/.github/workflows/i18n-validate-prs.yml
@@ -19,6 +19,20 @@ jobs:
         with:
           version: 7
 
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
       - name: Set freeCodeCamp Environment Variables
         run: cp sample.env .env
 

--- a/.github/workflows/i18n-validate-prs.yml
+++ b/.github/workflows/i18n-validate-prs.yml
@@ -10,9 +10,6 @@ jobs:
     # run only on PRs that camperbot opens with title that matches the curriculum sync
     if: ${{ github.event.pull_request.user.login == 'camperbot' && contains(github.event.pull_request.title, 'chore(i18n,learn)') }}
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        node-version: [18.x]
 
     steps:
       - name: Checkout Source Files
@@ -21,10 +18,6 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 7
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
-        with:
-          node-version: ${{ matrix.node-version }}
 
       - name: Set freeCodeCamp Environment Variables
         run: cp sample.env .env

--- a/.github/workflows/i18n-validate-prs.yml
+++ b/.github/workflows/i18n-validate-prs.yml
@@ -24,6 +24,12 @@ jobs:
         with:
           version: 7
 
+      - name: Override node version
+        shell: bash
+        if: ${{ matrix.node-version != 'default' }}
+        run: |
+          echo "use-node-version=${{ matrix.node-version }}" >> .npmrc
+
       - name: Get pnpm store directory
         shell: bash
         run: |

--- a/.github/workflows/i18n-validate-prs.yml
+++ b/.github/workflows/i18n-validate-prs.yml
@@ -23,7 +23,7 @@ jobs:
         id: pnpm-cache
         shell: bash
         run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache

--- a/.github/workflows/i18n-validate-prs.yml
+++ b/.github/workflows/i18n-validate-prs.yml
@@ -10,6 +10,11 @@ jobs:
     # run only on PRs that camperbot opens with title that matches the curriculum sync
     if: ${{ github.event.pull_request.user.login == 'camperbot' && contains(github.event.pull_request.title, 'chore(i18n,learn)') }}
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        # allowed values: default and full node versions (e.g. 18.14.2)
+        node-version: [default, 19.7.0]
+      fail-fast: true
 
     steps:
       - name: Checkout Source Files

--- a/.github/workflows/i18n-validate-prs.yml
+++ b/.github/workflows/i18n-validate-prs.yml
@@ -20,15 +20,14 @@ jobs:
           version: 7
 
       - name: Get pnpm store directory
-        id: pnpm-cache
         shell: bash
         run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - uses: actions/cache@v3
         name: Setup pnpm cache
         with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-

--- a/.github/workflows/node.js-find-unused.yml
+++ b/.github/workflows/node.js-find-unused.yml
@@ -21,6 +21,20 @@ jobs:
         with:
           version: 7
 
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
       - name: Set Environment variables
         run: |
           cp sample.env .env

--- a/.github/workflows/node.js-find-unused.yml
+++ b/.github/workflows/node.js-find-unused.yml
@@ -27,6 +27,12 @@ jobs:
         with:
           version: 7
 
+      - name: Override node version
+        shell: bash
+        if: ${{ matrix.node-version != 'default' }}
+        run: |
+          echo "use-node-version=${{ matrix.node-version }}" >> .npmrc
+
       - name: Get pnpm store directory
         shell: bash
         run: |

--- a/.github/workflows/node.js-find-unused.yml
+++ b/.github/workflows/node.js-find-unused.yml
@@ -13,6 +13,12 @@ jobs:
   lint:
     name: Find Unused
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        # allowed values: default and full node versions (e.g. 18.14.2)
+        node-version: [default, 19.7.0]
+      fail-fast: true
+
     steps:
       - name: Checkout Source Files
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3

--- a/.github/workflows/node.js-find-unused.yml
+++ b/.github/workflows/node.js-find-unused.yml
@@ -22,15 +22,14 @@ jobs:
           version: 7
 
       - name: Get pnpm store directory
-        id: pnpm-cache
         shell: bash
         run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - uses: actions/cache@v3
         name: Setup pnpm cache
         with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-

--- a/.github/workflows/node.js-find-unused.yml
+++ b/.github/workflows/node.js-find-unused.yml
@@ -25,7 +25,7 @@ jobs:
         id: pnpm-cache
         shell: bash
         run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache

--- a/.github/workflows/node.js-find-unused.yml
+++ b/.github/workflows/node.js-find-unused.yml
@@ -55,4 +55,6 @@ jobs:
         run: |
           echo pnpm version $(pnpm -v)
           pnpm install
+          pnpm node -v
+          cat .npmrc
           pnpm run knip

--- a/.github/workflows/node.js-find-unused.yml
+++ b/.github/workflows/node.js-find-unused.yml
@@ -13,12 +13,6 @@ jobs:
   lint:
     name: Find Unused
     runs-on: ubuntu-20.04
-
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version: [18.x]
-
     steps:
       - name: Checkout Source Files
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
@@ -26,10 +20,6 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 7
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
-        with:
-          node-version: ${{ matrix.node-version }}
 
       - name: Set Environment variables
         run: |

--- a/.github/workflows/node.js-tests-upcoming.yml
+++ b/.github/workflows/node.js-tests-upcoming.yml
@@ -25,6 +25,12 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        # allowed values: default and full node versions (e.g. 18.14.2)
+        node-version: [default, 19.7.0]
+      fail-fast: true
+
     steps:
       - name: Checkout Source Files
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
@@ -66,6 +72,12 @@ jobs:
     name: Test
     needs: lint
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        # allowed values: default and full node versions (e.g. 18.14.2)
+        node-version: [default, 19.7.0]
+      fail-fast: true
+
     steps:
       - name: Checkout Source Files
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3

--- a/.github/workflows/node.js-tests-upcoming.yml
+++ b/.github/workflows/node.js-tests-upcoming.yml
@@ -37,7 +37,7 @@ jobs:
         id: pnpm-cache
         shell: bash
         run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache
@@ -79,7 +79,7 @@ jobs:
         id: pnpm-cache
         shell: bash
         run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache

--- a/.github/workflows/node.js-tests-upcoming.yml
+++ b/.github/workflows/node.js-tests-upcoming.yml
@@ -68,6 +68,8 @@ jobs:
       - name: Lint Source Files
         run: |
           pnpm install
+          pnpm node -v
+          cat .npmrc
           pnpm run create:config
           npm i --prefix=curriculum-server
           npm i --prefix=web
@@ -121,6 +123,8 @@ jobs:
       - name: Install Dependencies
         run: |
           pnpm install
+          pnpm node -v
+          cat .npmrc
           pnpm run create:config
           pnpm run build:curriculum
 

--- a/.github/workflows/node.js-tests-upcoming.yml
+++ b/.github/workflows/node.js-tests-upcoming.yml
@@ -34,15 +34,14 @@ jobs:
           version: 7
 
       - name: Get pnpm store directory
-        id: pnpm-cache
         shell: bash
         run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - uses: actions/cache@v3
         name: Setup pnpm cache
         with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
@@ -76,15 +75,14 @@ jobs:
           version: 7
 
       - name: Get pnpm store directory
-        id: pnpm-cache
         shell: bash
         run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - uses: actions/cache@v3
         name: Setup pnpm cache
         with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-

--- a/.github/workflows/node.js-tests-upcoming.yml
+++ b/.github/workflows/node.js-tests-upcoming.yml
@@ -39,6 +39,12 @@ jobs:
         with:
           version: 7
 
+      - name: Override node version
+        shell: bash
+        if: ${{ matrix.node-version != 'default' }}
+        run: |
+          echo "use-node-version=${{ matrix.node-version }}" >> .npmrc
+
       - name: Get pnpm store directory
         shell: bash
         run: |
@@ -85,6 +91,12 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 7
+
+      - name: Override node version
+        shell: bash
+        if: ${{ matrix.node-version != 'default' }}
+        run: |
+          echo "use-node-version=${{ matrix.node-version }}" >> .npmrc
 
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/node.js-tests-upcoming.yml
+++ b/.github/workflows/node.js-tests-upcoming.yml
@@ -25,11 +25,6 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        node-version: [18.x]
-      fail-fast: false
-
     steps:
       - name: Checkout Source Files
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
@@ -37,10 +32,6 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 7
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
-        with:
-          node-version: ${{ matrix.node-version }}
 
       - name: Set Environment variables
         run: |
@@ -62,12 +53,6 @@ jobs:
     name: Test
     needs: lint
     runs-on: ubuntu-20.04
-
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version: [18.x]
-
     steps:
       - name: Checkout Source Files
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
@@ -75,10 +60,6 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 7
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
-        with:
-          node-version: ${{ matrix.node-version }}
 
       - name: Set Environment variables
         run: |

--- a/.github/workflows/node.js-tests-upcoming.yml
+++ b/.github/workflows/node.js-tests-upcoming.yml
@@ -33,6 +33,20 @@ jobs:
         with:
           version: 7
 
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
       - name: Set Environment variables
         run: |
           cp sample.env .env
@@ -60,6 +74,20 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 7
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
 
       - name: Set Environment variables
         run: |

--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -43,15 +43,14 @@ jobs:
           version: 7
 
       - name: Get pnpm store directory
-        id: pnpm-cache
         shell: bash
         run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - uses: actions/cache@v3
         name: Setup pnpm cache
         with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
@@ -88,15 +87,14 @@ jobs:
           version: 7
 
       - name: Get pnpm store directory
-        id: pnpm-cache
         shell: bash
         run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - uses: actions/cache@v3
         name: Setup pnpm cache
         with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
@@ -130,15 +128,14 @@ jobs:
           version: 7
 
       - name: Get pnpm store directory
-        id: pnpm-cache
         shell: bash
         run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - uses: actions/cache@v3
         name: Setup pnpm cache
         with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
@@ -179,15 +176,14 @@ jobs:
           version: 7
 
       - name: Get pnpm store directory
-        id: pnpm-cache
         shell: bash
         run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - uses: actions/cache@v3
         name: Setup pnpm cache
         with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-

--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -46,7 +46,7 @@ jobs:
         id: pnpm-cache
         shell: bash
         run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache
@@ -91,7 +91,7 @@ jobs:
         id: pnpm-cache
         shell: bash
         run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache
@@ -133,7 +133,7 @@ jobs:
         id: pnpm-cache
         shell: bash
         run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache
@@ -182,7 +182,7 @@ jobs:
         id: pnpm-cache
         shell: bash
         run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache

--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -47,6 +47,12 @@ jobs:
         with:
           version: 7
 
+      - name: Override node version
+        shell: bash
+        if: ${{ matrix.node-version != 'default' }}
+        run: |
+          echo "use-node-version=${{ matrix.node-version }}" >> .npmrc
+
       - name: Get pnpm store directory
         shell: bash
         run: |
@@ -97,6 +103,12 @@ jobs:
         with:
           version: 7
 
+      - name: Override node version
+        shell: bash
+        if: ${{ matrix.node-version != 'default' }}
+        run: |
+          echo "use-node-version=${{ matrix.node-version }}" >> .npmrc
+
       - name: Get pnpm store directory
         shell: bash
         run: |
@@ -143,6 +155,12 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 7
+
+      - name: Override node version
+        shell: bash
+        if: ${{ matrix.node-version != 'default' }}
+        run: |
+          echo "use-node-version=${{ matrix.node-version }}" >> .npmrc
 
       - name: Get pnpm store directory
         shell: bash
@@ -193,6 +211,12 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 7
+
+      - name: Override node version
+        shell: bash
+        if: ${{ matrix.node-version != 'default' }}
+        run: |
+          echo "use-node-version=${{ matrix.node-version }}" >> .npmrc
 
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -24,10 +24,6 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        node-version: [18.x]
-      fail-fast: false
 
     steps:
       - name: Checkout Source Files
@@ -45,11 +41,6 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 7
-
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
-        with:
-          node-version: ${{ matrix.node-version }}
 
       - name: Set Environment variables
         run: |
@@ -73,12 +64,6 @@ jobs:
     name: Test
     needs: lint
     runs-on: ubuntu-20.04
-
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version: [18.x]
-
     steps:
       - name: Checkout Source Files
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
@@ -87,11 +72,6 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 7
-
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
-        with:
-          node-version: ${{ matrix.node-version }}
 
       - name: Set Environment variables
         run: |
@@ -112,12 +92,6 @@ jobs:
     name: Test Upcoming Changes
     needs: lint
     runs-on: ubuntu-20.04
-
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version: [18.x]
-
     steps:
       - name: Checkout Source Files
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
@@ -126,11 +100,6 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 7
-
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
-        with:
-          node-version: ${{ matrix.node-version }}
 
       - name: Set Environment variables
         run: |
@@ -156,7 +125,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x]
         locale: [chinese, espanol]
 
     steps:
@@ -167,11 +135,6 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 7
-
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
-        with:
-          node-version: ${{ matrix.node-version }}
 
       - name: Set Environment variables
         run: |

--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -42,6 +42,20 @@ jobs:
         with:
           version: 7
 
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
       - name: Set Environment variables
         run: |
           cp sample.env .env
@@ -73,6 +87,20 @@ jobs:
         with:
           version: 7
 
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
       - name: Set Environment variables
         run: |
           cp sample.env .env
@@ -100,6 +128,20 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 7
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
 
       - name: Set Environment variables
         run: |
@@ -135,6 +177,20 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 7
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
 
       - name: Set Environment variables
         run: |

--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -78,6 +78,8 @@ jobs:
         run: |
           echo pnpm version $(pnpm -v)
           pnpm install
+          pnpm node -v
+          cat .npmrc
           pnpm run create:config
           npm i --prefix=curriculum-server
           npm i --prefix=web
@@ -131,6 +133,8 @@ jobs:
         run: |
           echo pnpm version $(pnpm -v)
           pnpm install
+          pnpm node -v
+          cat .npmrc
           pnpm run create:config
           pnpm run build:curriculum
 
@@ -185,6 +189,8 @@ jobs:
         run: |
           echo pnpm version $(pnpm -v)
           pnpm install
+          pnpm node -v
+          cat .npmrc
           pnpm run create:config
           pnpm run build:curriculum
 
@@ -243,6 +249,8 @@ jobs:
         run: |
           echo pnpm version $(pnpm -v)
           pnpm install
+          pnpm node -v
+          cat .npmrc
           pnpm run create:config
           pnpm run build:curriculum
 

--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -24,6 +24,11 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        # allowed values: default and full node versions (e.g. 18.14.2)
+        node-version: [default, 19.7.0]
+      fail-fast: true
 
     steps:
       - name: Checkout Source Files
@@ -77,6 +82,12 @@ jobs:
     name: Test
     needs: lint
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        # allowed values: default and full node versions (e.g. 18.14.2)
+        node-version: [default, 19.7.0]
+      fail-fast: true
+
     steps:
       - name: Checkout Source Files
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
@@ -118,6 +129,12 @@ jobs:
     name: Test Upcoming Changes
     needs: lint
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        # allowed values: default and full node versions (e.g. 18.14.2)
+        node-version: [default, 19.7.0]
+      fail-fast: true
+
     steps:
       - name: Checkout Source Files
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
@@ -164,6 +181,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # allowed values: default and full node versions (e.g. 18.14.2)
+        node-version: [default, 19.7.0]
         locale: [chinese, espanol]
 
     steps:

--- a/.npmrc
+++ b/.npmrc
@@ -2,3 +2,4 @@ auto-install-peers=true
 strict-peer-dependencies=true
 # TODO: consider reworking the scripts to avoid usage of pre/post scripts
 enable-pre-post-scripts=true
+use-node-version=18.14.2


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Since we're using `.npmrc` + pnpm to set the node version it will get downloaded and installed when needed. As such, we do not need to rely on the `setup-node` action in CI. This PR removes it.

We can still test against multiple node versions by appending to `.npmrc` (much like .env the last config is used).

Also, while `pnpm install` is considerably faster than `npm ci`, it still should be possible to save a bit of time by caching the node module store. i.e. download the cache as whole rather than individual node modules. precisely how much (or how little) remains to be seen.

<!-- Feel free to add any additional description of changes below this line -->
