### PR TITLE
fix: add `.keepOpen()` method explanation and examples to `chai-http` challenges

### DIFF
--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/run-functional-tests-on-an-api-response-using-chai-http-iii---put-method.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/run-functional-tests-on-an-api-response-using-chai-http-iii---put-method.md
@@ -17,6 +17,7 @@ To send a `PUT` request and a JSON object to the `'/travellers'` endpoint, you c
 ```js
 chai
   .request(server)
+  .keepOpen()
   .put('/travellers')
   .send({
     "surname": [last name of a traveller of the past]

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/run-functional-tests-on-api-endpoints-using-chai-http.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/run-functional-tests-on-api-endpoints-using-chai-http.md
@@ -19,6 +19,7 @@ suite('GET /hello?name=[name] => "hello [name]"', function () {
   test('?name=John', function (done) {
     chai
       .request(server)
+      .keepOpen()
       .get('/hello?name=John')
       .end(function (err, res) {
         assert.equal(res.status, 200, 'Response status should be 200');
@@ -34,6 +35,10 @@ The test sends a `GET` request to the server with a name as a URL query string (
 The first `assert.equal` checks if the status is equal to `200`. The second `assert.equal` checks that the response string (`res.text`) is equal to `"hello John"`.
 
 Also, notice the `done` parameter in the test's callback function. Calling it without an argument at the end of a test is necessary to signal that the asynchronous operation is complete.
+
+Finally, note the `keepOpen` method just after the `request` method. Normally you would run your tests from the command line, or as part of an automated integration process, and you could let `chai-http` start and stop your server automatically.
+
+However, the tests that run when you submit the link to your project require your server to be up, so you need to use the `keepOpen` method to prevent `chai-http` from stopping your server.
 
 # --instructions--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to https://github.com/freeCodeCamp/boilerplate-mochachai/pull/92

<!-- Feel free to add any additional description of changes below this line -->
We got an email in the support inbox recently saying that none of the Learn tests for the Mocha Chai projects were working. The dev console on Learn threw CORS and network errors.

After digging into the issue, I found that `chai-http` automatically stops the server it's connected to after running its tests.

So what was happening is that, when the boilerplate on Replit is started, it runs the unit and functional tests automatically, and has a backdoor API endpoint for the tests on Learn to run against. But since `chai-http` would stop the server automatically, the project on Replit would stop, and all incoming Learn tests would fail.

I'm not sure why this wasn't an issue before, but these updated examples, and the updates to the boilerplate in https://github.com/freeCodeCamp/boilerplate-mochachai/pull/92, should fix things.

Here's a link to the completed project on Replit with these changes for testing: https://replit.com/@scissorsneedfoo/boilerplate-mochachai-complete#tests/2_functional-tests.js