### PR TITLE
chore(deps): add missing dependencies

### DIFF
--- a/api-server/package.json
+++ b/api-server/package.json
@@ -72,6 +72,7 @@
     "rate-limit-mongo": "^2.3.2",
     "rx": "4.1.0",
     "stripe": "8.205.0",
+    "strong-error-handler": "3.5.0",
     "uuid": "3.4.0",
     "validator": "13.7.0"
   },

--- a/client/package.json
+++ b/client/package.json
@@ -171,6 +171,7 @@
     "@types/testing-library__jest-dom": "^5.14.5",
     "@types/validator": "^13.7.12",
     "autoprefixer": "10.4.14",
+    "babel-plugin-macros": "3.1.0",
     "babel-plugin-transform-imports": "2.0.0",
     "chokidar": "3.5.3",
     "copy-webpack-plugin": "9.1.0",

--- a/client/package.json
+++ b/client/package.json
@@ -137,6 +137,7 @@
     "validator": "13.9.0"
   },
   "devDependencies": {
+    "@babel/plugin-syntax-dynamic-import": "7.8.3",
     "@babel/types": "7.20.7",
     "@codesee/babel-plugin-instrument": "0.531.0",
     "@codesee/tracker": "0.531.0",

--- a/curriculum/package.json
+++ b/curriculum/package.json
@@ -53,6 +53,7 @@
     "lodash": "4.17.21",
     "mocha": "10.2.0",
     "mock-require": "3.0.3",
+    "ora": "5.4.1",
     "puppeteer": "10.4.0",
     "readdirp": "3.6.0",
     "string-similarity": "4.0.4",

--- a/curriculum/package.json
+++ b/curriculum/package.json
@@ -34,6 +34,7 @@
     "@babel/preset-env": "7.20.2",
     "@babel/preset-typescript": "7.18.6",
     "@babel/register": "7.18.9",
+    "@compodoc/live-server": "^1.2.3",
     "babel-plugin-dynamic-import-node": "2.3.3",
     "babel-plugin-lodash": "3.3.4",
     "babel-plugin-transform-runtime": "6.23.0",
@@ -43,6 +44,7 @@
     "chai": "4.3.7",
     "cross-env": "7.0.3",
     "css": "3.0.0",
+    "glob": "8.1.0",
     "invariant": "2.2.4",
     "joi": "17.8.3",
     "joi-objectid": "3.0.1",
@@ -54,7 +56,6 @@
     "puppeteer": "10.4.0",
     "readdirp": "3.6.0",
     "string-similarity": "4.0.4",
-    "unist-util-visit": "2.0.3",
-    "@compodoc/live-server": "^1.2.3"
+    "unist-util-visit": "2.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "challenge-editor": "npm-run-all -p challenge-editor:*",
     "challenge-editor:client": "cd ./tools/challenge-editor/client && pnpm start",
     "challenge-editor:server": "cd ./tools/challenge-editor/api && pnpm start",
-    "clean": "npm-run-all -p clean:*",
+    "clean": "npm-run-all -p clean:client clean:server clean:curriculum --serial clean:packages",
     "clean-and-develop": "pnpm run clean && pnpm install && pnpm run develop",
     "clean:client": "cd ./client && pnpm run clean",
     "clean:curriculum": "rimraf ./config/curriculum.json",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,6 @@
     "markdownlint": "0.27.0",
     "mock-fs": "5.2.0",
     "npm-run-all": "4.1.5",
-    "ora": "5.4.1",
     "prettier": "^2.8.0",
     "prismjs": "1.29.0",
     "process": "0.11.10",

--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
     "store": "2.0.12",
     "ts-node": "10.9.1",
     "typescript": "4.9.5",
-    "webpack-bundle-analyzer": "4.8.0"
+    "webpack-bundle-analyzer": "4.8.0",
+    "yargs": "17.7.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
+    "babel-jest": "29.5.0",
     "dotenv": "16.0.3",
     "invariant": "2.2.4",
     "pm2": "^5.2.2"

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "babel-jest": "29.5.0",
     "dotenv": "16.0.3",
     "invariant": "2.2.4",
     "pm2": "^5.2.2"
@@ -118,6 +117,7 @@
     "@types/node": "18.15.0",
     "@types/store": "2.0.2",
     "babel-eslint": "10.1.0",
+    "babel-jest": "29.5.0",
     "babel-plugin-transform-imports": "2.0.0",
     "cross-env": "7.0.3",
     "cypress": "10.11.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -323,6 +323,7 @@ importers:
       assert: 2.0.0
       autoprefixer: 10.4.14
       babel-loader: 8.3.0
+      babel-plugin-macros: 3.1.0
       babel-plugin-preval: 5.1.0
       babel-plugin-prismjs: 2.1.0
       babel-plugin-transform-imports: 2.0.0
@@ -549,6 +550,7 @@ importers:
       '@types/testing-library__jest-dom': 5.14.5
       '@types/validator': 13.7.12
       autoprefixer: 10.4.14_postcss@8.4.21
+      babel-plugin-macros: 3.1.0
       babel-plugin-transform-imports: 2.0.0
       chokidar: 3.5.3
       copy-webpack-plugin: 9.1.0_webpack@5.76.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,7 +46,6 @@ importers:
       markdownlint: 0.27.0
       mock-fs: 5.2.0
       npm-run-all: 4.1.5
-      ora: 5.4.1
       pm2: ^5.2.2
       prettier: ^2.8.0
       prismjs: 1.29.0
@@ -103,7 +102,6 @@ importers:
       markdownlint: 0.27.0
       mock-fs: 5.2.0
       npm-run-all: 4.1.5
-      ora: 5.4.1
       prettier: 2.8.4
       prismjs: 1.29.0
       process: 0.11.10
@@ -608,6 +606,7 @@ importers:
       lodash: 4.17.21
       mocha: 10.2.0
       mock-require: 3.0.3
+      ora: 5.4.1
       puppeteer: 10.4.0
       readdirp: 3.6.0
       string-similarity: 4.0.4
@@ -637,6 +636,7 @@ importers:
       lodash: 4.17.21
       mocha: 10.2.0
       mock-require: 3.0.3
+      ora: 5.4.1
       puppeteer: 10.4.0
       readdirp: 3.6.0
       string-similarity: 4.0.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,7 +59,6 @@ importers:
       webpack-bundle-analyzer: 4.8.0
       yargs: 17.7.1
     dependencies:
-      babel-jest: 29.5.0_@babel+core@7.20.12
       dotenv: 16.0.3
       invariant: 2.2.4
       pm2: 5.2.2
@@ -78,6 +77,7 @@ importers:
       '@types/node': 18.15.0
       '@types/store': 2.0.2
       babel-eslint: 10.1.0_eslint@7.32.0
+      babel-jest: 29.5.0_@babel+core@7.20.12
       babel-plugin-transform-imports: 2.0.0
       cross-env: 7.0.3
       cypress: 10.11.0
@@ -5296,7 +5296,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@sinclair/typebox': 0.25.24
-    dev: false
+    dev: true
 
   /@jest/source-map/27.5.1:
     resolution: {integrity: sha512-y9NIHUYF3PJRlHk98NdC/N1gl88BL08aQQgu4k4ZopQkCw9t9cV8mtl3TV8b/YCB8XaVTFrmUTAJvjsntDireg==}
@@ -5402,7 +5402,7 @@ packages:
       write-file-atomic: 4.0.2
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@jest/types/25.5.0:
     resolution: {integrity: sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==}
@@ -5456,7 +5456,7 @@ packages:
       '@types/node': 18.15.0
       '@types/yargs': 17.0.22
       chalk: 4.1.2
-    dev: false
+    dev: true
 
   /@jridgewell/gen-mapping/0.1.1:
     resolution: {integrity: sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==}
@@ -6177,7 +6177,7 @@ packages:
 
   /@sinclair/typebox/0.25.24:
     resolution: {integrity: sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==}
-    dev: false
+    dev: true
 
   /@sindresorhus/is/0.14.0:
     resolution: {integrity: sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==}
@@ -8548,7 +8548,6 @@ packages:
     resolution: {integrity: sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==}
     dependencies:
       '@types/yargs-parser': 21.0.0
-    dev: false
 
   /@types/yauzl/2.10.0:
     resolution: {integrity: sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==}
@@ -10080,7 +10079,7 @@ packages:
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /babel-loader/8.3.0_nwtvwtk5tmh22l2urnqucz7kqu:
     resolution: {integrity: sha512-H8SvsMF+m9t15HNLMipppzkC+Y2Yq+v3SonZyU70RBL/h1gxPkH08Ot8pEE9Z4Kd+czyWJClmFS8qzIP9OZ04Q==}
@@ -10180,7 +10179,7 @@ packages:
       '@babel/types': 7.21.2
       '@types/babel__core': 7.20.0
       '@types/babel__traverse': 7.18.3
-    dev: false
+    dev: true
 
   /babel-plugin-lodash/3.3.4:
     resolution: {integrity: sha512-yDZLjK7TCkWl1gpBeBGmuaDIFhZKmkoL+Cu2MUUjv5VxUZx/z7tBGBCBcQs5RI1Bkz5LLmNdjx7paOyQtMovyg==}
@@ -10858,7 +10857,7 @@ packages:
       '@babel/core': 7.20.12
       babel-plugin-jest-hoist: 29.5.0
       babel-preset-current-node-syntax: 1.0.1_@babel+core@7.20.12
-    dev: false
+    dev: true
 
   /babel-preset-react-app/10.0.1:
     resolution: {integrity: sha512-b0D9IZ1WhhCWkrTXyFuIIgqGzSkRIH5D5AmB0bXbzYAB1OBAwHcUeyWW2LorutLWF5btNo/N7r/cIdmvvKJlYg==}
@@ -12450,7 +12449,7 @@ packages:
 
   /convert-source-map/2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
-    dev: false
+    dev: true
 
   /cookie-parser/1.4.6:
     resolution: {integrity: sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==}
@@ -19347,7 +19346,7 @@ packages:
       walker: 1.0.8
     optionalDependencies:
       fsevents: 2.3.2
-    dev: false
+    dev: true
 
   /jest-jasmine2/27.5.1:
     resolution: {integrity: sha512-jtq7VVyG8SqAorDpApwiJJImd0V2wv1xzdheGHRGyuT7gZm6gG47QEskOlzsN1PG/6WNaCo5pmwMHDf3AkG2pQ==}
@@ -19478,7 +19477,7 @@ packages:
   /jest-regex-util/29.4.3:
     resolution: {integrity: sha512-O4FglZaMmWXbGHSQInfXewIsd1LMn9p3ZXB/6r4FOkyhX2/iP/soMG98jGvk/A3HAN78+5VWcBGO0BJAPRh4kg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dev: false
+    dev: true
 
   /jest-resolve-dependencies/27.5.1:
     resolution: {integrity: sha512-QQOOdY4PE39iawDn5rzbIePNigfe5B9Z91GDD1ae/xNDlu9kaat8QQ5EKnNmVWPV54hUdxCVwwj6YMgR2O7IOg==}
@@ -19654,7 +19653,7 @@ packages:
       ci-info: 3.8.0
       graceful-fs: 4.2.10
       picomatch: 2.3.1
-    dev: false
+    dev: true
 
   /jest-validate/27.5.1:
     resolution: {integrity: sha512-thkNli0LYTmOI1tDB3FI1S1RTp/Bqyd9pTarJwL87OIBFuqEb5Apv5EaApEudYg4g86e3CT6kM0RowkhtEnCBQ==}
@@ -19742,7 +19741,7 @@ packages:
       jest-util: 29.5.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
-    dev: false
+    dev: true
 
   /jest/27.5.1:
     resolution: {integrity: sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==}
@@ -30497,7 +30496,7 @@ packages:
     dependencies:
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
-    dev: false
+    dev: true
 
   /ws/7.4.5:
     resolution: {integrity: sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,7 @@ importers:
       ts-node: 10.9.1
       typescript: 4.9.5
       webpack-bundle-analyzer: 4.8.0
+      yargs: 17.7.1
     dependencies:
       dotenv: 16.0.3
       invariant: 2.2.4
@@ -110,6 +111,7 @@ importers:
       ts-node: 10.9.1_lwgqdwokjtwlohdqtbb6s252kq
       typescript: 4.9.5
       webpack-bundle-analyzer: 4.8.0
+      yargs: 17.7.1
 
   api:
     specifiers:
@@ -262,6 +264,7 @@ importers:
     specifiers:
       '@babel/plugin-proposal-export-default-from': 7.18.10
       '@babel/plugin-proposal-function-bind': 7.18.9
+      '@babel/plugin-syntax-dynamic-import': 7.8.3
       '@babel/plugin-transform-runtime': ^7.19.6
       '@babel/polyfill': 7.12.1
       '@babel/preset-env': 7.20.2
@@ -513,6 +516,7 @@ importers:
       uuid: 8.3.2
       validator: 13.9.0
     devDependencies:
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.20.12
       '@babel/types': 7.20.7
       '@codesee/babel-plugin-instrument': 0.531.0_@babel+core@7.20.12
       '@codesee/tracker': 0.531.0
@@ -589,6 +593,7 @@ importers:
       chai: 4.3.7
       cross-env: 7.0.3
       css: 3.0.0
+      glob: 8.1.0
       invariant: 2.2.4
       joi: 17.8.3
       joi-objectid: 3.0.1
@@ -617,6 +622,7 @@ importers:
       chai: 4.3.7
       cross-env: 7.0.3
       css: 3.0.0
+      glob: 8.1.0
       invariant: 2.2.4
       joi: 17.8.3
       joi-objectid: 3.0.1
@@ -11968,6 +11974,15 @@ packages:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+
+  /cliui/8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+    dev: true
 
   /clone-deep/4.0.1:
     resolution: {integrity: sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==}
@@ -30531,10 +30546,15 @@ packages:
   /yargs-parser/20.2.4:
     resolution: {integrity: sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==}
     engines: {node: '>=10'}
+    dev: true
 
   /yargs-parser/20.2.9:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
     engines: {node: '>=10'}
+
+  /yargs-parser/21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
     dev: true
 
   /yargs-unparser/2.0.0:
@@ -30573,7 +30593,20 @@ packages:
       require-directory: 2.1.1
       string-width: 4.2.3
       y18n: 5.0.8
-      yargs-parser: 20.2.4
+      yargs-parser: 20.2.9
+
+  /yargs/17.7.1:
+    resolution: {integrity: sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==}
+    engines: {node: '>=12'}
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.1.1
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+    dev: true
 
   /yauzl/2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,7 @@ importers:
       '@types/node': 18.15.0
       '@types/store': 2.0.2
       babel-eslint: 10.1.0
+      babel-jest: 29.5.0
       babel-plugin-transform-imports: 2.0.0
       cross-env: 7.0.3
       cypress: 10.11.0
@@ -58,15 +59,16 @@ importers:
       webpack-bundle-analyzer: 4.8.0
       yargs: 17.7.1
     dependencies:
+      babel-jest: 29.5.0_@babel+core@7.20.12
       dotenv: 16.0.3
       invariant: 2.2.4
       pm2: 5.2.2
     devDependencies:
-      '@babel/eslint-parser': 7.19.1_pv54mmcbvvc2ehtbbm4mt3a4my
-      '@babel/plugin-proposal-function-bind': 7.18.9_@babel+core@7.18.0
-      '@babel/preset-env': 7.20.2_@babel+core@7.18.0
-      '@babel/preset-react': 7.18.6_@babel+core@7.18.0
-      '@babel/preset-typescript': 7.18.6_@babel+core@7.18.0
+      '@babel/eslint-parser': 7.19.1_go3kp2l7mdrkdyt3xfyeu7ppfa
+      '@babel/plugin-proposal-function-bind': 7.18.9_@babel+core@7.20.12
+      '@babel/preset-env': 7.20.2_@babel+core@7.20.12
+      '@babel/preset-react': 7.18.6_@babel+core@7.20.12
+      '@babel/preset-typescript': 7.18.6_@babel+core@7.20.12
       '@testing-library/cypress': 8.0.7_cypress@10.11.0
       '@testing-library/dom': 8.20.0
       '@testing-library/jest-dom': 5.16.5
@@ -1949,7 +1951,7 @@ packages:
       '@babel/parser': 7.21.2
       '@babel/template': 7.20.7
       '@babel/traverse': 7.21.2
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
       convert-source-map: 1.9.0
       debug: 4.3.4
       gensync: 1.0.0-beta.2
@@ -1985,20 +1987,6 @@ packages:
       semver: 6.3.0
     dev: false
 
-  /@babel/eslint-parser/7.19.1_pv54mmcbvvc2ehtbbm4mt3a4my:
-    resolution: {integrity: sha512-AqNf2QWt1rtu2/1rLswy6CDP7H9Oh3mMhk177Y67Rg8d7RD9WfOLLv8CGn6tisFvS2htm86yIe1yLF6I1UDaGQ==}
-    engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
-    peerDependencies:
-      '@babel/core': '>=7.11.0'
-      eslint: ^7.5.0 || ^8.0.0
-    dependencies:
-      '@babel/core': 7.18.0
-      '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
-      eslint: 7.32.0
-      eslint-visitor-keys: 2.1.0
-      semver: 6.3.0
-    dev: true
-
   /@babel/generator/7.21.1:
     resolution: {integrity: sha512-1lT45bAYlQhFn/BHivJs43AiW2rg3/UbLyShGfF3C0KmHvO5fSghWd5kBJy30kpRRucGzXStvnnCFniCR2kXAA==}
     engines: {node: '>=6.9.0'}
@@ -2012,14 +2000,14 @@ packages:
     resolution: {integrity: sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
 
   /@babel/helper-builder-binary-assignment-operator-visitor/7.18.9:
     resolution: {integrity: sha512-yFQ0YCHoIqarl8BCRwBL8ulYUaZpz3bNsA7oFepAzee+8/+ImtADXNOmO5vJvsPff3qi+hvpkY/NYBTrBQgdNw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-explode-assignable-expression': 7.18.6
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
 
   /@babel/helper-compilation-targets/7.20.7_@babel+core@7.18.0:
     resolution: {integrity: sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==}
@@ -2163,7 +2151,7 @@ packages:
     resolution: {integrity: sha512-eyAYAsQmB80jNfg4baAtLeWAQHfHFiR483rzFK+BhETlGZaQC9bsfrugfXDCbRHLQbIA7U5NxhhOxN7p/dWIcg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
 
   /@babel/helper-function-name/7.21.0:
     resolution: {integrity: sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==}
@@ -2176,7 +2164,7 @@ packages:
     resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
 
   /@babel/helper-member-expression-to-functions/7.21.0:
     resolution: {integrity: sha512-Muu8cdZwNN6mRRNG6lAYErJ5X3bRevgYR2O8wN0yn7jJSnGDu6eG59RfT29JHxGUovyfrh6Pj0XzmR7drNVL3Q==}
@@ -2188,7 +2176,7 @@ packages:
     resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
 
   /@babel/helper-module-transforms/7.21.2:
     resolution: {integrity: sha512-79yj2AR4U/Oqq/WOV7Lx6hUjau1Zfo4cI+JLAVYeMV5XIlbOhmjEk5ulbTc9fMpmlojzZHkUUxAiK+UKn+hNQQ==}
@@ -2209,7 +2197,7 @@ packages:
     resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
 
   /@babel/helper-plugin-utils/7.10.4:
     resolution: {integrity: sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==}
@@ -2243,7 +2231,7 @@ packages:
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-wrap-function': 7.20.5
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
     transitivePeerDependencies:
       - supports-color
 
@@ -2256,7 +2244,7 @@ packages:
       '@babel/helper-optimise-call-expression': 7.18.6
       '@babel/template': 7.20.7
       '@babel/traverse': 7.21.2
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
     transitivePeerDependencies:
       - supports-color
 
@@ -2264,19 +2252,19 @@ packages:
     resolution: {integrity: sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
 
   /@babel/helper-skip-transparent-expression-wrappers/7.20.0:
     resolution: {integrity: sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
 
   /@babel/helper-split-export-declaration/7.18.6:
     resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
 
   /@babel/helper-string-parser/7.19.4:
     resolution: {integrity: sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==}
@@ -2297,7 +2285,7 @@ packages:
       '@babel/helper-function-name': 7.21.0
       '@babel/template': 7.20.7
       '@babel/traverse': 7.21.2
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
     transitivePeerDependencies:
       - supports-color
 
@@ -2438,19 +2426,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/plugin-proposal-class-properties/7.18.6_@babel+core@7.18.0:
-    resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.0
-      '@babel/helper-create-class-features-plugin': 7.21.0_@babel+core@7.18.0
-      '@babel/helper-plugin-utils': 7.20.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@babel/plugin-proposal-class-properties/7.18.6_@babel+core@7.20.12:
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
     engines: {node: '>=6.9.0'}
@@ -2557,17 +2532,6 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.20.12
 
-  /@babel/plugin-proposal-function-bind/7.18.9_@babel+core@7.18.0:
-    resolution: {integrity: sha512-9RfxqKkRBCCT0xoBl9AqieCMscJmSAL9HYixGMWH549jUpT9csWWK/HEYZEx9t9iW/PRSXgX95x9bDlgtAJGFA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.0
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-function-bind': 7.18.6_@babel+core@7.18.0
-    dev: true
-
   /@babel/plugin-proposal-function-bind/7.18.9_@babel+core@7.20.12:
     resolution: {integrity: sha512-9RfxqKkRBCCT0xoBl9AqieCMscJmSAL9HYixGMWH549jUpT9csWWK/HEYZEx9t9iW/PRSXgX95x9bDlgtAJGFA==}
     engines: {node: '>=6.9.0'}
@@ -2577,7 +2541,6 @@ packages:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-function-bind': 7.18.6_@babel+core@7.20.12
-    dev: false
 
   /@babel/plugin-proposal-json-strings/7.18.6_@babel+core@7.18.0:
     resolution: {integrity: sha512-lr1peyn9kOdbYc0xr0OdHTZ5FMqS6Di+H0Fz2I/JwMzGmzJETNeOFq2pBySw6X/KFL5EWDjlJuMsUGRFb8fQgQ==}
@@ -2710,20 +2673,6 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.20.12
       '@babel/plugin-transform-parameters': 7.20.7_@babel+core@7.20.12
-    dev: true
-
-  /@babel/plugin-proposal-object-rest-spread/7.20.7_@babel+core@7.18.0:
-    resolution: {integrity: sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/compat-data': 7.21.0
-      '@babel/core': 7.18.0
-      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.18.0
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.18.0
-      '@babel/plugin-transform-parameters': 7.20.7_@babel+core@7.18.0
     dev: true
 
   /@babel/plugin-proposal-object-rest-spread/7.20.7_@babel+core@7.20.12:
@@ -3003,16 +2952,6 @@ packages:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
 
-  /@babel/plugin-syntax-function-bind/7.18.6_@babel+core@7.18.0:
-    resolution: {integrity: sha512-wZN0Aq/AScknI9mKGcR3TpHdASMufFGaeJgc1rhPmLtZ/PniwjePSh8cfh8tXMB3U4kh/3cRKrLjDtedejg8jQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.0
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
   /@babel/plugin-syntax-function-bind/7.18.6_@babel+core@7.20.12:
     resolution: {integrity: sha512-wZN0Aq/AScknI9mKGcR3TpHdASMufFGaeJgc1rhPmLtZ/PniwjePSh8cfh8tXMB3U4kh/3cRKrLjDtedejg8jQ==}
     engines: {node: '>=6.9.0'}
@@ -3021,7 +2960,6 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
-    dev: false
 
   /@babel/plugin-syntax-import-assertions/7.20.0_@babel+core@7.18.0:
     resolution: {integrity: sha512-IUh1vakzNoWalR8ch/areW7qFopR2AEw03JlG7BbrDqmQ4X3q9uuipQwSGrUn7oGiemKjtSLDhNtQHzMHr1JdQ==}
@@ -3081,16 +3019,6 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-syntax-jsx/7.18.6_@babel+core@7.18.0:
-    resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -3259,16 +3187,6 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
-
-  /@babel/plugin-syntax-typescript/7.20.0_@babel+core@7.18.0:
-    resolution: {integrity: sha512-rd9TkG+u1CExzS4SM1BlMEhMXwFLKVjOAFFCDx9PbX5ycJWDoWMcwdJH9RhkPu1dOgn5TrxLot/Gx6lWFuAUNQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.0
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-syntax-typescript/7.20.0_@babel+core@7.20.12:
     resolution: {integrity: sha512-rd9TkG+u1CExzS4SM1BlMEhMXwFLKVjOAFFCDx9PbX5ycJWDoWMcwdJH9RhkPu1dOgn5TrxLot/Gx6lWFuAUNQ==}
@@ -3831,16 +3749,6 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-react-display-name/7.18.6_@babel+core@7.18.0:
-    resolution: {integrity: sha512-TV4sQ+T013n61uMoygyMRm+xf04Bd5oqFpv2jAEQwSZ8NwQA7zeRPg1LMVg2PWi3zWBz+CLKD+v5bcpZ/BS0aA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.0
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
   /@babel/plugin-transform-react-display-name/7.18.6_@babel+core@7.20.12:
     resolution: {integrity: sha512-TV4sQ+T013n61uMoygyMRm+xf04Bd5oqFpv2jAEQwSZ8NwQA7zeRPg1LMVg2PWi3zWBz+CLKD+v5bcpZ/BS0aA==}
     engines: {node: '>=6.9.0'}
@@ -3850,16 +3758,6 @@ packages:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
 
-  /@babel/plugin-transform-react-jsx-development/7.18.6_@babel+core@7.18.0:
-    resolution: {integrity: sha512-SA6HEjwYFKF7WDjWcMcMGUimmw/nhNRDWxr+KaLSCrkD/LMDBvWRmHAYgE1HDeF8KUuI8OAu+RT6EOtKxSW2qA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.0
-      '@babel/plugin-transform-react-jsx': 7.21.0_@babel+core@7.18.0
-    dev: true
-
   /@babel/plugin-transform-react-jsx-development/7.18.6_@babel+core@7.20.12:
     resolution: {integrity: sha512-SA6HEjwYFKF7WDjWcMcMGUimmw/nhNRDWxr+KaLSCrkD/LMDBvWRmHAYgE1HDeF8KUuI8OAu+RT6EOtKxSW2qA==}
     engines: {node: '>=6.9.0'}
@@ -3868,20 +3766,6 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/plugin-transform-react-jsx': 7.21.0_@babel+core@7.20.12
-
-  /@babel/plugin-transform-react-jsx/7.21.0_@babel+core@7.18.0:
-    resolution: {integrity: sha512-6OAWljMvQrZjR2DaNhVfRz6dkCAVV+ymcLUmaf8bccGOHn2v5rHJK3tTpij0BuhdYWP4LLaqj5lwcdlpAAPuvg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.0
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.18.0
-      '@babel/types': 7.21.2
-    dev: true
 
   /@babel/plugin-transform-react-jsx/7.21.0_@babel+core@7.20.12:
     resolution: {integrity: sha512-6OAWljMvQrZjR2DaNhVfRz6dkCAVV+ymcLUmaf8bccGOHn2v5rHJK3tTpij0BuhdYWP4LLaqj5lwcdlpAAPuvg==}
@@ -3895,17 +3779,6 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.20.12
       '@babel/types': 7.21.2
-
-  /@babel/plugin-transform-react-pure-annotations/7.18.6_@babel+core@7.18.0:
-    resolution: {integrity: sha512-I8VfEPg9r2TRDdvnHgPepTKvuRomzA8+u+nhY7qSI1fR2hRNebasZEETLyM5mAUr0Ku56OkXJ0I7NHJnO6cJiQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.0
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-react-pure-annotations/7.18.6_@babel+core@7.20.12:
     resolution: {integrity: sha512-I8VfEPg9r2TRDdvnHgPepTKvuRomzA8+u+nhY7qSI1fR2hRNebasZEETLyM5mAUr0Ku56OkXJ0I7NHJnO6cJiQ==}
@@ -4070,20 +3943,6 @@ packages:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
 
-  /@babel/plugin-transform-typescript/7.21.0_@babel+core@7.18.0:
-    resolution: {integrity: sha512-xo///XTPp3mDzTtrqXoBlK9eiAYW3wv9JXglcn/u1bi60RW11dEUxIgA8cbnDhutS1zacjMRmAwxE0gMklLnZg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.0
-      '@babel/helper-create-class-features-plugin': 7.21.0_@babel+core@7.18.0
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-typescript': 7.20.0_@babel+core@7.18.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@babel/plugin-transform-typescript/7.21.0_@babel+core@7.20.12:
     resolution: {integrity: sha512-xo///XTPp3mDzTtrqXoBlK9eiAYW3wv9JXglcn/u1bi60RW11dEUxIgA8cbnDhutS1zacjMRmAwxE0gMklLnZg==}
     engines: {node: '>=6.9.0'}
@@ -4230,92 +4089,6 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/preset-env/7.20.2_@babel+core@7.18.0:
-    resolution: {integrity: sha512-1G0efQEWR1EHkKvKHqbG+IN/QdgwfByUpM5V5QroDzGV2t3S/WXNQd693cHiHTlCFMpr9B6FkPFXDA2lQcKoDg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/compat-data': 7.21.0
-      '@babel/core': 7.18.0
-      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.18.0
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-validator-option': 7.21.0
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.18.6_@babel+core@7.18.0
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.20.7_@babel+core@7.18.0
-      '@babel/plugin-proposal-async-generator-functions': 7.20.7_@babel+core@7.18.0
-      '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.18.0
-      '@babel/plugin-proposal-class-static-block': 7.21.0_@babel+core@7.18.0
-      '@babel/plugin-proposal-dynamic-import': 7.18.6_@babel+core@7.18.0
-      '@babel/plugin-proposal-export-namespace-from': 7.18.9_@babel+core@7.18.0
-      '@babel/plugin-proposal-json-strings': 7.18.6_@babel+core@7.18.0
-      '@babel/plugin-proposal-logical-assignment-operators': 7.20.7_@babel+core@7.18.0
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6_@babel+core@7.18.0
-      '@babel/plugin-proposal-numeric-separator': 7.18.6_@babel+core@7.18.0
-      '@babel/plugin-proposal-object-rest-spread': 7.20.7_@babel+core@7.18.0
-      '@babel/plugin-proposal-optional-catch-binding': 7.18.6_@babel+core@7.18.0
-      '@babel/plugin-proposal-optional-chaining': 7.21.0_@babel+core@7.18.0
-      '@babel/plugin-proposal-private-methods': 7.18.6_@babel+core@7.18.0
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0_@babel+core@7.18.0
-      '@babel/plugin-proposal-unicode-property-regex': 7.18.6_@babel+core@7.18.0
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.18.0
-      '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.18.0
-      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.18.0
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.18.0
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.18.0
-      '@babel/plugin-syntax-import-assertions': 7.20.0_@babel+core@7.18.0
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.18.0
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.18.0
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.18.0
-      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.18.0
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.18.0
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.18.0
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.18.0
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.18.0
-      '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.18.0
-      '@babel/plugin-transform-arrow-functions': 7.20.7_@babel+core@7.18.0
-      '@babel/plugin-transform-async-to-generator': 7.20.7_@babel+core@7.18.0
-      '@babel/plugin-transform-block-scoped-functions': 7.18.6_@babel+core@7.18.0
-      '@babel/plugin-transform-block-scoping': 7.21.0_@babel+core@7.18.0
-      '@babel/plugin-transform-classes': 7.21.0_@babel+core@7.18.0
-      '@babel/plugin-transform-computed-properties': 7.20.7_@babel+core@7.18.0
-      '@babel/plugin-transform-destructuring': 7.20.7_@babel+core@7.18.0
-      '@babel/plugin-transform-dotall-regex': 7.18.6_@babel+core@7.18.0
-      '@babel/plugin-transform-duplicate-keys': 7.18.9_@babel+core@7.18.0
-      '@babel/plugin-transform-exponentiation-operator': 7.18.6_@babel+core@7.18.0
-      '@babel/plugin-transform-for-of': 7.21.0_@babel+core@7.18.0
-      '@babel/plugin-transform-function-name': 7.18.9_@babel+core@7.18.0
-      '@babel/plugin-transform-literals': 7.18.9_@babel+core@7.18.0
-      '@babel/plugin-transform-member-expression-literals': 7.18.6_@babel+core@7.18.0
-      '@babel/plugin-transform-modules-amd': 7.20.11_@babel+core@7.18.0
-      '@babel/plugin-transform-modules-commonjs': 7.21.2_@babel+core@7.18.0
-      '@babel/plugin-transform-modules-systemjs': 7.20.11_@babel+core@7.18.0
-      '@babel/plugin-transform-modules-umd': 7.18.6_@babel+core@7.18.0
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.20.5_@babel+core@7.18.0
-      '@babel/plugin-transform-new-target': 7.18.6_@babel+core@7.18.0
-      '@babel/plugin-transform-object-super': 7.18.6_@babel+core@7.18.0
-      '@babel/plugin-transform-parameters': 7.20.7_@babel+core@7.18.0
-      '@babel/plugin-transform-property-literals': 7.18.6_@babel+core@7.18.0
-      '@babel/plugin-transform-regenerator': 7.20.5_@babel+core@7.18.0
-      '@babel/plugin-transform-reserved-words': 7.18.6_@babel+core@7.18.0
-      '@babel/plugin-transform-shorthand-properties': 7.18.6_@babel+core@7.18.0
-      '@babel/plugin-transform-spread': 7.20.7_@babel+core@7.18.0
-      '@babel/plugin-transform-sticky-regex': 7.18.6_@babel+core@7.18.0
-      '@babel/plugin-transform-template-literals': 7.18.9_@babel+core@7.18.0
-      '@babel/plugin-transform-typeof-symbol': 7.18.9_@babel+core@7.18.0
-      '@babel/plugin-transform-unicode-escapes': 7.18.10_@babel+core@7.18.0
-      '@babel/plugin-transform-unicode-regex': 7.18.6_@babel+core@7.18.0
-      '@babel/preset-modules': 0.1.5_@babel+core@7.18.0
-      '@babel/types': 7.20.7
-      babel-plugin-polyfill-corejs2: 0.3.3_@babel+core@7.18.0
-      babel-plugin-polyfill-corejs3: 0.6.0_@babel+core@7.18.0
-      babel-plugin-polyfill-regenerator: 0.4.1_@babel+core@7.18.0
-      core-js-compat: 3.29.0
-      semver: 6.3.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@babel/preset-env/7.20.2_@babel+core@7.20.12:
     resolution: {integrity: sha512-1G0efQEWR1EHkKvKHqbG+IN/QdgwfByUpM5V5QroDzGV2t3S/WXNQd693cHiHTlCFMpr9B6FkPFXDA2lQcKoDg==}
     engines: {node: '>=6.9.0'}
@@ -4438,21 +4211,6 @@ packages:
       '@babel/types': 7.20.7
       esutils: 2.0.3
 
-  /@babel/preset-react/7.18.6_@babel+core@7.18.0:
-    resolution: {integrity: sha512-zXr6atUmyYdiWRVLOZahakYmOBHtWc2WGCkP8PYTgZi0iJXDY2CN180TdrIW4OGOAdLc7TifzDIvtx6izaRIzg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.0
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-validator-option': 7.21.0
-      '@babel/plugin-transform-react-display-name': 7.18.6_@babel+core@7.18.0
-      '@babel/plugin-transform-react-jsx': 7.21.0_@babel+core@7.18.0
-      '@babel/plugin-transform-react-jsx-development': 7.18.6_@babel+core@7.18.0
-      '@babel/plugin-transform-react-pure-annotations': 7.18.6_@babel+core@7.18.0
-    dev: true
-
   /@babel/preset-react/7.18.6_@babel+core@7.20.12:
     resolution: {integrity: sha512-zXr6atUmyYdiWRVLOZahakYmOBHtWc2WGCkP8PYTgZi0iJXDY2CN180TdrIW4OGOAdLc7TifzDIvtx6izaRIzg==}
     engines: {node: '>=6.9.0'}
@@ -4466,20 +4224,6 @@ packages:
       '@babel/plugin-transform-react-jsx': 7.21.0_@babel+core@7.20.12
       '@babel/plugin-transform-react-jsx-development': 7.18.6_@babel+core@7.20.12
       '@babel/plugin-transform-react-pure-annotations': 7.18.6_@babel+core@7.20.12
-
-  /@babel/preset-typescript/7.18.6_@babel+core@7.18.0:
-    resolution: {integrity: sha512-s9ik86kXBAnD760aybBucdpnLsAt0jK1xqJn2juOn9lkOvSHV60os5hxoVJsPzMQxvnUJFAlkont2DvvaYEBtQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.0
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-validator-option': 7.21.0
-      '@babel/plugin-transform-typescript': 7.21.0_@babel+core@7.18.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /@babel/preset-typescript/7.18.6_@babel+core@7.20.12:
     resolution: {integrity: sha512-s9ik86kXBAnD760aybBucdpnLsAt0jK1xqJn2juOn9lkOvSHV60os5hxoVJsPzMQxvnUJFAlkont2DvvaYEBtQ==}
@@ -4569,7 +4313,7 @@ packages:
     dependencies:
       '@babel/code-frame': 7.18.6
       '@babel/parser': 7.21.2
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
 
   /@babel/traverse/7.21.2:
     resolution: {integrity: sha512-ts5FFU/dSUPS13tv8XiEObDu9K+iagEKME9kAbaP7r0Y9KtZJZ+NGndDvWoRAYNpeWafbpFeki3q9QoMD6gxyw==}
@@ -5547,6 +5291,13 @@ packages:
       '@sinclair/typebox': 0.24.51
     dev: false
 
+  /@jest/schemas/29.4.3:
+    resolution: {integrity: sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@sinclair/typebox': 0.25.24
+    dev: false
+
   /@jest/source-map/27.5.1:
     resolution: {integrity: sha512-y9NIHUYF3PJRlHk98NdC/N1gl88BL08aQQgu4k4ZopQkCw9t9cV8mtl3TV8b/YCB8XaVTFrmUTAJvjsntDireg==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -5630,6 +5381,29 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@jest/transform/29.5.0:
+    resolution: {integrity: sha512-8vbeZWqLJOvHaDfeMuoHITGKSz5qWc9u04lnWrQE3VyuSw604PzQM824ZeX9XSjUCeDiE3GuxZe5UKa8J61NQw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@babel/core': 7.20.12
+      '@jest/types': 29.5.0
+      '@jridgewell/trace-mapping': 0.3.17
+      babel-plugin-istanbul: 6.1.1
+      chalk: 4.1.2
+      convert-source-map: 2.0.0
+      fast-json-stable-stringify: 2.1.0
+      graceful-fs: 4.2.10
+      jest-haste-map: 29.5.0
+      jest-regex-util: 29.4.3
+      jest-util: 29.5.0
+      micromatch: 4.0.5
+      pirates: 4.0.5
+      slash: 3.0.0
+      write-file-atomic: 4.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@jest/types/25.5.0:
     resolution: {integrity: sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==}
     engines: {node: '>= 8.3'}
@@ -5665,6 +5439,18 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/schemas': 28.1.3
+      '@types/istanbul-lib-coverage': 2.0.4
+      '@types/istanbul-reports': 3.0.1
+      '@types/node': 18.15.0
+      '@types/yargs': 17.0.22
+      chalk: 4.1.2
+    dev: false
+
+  /@jest/types/29.5.0:
+    resolution: {integrity: sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/schemas': 29.4.3
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
       '@types/node': 18.15.0
@@ -6387,6 +6173,10 @@ packages:
 
   /@sinclair/typebox/0.24.51:
     resolution: {integrity: sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==}
+    dev: false
+
+  /@sinclair/typebox/0.25.24:
+    resolution: {integrity: sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==}
     dev: false
 
   /@sindresorhus/is/0.14.0:
@@ -8102,7 +7892,7 @@ packages:
     resolution: {integrity: sha512-+n8dL/9GWblDO0iU6eZAwEIJVr5DWigtle+Q6HLOrh/pdbXOhOtqzq8VPPE2zvNJzSKY4vH/z3iT3tn0A3ypiQ==}
     dependencies:
       '@babel/parser': 7.21.2
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
       '@types/babel__generator': 7.6.4
       '@types/babel__template': 7.4.1
       '@types/babel__traverse': 7.18.3
@@ -8110,18 +7900,18 @@ packages:
   /@types/babel__generator/7.6.4:
     resolution: {integrity: sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
 
   /@types/babel__template/7.4.1:
     resolution: {integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==}
     dependencies:
       '@babel/parser': 7.21.2
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
 
   /@types/babel__traverse/7.18.3:
     resolution: {integrity: sha512-1kbcJ40lLB7MHsj39U4Sh1uTd2E7rLEa79kmDpI6cy+XiXsteB3POdQomoq4FxszMrO3ZYchkhYJw7A2862b3w==}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
 
   /@types/body-parser/1.19.2:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
@@ -10274,6 +10064,24 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /babel-jest/29.5.0_@babel+core@7.20.12:
+    resolution: {integrity: sha512-mA4eCDh5mSo2EcA9xQjVTpmbbNk32Zb3Q3QFQsNhaK56Q+yoXowzFodLux30HRgyOho5rsQ6B0P9QpMkvvnJ0Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@babel/core': ^7.8.0
+    dependencies:
+      '@babel/core': 7.20.12
+      '@jest/transform': 29.5.0
+      '@types/babel__core': 7.20.0
+      babel-plugin-istanbul: 6.1.1
+      babel-preset-jest: 29.5.0_@babel+core@7.20.12
+      chalk: 4.1.2
+      graceful-fs: 4.2.10
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /babel-loader/8.3.0_nwtvwtk5tmh22l2urnqucz7kqu:
     resolution: {integrity: sha512-H8SvsMF+m9t15HNLMipppzkC+Y2Yq+v3SonZyU70RBL/h1gxPkH08Ot8pEE9Z4Kd+czyWJClmFS8qzIP9OZ04Q==}
     engines: {node: '>= 8.9'}
@@ -10360,9 +10168,19 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@babel/template': 7.20.7
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
       '@types/babel__core': 7.20.0
       '@types/babel__traverse': 7.18.3
+
+  /babel-plugin-jest-hoist/29.5.0:
+    resolution: {integrity: sha512-zSuuuAlTMT4mzLj2nPnUm6fsE6270vdOfnpbJ+RmruU75UhLFvL0N2NgI7xpeS7NaB6hGqmd5pVpGTDYvi4Q3w==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@babel/template': 7.20.7
+      '@babel/types': 7.21.2
+      '@types/babel__core': 7.20.0
+      '@types/babel__traverse': 7.18.3
+    dev: false
 
   /babel-plugin-lodash/3.3.4:
     resolution: {integrity: sha512-yDZLjK7TCkWl1gpBeBGmuaDIFhZKmkoL+Cu2MUUjv5VxUZx/z7tBGBCBcQs5RI1Bkz5LLmNdjx7paOyQtMovyg==}
@@ -10449,18 +10267,6 @@ packages:
       - supports-color
     dev: true
 
-  /babel-plugin-polyfill-corejs3/0.6.0_@babel+core@7.18.0:
-    resolution: {integrity: sha512-+eHqR6OPcBhJOGgsIar7xoAB1GcSwVUA3XjAd7HJNzOXT4wv6/H7KIdA/Nc60cvUlDbKApmqNvD1B1bzOt4nyA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.0
-      '@babel/helper-define-polyfill-provider': 0.3.3_@babel+core@7.18.0
-      core-js-compat: 3.29.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /babel-plugin-polyfill-corejs3/0.6.0_@babel+core@7.20.12:
     resolution: {integrity: sha512-+eHqR6OPcBhJOGgsIar7xoAB1GcSwVUA3XjAd7HJNzOXT4wv6/H7KIdA/Nc60cvUlDbKApmqNvD1B1bzOt4nyA==}
     peerDependencies:
@@ -10474,17 +10280,6 @@ packages:
 
   /babel-plugin-polyfill-regenerator/0.3.1_@babel+core@7.18.0:
     resolution: {integrity: sha512-Y2B06tvgHYt1x0yz17jGkGeeMr5FeKUu+ASJ+N6nB5lQ8Dapfg42i0OVrf8PNGJ3zKL4A23snMi1IRwrqqND7A==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.0
-      '@babel/helper-define-polyfill-provider': 0.3.3_@babel+core@7.18.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /babel-plugin-polyfill-regenerator/0.4.1_@babel+core@7.18.0:
-    resolution: {integrity: sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -11053,6 +10848,17 @@ packages:
       '@babel/core': 7.20.12
       babel-plugin-jest-hoist: 27.5.1
       babel-preset-current-node-syntax: 1.0.1_@babel+core@7.20.12
+
+  /babel-preset-jest/29.5.0_@babel+core@7.20.12:
+    resolution: {integrity: sha512-JOMloxOqdiBSxMAzjRaH023/vvcaSaec49zvg+2LmNsktC7ei39LTJGw02J+9uUtTZUq6xbLyJ4dxe9sSmIuAg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.20.12
+      babel-plugin-jest-hoist: 29.5.0
+      babel-preset-current-node-syntax: 1.0.1_@babel+core@7.20.12
+    dev: false
 
   /babel-preset-react-app/10.0.1:
     resolution: {integrity: sha512-b0D9IZ1WhhCWkrTXyFuIIgqGzSkRIH5D5AmB0bXbzYAB1OBAwHcUeyWW2LorutLWF5btNo/N7r/cIdmvvKJlYg==}
@@ -12641,6 +12447,10 @@ packages:
 
   /convert-source-map/1.9.0:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
+
+  /convert-source-map/2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+    dev: false
 
   /cookie-parser/1.4.6:
     resolution: {integrity: sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==}
@@ -19520,6 +19330,25 @@ packages:
     optionalDependencies:
       fsevents: 2.3.2
 
+  /jest-haste-map/29.5.0:
+    resolution: {integrity: sha512-IspOPnnBro8YfVYSw6yDRKh/TiCdRngjxeacCps1cQ9cgVN6+10JUcuJ1EabrgYLOATsIAigxA0rLR9x/YlrSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/types': 29.5.0
+      '@types/graceful-fs': 4.1.6
+      '@types/node': 18.15.0
+      anymatch: 3.1.3
+      fb-watchman: 2.0.2
+      graceful-fs: 4.2.10
+      jest-regex-util: 29.4.3
+      jest-util: 29.5.0
+      jest-worker: 29.5.0
+      micromatch: 4.0.5
+      walker: 1.0.8
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: false
+
   /jest-jasmine2/27.5.1:
     resolution: {integrity: sha512-jtq7VVyG8SqAorDpApwiJJImd0V2wv1xzdheGHRGyuT7gZm6gG47QEskOlzsN1PG/6WNaCo5pmwMHDf3AkG2pQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -19646,6 +19475,11 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dev: false
 
+  /jest-regex-util/29.4.3:
+    resolution: {integrity: sha512-O4FglZaMmWXbGHSQInfXewIsd1LMn9p3ZXB/6r4FOkyhX2/iP/soMG98jGvk/A3HAN78+5VWcBGO0BJAPRh4kg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dev: false
+
   /jest-resolve-dependencies/27.5.1:
     resolution: {integrity: sha512-QQOOdY4PE39iawDn5rzbIePNigfe5B9Z91GDD1ae/xNDlu9kaat8QQ5EKnNmVWPV54hUdxCVwwj6YMgR2O7IOg==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -19754,7 +19588,7 @@ packages:
       '@babel/generator': 7.21.1
       '@babel/plugin-syntax-typescript': 7.20.0_@babel+core@7.20.12
       '@babel/traverse': 7.21.2
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
       '@types/babel__traverse': 7.18.3
@@ -19803,6 +19637,18 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/types': 28.1.3
+      '@types/node': 18.15.0
+      chalk: 4.1.2
+      ci-info: 3.8.0
+      graceful-fs: 4.2.10
+      picomatch: 2.3.1
+    dev: false
+
+  /jest-util/29.5.0:
+    resolution: {integrity: sha512-RYMgG/MTadOr5t8KdhejfvUU82MxsCu5MF6KuDUHl+NuwzUt+Sm6jJWxTJVrDR1j5M/gJVCPKQEpWXY+yIQ6lQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/types': 29.5.0
       '@types/node': 18.15.0
       chalk: 4.1.2
       ci-info: 3.8.0
@@ -19884,6 +19730,16 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@types/node': 18.15.0
+      merge-stream: 2.0.0
+      supports-color: 8.1.1
+    dev: false
+
+  /jest-worker/29.5.0:
+    resolution: {integrity: sha512-NcrQnevGoSp4b5kg+akIpthoAFHxPBcb5P6mYPY0fUNT+sSvmtu6jlkEle3anczUKIKEbMxFimk9oTP/tpIPgA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@types/node': 18.15.0
+      jest-util: 29.5.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: false
@@ -30634,6 +30490,14 @@ packages:
       is-typedarray: 1.0.0
       signal-exit: 3.0.7
       typedarray-to-buffer: 3.1.5
+
+  /write-file-atomic/4.0.2:
+    resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    dependencies:
+      imurmurhash: 0.1.4
+      signal-exit: 3.0.7
+    dev: false
 
   /ws/7.4.5:
     resolution: {integrity: sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,11 +62,11 @@ importers:
       invariant: 2.2.4
       pm2: 5.2.2
     devDependencies:
-      '@babel/eslint-parser': 7.19.1_go3kp2l7mdrkdyt3xfyeu7ppfa
-      '@babel/plugin-proposal-function-bind': 7.18.9_@babel+core@7.20.12
-      '@babel/preset-env': 7.20.2_@babel+core@7.20.12
-      '@babel/preset-react': 7.18.6_@babel+core@7.20.12
-      '@babel/preset-typescript': 7.18.6_@babel+core@7.20.12
+      '@babel/eslint-parser': 7.19.1_pv54mmcbvvc2ehtbbm4mt3a4my
+      '@babel/plugin-proposal-function-bind': 7.18.9_@babel+core@7.18.0
+      '@babel/preset-env': 7.20.2_@babel+core@7.18.0
+      '@babel/preset-react': 7.18.6_@babel+core@7.18.0
+      '@babel/preset-typescript': 7.18.6_@babel+core@7.18.0
       '@testing-library/cypress': 8.0.7_cypress@10.11.0
       '@testing-library/dom': 8.20.0
       '@testing-library/jest-dom': 5.16.5
@@ -195,6 +195,7 @@ importers:
       rx: 4.1.0
       smee-client: 1.2.3
       stripe: 8.205.0
+      strong-error-handler: 3.5.0
       uuid: 3.4.0
       validator: 13.7.0
     dependencies:
@@ -242,6 +243,7 @@ importers:
       rate-limit-mongo: 2.3.2
       rx: 4.1.0
       stripe: 8.205.0
+      strong-error-handler: 3.5.0
       uuid: 3.4.0
       validator: 13.7.0
     devDependencies:
@@ -1983,6 +1985,20 @@ packages:
       semver: 6.3.0
     dev: false
 
+  /@babel/eslint-parser/7.19.1_pv54mmcbvvc2ehtbbm4mt3a4my:
+    resolution: {integrity: sha512-AqNf2QWt1rtu2/1rLswy6CDP7H9Oh3mMhk177Y67Rg8d7RD9WfOLLv8CGn6tisFvS2htm86yIe1yLF6I1UDaGQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
+    peerDependencies:
+      '@babel/core': '>=7.11.0'
+      eslint: ^7.5.0 || ^8.0.0
+    dependencies:
+      '@babel/core': 7.18.0
+      '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
+      eslint: 7.32.0
+      eslint-visitor-keys: 2.1.0
+      semver: 6.3.0
+    dev: true
+
   /@babel/generator/7.21.1:
     resolution: {integrity: sha512-1lT45bAYlQhFn/BHivJs43AiW2rg3/UbLyShGfF3C0KmHvO5fSghWd5kBJy30kpRRucGzXStvnnCFniCR2kXAA==}
     engines: {node: '>=6.9.0'}
@@ -2422,6 +2438,19 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/plugin-proposal-class-properties/7.18.6_@babel+core@7.18.0:
+    resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.18.0
+      '@babel/helper-create-class-features-plugin': 7.21.0_@babel+core@7.18.0
+      '@babel/helper-plugin-utils': 7.20.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/plugin-proposal-class-properties/7.18.6_@babel+core@7.20.12:
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
     engines: {node: '>=6.9.0'}
@@ -2528,6 +2557,17 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.20.12
 
+  /@babel/plugin-proposal-function-bind/7.18.9_@babel+core@7.18.0:
+    resolution: {integrity: sha512-9RfxqKkRBCCT0xoBl9AqieCMscJmSAL9HYixGMWH549jUpT9csWWK/HEYZEx9t9iW/PRSXgX95x9bDlgtAJGFA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.18.0
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/plugin-syntax-function-bind': 7.18.6_@babel+core@7.18.0
+    dev: true
+
   /@babel/plugin-proposal-function-bind/7.18.9_@babel+core@7.20.12:
     resolution: {integrity: sha512-9RfxqKkRBCCT0xoBl9AqieCMscJmSAL9HYixGMWH549jUpT9csWWK/HEYZEx9t9iW/PRSXgX95x9bDlgtAJGFA==}
     engines: {node: '>=6.9.0'}
@@ -2537,6 +2577,7 @@ packages:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-function-bind': 7.18.6_@babel+core@7.20.12
+    dev: false
 
   /@babel/plugin-proposal-json-strings/7.18.6_@babel+core@7.18.0:
     resolution: {integrity: sha512-lr1peyn9kOdbYc0xr0OdHTZ5FMqS6Di+H0Fz2I/JwMzGmzJETNeOFq2pBySw6X/KFL5EWDjlJuMsUGRFb8fQgQ==}
@@ -2669,6 +2710,20 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.20.12
       '@babel/plugin-transform-parameters': 7.20.7_@babel+core@7.20.12
+    dev: true
+
+  /@babel/plugin-proposal-object-rest-spread/7.20.7_@babel+core@7.18.0:
+    resolution: {integrity: sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/compat-data': 7.21.0
+      '@babel/core': 7.18.0
+      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.18.0
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.18.0
+      '@babel/plugin-transform-parameters': 7.20.7_@babel+core@7.18.0
     dev: true
 
   /@babel/plugin-proposal-object-rest-spread/7.20.7_@babel+core@7.20.12:
@@ -2948,6 +3003,16 @@ packages:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
 
+  /@babel/plugin-syntax-function-bind/7.18.6_@babel+core@7.18.0:
+    resolution: {integrity: sha512-wZN0Aq/AScknI9mKGcR3TpHdASMufFGaeJgc1rhPmLtZ/PniwjePSh8cfh8tXMB3U4kh/3cRKrLjDtedejg8jQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.18.0
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: true
+
   /@babel/plugin-syntax-function-bind/7.18.6_@babel+core@7.20.12:
     resolution: {integrity: sha512-wZN0Aq/AScknI9mKGcR3TpHdASMufFGaeJgc1rhPmLtZ/PniwjePSh8cfh8tXMB3U4kh/3cRKrLjDtedejg8jQ==}
     engines: {node: '>=6.9.0'}
@@ -2956,6 +3021,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
+    dev: false
 
   /@babel/plugin-syntax-import-assertions/7.20.0_@babel+core@7.18.0:
     resolution: {integrity: sha512-IUh1vakzNoWalR8ch/areW7qFopR2AEw03JlG7BbrDqmQ4X3q9uuipQwSGrUn7oGiemKjtSLDhNtQHzMHr1JdQ==}
@@ -3015,6 +3081,16 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: true
+
+  /@babel/plugin-syntax-jsx/7.18.6_@babel+core@7.18.0:
+    resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.18.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -3183,6 +3259,16 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
+
+  /@babel/plugin-syntax-typescript/7.20.0_@babel+core@7.18.0:
+    resolution: {integrity: sha512-rd9TkG+u1CExzS4SM1BlMEhMXwFLKVjOAFFCDx9PbX5ycJWDoWMcwdJH9RhkPu1dOgn5TrxLot/Gx6lWFuAUNQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.18.0
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: true
 
   /@babel/plugin-syntax-typescript/7.20.0_@babel+core@7.20.12:
     resolution: {integrity: sha512-rd9TkG+u1CExzS4SM1BlMEhMXwFLKVjOAFFCDx9PbX5ycJWDoWMcwdJH9RhkPu1dOgn5TrxLot/Gx6lWFuAUNQ==}
@@ -3745,6 +3831,16 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
+  /@babel/plugin-transform-react-display-name/7.18.6_@babel+core@7.18.0:
+    resolution: {integrity: sha512-TV4sQ+T013n61uMoygyMRm+xf04Bd5oqFpv2jAEQwSZ8NwQA7zeRPg1LMVg2PWi3zWBz+CLKD+v5bcpZ/BS0aA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.18.0
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: true
+
   /@babel/plugin-transform-react-display-name/7.18.6_@babel+core@7.20.12:
     resolution: {integrity: sha512-TV4sQ+T013n61uMoygyMRm+xf04Bd5oqFpv2jAEQwSZ8NwQA7zeRPg1LMVg2PWi3zWBz+CLKD+v5bcpZ/BS0aA==}
     engines: {node: '>=6.9.0'}
@@ -3754,6 +3850,16 @@ packages:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
 
+  /@babel/plugin-transform-react-jsx-development/7.18.6_@babel+core@7.18.0:
+    resolution: {integrity: sha512-SA6HEjwYFKF7WDjWcMcMGUimmw/nhNRDWxr+KaLSCrkD/LMDBvWRmHAYgE1HDeF8KUuI8OAu+RT6EOtKxSW2qA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.18.0
+      '@babel/plugin-transform-react-jsx': 7.21.0_@babel+core@7.18.0
+    dev: true
+
   /@babel/plugin-transform-react-jsx-development/7.18.6_@babel+core@7.20.12:
     resolution: {integrity: sha512-SA6HEjwYFKF7WDjWcMcMGUimmw/nhNRDWxr+KaLSCrkD/LMDBvWRmHAYgE1HDeF8KUuI8OAu+RT6EOtKxSW2qA==}
     engines: {node: '>=6.9.0'}
@@ -3762,6 +3868,20 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/plugin-transform-react-jsx': 7.21.0_@babel+core@7.20.12
+
+  /@babel/plugin-transform-react-jsx/7.21.0_@babel+core@7.18.0:
+    resolution: {integrity: sha512-6OAWljMvQrZjR2DaNhVfRz6dkCAVV+ymcLUmaf8bccGOHn2v5rHJK3tTpij0BuhdYWP4LLaqj5lwcdlpAAPuvg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.18.0
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.18.0
+      '@babel/types': 7.21.2
+    dev: true
 
   /@babel/plugin-transform-react-jsx/7.21.0_@babel+core@7.20.12:
     resolution: {integrity: sha512-6OAWljMvQrZjR2DaNhVfRz6dkCAVV+ymcLUmaf8bccGOHn2v5rHJK3tTpij0BuhdYWP4LLaqj5lwcdlpAAPuvg==}
@@ -3775,6 +3895,17 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.20.12
       '@babel/types': 7.21.2
+
+  /@babel/plugin-transform-react-pure-annotations/7.18.6_@babel+core@7.18.0:
+    resolution: {integrity: sha512-I8VfEPg9r2TRDdvnHgPepTKvuRomzA8+u+nhY7qSI1fR2hRNebasZEETLyM5mAUr0Ku56OkXJ0I7NHJnO6cJiQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.18.0
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: true
 
   /@babel/plugin-transform-react-pure-annotations/7.18.6_@babel+core@7.20.12:
     resolution: {integrity: sha512-I8VfEPg9r2TRDdvnHgPepTKvuRomzA8+u+nhY7qSI1fR2hRNebasZEETLyM5mAUr0Ku56OkXJ0I7NHJnO6cJiQ==}
@@ -3939,6 +4070,20 @@ packages:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
 
+  /@babel/plugin-transform-typescript/7.21.0_@babel+core@7.18.0:
+    resolution: {integrity: sha512-xo///XTPp3mDzTtrqXoBlK9eiAYW3wv9JXglcn/u1bi60RW11dEUxIgA8cbnDhutS1zacjMRmAwxE0gMklLnZg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.18.0
+      '@babel/helper-create-class-features-plugin': 7.21.0_@babel+core@7.18.0
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/plugin-syntax-typescript': 7.20.0_@babel+core@7.18.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/plugin-transform-typescript/7.21.0_@babel+core@7.20.12:
     resolution: {integrity: sha512-xo///XTPp3mDzTtrqXoBlK9eiAYW3wv9JXglcn/u1bi60RW11dEUxIgA8cbnDhutS1zacjMRmAwxE0gMklLnZg==}
     engines: {node: '>=6.9.0'}
@@ -4085,6 +4230,92 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/preset-env/7.20.2_@babel+core@7.18.0:
+    resolution: {integrity: sha512-1G0efQEWR1EHkKvKHqbG+IN/QdgwfByUpM5V5QroDzGV2t3S/WXNQd693cHiHTlCFMpr9B6FkPFXDA2lQcKoDg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/compat-data': 7.21.0
+      '@babel/core': 7.18.0
+      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.18.0
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-validator-option': 7.21.0
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.18.6_@babel+core@7.18.0
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.20.7_@babel+core@7.18.0
+      '@babel/plugin-proposal-async-generator-functions': 7.20.7_@babel+core@7.18.0
+      '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.18.0
+      '@babel/plugin-proposal-class-static-block': 7.21.0_@babel+core@7.18.0
+      '@babel/plugin-proposal-dynamic-import': 7.18.6_@babel+core@7.18.0
+      '@babel/plugin-proposal-export-namespace-from': 7.18.9_@babel+core@7.18.0
+      '@babel/plugin-proposal-json-strings': 7.18.6_@babel+core@7.18.0
+      '@babel/plugin-proposal-logical-assignment-operators': 7.20.7_@babel+core@7.18.0
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6_@babel+core@7.18.0
+      '@babel/plugin-proposal-numeric-separator': 7.18.6_@babel+core@7.18.0
+      '@babel/plugin-proposal-object-rest-spread': 7.20.7_@babel+core@7.18.0
+      '@babel/plugin-proposal-optional-catch-binding': 7.18.6_@babel+core@7.18.0
+      '@babel/plugin-proposal-optional-chaining': 7.21.0_@babel+core@7.18.0
+      '@babel/plugin-proposal-private-methods': 7.18.6_@babel+core@7.18.0
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0_@babel+core@7.18.0
+      '@babel/plugin-proposal-unicode-property-regex': 7.18.6_@babel+core@7.18.0
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.18.0
+      '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.18.0
+      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.18.0
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.18.0
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.18.0
+      '@babel/plugin-syntax-import-assertions': 7.20.0_@babel+core@7.18.0
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.18.0
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.18.0
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.18.0
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.18.0
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.18.0
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.18.0
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.18.0
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.18.0
+      '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.18.0
+      '@babel/plugin-transform-arrow-functions': 7.20.7_@babel+core@7.18.0
+      '@babel/plugin-transform-async-to-generator': 7.20.7_@babel+core@7.18.0
+      '@babel/plugin-transform-block-scoped-functions': 7.18.6_@babel+core@7.18.0
+      '@babel/plugin-transform-block-scoping': 7.21.0_@babel+core@7.18.0
+      '@babel/plugin-transform-classes': 7.21.0_@babel+core@7.18.0
+      '@babel/plugin-transform-computed-properties': 7.20.7_@babel+core@7.18.0
+      '@babel/plugin-transform-destructuring': 7.20.7_@babel+core@7.18.0
+      '@babel/plugin-transform-dotall-regex': 7.18.6_@babel+core@7.18.0
+      '@babel/plugin-transform-duplicate-keys': 7.18.9_@babel+core@7.18.0
+      '@babel/plugin-transform-exponentiation-operator': 7.18.6_@babel+core@7.18.0
+      '@babel/plugin-transform-for-of': 7.21.0_@babel+core@7.18.0
+      '@babel/plugin-transform-function-name': 7.18.9_@babel+core@7.18.0
+      '@babel/plugin-transform-literals': 7.18.9_@babel+core@7.18.0
+      '@babel/plugin-transform-member-expression-literals': 7.18.6_@babel+core@7.18.0
+      '@babel/plugin-transform-modules-amd': 7.20.11_@babel+core@7.18.0
+      '@babel/plugin-transform-modules-commonjs': 7.21.2_@babel+core@7.18.0
+      '@babel/plugin-transform-modules-systemjs': 7.20.11_@babel+core@7.18.0
+      '@babel/plugin-transform-modules-umd': 7.18.6_@babel+core@7.18.0
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.20.5_@babel+core@7.18.0
+      '@babel/plugin-transform-new-target': 7.18.6_@babel+core@7.18.0
+      '@babel/plugin-transform-object-super': 7.18.6_@babel+core@7.18.0
+      '@babel/plugin-transform-parameters': 7.20.7_@babel+core@7.18.0
+      '@babel/plugin-transform-property-literals': 7.18.6_@babel+core@7.18.0
+      '@babel/plugin-transform-regenerator': 7.20.5_@babel+core@7.18.0
+      '@babel/plugin-transform-reserved-words': 7.18.6_@babel+core@7.18.0
+      '@babel/plugin-transform-shorthand-properties': 7.18.6_@babel+core@7.18.0
+      '@babel/plugin-transform-spread': 7.20.7_@babel+core@7.18.0
+      '@babel/plugin-transform-sticky-regex': 7.18.6_@babel+core@7.18.0
+      '@babel/plugin-transform-template-literals': 7.18.9_@babel+core@7.18.0
+      '@babel/plugin-transform-typeof-symbol': 7.18.9_@babel+core@7.18.0
+      '@babel/plugin-transform-unicode-escapes': 7.18.10_@babel+core@7.18.0
+      '@babel/plugin-transform-unicode-regex': 7.18.6_@babel+core@7.18.0
+      '@babel/preset-modules': 0.1.5_@babel+core@7.18.0
+      '@babel/types': 7.20.7
+      babel-plugin-polyfill-corejs2: 0.3.3_@babel+core@7.18.0
+      babel-plugin-polyfill-corejs3: 0.6.0_@babel+core@7.18.0
+      babel-plugin-polyfill-regenerator: 0.4.1_@babel+core@7.18.0
+      core-js-compat: 3.29.0
+      semver: 6.3.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/preset-env/7.20.2_@babel+core@7.20.12:
     resolution: {integrity: sha512-1G0efQEWR1EHkKvKHqbG+IN/QdgwfByUpM5V5QroDzGV2t3S/WXNQd693cHiHTlCFMpr9B6FkPFXDA2lQcKoDg==}
     engines: {node: '>=6.9.0'}
@@ -4207,6 +4438,21 @@ packages:
       '@babel/types': 7.20.7
       esutils: 2.0.3
 
+  /@babel/preset-react/7.18.6_@babel+core@7.18.0:
+    resolution: {integrity: sha512-zXr6atUmyYdiWRVLOZahakYmOBHtWc2WGCkP8PYTgZi0iJXDY2CN180TdrIW4OGOAdLc7TifzDIvtx6izaRIzg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.18.0
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-validator-option': 7.21.0
+      '@babel/plugin-transform-react-display-name': 7.18.6_@babel+core@7.18.0
+      '@babel/plugin-transform-react-jsx': 7.21.0_@babel+core@7.18.0
+      '@babel/plugin-transform-react-jsx-development': 7.18.6_@babel+core@7.18.0
+      '@babel/plugin-transform-react-pure-annotations': 7.18.6_@babel+core@7.18.0
+    dev: true
+
   /@babel/preset-react/7.18.6_@babel+core@7.20.12:
     resolution: {integrity: sha512-zXr6atUmyYdiWRVLOZahakYmOBHtWc2WGCkP8PYTgZi0iJXDY2CN180TdrIW4OGOAdLc7TifzDIvtx6izaRIzg==}
     engines: {node: '>=6.9.0'}
@@ -4220,6 +4466,20 @@ packages:
       '@babel/plugin-transform-react-jsx': 7.21.0_@babel+core@7.20.12
       '@babel/plugin-transform-react-jsx-development': 7.18.6_@babel+core@7.20.12
       '@babel/plugin-transform-react-pure-annotations': 7.18.6_@babel+core@7.20.12
+
+  /@babel/preset-typescript/7.18.6_@babel+core@7.18.0:
+    resolution: {integrity: sha512-s9ik86kXBAnD760aybBucdpnLsAt0jK1xqJn2juOn9lkOvSHV60os5hxoVJsPzMQxvnUJFAlkont2DvvaYEBtQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.18.0
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-validator-option': 7.21.0
+      '@babel/plugin-transform-typescript': 7.21.0_@babel+core@7.18.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /@babel/preset-typescript/7.18.6_@babel+core@7.20.12:
     resolution: {integrity: sha512-s9ik86kXBAnD760aybBucdpnLsAt0jK1xqJn2juOn9lkOvSHV60os5hxoVJsPzMQxvnUJFAlkont2DvvaYEBtQ==}
@@ -10189,6 +10449,18 @@ packages:
       - supports-color
     dev: true
 
+  /babel-plugin-polyfill-corejs3/0.6.0_@babel+core@7.18.0:
+    resolution: {integrity: sha512-+eHqR6OPcBhJOGgsIar7xoAB1GcSwVUA3XjAd7HJNzOXT4wv6/H7KIdA/Nc60cvUlDbKApmqNvD1B1bzOt4nyA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.18.0
+      '@babel/helper-define-polyfill-provider': 0.3.3_@babel+core@7.18.0
+      core-js-compat: 3.29.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /babel-plugin-polyfill-corejs3/0.6.0_@babel+core@7.20.12:
     resolution: {integrity: sha512-+eHqR6OPcBhJOGgsIar7xoAB1GcSwVUA3XjAd7HJNzOXT4wv6/H7KIdA/Nc60cvUlDbKApmqNvD1B1bzOt4nyA==}
     peerDependencies:
@@ -10202,6 +10474,17 @@ packages:
 
   /babel-plugin-polyfill-regenerator/0.3.1_@babel+core@7.18.0:
     resolution: {integrity: sha512-Y2B06tvgHYt1x0yz17jGkGeeMr5FeKUu+ASJ+N6nB5lQ8Dapfg42i0OVrf8PNGJ3zKL4A23snMi1IRwrqqND7A==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.18.0
+      '@babel/helper-define-polyfill-provider': 0.3.3_@babel+core@7.18.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /babel-plugin-polyfill-regenerator/0.4.1_@babel+core@7.18.0:
+    resolution: {integrity: sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Ref: https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/4412950179/jobs/7732907368

The underlying issue was that pnpm no longer adds `NODE_PATH=node_modules/.pnpm` to scripts and several of our scripts were relying on that behaviour. This PR fixes that issue by installing all our dependencies rather than relying on them being present in the 'global store'.

<!-- Feel free to add any additional description of changes below this line -->
