### PR TITLE
fix: registration form step 47 for the latest version of Safari

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/62b30924c5e4ef0daba23b5e.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/62b30924c5e4ef0daba23b5e.md
@@ -27,7 +27,7 @@ Your `fieldset:last-of-type` should have `border-bottom` set as `none`.
 
 ```js
 const borderBottom = new __helpers.CSSHelp(document).getStyle('fieldset:last-of-type')?.borderBottom;
-assert(borderBottom === 'none' || borderBottom === 'medium none');
+assert(borderBottom === 'none' || borderBottom === 'medium none' || borderBottom === 'medium');
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #49937

<!-- Feel free to add any additional description of changes below this line -->
The following test was not passing on the latest version of safari:
`assert(borderBottom === 'none' || borderBottom === 'medium none');`

Affected Page:
https://www.freecodecamp.org/learn/2022/responsive-web-design/learn-html-forms-by-building-a-registration-form/step-47

Used console.log to find out what string safari returned, turns out it now returns 'medium' for 'border-bottom: none'

<img width="660" alt="Screenshot 2023-04-05 at 5 00 09 AM" src="https://user-images.githubusercontent.com/29229092/230086026-563e76f8-097a-4700-9610-e889973d9e66.png">

Pushed the following changed after removing the console.log line. Tested on safari and chrome

![Screenshot 2023-04-05 at 5 00 35 AM](https://user-images.githubusercontent.com/29229092/230087065-de37ff59-e83a-40fa-9006-411936f272ca.png)


