### PR TITLE
feat(client): Children for Spacer Component

### DIFF
--- a/client/src/components/helpers/spacer.tsx
+++ b/client/src/components/helpers/spacer.tsx
@@ -10,13 +10,15 @@ const Padding = Object.freeze({
 type PaddingKeys = keyof typeof Padding;
 interface SpacerProps {
   size: PaddingKeys;
+  children?: React.ReactNode;
 }
 
-const Spacer = ({ size }: SpacerProps): JSX.Element => (
-  <div
-    className='spacer'
-    style={{ padding: `${Padding[size]}px 0`, height: '1px' }}
-  />
+const Spacer = ({ size, children }: SpacerProps): JSX.Element => (
+  <div className='spacer' style={{ paddingBlock: `${Padding[size]}px` }}>
+    {children && (
+      <div style={{ paddingBlock: `${Padding[size]}px` }}>{children}</div>
+    )}
+  </div>
 );
 
 export default Spacer;

--- a/client/src/pages/donate.tsx
+++ b/client/src/pages/donate.tsx
@@ -67,51 +67,51 @@ function DonatePage({
     <>
       <Helmet title={`${t('donate.title')} | freeCodeCamp.org`} />
       <Grid className='donate-page-wrapper'>
-        <Spacer size='medium' />
-        <Row>
-          <>
-            <Col lg={6} lgOffset={0} md={8} mdOffset={2} sm={10} smOffset={1}>
-              <Row>
-                <Col className={'text-center'} xs={12}>
-                  {isDonating ? (
-                    <h2>{t('donate.thank-you')}</h2>
-                  ) : (
-                    <h2>{t('donate.help-more')}</h2>
-                  )}
-                  <Spacer size='medium' />
-                </Col>
-              </Row>
-              {isDonating ? (
-                <Alert data-cy='donate-alert' closeLabel={t('buttons.close')}>
-                  <p data-cy='donate.thank-you'>{t('donate.thank-you')}</p>
-                  <br />
-                  <DonationOptionsAlertText />
-                </Alert>
-              ) : null}
-              <DonationText />
-              <Row>
-                <Col xs={12}>
-                  <DonateForm paymentContext={PaymentContext.DonatePage} />
-                </Col>
-              </Row>
-              <Spacer size='exLarge' />
-              <Row className='donate-support' id='FAQ'>
-                <Col className={'text-center'} xs={12}>
-                  <hr />
-                  <h2>{t('donate.faq')}</h2>
-                  <Spacer size='medium' />
-                </Col>
-                <Col xs={12}>
-                  <DonationFaqText />
-                </Col>
-              </Row>
-            </Col>
-            <Col lg={6}>
-              <CampersImage pageName='donate' />
-            </Col>
-          </>
-        </Row>
-        <Spacer size='medium' />
+        <Spacer size='medium'>
+          <Row>
+            <>
+              <Col lg={6} lgOffset={0} md={8} mdOffset={2} sm={10} smOffset={1}>
+                <Row>
+                  <Col className={'text-center'} xs={12}>
+                    {isDonating ? (
+                      <h2>{t('donate.thank-you')}</h2>
+                    ) : (
+                      <h2>{t('donate.help-more')}</h2>
+                    )}
+                    <Spacer size='medium' />
+                  </Col>
+                </Row>
+                {isDonating ? (
+                  <Alert data-cy='donate-alert' closeLabel={t('buttons.close')}>
+                    <p data-cy='donate.thank-you'>{t('donate.thank-you')}</p>
+                    <br />
+                    <DonationOptionsAlertText />
+                  </Alert>
+                ) : null}
+                <DonationText />
+                <Row>
+                  <Col xs={12}>
+                    <DonateForm paymentContext={PaymentContext.DonatePage} />
+                  </Col>
+                </Row>
+                <Spacer size='exLarge' />
+                <Row className='donate-support' id='FAQ'>
+                  <Col className={'text-center'} xs={12}>
+                    <hr />
+                    <h2>{t('donate.faq')}</h2>
+                    <Spacer size='medium' />
+                  </Col>
+                  <Col xs={12}>
+                    <DonationFaqText />
+                  </Col>
+                </Row>
+              </Col>
+              <Col lg={6}>
+                <CampersImage pageName='donate' />
+              </Col>
+            </>
+          </Row>
+        </Spacer>
       </Grid>
     </>
   );


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #49828

<!-- Feel free to add any additional description of changes below this line -->
* Added children props in the Spacer component.
* Made it optional, as we might not need it everywhere.
* Replaced the padding property with paddingBlock.
* Added additional div in case where children props exists, because if it does the paddingBlock would act as 15px top and 15px bottom of the container in case of medium. On the other hand, when children doesn't exist, it acts as 30px on the same line by calculating 15px top and 15px bottom.
* Tested it on /donate page, and it works as expected. Would implement it wherever needed in some other issue to avoid cumbersome.
* Have tested it personally on GitPod which works fine.