### PR TITLE
fix(e2e): disable running on firefox temporarily

### DIFF
--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -75,15 +75,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        browsers: [chrome, firefox, electron]
+        browsers: [
+            chrome,
+            # firefox,
+            electron
+          ]
         node-version: [18.x]
         include:
           - browsers: electron
             spec: cypress/e2e/default/learn/challenges/projects.ts
           - browsers: chrome
             spec: cypress/e2e/default/**/*.{js,ts}
-          - browsers: firefox
-            spec: cypress/e2e/default/**/*.{js,ts}
+          # - browsers: firefox
+          #   spec: cypress/e2e/default/**/*.{js,ts}
     services:
       mongodb:
         image: mongo:4.4
@@ -113,13 +117,13 @@ jobs:
           tar -xf client-artifact.tar
           rm client-artifact.tar
 
-      - name: Downgrade Firefox
-        run: |
-          curl https://ftp.mozilla.org/pub/firefox/releases/101.0/linux-x86_64/en-US/firefox-101.0.tar.bz2 --output firefox-101.0.tar.bz2
-          tar -xjf firefox-101.0.tar.bz2
-          sudo mv firefox /opt/
-          sudo mv /usr/bin/firefox /usr/bin/firefox_old
-          sudo ln -s /opt/firefox/firefox /usr/bin/firefox
+      # - name: Downgrade Firefox
+      #   run: |
+      #     curl https://ftp.mozilla.org/pub/firefox/releases/101.0/linux-x86_64/en-US/firefox-101.0.tar.bz2 --output firefox-101.0.tar.bz2
+      #     tar -xjf firefox-101.0.tar.bz2
+      #     sudo mv firefox /opt/
+      #     sudo mv /usr/bin/firefox /usr/bin/firefox_old
+      #     sudo ln -s /opt/firefox/firefox /usr/bin/firefox
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2


### PR DESCRIPTION
Disabled E2E tests on Firefox because they are stalling on all runs. We need to investigate further. 

Will do experiments in #49947 