### PR TITLE
chore(curriculum): no quotes in code strings

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/record-collection.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/record-collection.md
@@ -21,8 +21,8 @@ Complete the function using the rules below to modify the object passed to the f
 
 -   Your function must always return the entire `records` object.
 -   If `value` is an empty string, delete the given `prop` property from the album.
--   If `prop` isn’t `"tracks"` and `value` isn't an empty string, assign the `value` to that album’s `prop`.
--   If `prop` is `"tracks"` and value isn’t an empty string, add the `value` to the end of the album’s `"tracks"` array. You need to create this array first if the album does not have a `"tracks"` property.
+-   If `prop` isn’t `tracks` and `value` isn't an empty string, assign the `value` to that album’s `prop`.
+-   If `prop` is `tracks` and value isn’t an empty string, add the `value` to the end of the album’s `tracks` array. You need to create this array first if the album does not have a `tracks` property.
 
 **Note:** A copy of the `recordCollection` object is used for the tests. You should not directly modify the `recordCollection` object.
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/record-collection.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/record-collection.md
@@ -21,8 +21,8 @@ Complete the function using the rules below to modify the object passed to the f
 
 -   Your function must always return the entire `records` object.
 -   If `value` is an empty string, delete the given `prop` property from the album.
--   If `prop` isn’t `tracks` and `value` isn't an empty string, assign the `value` to that album’s `prop`.
--   If `prop` is `tracks` and value isn’t an empty string, add the `value` to the end of the album’s `tracks` array. You need to create this array first if the album does not have a `tracks` property.
+-   If `prop` isn't `tracks` and `value` isn't an empty string, assign the `value` to that album's `prop`.
+-   If `prop` is `tracks` and value isn't an empty string, add the `value` to the end of the album's `tracks` array. You need to create this array first if the album does not have a `tracks` property.
 
 **Note:** A copy of the `recordCollection` object is used for the tests. You should not directly modify the `recordCollection` object.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

As part of our i18n standards, we don't wrap strings in quotes when we use code tags.