### PR TITLE
fix(client): remove unused i18next variable

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -747,7 +747,7 @@
   "forum-help": {
     "browser-info": "**Your browser information:**",
     "user-agent": "User Agent is: <code>{{userAgent}}</code>",
-    "challenge": "**Challenge:** {{challengeTitle}}",
+    "challenge": "**Challenge:**",
     "challenge-link": "**Link to the challenge:**",
     "whats-happening": "**Tell us what's happening:**",
     "describe": "Describe your issue in detail here.",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #49884 

This bug has been long-standing, but we never noticed, because, by default for `i18next@<21` the unused variable was ignored. Since we updated, the `{{challengeTitle}}` var has been treated as a literal string.

_someone please remind me if I need to update other `translations.json` files?