### PR TITLE
chore(tools): test intro file structure

### DIFF
--- a/client/i18n/locales.test.ts
+++ b/client/i18n/locales.test.ts
@@ -1,8 +1,22 @@
 import fs from 'fs';
 import { setup } from 'jest-json-schema-extended';
 import { availableLangs, LangNames, LangCodes } from '../../config/i18n';
+import intro from './locales/english/intro.json';
 
 setup();
+
+interface Intro {
+  [superBlock: string]: {
+    title: string;
+    intro: string[];
+    blocks: {
+      [block: string]: {
+        title: string;
+        intro: string[];
+      };
+    };
+  };
+}
 
 const filesThatShouldExist = [
   {
@@ -50,6 +64,23 @@ describe('Locale tests:', () => {
             .includes(lang)
         ).toBe(true);
       });
+    });
+  });
+});
+
+describe('Intro file structure tests:', () => {
+  const typedIntro = intro as unknown as Intro;
+  const superblocks = Object.keys(typedIntro).filter(
+    key => key !== 'misc-text'
+  );
+  superblocks.forEach(superBlock => {
+    expect(typeof typedIntro[superBlock].title).toBe('string');
+    expect(typedIntro[superBlock].intro).toBeInstanceOf(Array);
+    expect(typedIntro[superBlock].blocks).toBeInstanceOf(Object);
+    const blocks = Object.keys(typedIntro[superBlock].blocks);
+    blocks.forEach(block => {
+      expect(typeof typedIntro[superBlock].blocks[block].title).toBe('string');
+      expect(typedIntro[superBlock].blocks[block].intro).toBeInstanceOf(Array);
     });
   });
 });

--- a/client/i18n/locales.test.ts
+++ b/client/i18n/locales.test.ts
@@ -1,12 +1,13 @@
 import fs from 'fs';
 import { setup } from 'jest-json-schema-extended';
 import { availableLangs, LangNames, LangCodes } from '../../config/i18n';
+import { SuperBlocks } from '../../config/certification-settings';
 import intro from './locales/english/intro.json';
 
 setup();
 
 interface Intro {
-  [superBlock: string]: {
+  [key: string]: {
     title: string;
     intro: string[];
     blocks: {
@@ -70,10 +71,8 @@ describe('Locale tests:', () => {
 
 describe('Intro file structure tests:', () => {
   const typedIntro = intro as unknown as Intro;
-  const superblocks = Object.keys(typedIntro).filter(
-    key => key !== 'misc-text'
-  );
-  superblocks.forEach(superBlock => {
+  const superblocks = Object.values(SuperBlocks);
+  for (const superBlock of superblocks) {
     expect(typeof typedIntro[superBlock].title).toBe('string');
     expect(typedIntro[superBlock].intro).toBeInstanceOf(Array);
     expect(typedIntro[superBlock].blocks).toBeInstanceOf(Object);
@@ -82,5 +81,5 @@ describe('Intro file structure tests:', () => {
       expect(typeof typedIntro[superBlock].blocks[block].title).toBe('string');
       expect(typedIntro[superBlock].blocks[block].intro).toBeInstanceOf(Array);
     });
-  });
+  }
 });


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Happy to toss this if we feel it's overcompensating, but... A curriculum project PR was rebased and the intro key was lost in the merge conflict - this adds a test that every block has an intro array and title.

This resolves a silent issue where a build will succeed, but expanding the block triggers an error that `intros.map` is not a function.