### PR TITLE
fix(client): Prevent saving invalid portfolio item

### DIFF
--- a/client/src/components/settings/portfolio.tsx
+++ b/client/src/components/settings/portfolio.tsx
@@ -81,10 +81,19 @@ class PortfolioSettings extends Component<PortfolioProps, PortfolioState> {
 
   updateItem = (id: string) => {
     const { portfolio, unsavedItemId } = this.state;
+    const updatingPortfolio = [...portfolio];
+
     if (unsavedItemId === id) {
       this.setState({ unsavedItemId: null });
+    } else {
+      if (unsavedItemId) {
+        const unsavedItemIndex = updatingPortfolio.findIndex(
+          item => item.id === unsavedItemId
+        );
+        updatingPortfolio.splice(unsavedItemIndex, 1);
+      }
     }
-    this.props.updatePortfolio({ portfolio });
+    this.props.updatePortfolio({ portfolio: updatingPortfolio });
   };
 
   handleAdd = () => {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!-- Feel free to add any additional description of changes below this line -->
Unsaved portfolio item is being saved when updating an existing one, bypassing any validation.
This commit removes the unsaved item from portfolio before saving it, while the unsaved item is kept in state so user can keep editing it.

This bug was referenced on this comment: https://github.com/freeCodeCamp/freeCodeCamp/issues/49132#issuecomment-1476031123