### PR TITLE
refactor(client): align campers type with stored User (#49982

### DIFF
--- a/client/src/components/profile/__snapshots__/profile.test.tsx.snap
+++ b/client/src/components/profile/__snapshots__/profile.test.tsx.snap
@@ -273,6 +273,11 @@ exports[`<Profile/> renders correctly 1`] = `
       
       
       <br />
+      <p
+        class="text-center points"
+      >
+        profile.total-points
+      </p>
     </div>
     <div
       class="spacer"

--- a/client/src/components/profile/components/camper.tsx
+++ b/client/src/components/profile/components/camper.tsx
@@ -8,6 +8,7 @@ import { Col, Row } from '@freecodecamp/react-bootstrap';
 import React from 'react';
 import type { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
+import type { User } from '../../../redux/prop-types';
 
 import envData from '../../../../../config/env.json';
 import { getLangCode } from '../../../../../config/i18n';
@@ -21,21 +22,23 @@ const { clientLocale } = envData;
 
 const localeCode = getLangCode(clientLocale);
 
-interface CamperProps {
-  about: string;
-  githubProfile: string;
-  isDonating: boolean;
-  joinDate: string;
-  linkedin: string;
-  location: string;
-  name: string;
-  picture: string;
-  points: number | null;
-  twitter: string;
-  username: string;
-  website: string;
-  yearsTopContributor: string[];
-}
+export type CamperProps = Pick<
+  User,
+  | 'about'
+  | 'githubProfile'
+  | 'isDonating'
+  | 'linkedin'
+  | 'points'
+  | 'username'
+  | 'twitter'
+  | 'yearsTopContributor'
+  | 'location'
+  | 'website'
+  | 'picture'
+  | 'name'
+  | 'joinDate'
+  | 'twitter'
+>;
 
 function joinArray(array: string[], t: TFunction): string {
   return array.reduce((string, item, index, array) => {
@@ -124,11 +127,9 @@ function Camper({
         </div>
       )}
       <br />
-      {typeof points === 'number' ? (
-        <p className='text-center points'>
-          {t('profile.total-points', { count: points })}
-        </p>
-      ) : null}
+      <p className='text-center points'>
+        {t('profile.total-points', { count: points })}
+      </p>
     </div>
   );
 }

--- a/client/src/components/settings/about.tsx
+++ b/client/src/components/settings/about.tsx
@@ -12,6 +12,7 @@ import { withTranslation } from 'react-i18next';
 import isURL from 'validator/lib/isURL';
 import { FullWidthRow, Spacer } from '../helpers';
 import BlockSaveButton from '../helpers/form/block-save-button';
+import type { CamperProps } from '../profile/components/camper';
 import SoundSettings from './sound';
 import ThemeSettings, { Themes } from './theme';
 import UsernameSettings from './username';
@@ -25,13 +26,17 @@ type FormValues = {
   about: string;
 };
 
-type AboutProps = {
-  about: string;
+type AboutProps = Omit<
+  CamperProps,
+  | 'linkedin'
+  | 'joinDate'
+  | 'isDonating'
+  | 'githubProfile'
+  | 'twitter'
+  | 'website'
+  | 'yearsTopContributor'
+> & {
   currentTheme: Themes;
-  location: string;
-  name: string;
-  picture: string;
-  points: number;
   sound: boolean;
   keyboardShortcuts: boolean;
   submitNewAbout: (formValues: FormValues) => void;
@@ -39,7 +44,6 @@ type AboutProps = {
   toggleNightMode: (theme: Themes) => void;
   toggleSoundMode: (sound: boolean) => void;
   toggleKeyboardShortcuts: (keyboardShortcuts: boolean) => void;
-  username: string;
 };
 
 type AboutState = {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The types weren't aligned which cased one type to wrong, this fix the type and align them with each others

<!-- Feel free to add any additional description of changes below this line -->
