### PR TITLE
feat: send RWD render times to GA

### DIFF
--- a/client/src/redux/action-types.js
+++ b/client/src/redux/action-types.js
@@ -7,6 +7,7 @@ export const actionTypes = createTypes(
     'appMount',
     'hardGoTo',
     'allowBlockDonationRequests',
+    'setRenderStartTime',
     'hideCodeAlly',
     'preventBlockDonationRequests',
     'preventProgressDonationRequests',

--- a/client/src/redux/actions.js
+++ b/client/src/redux/actions.js
@@ -13,6 +13,7 @@ export const executeGA = createAction(actionTypes.executeGA);
 export const allowBlockDonationRequests = createAction(
   actionTypes.allowBlockDonationRequests
 );
+export const setRenderStartTime = createAction(actionTypes.setRenderStartTime);
 export const closeDonationModal = createAction(actionTypes.closeDonationModal);
 export const openDonationModal = createAction(actionTypes.openDonationModal);
 export const preventBlockDonationRequests = createAction(

--- a/client/src/redux/ga-saga.js
+++ b/client/src/redux/ga-saga.js
@@ -2,7 +2,7 @@ import { all, call, takeEvery } from 'redux-saga/effects';
 import TagManager from '../analytics';
 
 function* callGaType({
-  payload: { action, duration, amount, event, pagePath, render_time_msec }
+  payload: { action, duration, amount, event, pagePath, challengeRenderTime }
 }) {
   if (event === 'page_view') {
     yield call(TagManager.dataLayer, {
@@ -22,7 +22,7 @@ function* callGaType({
     yield call(TagManager.dataLayer, {
       dataLayer: {
         event,
-        render_time_msec
+        render_time_msec: challengeRenderTime
       }
     });
   } else {

--- a/client/src/redux/ga-saga.js
+++ b/client/src/redux/ga-saga.js
@@ -2,7 +2,7 @@ import { all, call, takeEvery } from 'redux-saga/effects';
 import TagManager from '../analytics';
 
 function* callGaType({
-  payload: { action, duration, amount, event, pagePath }
+  payload: { action, duration, amount, event, pagePath, render_time_msec }
 }) {
   if (event === 'page_view') {
     yield call(TagManager.dataLayer, {
@@ -16,6 +16,13 @@ function* callGaType({
       dataLayer: {
         event,
         action
+      }
+    });
+  } else if (event === 'render_time') {
+    yield call(TagManager.dataLayer, {
+      dataLayer: {
+        event,
+        render_time_msec
       }
     });
   } else {

--- a/client/src/redux/index.js
+++ b/client/src/redux/index.js
@@ -68,6 +68,7 @@ const initialState = {
   showSignoutModal: false,
   isOnline: true,
   isServerOnline: true,
+  renderStartTime: null,
   donationFormState: {
     ...defaultDonationFormState
   }
@@ -128,6 +129,12 @@ export const reducer = handleActions(
       return {
         ...state,
         recentlyClaimedBlock: payload
+      };
+    },
+    [actionTypes.setRenderStartTime]: (state, { payload }) => {
+      return {
+        ...state,
+        renderStartTime: payload
       };
     },
     [actionTypes.updateDonationFormState]: (state, { payload }) => ({

--- a/client/src/redux/selectors.js
+++ b/client/src/redux/selectors.js
@@ -219,3 +219,5 @@ export const userSelector = state => {
 
   return state[MainApp].user[username] || {};
 };
+
+export const renderStartTimeSelector = state => state[MainApp].renderStartTime;

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -1156,7 +1156,7 @@ const Editor = (props: EditorProps): JSX.Element => {
   }, [props.challengeFiles, props.isResetting]);
 
   useEffect(() => {
-    props.sendRenderTime(new Date().getTime());
+    props.sendRenderTime(Date.now());
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.description]);
 

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -47,7 +47,8 @@ import {
   initTests,
   stopResetting,
   openModal,
-  resetAttempts
+  resetAttempts,
+  sendRenderTime
 } from '../redux/actions';
 import {
   attemptsSelector,
@@ -91,6 +92,7 @@ export interface EditorProps {
   output: string[];
   resizeProps: ResizeProps;
   saveChallenge: () => void;
+  sendRenderTime: (renderTime: number) => void;
   saveEditorContent: () => void;
   setEditorFocusability: (isFocusable: boolean) => void;
   submitChallenge: () => void;
@@ -176,6 +178,7 @@ const mapDispatchToProps = {
   initTests,
   stopResetting,
   resetAttempts,
+  sendRenderTime,
   openHelpModal: () => openModal('help'),
   openResetModal: () => openModal('reset')
 };
@@ -1151,6 +1154,11 @@ const Editor = (props: EditorProps): JSX.Element => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.challengeFiles, props.isResetting]);
+
+  useEffect(() => {
+    props.sendRenderTime(new Date().getTime());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.description]);
 
   useEffect(() => {
     const { showProjectPreview, previewOpen } = props;

--- a/client/src/templates/Challenges/redux/action-types.js
+++ b/client/src/templates/Challenges/redux/action-types.js
@@ -33,19 +33,18 @@ export const actionTypes = createTypes(
     'closeModal',
     'openModal',
     'setIsAdvancing',
-
     'previewMounted',
     'projectPreviewMounted',
     'storePortalWindow',
     'removePortalWindow',
     'challengeMounted',
+    'sendRenderTime',
     'checkChallenge',
     'executeChallenge',
     'resetChallenge',
     'stopResetting',
     'submitChallenge',
     'resetAttempts',
-
     'setEditorFocusability',
     'toggleVisibleEditor'
   ],

--- a/client/src/templates/Challenges/redux/actions.js
+++ b/client/src/templates/Challenges/redux/actions.js
@@ -64,6 +64,7 @@ export const storePortalWindow = createAction(actionTypes.storePortalWindow);
 export const removePortalWindow = createAction(actionTypes.removePortalWindow);
 
 export const challengeMounted = createAction(actionTypes.challengeMounted);
+export const sendRenderTime = createAction(actionTypes.sendRenderTime);
 export const checkChallenge = createAction(actionTypes.checkChallenge);
 export const executeChallenge = createAction(actionTypes.executeChallenge);
 export const resetChallenge = createAction(actionTypes.resetChallenge);

--- a/client/src/templates/Challenges/redux/completion-epic.js
+++ b/client/src/templates/Challenges/redux/completion-epic.js
@@ -16,6 +16,7 @@ import { challengeTypes, submitTypes } from '../../../../utils/challenge-types';
 import { actionTypes as submitActionTypes } from '../../../redux/action-types';
 import {
   allowBlockDonationRequests,
+  setRenderStartTime,
   submitComplete,
   updateComplete,
   updateFailed
@@ -203,6 +204,7 @@ export default function completionEpic(action$, state$) {
             ? of(x, allowBlockDonationRequests({ superBlock, block }))
             : of(x)
         ),
+        mergeMap(x => of(x, setRenderStartTime(new Date().getTime()))),
         tap(res => {
           if (res.type !== submitActionTypes.updateFailed) {
             navigate(pathToNavigateTo);

--- a/client/src/templates/Challenges/redux/completion-epic.js
+++ b/client/src/templates/Challenges/redux/completion-epic.js
@@ -204,7 +204,7 @@ export default function completionEpic(action$, state$) {
             ? of(x, allowBlockDonationRequests({ superBlock, block }))
             : of(x)
         ),
-        mergeMap(x => of(x, setRenderStartTime(new Date().getTime()))),
+        mergeMap(x => of(x, setRenderStartTime(Date.now()))),
         tap(res => {
           if (res.type !== submitActionTypes.updateFailed) {
             navigate(pathToNavigateTo);

--- a/client/src/templates/Challenges/redux/current-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/current-challenge-saga.js
@@ -1,7 +1,9 @@
-import { put, takeEvery } from 'redux-saga/effects';
+import { put, takeEvery, select } from 'redux-saga/effects';
 import store from 'store';
 
 import { randomCompliment } from '../../../utils/get-words';
+import { executeGA, setRenderStartTime } from '../../../redux/actions';
+import { renderStartTimeSelector } from '../../../redux/selectors';
 import { CURRENT_CHALLENGE_KEY } from './action-types';
 import { updateSuccessMessage } from './actions';
 
@@ -30,9 +32,28 @@ function* updateSuccessMessageSaga() {
   yield put(updateSuccessMessage(randomCompliment()));
 }
 
+function* sendRenderTimeSaga({ payload }) {
+  /*
+    This saga sends the difference between a challenge submission time 
+    and next challenge's description change time to google analytics.
+  */
+  const renderStartTime = yield select(renderStartTimeSelector);
+  if (renderStartTime) {
+    const challengeRenderTime = payload - renderStartTime;
+    yield put(setRenderStartTime(null));
+    yield put(
+      executeGA({
+        event: 'render_time',
+        render_time_msec: challengeRenderTime
+      })
+    );
+  }
+}
+
 export function createCurrentChallengeSaga(types) {
   return [
     takeEvery(types.challengeMounted, currentChallengeSaga),
-    takeEvery(types.challengeMounted, updateSuccessMessageSaga)
+    takeEvery(types.challengeMounted, updateSuccessMessageSaga),
+    takeEvery(types.sendRenderTime, sendRenderTimeSaga)
   ];
 }

--- a/client/src/templates/Challenges/redux/current-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/current-challenge-saga.js
@@ -44,7 +44,7 @@ function* sendRenderTimeSaga({ payload }) {
     yield put(
       executeGA({
         event: 'render_time',
-        render_time_msec: challengeRenderTime
+        challengeRenderTime
       })
     );
   }


### PR DESCRIPTION
This saga sends the difference between a challenge submission time and next challenge's description change time to google analytics. 

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
