### PR TITLE
fix(client): warn user on failed submission for backend project

### DIFF
--- a/client/src/templates/Challenges/redux/completion-epic.js
+++ b/client/src/templates/Challenges/redux/completion-epic.js
@@ -10,6 +10,8 @@ import {
   tap,
   mergeMap
 } from 'rxjs/operators';
+import { createFlashMessage } from '../../../components/Flash/redux';
+import standardErrorMessage from '../../../utils/standard-error-message';
 import { challengeTypes, submitTypes } from '../../../../utils/challenge-types';
 import { actionTypes as submitActionTypes } from '../../../redux/action-types';
 import {
@@ -204,6 +206,8 @@ export default function completionEpic(action$, state$) {
         tap(res => {
           if (res.type !== submitActionTypes.updateFailed) {
             navigate(pathToNavigateTo);
+          } else {
+            createFlashMessage(standardErrorMessage);
           }
         }),
         concat(of(closeModal('completion')))


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to #49883

<!-- Feel free to add any additional description of changes below this line -->

I used `createFlashMessage` as suggested here: https://github.com/freeCodeCamp/freeCodeCamp/pull/46734#issuecomment-1273414965
But I'm not sure what is the expected behavior for this message.