### PR TITLE
feat: comment on i18n failure

### DIFF
--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -207,19 +207,19 @@ jobs:
       - uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975 # v6
         with:
           github-token: ${{ secrets.CAMPERBOT_NO_TRANSLATE }}
-        script: |
-          const isDev = await github.rest.teams.getMembershipForUserInOrg({
-            org: "freeCodeCamp",
-            team_slug: "dev-team",
-            username: context.payload.pull_request.user.login
-          }).catch(() => ({status: 404}));
-          if (context.payload.pull_request.user.login !== "camperbot" && isDev.status !== 200) {
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: "Hi,\n\nIt looks like the localization tests have failed. This is normal when there are significant curriculum changes in the English version.\n\nPlease check with the dev-team on [Discord](https://discord.gg/KVUmVXA) or our [forums](https://forum.freecodecamp.org) if this means a Crowdin sync is required to address the scenario. They will confirm and take over helping you through the PR.\n\nThanks for your understanding and contribution."
-            })
-          } else if (isDev.status === 200) {
-            core.setFailed('This PR appears to touch translated curriculum files, but since you are on the dev team there is no message.');
-          }
+          script: |
+            const isDev = await github.rest.teams.getMembershipForUserInOrg({
+              org: "freeCodeCamp",
+              team_slug: "dev-team",
+              username: context.payload.pull_request.user.login
+            }).catch(() => ({status: 404}));
+            if (context.payload.pull_request.user.login !== "camperbot" && isDev.status !== 200) {
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: "Hi,\n\nIt looks like the localization tests have failed. This is expected when there are significant curriculum changes in the English version.\n\nThis could mean a Crowdin sync is required to address the scenario. Please check with our staff developer team, either on [Discord](https://discord.gg/KVUmVXA) or our [forums](https://forum.freecodecamp.org). They will confirm and take over helping you through the PR.\n\nThanks for your understanding and contribution."
+              })
+            } else if (isDev.status === 200) {
+              core.setFailed('This PR appears to touch translated curriculum files, but since you are on the dev team there is no message.');
+            }

--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -197,3 +197,29 @@ jobs:
           CURRICULUM_LOCALE: ${{ matrix.locale }}
           CLIENT_LOCALE: ${{ matrix.locale }}
         run: pnpm test
+
+  failure-comment:
+    name: Comment on i18n Failure
+    needs: ['test', 'test-localization']
+    runs-on: ubuntu-20.04
+    if: ${{ needs.test.result == 'success' && needs.test-localization.result == 'failure' }}
+    steps:
+      - uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975 # v6
+        with:
+          github-token: ${{ secrets.CAMPERBOT_NO_TRANSLATE }}
+        script: |
+          const isDev = await github.rest.teams.getMembershipForUserInOrg({
+            org: "freeCodeCamp",
+            team_slug: "dev-team",
+            username: context.payload.pull_request.user.login
+          }).catch(() => ({status: 404}));
+          if (context.payload.pull_request.user.login !== "camperbot" && isDev.status !== 200) {
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "Hi,\n\nIt looks like the localization tests have failed. This is normal when there are significant curriculum changes in the English version.\n\nPlease check with the dev-team on [Discord]() or our [forums](https://forum.freecodecamp.org) if this means a Crowdin sync is required to address the scenario. They will confirm and take over helping you through the PR.\n\nThanks for your understanding and contribution."
+            })
+          } else if (isDev.status === 200) {
+            core.setFailed('This PR appears to touch translated curriculum files, but since you are on the dev team there is no message.');
+          }

--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -202,7 +202,7 @@ jobs:
     name: Comment on i18n Failure
     needs: ['test', 'test-localization']
     runs-on: ubuntu-20.04
-    if: ${{ needs.test.result == 'success' && needs.test-localization.result == 'failure' }}
+    if: ${{ always() && needs.test.result == 'success' && needs.test-localization.result == 'failure' }}
     steps:
       - uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975 # v6
         with:

--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -218,7 +218,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: "Hi,\n\nIt looks like the localization tests have failed. This is normal when there are significant curriculum changes in the English version.\n\nPlease check with the dev-team on [Discord]() or our [forums](https://forum.freecodecamp.org) if this means a Crowdin sync is required to address the scenario. They will confirm and take over helping you through the PR.\n\nThanks for your understanding and contribution."
+              body: "Hi,\n\nIt looks like the localization tests have failed. This is normal when there are significant curriculum changes in the English version.\n\nPlease check with the dev-team on [Discord](https://discord.gg/KVUmVXA) or our [forums](https://forum.freecodecamp.org) if this means a Crowdin sync is required to address the scenario. They will confirm and take over helping you through the PR.\n\nThanks for your understanding and contribution."
             })
           } else if (isDev.status === 200) {
             core.setFailed('This PR appears to touch translated curriculum files, but since you are on the dev team there is no message.');


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related #49698 

<!-- Feel free to add any additional description of changes below this line -->

Okay, this has been [tested](https://github.com/naomi-lgbt/actions-testing/pull/63) and is ready to go.

The logic here is that if the localisation tests fail, but the English tests pass, that's a potential indicator that we need to do a sync (not always, tests can be flaky, but it'll let the contributor know to reach out to us).
