### PR TITLE
fix(client): use translated string for 'Certification' in timeline

### DIFF
--- a/client/src/components/profile/components/time-line.tsx
+++ b/client/src/components/profile/components/time-line.tsx
@@ -8,11 +8,7 @@ import { connect } from 'react-redux';
 
 import envData from '../../../../../config/env.json';
 import { getLangCode } from '../../../../../config/i18n';
-import {
-  getCertIds,
-  getPathFromID,
-  getTitleFromId
-} from '../../../../../utils';
+import { getCertIds, getPathFromID } from '../../../../../utils';
 import { regeneratePathAndHistory } from '../../../../../utils/polyvinyl';
 import CertificationIcon from '../../../assets/icons/certification';
 import { CompletedChallenge } from '../../../redux/prop-types';
@@ -254,13 +250,11 @@ function useIdToNameMap(t: TFunction): Map<string, NameMap> {
   `);
   const idToNameMap = new Map();
   for (const id of getCertIds()) {
-    const challengeTitle = getTitleFromId(id);
+    const certPath = getPathFromID(id);
+    const certName = t(`certification.title.${certPath}`);
     idToNameMap.set(id, {
-      challengeTitle: `${t(
-        `certification.title.${challengeTitle}`,
-        challengeTitle
-      )} Certification`,
-      certPath: getPathFromID(id)
+      challengeTitle: certName,
+      certPath: certPath
     });
   }
   edges.forEach(


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

---

<!-- Feel free to add any additional description of changes below this line -->
Currently in the timeline, the word `Certification` is hard coded and concatenated with the translated certification title.

Fixed it to use the translation string that includes `Certification`. You can see the translation strings [here](https://github.com/freeCodeCamp/freeCodeCamp/blob/4d1fe9c6407c282d238132d82085cd41b31135a7/client/i18n/locales/english/translations.json#L692-L726).

![cert_timeline](https://user-images.githubusercontent.com/25644062/224399808-f293dbd0-5b2b-4cc3-9369-6aa15a643049.png)
