### PR TITLE
fix(client): clean up styles on controls above multi-file editor

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -309,7 +309,8 @@
       "console": "Console",
       "instructions": "Instructions",
       "notes": "Notes",
-      "preview": "Preview"
+      "preview": "Preview",
+      "editor": "Editor"
     },
     "editor-alerts": {
       "tab-trapped": "Pressing tab will now insert the tab character",

--- a/client/src/components/layouts/rtl-layout.css
+++ b/client/src/components/layouts/rtl-layout.css
@@ -99,11 +99,6 @@ New RWD project challenge
   gap: 10px;
 }
 
-[dir='rtl'] .monaco-editor-tabs button:not(:first-child) {
-  border-left: 2px solid;
-  border-right: none;
-}
-
 /* Align the the Arabic head with the corresponding English word */
 
 [dir='rtl'] .table thead:first-child tr:first-child th {

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -108,6 +108,7 @@
 #mobile-layout .nav-tabs > li {
   flex: 1;
   text-align: center;
+  margin-bottom: 0;
 }
 
 #mobile-layout .nav-tabs > li > a {
@@ -115,20 +116,19 @@
   padding: 5px 10px;
   text-decoration: none;
   font-size: 0.8em;
+  border: 0;
 }
 
 #mobile-layout .nav-tabs > li.active > a {
-  color: var(--quaternary-color);
-  background-color: var(--quaternary-background);
-  border: 1px solid var(--secondary-color);
-  border-bottom-color: transparent;
+  color: var(--secondary-background);
+  background-color: var(--quaternary-color);
+  border: 0;
   font-weight: 900;
 }
 
 #mobile-layout .nav-tabs > li:not(.active) > a:hover {
-  border: 1px solid transparent;
-  background: var(--quaternary-color);
-  color: var(--quaternary-background);
+  background: var(--quaternary-background);
+  color: var(--secondary-color);
 }
 
 #mobile-layout .tab-content {

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -28,6 +28,21 @@
   color: var(--secondary-background);
 }
 
+.action-row button:hover {
+  color: var(--secondary-color);
+  background-color: var(--primary-background);
+}
+
+.action-row button[aria-expanded='true']:hover {
+  background-color: var(--quaternary-color);
+  color: var(--secondary-background);
+}
+
+.action-row button:focus-visible {
+  position: relative;
+  z-index: 20;
+}
+
 .tabs-row {
   display: flex;
   flex-direction: row;
@@ -68,25 +83,6 @@
   background-color: var(--secondary-background);
 }
 
-.monaco-editor-tabs button:hover {
-  color: var(--secondary-color);
-  background-color: var(--secondary-background);
-}
-
-.monaco-editor-tabs button[aria-expanded='true']:hover {
-  background-color: var(--quaternary-color);
-  color: var(--secondary-background);
-}
-
-.monaco-editor-tabs button:not([aria-expanded='true']):hover {
-  background-color: var(--primary-background);
-}
-
-.monaco-editor-tabs button:focus-visible {
-  position: relative;
-  z-index: 20;
-}
-
 .panel-display-tabs button:first-child,
 .tabs-row > button:first-child {
   margin: 0 10px 0 0;
@@ -98,21 +94,6 @@
 
 .panel-display-tabs button:nth-last-child(2) {
   border-inline-end-width: 1px;
-}
-
-.panel-display-tabs button:focus-visible {
-  position: relative;
-  z-index: 10;
-}
-
-.panel-display-tabs button:hover {
-  color: var(--secondary-color);
-  background-color: var(--secondary-background);
-}
-
-.panel-display-tabs button[aria-expanded='true']:hover {
-  background-color: var(--quaternary-color);
-  color: var(--secondary-background);
 }
 
 .restart-step-tab {

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -22,15 +22,10 @@
   border-bottom: 1px solid var(--quaternary-background);
 }
 
-.monaco-editor-tabs [aria-expanded='true'],
 .action-row [aria-expanded='true'] {
-  border-color: var(--secondary-color);
-  background-color: var(--secondary-color);
-  color: var(--secondary-background);
-}
-
-.light-palette .monaco-editor-tabs [aria-expanded='true'] {
+  border-color: var(--primary-color);
   background-color: var(--primary-color);
+  color: var(--secondary-background);
 }
 
 .tabs-row {
@@ -63,7 +58,7 @@
   width: 2px;
   height: 100%;
   margin-inline-start: -2px;
-  background-color: var(--secondary-color);
+  background-color: var(--primary-color);
 }
 
 /* Firefox doesn't have :has() yet but this ruleset is not essential */
@@ -83,7 +78,7 @@
   color: var(--secondary-background);
 }
 
-.dark-palette .monaco-editor-tabs button:not([aria-expanded='true']):hover {
+.monaco-editor-tabs button:not([aria-expanded='true']):hover {
   background-color: var(--primary-background);
 }
 

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -29,6 +29,10 @@
   color: var(--secondary-background);
 }
 
+.light-palette .monaco-editor-tabs [aria-expanded='true'] {
+  background-color: var(--primary-color);
+}
+
 .tabs-row {
   display: flex;
   flex-direction: row;
@@ -47,13 +51,73 @@
   margin-inline-end: auto;
 }
 
-.monaco-editor-tabs button:not(:first-child) {
-  border-left: none;
+.monaco-editor-tabs button:not(:last-of-type) {
+  border-inline-end: 0;
+}
+
+.monaco-editor-tabs button:not(:first-of-type) {
+  border-inline-start: 0;
+}
+
+.monaco-editor-tabs .editor-tab-separator {
+  width: 2px;
+  height: 100%;
+  margin-inline-start: -2px;
+  background-color: var(--secondary-color);
+}
+
+/* Firefox doesn't have :has() yet but this ruleset is not essential */
+.monaco-editor-tabs
+  button[aria-expanded='true']
+  + .editor-tab-separator:has(+ button[aria-expanded='true']) {
+  background-color: var(--secondary-background);
+}
+
+.monaco-editor-tabs button:hover {
+  color: var(--secondary-color);
+  background-color: var(--secondary-background);
+}
+
+.monaco-editor-tabs button[aria-expanded='true']:hover {
+  background-color: var(--quaternary-color);
+  color: var(--secondary-background);
+}
+
+.dark-palette .monaco-editor-tabs button:not([aria-expanded='true']):hover {
+  background-color: var(--primary-background);
+}
+
+.monaco-editor-tabs button:focus-visible {
+  position: relative;
+  z-index: 20;
 }
 
 .panel-display-tabs button:first-child,
 .tabs-row > button:first-child {
   margin: 0 10px 0 0;
+}
+
+.panel-display-tabs button:last-of-type {
+  border-inline-start-width: 1px;
+}
+
+.panel-display-tabs button:nth-last-child(2) {
+  border-inline-end-width: 1px;
+}
+
+.panel-display-tabs button:focus-visible {
+  position: relative;
+  z-index: 10;
+}
+
+.panel-display-tabs button:hover {
+  color: var(--secondary-color);
+  background-color: var(--secondary-background);
+}
+
+.panel-display-tabs button[aria-expanded='true']:hover {
+  background-color: var(--quaternary-color);
+  color: var(--secondary-background);
 }
 
 .restart-step-tab {
@@ -67,8 +131,10 @@
 }
 
 #mobile-layout .nav-tabs {
-  margin-inline-start: 2px;
+  margin: 0 1px;
+  padding: 0;
   display: flex;
+  border-bottom: 1px solid var(--quaternary-color);
 }
 
 #mobile-layout .nav-tabs > li {
@@ -77,13 +143,24 @@
 }
 
 #mobile-layout .nav-tabs > li > a {
+  margin-inline-end: 0;
   padding: 5px 10px;
   text-decoration: none;
   font-size: 0.8em;
 }
 
-#mobile-layout .nav-tabs > li > a:hover {
-  color: var(--gray-85);
+#mobile-layout .nav-tabs > li.active > a {
+  color: var(--quaternary-color);
+  background-color: var(--quaternary-background);
+  border: 1px solid var(--secondary-color);
+  border-bottom-color: transparent;
+  font-weight: 900;
+}
+
+#mobile-layout .nav-tabs > li:not(.active) > a:hover {
+  border: 1px solid transparent;
+  background: var(--quaternary-color);
+  color: var(--quaternary-background);
 }
 
 #mobile-layout .tab-content {
@@ -118,11 +195,6 @@
   }
 }
 
-#mobile-layout .nav-tabs > li.active > a {
-  color: var(--quaternary-color);
-  background-color: var(--quaternary-background);
-}
-
 #mobile-layout .monaco-editor-tabs {
   padding: 10px;
   width: 100%;
@@ -135,7 +207,7 @@
 
 /* Focus indicator for tab panel */
 .nav-tabs [role='tab']:focus {
-  outline-offset: -2px;
+  outline-offset: -3px;
 }
 
 .nav-tabs [role='tab']:focus:not(:focus-visible) {

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -68,13 +68,6 @@
   margin-inline-end: auto;
 }
 
-.monaco-editor-tabs .editor-tab-separator {
-  width: 2px;
-  height: 100%;
-  margin-inline-start: -2px;
-  background-color: var(--primary-color);
-}
-
 .panel-display-tabs button:first-child,
 .tabs-row > button:first-child {
   margin: 0 10px 0 0;

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -22,23 +22,26 @@
   border-bottom: 1px solid var(--quaternary-background);
 }
 
-.action-row [aria-expanded='true'] {
+.monaco-editor-tabs button[aria-expanded='true'],
+.panel-display-tabs button[aria-expanded='true'] {
   border-color: var(--primary-color);
   background-color: var(--primary-color);
   color: var(--secondary-background);
 }
 
-.action-row button:hover {
+.monaco-editor-tabs button:hover,
+.panel-display-tabs button:hover {
   color: var(--secondary-color);
   background-color: var(--primary-background);
 }
 
-.action-row button[aria-expanded='true']:hover {
+.monaco-editor-tabs button[aria-expanded='true']:hover,
+.panel-display-tabs button[aria-expanded='true']:hover {
   background-color: var(--quaternary-color);
   color: var(--secondary-background);
 }
 
-.action-row button:focus-visible {
+.panel-display-tabs button:focus-visible {
   position: relative;
   z-index: 20;
 }
@@ -52,8 +55,12 @@
 .tabs-row button,
 .monaco-editor-tabs button {
   padding: 6px 12px;
-  border-width: 2px;
+  border-width: 3px;
   border-style: solid;
+}
+
+.monaco-editor-tabs button + button {
+  margin-inline-start: 3px;
 }
 
 .monaco-editor-tabs {
@@ -61,26 +68,11 @@
   margin-inline-end: auto;
 }
 
-.monaco-editor-tabs button:not(:last-of-type) {
-  border-inline-end: 0;
-}
-
-.monaco-editor-tabs button:not(:first-of-type) {
-  border-inline-start: 0;
-}
-
 .monaco-editor-tabs .editor-tab-separator {
   width: 2px;
   height: 100%;
   margin-inline-start: -2px;
   background-color: var(--primary-color);
-}
-
-/* Firefox doesn't have :has() yet but this ruleset is not essential */
-.monaco-editor-tabs
-  button[aria-expanded='true']
-  + .editor-tab-separator:has(+ button[aria-expanded='true']) {
-  background-color: var(--secondary-background);
 }
 
 .panel-display-tabs button:first-child,

--- a/client/src/templates/Challenges/classic/editor-tabs.tsx
+++ b/client/src/templates/Challenges/classic/editor-tabs.tsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 
+import i18next from 'i18next';
 import { sortChallengeFiles } from '../../../../../utils/sort-challengefiles';
 import { ChallengeFile, ChallengeFiles } from '../../../redux/prop-types';
 import { toggleVisibleEditor } from '../redux/actions';
@@ -47,8 +48,10 @@ class EditorTabs extends Component<EditorTabsProps> {
               data-cy={`editor-tab-${challengeFile.fileKey}`}
               onClick={() => toggleVisibleEditor(challengeFile.fileKey)}
             >
-              <span>{`${challengeFile.name}.${challengeFile.ext}`}</span>{' '}
-              <span className='sr-only'>editor</span>
+              {`${challengeFile.name}.${challengeFile.ext}`}{' '}
+              <span className='sr-only'>
+                {i18next.t('learn.editor-tabs.editor')}
+              </span>
             </button>
           )
         )}

--- a/client/src/templates/Challenges/classic/editor-tabs.tsx
+++ b/client/src/templates/Challenges/classic/editor-tabs.tsx
@@ -40,25 +40,16 @@ class EditorTabs extends Component<EditorTabsProps> {
       <div className='monaco-editor-tabs'>
         {/* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call */}
         {sortChallengeFiles(challengeFiles).map(
-          (
-            challengeFile: ChallengeFile,
-            index: number,
-            array: ChallengeFile[]
-          ) => (
-            <>
-              <button
-                aria-expanded={visibleEditors[challengeFile.fileKey] ?? 'false'}
-                key={challengeFile.fileKey}
-                data-cy={`editor-tab-${challengeFile.fileKey}`}
-                onClick={() => toggleVisibleEditor(challengeFile.fileKey)}
-              >
-                <span>{`${challengeFile.name}.${challengeFile.ext}`}</span>{' '}
-                <span className='sr-only'>editor</span>
-              </button>
-              {index !== array.length - 1 && (
-                <div className='editor-tab-separator' />
-              )}
-            </>
+          (challengeFile: ChallengeFile) => (
+            <button
+              aria-expanded={visibleEditors[challengeFile.fileKey] ?? 'false'}
+              key={challengeFile.fileKey}
+              data-cy={`editor-tab-${challengeFile.fileKey}`}
+              onClick={() => toggleVisibleEditor(challengeFile.fileKey)}
+            >
+              <span>{`${challengeFile.name}.${challengeFile.ext}`}</span>{' '}
+              <span className='sr-only'>editor</span>
+            </button>
           )
         )}
       </div>

--- a/client/src/templates/Challenges/classic/editor-tabs.tsx
+++ b/client/src/templates/Challenges/classic/editor-tabs.tsx
@@ -40,16 +40,25 @@ class EditorTabs extends Component<EditorTabsProps> {
       <div className='monaco-editor-tabs'>
         {/* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call */}
         {sortChallengeFiles(challengeFiles).map(
-          (challengeFile: ChallengeFile) => (
-            <button
-              aria-expanded={visibleEditors[challengeFile.fileKey] ?? 'false'}
-              key={challengeFile.fileKey}
-              data-cy={`editor-tab-${challengeFile.fileKey}`}
-              onClick={() => toggleVisibleEditor(challengeFile.fileKey)}
-            >
-              {`${challengeFile.name}.${challengeFile.ext}`}{' '}
-              <span className='sr-only'>editor</span>
-            </button>
+          (
+            challengeFile: ChallengeFile,
+            index: number,
+            array: ChallengeFile[]
+          ) => (
+            <>
+              <button
+                aria-expanded={visibleEditors[challengeFile.fileKey] ?? 'false'}
+                key={challengeFile.fileKey}
+                data-cy={`editor-tab-${challengeFile.fileKey}`}
+                onClick={() => toggleVisibleEditor(challengeFile.fileKey)}
+              >
+                <span>{`${challengeFile.name}.${challengeFile.ext}`}</span>{' '}
+                <span className='sr-only'>editor</span>
+              </button>
+              {index !== array.length - 1 && (
+                <div className='editor-tab-separator' />
+              )}
+            </>
           )
         )}
       </div>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This originally started out as just fixing up the keyboard focus outlines for the buttons and tabs control above the multi-file editor, but then I included a few more fixes for those controls while I was at it. I think most of these updates are not controversial, but of course if something doesn't fit then I'll be happy to remove it or make any necessary changes. The main fixes are:

-  Ensure all four sides of keyboard focus outline are showing for all buttons (some of them were only showing three sides)
- Add borders to tab control in light mode so it mimics look of tab control in dark mode (I think this is necessary for accessibility because the shade of gray we are using for the active tab does not have enough contrast).
- Add separator between adjacent file editor buttons when both are expanded (does not work in Firefox at the moment but I think that's OK since this is not an essential fix).
- Fix hover state appearance on toggle buttons so that it reflects a state change has happened as soon as the button is clicked.

The last one has slightly annoyed me for a while now :slightly_smiling_face: I think it is better if the visual state of the button changes immediately when clicked instead of only after the mouse has moved off of it. The side effect is that the contrast of the hover state is not quite as big now, especially for the darker color. Hover states are not required in WCAG and thus do not have minimum contrast requirements, but we might want to consider creating a new hover background color for the darker button if we feel it does not have enough contrast. Another option would be to do away with the background change on hover and consider other styling changes for the hover state.
