### PR TITLE
fix(curriculum): Reorder information in Record Collection challenge

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/record-collection.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/record-collection.md
@@ -22,7 +22,7 @@ Complete the function using the rules below to modify the object passed to the f
 -   Your function must always return the entire `records` object.
 -   If `value` is an empty string, delete the given `prop` property from the album.
 -   If `prop` isn't `tracks` and `value` isn't an empty string, assign the `value` to that album's `prop`.
--   If `prop` is `tracks` and value isn't an empty string, add the `value` to the end of the album's `tracks` array. You need to create this array first if the album does not have a `tracks` property.
+-   If `prop` is `tracks` and `value` isn't an empty string, update the album's `tracks` array. If the album does not have a `tracks` property, then you need to create this array first. Add the `value` to the end of the album's `tracks` array.
 
 **Note:** A copy of the `recordCollection` object is used for the tests. You should not directly modify the `recordCollection` object.
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/record-collection.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/record-collection.md
@@ -22,7 +22,7 @@ Complete the function using the rules below to modify the object passed to the f
 -   Your function must always return the entire `records` object.
 -   If `value` is an empty string, delete the given `prop` property from the album.
 -   If `prop` isn't `tracks` and `value` isn't an empty string, assign the `value` to that album's `prop`.
--   If `prop` is `tracks` and `value` isn't an empty string, update the album's `tracks` array. If the album does not have a `tracks` property, then you need to create this array first. Add the `value` to the end of the album's `tracks` array.
+-   If `prop` is `tracks` and `value` isn't an empty string, you need to update the album's `tracks` array. First, if the album does not have a `tracks` property, assign it an empty array. Then add the `value` as the last item in the album's `tracks` array.
 
 **Note:** A copy of the `recordCollection` object is used for the tests. You should not directly modify the `recordCollection` object.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #50182

<!-- Feel free to add any additional description of changes below this line -->

This focuses on the clarity of the instruction. I think we can handle this question of not being clear that `"tracks"`  is a string literal in a code block separately.
