### PR TITLE
feat(client): adjustable scrollbar width in code editor

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -114,7 +114,7 @@
     "for": "Account Settings for {{username}}",
     "sound-mode": "This adds the pleasant sound of acoustic guitar throughout the website. You'll get musical feedback as you type in the editor, complete challenges, claim certifications, and more.",
     "sound-volume": "Campfire Volume:",
-    "scrollbar-width": "Scrollbar Width",
+    "scrollbar-width": "Editor Scrollbar Width",
     "username": {
       "contains invalid characters": "Username \"{{username}}\" contains invalid characters",
       "is too short": "Username \"{{username}}\" is too short",

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -114,6 +114,7 @@
     "for": "Account Settings for {{username}}",
     "sound-mode": "This adds the pleasant sound of acoustic guitar throughout the website. You'll get musical feedback as you type in the editor, complete challenges, claim certifications, and more.",
     "sound-volume": "Campfire Volume:",
+    "scrollbar-width": "Scrollbar Width",
     "username": {
       "contains invalid characters": "Username \"{{username}}\" contains invalid characters",
       "is too short": "Username \"{{username}}\" is too short",

--- a/client/src/components/settings/about.tsx
+++ b/client/src/components/settings/about.tsx
@@ -17,6 +17,7 @@ import ThemeSettings, { Themes } from './theme';
 import UsernameSettings from './username';
 import KeyboardShortcutsSettings from './keyboard-shortcuts';
 import SectionHeader from './section-header';
+import ScrollbarWidthSettings from './scrollbar-width';
 
 type FormValues = {
   name: string;
@@ -284,6 +285,7 @@ class AboutSettings extends Component<AboutProps, AboutState> {
             keyboardShortcuts={keyboardShortcuts}
             toggleKeyboardShortcuts={toggleKeyboardShortcuts}
           />
+          <ScrollbarWidthSettings />
         </FullWidthRow>
       </>
     );

--- a/client/src/components/settings/keyboard-shortcuts.tsx
+++ b/client/src/components/settings/keyboard-shortcuts.tsx
@@ -1,6 +1,7 @@
 import { Form } from '@freecodecamp/react-bootstrap';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { Spacer } from '../helpers';
 
 import ToggleButtonSetting from './toggle-button-setting';
 
@@ -31,6 +32,7 @@ export default function KeyboardShortcutsSettings({
           toggleKeyboardShortcuts(keyboardShortcuts ? false : true);
         }}
       />
+      <Spacer size='medium'></Spacer>
     </Form>
   );
 }

--- a/client/src/components/settings/scrollbar-width.css
+++ b/client/src/components/settings/scrollbar-width.css
@@ -1,7 +1,7 @@
 input.scrollbar-width[type='range'] {
   -webkit-appearance: none;
   appearance: none;
-  margin-top: 0.5em;
+  margin-top: 1em;
   border: 1px solid #8c8c8c;
 }
 
@@ -11,7 +11,7 @@ input.scrollbar-width[type='range'] {
 
 input.scrollbar-width[type='range']:focus-visible {
   outline: 3px solid var(--focus-outline-color);
-  outline-offset: 2px;
+  outline-offset: 1px;
 }
 
 input.scrollbar-width[type='range']::-webkit-slider-runnable-track {
@@ -48,11 +48,33 @@ input.scrollbar-width[type='range']::-moz-range-thumb {
   background: #3d3d3d;
 }
 
-.scrollbar-width + svg {
-  position: relative;
-  top: -5px;
+.scrollbar-width-numbers {
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
 }
 
-.range__tick {
-  fill: var(--secondary-color);
+.scrollbar-width-numbers span:nth-child(1) {
+  position: relative;
+  left: 0.3rem;
+}
+
+.scrollbar-width-numbers span:nth-child(2) {
+  position: relative;
+  left: 0.425rem;
+}
+
+.scrollbar-width-numbers span:nth-child(3) {
+  position: relative;
+  left: 0.325rem;
+}
+
+.scrollbar-width-numbers span:nth-child(4) {
+  position: relative;
+  left: 0.175rem;
+}
+
+.scrollbar-width-numbers .selected {
+  font-weight: 900;
+  background-color: transparent;
 }

--- a/client/src/components/settings/scrollbar-width.css
+++ b/client/src/components/settings/scrollbar-width.css
@@ -1,12 +1,15 @@
+label[for='scrollbar-width-slider'] {
+  margin-bottom: 1rem;
+}
+
 input.scrollbar-width[type='range'] {
   -webkit-appearance: none;
   appearance: none;
-  margin-top: 1em;
-  border: 1px solid #8c8c8c;
-}
-
-.dark-palette input.scrollbar-width[type='range'] {
-  border: 1px solid #fff;
+  border: 0;
+  background: transparent;
+  position: relative;
+  height: calc(1rem + 6px);
+  background: transparent;
 }
 
 input.scrollbar-width[type='range']:focus-visible {
@@ -16,36 +19,40 @@ input.scrollbar-width[type='range']:focus-visible {
 
 input.scrollbar-width[type='range']::-webkit-slider-runnable-track {
   width: 100%;
-  background: #fff;
+  height: 5px;
+  background: var(--secondary-color);
 }
 
 input.scrollbar-width[type='range']::-webkit-slider-thumb {
   /* box-shadow is needed to allow left hand side of slider track to have 
      same color as right side. */
   box-shadow: 1px 1px 1px #3d3d3d;
-  background: #3d3d3d;
+  background: var(--secondary-color);
   -webkit-appearance: none;
-  width: 19px;
-  border: 0;
+  width: calc(1rem + 6px);
+  height: calc(1rem + 6px);
+  margin-top: -0.5rem;
 }
 
 input.scrollbar-width[type='range']::-moz-range-track {
   width: 100%;
-  height: 25px;
-  background: #fff;
+  height: 5px;
+  background: var(--secondary-color);
 }
 
 input.scrollbar-width[type='range']::-moz-range-progress {
-  background: #fff;
-  height: 25px;
+  background: var(--secondary-color);
+  height: 5px;
 }
 
 input.scrollbar-width[type='range']::-moz-range-thumb {
   box-shadow: 1px 1px 1px #3d3d3d;
-  border: 0;
-  height: 25px;
-  width: 19px;
-  background: #3d3d3d;
+  border: 3px solid var(--secondary-color);
+  height: 1rem;
+  width: 1rem;
+  background: var(--secondary-color);
+  position: relative;
+  z-index: 400;
 }
 
 .scrollbar-width-numbers {
@@ -61,7 +68,7 @@ input.scrollbar-width[type='range']::-moz-range-thumb {
 
 .scrollbar-width-numbers span:nth-child(2) {
   position: relative;
-  left: 0.425rem;
+  left: 0.5rem;
 }
 
 .scrollbar-width-numbers span:nth-child(3) {
@@ -71,10 +78,61 @@ input.scrollbar-width[type='range']::-moz-range-thumb {
 
 .scrollbar-width-numbers span:nth-child(4) {
   position: relative;
-  left: 0.175rem;
+  left: 0.15rem;
+}
+
+.scrollbar-width-numbers span:nth-child(5) {
+  position: relative;
+  left: -0.05rem;
 }
 
 .scrollbar-width-numbers .selected {
   font-weight: 900;
   background-color: transparent;
+}
+
+.scrollbar-width-container .scrollbar-width-ticks {
+  position: relative;
+  display: flex;
+}
+
+.scrollbar-width-container .tick {
+  height: 1rem;
+  width: 1rem;
+  border: 2px solid var(--secondary-color);
+  background: var(--secondary-background);
+  position: absolute;
+  z-index: 200;
+  top: 3px;
+  position: absolute;
+  display: block;
+}
+
+.scrollbar-width-container .tick[data-current='true'] {
+  z-index: -1;
+}
+
+.scrollbar-width-ticks .tick:nth-child(1) {
+  left: 3px;
+}
+
+.scrollbar-width-ticks .tick:nth-child(2) {
+  left: calc(25% - 0.25rem + 2px);
+}
+
+.scrollbar-width-ticks .tick:nth-child(3) {
+  left: calc(50% - 0.5rem + 0.5px);
+}
+
+.scrollbar-width-ticks .tick:nth-child(4) {
+  left: calc(75% - 0.5rem - 5px);
+}
+
+.scrollbar-width-ticks .tick:nth-child(5) {
+  left: calc(100% - 1rem - 2px);
+}
+
+.scrollbar-width-ticks .tick:hover,
+.scrollbar-width-numbers span:hover {
+  cursor: pointer;
 }

--- a/client/src/components/settings/scrollbar-width.css
+++ b/client/src/components/settings/scrollbar-width.css
@@ -1,0 +1,58 @@
+input.scrollbar-width[type='range'] {
+  -webkit-appearance: none;
+  appearance: none;
+  margin-top: 0.5em;
+  border: 1px solid #8c8c8c;
+}
+
+.dark-palette input.scrollbar-width[type='range'] {
+  border: 1px solid #fff;
+}
+
+input.scrollbar-width[type='range']:focus-visible {
+  outline: 3px solid var(--focus-outline-color);
+  outline-offset: 2px;
+}
+
+input.scrollbar-width[type='range']::-webkit-slider-runnable-track {
+  width: 100%;
+  background: #fff;
+}
+
+input.scrollbar-width[type='range']::-webkit-slider-thumb {
+  /* box-shadow is needed to allow left hand side of slider track to have 
+     same color as right side. */
+  box-shadow: 1px 1px 1px #3d3d3d;
+  background: #3d3d3d;
+  -webkit-appearance: none;
+  width: 19px;
+  border: 0;
+}
+
+input.scrollbar-width[type='range']::-moz-range-track {
+  width: 100%;
+  height: 25px;
+  background: #fff;
+}
+
+input.scrollbar-width[type='range']::-moz-range-progress {
+  background: #fff;
+  height: 25px;
+}
+
+input.scrollbar-width[type='range']::-moz-range-thumb {
+  box-shadow: 1px 1px 1px #3d3d3d;
+  border: 0;
+  height: 25px;
+  width: 19px;
+  background: #3d3d3d;
+}
+
+.scrollbar-width + svg {
+  position: relative;
+  top: -5px;
+}
+
+.range__tick {
+  fill: var(--secondary-color);
+}

--- a/client/src/components/settings/scrollbar-width.css
+++ b/client/src/components/settings/scrollbar-width.css
@@ -68,27 +68,27 @@ input.scrollbar-width[type='range']:focus-visible::-moz-range-thumb {
 
 .scrollbar-width-numbers span:nth-child(1) {
   position: relative;
-  left: 0.375rem;
+  inset-inline-start: 0.375rem;
 }
 
 .scrollbar-width-numbers span:nth-child(2) {
   position: relative;
-  left: 0.5rem;
+  inset-inline-start: 0.5rem;
 }
 
 .scrollbar-width-numbers span:nth-child(3) {
   position: relative;
-  left: 0.325rem;
+  inset-inline-start: 0.325rem;
 }
 
 .scrollbar-width-numbers span:nth-child(4) {
   position: relative;
-  left: 0.15rem;
+  inset-inline-start: 0.15rem;
 }
 
 .scrollbar-width-numbers span:nth-child(5) {
   position: relative;
-  left: -0.05rem;
+  inset-inline-start: -0.05rem;
 }
 
 .scrollbar-width-numbers .selected {
@@ -117,11 +117,13 @@ input.scrollbar-width[type='range']:focus-visible::-moz-range-thumb {
   z-index: -1;
 }
 
-.scrollbar-width-ticks .tick:nth-child(1) {
+.scrollbar-width-ticks .tick:nth-child(1),
+[dir='rtl'] .scrollbar-width-ticks .tick:nth-child(5) {
   left: 3px;
 }
 
-.scrollbar-width-ticks .tick:nth-child(2) {
+.scrollbar-width-ticks .tick:nth-child(2),
+[dir='rtl'] .scrollbar-width-ticks .tick:nth-child(4) {
   left: calc(25% - 0.25rem + 2px);
 }
 
@@ -129,11 +131,13 @@ input.scrollbar-width[type='range']:focus-visible::-moz-range-thumb {
   left: calc(50% - 0.5rem + 0.5px);
 }
 
-.scrollbar-width-ticks .tick:nth-child(4) {
+.scrollbar-width-ticks .tick:nth-child(4),
+[dir='rtl'] .scrollbar-width-ticks .tick:nth-child(2) {
   left: calc(75% - 0.5rem - 5px);
 }
 
-.scrollbar-width-ticks .tick:nth-child(5) {
+.scrollbar-width-ticks .tick:nth-child(5),
+[dir='rtl'] .scrollbar-width-ticks .tick:nth-child(1) {
   left: calc(100% - 1rem - 2px);
 }
 

--- a/client/src/components/settings/scrollbar-width.css
+++ b/client/src/components/settings/scrollbar-width.css
@@ -12,11 +12,6 @@ input.scrollbar-width[type='range'] {
   background: transparent;
 }
 
-input.scrollbar-width[type='range']:focus-visible {
-  outline: 3px solid var(--focus-outline-color);
-  outline-offset: 1px;
-}
-
 input.scrollbar-width[type='range']::-webkit-slider-runnable-track {
   width: 100%;
   height: 5px;
@@ -32,6 +27,11 @@ input.scrollbar-width[type='range']::-webkit-slider-thumb {
   width: calc(1rem + 6px);
   height: calc(1rem + 6px);
   margin-top: -0.5rem;
+}
+
+input.scrollbar-width[type='range']:focus-visible::-webkit-slider-thumb {
+  outline: 3px solid var(--focus-outline-color);
+  outline-offset: -3px;
 }
 
 input.scrollbar-width[type='range']::-moz-range-track {
@@ -55,6 +55,11 @@ input.scrollbar-width[type='range']::-moz-range-thumb {
   z-index: 400;
 }
 
+input.scrollbar-width[type='range']:focus-visible::-moz-range-thumb {
+  outline: 3px solid var(--focus-outline-color);
+  outline-offset: -3px;
+}
+
 .scrollbar-width-numbers {
   display: flex;
   width: 100%;
@@ -63,7 +68,7 @@ input.scrollbar-width[type='range']::-moz-range-thumb {
 
 .scrollbar-width-numbers span:nth-child(1) {
   position: relative;
-  left: 0.3rem;
+  left: 0.375rem;
 }
 
 .scrollbar-width-numbers span:nth-child(2) {

--- a/client/src/components/settings/scrollbar-width.css
+++ b/client/src/components/settings/scrollbar-width.css
@@ -107,7 +107,7 @@ input.scrollbar-width[type='range']:focus-visible::-moz-range-thumb {
   border: 2px solid var(--secondary-color);
   background: var(--secondary-background);
   position: absolute;
-  z-index: 200;
+  z-index: 100;
   top: 3px;
   position: absolute;
   display: block;
@@ -140,4 +140,12 @@ input.scrollbar-width[type='range']:focus-visible::-moz-range-thumb {
 .scrollbar-width-ticks .tick:hover,
 .scrollbar-width-numbers span:hover {
   cursor: pointer;
+}
+
+.scrollbar-width-preview {
+  display: inline-block;
+  background: var(--secondary-color);
+  height: 1.5rem;
+  position: absolute;
+  margin: 0 0.5rem;
 }

--- a/client/src/components/settings/scrollbar-width.css
+++ b/client/src/components/settings/scrollbar-width.css
@@ -9,7 +9,6 @@ input.scrollbar-width[type='range'] {
   background: transparent;
   position: relative;
   height: calc(1rem + 6px);
-  background: transparent;
 }
 
 input.scrollbar-width[type='range']::-webkit-slider-runnable-track {
@@ -109,7 +108,6 @@ input.scrollbar-width[type='range']:focus-visible::-moz-range-thumb {
   position: absolute;
   z-index: 100;
   top: 3px;
-  position: absolute;
   display: block;
 }
 

--- a/client/src/components/settings/scrollbar-width.tsx
+++ b/client/src/components/settings/scrollbar-width.tsx
@@ -3,6 +3,7 @@ import React, { ChangeEvent, useState, useRef } from 'react';
 import store from 'store';
 import { useTranslation } from 'react-i18next';
 import { Spacer } from '../helpers';
+import { getScrollbarWidth } from '../../utils/scrollbar-width';
 import './scrollbar-width.css';
 
 const ticks = [5, 10, 15, 20, 25];
@@ -11,11 +12,6 @@ export default function ScrollbarWidthSettings(): JSX.Element {
   const { t } = useTranslation();
   const [scrollbarWidth, setScrollbarWidth] = useState(getScrollbarWidth());
   const rangeRef = useRef<HTMLInputElement>(null);
-
-  function getScrollbarWidth() {
-    const storedWidth = parseInt(store.get('monacoScrollbarWidth'));
-    return storedWidth >= 5 || storedWidth <= 25 ? storedWidth : 5;
-  }
 
   function handleChange(event: ChangeEvent<HTMLInputElement>) {
     const inputValue = Number(event.target.value);

--- a/client/src/components/settings/scrollbar-width.tsx
+++ b/client/src/components/settings/scrollbar-width.tsx
@@ -3,10 +3,13 @@ import React, { ChangeEvent, useState } from 'react';
 import store from 'store';
 import { useTranslation } from 'react-i18next';
 import { Spacer } from '../helpers';
+import './scrollbar-width.css';
 
 export default function ScrollbarWidthSettings(): JSX.Element {
   const { t } = useTranslation();
   const [scrollbarWidth, setScrollbarWidth] = useState(getScrollbarWidth());
+  const tickHeight = 10;
+  const tickWidth = 3;
 
   function getScrollbarWidth() {
     const storedWidth = parseInt(store.get('monacoScrollbarWidth'));
@@ -22,7 +25,8 @@ export default function ScrollbarWidthSettings(): JSX.Element {
   return (
     <Form inline={true} onSubmit={(e: React.FormEvent) => e.preventDefault()}>
       <label htmlFor='scrollbar-width-slider'>
-        {t('settings.scrollbar-width')}
+        {t('settings.scrollbar-width')}:{' '}
+        <span aria-hidden='true'>{scrollbarWidth}</span>
       </label>
       <input
         type='range'
@@ -30,10 +34,52 @@ export default function ScrollbarWidthSettings(): JSX.Element {
         max='25'
         step='5'
         id='scrollbar-width-slider'
+        className='scrollbar-width'
         defaultValue={scrollbarWidth}
-        className='soundbar'
         onInput={handleChange}
       />
+      <svg
+        role='presentation'
+        width='100%'
+        height={tickHeight}
+        xmlns='http://www.w3.org/2000/svg'
+      >
+        <rect
+          className='range__tick'
+          x='8'
+          y='0'
+          width={tickWidth}
+          height={tickHeight}
+        ></rect>
+        <rect
+          className='range__tick'
+          x='25.6%'
+          y='0'
+          width={tickWidth}
+          height={tickHeight}
+        ></rect>
+        <rect
+          className='range__tick'
+          x='50%'
+          y='0'
+          width={tickWidth}
+          height={tickHeight}
+        ></rect>
+        <rect
+          className='range__tick'
+          x='74%'
+          y='0'
+          width={tickWidth}
+          height={tickHeight}
+        ></rect>
+        <rect
+          className='range__tick'
+          x='98.25%'
+          y='0'
+          width={tickWidth}
+          height={tickHeight}
+        ></rect>
+      </svg>
       <Spacer size='medium'></Spacer>
     </Form>
   );

--- a/client/src/components/settings/scrollbar-width.tsx
+++ b/client/src/components/settings/scrollbar-width.tsx
@@ -1,13 +1,16 @@
 import { Form } from '@freecodecamp/react-bootstrap';
-import React, { ChangeEvent, useState } from 'react';
+import React, { ChangeEvent, useState, useRef } from 'react';
 import store from 'store';
 import { useTranslation } from 'react-i18next';
 import { Spacer } from '../helpers';
 import './scrollbar-width.css';
 
+const ticks = [5, 10, 15, 20, 25];
+
 export default function ScrollbarWidthSettings(): JSX.Element {
   const { t } = useTranslation();
   const [scrollbarWidth, setScrollbarWidth] = useState(getScrollbarWidth());
+  const rangeRef = useRef<HTMLInputElement>(null);
 
   function getScrollbarWidth() {
     const storedWidth = parseInt(store.get('monacoScrollbarWidth'));
@@ -20,35 +23,61 @@ export default function ScrollbarWidthSettings(): JSX.Element {
     store.set('monacoScrollbarWidth', inputValue);
   }
 
+  function handleClick(event: React.MouseEvent<HTMLSpanElement>) {
+    const target = event.target as HTMLSpanElement;
+    const newScrollbarWidth = Number(target.dataset.value);
+
+    if (!rangeRef?.current || !ticks.includes(newScrollbarWidth)) return;
+    rangeRef.current.focus();
+
+    if (newScrollbarWidth === scrollbarWidth) return;
+    rangeRef.current.value = String(newScrollbarWidth);
+    setScrollbarWidth(newScrollbarWidth);
+    store.set('monacoScrollbarWidth', newScrollbarWidth);
+  }
+
+  /* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
+
   return (
     <Form inline={true} onSubmit={(e: React.FormEvent) => e.preventDefault()}>
       <label htmlFor='scrollbar-width-slider'>
         {t('settings.scrollbar-width')}
       </label>
-      <input
-        type='range'
-        min='5'
-        max='25'
-        step='5'
-        id='scrollbar-width-slider'
-        className='scrollbar-width'
-        defaultValue={scrollbarWidth}
-        onInput={handleChange}
-      />
-      <div className='scrollbar-width-numbers' aria-hidden='true'>
-        <span {...(scrollbarWidth === 5 && { className: 'selected' })}>5</span>
-        <span {...(scrollbarWidth === 10 && { className: 'selected' })}>
-          10
-        </span>
-        <span {...(scrollbarWidth === 15 && { className: 'selected' })}>
-          15
-        </span>
-        <span {...(scrollbarWidth === 20 && { className: 'selected' })}>
-          20
-        </span>
-        <span {...(scrollbarWidth === 25 && { className: 'selected' })}>
-          25
-        </span>
+      <div className='scrollbar-width-container'>
+        <div className='scrollbar-width-ticks' aria-hidden='true'>
+          {ticks.map(tick => (
+            <span
+              className='tick'
+              onClick={handleClick}
+              data-value={tick}
+              key={`tick${tick}`}
+              {...(scrollbarWidth === tick && { 'data-current': true })}
+            />
+          ))}
+        </div>
+        <input
+          type='range'
+          min='5'
+          max='25'
+          step='5'
+          id='scrollbar-width-slider'
+          className='scrollbar-width'
+          defaultValue={scrollbarWidth}
+          onInput={handleChange}
+          ref={rangeRef}
+        />
+        <div className='scrollbar-width-numbers' aria-hidden='true'>
+          {ticks.map(tick => (
+            <span
+              onClick={handleClick}
+              data-value={tick}
+              key={`num${tick}`}
+              {...(scrollbarWidth === tick && { className: 'selected' })}
+            >
+              {tick}
+            </span>
+          ))}
+        </div>
       </div>
       <Spacer size='medium'></Spacer>
     </Form>

--- a/client/src/components/settings/scrollbar-width.tsx
+++ b/client/src/components/settings/scrollbar-width.tsx
@@ -1,0 +1,42 @@
+import { Form } from '@freecodecamp/react-bootstrap';
+import React, { ChangeEvent, useState } from 'react';
+import store from 'store';
+import { useTranslation } from 'react-i18next';
+import { Spacer } from '../helpers';
+
+export default function ScrollbarWidthSettings(): JSX.Element {
+  const { t } = useTranslation();
+  const [scrollbarWidth, setScrollbarWidth] = useState(getScrollbarWidth());
+
+  function getScrollbarWidth() {
+    const storedWidth = parseInt(store.get('monacoScrollbarWidth'));
+    return storedWidth >= 5 || storedWidth <= 25 ? storedWidth : 5;
+  }
+
+  function handleChange(event: ChangeEvent<HTMLInputElement>) {
+    const inputValue = Number(event.target.value);
+    setScrollbarWidth(inputValue);
+    store.set('monacoScrollbarWidth', inputValue);
+  }
+
+  return (
+    <Form inline={true} onSubmit={(e: React.FormEvent) => e.preventDefault()}>
+      <label htmlFor='scrollbar-width-slider'>
+        {t('settings.scrollbar-width')}
+      </label>
+      <input
+        type='range'
+        min='5'
+        max='25'
+        step='5'
+        id='scrollbar-width-slider'
+        defaultValue={scrollbarWidth}
+        className='soundbar'
+        onInput={handleChange}
+      />
+      <Spacer size='medium'></Spacer>
+    </Form>
+  );
+}
+
+ScrollbarWidthSettings.displayName = 'ScrollbarWidthSettings';

--- a/client/src/components/settings/scrollbar-width.tsx
+++ b/client/src/components/settings/scrollbar-width.tsx
@@ -41,7 +41,11 @@ export default function ScrollbarWidthSettings(): JSX.Element {
   return (
     <Form inline={true} onSubmit={(e: React.FormEvent) => e.preventDefault()}>
       <label htmlFor='scrollbar-width-slider'>
-        {t('settings.scrollbar-width')}
+        {t('settings.scrollbar-width')}:
+        <span
+          className='scrollbar-width-preview'
+          style={{ width: `${scrollbarWidth}px` } as React.CSSProperties}
+        />
       </label>
       <div className='scrollbar-width-container'>
         <div className='scrollbar-width-ticks' aria-hidden='true'>

--- a/client/src/components/settings/scrollbar-width.tsx
+++ b/client/src/components/settings/scrollbar-width.tsx
@@ -8,8 +8,6 @@ import './scrollbar-width.css';
 export default function ScrollbarWidthSettings(): JSX.Element {
   const { t } = useTranslation();
   const [scrollbarWidth, setScrollbarWidth] = useState(getScrollbarWidth());
-  const tickHeight = 10;
-  const tickWidth = 3;
 
   function getScrollbarWidth() {
     const storedWidth = parseInt(store.get('monacoScrollbarWidth'));
@@ -25,8 +23,7 @@ export default function ScrollbarWidthSettings(): JSX.Element {
   return (
     <Form inline={true} onSubmit={(e: React.FormEvent) => e.preventDefault()}>
       <label htmlFor='scrollbar-width-slider'>
-        {t('settings.scrollbar-width')}:{' '}
-        <span aria-hidden='true'>{scrollbarWidth}</span>
+        {t('settings.scrollbar-width')}
       </label>
       <input
         type='range'
@@ -38,48 +35,21 @@ export default function ScrollbarWidthSettings(): JSX.Element {
         defaultValue={scrollbarWidth}
         onInput={handleChange}
       />
-      <svg
-        role='presentation'
-        width='100%'
-        height={tickHeight}
-        xmlns='http://www.w3.org/2000/svg'
-      >
-        <rect
-          className='range__tick'
-          x='8'
-          y='0'
-          width={tickWidth}
-          height={tickHeight}
-        ></rect>
-        <rect
-          className='range__tick'
-          x='25.6%'
-          y='0'
-          width={tickWidth}
-          height={tickHeight}
-        ></rect>
-        <rect
-          className='range__tick'
-          x='50%'
-          y='0'
-          width={tickWidth}
-          height={tickHeight}
-        ></rect>
-        <rect
-          className='range__tick'
-          x='74%'
-          y='0'
-          width={tickWidth}
-          height={tickHeight}
-        ></rect>
-        <rect
-          className='range__tick'
-          x='98.25%'
-          y='0'
-          width={tickWidth}
-          height={tickHeight}
-        ></rect>
-      </svg>
+      <div className='scrollbar-width-numbers' aria-hidden='true'>
+        <span {...(scrollbarWidth === 5 && { className: 'selected' })}>5</span>
+        <span {...(scrollbarWidth === 10 && { className: 'selected' })}>
+          10
+        </span>
+        <span {...(scrollbarWidth === 15 && { className: 'selected' })}>
+          15
+        </span>
+        <span {...(scrollbarWidth === 20 && { className: 'selected' })}>
+          20
+        </span>
+        <span {...(scrollbarWidth === 25 && { className: 'selected' })}>
+          25
+        </span>
+      </div>
       <Spacer size='medium'></Spacer>
     </Form>
   );

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -761,13 +761,18 @@ const Editor = (props: EditorProps): JSX.Element => {
     return domNode;
   }
 
+  // Take the current scrollbar width into account
+  function getEditorContentWidth(editor: editor.IStandaloneCodeEditor) {
+    return editor.getLayoutInfo().contentWidth - getScrollbarWidth();
+  }
+
   function createOutputNode(editor: editor.IStandaloneCodeEditor) {
     if (dataRef.current.outputNode) return dataRef.current.outputNode;
     const outputNode = document.createElement('div');
     outputNode.classList.add('editor-lower-jaw');
     outputNode.setAttribute('id', 'editor-lower-jaw');
     outputNode.style.left = `${editor.getLayoutInfo().contentLeft}px`;
-    outputNode.style.width = `${editor.getLayoutInfo().contentWidth}px`;
+    outputNode.style.width = `${getEditorContentWidth(editor)}px`;
     outputNode.style.top = getOutputZoneTop();
     dataRef.current.outputNode = outputNode;
     return outputNode;
@@ -975,7 +980,7 @@ const Editor = (props: EditorProps): JSX.Element => {
     const getDomNode = () => domNode;
     const getPosition = () => {
       if (getTop) {
-        domNode.style.width = `${editor.getLayoutInfo().contentWidth}px`;
+        domNode.style.width = `${getEditorContentWidth(editor)}px`;
         domNode.style.top = getTop();
       }
       // must return null, so that Monaco knows the widget will position

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -286,7 +286,7 @@ const Editor = (props: EditorProps): JSX.Element => {
       vertical: 'visible',
       verticalHasArrows: false,
       useShadows: false,
-      verticalScrollbarSize: 5
+      verticalScrollbarSize: getScrollbarWidth()
     },
     parameterHints: {
       enabled: false
@@ -303,6 +303,11 @@ const Editor = (props: EditorProps): JSX.Element => {
     suggestOnTriggerCharacters: false,
     lineNumbersMinChars: 2
   };
+
+  function getScrollbarWidth() {
+    const storedWidth = parseInt(store.get('monacoScrollbarWidth'));
+    return storedWidth >= 5 || storedWidth <= 25 ? storedWidth : 5;
+  }
 
   const getEditableRegionFromRedux = () => {
     const { challengeFiles, fileKey } = props;

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -61,6 +61,7 @@ import {
 } from '../redux/selectors';
 import GreenPass from '../../../assets/icons/green-pass';
 import { enhancePrismAccessibility } from '../utils/index';
+import { getScrollbarWidth } from '../../../utils/scrollbar-width';
 import LowerJaw from './lower-jaw';
 
 import './editor.css';
@@ -303,11 +304,6 @@ const Editor = (props: EditorProps): JSX.Element => {
     suggestOnTriggerCharacters: false,
     lineNumbersMinChars: 2
   };
-
-  function getScrollbarWidth() {
-    const storedWidth = parseInt(store.get('monacoScrollbarWidth'));
-    return storedWidth >= 5 || storedWidth <= 25 ? storedWidth : 5;
-  }
 
   const getEditableRegionFromRedux = () => {
     const { challengeFiles, fileKey } = props;

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -624,7 +624,7 @@ const Editor = (props: EditorProps): JSX.Element => {
 
     // make sure the overlayWidget has resized before using it to set the height
 
-    domNode.style.width = `${editor.getLayoutInfo().contentWidth}px`;
+    domNode.style.width = `${getEditorContentWidth(editor)}px`;
 
     // We have to wait for the viewZone to finish rendering before adjusting the
     // position of the content widget (i.e. trigger it via onDomNodeTop). If
@@ -694,7 +694,7 @@ const Editor = (props: EditorProps): JSX.Element => {
     editor: editor.IStandaloneCodeEditor
   ) => {
     // make sure the overlayWidget has resized before using it to set the height
-    outputNode.style.width = `${editor.getLayoutInfo().contentWidth}px`;
+    outputNode.style.width = `${getEditorContentWidth(editor)}px`;
     // We have to wait for the viewZone to finish rendering before adjusting the
     // position of the overlayWidget (i.e. trigger it via onComputedHeight). If
     // not the editor may report the wrong value for position of the lines.
@@ -754,7 +754,7 @@ const Editor = (props: EditorProps): JSX.Element => {
     domNode.style.userSelect = 'text';
 
     domNode.style.left = `${editor.getLayoutInfo().contentLeft}px`;
-    domNode.style.width = `${editor.getLayoutInfo().contentWidth}px`;
+    domNode.style.width = `${getEditorContentWidth(editor)}px`;
 
     domNode.style.top = getDescriptionZoneTop();
     dataRef.current.descriptionNode = domNode;

--- a/client/src/utils/scrollbar-width.ts
+++ b/client/src/utils/scrollbar-width.ts
@@ -1,0 +1,6 @@
+import store from 'store';
+
+export function getScrollbarWidth(): number {
+  const storedWidth = parseInt(store.get('monacoScrollbarWidth'));
+  return storedWidth >= 5 || storedWidth <= 25 ? storedWidth : 5;
+}

--- a/cypress/e2e/default/settings/scrollbar-width.ts
+++ b/cypress/e2e/default/settings/scrollbar-width.ts
@@ -1,0 +1,41 @@
+describe('Editor scrollbar width', () => {
+  beforeEach(() => {
+    cy.login();
+    cy.visit('/settings');
+  });
+
+  let upperJawWidth;
+
+  it('Default editor scrollbar width should be 5px', () => {
+    cy.get('#scrollbar-width-slider').should('have.value', '5');
+    cy.visit(
+      '/learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-2'
+    );
+    cy.get('.editor-upper-jaw').then($editorUpperJaw => {
+      upperJawWidth = Number($editorUpperJaw.outerWidth());
+    });
+    cy.get('#editor-lower-jaw').should($editorLowerJaw => {
+      expect(upperJawWidth).to.equal(Number($editorLowerJaw.outerWidth()));
+    });
+    cy.get('.monaco-scrollable-element').should($scrollable => {
+      expect(upperJawWidth).to.equal(Number($scrollable.outerWidth()) - 5);
+    });
+  });
+
+  it('Should allow you to change editor scrollbar width to 25px', () => {
+    cy.get('.scrollbar-width-numbers > [data-value="25"]').click();
+    cy.get('#scrollbar-width-slider').should('have.value', '25');
+    cy.visit(
+      '/learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-2'
+    );
+    cy.get('.editor-upper-jaw').then($editorUpperJaw => {
+      upperJawWidth = Number($editorUpperJaw.outerWidth());
+    });
+    cy.get('#editor-lower-jaw').should($editorLowerJaw => {
+      expect(upperJawWidth).to.equal(Number($editorLowerJaw.outerWidth()));
+    });
+    cy.get('.monaco-scrollable-element').should($scrollable => {
+      expect(upperJawWidth).to.equal(Number($scrollable.outerWidth()) - 25);
+    });
+  });
+});


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Based on the excellent suggestion from @raisedadead in this forum post:

https://forum.freecodecamp.org/t/scroll-wheel-size-is-too-small/602363

This implements the ability for the user to customize the width of the vertical scroll bar in the monaco editor.