### PR TITLE
Revert "feat(curriculum): test for period after "Total Liabilities""

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-more-about-css-pseudo-selectors-by-building-a-balance-sheet/61fd990577d8227dd93fbeeb.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-more-about-css-pseudo-selectors-by-building-a-balance-sheet/61fd990577d8227dd93fbeeb.md
@@ -19,12 +19,6 @@ Your fourth `tr` should have a `th` element.
 assert(document.querySelectorAll('table')?.[1]?.querySelector('tbody')?.querySelectorAll('tr')?.[3]?.querySelector('th'));
 ```
 
-Your text `Total Liabilities` should not include period `.`.
-
-```js
-assert(document.querySelectorAll('table')?.[1]?.querySelector('tbody')?.querySelectorAll('tr')?.[3]?.querySelector('th')?.innerText !== 'Total Liabilities.');
-```
-
 Your `th` element should have the text `Total Liabilities`.
 
 ```js


### PR DESCRIPTION
Based on Shaun comment https://github.com/freeCodeCamp/freeCodeCamp/pull/50036#discussion_r1163120016, here is the comment

> For future reference, we should not use specific negative tests, unless we have explicitly asked Campers to remove something.
>
> If we have this test, why not have a test for an exclamation mark? Or, a quotation mark? Or, the number 2?

which make senses, and the original issue shouldn't happen when `https://github.com/freeCodeCamp/freeCodeCamp/issues/50034` is triaged, so we can revert the changes because

- the issue wasn't triaged.
- it doesn't follow our workflow.
- it can be solved through CSS, weither through changing the color of background or adding border.