### PR TITLE
fix(client): remeasureFonts when fonts are loaded

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -427,6 +427,10 @@ const Editor = (props: EditorProps): JSX.Element => {
       accessibilitySupport: accessibilityMode ? 'on' : 'auto'
     });
 
+    document.fonts.ready
+      .then(() => monaco.editor.remeasureFonts())
+      .catch(err => console.error(err));
+
     // Focus should not automatically leave the 'Code' tab when using a keyboard
     // to navigate the tablist.
     if (!isMobileLayout || !isUsingKeyboardInTablist) {


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #49771 

---
- Issue seems to be caused by using custom font, which not necessarily is fully loaded when editor does it things - in which case the fallback font is used. https://github.com/microsoft/monaco-editor/issues/648#issuecomment-564978560
- I've checked if remeasuring would work, when added to `editorWillMount` instead - it did not.
- Eslint was complaining about floating promise, so I've added `.catch`, not sure if something more elaborate is needed or worth here, or throwing instead.