### PR TITLE
feat(tools): make gen component template smarter

### DIFF
--- a/tools/ui-components/utils/gen-component-template.ts
+++ b/tools/ui-components/utils/gen-component-template.ts
@@ -12,7 +12,8 @@ export const ${name} = (props: ${name}Props):JSX.Element => {
 // types.ts
 export const type = (name: string): string => `
 export interface ${name}Props {
-  className?: string
+  className?: string;
+  children?: string;
 }
 `;
 
@@ -20,14 +21,15 @@ export interface ${name}Props {
 export const test = (name: string): string => `
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+// import userEvent from '@testing-library/user-event';
 
 import { ${name} } from '.';
 
 describe('<${name} />', () => {
   it('should render ${name} correctly', () => {
-    render<${name}>Test</${name}>;
+    render(<${name}>Test</${name}>);
     expect(screen.getByText('Test')).toBeInTheDocument();
+  });
 });
 `;
 
@@ -35,7 +37,7 @@ describe('<${name} />', () => {
 export const story = (name: string): string => `
 import React from 'react';
 import { Story } from '@storybook/react';
-import { ${name}, ${name}Props } from '.';
+import type { ${name}, ${name}Props } from '.';
 
 const story = {
   title: 'Example/${name}',

--- a/tools/ui-components/utils/gen-component-template.ts
+++ b/tools/ui-components/utils/gen-component-template.ts
@@ -37,7 +37,7 @@ describe('<${name} />', () => {
 export const story = (name: string): string => `
 import React from 'react';
 import { Story } from '@storybook/react';
-import type { ${name}, ${name}Props } from '.';
+import { ${name}, ${name}Props } from '.';
 
 const story = {
   title: 'Example/${name}',

--- a/tools/ui-components/utils/gen-component-template.ts
+++ b/tools/ui-components/utils/gen-component-template.ts
@@ -4,8 +4,8 @@ import React from 'react';
 
 import { ${name}Props } from './types';
 
-export const ${name} = ({}: ${name}Props) => {
-  return <div>Hello, I am a ${name} component</div>;
+export const ${name} = (props: ${name}Props):JSX.Element => {
+  return <div {...props}>Hello, I am a ${name} component</div>;
 };
 `;
 
@@ -25,7 +25,9 @@ import userEvent from '@testing-library/user-event';
 import { ${name} } from '.';
 
 describe('<${name} />', () => {
-  it('should render correctly', () => {});
+  it('should render ${name} correctly', () => {
+    render<${name}>Test</${name}>;
+    expect(screen.getByText('Test')).toBeInTheDocument();
 });
 `;
 
@@ -37,7 +39,15 @@ import { ${name}, ${name}Props } from '.';
 
 const story = {
   title: 'Example/${name}',
-  component: ${name}
+  component: ${name},
+  parameters: {
+    controls: {
+      include: ['className']
+    }
+  },
+  argType: {
+    className: { control: { type: 'text' } },
+  }
 };
 
 const Template: Story<${name}Props> = args => {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->
One of the worst feeling you get after researching is the block you face when you see error message, after you have run the `pnpm run gen-component` command.

This aims to make the new component generated without errors, and with some extra codes as hints of what to do with the test and storybook, I may update the type to use `ComponentProps` instead of `className`, but this is maybe too much 🤔.
<!-- Feel free to add any additional description of changes below this line -->
