### PR TITLE
fix(curriculum): server timezone/date issue and format

### DIFF
--- a/curriculum/challenges/english/05-back-end-development-and-apis/back-end-development-and-apis-projects/exercise-tracker.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/back-end-development-and-apis-projects/exercise-tracker.md
@@ -519,7 +519,8 @@ async(getUserInput) => {
       description: 'test',
       duration: 60,
       _id,
-      date: new Date().toDateString()
+      date: new Date().toLocaleDateString("en-US", {timeZone: "UTC", weekday: "short", month: "short", 
+                                                    day: "2-digit", year: "numeric"}).replaceAll(',', '')
     };
     const addRes = await fetch(url + `/api/users/${_id}/exercises`, {
       method: 'POST',

--- a/curriculum/challenges/english/05-back-end-development-and-apis/back-end-development-and-apis-projects/exercise-tracker.md
+++ b/curriculum/challenges/english/05-back-end-development-and-apis/back-end-development-and-apis-projects/exercise-tracker.md
@@ -519,8 +519,9 @@ async(getUserInput) => {
       description: 'test',
       duration: 60,
       _id,
-      date: new Date().toLocaleDateString("en-US", {timeZone: "UTC", weekday: "short", month: "short", 
-                                                    day: "2-digit", year: "numeric"}).replaceAll(',', '')
+      date: new Date().toLocaleDateString("en-US", {
+        timeZone: "UTC", weekday: "short", month: "short",
+        day: "2-digit", year: "numeric"
     };
     const addRes = await fetch(url + `/api/users/${_id}/exercises`, {
       method: 'POST',


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #44475 

<!-- Feel free to add any additional description of changes below this line -->

Both submissions contain same code, in before case, submission is unfairly denied because the time zone of replit server differs from local time, causing incorrect insertion when checking for date. Possible to test yourself using this repl.it: https://boilerplate-project-exercisetracker-1.mickeymind.repl.co/

Before:  Test case uses local time zone which checks for date of April 07 (1 day ahead of submission date). 

      Replit uses UTC time zone which can be up to 14 hours behind local time.

![image](https://user-images.githubusercontent.com/103330664/230502991-58df69c3-8bbe-45cc-b288-195bb6abd09a.png)

After: Test case uses UTC time zone which checks for date of April 06 (actual submission date). 

      Put simply, both servers now only output and check for UTC time zone, so doesn't matter what time zone you submit from 
     (as long as the code works)

![image](https://user-images.githubusercontent.com/103330664/230504087-ec98c3a8-de81-47ba-82ca-c36c5a6cb6dc.png)


