### PR TITLE
feat(UI): take back to learn map after finishing a block

### DIFF
--- a/client/src/templates/Challenges/redux/completion-epic.js
+++ b/client/src/templates/Challenges/redux/completion-epic.js
@@ -221,7 +221,7 @@ export default function completionEpic(action$, state$) {
         action.type === submitActionTypes.submitComplete;
 
       return submitter(type, state).pipe(
-        concat(of(setIsAdvancing(lastChallengeInBlock))),
+        concat(of(setIsAdvancing(!lastChallengeInBlock))),
         mergeMap(x =>
           canAllowDonationRequest(state, x)
             ? of(x, allowBlockDonationRequests({ superBlock, block }))

--- a/client/src/templates/Challenges/redux/completion-epic.js
+++ b/client/src/templates/Challenges/redux/completion-epic.js
@@ -187,8 +187,13 @@ export default function completionEpic(action$, state$) {
     switchMap(({ type }) => {
       const state = state$.value;
 
-      const { nextChallengePath, challengeType, superBlock, block } =
-        challengeMetaSelector(state);
+      const {
+        nextChallengePath,
+        challengeType,
+        superBlock,
+        block,
+        prevChallengePath
+      } = challengeMetaSelector(state);
 
       let submitter = () => of({ type: 'no-user-signed-in' });
       if (
@@ -208,8 +213,18 @@ export default function completionEpic(action$, state$) {
       const isNextChallengeInSameSuperBlock =
         nextChallengePath.includes(superBlock);
 
+      const nextPathParts = nextChallengePath.split('/');
+      const prevPathParts = prevChallengePath.split('/');
+
+      const nextStep = nextPathParts[nextPathParts.length - 2];
+      const prevStep = prevPathParts[prevPathParts.length - 2];
+
       const pathToNavigateTo = isNextChallengeInSameSuperBlock
-        ? nextChallengePath
+        ? nextChallengePath.includes(superBlock) &&
+          (nextStep === prevStep ||
+            nextPathParts[nextPathParts.length - 1] === 'step-2')
+          ? nextChallengePath
+          : `/learn/${superBlock}/#${nextStep}`
         : `/learn/${superBlock}/#${superBlock}-projects`;
 
       const canAllowDonationRequest = (state, action) =>

--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -20,7 +20,13 @@ const initialState = {
   challengeMeta: {
     superBlock: '',
     block: '',
+    blockHashSlug: '/',
     id: '',
+    nextChallengeMeta: {
+      superBlock: '',
+      block: '',
+      blockHashSlug: '/'
+    },
     nextChallengePath: '/',
     prevChallengePath: '/',
     challengeType: -1

--- a/client/utils/gatsby/challenge-page-creator.js
+++ b/client/utils/gatsby/challenge-page-creator.js
@@ -75,6 +75,31 @@ function getTemplateComponent(challengeType) {
   return views[viewTypes[challengeType]];
 }
 
+function getNextChallengeMeta(_node, index, nodeArray) {
+  const next = nodeArray[index + 1];
+  if (next) {
+    const { superBlock, block } = next.node.challenge;
+    return {
+      superBlock,
+      block,
+      blockHashSlug: createBlockHashSlug(_node)
+    };
+  }
+  return null;
+}
+
+function createBlockHashSlug(_node) {
+  if (_node) {
+    const {
+      block,
+      fields: { slug }
+    } = _node;
+    const re = new RegExp(`${block}.*`);
+    return slug.replace(re, `#${block}`);
+  }
+  return null;
+}
+
 exports.createChallengePages = function (createPage) {
   return function ({ node: { challenge } }, index, allChallengeEdges) {
     const {
@@ -96,6 +121,7 @@ exports.createChallengePages = function (createPage) {
       component: getTemplateComponent(challengeType),
       context: {
         challengeMeta: {
+          blockHashSlug: createBlockHashSlug(challenge),
           dashedName,
           certification,
           superBlock,
@@ -103,6 +129,11 @@ exports.createChallengePages = function (createPage) {
           isFirstStep: getIsFirstStep(challenge, index, allChallengeEdges),
           template,
           required,
+          nextChallengeMeta: getNextChallengeMeta(
+            challenge,
+            index,
+            allChallengeEdges
+          ),
           nextChallengePath: getNextChallengePath(
             challenge,
             index,

--- a/cypress/e2e/default/learn/challenges/navigation.ts
+++ b/cypress/e2e/default/learn/challenges/navigation.ts
@@ -5,14 +5,8 @@ const challenge1 = {
     '/learn/front-end-development-libraries/front-end-development-libraries-projects/build-a-25--5-clock'
 };
 
-// last in block
-const challenge2 = {
-  url: '/learn/project-euler/project-euler-problems-301-to-400/problem-400-fibonacci-tree-game',
-  nextUrl: '/learn/project-euler/#project-euler-problems-301-to-400'
-};
-
 // last in superblock
-const challenge3 = {
+const challenge2 = {
   url: '/learn/college-algebra-with-python/build-a-data-graph-explorer-project/build-a-data-graph-explorer',
   nextUrl:
     '/learn/college-algebra-with-python/#build-a-data-graph-explorer-project'
@@ -35,28 +29,10 @@ describe('submitting a challenge', () => {
     cy.url().should('include', challenge1.nextUrl);
   });
 
-  it('at the end of a block should take you to the superblock page with the current block hash', () => {
-    const solution =
-      'function fibonacciTreeGame() {{}return 438505383468410600{}}';
-    cy.visit(challenge2.url);
-    const selectAllKeys = Cypress.platform == 'darwin' ? '{cmd}a' : '{ctrl}a';
-    cy.get(`${'.react-monaco-editor-container'} textarea:first`, {
-      timeout: 16000
-    }).as('editor');
-
-    cy.get('@editor')
-      .type(selectAllKeys)
-      .type('{backspace}')
-      .type(solution)
-      .type('{ctrl}{enter}');
-    cy.contains('Submit and go to next challenge').click();
-    cy.url().should('include', challenge2.nextUrl);
-  });
-
   it('at the end of a superblock should take you to the superblock page with the current block hash', () => {
-    cy.visit(challenge3.url);
+    cy.visit(challenge2.url);
     cy.get('#solution').type('https://example.com').type('{enter}');
     cy.contains('Submit and go to next challenge').click();
-    cy.url().should('include', challenge3.nextUrl);
+    cy.url().should('include', challenge2.nextUrl);
   });
 });

--- a/cypress/e2e/default/learn/challenges/navigation.ts
+++ b/cypress/e2e/default/learn/challenges/navigation.ts
@@ -1,0 +1,54 @@
+// middle of block
+const challenge1 = {
+  url: '/learn/front-end-development-libraries/front-end-development-libraries-projects/build-a-javascript-calculator',
+  nextUrl:
+    '/learn/front-end-development-libraries/front-end-development-libraries-projects/build-a-25--5-clock'
+};
+
+// last in block
+const challenge2 = {
+  url: '/learn/data-analysis-with-python/numpy/loading-data-and-advanced-indexing',
+  nextUrl: '/learn/data-analysis-with-python/#numpy'
+};
+
+// last in superblock
+const challenge3 = {
+  url: '/learn/college-algebra-with-python/build-a-data-graph-explorer-project/build-a-data-graph-explorer',
+  nextUrl:
+    '/learn/college-algebra-with-python/#build-a-data-graph-explorer-project'
+};
+
+describe('submitting a challenge', () => {
+  before(() => {
+    cy.exec('pnpm run seed');
+    cy.login();
+  });
+
+  beforeEach(() => {
+    cy.preserveSession();
+  });
+
+  it('in the middle of a block should take you to the next challenge', () => {
+    cy.visit(challenge1.url);
+    cy.get('#solution').type('https://example.com').type('{enter}');
+    cy.contains('Submit and go to next challenge').click();
+    cy.url().should('include', challenge1.nextUrl);
+  });
+
+  it('at the end of a block should take you to the superblock page with the current block hash', () => {
+    cy.visit(challenge2.url);
+    cy.get('.video-quiz-option-label')
+      .filter(':eq(2)') // Select the third item (index starts at 0)
+      .click()
+      .type('{ctrl}{enter}');
+    cy.contains('Submit and go to next challenge').click();
+    cy.url().should('include', challenge2.nextUrl);
+  });
+
+  it('at the end of a superblock should take you to the superblock page with the current block hash', () => {
+    cy.visit(challenge3.url);
+    cy.get('#solution').type('https://example.com').type('{enter}');
+    cy.contains('Submit and go to next challenge').click();
+    cy.url().should('include', challenge3.nextUrl);
+  });
+});

--- a/cypress/e2e/default/learn/challenges/navigation.ts
+++ b/cypress/e2e/default/learn/challenges/navigation.ts
@@ -7,8 +7,8 @@ const challenge1 = {
 
 // last in block
 const challenge2 = {
-  url: '/learn/data-analysis-with-python/numpy/loading-data-and-advanced-indexing',
-  nextUrl: '/learn/data-analysis-with-python/#numpy'
+  url: '/learn/project-euler/project-euler-problems-301-to-400/problem-400-fibonacci-tree-game',
+  nextUrl: '/learn/project-euler/#project-euler-problems-301-to-400'
 };
 
 // last in superblock
@@ -36,10 +36,18 @@ describe('submitting a challenge', () => {
   });
 
   it('at the end of a block should take you to the superblock page with the current block hash', () => {
+    const solution =
+      'function fibonacciTreeGame() {{}return 438505383468410600{}}';
     cy.visit(challenge2.url);
-    cy.get('.video-quiz-option-label')
-      .filter(':eq(2)') // Select the third item (index starts at 0)
-      .click()
+    const selectAllKeys = Cypress.platform == 'darwin' ? '{cmd}a' : '{ctrl}a';
+    cy.get(`${'.react-monaco-editor-container'} textarea:first`, {
+      timeout: 16000
+    }).as('editor');
+
+    cy.get('@editor')
+      .type(selectAllKeys)
+      .type('{backspace}')
+      .type(solution)
       .type('{ctrl}{enter}');
     cy.contains('Submit and go to next challenge').click();
     cy.url().should('include', challenge2.nextUrl);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #49170 

<!-- Feel free to add any additional description of changes below this line -->
Now, campers are taken back to the map after finishing a block instead of directly starting the next block step-1 in Responsive Web Design Certification.