### PR TITLE
feat(tools): make context more generic

### DIFF
--- a/tools/ui-components/src/control-label/control-label.tsx
+++ b/tools/ui-components/src/control-label/control-label.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { FormContext } from '../form-context';
+import { ProvideContext } from '../provide-context';
 
 import { ControlLabelProps } from './types';
 
@@ -8,7 +8,7 @@ export const ControlLabel = ({
   srOnly,
   ...props
 }: ControlLabelProps): JSX.Element => {
-  const { controlId } = useContext(FormContext);
+  const { data: controlId } = useContext(ProvideContext);
   const screenOnlyClass = srOnly ? 'sr-only ' : '';
   return (
     <label

--- a/tools/ui-components/src/form-context/form-context.tsx
+++ b/tools/ui-components/src/form-context/form-context.tsx
@@ -1,5 +1,0 @@
-import { createContext } from 'react';
-
-import { FormContextProps } from './types';
-
-export const FormContext = createContext<FormContextProps>({});

--- a/tools/ui-components/src/form-context/index.ts
+++ b/tools/ui-components/src/form-context/index.ts
@@ -1,2 +1,0 @@
-export { FormContext } from './form-context';
-export type { FormContextProps } from './types';

--- a/tools/ui-components/src/form-context/types.ts
+++ b/tools/ui-components/src/form-context/types.ts
@@ -1,3 +1,0 @@
-export interface FormContextProps {
-  controlId?: string;
-}

--- a/tools/ui-components/src/provide-context/index.ts
+++ b/tools/ui-components/src/provide-context/index.ts
@@ -1,0 +1,7 @@
+import { createContext } from 'react';
+
+export type ContextProps<T = string> = {
+  data?: T;
+};
+
+export const ProvideContext = createContext<ContextProps>({});


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

To pass the context `bsSize` to panel's headers, I needed to create a hook similar to `formContext`, but to save time and to not waste effort, I have DRY it, so it can be used in different places, with different types of context.


Although I think this is ready for review, I think it's better to wait for https://github.com/freeCodeCamp/freeCodeCamp/pull/46758 to merge, because I may be misunderstanding context and this may be breaking the formGroup, and formGroup has the test that test for context anyway. 🤷 
<!-- Feel free to add any additional description of changes below this line -->
