### PR TITLE
feat: standardize analytics

### DIFF
--- a/client/src/client-only-routes/show-certification.tsx
+++ b/client/src/client-only-routes/show-certification.tsx
@@ -155,7 +155,7 @@ const ShowCertification = (props: ShowCertificationProps): JSX.Element => {
     ) {
       setIsDonationDisplayed(true);
       executeGA({
-        event: 'donationview',
+        event: 'donation_view',
         action: 'Displayed Certificate Donation'
       });
     }

--- a/client/src/components/Donation/donation-modal.tsx
+++ b/client/src/components/Donation/donation-modal.tsx
@@ -70,7 +70,7 @@ function DonateModal({
       void playTone('donation');
       executeGA({ event: 'pageview', pagePath: '/donation-modal' });
       executeGA({
-        event: 'donationview',
+        event: 'donation_view',
         action: `Displayed ${
           recentlyClaimedBlock !== null ? 'Block' : 'Progress'
         } Donation Modal`

--- a/client/src/components/growth-book/growth-book-wrapper.tsx
+++ b/client/src/components/growth-book/growth-book-wrapper.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import React, { ReactNode, useEffect } from 'react';
 import sha1 from 'sha-1';
 import {
@@ -16,7 +17,22 @@ const { clientLocale, growthbookUri } = envData as {
   growthbookUri: string | null;
 };
 
-const growthbook = new GrowthBook();
+declare global {
+  interface Window {
+    dataLayer: [Record<string, number | string>];
+  }
+}
+
+const growthbook = new GrowthBook({
+  trackingCallback: (experiment, result) => {
+    window?.dataLayer.push({
+      event: 'experiment_viewed',
+      event_category: 'experiment',
+      experiment_id: experiment.key,
+      variation_id: result.variationId
+    });
+  }
+});
 
 const mapStateToProps = createSelector(
   isSignedInSelector,

--- a/client/src/pages/donate.tsx
+++ b/client/src/pages/donate.tsx
@@ -55,7 +55,7 @@ function DonatePage({
 }: DonatePageProps) {
   useEffect(() => {
     executeGA({
-      event: 'donationview',
+      event: 'donation_view',
       action: `Displayed Donate Page`
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/client/src/pages/learn.tsx
+++ b/client/src/pages/learn.tsx
@@ -83,7 +83,7 @@ function LearnPage({
 
   const onDonationAlertClick = () => {
     executeGA({
-      event: 'donationrelated',
+      event: 'donation_related',
       action: `Learn Donation Alert Click`,
       duration: defaultDonation.donationDuration,
       amount: defaultDonation.donationAmount

--- a/client/src/redux/donation-saga.js
+++ b/client/src/redux/donation-saga.js
@@ -105,7 +105,7 @@ export function* postChargeSaga({
       executeGA({
         event:
           paymentProvider === PaymentProvider.Patreon
-            ? 'donationrelated'
+            ? 'donation_related'
             : 'donation',
         action: stringifyDonationEvents(paymentContext, paymentProvider),
         duration,

--- a/client/src/redux/donation-saga.test.js
+++ b/client/src/redux/donation-saga.test.js
@@ -113,7 +113,7 @@ describe('donation-saga', () => {
 
     const patreonAnalyticsDataMock = analyticsDataMock;
     patreonAnalyticsDataMock.action = 'Donate Page Patreon Payment Redirection';
-    patreonAnalyticsDataMock.event = 'donationrelated';
+    patreonAnalyticsDataMock.event = 'donation_related';
     return expectSaga(postChargeSaga, patreonDataMock)
       .not.call.fn(addDonation)
       .not.call.fn(postChargeStripeCard)

--- a/client/src/redux/ga-saga.js
+++ b/client/src/redux/ga-saga.js
@@ -4,14 +4,14 @@ import TagManager from '../analytics';
 function* callGaType({
   payload: { action, duration, amount, event, pagePath }
 }) {
-  if (event === 'pageview') {
+  if (event === 'page_view') {
     yield call(TagManager.dataLayer, {
       dataLayer: {
         event,
         pagePath
       }
     });
-  } else if (event === 'donationview') {
+  } else if (event === 'donation_view') {
     yield call(TagManager.dataLayer, {
       dataLayer: {
         event,
@@ -19,7 +19,7 @@ function* callGaType({
       }
     });
   } else {
-    // donation and donationrelated
+    // donation and donation_related
     yield call(TagManager.dataLayer, {
       dataLayer: {
         event,

--- a/client/src/redux/ga-saga.test.js
+++ b/client/src/redux/ga-saga.test.js
@@ -10,7 +10,7 @@ describe('ga-saga', () => {
       action: 'Learn Donation Alert Click',
       amount: 500,
       duration: 'month',
-      event: 'donationrelated'
+      event: 'donation_related'
     };
     return (
       expectSaga(createGaSaga, actionTypes)


### PR DESCRIPTION
- feat: standardize analytics' naming convention
- feat: add experiment view event to GrowthBook as demonstrated in [docs](https://docs.growthbook.io/guide/GA4-google-analytics#tracking-experiment-exposure).

Note: dataLayer is used instead of gtag, but they both achieve the same result.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

