### PR TITLE
fix(client): only fetch if username exists

### DIFF
--- a/client/src/client-only-routes/show-profile-or-four-oh-four.tsx
+++ b/client/src/client-only-routes/show-profile-or-four-oh-four.tsx
@@ -1,5 +1,5 @@
 import { isEmpty } from 'lodash-es';
-import React, { Component } from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 
 import { isBrowser } from '../../utils/index';
@@ -22,7 +22,7 @@ interface ShowProfileOrFourOhFourProps {
     errored: boolean;
   };
   isSessionUser: boolean;
-  maybeUser: string;
+  maybeUser?: string;
   requestedUser: User;
   showLoading: boolean;
 }
@@ -57,36 +57,36 @@ const mapDispatchToProps: {
   fetchProfileForUser
 };
 
-class ShowProfileOrFourOhFour extends Component<ShowProfileOrFourOhFourProps> {
-  componentDidMount() {
-    const { requestedUser, maybeUser, fetchProfileForUser } = this.props;
+function ShowProfileOrFourOhFour({
+  requestedUser,
+  maybeUser,
+  fetchProfileForUser,
+  isSessionUser,
+  showLoading
+}: ShowProfileOrFourOhFourProps) {
+  useEffect(() => {
+    // If the user is not already in the store, fetch it
     if (isEmpty(requestedUser)) {
-      fetchProfileForUser(maybeUser);
-    }
-  }
-
-  render() {
-    if (!isBrowser()) {
-      return null;
-    }
-
-    const { isSessionUser, requestedUser, showLoading } = this.props;
-    if (isEmpty(requestedUser)) {
-      if (showLoading) {
-        // We don't know if /:maybeUser is a user or not, we will show
-        // the loader until we get a response from the API
-        return <Loader fullScreen={true} />;
+      if (maybeUser) {
+        fetchProfileForUser(maybeUser);
       }
-      // We have a response from the API, but there is nothing in the store
-      // for /:maybeUser. We can derive from this state the /:maybeUser is not
-      // a user the API recognises, so we 404
-      return <FourOhFour />;
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-    // We have a response from the API, and we have some state in the
-    // store for /:maybeUser, we now handover rendering to the Profile component
-    return <Profile isSessionUser={isSessionUser} user={requestedUser} />;
+  if (!isBrowser()) {
+    return null;
   }
+
+  return isEmpty(requestedUser) ? (
+    showLoading ? (
+      <Loader fullScreen={true} />
+    ) : (
+      <FourOhFour />
+    )
+  ) : (
+    <Profile isSessionUser={isSessionUser} user={requestedUser} />
+  );
 }
 
 export default connect(


### PR DESCRIPTION
A test to see if the number of sentry errors decreases after this commit

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This is the only place `/user/get-public-profile` is called, and there is no truthy check on the argument. So, I hope this will remove the `Error: username is a required argument` for this route.

I cannot confirm if the typing for `maybeUser` is correct. From what I can tell, Reach Router should ignore any path where `/:maybeUser` is `undefined`. So, potentially, a check for `maybeUser !== ''` is enough.

_on top of the test, I refactored into a functional component_