### PR TITLE
fix(client): align multifileEditor with hotkey types

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -74,7 +74,7 @@ export interface EditorProps {
   canFocus: boolean;
   challengeFiles: ChallengeFiles;
   challengeType: number;
-  containerRef: MutableRefObject<HTMLElement | undefined>;
+  containerRef?: React.RefObject<HTMLElement>;
   description: string;
   dimensions?: Dimensions;
   editorRef: MutableRefObject<editor.IStandaloneCodeEditor | undefined>;
@@ -825,7 +825,7 @@ const Editor = (props: EditorProps): JSX.Element => {
   }
 
   function focusOnHotkeys() {
-    const currContainerRef = props.containerRef.current;
+    const currContainerRef = props.containerRef?.current;
     if (currContainerRef) {
       currContainerRef.focus();
     }

--- a/client/src/templates/Challenges/classic/multifile-editor.tsx
+++ b/client/src/templates/Challenges/classic/multifile-editor.tsx
@@ -42,6 +42,7 @@ type MultifileEditorProps = Pick<
 > & {
   visibleEditors: VisibleEditors;
 };
+
 const mapStateToProps = createSelector(
   visibleEditorsSelector,
   canFocusEditorSelector,

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -211,7 +211,7 @@ function ShowClassic({
   const { t } = useTranslation();
   const [resizing, setResizing] = useState(false);
   const [usingKeyboardInTablist, setUsingKeyboardInTablist] = useState(false);
-  const containerRef = useRef<HTMLElement>();
+  const containerRef = useRef<HTMLElement>(null);
   const editorRef = useRef<editor.IStandaloneCodeEditor>();
   const instructionsPanelRef = useRef<HTMLDivElement>(null);
   const isMobile = useMediaQuery({
@@ -415,12 +415,12 @@ function ShowClassic({
     <Hotkeys
       challengeType={challengeType}
       executeChallenge={executeChallenge}
-      innerRef={containerRef}
+      containerRef={containerRef}
       instructionsPanelRef={instructionsPanelRef}
       nextChallengePath={nextChallengePath}
       prevChallengePath={prevChallengePath}
       usesMultifileEditor={usesMultifileEditor}
-      {...(editorRef && { editorRef: editorRef })}
+      editorRef={editorRef}
     >
       <LearnLayout hasEditableBoundaries={hasEditableBoundaries}>
         <Helmet title={windowTitle} />

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -415,7 +415,7 @@ function ShowClassic({
     <Hotkeys
       challengeType={challengeType}
       executeChallenge={executeChallenge}
-      ref={containerRef}
+      containerRef={containerRef}
       instructionsPanelRef={instructionsPanelRef}
       nextChallengePath={nextChallengePath}
       prevChallengePath={prevChallengePath}

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -415,7 +415,7 @@ function ShowClassic({
     <Hotkeys
       challengeType={challengeType}
       executeChallenge={executeChallenge}
-      containerRef={containerRef}
+      ref={containerRef}
       instructionsPanelRef={instructionsPanelRef}
       nextChallengePath={nextChallengePath}
       prevChallengePath={prevChallengePath}

--- a/client/src/templates/Challenges/codeally/show.tsx
+++ b/client/src/templates/Challenges/codeally/show.tsx
@@ -113,7 +113,7 @@ interface ShowCodeAllyProps {
 
 class ShowCodeAlly extends Component<ShowCodeAllyProps> {
   static displayName: string;
-  private _container: React.RefObject<HTMLElement> | undefined =
+  private container: React.RefObject<HTMLElement> | undefined =
     React.createRef();
 
   componentDidMount(): void {
@@ -134,7 +134,7 @@ class ShowCodeAlly extends Component<ShowCodeAllyProps> {
       helpCategory
     });
     challengeMounted(challengeMeta.id);
-    this._container?.current?.focus();
+    this.container?.current?.focus();
   }
 
   componentWillUnmount() {
@@ -251,7 +251,7 @@ class ShowCodeAlly extends Component<ShowCodeAllyProps> {
       </LearnLayout>
     ) : (
       <Hotkeys
-        containerRef={this._container}
+        containerRef={this.container}
         nextChallengePath={nextChallengePath}
         prevChallengePath={prevChallengePath}
       >

--- a/client/src/templates/Challenges/codeally/show.tsx
+++ b/client/src/templates/Challenges/codeally/show.tsx
@@ -20,7 +20,7 @@ import { challengeTypes } from '../../../../../shared/config/challenge-types';
 import CompletionModal from '../components/completion-modal';
 import GreenPass from '../../../assets/icons/green-pass';
 import HelpModal from '../components/help-modal';
-import Hotkeys, { type HotkeysProps } from '../components/hotkeys';
+import Hotkeys from '../components/hotkeys';
 import { hideCodeAlly, tryToShowCodeAlly } from '../../../redux/actions';
 import {
   completedChallengesSelector,
@@ -113,7 +113,8 @@ interface ShowCodeAllyProps {
 
 class ShowCodeAlly extends Component<ShowCodeAllyProps> {
   static displayName: string;
-  private _container: HotkeysProps['containerRef'] | undefined;
+  private _container: React.RefObject<HTMLElement> | undefined =
+    React.createRef();
 
   componentDidMount(): void {
     const {
@@ -133,7 +134,6 @@ class ShowCodeAlly extends Component<ShowCodeAllyProps> {
       helpCategory
     });
     challengeMounted(challengeMeta.id);
-    this._container = React.createRef();
     this._container?.current?.focus();
   }
 
@@ -251,7 +251,7 @@ class ShowCodeAlly extends Component<ShowCodeAllyProps> {
       </LearnLayout>
     ) : (
       <Hotkeys
-        containerRef={this._container}
+        ref={this._container}
         nextChallengePath={nextChallengePath}
         prevChallengePath={prevChallengePath}
       >

--- a/client/src/templates/Challenges/codeally/show.tsx
+++ b/client/src/templates/Challenges/codeally/show.tsx
@@ -1,7 +1,7 @@
 // Package Utilities
 import { Alert, Col, Row, Button } from '@freecodecamp/react-bootstrap';
 import { graphql } from 'gatsby';
-import React, { Component, RefObject } from 'react';
+import React, { Component } from 'react';
 import Helmet from 'react-helmet';
 import type { TFunction } from 'i18next';
 import { Trans, withTranslation } from 'react-i18next';
@@ -20,7 +20,7 @@ import { challengeTypes } from '../../../../../shared/config/challenge-types';
 import CompletionModal from '../components/completion-modal';
 import GreenPass from '../../../assets/icons/green-pass';
 import HelpModal from '../components/help-modal';
-import Hotkeys from '../components/hotkeys';
+import Hotkeys, { type HotkeysProps } from '../components/hotkeys';
 import { hideCodeAlly, tryToShowCodeAlly } from '../../../redux/actions';
 import {
   completedChallengesSelector,
@@ -113,7 +113,7 @@ interface ShowCodeAllyProps {
 
 class ShowCodeAlly extends Component<ShowCodeAllyProps> {
   static displayName: string;
-  private _container: RefObject<HTMLElement> | undefined;
+  private _container: HotkeysProps['containerRef'] | undefined;
 
   componentDidMount(): void {
     const {
@@ -133,7 +133,7 @@ class ShowCodeAlly extends Component<ShowCodeAllyProps> {
       helpCategory
     });
     challengeMounted(challengeMeta.id);
-
+    this._container = React.createRef();
     this._container?.current?.focus();
   }
 
@@ -237,7 +237,6 @@ class ShowCodeAlly extends Component<ShowCodeAllyProps> {
       challenge => challenge.id === challengeId
     );
     const titleContext = t('learn.github-link');
-
     return showCodeAlly ? (
       <LearnLayout>
         <Helmet title={windowTitle} />
@@ -252,7 +251,7 @@ class ShowCodeAlly extends Component<ShowCodeAllyProps> {
       </LearnLayout>
     ) : (
       <Hotkeys
-        innerRef={this._container}
+        containerRef={this._container}
         nextChallengePath={nextChallengePath}
         prevChallengePath={prevChallengePath}
       >

--- a/client/src/templates/Challenges/codeally/show.tsx
+++ b/client/src/templates/Challenges/codeally/show.tsx
@@ -113,8 +113,7 @@ interface ShowCodeAllyProps {
 
 class ShowCodeAlly extends Component<ShowCodeAllyProps> {
   static displayName: string;
-  private container: React.RefObject<HTMLElement> | undefined =
-    React.createRef();
+  private container: React.RefObject<HTMLElement> = React.createRef();
 
   componentDidMount(): void {
     const {
@@ -134,7 +133,7 @@ class ShowCodeAlly extends Component<ShowCodeAllyProps> {
       helpCategory
     });
     challengeMounted(challengeMeta.id);
-    this.container?.current?.focus();
+    this.container.current?.focus();
   }
 
   componentWillUnmount() {

--- a/client/src/templates/Challenges/codeally/show.tsx
+++ b/client/src/templates/Challenges/codeally/show.tsx
@@ -251,7 +251,7 @@ class ShowCodeAlly extends Component<ShowCodeAllyProps> {
       </LearnLayout>
     ) : (
       <Hotkeys
-        ref={this._container}
+        containerRef={this._container}
         nextChallengePath={nextChallengePath}
         prevChallengePath={prevChallengePath}
       >

--- a/client/src/templates/Challenges/components/hotkeys.tsx
+++ b/client/src/templates/Challenges/components/hotkeys.tsx
@@ -73,11 +73,7 @@ export type HotkeysProps = Pick<
   > &
   Pick<
     EditorProps,
-    | 'containerRef'
-    | 'tests'
-    | 'challengeFiles'
-    | 'submitChallenge'
-    | 'setEditorFocusability'
+    'tests' | 'challengeFiles' | 'submitChallenge' | 'setEditorFocusability'
   > & {
     canFocusEditor: boolean;
     children: React.ReactElement;
@@ -88,112 +84,121 @@ export type HotkeysProps = Pick<
     user: User;
   };
 
-function Hotkeys({
-  canFocusEditor,
-  challengeType,
-  children,
-  instructionsPanelRef,
-  editorRef,
-  executeChallenge,
-  containerRef,
-  nextChallengePath,
-  prevChallengePath,
-  setEditorFocusability,
-  setIsAdvancing,
-  submitChallenge,
-  tests,
-  usesMultifileEditor,
-  openShortcutsModal,
-  user: { keyboardShortcuts }
-}: HotkeysProps): JSX.Element {
-  const handlers = {
-    executeChallenge: (keyEvent?: KeyboardEvent) => {
-      // the 'enter' part of 'ctrl+enter' stops HotKeys from listening, so it
-      // needs to be prevented.
-      // TODO: 'enter' on its own also disables HotKeys, but default behaviour
-      // should not be prevented in that case.
-      keyEvent?.preventDefault();
-
-      if (!executeChallenge) return;
-
-      const testsArePassing = tests.every(test => test.pass && !test.err);
-
-      if (
-        usesMultifileEditor &&
-        typeof challengeType == 'number' &&
-        !isFinalProject(challengeType)
-      ) {
-        if (testsArePassing) {
-          submitChallenge();
-        } else {
-          executeChallenge();
-        }
-      } else {
-        executeChallenge({ showCompletionModal: true });
-      }
+const Hotkeys = React.forwardRef<HTMLElement, HotkeysProps>(
+  (
+    {
+      canFocusEditor,
+      challengeType,
+      children,
+      instructionsPanelRef,
+      editorRef,
+      executeChallenge,
+      nextChallengePath,
+      prevChallengePath,
+      setEditorFocusability,
+      setIsAdvancing,
+      submitChallenge,
+      tests,
+      usesMultifileEditor,
+      openShortcutsModal,
+      user: { keyboardShortcuts }
     },
-    ...(keyboardShortcuts
-      ? {
-          focusEditor: (keyEvent?: KeyboardEvent) => {
-            keyEvent?.preventDefault();
-            if (editorRef && editorRef.current) {
-              editorRef.current.focus();
-            }
-          },
-          focusInstructionsPanel: () => {
-            if (instructionsPanelRef && instructionsPanelRef.current) {
-              instructionsPanelRef.current.focus();
-            }
-          },
-          navigationMode: () => setEditorFocusability(false),
-          navigatePrev: () => {
-            if (!canFocusEditor) {
-              if (prevChallengePath) {
-                setIsAdvancing(true);
-                void navigate(prevChallengePath);
-              } else {
-                void navigate('/learn');
+    ref
+  ) => {
+    const handlers = {
+      executeChallenge: (keyEvent?: KeyboardEvent) => {
+        // the 'enter' part of 'ctrl+enter' stops HotKeys from listening, so it
+        // needs to be prevented.
+        // TODO: 'enter' on its own also disables HotKeys, but default behaviour
+        // should not be prevented in that case.
+        keyEvent?.preventDefault();
+
+        if (!executeChallenge) return;
+
+        const testsArePassing = tests.every(test => test.pass && !test.err);
+
+        if (
+          usesMultifileEditor &&
+          typeof challengeType == 'number' &&
+          !isFinalProject(challengeType)
+        ) {
+          if (testsArePassing) {
+            submitChallenge();
+          } else {
+            executeChallenge();
+          }
+        } else {
+          executeChallenge({ showCompletionModal: true });
+        }
+      },
+      ...(keyboardShortcuts
+        ? {
+            focusEditor: (keyEvent?: KeyboardEvent) => {
+              keyEvent?.preventDefault();
+              if (editorRef && editorRef.current) {
+                editorRef.current.focus();
               }
-            }
-          },
-          navigateNext: () => {
-            if (!canFocusEditor) {
-              if (nextChallengePath) {
-                setIsAdvancing(true);
-                void navigate(nextChallengePath);
-              } else {
-                void navigate('/learn');
+            },
+            focusInstructionsPanel: () => {
+              if (instructionsPanelRef && instructionsPanelRef.current) {
+                instructionsPanelRef.current.focus();
               }
-            }
-          },
-          showShortcuts: (keyEvent?: KeyboardEvent) => {
-            if (!canFocusEditor && keyEvent?.shiftKey && keyEvent.key === '?') {
-              openShortcutsModal();
+            },
+            navigationMode: () => setEditorFocusability(false),
+            navigatePrev: () => {
+              if (!canFocusEditor) {
+                if (prevChallengePath) {
+                  setIsAdvancing(true);
+                  void navigate(prevChallengePath);
+                } else {
+                  void navigate('/learn');
+                }
+              }
+            },
+            navigateNext: () => {
+              if (!canFocusEditor) {
+                if (nextChallengePath) {
+                  setIsAdvancing(true);
+                  void navigate(nextChallengePath);
+                } else {
+                  void navigate('/learn');
+                }
+              }
+            },
+            showShortcuts: (keyEvent?: KeyboardEvent) => {
+              if (
+                !canFocusEditor &&
+                keyEvent?.shiftKey &&
+                keyEvent.key === '?'
+              ) {
+                openShortcutsModal();
+              }
             }
           }
-        }
-      : {})
-  };
-  // GlobalHotKeys is always mounted and tracks all keypresses. Without it,
-  // keyup events can be missed and react-hotkeys assumes that that key is still
-  // being pressed.
-  // allowChanges is necessary if the handlers depend on props (in this case
-  // canFocusEditor)
-  return (
-    <>
-      <HotKeys
-        id='editor-layout'
-        allowChanges={true}
-        handlers={handlers}
-        innerRef={containerRef}
-        keyMap={keyMap}
-      >
-        {children}
-        <GlobalHotKeys />
-      </HotKeys>
-    </>
-  );
-}
+        : {})
+    };
+    // GlobalHotKeys is always mounted and tracks all keypresses. Without it,
+    // keyup events can be missed and react-hotkeys assumes that that key is still
+    // being pressed.
+    // allowChanges is necessary if the handlers depend on props (in this case
+    // canFocusEditor)
+    return (
+      <>
+        <HotKeys
+          id='editor-layout'
+          allowChanges={true}
+          handlers={handlers}
+          // assert type because react-hotkeys doesn't expect forward the ref like
+          innerRef={ref as React.RefObject<HTMLElement>}
+          keyMap={keyMap}
+        >
+          {children}
+          <GlobalHotKeys />
+        </HotKeys>
+      </>
+    );
+  }
+);
 
 Hotkeys.displayName = 'Hotkeys';
 

--- a/client/src/templates/Challenges/exam/show.tsx
+++ b/client/src/templates/Challenges/exam/show.tsx
@@ -514,7 +514,7 @@ class ShowExam extends Component<ShowExamProps, ShowExamState> {
       </Container>
     ) : (
       <Hotkeys
-        containerRef={this._container}
+        ref={this._container}
         nextChallengePath={nextChallengePath}
         prevChallengePath={prevChallengePath}
       >

--- a/client/src/templates/Challenges/exam/show.tsx
+++ b/client/src/templates/Challenges/exam/show.tsx
@@ -138,7 +138,7 @@ function convertMd(md: string): string {
 
 class ShowExam extends Component<ShowExamProps, ShowExamState> {
   static displayName: string;
-  private container: RefObject<HTMLElement> | undefined;
+  private container: RefObject<HTMLElement> | undefined = React.createRef();
   timerInterval!: NodeJS.Timeout;
 
   constructor(props: ShowExamProps) {
@@ -179,7 +179,6 @@ class ShowExam extends Component<ShowExamProps, ShowExamState> {
     });
     challengeMounted(challengeMeta.id);
 
-    this.container = React.createRef();
     this.container?.current?.focus();
   }
 

--- a/client/src/templates/Challenges/exam/show.tsx
+++ b/client/src/templates/Challenges/exam/show.tsx
@@ -514,7 +514,7 @@ class ShowExam extends Component<ShowExamProps, ShowExamState> {
       </Container>
     ) : (
       <Hotkeys
-        ref={this._container}
+        containerRef={this._container}
         nextChallengePath={nextChallengePath}
         prevChallengePath={prevChallengePath}
       >

--- a/client/src/templates/Challenges/exam/show.tsx
+++ b/client/src/templates/Challenges/exam/show.tsx
@@ -179,6 +179,7 @@ class ShowExam extends Component<ShowExamProps, ShowExamState> {
     });
     challengeMounted(challengeMeta.id);
 
+    this._container = React.createRef();
     this._container?.current?.focus();
   }
 
@@ -513,7 +514,7 @@ class ShowExam extends Component<ShowExamProps, ShowExamState> {
       </Container>
     ) : (
       <Hotkeys
-        innerRef={this._container}
+        containerRef={this._container}
         nextChallengePath={nextChallengePath}
         prevChallengePath={prevChallengePath}
       >

--- a/client/src/templates/Challenges/exam/show.tsx
+++ b/client/src/templates/Challenges/exam/show.tsx
@@ -138,7 +138,7 @@ function convertMd(md: string): string {
 
 class ShowExam extends Component<ShowExamProps, ShowExamState> {
   static displayName: string;
-  private _container: RefObject<HTMLElement> | undefined;
+  private container: RefObject<HTMLElement> | undefined;
   timerInterval!: NodeJS.Timeout;
 
   constructor(props: ShowExamProps) {
@@ -179,8 +179,8 @@ class ShowExam extends Component<ShowExamProps, ShowExamState> {
     });
     challengeMounted(challengeMeta.id);
 
-    this._container = React.createRef();
-    this._container?.current?.focus();
+    this.container = React.createRef();
+    this.container?.current?.focus();
   }
 
   componentWillUnmount() {
@@ -514,7 +514,7 @@ class ShowExam extends Component<ShowExamProps, ShowExamState> {
       </Container>
     ) : (
       <Hotkeys
-        containerRef={this._container}
+        containerRef={this.container}
         nextChallengePath={nextChallengePath}
         prevChallengePath={prevChallengePath}
       >

--- a/client/src/templates/Challenges/ms-trophy/show.tsx
+++ b/client/src/templates/Challenges/ms-trophy/show.tsx
@@ -84,7 +84,7 @@ interface MsTrophyProps {
 // Component
 class MsTrophy extends Component<MsTrophyProps> {
   static displayName: string;
-  private _container: HTMLElement | null = null;
+  private _container: React.RefObject<HTMLElement> | undefined;
 
   constructor(props: MsTrophyProps) {
     super(props);
@@ -108,7 +108,8 @@ class MsTrophy extends Component<MsTrophyProps> {
       helpCategory
     });
     challengeMounted(challengeMeta.id);
-    this._container?.focus();
+    this._container = React.createRef();
+    this._container?.current?.focus();
   }
 
   componentDidUpdate(prevProps: MsTrophyProps): void {
@@ -178,7 +179,7 @@ class MsTrophy extends Component<MsTrophyProps> {
 
     return (
       <Hotkeys
-        innerRef={(c: HTMLElement | null) => (this._container = c)}
+        ref={this._container}
         nextChallengePath={nextChallengePath}
         prevChallengePath={prevChallengePath}
       >

--- a/client/src/templates/Challenges/ms-trophy/show.tsx
+++ b/client/src/templates/Challenges/ms-trophy/show.tsx
@@ -179,7 +179,7 @@ class MsTrophy extends Component<MsTrophyProps> {
 
     return (
       <Hotkeys
-        ref={this._container}
+        containerRef={this._container}
         nextChallengePath={nextChallengePath}
         prevChallengePath={prevChallengePath}
       >

--- a/client/src/templates/Challenges/ms-trophy/show.tsx
+++ b/client/src/templates/Challenges/ms-trophy/show.tsx
@@ -84,7 +84,7 @@ interface MsTrophyProps {
 // Component
 class MsTrophy extends Component<MsTrophyProps> {
   static displayName: string;
-  private _container: React.RefObject<HTMLElement> | undefined;
+  private container: React.RefObject<HTMLElement> | undefined;
 
   constructor(props: MsTrophyProps) {
     super(props);
@@ -108,8 +108,8 @@ class MsTrophy extends Component<MsTrophyProps> {
       helpCategory
     });
     challengeMounted(challengeMeta.id);
-    this._container = React.createRef();
-    this._container?.current?.focus();
+    this.container = React.createRef();
+    this.container?.current?.focus();
   }
 
   componentDidUpdate(prevProps: MsTrophyProps): void {
@@ -179,7 +179,7 @@ class MsTrophy extends Component<MsTrophyProps> {
 
     return (
       <Hotkeys
-        containerRef={this._container}
+        containerRef={this.container}
         nextChallengePath={nextChallengePath}
         prevChallengePath={prevChallengePath}
       >

--- a/client/src/templates/Challenges/ms-trophy/show.tsx
+++ b/client/src/templates/Challenges/ms-trophy/show.tsx
@@ -84,7 +84,8 @@ interface MsTrophyProps {
 // Component
 class MsTrophy extends Component<MsTrophyProps> {
   static displayName: string;
-  private container: React.RefObject<HTMLElement> | undefined;
+  private container: React.RefObject<HTMLElement> | undefined =
+    React.createRef();
 
   constructor(props: MsTrophyProps) {
     super(props);
@@ -108,7 +109,6 @@ class MsTrophy extends Component<MsTrophyProps> {
       helpCategory
     });
     challengeMounted(challengeMeta.id);
-    this.container = React.createRef();
     this.container?.current?.focus();
   }
 

--- a/client/src/templates/Challenges/ms-trophy/show.tsx
+++ b/client/src/templates/Challenges/ms-trophy/show.tsx
@@ -84,8 +84,7 @@ interface MsTrophyProps {
 // Component
 class MsTrophy extends Component<MsTrophyProps> {
   static displayName: string;
-  private container: React.RefObject<HTMLElement> | undefined =
-    React.createRef();
+  private container: React.RefObject<HTMLElement> = React.createRef();
 
   constructor(props: MsTrophyProps) {
     super(props);
@@ -109,7 +108,7 @@ class MsTrophy extends Component<MsTrophyProps> {
       helpCategory
     });
     challengeMounted(challengeMeta.id);
-    this.container?.current?.focus();
+    this.container.current?.focus();
   }
 
   componentDidUpdate(prevProps: MsTrophyProps): void {

--- a/client/src/templates/Challenges/odin/show.tsx
+++ b/client/src/templates/Challenges/odin/show.tsx
@@ -17,7 +17,7 @@ import Loader from '../../../components/helpers/loader';
 import Spacer from '../../../components/helpers/spacer';
 import LearnLayout from '../../../components/layouts/learn';
 import { ChallengeNode, ChallengeMeta } from '../../../redux/prop-types';
-import Hotkeys, { type HotkeysProps } from '../components/hotkeys';
+import Hotkeys from '../components/hotkeys';
 import VideoPlayer from '../components/video-player';
 import CompletionModal from '../components/completion-modal';
 import HelpModal from '../components/help-modal';
@@ -83,7 +83,7 @@ interface ShowOdinState {
 // Component
 class ShowOdin extends Component<ShowOdinProps, ShowOdinState> {
   static displayName: string;
-  private _container: HotkeysProps['containerRef'] | undefined;
+  private _container: React.RefObject<HTMLElement> | undefined;
 
   constructor(props: ShowOdinProps) {
     super(props);
@@ -237,7 +237,7 @@ class ShowOdin extends Component<ShowOdinProps, ShowOdinState> {
         executeChallenge={() => {
           this.handleSubmit(solution, openCompletionModal, assignments);
         }}
-        containerRef={this._container}
+        ref={this._container}
         nextChallengePath={nextChallengePath}
         prevChallengePath={prevChallengePath}
       >

--- a/client/src/templates/Challenges/odin/show.tsx
+++ b/client/src/templates/Challenges/odin/show.tsx
@@ -237,7 +237,7 @@ class ShowOdin extends Component<ShowOdinProps, ShowOdinState> {
         executeChallenge={() => {
           this.handleSubmit(solution, openCompletionModal, assignments);
         }}
-        ref={this._container}
+        containerRef={this._container}
         nextChallengePath={nextChallengePath}
         prevChallengePath={prevChallengePath}
       >

--- a/client/src/templates/Challenges/odin/show.tsx
+++ b/client/src/templates/Challenges/odin/show.tsx
@@ -83,8 +83,7 @@ interface ShowOdinState {
 // Component
 class ShowOdin extends Component<ShowOdinProps, ShowOdinState> {
   static displayName: string;
-  private container: React.RefObject<HTMLElement> | undefined =
-    React.createRef();
+  private container: React.RefObject<HTMLElement> = React.createRef();
 
   constructor(props: ShowOdinProps) {
     super(props);
@@ -120,7 +119,7 @@ class ShowOdin extends Component<ShowOdinProps, ShowOdinState> {
       helpCategory
     });
     challengeMounted(challengeMeta.id);
-    this.container?.current?.focus();
+    this.container.current?.focus();
   }
 
   componentDidUpdate(prevProps: ShowOdinProps): void {

--- a/client/src/templates/Challenges/odin/show.tsx
+++ b/client/src/templates/Challenges/odin/show.tsx
@@ -17,7 +17,7 @@ import Loader from '../../../components/helpers/loader';
 import Spacer from '../../../components/helpers/spacer';
 import LearnLayout from '../../../components/layouts/learn';
 import { ChallengeNode, ChallengeMeta } from '../../../redux/prop-types';
-import Hotkeys from '../components/hotkeys';
+import Hotkeys, { type HotkeysProps } from '../components/hotkeys';
 import VideoPlayer from '../components/video-player';
 import CompletionModal from '../components/completion-modal';
 import HelpModal from '../components/help-modal';
@@ -83,7 +83,7 @@ interface ShowOdinState {
 // Component
 class ShowOdin extends Component<ShowOdinProps, ShowOdinState> {
   static displayName: string;
-  private _container: HTMLElement | null | undefined;
+  private _container: HotkeysProps['containerRef'] | undefined;
 
   constructor(props: ShowOdinProps) {
     super(props);
@@ -119,7 +119,8 @@ class ShowOdin extends Component<ShowOdinProps, ShowOdinState> {
       helpCategory
     });
     challengeMounted(challengeMeta.id);
-    this._container?.focus();
+    this._container = React.createRef();
+    this._container?.current?.focus();
   }
 
   componentDidUpdate(prevProps: ShowOdinProps): void {
@@ -236,7 +237,7 @@ class ShowOdin extends Component<ShowOdinProps, ShowOdinState> {
         executeChallenge={() => {
           this.handleSubmit(solution, openCompletionModal, assignments);
         }}
-        innerRef={(c: HTMLElement | null) => (this._container = c)}
+        containerRef={this._container}
         nextChallengePath={nextChallengePath}
         prevChallengePath={prevChallengePath}
       >

--- a/client/src/templates/Challenges/odin/show.tsx
+++ b/client/src/templates/Challenges/odin/show.tsx
@@ -83,7 +83,8 @@ interface ShowOdinState {
 // Component
 class ShowOdin extends Component<ShowOdinProps, ShowOdinState> {
   static displayName: string;
-  private container: React.RefObject<HTMLElement> | undefined;
+  private container: React.RefObject<HTMLElement> | undefined =
+    React.createRef();
 
   constructor(props: ShowOdinProps) {
     super(props);
@@ -119,7 +120,6 @@ class ShowOdin extends Component<ShowOdinProps, ShowOdinState> {
       helpCategory
     });
     challengeMounted(challengeMeta.id);
-    this.container = React.createRef();
     this.container?.current?.focus();
   }
 

--- a/client/src/templates/Challenges/odin/show.tsx
+++ b/client/src/templates/Challenges/odin/show.tsx
@@ -83,7 +83,7 @@ interface ShowOdinState {
 // Component
 class ShowOdin extends Component<ShowOdinProps, ShowOdinState> {
   static displayName: string;
-  private _container: React.RefObject<HTMLElement> | undefined;
+  private container: React.RefObject<HTMLElement> | undefined;
 
   constructor(props: ShowOdinProps) {
     super(props);
@@ -119,8 +119,8 @@ class ShowOdin extends Component<ShowOdinProps, ShowOdinState> {
       helpCategory
     });
     challengeMounted(challengeMeta.id);
-    this._container = React.createRef();
-    this._container?.current?.focus();
+    this.container = React.createRef();
+    this.container?.current?.focus();
   }
 
   componentDidUpdate(prevProps: ShowOdinProps): void {
@@ -237,7 +237,7 @@ class ShowOdin extends Component<ShowOdinProps, ShowOdinState> {
         executeChallenge={() => {
           this.handleSubmit(solution, openCompletionModal, assignments);
         }}
-        containerRef={this._container}
+        containerRef={this.container}
         nextChallengePath={nextChallengePath}
         prevChallengePath={prevChallengePath}
       >

--- a/client/src/templates/Challenges/projects/backend/show.tsx
+++ b/client/src/templates/Challenges/projects/backend/show.tsx
@@ -100,7 +100,8 @@ interface BackEndProps {
 // Component
 class BackEnd extends Component<BackEndProps> {
   static displayName: string;
-  private container: React.RefObject<HTMLElement> | undefined;
+  private container: React.RefObject<HTMLElement> | undefined =
+    React.createRef();
 
   constructor(props: BackEndProps) {
     super(props);
@@ -112,7 +113,6 @@ class BackEnd extends Component<BackEndProps> {
   componentDidMount() {
     this.initializeComponent();
     window.addEventListener('resize', () => this.updateDimensions());
-    this.container = React.createRef();
     this.container?.current?.focus();
   }
 

--- a/client/src/templates/Challenges/projects/backend/show.tsx
+++ b/client/src/templates/Challenges/projects/backend/show.tsx
@@ -21,7 +21,7 @@ import {
   Test
 } from '../../../../redux/prop-types';
 import ChallengeDescription from '../../components/challenge-description';
-import Hotkeys from '../../components/hotkeys';
+import Hotkeys, { type HotkeysProps } from '../../components/hotkeys';
 import ChallengeTitle from '../../components/challenge-title';
 import CompletionModal from '../../components/completion-modal';
 import HelpModal from '../../components/help-modal';
@@ -100,8 +100,7 @@ interface BackEndProps {
 // Component
 class BackEnd extends Component<BackEndProps> {
   static displayName: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private _container: any;
+  private _container: HotkeysProps['containerRef'] | undefined;
   constructor(props: BackEndProps) {
     super(props);
     this.state = {};
@@ -112,7 +111,8 @@ class BackEnd extends Component<BackEndProps> {
   componentDidMount() {
     this.initializeComponent();
     window.addEventListener('resize', () => this.updateDimensions());
-    this._container.focus();
+    this._container = React.createRef();
+    this._container?.current?.focus();
   }
 
   updateDimensions() {
@@ -221,7 +221,7 @@ class BackEnd extends Component<BackEndProps> {
 
     return (
       <Hotkeys
-        innerRef={(c: HTMLElement | null) => (this._container = c)}
+        containerRef={this._container}
         nextChallengePath={nextChallengePath}
         prevChallengePath={prevChallengePath}
       >

--- a/client/src/templates/Challenges/projects/backend/show.tsx
+++ b/client/src/templates/Challenges/projects/backend/show.tsx
@@ -222,7 +222,7 @@ class BackEnd extends Component<BackEndProps> {
 
     return (
       <Hotkeys
-        ref={this.container}
+        containerRef={this.container}
         nextChallengePath={nextChallengePath}
         prevChallengePath={prevChallengePath}
       >

--- a/client/src/templates/Challenges/projects/backend/show.tsx
+++ b/client/src/templates/Challenges/projects/backend/show.tsx
@@ -21,7 +21,7 @@ import {
   Test
 } from '../../../../redux/prop-types';
 import ChallengeDescription from '../../components/challenge-description';
-import Hotkeys, { type HotkeysProps } from '../../components/hotkeys';
+import Hotkeys from '../../components/hotkeys';
 import ChallengeTitle from '../../components/challenge-title';
 import CompletionModal from '../../components/completion-modal';
 import HelpModal from '../../components/help-modal';
@@ -100,7 +100,8 @@ interface BackEndProps {
 // Component
 class BackEnd extends Component<BackEndProps> {
   static displayName: string;
-  private _container: HotkeysProps['containerRef'] | undefined;
+  private container: React.RefObject<HTMLElement> | undefined;
+
   constructor(props: BackEndProps) {
     super(props);
     this.state = {};
@@ -111,8 +112,8 @@ class BackEnd extends Component<BackEndProps> {
   componentDidMount() {
     this.initializeComponent();
     window.addEventListener('resize', () => this.updateDimensions());
-    this._container = React.createRef();
-    this._container?.current?.focus();
+    this.container = React.createRef();
+    this.container?.current?.focus();
   }
 
   updateDimensions() {
@@ -221,7 +222,7 @@ class BackEnd extends Component<BackEndProps> {
 
     return (
       <Hotkeys
-        containerRef={this._container}
+        ref={this.container}
         nextChallengePath={nextChallengePath}
         prevChallengePath={prevChallengePath}
       >

--- a/client/src/templates/Challenges/projects/backend/show.tsx
+++ b/client/src/templates/Challenges/projects/backend/show.tsx
@@ -100,8 +100,7 @@ interface BackEndProps {
 // Component
 class BackEnd extends Component<BackEndProps> {
   static displayName: string;
-  private container: React.RefObject<HTMLElement> | undefined =
-    React.createRef();
+  private container: React.RefObject<HTMLElement> = React.createRef();
 
   constructor(props: BackEndProps) {
     super(props);
@@ -113,7 +112,7 @@ class BackEnd extends Component<BackEndProps> {
   componentDidMount() {
     this.initializeComponent();
     window.addEventListener('resize', () => this.updateDimensions());
-    this.container?.current?.focus();
+    this.container.current?.focus();
   }
 
   updateDimensions() {

--- a/client/src/templates/Challenges/projects/frontend/show.tsx
+++ b/client/src/templates/Challenges/projects/frontend/show.tsx
@@ -14,7 +14,7 @@ import Spacer from '../../../../components/helpers/spacer';
 import LearnLayout from '../../../../components/layouts/learn';
 import { ChallengeNode, ChallengeMeta } from '../../../../redux/prop-types';
 import ChallengeDescription from '../../components/challenge-description';
-import Hotkeys, { type HotkeysProps } from '../../components/hotkeys';
+import Hotkeys from '../../components/hotkeys';
 import ChallengeTitle from '../../components/challenge-title';
 import CompletionModal from '../../components/completion-modal';
 import HelpModal from '../../components/help-modal';
@@ -65,7 +65,7 @@ interface ProjectProps {
 // Component
 class Project extends Component<ProjectProps> {
   static displayName: string;
-  private _container: HotkeysProps['containerRef'] | undefined;
+  private container: React.RefObject<HTMLElement> | undefined;
 
   constructor(props: ProjectProps) {
     super(props);
@@ -89,8 +89,8 @@ class Project extends Component<ProjectProps> {
       helpCategory
     });
     challengeMounted(challengeMeta.id);
-    this._container = React.createRef();
-    this._container?.current?.focus();
+    this.container = React.createRef();
+    this.container?.current?.focus();
   }
 
   componentDidUpdate(prevProps: ProjectProps): void {
@@ -163,7 +163,7 @@ class Project extends Component<ProjectProps> {
 
     return (
       <Hotkeys
-        containerRef={this._container}
+        ref={this.container}
         nextChallengePath={nextChallengePath}
         prevChallengePath={prevChallengePath}
       >

--- a/client/src/templates/Challenges/projects/frontend/show.tsx
+++ b/client/src/templates/Challenges/projects/frontend/show.tsx
@@ -65,7 +65,8 @@ interface ProjectProps {
 // Component
 class Project extends Component<ProjectProps> {
   static displayName: string;
-  private container: React.RefObject<HTMLElement> | undefined;
+  private container: React.RefObject<HTMLElement> | undefined =
+    React.createRef();
 
   constructor(props: ProjectProps) {
     super(props);
@@ -89,7 +90,6 @@ class Project extends Component<ProjectProps> {
       helpCategory
     });
     challengeMounted(challengeMeta.id);
-    this.container = React.createRef();
     this.container?.current?.focus();
   }
 

--- a/client/src/templates/Challenges/projects/frontend/show.tsx
+++ b/client/src/templates/Challenges/projects/frontend/show.tsx
@@ -163,7 +163,7 @@ class Project extends Component<ProjectProps> {
 
     return (
       <Hotkeys
-        ref={this.container}
+        containerRef={this.container}
         nextChallengePath={nextChallengePath}
         prevChallengePath={prevChallengePath}
       >

--- a/client/src/templates/Challenges/projects/frontend/show.tsx
+++ b/client/src/templates/Challenges/projects/frontend/show.tsx
@@ -65,8 +65,7 @@ interface ProjectProps {
 // Component
 class Project extends Component<ProjectProps> {
   static displayName: string;
-  private container: React.RefObject<HTMLElement> | undefined =
-    React.createRef();
+  private container: React.RefObject<HTMLElement> = React.createRef();
 
   constructor(props: ProjectProps) {
     super(props);
@@ -90,7 +89,7 @@ class Project extends Component<ProjectProps> {
       helpCategory
     });
     challengeMounted(challengeMeta.id);
-    this.container?.current?.focus();
+    this.container.current?.focus();
   }
 
   componentDidUpdate(prevProps: ProjectProps): void {

--- a/client/src/templates/Challenges/projects/frontend/show.tsx
+++ b/client/src/templates/Challenges/projects/frontend/show.tsx
@@ -14,7 +14,7 @@ import Spacer from '../../../../components/helpers/spacer';
 import LearnLayout from '../../../../components/layouts/learn';
 import { ChallengeNode, ChallengeMeta } from '../../../../redux/prop-types';
 import ChallengeDescription from '../../components/challenge-description';
-import Hotkeys from '../../components/hotkeys';
+import Hotkeys, { type HotkeysProps } from '../../components/hotkeys';
 import ChallengeTitle from '../../components/challenge-title';
 import CompletionModal from '../../components/completion-modal';
 import HelpModal from '../../components/help-modal';
@@ -65,7 +65,7 @@ interface ProjectProps {
 // Component
 class Project extends Component<ProjectProps> {
   static displayName: string;
-  private _container: HTMLElement | null = null;
+  private _container: HotkeysProps['containerRef'] | undefined;
 
   constructor(props: ProjectProps) {
     super(props);
@@ -89,7 +89,8 @@ class Project extends Component<ProjectProps> {
       helpCategory
     });
     challengeMounted(challengeMeta.id);
-    this._container?.focus();
+    this._container = React.createRef();
+    this._container?.current?.focus();
   }
 
   componentDidUpdate(prevProps: ProjectProps): void {
@@ -162,7 +163,7 @@ class Project extends Component<ProjectProps> {
 
     return (
       <Hotkeys
-        innerRef={(c: HTMLElement | null) => (this._container = c)}
+        containerRef={this._container}
         nextChallengePath={nextChallengePath}
         prevChallengePath={prevChallengePath}
       >

--- a/client/src/templates/Challenges/video/show.tsx
+++ b/client/src/templates/Challenges/video/show.tsx
@@ -83,8 +83,7 @@ interface ShowVideoState {
 // Component
 class ShowVideo extends Component<ShowVideoProps, ShowVideoState> {
   static displayName: string;
-  private container: React.RefObject<HTMLElement> | undefined =
-    React.createRef();
+  private container: React.RefObject<HTMLElement> = React.createRef();
 
   constructor(props: ShowVideoProps) {
     super(props);
@@ -118,7 +117,7 @@ class ShowVideo extends Component<ShowVideoProps, ShowVideoState> {
       helpCategory
     });
     challengeMounted(challengeMeta.id);
-    this.container?.current?.focus();
+    this.container.current?.focus();
   }
 
   componentDidUpdate(prevProps: ShowVideoProps): void {

--- a/client/src/templates/Challenges/video/show.tsx
+++ b/client/src/templates/Challenges/video/show.tsx
@@ -214,7 +214,7 @@ class ShowVideo extends Component<ShowVideoProps, ShowVideoState> {
         executeChallenge={() => {
           this.handleSubmit(solution, openCompletionModal);
         }}
-        ref={this.container}
+        containerRef={this.container}
         nextChallengePath={nextChallengePath}
         prevChallengePath={prevChallengePath}
       >

--- a/client/src/templates/Challenges/video/show.tsx
+++ b/client/src/templates/Challenges/video/show.tsx
@@ -19,7 +19,7 @@ import LearnLayout from '../../../components/layouts/learn';
 import { ChallengeNode, ChallengeMeta } from '../../../redux/prop-types';
 import { challengeTypes } from '../../../../../shared/config/challenge-types';
 import ChallengeDescription from '../components/challenge-description';
-import Hotkeys, { type HotkeysProps } from '../components/hotkeys';
+import Hotkeys from '../components/hotkeys';
 import VideoPlayer from '../components/video-player';
 import ChallengeTitle from '../components/challenge-title';
 import CompletionModal from '../components/completion-modal';
@@ -83,7 +83,7 @@ interface ShowVideoState {
 // Component
 class ShowVideo extends Component<ShowVideoProps, ShowVideoState> {
   static displayName: string;
-  private _container: HotkeysProps['containerRef'] | undefined;
+  private container: React.RefObject<HTMLElement> | undefined;
 
   constructor(props: ShowVideoProps) {
     super(props);
@@ -117,8 +117,8 @@ class ShowVideo extends Component<ShowVideoProps, ShowVideoState> {
       helpCategory
     });
     challengeMounted(challengeMeta.id);
-    this._container = React.createRef();
-    this._container?.current?.focus();
+    this.container = React.createRef();
+    this.container?.current?.focus();
   }
 
   componentDidUpdate(prevProps: ShowVideoProps): void {
@@ -214,7 +214,7 @@ class ShowVideo extends Component<ShowVideoProps, ShowVideoState> {
         executeChallenge={() => {
           this.handleSubmit(solution, openCompletionModal);
         }}
-        containerRef={this._container}
+        ref={this.container}
         nextChallengePath={nextChallengePath}
         prevChallengePath={prevChallengePath}
       >

--- a/client/src/templates/Challenges/video/show.tsx
+++ b/client/src/templates/Challenges/video/show.tsx
@@ -83,7 +83,8 @@ interface ShowVideoState {
 // Component
 class ShowVideo extends Component<ShowVideoProps, ShowVideoState> {
   static displayName: string;
-  private container: React.RefObject<HTMLElement> | undefined;
+  private container: React.RefObject<HTMLElement> | undefined =
+    React.createRef();
 
   constructor(props: ShowVideoProps) {
     super(props);
@@ -117,7 +118,6 @@ class ShowVideo extends Component<ShowVideoProps, ShowVideoState> {
       helpCategory
     });
     challengeMounted(challengeMeta.id);
-    this.container = React.createRef();
     this.container?.current?.focus();
   }
 

--- a/client/src/templates/Challenges/video/show.tsx
+++ b/client/src/templates/Challenges/video/show.tsx
@@ -19,7 +19,7 @@ import LearnLayout from '../../../components/layouts/learn';
 import { ChallengeNode, ChallengeMeta } from '../../../redux/prop-types';
 import { challengeTypes } from '../../../../../shared/config/challenge-types';
 import ChallengeDescription from '../components/challenge-description';
-import Hotkeys from '../components/hotkeys';
+import Hotkeys, { type HotkeysProps } from '../components/hotkeys';
 import VideoPlayer from '../components/video-player';
 import ChallengeTitle from '../components/challenge-title';
 import CompletionModal from '../components/completion-modal';
@@ -83,7 +83,7 @@ interface ShowVideoState {
 // Component
 class ShowVideo extends Component<ShowVideoProps, ShowVideoState> {
   static displayName: string;
-  private _container: HTMLElement | null | undefined;
+  private _container: HotkeysProps['containerRef'] | undefined;
 
   constructor(props: ShowVideoProps) {
     super(props);
@@ -117,7 +117,8 @@ class ShowVideo extends Component<ShowVideoProps, ShowVideoState> {
       helpCategory
     });
     challengeMounted(challengeMeta.id);
-    this._container?.focus();
+    this._container = React.createRef();
+    this._container?.current?.focus();
   }
 
   componentDidUpdate(prevProps: ShowVideoProps): void {
@@ -213,7 +214,7 @@ class ShowVideo extends Component<ShowVideoProps, ShowVideoState> {
         executeChallenge={() => {
           this.handleSubmit(solution, openCompletionModal);
         }}
-        innerRef={(c: HTMLElement | null) => (this._container = c)}
+        containerRef={this._container}
         nextChallengePath={nextChallengePath}
         prevChallengePath={prevChallengePath}
       >


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

While reviewing Ahmad PR, I notice how these types are linked, but they were changed slightly.

This PR aligns these types.

<!-- Feel free to add any additional description of changes below this line -->
