### PR TITLE
refactor(client): remove extra element from the profile item setting

### DIFF
--- a/client/src/components/settings/portfolio.tsx
+++ b/client/src/components/settings/portfolio.tsx
@@ -337,11 +337,7 @@ class PortfolioSettings extends Component<PortfolioProps, PortfolioState> {
       <section id='portfolio-settings'>
         <SectionHeader>{t('settings.headings.portfolio')}</SectionHeader>
         <FullWidthRow>
-          <div className='portfolio-settings-intro'>
-            <p className='p-intro'>{t('settings.share-projects')}</p>
-          </div>
-        </FullWidthRow>
-        <FullWidthRow>
+          <p>{t('settings.share-projects')}</p>
           <Spacer size='small' />
           <Button
             block={true}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

While reviewing PR, I found this extra unneeded elements, this clean them

![image](https://user-images.githubusercontent.com/88248797/233961992-be0e985c-1a74-48b6-a99a-035cfd173f4b.png)

The affected page is https://www.freecodecamp.org/settings

<!-- Feel free to add any additional description of changes below this line -->
