### PR TITLE
feat(tools): remove assertion in params inside challenge editor

### DIFF
--- a/tools/challenge-editor/client/interfaces/prop-types.ts
+++ b/tools/challenge-editor/client/interfaces/prop-types.ts
@@ -1,17 +1,9 @@
-export interface ChallengeContentRequiredProps {
+export interface BlockRequiredProps {
   superblock?: string;
   block?: string;
+}
+
+export interface ChallengeContentRequiredProps extends BlockRequiredProps {
   challenge?: string;
   content: string;
-}
-
-export interface ChallengeRequiredProps {
-  superblock: string;
-  block: string;
-  challenge: string;
-}
-
-export interface BlockRequiredProps {
-  superblock: string;
-  block: string;
 }

--- a/tools/challenge-editor/client/interfaces/prop-types.ts
+++ b/tools/challenge-editor/client/interfaces/prop-types.ts
@@ -1,7 +1,7 @@
 export interface ChallengeContentRequiredProps {
-  superblock: string;
-  block: string;
-  challenge: string;
+  superblock?: string;
+  block?: string;
+  challenge?: string;
   content: string;
 }
 

--- a/tools/challenge-editor/client/src/components/editor/editor.tsx
+++ b/tools/challenge-editor/client/src/components/editor/editor.tsx
@@ -22,11 +22,7 @@ const Editor = () => {
     fileData: ''
   });
   const [input, setInput] = useState('');
-  const params = useParams() as {
-    superblock: string;
-    block: string;
-    challenge: string;
-  };
+  const params = useParams();
 
   useEffect(() => {
     fetchData();

--- a/tools/challenge-editor/client/src/components/editor/editor.tsx
+++ b/tools/challenge-editor/client/src/components/editor/editor.tsx
@@ -22,7 +22,7 @@ const Editor = () => {
     fileData: ''
   });
   const [input, setInput] = useState('');
-  const params = useParams();
+  const { superblock, block, challenge } = useParams();
 
   useEffect(() => {
     fetchData();
@@ -31,9 +31,7 @@ const Editor = () => {
 
   const fetchData = () => {
     setLoading(true);
-    fetch(
-      `${API_LOCATION}/${params.superblock}/${params.block}/${params.challenge}`
-    )
+    fetch(`${API_LOCATION}/${superblock}/${block}/${challenge}`)
       .then(res => res.json() as Promise<ChallengeContent>)
       .then(
         content => {
@@ -66,7 +64,7 @@ const Editor = () => {
     <div>
       <h1>{items.name}</h1>
       <span className='breadcrumb'>
-        {params.superblock} / {params.block}
+        {superblock} / {block}
       </span>
       <CodeMirror
         value={input}
@@ -82,15 +80,13 @@ const Editor = () => {
         }}
       />
       <SaveChallenge
-        superblock={params.superblock}
-        block={params.block}
-        challenge={params.challenge}
+        superblock={superblock}
+        block={block}
+        challenge={challenge}
         content={input}
       />
       <p>
-        <Link to={`/${params.superblock}/${params.block}`}>
-          Return to Block
-        </Link>
+        <Link to={`/${superblock}/${block}`}>Return to Block</Link>
       </p>
     </div>
   );


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Same types, but with indication that these properties can be undefined. 

Although there will always be a challenge, superblock, and block. The challenge editor can fail to get them, which result that they become undefined.

<!-- Feel free to add any additional description of changes below this line -->
