### PR TITLE
feat(curriculum): test for period after "Total Liabilities"

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-more-about-css-pseudo-selectors-by-building-a-balance-sheet/61fd990577d8227dd93fbeeb.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-more-about-css-pseudo-selectors-by-building-a-balance-sheet/61fd990577d8227dd93fbeeb.md
@@ -19,6 +19,12 @@ Your fourth `tr` should have a `th` element.
 assert(document.querySelectorAll('table')?.[1]?.querySelector('tbody')?.querySelectorAll('tr')?.[3]?.querySelector('th'));
 ```
 
+Your text `Total Liabilities` should not include period `.`.
+
+```js
+assert(document.querySelectorAll('table')?.[1]?.querySelector('tbody')?.querySelectorAll('tr')?.[3]?.querySelector('th')?.innerText !== 'Total Liabilities.');
+```
+
 Your `th` element should have the text `Total Liabilities`.
 
 ```js


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #48985 

<!-- Feel free to add any additional description of changes below this line -->
This fix adds a test to check if the user submits code that includes a period **.** after **Liabilities**, as discussed in the issue.

Test the display of Hint:

![image](https://user-images.githubusercontent.com/97413019/230993664-16911ec1-fdd6-4920-94ca-e7fb6fa5dd3b.png)
