### PR TITLE
fix(client): rendering the block title as an array

### DIFF
--- a/client/src/templates/Introduction/components/__snapshots__/block-intros.test.tsx.snap
+++ b/client/src/templates/Introduction/components/__snapshots__/block-intros.test.tsx.snap
@@ -4,11 +4,19 @@ exports[`<BlockIntros /> matches snapshot 1`] = `
 <div
   className="block-description"
 >
-  <p>
-    first paragraph
-  </p>
-  <p>
-    second paragraph
-  </p>
+  <p
+    dangerouslySetInnerHTML={
+      {
+        "__html": "first paragraph",
+      }
+    }
+  />
+  <p
+    dangerouslySetInnerHTML={
+      {
+        "__html": "second paragraph",
+      }
+    }
+  />
 </div>
 `;

--- a/client/src/templates/Introduction/components/__snapshots__/block-intros.test.tsx.snap
+++ b/client/src/templates/Introduction/components/__snapshots__/block-intros.test.tsx.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<BlockIntros /> matches snapshot 1`] = `
+<div
+  className="block-description"
+>
+  <p>
+    first paragraph
+  </p>
+  <p>
+    second paragraph
+  </p>
+</div>
+`;

--- a/client/src/templates/Introduction/components/block-intros.test.tsx
+++ b/client/src/templates/Introduction/components/block-intros.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import { BlockIntros } from './block';
+
+const arrString = ['first paragraph', 'second paragraph'];
+
+describe('<BlockIntros />', () => {
+  it('matches snapshot', () => {
+    const tree = renderer.create(<BlockIntros intros={arrString} />);
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import type { TFunction } from 'i18next';
+import type { DefaultTFuncReturn, TFunction } from 'i18next';
 import { withTranslation } from 'react-i18next';
 import { ProgressBar } from '@freecodecamp/react-bootstrap';
 import { connect } from 'react-redux';
@@ -61,9 +61,6 @@ interface BlockProps {
   toggleBlock: typeof toggleBlock;
 }
 
-// the real type of TFunction is the type below, because intro can be an array of strings
-// type RealTypeOFTFunction = TFunction & ((key: string) => string[]);
-// But changing the type will require refactoring that isn't worth it for a wrong type.
 export const BlockIntros = ({ intros }: { intros: string[] }): JSX.Element => {
   return (
     <div className='block-description'>
@@ -134,11 +131,12 @@ class Block extends Component<BlockProps> {
     });
 
     const blockTitle = t(`intro:${superBlock}.blocks.${blockDashedName}.title`);
-    // the reason we are flating the array, to please TypeScript.
-    // but it isn't needed, because of intro structure as mention in BlockIntos component
-    const blockIntroArr = [
-      t(`intro:${superBlock}.blocks.${blockDashedName}.intro`)
-    ].flat();
+    // the real type of TFunction is the type below, because intro can be an array of strings
+    // type RealTypeOFTFunction = TFunction & ((key: string) => string[]);
+    // But changing the type will require refactoring that isn't worth it for a wrong type.
+    const blockIntroArr = t<string, DefaultTFuncReturn & string[]>(
+      `intro:${superBlock}.blocks.${blockDashedName}.intro`
+    );
     const expandText = t('intro:misc-text.expand');
     const collapseText = t('intro:misc-text.collapse');
 

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -68,7 +68,7 @@ export const BlockIntros = ({ intros }: { intros: string[] }): JSX.Element => {
   return (
     <div className='block-description'>
       {intros.map((title, i) => (
-        <p key={i}>{title}</p>
+        <p dangerouslySetInnerHTML={{ __html: title }} key={i} />
       ))}
     </div>
   );

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -64,11 +64,15 @@ interface BlockProps {
 // the real type of TFunction is the type below, because intro can be an array of strings
 // type RealTypeOFTFunction = TFunction & ((key: string) => string[]);
 // But changing it will require refactoring that isn't worth it for a wrong type.
-const RenderBlockIntros = ({ str }: { str: string[] }) => {
+const RenderBlockIntros = ({
+  titleParagraphs
+}: {
+  titleParagraphs: string[];
+}) => {
   return (
     <div className='block-description'>
-      {str.map((child, i) => (
-        <p key={i}>{child}</p>
+      {titleParagraphs.map((title, i) => (
+        <p key={i}>{title}</p>
       ))}
     </div>
   );
@@ -171,7 +175,7 @@ class Block extends Component<BlockProps> {
                 </div>
               )}
             </div>
-            <RenderBlockIntros str={blockIntroArr} />
+            <RenderBlockIntros titleParagraphs={blockIntroArr} />
             <button
               aria-expanded={isExpanded}
               className='map-title'
@@ -228,7 +232,7 @@ class Block extends Component<BlockProps> {
                 </div>
               )}
             </div>
-            <RenderBlockIntros str={blockIntroArr} />
+            <RenderBlockIntros titleParagraphs={blockIntroArr} />
             <Challenges
               challengesWithCompleted={challengesWithCompleted}
               isProjectBlock={isProjectBlock}
@@ -289,7 +293,9 @@ class Block extends Component<BlockProps> {
                 </Link>
               )}
             </div>
-            {isExpanded && <RenderBlockIntros str={blockIntroArr} />}
+            {isExpanded && (
+              <RenderBlockIntros titleParagraphs={blockIntroArr} />
+            )}
             {isExpanded && (
               <Challenges
                 challengesWithCompleted={challengesWithCompleted}
@@ -330,7 +336,7 @@ class Block extends Component<BlockProps> {
               {this.renderCheckMark(isBlockCompleted)}
               <h3 className='block-grid-title'>{blockTitle}</h3>
             </div>
-            <RenderBlockIntros str={blockIntroArr} />
+            <RenderBlockIntros titles={blockIntroArr} />
           </Link>
         </div>
       </ScrollableAnchor>

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -63,15 +63,11 @@ interface BlockProps {
 
 // the real type of TFunction is the type below, because intro can be an array of strings
 // type RealTypeOFTFunction = TFunction & ((key: string) => string[]);
-// But changing it will require refactoring that isn't worth it for a wrong type.
-const RenderBlockIntros = ({
-  titleParagraphs
-}: {
-  titleParagraphs: string[];
-}) => {
+// But changing the type will require refactoring that isn't worth it for a wrong type.
+const BlockIntros = ({ intros }: { intros: string[] }) => {
   return (
     <div className='block-description'>
-      {titleParagraphs.map((title, i) => (
+      {intros.map((title, i) => (
         <p key={i}>{title}</p>
       ))}
     </div>
@@ -138,9 +134,11 @@ class Block extends Component<BlockProps> {
     });
 
     const blockTitle = t(`intro:${superBlock}.blocks.${blockDashedName}.title`);
-    const blockIntroArr = t(
-      `intro:${superBlock}.blocks.${blockDashedName}.intro`
-    );
+    // the reason we are flating the array, to please TypeScript.
+    // but it isn't needed, because of intro structure as mention in BlockIntos component
+    const blockIntroArr = [
+      t(`intro:${superBlock}.blocks.${blockDashedName}.intro`)
+    ].flat();
     const expandText = t('intro:misc-text.expand');
     const collapseText = t('intro:misc-text.collapse');
 
@@ -175,7 +173,7 @@ class Block extends Component<BlockProps> {
                 </div>
               )}
             </div>
-            <RenderBlockIntros titleParagraphs={blockIntroArr} />
+            <BlockIntros intros={blockIntroArr} />
             <button
               aria-expanded={isExpanded}
               className='map-title'
@@ -232,7 +230,7 @@ class Block extends Component<BlockProps> {
                 </div>
               )}
             </div>
-            <RenderBlockIntros titleParagraphs={blockIntroArr} />
+            <BlockIntros intros={blockIntroArr} />
             <Challenges
               challengesWithCompleted={challengesWithCompleted}
               isProjectBlock={isProjectBlock}
@@ -293,9 +291,7 @@ class Block extends Component<BlockProps> {
                 </Link>
               )}
             </div>
-            {isExpanded && (
-              <RenderBlockIntros titleParagraphs={blockIntroArr} />
-            )}
+            {isExpanded && <BlockIntros intros={blockIntroArr} />}
             {isExpanded && (
               <Challenges
                 challengesWithCompleted={challengesWithCompleted}
@@ -336,7 +332,7 @@ class Block extends Component<BlockProps> {
               {this.renderCheckMark(isBlockCompleted)}
               <h3 className='block-grid-title'>{blockTitle}</h3>
             </div>
-            <RenderBlockIntros titles={blockIntroArr} />
+            <BlockIntros intros={blockIntroArr} />
           </Link>
         </div>
       </ScrollableAnchor>

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -64,7 +64,7 @@ interface BlockProps {
 // the real type of TFunction is the type below, because intro can be an array of strings
 // type RealTypeOFTFunction = TFunction & ((key: string) => string[]);
 // But changing the type will require refactoring that isn't worth it for a wrong type.
-const BlockIntros = ({ intros }: { intros: string[] }) => {
+export const BlockIntros = ({ intros }: { intros: string[] }): JSX.Element => {
   return (
     <div className='block-description'>
       {intros.map((title, i) => (

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -60,6 +60,20 @@ interface BlockProps {
   t: TFunction;
   toggleBlock: typeof toggleBlock;
 }
+
+// the real type of TFunction is the type below, because intro can be an array of strings
+// type RealTypeOFTFunction = TFunction & ((key: string) => string[]);
+// But changing it will require refactoring that isn't worth it for a wrong type.
+const RenderBlockIntros = ({ str }: { str: string[] }) => {
+  return (
+    <div className='block-description'>
+      {str.map((child, i) => (
+        <p key={i}>{child}</p>
+      ))}
+    </div>
+  );
+};
+
 class Block extends Component<BlockProps> {
   static displayName: string;
   constructor(props: BlockProps) {
@@ -79,16 +93,6 @@ class Block extends Component<BlockProps> {
       <GreenPass hushScreenReaderText />
     ) : (
       <GreenNotCompleted hushScreenReaderText />
-    );
-  }
-
-  renderBlockIntros(arr: string[]): JSX.Element {
-    return (
-      <div className='block-description'>
-        {arr.map((str, i) => (
-          <p dangerouslySetInnerHTML={{ __html: str }} key={i} />
-        ))}
-      </div>
     );
   }
 
@@ -130,9 +134,9 @@ class Block extends Component<BlockProps> {
     });
 
     const blockTitle = t(`intro:${superBlock}.blocks.${blockDashedName}.title`);
-    const blockIntroArr = [
-      t(`intro:${superBlock}.blocks.${blockDashedName}.intro`)
-    ];
+    const blockIntroArr = t(
+      `intro:${superBlock}.blocks.${blockDashedName}.intro`
+    );
     const expandText = t('intro:misc-text.expand');
     const collapseText = t('intro:misc-text.collapse');
 
@@ -167,7 +171,7 @@ class Block extends Component<BlockProps> {
                 </div>
               )}
             </div>
-            {this.renderBlockIntros(blockIntroArr)}
+            <RenderBlockIntros str={blockIntroArr} />
             <button
               aria-expanded={isExpanded}
               className='map-title'
@@ -224,7 +228,7 @@ class Block extends Component<BlockProps> {
                 </div>
               )}
             </div>
-            {this.renderBlockIntros(blockIntroArr)}
+            <RenderBlockIntros str={blockIntroArr} />
             <Challenges
               challengesWithCompleted={challengesWithCompleted}
               isProjectBlock={isProjectBlock}
@@ -285,7 +289,7 @@ class Block extends Component<BlockProps> {
                 </Link>
               )}
             </div>
-            {isExpanded && this.renderBlockIntros(blockIntroArr)}
+            {isExpanded && <RenderBlockIntros str={blockIntroArr} />}
             {isExpanded && (
               <Challenges
                 challengesWithCompleted={challengesWithCompleted}
@@ -326,7 +330,7 @@ class Block extends Component<BlockProps> {
               {this.renderCheckMark(isBlockCompleted)}
               <h3 className='block-grid-title'>{blockTitle}</h3>
             </div>
-            {this.renderBlockIntros(blockIntroArr)}
+            <RenderBlockIntros str={blockIntroArr} />
           </Link>
         </div>
       </ScrollableAnchor>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #49923

This solves another issue too. The renderblock keeps re-rendering, which stop the selection highlight from sticking.

[rec-tab (2).webm](https://user-images.githubusercontent.com/88248797/229337089-6df03e2f-98de-4d15-9b31-06b863992c9a.webm)


The new look

![image](https://user-images.githubusercontent.com/88248797/229338072-01d43075-ee36-498c-85d3-8933e2e3785d.png)


<!-- Feel free to add any additional description of changes below this line -->
