### PR TITLE
fix(actions,e2e): update spec formats

### DIFF
--- a/.github/workflows/e2e-mobile.yml
+++ b/.github/workflows/e2e-mobile.yml
@@ -69,6 +69,17 @@ jobs:
           flutter pub get
           flutter test test/widget_test.dart
 
+        # This is a workaround for the fact that Cypress does not support
+        # running in a sub-directory.
+        #
+        # In our cypress config, we default to the cypress/e2e/default directory.
+        # We need to change this to cypress/e2e/ for the specific tests we are running
+        # in this workflow.
+        #
+      - name: Adjust the Cypress Config for 3rd party donation tests
+        run: |
+          sed -i 's#cypress/e2e/default/#cypress/e2e/#g' cypress.config.js
+
       - name: Cypress run
         uses: cypress-io/github-action@v4
         with:

--- a/.github/workflows/e2e-third-party.yml
+++ b/.github/workflows/e2e-third-party.yml
@@ -8,6 +8,8 @@ on:
       - 'prod-**'
     paths-ignore:
       - 'docs/**'
+  # to test this ad-hoc
+  workflow_dispatch:
 
 jobs:
   do-everything:
@@ -66,6 +68,14 @@ jobs:
       - name: Move serve.json to Public Folder
         run: cp client-config/serve.json client/public/serve.json
 
+        # In our cypress config, we default to the cypress/e2e/default directory.
+        # We need to change this to cypress/e2e/ for the specific tests we are running
+        # in this workflow.
+        #
+      - name: Adjust the Cypress Config for 3rd party donation tests
+        run: |
+          sed -i 's#cypress/e2e/default/#cypress/e2e/#g' cypress.config.js
+
       - name: Cypress run
         uses: cypress-io/github-action@v4
         with:
@@ -75,5 +85,4 @@ jobs:
           wait-on-timeout: 1200
           config: baseUrl=http://localhost:8000
           browser: chrome
-
-          spec: cypress/e2e/third-party/*.{js,ts}
+          spec: 'cypress/e2e/third-party/donate-page.ts'

--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -80,10 +80,7 @@ jobs:
         include:
           - browsers: electron
             spec: cypress/e2e/default/learn/challenges/projects.ts
-          - browsers: chrome
-            spec: cypress/e2e/default/**/*.{js,ts}
-          # - browsers: firefox
-          #   spec: cypress/e2e/default/**/*.{js,ts}
+
     services:
       mongodb:
         image: mongo:4.4
@@ -147,5 +144,4 @@ jobs:
           wait-on-timeout: 1200
           config: baseUrl=http://localhost:8000
           browser: ${{ matrix.browsers }}
-
           spec: ${{ matrix.spec }}


### PR DESCRIPTION
This PR should fix the broken tests on third-party workflows and clean up the normal workflows:

- Added a `worlflow_displatch` to help test workflow before they hit the `prod-**` branch
- DRY the code for the normal workflow for the web, the specs are defined in the cypress config.
