### PR TITLE
refactor(client): wrong TFunction type in searchBar

### DIFF
--- a/client/src/components/search/searchBar/search-bar-optimized.tsx
+++ b/client/src/components/search/searchBar/search-bar-optimized.tsx
@@ -3,12 +3,11 @@ import { useTranslation } from 'react-i18next';
 import Magnifier from '../../../assets/icons/magnifier';
 import InputReset from '../../../assets/icons/input-reset';
 import { searchPageUrl } from '../../../utils/algolia-locale-setup';
+import type { SearchBarProps } from './search-bar';
 
-type Props = {
-  innerRef?: React.RefObject<HTMLDivElement>;
-};
-
-const SearchBarOptimized = ({ innerRef }: Props): JSX.Element => {
+const SearchBarOptimized = ({
+  innerRef
+}: Pick<SearchBarProps, 'innerRef'>): JSX.Element => {
   const { t } = useTranslation();
   const placeholder = t('search.placeholder');
   const searchUrl = searchPageUrl;

--- a/client/src/components/search/searchBar/search-bar.tsx
+++ b/client/src/components/search/searchBar/search-bar.tsx
@@ -39,14 +39,14 @@ const mapDispatchToProps = (dispatch: Dispatch<AnyAction>) =>
     dispatch
   );
 
-type SearchBarProps = {
+export type SearchBarProps = {
   innerRef?: React.RefObject<HTMLDivElement>;
   toggleSearchDropdown: typeof toggleSearchDropdown;
   toggleSearchFocused: typeof toggleSearchFocused;
   updateSearchQuery: typeof updateSearchQuery;
   isDropdownEnabled?: boolean;
   isSearchFocused?: boolean;
-  t?: TFunction;
+  t: TFunction;
 };
 type SearchBarState = {
   index: number;
@@ -187,9 +187,6 @@ export class SearchBar extends Component<SearchBarProps, SearchBarState> {
   render(): JSX.Element {
     const { isDropdownEnabled, isSearchFocused, innerRef, t } = this.props;
     const { index } = this.state;
-    const submitTitle = t ? t('icons.magnifier') : '';
-    const resetTitle = t ? t('icons.input-reset') : '';
-    const placeholder = t ? t('search.placeholder') : '';
 
     return (
       <WithInstantSearch>
@@ -201,7 +198,7 @@ export class SearchBar extends Component<SearchBarProps, SearchBarState> {
           <HotKeys handlers={this.keyHandlers} keyMap={this.keyMap}>
             <div className='fcc_search_wrapper'>
               <label className='fcc_sr_only' htmlFor='fcc_instantsearch'>
-                {t ? t('search.label') : ''}
+                {t('search.label')}
               </label>
               <ObserveKeys except={['Space']}>
                 <div onFocus={this.handleFocus} role='textbox'>
@@ -213,9 +210,9 @@ export class SearchBar extends Component<SearchBarProps, SearchBarState> {
                     }}
                     showLoadingIndicator={false}
                     translations={{
-                      submitTitle: submitTitle,
-                      resetTitle: resetTitle,
-                      placeholder: placeholder
+                      submitTitle: t('icons.magnifier'),
+                      resetTitle: t('icons.input-reset'),
+                      placeholder: t('search.placeholder')
                     }}
                   />
                 </div>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

While adding TFunction, I found this one type that has the wrong type, this aims to sort it

<!-- Feel free to add any additional description of changes below this line -->
