### PR TITLE
fix(tools): sort small issues in formControl

### DIFF
--- a/tools/ui-components/src/form-control/form-control.tsx
+++ b/tools/ui-components/src/form-control/form-control.tsx
@@ -1,12 +1,18 @@
 import React, { useContext } from 'react';
 import { FormContext } from '../form-group/form-group';
 
-import { FormControlFeedback as Feedback } from './form-control-feedback';
-import { FormControlStatic as Static } from './form-control-static';
+import { FormControlFeedback } from './form-control-feedback';
+import { FormControlStatic } from './form-control-static';
 import { FormControlProps } from './types';
 
 // Uses controlId from <FormGroup> if not explicitly specified.
 // type Only relevant if componentClass is 'input'.
+let variantClass: string;
+const defaultClasses =
+  'outline-0 block w-full py-1.5 px-2.5 text-md text-foreground-primary ' +
+  'bg-background-primary bg-none rounded-none border-1 border-solid ' +
+  'border-background-quaternary shadow-none ' +
+  'transition ease-in-out duration-150 focus:border-foreground-tertiary';
 
 const FormControl = ({
   id,
@@ -23,13 +29,7 @@ const FormControl = ({
 }: FormControlProps): JSX.Element => {
   const { controlId } = useContext(FormContext);
 
-  const defaultClasses =
-    'outline-0 block w-full py-1.5 px-2.5 text-md text-foreground-primary ' +
-    'bg-background-primary bg-none rounded-none border-1 border-solid ' +
-    'border-background-quaternary shadow-none ' +
-    'transition ease-in-out duration-150 focus:border-foreground-tertiary';
   const Component = componentClass || 'input';
-  let variantClass;
   if (Component !== 'textarea') variantClass = ' h-8';
 
   //row and componentClass
@@ -51,6 +51,7 @@ const FormControl = ({
   );
 };
 
-const MainFormControl = Object.assign(FormControl, { Feedback, Static });
+FormControl.Feedback = FormControlFeedback;
+FormControl.Static = FormControlStatic;
 
-export { MainFormControl as FormControl };
+export { FormControl };

--- a/tools/ui-components/src/form-control/types.ts
+++ b/tools/ui-components/src/form-control/types.ts
@@ -9,31 +9,26 @@ type ChangibleValues =
       readonly?: never;
     }
   | {
-      value: string;
+      value?: string;
       onChange?: never;
       readonly: boolean;
     }
   | {
-      value: string;
+      value?: string;
       onChange: (event: React.ChangeEvent<FormControlElement>) => void;
       readonly?: never;
     };
 
 export type FormControlProps = React.HTMLAttributes<FormControlElement> & {
-  id?: string;
-  className?: string;
   testId?: string;
   componentClass?: 'textarea' | 'input';
-  placeholder?: string;
   name?: string;
   required?: boolean;
   rows?: number;
   type?: 'text' | 'email' | 'url';
 } & ChangibleValues;
 
-export interface FormControlVariationProps {
-  className?: string;
-  children?: React.ReactNode;
-  id?: string;
-  testId?: string;
-}
+export type FormControlVariationProps = Pick<
+  FormControlProps,
+  'className' | 'children' | 'id' | 'testId'
+>;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The only noteworthy change is changing the type, because it's possible to create a `formControl` without `value`, but with `onChange` or `readonly`.

Aka
```ts
<FormControl readonly />
<FormControl onChange />
```

The other changes are stop rendering the values when the component mounts, remove the need for object.assign, and clean extra props.


Can we Closes #45459? 

<!-- Feel free to add any additional description of changes below this line -->
