### PR TITLE
feat: remove babel polyfill package

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -36,7 +36,6 @@
     "@babel/plugin-proposal-export-default-from": "7.18.10",
     "@babel/plugin-proposal-function-bind": "7.18.9",
     "@babel/plugin-transform-runtime": "^7.19.6",
-    "@babel/polyfill": "7.12.1",
     "@babel/preset-env": "7.21.4",
     "@babel/preset-react": "7.18.6",
     "@babel/runtime": "^7.20.13",

--- a/client/src/client/frame-runner.ts
+++ b/client/src/client/frame-runner.ts
@@ -1,4 +1,3 @@
-import '@babel/polyfill';
 import jQuery from 'jquery';
 import * as helpers from '@freecodecamp/curriculum-helpers';
 

--- a/client/src/client/workers/test-evaluator.ts
+++ b/client/src/client/workers/test-evaluator.ts
@@ -1,5 +1,4 @@
 import chai from 'chai';
-import '@babel/polyfill';
 import { toString as __toString } from 'lodash-es';
 import * as helpers from '@freecodecamp/curriculum-helpers';
 import { format as __format } from '../../utils/format';

--- a/curriculum/package.json
+++ b/curriculum/package.json
@@ -30,7 +30,6 @@
   },
   "devDependencies": {
     "@babel/core": "7.21.4",
-    "@babel/polyfill": "7.12.1",
     "@babel/preset-env": "7.21.4",
     "@babel/preset-typescript": "7.21.4",
     "@babel/register": "7.21.0",

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-loop-func */
 const path = require('path');
 const vm = require('vm');
 const { assert, AssertionError } = require('chai');
@@ -16,7 +15,6 @@ const stringSimilarity = require('string-similarity');
 mockRequire('lodash-es', lodash);
 
 const clientPath = path.resolve(__dirname, '../../client');
-require('@babel/polyfill');
 require('@babel/register')({
   root: clientPath,
   babelrc: false,
@@ -34,10 +32,8 @@ const {
 } = require('../../client/src/templates/Challenges/utils/worker-executor');
 const { challengeTypes } = require('../../client/utils/challenge-types');
 // the config files are created during the build, but not before linting
-/* eslint-disable import/no-unresolved */
 const testEvaluator =
   require('../../config/client/test-evaluator.json').filename;
-/* eslint-enable import/no-unresolved */
 
 const { getLines } = require('../../utils/get-lines');
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -424,9 +424,6 @@ importers:
       '@babel/plugin-transform-runtime':
         specifier: ^7.19.6
         version: 7.21.0(@babel/core@7.21.4)
-      '@babel/polyfill':
-        specifier: 7.12.1
-        version: 7.12.1
       '@babel/preset-env':
         specifier: 7.21.4
         version: 7.21.4(@babel/core@7.21.4)
@@ -889,9 +886,6 @@ importers:
       '@babel/core':
         specifier: 7.21.4
         version: 7.21.4
-      '@babel/polyfill':
-        specifier: 7.12.1
-        version: 7.12.1
       '@babel/preset-env':
         specifier: 7.21.4
         version: 7.21.4(@babel/core@7.21.4)
@@ -5340,13 +5334,6 @@ packages:
       '@babel/core': 7.21.4
       '@babel/helper-create-regexp-features-plugin': 7.21.0(@babel/core@7.21.4)
       '@babel/helper-plugin-utils': 7.20.2
-
-  /@babel/polyfill@7.12.1:
-    resolution: {integrity: sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==}
-    deprecated: 🚨 This package has been deprecated in favor of separate inclusion of a polyfill and regenerator-runtime (when needed). See the @babel/polyfill docs (https://babeljs.io/docs/en/babel-polyfill) for more information.
-    dependencies:
-      core-js: 2.6.12
-      regenerator-runtime: 0.13.11
 
   /@babel/preset-env@7.18.0(@babel/core@7.18.0):
     resolution: {integrity: sha512-cP74OMs7ECLPeG1reiCQ/D/ypyOxgfm8uR6HRYV23vTJ7Lu1nbgj9DQDo/vH59gnn7GOAwtTDPPYV4aXzsMKHA==}
@@ -14387,6 +14374,7 @@ packages:
     resolution: {integrity: sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==}
     deprecated: core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.
     requiresBuild: true
+    dev: true
 
   /core-js@3.29.0:
     resolution: {integrity: sha512-VG23vuEisJNkGl6XQmFJd3rEG/so/CNatqeE+7uZAwTSwFeB/qaO0be8xZYUNWprJ/GIwL8aMt9cj1kvbpTZhg==}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

after the three PRs are tested and merged, we can say goodbye to polyfill 

Ref #49916
Ref #49915
Ref #49914
<!-- Feel free to add any additional description of changes below this line -->

Edit: I am hoping by remove it, we won't get error about `eslint-plugin-testing-library@4.12.4` anymore