### PR TITLE
fix: only send 500+ status errors to Sentry

### DIFF
--- a/api-server/src/server/middleware.json
+++ b/api-server/src/server/middleware.json
@@ -50,12 +50,6 @@
     "./middlewares/error-handlers": {}
   },
   "final:after": {
-    "./middlewares/sentry-error-handler": {},
-    "strong-error-handler": {
-      "params": {
-        "debug": false,
-        "log": true
-      }
-    }
+    "./middlewares/sentry-error-handler": {}
   }
 }

--- a/api-server/src/server/middleware.json
+++ b/api-server/src/server/middleware.json
@@ -45,11 +45,14 @@
     }
   },
   "files": {},
+  "final:before": {
+    "./middlewares/set-statuscode": {}
+  },
   "final": {
     "./middlewares/csurf-error-handler": {},
-    "./middlewares/error-handlers": {}
+    "./middlewares/sentry-error-handler": {}
   },
   "final:after": {
-    "./middlewares/sentry-error-handler": {}
+    "./middlewares/error-handlers": {}
   }
 }

--- a/api-server/src/server/middleware.json
+++ b/api-server/src/server/middleware.json
@@ -45,10 +45,12 @@
     }
   },
   "files": {},
+  "final": {
+    "./middlewares/csurf-error-handler": {},
+    "./middlewares/error-handlers": {}
+  },
   "final:after": {
     "./middlewares/sentry-error-handler": {},
-    "./middlewares/csurf-error-handler": {},
-    "./middlewares/error-handlers": {},
     "strong-error-handler": {
       "params": {
         "debug": false,

--- a/api-server/src/server/middlewares/error-handlers.js
+++ b/api-server/src/server/middlewares/error-handlers.js
@@ -24,7 +24,9 @@ const isDev = process.env.FREECODECAMP_NODE_ENV !== 'production';
 
 export default function prodErrorHandler() {
   // error handling in production.
-  return function (err, req, res, next) {
+  // NOTE: _next is not used, but has to be there or the middleware will be
+  // silently ignored
+  return function (err, req, res, _next) {
     // response for when req.body is bigger than body-parser's size limit
     if (err?.type === 'entity.too.large') {
       return res.status('413').send('Request payload is too large');
@@ -32,11 +34,6 @@ export default function prodErrorHandler() {
 
     const { origin } = getRedirectParams(req);
     const handled = unwrapHandledError(err);
-    // respect handled error status, with sensible fallbacks - only fall back to
-    // 500 when something has gone wrong with the error handling
-    let status = (handled.status || err.statusCode || res.statusCode) ?? 500;
-
-    res.status(status);
 
     // parse res type
     const accept = accepts(req);
@@ -63,6 +60,5 @@ export default function prodErrorHandler() {
       }
       res.redirectWithFlash(redirectTo);
     }
-    next(err);
   };
 }

--- a/api-server/src/server/middlewares/error-handlers.js
+++ b/api-server/src/server/middlewares/error-handlers.js
@@ -24,7 +24,7 @@ const isDev = process.env.FREECODECAMP_NODE_ENV !== 'production';
 
 export default function prodErrorHandler() {
   // error handling in production.
-  return function (err, req, res, _next) {
+  return function (err, req, res, next) {
     // response for when req.body is bigger than body-parser's size limit
     if (err?.type === 'entity.too.large') {
       return res.status('413').send('Request payload is too large');
@@ -53,7 +53,7 @@ export default function prodErrorHandler() {
     }
 
     if (type === 'json') {
-      return res.json({
+      res.json({
         type: handled.type || 'errors',
         message
       });
@@ -61,7 +61,8 @@ export default function prodErrorHandler() {
       if (typeof req.flash === 'function') {
         req.flash(handled.type || 'danger', message);
       }
-      return res.redirectWithFlash(redirectTo);
+      res.redirectWithFlash(redirectTo);
     }
+    next(err);
   };
 }

--- a/api-server/src/server/middlewares/error-handlers.js
+++ b/api-server/src/server/middlewares/error-handlers.js
@@ -32,11 +32,10 @@ export default function prodErrorHandler() {
 
     const { origin } = getRedirectParams(req);
     const handled = unwrapHandledError(err);
-    // respect handled error status
-    let status = handled.status || err.status || res.statusCode;
-    if (!handled.status && status < 400) {
-      status = 500;
-    }
+    // respect handled error status, with sensible fallbacks - only fall back to
+    // 500 when something has gone wrong with the error handling
+    let status = (handled.status || err.statusCode || res.statusCode) ?? 500;
+
     res.status(status);
 
     // parse res type

--- a/api-server/src/server/middlewares/sentry-error-handler.js
+++ b/api-server/src/server/middlewares/sentry-error-handler.js
@@ -17,7 +17,8 @@ export default function sentryErrorHandler() {
         shouldHandleError(err) {
           // CSRF errors have status 403, consider ignoring them once csurf is
           // no longer rejecting people incorrectly.
-          return !isHandledError(err) && (!err.status || err.status >= 500);
+          const isServerError = !err.statusCode || err.statusCode >= 500;
+          return !isHandledError(err) && isServerError;
         }
       });
 }

--- a/api-server/src/server/middlewares/set-statuscode.js
+++ b/api-server/src/server/middlewares/set-statuscode.js
@@ -10,6 +10,9 @@ export default function setStatusCode() {
       (handled.status || err.statusCode || res.statusCode) ?? 500;
 
     res.status(statusCode);
+    // We overwrite the error's status code, so that Sentry can determine if it
+    // needs to report the error
+    err.statusCode = statusCode;
     next(err);
   };
 }

--- a/api-server/src/server/middlewares/set-statuscode.js
+++ b/api-server/src/server/middlewares/set-statuscode.js
@@ -1,0 +1,15 @@
+import { unwrapHandledError } from '../utils/create-handled-error';
+
+export default function setStatusCode() {
+  return function (err, _req, res, next) {
+    const handled = unwrapHandledError(err);
+
+    // respect handled error status, with sensible fallbacks - only fall back to
+    // 500 when something has gone wrong with the error handling
+    const statusCode =
+      (handled.status || err.statusCode || res.statusCode) ?? 500;
+
+    res.status(statusCode);
+    next(err);
+  };
+}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The motivation for this PR is that we currently send all validation errors to Sentry. Since the api cannot control what requests it receives, it should not do this. Instead, it should only report errors when there is an unhandled server error (i.e. >= 500 status caused by something unexpected).

<!-- Feel free to add any additional description of changes below this line -->
