### PR TITLE
fix: Improve wording in Record Collection instructions

### DIFF
--- a/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/record-collection.md
+++ b/curriculum/challenges/arabic/02-javascript-algorithms-and-data-structures/basic-javascript/record-collection.md
@@ -22,8 +22,7 @@ Complete the function using the rules below to modify the object passed to the f
 -   Your function must always return the entire `records` object.
 -   If `value` is an empty string, delete the given `prop` property from the album.
 -   If `prop` isn’t `"tracks"` and `value` isn't an empty string, assign the `value` to that album’s `prop`.
--   If `prop` is `"tracks"` and `value` isn’t an empty string, add the `value` to the end of the album’s existing `"tracks"` array.
--   If the album doesn’t have a `"tracks"` property, create a new array for the album's `"tracks"` property before adding the `value` to it.
+-   If `prop` is `"tracks"` and `value` isn’t an empty string, add the `value` to the end of the album’s `"tracks"` array. You need to create this array first if the album does not have a `"tracks"` property.
 
 **Note:** A copy of the `recordCollection` object is used for the tests. You should not directly modify the `recordCollection` object.
 

--- a/curriculum/challenges/chinese-traditional/02-javascript-algorithms-and-data-structures/basic-javascript/record-collection.md
+++ b/curriculum/challenges/chinese-traditional/02-javascript-algorithms-and-data-structures/basic-javascript/record-collection.md
@@ -22,8 +22,7 @@ Complete the function using the rules below to modify the object passed to the f
 -   Your function must always return the entire `records` object.
 -   If `value` is an empty string, delete the given `prop` property from the album.
 -   If `prop` isn’t `"tracks"` and `value` isn't an empty string, assign the `value` to that album’s `prop`.
--   If `prop` is `"tracks"` and `value` isn’t an empty string, add the `value` to the end of the album’s existing `"tracks"` array.
--   If the album doesn’t have a `"tracks"` property, create a new array for the album's `"tracks"` property before adding the `value` to it.
+-   If `prop` is `"tracks"` and `value` isn’t an empty string, add the `value` to the end of the album’s `"tracks"` array. You need to create this array first if the album does not have a `"tracks"` property.
 
 **Note:** A copy of the `recordCollection` object is used for the tests. You should not directly modify the `recordCollection` object.
 

--- a/curriculum/challenges/chinese/02-javascript-algorithms-and-data-structures/basic-javascript/record-collection.md
+++ b/curriculum/challenges/chinese/02-javascript-algorithms-and-data-structures/basic-javascript/record-collection.md
@@ -22,8 +22,7 @@ Complete the function using the rules below to modify the object passed to the f
 -   Your function must always return the entire `records` object.
 -   If `value` is an empty string, delete the given `prop` property from the album.
 -   If `prop` isn’t `"tracks"` and `value` isn't an empty string, assign the `value` to that album’s `prop`.
--   If `prop` is `"tracks"` and `value` isn’t an empty string, add the `value` to the end of the album’s existing `"tracks"` array.
--   If the album doesn’t have a `"tracks"` property, create a new array for the album's `"tracks"` property before adding the `value` to it.
+-   If `prop` is `"tracks"` and `value` isn’t an empty string, add the `value` to the end of the album’s `"tracks"` array. You need to create this array first if the album does not have a `"tracks"` property.
 
 **Note:** A copy of the `recordCollection` object is used for the tests. You should not directly modify the `recordCollection` object.
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/record-collection.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/record-collection.md
@@ -22,8 +22,7 @@ Complete the function using the rules below to modify the object passed to the f
 -   Your function must always return the entire `records` object.
 -   If `value` is an empty string, delete the given `prop` property from the album.
 -   If `prop` isn’t `"tracks"` and `value` isn't an empty string, assign the `value` to that album’s `prop`.
--   If `prop` is `"tracks"` and `value` isn’t an empty string, add the `value` to the end of the album’s existing `"tracks"` array.
--   If the album doesn’t have a `"tracks"` property, create a new array for the album's `"tracks"` property before adding the `value` to it.
+-   If `prop` is `"tracks"` and `value` isn’t an empty string, add the `value` to the end of the album’s `"tracks"` array. You need to create this array first if the album does not have a `"tracks"` property.
 
 **Note:** A copy of the `recordCollection` object is used for the tests. You should not directly modify the `recordCollection` object.
 

--- a/curriculum/challenges/german/02-javascript-algorithms-and-data-structures/basic-javascript/record-collection.md
+++ b/curriculum/challenges/german/02-javascript-algorithms-and-data-structures/basic-javascript/record-collection.md
@@ -22,8 +22,7 @@ Complete the function using the rules below to modify the object passed to the f
 -   Your function must always return the entire `records` object.
 -   If `value` is an empty string, delete the given `prop` property from the album.
 -   If `prop` isn’t `"tracks"` and `value` isn't an empty string, assign the `value` to that album’s `prop`.
--   If `prop` is `"tracks"` and `value` isn’t an empty string, add the `value` to the end of the album’s existing `"tracks"` array.
--   If the album doesn’t have a `"tracks"` property, create a new array for the album's `"tracks"` property before adding the `value` to it.
+-   If `prop` is `"tracks"` and `value` isn’t an empty string, add the `value` to the end of the album’s `"tracks"` array. You need to create this array first if the album does not have a `"tracks"` property.
 
 **Note:** A copy of the `recordCollection` object is used for the tests. You should not directly modify the `recordCollection` object.
 

--- a/curriculum/challenges/japanese/02-javascript-algorithms-and-data-structures/basic-javascript/record-collection.md
+++ b/curriculum/challenges/japanese/02-javascript-algorithms-and-data-structures/basic-javascript/record-collection.md
@@ -22,8 +22,7 @@ Complete the function using the rules below to modify the object passed to the f
 -   Your function must always return the entire `records` object.
 -   If `value` is an empty string, delete the given `prop` property from the album.
 -   If `prop` isn’t `"tracks"` and `value` isn't an empty string, assign the `value` to that album’s `prop`.
--   If `prop` is `"tracks"` and `value` isn’t an empty string, add the `value` to the end of the album’s existing `"tracks"` array.
--   If the album doesn’t have a `"tracks"` property, create a new array for the album's `"tracks"` property before adding the `value` to it.
+-   If `prop` is `"tracks"` and `value` isn’t an empty string, add the `value` to the end of the album’s `"tracks"` array. You need to create this array first if the album does not have a `"tracks"` property.
 
 **Note:** A copy of the `recordCollection` object is used for the tests. You should not directly modify the `recordCollection` object.
 

--- a/curriculum/challenges/ukrainian/02-javascript-algorithms-and-data-structures/basic-javascript/record-collection.md
+++ b/curriculum/challenges/ukrainian/02-javascript-algorithms-and-data-structures/basic-javascript/record-collection.md
@@ -22,8 +22,7 @@ Complete the function using the rules below to modify the object passed to the f
 -   Your function must always return the entire `records` object.
 -   If `value` is an empty string, delete the given `prop` property from the album.
 -   If `prop` isn’t `"tracks"` and `value` isn't an empty string, assign the `value` to that album’s `prop`.
--   If `prop` is `"tracks"` and `value` isn’t an empty string, add the `value` to the end of the album’s existing `"tracks"` array.
--   If the album doesn’t have a `"tracks"` property, create a new array for the album's `"tracks"` property before adding the `value` to it.
+-   If `prop` is `"tracks"` and `value` isn’t an empty string, add the `value` to the end of the album’s `"tracks"` array. You need to create this array first if the album does not have a `"tracks"` property.
 
 **Note:** A copy of the `recordCollection` object is used for the tests. You should not directly modify the `recordCollection` object.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #49922

<!-- Feel free to add any additional description of changes below this line -->
Fixed: Improve wording in Record Collection Instructions

This commit updates the wording in the Record Collection instructions to make it clearer that users should read the last two bullet points together. 

Changes made in the last two bullet points by replacing them with:

- If prop is "tracks" and value isn’t an empty string, add the value to the end of the album’s "tracks" array. You need to create this array first if the album does not have a "tracks" property.
