### PR TITLE
fix(a11y): certification project cards (#50019

### DIFF
--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -306,32 +306,40 @@ class Block extends Component<BlockProps> {
     const GridProjectBlock = (
       <ScrollableAnchor id={blockDashedName}>
         <div className='block block-grid grid-project-block'>
-          <Link
-            className='block-header'
-            onClick={() => {
-              this.handleBlockClick();
-            }}
-            to={challengesWithCompleted[0].fields.slug}
-          >
-            <div className='tags-wrapper'>
-              <span className='cert-tag'>
-                {t('misc.certification-project')}
-              </span>
-              {!isAuditedCert(curriculumLocale, superBlock) && (
-                <Link
-                  className='cert-tag'
-                  to={t('links:help-translate-link-url')}
-                >
-                  {t('misc.translation-pending')}
-                </Link>
-              )}
-            </div>
-            <div className='title-wrapper map-title'>
-              {this.renderCheckMark(isBlockCompleted)}
-              <h3 className='block-grid-title'>{blockTitle}</h3>
-            </div>
-            <BlockIntros intros={blockIntroArr} />
-          </Link>
+          <div className='tags-wrapper'>
+            <span className='cert-tag' aria-hidden='true'>
+              {t('misc.certification-project')}
+            </span>
+            {!isAuditedCert(curriculumLocale, superBlock) && (
+              <Link
+                className='cert-tag'
+                to={t('links:help-translate-link-url')}
+              >
+                {t('misc.translation-pending')}{' '}
+                <span className='sr-only'>
+                  {blockTitle} {t('misc.certification-project')}
+                </span>
+              </Link>
+            )}
+          </div>
+          <div className='title-wrapper map-title'>
+            <h3 className='block-grid-title'>
+              <Link
+                className='block-header'
+                onClick={() => {
+                  this.handleBlockClick();
+                }}
+                to={challengesWithCompleted[0].fields.slug}
+              >
+                {this.renderCheckMark(isBlockCompleted)}
+                {blockTitle}{' '}
+                <span className='sr-only'>
+                  {t('misc.certification-project')}
+                </span>
+              </Link>
+            </h3>
+          </div>
+          <BlockIntros intros={blockIntroArr} />
         </div>
       </ScrollableAnchor>
     );

--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -468,4 +468,40 @@ ToDo: find out why, and remove the need for it */
 
 .grid-project-block {
   margin-bottom: 50px;
+  padding: 18px 15px;
+  position: relative;
+}
+
+.grid-project-block:hover {
+  cursor: pointer;
+  background: var(--tertiary-background);
+}
+
+.grid-project-block a.block-header {
+  padding: 0;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: baseline;
+  gap: 10px;
+}
+
+/* make entire certification card clickable */
+.grid-project-block a.block-header::after {
+  content: '';
+  display: block;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+
+.grid-project-block .tags-wrapper a {
+  position: relative;
+  z-index: 100;
+}
+
+.grid-project-block:hover:has(.tags-wrapper a:hover) {
+  background: var(--primary-background);
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

The Certification Project cards for the New RWD curriculum needed a little accessibility update. Rather than wrap all of the content in a link, current best practice is to only have one element in the card act as a link (the `h3` in this case) and then use CSS to extend the clickable area to the entire card. You should not notice any difference in the layout or functionality. Only screen reader users will notice these changes. The one downside to this approach is that the text in the card is no longer selectable for copy/paste with a mouse. There is a satisfactory fix for this using JS and measuring the delay between the mousedown and mouseup events to determine whether it is a click or a copy/paste. I can implement it if we think it is needed.  

On a side note, in the New RWD curriculum, the heading text is just the name of the project, without the word "project" after it. This is nice because we can then add the sr-only text "certification project" after the heading text for screen reader users. I am noticing though in the JS ADS Beta that the heading text is including the word "project" which isn't so great because adding "certification project" after that duplicates the word "project". I think we need to decide whether the heading text for these is going to include the word "project" at the end and then make that decision the universal standard across the board.