### PR TITLE
fix(client): hack the outline look for the logo in the nav bar

### DIFF
--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -33,6 +33,16 @@
   -ms-overflow-scrolling: touch;
 }
 
+#universal-nav-logo:focus-visible {
+  outline-offset: -3px;
+}
+
+@supports not selector(:focus-visible) {
+  #universal-nav-logo:focus {
+    outline-offset: -3px;
+  }
+}
+
 .universal-nav-right {
   display: flex;
   justify-content: flex-end;

--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -33,14 +33,8 @@
   -ms-overflow-scrolling: touch;
 }
 
-#universal-nav-logo:focus-visible {
+#universal-nav-logo:focus {
   outline-offset: -3px;
-}
-
-@supports not selector(:focus-visible) {
-  #universal-nav-logo:focus {
-    outline-offset: -3px;
-  }
 }
 
 .universal-nav-right {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I hate this hack, but making Grid is talking a while, because I am jiggling between things.

This is a quick hack, but it isn't a fix, if the logo ever change or if we wanted to move area in the navbar. Because of `height: 100%` attribute, Grid is still the way to go 😞.


new look 
![image](https://user-images.githubusercontent.com/88248797/228911433-7e78b29a-0af7-47a7-aa1f-d0a3b1b93c1a.png)

<!-- Feel free to add any additional description of changes below this line -->
