### PR TITLE
fix(client): conditionally render #universal-nav-left

### DIFF
--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -504,9 +504,7 @@ button.nav-link[aria-disabled='true'] {
 
   #universal-nav-logo {
     display: flex;
-    position: absolute;
     padding-top: 0.2em;
-    top: 0;
   }
 
   .expand-nav {

--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -503,7 +503,6 @@ button.nav-link[aria-disabled='true'] {
   }
 
   #universal-nav-logo {
-    display: flex;
     padding-top: 0.2em;
   }
 

--- a/client/src/components/Header/components/universal-nav.tsx
+++ b/client/src/components/Header/components/universal-nav.tsx
@@ -56,11 +56,15 @@ export const UniversalNav = ({
       className={`universal-nav${displayMenu ? ' expand-nav' : ''}`}
       id='universal-nav'
     >
-      <div
-        className={`universal-nav-left${displayMenu ? ' display-search' : ''}`}
-      >
-        <Media minWidth={SEARCH_EXPOSED_WIDTH + 1}>{search}</Media>
-      </div>
+      <Media minWidth={SEARCH_EXPOSED_WIDTH + 1}>
+        <div
+          className={`universal-nav-left${
+            displayMenu ? ' display-search' : ''
+          }`}
+        >
+          {search}
+        </div>
+      </Media>
       <Link id='universal-nav-logo' to='/learn'>
         <NavLogo />
       </Link>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #49985

<!-- Feel free to add any additional description of changes below this line -->

This is mainly just a code example to go with the comment I made on the issue. As I said, I might have missed a reason why we can't do this.

- This wraps the element in the `Media` component instead of just wrapping the content.
- Removes `position: absolute` and offset from `#universal-nav-logo` in a media query.

---

Side note:

I left `display: flex` on the `#universal-nav-logo` selector in the media query, but I'm not sure why it needs to be set again inside the media query. The element is already a flexbox.
