### PR TITLE
feat(client): remove polyfill from test challenges

### DIFF
--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-loop-func */
 const path = require('path');
 const vm = require('vm');
 const { assert, AssertionError } = require('chai');
@@ -16,7 +15,6 @@ const stringSimilarity = require('string-similarity');
 mockRequire('lodash-es', lodash);
 
 const clientPath = path.resolve(__dirname, '../../client');
-require('@babel/polyfill');
 require('@babel/register')({
   root: clientPath,
   babelrc: false,
@@ -34,10 +32,8 @@ const {
 } = require('../../client/src/templates/Challenges/utils/worker-executor');
 const { challengeTypes } = require('../../client/utils/challenge-types');
 // the config files are created during the build, but not before linting
-/* eslint-disable import/no-unresolved */
 const testEvaluator =
   require('../../config/client/test-evaluator.json').filename;
-/* eslint-enable import/no-unresolved */
 
 const { getLines } = require('../../utils/get-lines');
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

https://babeljs.io/docs/babel-polyfill, the polyfill was adding `Promise`, `WeakMap` and other stuff. but as far as I know, this isn't needed anymore. I haven't made one PR because it affects important parts, so there is a less chance of breaking changes

<!-- Feel free to add any additional description of changes below this line -->
