### PR TITLE
feat(client): hide the outline instead of removing it

### DIFF
--- a/client/src/components/Donation/donation.css
+++ b/client/src/components/Donation/donation.css
@@ -109,7 +109,7 @@
 
 .donation-form .form-control:focus {
   border-color: #66afe9;
-  outline: 0;
+  outline-color: transparent;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075),
     0 0 8px rgba(102, 175, 233, 0.6);
 }

--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -147,16 +147,10 @@ li > button.nav-link-signout:not([aria-disabled='true']):is(:hover, :focus) {
   border-bottom: 0.1rem solid var(--gray-45) !important;
 }
 
-button.nav-link:focus {
+button.nav-link:focus-visible {
   color: var(--tertiary-color);
   background-color: var(--tertiary-background);
   outline-offset: -4px;
-}
-
-button.nav-link:focus:not(:focus-visible) {
-  background-color: inherit;
-  color: #fff;
-  outline-color: transparent;
 }
 
 button.nav-link:not([aria-disabled='true']):hover {
@@ -323,14 +317,8 @@ button.nav-link[aria-disabled='true'] {
 }
 
 .exposed-button-nav:focus {
-  outline: 3px solid var(--blue-mid);
-  outline-offset: 0;
   background-color: var(--gray-90);
   color: var(--gray-00);
-}
-
-.exposed-button-nav:focus:not(:focus-visible) {
-  outline: none;
 }
 
 .avatar-nav-link {
@@ -464,10 +452,6 @@ button.nav-link[aria-disabled='true'] {
   box-sizing: content-box;
   margin-inline-start: -30px;
   padding-inline: 35px;
-}
-
-.ais-SearchBox-submit:focus:not(:focus-visible) {
-  outline-color: transparent;
 }
 
 #toggle-button-nav .menu-btn-text,

--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -110,7 +110,7 @@
   text-decoration: none;
   background-color: var(--gray-10);
   cursor: pointer;
-  outline: none !important;
+  outline-color: transparent !important;
 }
 
 li > button.nav-link-signout:not([aria-disabled='true']):is(:hover, :focus) {
@@ -156,7 +156,7 @@ button.nav-link:focus {
 button.nav-link:focus:not(:focus-visible) {
   background-color: inherit;
   color: #fff;
-  outline: none;
+  outline-color: transparent;
 }
 
 button.nav-link:not([aria-disabled='true']):hover {
@@ -467,7 +467,7 @@ button.nav-link[aria-disabled='true'] {
 }
 
 .ais-SearchBox-submit:focus:not(:focus-visible) {
-  outline: none;
+  outline-color: transparent;
 }
 
 #toggle-button-nav .menu-btn-text,

--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -313,7 +313,7 @@ fieldset[disabled] .btn-primary.focus {
   text-decoration: underline;
   background: transparent;
   padding: 0;
-  outline: 0;
+  outline-color: transparent;
 }
 .btn-link:hover,
 .btn-link:focus:active {
@@ -426,7 +426,7 @@ strong {
 }
 
 input {
-  outline: none;
+  outline-color: transparent;
   border-color: var(--quaternary-background);
   -webkit-box-shadow: none !important;
   -moz-box-shadow: none !important;

--- a/client/src/components/profile/components/portfolio-projects.css
+++ b/client/src/components/profile/components/portfolio-projects.css
@@ -123,7 +123,7 @@
 }
 
 .timeline-pagination_list_item > button {
-  outline: none;
+  outline-color: transparent;
 }
 
 /* Timeline table styles */

--- a/client/src/components/search/searchBar/searchbar-base.css
+++ b/client/src/components/search/searchBar/searchbar-base.css
@@ -245,7 +245,7 @@ a[class^='ais-'] {
   border-radius: 0px;
   -webkit-transition: background-color 0.2s ease-out;
   transition: background-color 0.2s ease-out;
-  outline: none;
+  outline-color: transparent;
 }
 .ais-ClearRefinements-button:hover,
 .ais-ClearRefinements-button:focus,
@@ -485,7 +485,7 @@ a[class^='ais-'] {
   border-radius: 0px;
   -webkit-transition: 0.2s ease-out;
   transition: 0.2s ease-out;
-  outline: none;
+  outline-color: transparent;
 }
 .ais-RangeInput-submit:hover,
 .ais-RangeInput-submit:focus {

--- a/client/src/components/settings/sound.css
+++ b/client/src/components/settings/sound.css
@@ -11,7 +11,7 @@ input[type='range'] {
 }
 
 input[type='range']:focus {
-  outline: none;
+  outline-color: transparent;
 }
 /* Special styling for WebKit/Blink */
 input[type='range']::-webkit-slider-thumb {

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -137,7 +137,3 @@
 .nav-tabs [role='tab']:focus {
   outline-offset: -2px;
 }
-
-.nav-tabs [role='tab']:focus:not(:focus-visible) {
-  outline-color: transparent;
-}

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -139,5 +139,5 @@
 }
 
 .nav-tabs [role='tab']:focus:not(:focus-visible) {
-  outline: none;
+  outline-color: transparent;
 }

--- a/client/src/templates/Challenges/components/challenge-title.css
+++ b/client/src/templates/Challenges/components/challenge-title.css
@@ -39,10 +39,6 @@
   background-color: inherit;
 }
 
-.challenge-title-breadcrumbs ol a:focus:not(:focus-visible) {
-  outline-color: transparent;
-}
-
 .challenge-title-breadcrumbs ol a:hover {
   background-color: inherit;
   text-decoration: underline;

--- a/client/src/templates/Challenges/components/challenge-title.css
+++ b/client/src/templates/Challenges/components/challenge-title.css
@@ -40,7 +40,7 @@
 }
 
 .challenge-title-breadcrumbs ol a:focus:not(:focus-visible) {
-  outline: none;
+  outline-color: transparent;
 }
 
 .challenge-title-breadcrumbs ol a:hover {

--- a/client/src/templates/Challenges/components/hotkeys.css
+++ b/client/src/templates/Challenges/components/hotkeys.css
@@ -1,4 +1,4 @@
 /* hide the outline for the HotKeys component */
 div[tabindex='-1']:focus {
-  outline: none;
+  outline-color: transparent;
 }

--- a/client/src/templates/Challenges/components/output.css
+++ b/client/src/templates/Challenges/components/output.css
@@ -14,10 +14,12 @@ pre.output-text code {
   padding: 2px 4px;
 }
 
-.output-text:focus {
+.output-text:focus-visible {
   outline-offset: -2px;
 }
 
-.output-text:focus:not(:focus-visible) {
-  outline-color: transparent;
+@supports not selector(:focus-visible) {
+  .output-text:focus {
+    outline-offset: -2px;
+  }
 }

--- a/client/src/templates/Challenges/components/output.css
+++ b/client/src/templates/Challenges/components/output.css
@@ -19,5 +19,5 @@ pre.output-text code {
 }
 
 .output-text:focus:not(:focus-visible) {
-  outline: none;
+  outline-color: transparent;
 }

--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -51,7 +51,7 @@ a.cert-tag:active {
 }
 
 .block-grid .challenge-jump-link a:focus:not(:focus-visible) {
-  outline: none;
+  outline-color: transparent;
 }
 
 .block-title-translation-cta {
@@ -258,7 +258,7 @@ button.map-title {
 }
 
 .map-challenges-grid .map-challenge-title a:focus:not(:focus-visible) {
-  outline: none;
+  outline-color: transparent;
 }
 
 .map-challenges-grid {

--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -50,10 +50,6 @@ a.cert-tag:active {
   margin: 0 25px 25px;
 }
 
-.block-grid .challenge-jump-link a:focus:not(:focus-visible) {
-  outline-color: transparent;
-}
-
 .block-title-translation-cta {
   white-space: nowrap;
   padding: 0.2em 0.5em;
@@ -255,10 +251,6 @@ button.map-title {
 
 .map-challenges-grid .map-challenge-title a:focus {
   outline-offset: -2px;
-}
-
-.map-challenges-grid .map-challenge-title a:focus:not(:focus-visible) {
-  outline-color: transparent;
 }
 
 .map-challenges-grid {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

In high contrast mode, which used for accessibility, outline is needed to provide contrast, this aims to show it in high contrast mode

<!-- Feel free to add any additional description of changes below this line -->
