### PR TITLE
fix(curriculum): Fixing a typo in curriculum

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-the-css-box-model-by-building-a-rothko-painting/60a3e3396c7b40068ad69993.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-the-css-box-model-by-building-a-rothko-painting/60a3e3396c7b40068ad69993.md
@@ -7,7 +7,7 @@ dashedName: step-41
 
 # --description--
 
-Use the `border-radius` property on the `.two` selector, to set its top-left and bottom-right radius to `8px`, and top-right and bottom-left radius to `10px`.
+Use the `border-radius` property on the `.two` selector, to set its top-left radius and bottom-right radius to `8px`, and top-right radius and bottom-left radius to `10px`.
 
 # --hints--
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-the-css-box-model-by-building-a-rothko-painting/60a3e3396c7b40068ad69993.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-the-css-box-model-by-building-a-rothko-painting/60a3e3396c7b40068ad69993.md
@@ -7,7 +7,7 @@ dashedName: step-41
 
 # --description--
 
-Use the `border-radius` property on the `.two` selector, to set its top-left and bottom-right radii to `8px`, and top-right and bottom-left radii to `10px`.
+Use the `border-radius` property on the `.two` selector, to set its top-left and bottom-right radius to `8px`, and top-right and bottom-left radius to `10px`.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!-- Feel free to add any additional description of changes below this line -->

I fixed a typo in the word `radius` as it was spelled `radii` before. This does not fix a current issue, I just noticed it while doing the course.
