### PR TITLE
feat(client): add new radio button

### DIFF
--- a/client/src/components/settings/privacy.tsx
+++ b/client/src/components/settings/privacy.tsx
@@ -13,7 +13,7 @@ import { submitProfileUI } from '../../redux/settings/actions';
 import FullWidthRow from '../helpers/full-width-row';
 import Spacer from '../helpers/spacer';
 import SectionHeader from './section-header';
-import ToggleSetting from './toggle-setting';
+import { RadioSetting } from './radio-setting';
 
 const mapStateToProps = createSelector(userSelector, user => ({
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -30,6 +30,30 @@ type PrivacyProps = {
     profileUI: ProfileUI;
     username: string;
   };
+};
+
+type PrivacyRadioButtonsProps = {
+  value: string;
+  inputLabel: string;
+  pressed: boolean;
+  onChange: () => void;
+};
+
+const PrivacyRadioButtons = ({
+  value,
+  inputLabel,
+  pressed,
+  onChange
+}: PrivacyRadioButtonsProps) => {
+  return (
+    <fieldset onChange={onChange}>
+      <legend style={{ visibility: 'hidden' }}>
+        Select your {value} option
+      </legend>
+      <input aria-checked={pressed} type='radio' name={value} value={value} />
+      <label htmlFor={value}>{inputLabel}</label>
+    </fieldset>
+  );
 };
 
 function PrivacySettings({
@@ -60,8 +84,11 @@ function PrivacySettings({
       <FullWidthRow>
         <p>{t('settings.privacy')}</p>
         <Form inline={true} onSubmit={submitNewProfileSettings}>
-          <div role='group' aria-label={t('settings.headings.privacy')}>
-            <ToggleSetting
+          <fieldset>
+            <legend style={{ visibility: 'hidden' }}>
+              {t('settings.headings.privacy')}
+            </legend>
+            <RadioSetting
               action={t('settings.labels.my-profile')}
               explain={t('settings.disabled')}
               flag={privacyValues['isLocked']}
@@ -70,7 +97,7 @@ function PrivacySettings({
               onLabel={t('buttons.private')}
               toggleFlag={toggleFlag('isLocked')}
             />
-            <ToggleSetting
+            <RadioSetting
               action={t('settings.labels.my-name')}
               explain={t('settings.private-name')}
               flag={!privacyValues['showName']}
@@ -79,7 +106,7 @@ function PrivacySettings({
               onLabel={t('buttons.private')}
               toggleFlag={toggleFlag('showName')}
             />
-            <ToggleSetting
+            <RadioSetting
               action={t('settings.labels.my-location')}
               flag={!privacyValues['showLocation']}
               flagName='showLocation'
@@ -87,7 +114,7 @@ function PrivacySettings({
               onLabel={t('buttons.private')}
               toggleFlag={toggleFlag('showLocation')}
             />
-            <ToggleSetting
+            <RadioSetting
               action={t('settings.labels.my-about')}
               flag={!privacyValues['showAbout']}
               flagName='showAbout'
@@ -95,7 +122,7 @@ function PrivacySettings({
               onLabel={t('buttons.private')}
               toggleFlag={toggleFlag('showAbout')}
             />
-            <ToggleSetting
+            <RadioSetting
               action={t('settings.labels.my-points')}
               flag={!privacyValues['showPoints']}
               flagName='showPoints'
@@ -103,7 +130,7 @@ function PrivacySettings({
               onLabel={t('buttons.private')}
               toggleFlag={toggleFlag('showPoints')}
             />
-            <ToggleSetting
+            <RadioSetting
               action={t('settings.labels.my-heatmap')}
               flag={!privacyValues['showHeatMap']}
               flagName='showHeatMap'
@@ -111,7 +138,7 @@ function PrivacySettings({
               onLabel={t('buttons.private')}
               toggleFlag={toggleFlag('showHeatMap')}
             />
-            <ToggleSetting
+            <RadioSetting
               action={t('settings.labels.my-certs')}
               explain={t('settings.disabled')}
               flag={!privacyValues['showCerts']}
@@ -120,7 +147,7 @@ function PrivacySettings({
               onLabel={t('buttons.private')}
               toggleFlag={toggleFlag('showCerts')}
             />
-            <ToggleSetting
+            <RadioSetting
               action={t('settings.labels.my-portfolio')}
               flag={!privacyValues['showPortfolio']}
               flagName='showPortfolio'
@@ -128,7 +155,7 @@ function PrivacySettings({
               onLabel={t('buttons.private')}
               toggleFlag={toggleFlag('showPortfolio')}
             />
-            <ToggleSetting
+            <RadioSetting
               action={t('settings.labels.my-timeline')}
               explain={t('settings.disabled')}
               flag={!privacyValues['showTimeLine']}
@@ -137,7 +164,7 @@ function PrivacySettings({
               onLabel={t('buttons.private')}
               toggleFlag={toggleFlag('showTimeLine')}
             />
-            <ToggleSetting
+            <RadioSetting
               action={t('settings.labels.my-donations')}
               flag={!privacyValues['showDonation']}
               flagName='showPortfolio'
@@ -145,7 +172,13 @@ function PrivacySettings({
               onLabel={t('buttons.private')}
               toggleFlag={toggleFlag('showDonation')}
             />
-          </div>
+            <PrivacyRadioButtons
+              inputLabel={t('settings.labels.my-donations')}
+              pressed={!privacyValues['showDonation']}
+              value='showPortfolio'
+              onChange={toggleFlag('showDonation')}
+            />
+          </fieldset>
           <Button
             type='submit'
             bsSize='lg'

--- a/client/src/components/settings/radio-setting.tsx
+++ b/client/src/components/settings/radio-setting.tsx
@@ -1,0 +1,54 @@
+import {
+  FormGroup,
+  ControlLabel,
+  HelpBlock
+} from '@freecodecamp/react-bootstrap';
+import React from 'react';
+
+import { ButtonSpacer } from '../helpers';
+import TB from '../helpers/toggle-button';
+
+import './toggle-setting.css';
+
+type ToggleSettingProps = {
+  action: string;
+  explain?: string;
+  flag: boolean;
+  flagName: string;
+  toggleFlag: () => void;
+  offLabel: string;
+  onLabel: string;
+};
+
+export const RadioSetting = ({
+  action,
+  explain,
+  flag,
+  flagName,
+  toggleFlag,
+  ...restProps
+}: ToggleSettingProps): JSX.Element => {
+  return (
+    <>
+      <div className='toggle-setting-container'>
+        <FormGroup>
+          <ControlLabel className='toggle-label' htmlFor={flagName}>
+            <strong>{action}</strong>
+            {explain ? (
+              <HelpBlock>
+                <em>{explain}</em>
+              </HelpBlock>
+            ) : null}
+          </ControlLabel>
+          <TB
+            name={flagName}
+            onChange={toggleFlag}
+            value={flag}
+            {...restProps}
+          />
+        </FormGroup>
+      </div>
+      <ButtonSpacer />
+    </>
+  );
+};


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Although the camper applied outline to interactive elements in this PR #49579, it didn't affect the buttons like I have expected, this happened because bootstarp has properties that reduce the input size too small, this aims to create new button without the bootstrap properties

---

Just applying some fieldset and legend for that section mentioned in this issue while I am at it, Ref #49214

<!-- Feel free to add any additional description of changes below this line -->
