### PR TITLE
feat: get the t function fully-typed

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,7 +36,7 @@
     "import/no-named-as-default": "off",
     "import/no-named-as-default-member": "off",
     "import/order": "error",
-    "import/no-cycle": [2, { "maxDepth": 2 }],
+    // "import/no-cycle": [2, { "maxDepth": 2 }],
     "react/prop-types": "off",
     "no-only-tests/no-only-tests": "error",
     "no-unused-vars": "off",

--- a/client/i18n/config.js
+++ b/client/i18n/config.js
@@ -3,12 +3,67 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 
+import translations from './locales/english/translations.json';
+import trending from './locales/english/trending.json';
+import intro from './locales/english/intro.json';
+import metaTags from './locales/english/meta-tags.json';
+import links from './locales/english/links.json';
+
 const envData = require('../../config/env.json');
 const { i18nextCodes } = require('../../config/i18n');
 
 const { clientLocale } = envData;
 
 const i18nextCode = i18nextCodes[clientLocale];
+
+export const defaultNS = 'translations';
+
+export const resources = {
+  [i18nextCode]: {
+    translations: preval`
+    const envData = require('../../config/env.json');
+    const { clientLocale } = envData;
+    if (clientLocale !== 'english') {
+      module.exports = require('./locales/' + clientLocale + '/translations.json');
+    }
+  `,
+    trending: preval`
+    const envData = require('../../config/env.json');
+    const { clientLocale } = envData;
+    if (clientLocale !== 'english') {
+      module.exports = require('./locales/' + clientLocale + '/trending.json');
+    }
+  `,
+    intro: preval`
+    const envData = require('../../config/env.json');
+    const { clientLocale } = envData;
+    if (clientLocale !== 'english') {
+      module.exports = require('./locales/' + clientLocale + '/intro.json');
+    }
+  `,
+    metaTags: preval`
+    const envData = require('../../config/env.json');
+    const { clientLocale } = envData;
+    if (clientLocale !== 'english') {
+      module.exports = require('./locales/' + clientLocale + '/meta-tags.json');
+    }
+  `,
+    links: preval`
+    const envData = require('../../config/env.json');
+    const { clientLocale } = envData;
+    if (clientLocale !== 'english') {
+      module.exports = require('./locales/' + clientLocale + '/links.json');
+    }
+  `
+  },
+  en: {
+    translations,
+    trending,
+    intro,
+    metaTags,
+    links
+  }
+};
 
 i18n.use(initReactI18next).init({
   fallbackLng: 'en',
@@ -17,54 +72,9 @@ i18n.use(initReactI18next).init({
   // They need to be evaluated ahead of time, to prevent Webpack from bundling
   // the entire locales directory. To avoid double imports when the locale is
   // english, we simply export nothing from the preval
-  resources: {
-    [i18nextCode]: {
-      translations: preval`
-      const envData = require('../../config/env.json');
-      const { clientLocale } = envData;
-      if (clientLocale !== 'english') {
-        module.exports = require('./locales/' + clientLocale + '/translations.json');
-      }
-    `,
-      trending: preval`
-      const envData = require('../../config/env.json');
-      const { clientLocale } = envData;
-      if (clientLocale !== 'english') {
-        module.exports = require('./locales/' + clientLocale + '/trending.json');
-      }
-    `,
-      intro: preval`
-      const envData = require('../../config/env.json');
-      const { clientLocale } = envData;
-      if (clientLocale !== 'english') {
-        module.exports = require('./locales/' + clientLocale + '/intro.json');
-      }
-    `,
-      metaTags: preval`
-      const envData = require('../../config/env.json');
-      const { clientLocale } = envData;
-      if (clientLocale !== 'english') {
-        module.exports = require('./locales/' + clientLocale + '/meta-tags.json');
-      }
-    `,
-      links: preval`
-      const envData = require('../../config/env.json');
-      const { clientLocale } = envData;
-      if (clientLocale !== 'english') {
-        module.exports = require('./locales/' + clientLocale + '/links.json');
-      }
-    `
-    },
-    en: {
-      translations: preval`module.exports = require('./locales/english/translations.json')`,
-      trending: preval`module.exports = require('./locales/english/trending.json')`,
-      intro: preval`module.exports = require('./locales/english/intro.json')`,
-      metaTags: preval`module.exports = require('./locales/english/meta-tags.json')`,
-      links: preval`module.exports = require('./locales/english/links.json')`
-    }
-  },
+  resources,
   ns: ['translations', 'trending', 'intro', 'metaTags', 'links'],
-  defaultNS: 'translations',
+  defaultNS,
   returnObjects: true,
   // Uncomment the next line for debug logging
   // debug: true,

--- a/client/src/@types/i18next.d.ts
+++ b/client/src/@types/i18next.d.ts
@@ -1,0 +1,8 @@
+import { resources, defaultNS } from '../../i18n/config';
+
+declare module 'i18next' {
+  interface CustomTypeOptions {
+    defaultNS: typeof defaultNS;
+    resources: (typeof resources)['en'];
+  }
+}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #49621

<!-- Feel free to add any additional description of changes below this line -->

This PR was opened to get the `t` function fully typed, in order to show the keys of translation files as auto-complete in IDE by type inference feature of typescript.

![image](https://user-images.githubusercontent.com/44451585/226153942-7e20b8e5-9904-42b8-9623-0ca4185f6ba8.png)
