### PR TITLE
fix(api-server): return usable flash type to client

### DIFF
--- a/api-server/src/server/middlewares/error-handlers.js
+++ b/api-server/src/server/middlewares/error-handlers.js
@@ -55,7 +55,7 @@ export default function prodErrorHandler() {
 
     if (type === 'json') {
       return res.json({
-        type: handled.type || 'errors',
+        type: handled.type || 'danger',
         message
       });
     } else {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Fixes situations where server will appear to silently error on client, due to incompatible `type` for flash messages.

<img width="497" alt="image" src="https://user-images.githubusercontent.com/51722130/232494971-e4c5e3b0-408c-4705-9299-de954d79e03e.png">
