### PR TITLE
fix(pnpm): disable strict peers flag

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,5 @@
-# Particularly since we're installing them automatically, we want to know about
-# any conflicts
-strict-peer-dependencies=true
+# Disable until we can enable this again
+strict-peer-dependencies=false
 # A lot of our scripts rely on pre and post scripts, so this is necessary for
 # now
 enable-pre-post-scripts=true


### PR DESCRIPTION
This will disable the `strict-peer-dependencies` so that we can accept renovate PRs. This is going to lead to inconsistency in some cases but enabling the flag is a blocker at the moment.
