### PR TITLE
feat(api): please eslint error

### DIFF
--- a/api/src/server.test.ts
+++ b/api/src/server.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import request from 'supertest';
 
 describe('GET /', () => {
@@ -12,7 +13,7 @@ describe('GET /', () => {
   });
 
   test('should have OWASP recommended headers', async () => {
-    res = await request(fastify?.server).get('/');
+    const res = await request(fastifyTestInstance?.server).get('/');
     // We also set Strict-Transport-Security, but only in production.
     expect(res?.headers).toMatchObject({
       'cache-control': 'no-store',


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

eslint isn't pleased with this PR https://github.com/freeCodeCamp/freeCodeCamp/pull/49994, I think there is a rule enabled, after the PR was opened.

Anyway this is a short fix, until oliver is better and sort this himself, or Tom wake up and sort it. 🤷 

<!-- Feel free to add any additional description of changes below this line -->
