### PR TITLE
fix(curriculum): Bad Grammar Cat photo App 8

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dc24073f86c76b9248c6ebb.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dc24073f86c76b9248c6ebb.md
@@ -7,9 +7,13 @@ dashedName: step-8
 
 # --description--
 
-HTML <dfn>attributes</dfn> are special words used inside the opening tag of an element to control the element's behavior. The `src` attribute in an `img` element specifies the image's URL (where the image is located). An example of an `img` element using an `src` attribute: `<img src="https://www.example.com/the-image.jpg">`.
+HTML <dfn>attributes</dfn> are special words used inside the opening tag of an element to control the element's behavior. For instance, the `src` attribute in an `img` element specifies the image's URL, which indicates where the image is located. Here is an example of an `img` element using an src attribute: 
 
-Inside the existing `img` element, add an `src` attribute with this URL:
+```html
+<img src="https://www.example.com/the-image.jpg">
+```
+
+Add an src attribute with this URL inside the existing img element:
 
 `https://cdn.freecodecamp.org/curriculum/cat-photo-app/relaxing-cat.jpg`
 


### PR DESCRIPTION
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Before:
![Screenshot 2023-04-05 235553](https://user-images.githubusercontent.com/119855064/230173387-8bae1a28-6345-4b02-a9db-292d6fc732ab.png)

After:
![Screenshot 2023-04-05 235531](https://user-images.githubusercontent.com/119855064/230173518-8411077d-a57a-4a27-8d0c-640625310dd3.png)

Closes #49964


Fixed the Grammar and did some Formatting.

