### PR TITLE
fix(ui): re-enable pointer events on upper jaw

### DIFF
--- a/client/src/templates/Challenges/classic/editor.css
+++ b/client/src/templates/Challenges/classic/editor.css
@@ -12,10 +12,6 @@
   contain: none !important;
 }
 
-.editor-upper-jaw {
-  pointer-events: none;
-}
-
 .vs .monaco-scrollable-element > .scrollbar > .slider {
   z-index: 11;
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

A few days ago we merged [#48586](https://github.com/freeCodeCamp/freeCodeCamp/pull/48586) and it included CSS to disable pointer events on the upper jaw. I can't see any reason why this is necessary for that PR and it definitely prevents people from copy/pasting from the instructions. I think this just slipped by us.
