### PR TITLE
test(api): always start server before testing

### DIFF
--- a/api/jest.config.ts
+++ b/api/jest.config.ts
@@ -5,7 +5,8 @@ const config: Config = {
   testRegex: '\\.test\\.ts$',
   transform: {
     '^.+\\.ts$': 'ts-jest'
-  }
+  },
+  setupFilesAfterEnv: ['<rootDir>/jest.start-server.ts']
 };
 
 export default config;

--- a/api/jest.start-server.ts
+++ b/api/jest.start-server.ts
@@ -1,0 +1,18 @@
+import { build } from './src/app';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var fastifyTestInstance: Awaited<ReturnType<typeof build>>;
+}
+
+beforeAll(async () => {
+  const fastify = await build();
+  await fastify.ready();
+  global.fastifyTestInstance = fastify;
+});
+
+afterAll(async () => {
+  // Due to a prisma bug, this is not enough, we need to --force-exit jest:
+  // https://github.com/prisma/prisma/issues/18146
+  await fastifyTestInstance?.close();
+});

--- a/api/src/server.test.ts
+++ b/api/src/server.test.ts
@@ -1,28 +1,13 @@
-import request, { Response } from 'supertest';
-
-import { build } from './app';
+import request from 'supertest';
 
 describe('GET /', () => {
-  let res: undefined | Response;
-  let fastify: undefined | Awaited<ReturnType<typeof build>>;
-
-  beforeAll(async () => {
-    fastify = await build();
-    await fastify.ready();
-  }, 20000);
-
-  afterAll(async () => {
-    // Due to a prisma bug, this is not enough, we need to --force-exit jest:
-    // https://github.com/prisma/prisma/issues/18146
-    await fastify?.close();
-  });
-
   test('have a 200 response', async () => {
-    res = await request(fastify?.server).get('/');
+    const res = await request(fastifyTestInstance?.server).get('/');
     expect(res?.statusCode).toBe(200);
   });
 
-  test('return { "hello": "world"}', () => {
+  test('return { "hello": "world"}', async () => {
+    const res = await request(fastifyTestInstance?.server).get('/');
     expect(res?.body).toEqual({ hello: 'world' });
   });
 });


### PR DESCRIPTION
The goal is to remove boilerplate from tests by adding a common task
(starting up the server) to part of Jest's setup.

It's quite fast to start up the server ( roughly 400ms), so as long as
we don't create hundreds of suites, it should not be a big deal perf
wise.

Unfortunately it's not possible to both add the fastify instance as a
global and set it up once. At the time of writing, Jest does not support
this.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
