### PR TITLE
feat(client): use showPoints to hide points instead of mutating the points

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -221,8 +221,7 @@
     "tweet": "I just earned the {{certTitle}} certification @freeCodeCamp! Check it out here: {{certURL}}",
     "avatar": "{{username}}'s avatar",
     "joined": "Joined {{date}}",
-    "total-points": "{{count}} total point",
-    "total-points_plural": "{{count}} total points",
+    "total-points": "Number of points: {{count}}",
     "points": "{{count}} point on {{date}}",
     "points_plural": "{{count}} points on {{date}}",
     "page-number": "{{pageNumber}} of {{totalPages}}"

--- a/client/src/components/profile/__snapshots__/profile.test.tsx.snap
+++ b/client/src/components/profile/__snapshots__/profile.test.tsx.snap
@@ -273,11 +273,6 @@ exports[`<Profile/> renders correctly 1`] = `
       
       
       <br />
-      <p
-        class="text-center points"
-      >
-        profile.total-points
-      </p>
     </div>
     <div
       class="spacer"

--- a/client/src/components/profile/components/camper.tsx
+++ b/client/src/components/profile/components/camper.tsx
@@ -28,7 +28,6 @@ export type CamperProps = Pick<
   | 'githubProfile'
   | 'isDonating'
   | 'linkedin'
-  | 'points'
   | 'username'
   | 'twitter'
   | 'yearsTopContributor'
@@ -67,7 +66,6 @@ function Camper({
   name,
   username,
   location,
-  points,
   picture,
   about,
   yearsTopContributor,
@@ -127,9 +125,6 @@ function Camper({
         </div>
       )}
       <br />
-      <p className='text-center points'>
-        {t('profile.total-points', { count: points })}
-      </p>
     </div>
   );
 }

--- a/client/src/components/profile/profile.tsx
+++ b/client/src/components/profile/profile.tsx
@@ -49,7 +49,13 @@ function renderMessage(
   );
 }
 
-function renderProfile(user: ProfileProps['user']): JSX.Element {
+function UserProfile({
+  user,
+  t
+}: {
+  user: ProfileProps['user'];
+  t: TFunction;
+}): JSX.Element {
   const {
     profileUI: {
       showAbout = false,
@@ -90,12 +96,16 @@ function renderProfile(user: ProfileProps['user']): JSX.Element {
         location={showLocation ? location : ''}
         name={showName ? name : ''}
         picture={picture}
-        points={showPoints ? points : null}
         twitter={twitter}
         username={username}
         website={website}
         yearsTopContributor={yearsTopContributor}
       />
+      {showPoints && (
+        <p className='text-center points'>
+          {t('profile.total-points', { count: points })}
+        </p>
+      )}
       {showHeatMap ? <HeatMap calendar={calendar} /> : null}
       {showCerts ? <Certifications username={username} /> : null}
       {showPortfolio ? (
@@ -125,7 +135,7 @@ function Profile({ user, isSessionUser }: ProfileProps): JSX.Element {
       <Grid>
         <Spacer size='medium' />
         {isLocked ? renderMessage(isSessionUser, username, t) : null}
-        {!isLocked || isSessionUser ? renderProfile(user) : null}
+        {(!isLocked || isSessionUser) && <UserProfile user={user} t={t} />}
         {isSessionUser ? null : (
           <Row className='text-center'>
             <Link to={`/user/${username}/report-user`}>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

![image](https://user-images.githubusercontent.com/88248797/233305795-fdf4ca98-aa65-40f6-a468-97c117e3e46a.png)

After aligning the types, and removing the mutation of point to null, we can start using `ShowPoints` as a boolean to show the element, instead of changing the value of points, which isn't what point are.

<!-- Feel free to add any additional description of changes below this line -->
