### PR TITLE
docs: Added command to build config dependency

### DIFF
--- a/docs/how-to-setup-freecodecamp-locally.md
+++ b/docs/how-to-setup-freecodecamp-locally.md
@@ -228,7 +228,7 @@ The keys in the `.env` file are _not_ required to be changed to run the app loca
 This step will install the dependencies required for the application to run:
 
 ```console
-pnpm install
+pnpm install && pnpm run create:config
 ```
 
 #### Step 3: Start MongoDB and Seed the Database


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!-- Feel free to add any additional description of changes below this line -->
Description:

When I was going through the setup of the inital local env I ran into a `module not found` error. 

This was caused by a `require` in the mongo `seed-demo-user.js` script for the `config/misc.js` module that had not yet been compiled in the config dir. 

I saw that someone in the discord ran into the same error and so I figured it would be good to mention this command in the docs.
