### PR TITLE
feat(client): remove babel polyfill from frame runner

### DIFF
--- a/client/src/client/frame-runner.ts
+++ b/client/src/client/frame-runner.ts
@@ -1,4 +1,3 @@
-import '@babel/polyfill';
 import jQuery from 'jquery';
 import * as helpers from '@freecodecamp/curriculum-helpers';
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

https://babeljs.io/docs/babel-polyfill, the polyfill was adding `Promise`, `WeakMap` and other stuff. but as far as I know, this isn't needed anymore. I haven't made one PR because it affects important parts, so there is a less chance of breaking changes

<!-- Feel free to add any additional description of changes below this line -->
