### PR TITLE
fix(client): allow endpoint on projects

### DIFF
--- a/client/src/components/formHelpers/form-fields.tsx
+++ b/client/src/components/formHelpers/form-fields.tsx
@@ -65,7 +65,7 @@ function FormFields(props: FormFieldsProps): JSX.Element {
     // If local link is allowed, use path validator
     // Always used fCCValidator and httpValidator
     const validators = [fCCValidator, httpValidator];
-    const isSolutionLink = name !== 'githubLink'
+    const isSolutionLink = name !== 'githubLink';
     if (isSolutionLink && !isEditorLinkAllowed) {
       validators.push(editorValidator);
       if (isLocalLinkAllowed) {

--- a/client/src/components/formHelpers/form-fields.tsx
+++ b/client/src/components/formHelpers/form-fields.tsx
@@ -59,12 +59,23 @@ function FormFields(props: FormFieldsProps): JSX.Element {
         validationError = (err as { message?: string })?.message;
       }
     }
+
+    // If editor link is not allowed, use editor validator
+    // If local link is not allowed, use local validator
+    // If local link is allowed, use path validator
+    // Always used fCCValidator and httpValidator
+    const validators = new Set([fCCValidator, httpValidator]);
+    if (name !== 'githubLink' && !isEditorLinkAllowed) {
+      validators.add(editorValidator);
+      if (isLocalLinkAllowed) {
+        validators.add(pathValidator);
+      }
+    }
+    if (!isLocalLinkAllowed) {
+      validators.add(localhostValidator);
+    }
     const validationWarning = composeValidators(
-      name === 'githubLink' || isEditorLinkAllowed ? null : editorValidator,
-      fCCValidator,
-      httpValidator,
-      isLocalLinkAllowed ? null : localhostValidator,
-      pathValidator
+      ...Array.from(validators.values())
     )(value);
     const message: string = (error ||
       validationError ||

--- a/client/src/components/formHelpers/form-fields.tsx
+++ b/client/src/components/formHelpers/form-fields.tsx
@@ -65,7 +65,8 @@ function FormFields(props: FormFieldsProps): JSX.Element {
     // If local link is allowed, use path validator
     // Always used fCCValidator and httpValidator
     const validators = [fCCValidator, httpValidator];
-    if (name !== 'githubLink' && !isEditorLinkAllowed) {
+    const isSolutionLink = name !== 'githubLink'
+    if (isSolutionLink && !isEditorLinkAllowed) {
       validators.push(editorValidator);
       if (isLocalLinkAllowed) {
         validators.push(pathValidator);

--- a/client/src/components/formHelpers/form-fields.tsx
+++ b/client/src/components/formHelpers/form-fields.tsx
@@ -64,19 +64,17 @@ function FormFields(props: FormFieldsProps): JSX.Element {
     // If local link is not allowed, use local validator
     // If local link is allowed, use path validator
     // Always used fCCValidator and httpValidator
-    const validators = new Set([fCCValidator, httpValidator]);
+    const validators = [fCCValidator, httpValidator];
     if (name !== 'githubLink' && !isEditorLinkAllowed) {
-      validators.add(editorValidator);
+      validators.push(editorValidator);
       if (isLocalLinkAllowed) {
-        validators.add(pathValidator);
+        validators.push(pathValidator);
       }
     }
     if (!isLocalLinkAllowed) {
-      validators.add(localhostValidator);
+      validators.push(localhostValidator);
     }
-    const validationWarning = composeValidators(
-      ...Array.from(validators.values())
-    )(value);
+    const validationWarning = composeValidators(...validators)(value);
     const message: string = (error ||
       validationError ||
       validationWarning) as string;

--- a/client/src/components/formHelpers/form-fields.tsx
+++ b/client/src/components/formHelpers/form-fields.tsx
@@ -60,10 +60,6 @@ function FormFields(props: FormFieldsProps): JSX.Element {
       }
     }
 
-    // If editor link is not allowed, use editor validator
-    // If local link is not allowed, use local validator
-    // If local link is allowed, use path validator
-    // Always used fCCValidator and httpValidator
     const validators = [fCCValidator, httpValidator];
     const isSolutionLink = name !== 'githubLink';
     if (isSolutionLink && !isEditorLinkAllowed) {

--- a/client/src/components/formHelpers/form.tsx
+++ b/client/src/components/formHelpers/form.tsx
@@ -42,13 +42,19 @@ function formatUrlValues(
     invalidValues: []
   };
   const urlValues = Object.keys(values).reduce((result, key: string) => {
+    // NOTE: pathValidator is not used here, because it is only used as a
+    // suggestion - should not prevent form submission
+    const validators = [fCCValidator, httpValidator];
+    const isSolutionLink = key !== 'githubLink';
+    if (isSolutionLink && !isEditorLinkAllowed) {
+      validators.push(editorValidator);
+    }
+    if (!isLocalLinkAllowed) {
+      validators.push(localhostValidator);
+    }
+
     let value: string = values[key];
-    const nullOrWarning: JSX.Element | null = composeValidators(
-      fCCValidator,
-      httpValidator,
-      isLocalLinkAllowed ? null : localhostValidator,
-      key === 'githubLink' || isEditorLinkAllowed ? null : editorValidator
-    )(value);
+    const nullOrWarning = composeValidators(...validators)(value);
     if (nullOrWarning) {
       validatedValues.invalidValues.push(nullOrWarning);
     }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

It gets overwhelming the number of times that validation message appears, when it could (often is) completely valid.

Does as the comment says:

```js
// If editor link is not allowed, use editor validator
// If local link is not allowed, use local validator
// If local link is allowed, use path validator
// Always used fCCValidator and httpValidator
```

I refactored, because I did not like the look of:

```js
name === 'githubLink' || isEditorLinkAllowed || !isLocalLinkAllowed : null ? pathValidator
```