### PR TITLE
feat: Allow Spacer component to accept children and control spacing direction

### DIFF
--- a/client/src/components/helpers/spacer.tsx
+++ b/client/src/components/helpers/spacer.tsx
@@ -10,13 +10,24 @@ const Padding = Object.freeze({
 type PaddingKeys = keyof typeof Padding;
 interface SpacerProps {
   size: PaddingKeys;
+  children?: JSX.Element;
+  direction?: 'top' | 'bottom';
 }
 
-const Spacer = ({ size }: SpacerProps): JSX.Element => (
+const Spacer = ({ size, children, direction }: SpacerProps): JSX.Element => (
   <div
     className='spacer'
-    style={{ padding: `${Padding[size]}px 0`, height: '1px' }}
-  />
+    style={{
+      padding:
+        direction === 'top'
+          ? `${Padding[size] * 2}px 0 0 0`
+          : direction === 'bottom'
+          ? `0 0 ${Padding[size] * 2}px 0`
+          : `${Padding[size]}px 0`
+    }}
+  >
+    {children}
+  </div>
 );
 
 export default Spacer;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #49828

<!-- Feel free to add any additional description of changes below this line -->
Spacer Component would be able to accept children. The previous usage of this component does not change. Added option to choose a direction of the padding of the spacer to the top, or bottom. 