### PR TITLE
fix(client): import Tfunction from i18next in privacy inputs

### DIFF
--- a/client/src/components/settings/privacy.tsx
+++ b/client/src/components/settings/privacy.tsx
@@ -1,6 +1,7 @@
 import { Button, Form } from '@freecodecamp/react-bootstrap';
 import React, { useState } from 'react';
-import { TFunction, withTranslation } from 'react-i18next';
+import { TFunction } from 'i18next';
+import { withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import type { Dispatch } from 'redux';
@@ -54,16 +55,23 @@ function PrivacySettings({
     setMadeChanges(false);
   }
 
+  const ariaLabel = t('settings.headings.privacy');
+  const explainContext = new Map([
+    ['isLocked', t('settings.disabled')],
+    ['showName', t('settings.private-name')],
+    ['showCerts', t('settings.disabled')],
+    ['showTimeLine', t('settings.disabled')]
+  ]);
   return (
     <div className='privacy-settings' id='privacy-settings'>
       <SectionHeader>{t('settings.headings.privacy')}</SectionHeader>
       <FullWidthRow>
         <p>{t('settings.privacy')}</p>
         <Form inline={true} onSubmit={submitNewProfileSettings}>
-          <div role='group' aria-label={t('settings.headings.privacy')}>
+          <div role='group' aria-label={ariaLabel}>
             <ToggleSetting
               action={t('settings.labels.my-profile')}
-              explain={t('settings.disabled')}
+              explain={explainContext.get('isLocked')}
               flag={privacyValues['isLocked']}
               flagName='isLocked'
               offLabel={t('buttons.public')}
@@ -72,7 +80,7 @@ function PrivacySettings({
             />
             <ToggleSetting
               action={t('settings.labels.my-name')}
-              explain={t('settings.private-name')}
+              explain={explainContext.get('showName')}
               flag={!privacyValues['showName']}
               flagName='name'
               offLabel={t('buttons.public')}
@@ -113,7 +121,7 @@ function PrivacySettings({
             />
             <ToggleSetting
               action={t('settings.labels.my-certs')}
-              explain={t('settings.disabled')}
+              explain={explainContext.get('showCerts')}
               flag={!privacyValues['showCerts']}
               flagName='showCerts'
               offLabel={t('buttons.public')}
@@ -130,7 +138,7 @@ function PrivacySettings({
             />
             <ToggleSetting
               action={t('settings.labels.my-timeline')}
-              explain={t('settings.disabled')}
+              explain={explainContext.get('showTimeLine')}
               flag={!privacyValues['showTimeLine']}
               flagName='showTimeLine'
               offLabel={t('buttons.public')}

--- a/client/src/components/settings/privacy.tsx
+++ b/client/src/components/settings/privacy.tsx
@@ -1,7 +1,6 @@
 import { Button, Form } from '@freecodecamp/react-bootstrap';
 import React, { useState } from 'react';
-import { TFunction } from 'i18next';
-import { withTranslation } from 'react-i18next';
+import { useTranslation, withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import type { Dispatch } from 'redux';
@@ -26,18 +25,14 @@ const mapDispatchToProps = (dispatch: Dispatch) =>
 
 type PrivacyProps = {
   submitProfileUI: (profileUI: ProfileUI) => void;
-  t: TFunction;
   user: {
     profileUI: ProfileUI;
     username: string;
   };
 };
 
-function PrivacySettings({
-  submitProfileUI,
-  t,
-  user
-}: PrivacyProps): JSX.Element {
+function PrivacySettings({ submitProfileUI, user }: PrivacyProps): JSX.Element {
+  const { t } = useTranslation();
   const [privacyValues, setPrivacyValues] = useState({ ...user.profileUI });
 
   const [madeChanges, setMadeChanges] = useState(false);
@@ -55,23 +50,16 @@ function PrivacySettings({
     setMadeChanges(false);
   }
 
-  const ariaLabel = t('settings.headings.privacy');
-  const explainContext = new Map([
-    ['isLocked', t('settings.disabled')],
-    ['showName', t('settings.private-name')],
-    ['showCerts', t('settings.disabled')],
-    ['showTimeLine', t('settings.disabled')]
-  ]);
   return (
     <div className='privacy-settings' id='privacy-settings'>
       <SectionHeader>{t('settings.headings.privacy')}</SectionHeader>
       <FullWidthRow>
         <p>{t('settings.privacy')}</p>
         <Form inline={true} onSubmit={submitNewProfileSettings}>
-          <div role='group' aria-label={ariaLabel}>
+          <div role='group' aria-label={t('settings.headings.privacy')}>
             <ToggleSetting
               action={t('settings.labels.my-profile')}
-              explain={explainContext.get('isLocked')}
+              explain={t('settings.disabled')}
               flag={privacyValues['isLocked']}
               flagName='isLocked'
               offLabel={t('buttons.public')}
@@ -80,7 +68,7 @@ function PrivacySettings({
             />
             <ToggleSetting
               action={t('settings.labels.my-name')}
-              explain={explainContext.get('showName')}
+              explain={t('settings.private-name')}
               flag={!privacyValues['showName']}
               flagName='name'
               offLabel={t('buttons.public')}
@@ -121,7 +109,7 @@ function PrivacySettings({
             />
             <ToggleSetting
               action={t('settings.labels.my-certs')}
-              explain={explainContext.get('showCerts')}
+              explain={t('settings.disabled')}
               flag={!privacyValues['showCerts']}
               flagName='showCerts'
               offLabel={t('buttons.public')}
@@ -138,7 +126,7 @@ function PrivacySettings({
             />
             <ToggleSetting
               action={t('settings.labels.my-timeline')}
-              explain={explainContext.get('showTimeLine')}
+              explain={t('settings.disabled')}
               flag={!privacyValues['showTimeLine']}
               flagName='showTimeLine'
               offLabel={t('buttons.public')}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Ref https://github.com/freeCodeCamp/freeCodeCamp/pull/49800

TFunction is local type in react-i18next, so this aims to import it from where it's valid

<!-- Feel free to add any additional description of changes below this line -->
