### PR TITLE
fix: ensure correct types for project links

### DIFF
--- a/client/src/client-only-routes/show-project-links.tsx
+++ b/client/src/client-only-routes/show-project-links.tsx
@@ -1,5 +1,5 @@
 import { Table } from '@freecodecamp/react-bootstrap';
-import { find, first } from 'lodash-es';
+import { find } from 'lodash-es';
 import React, { useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -7,10 +7,7 @@ import { connect } from 'react-redux';
 import { Link, Spacer } from '../components/helpers';
 import ProjectModal from '../components/SolutionViewer/project-modal';
 import { CompletedChallenge, User } from '../redux/prop-types';
-import {
-  legacyProjectMap,
-  projectMap
-} from '../resources/cert-and-project-map';
+import { fullProjectMap } from '../resources/cert-and-project-map';
 
 import { SolutionDisplayWidget } from '../components/solution-display-widget';
 import ProjectPreviewModal from '../templates/Challenges/components/project-preview-modal';
@@ -91,9 +88,11 @@ const ShowProjectLinks = (props: ShowProjectLinksProps): JSX.Element => {
     );
   };
 
-  const renderProjectsFor = (certName: string) => {
+  const renderProjectsFor = (
+    certName: keyof typeof fullProjectMap | 'Legacy Full Stack'
+  ) => {
     if (certName === 'Legacy Full Stack') {
-      const legacyCerts = [
+      const certs = [
         { title: 'Responsive Web Design' },
         { title: 'JavaScript Algorithms and Data Structures' },
         { title: 'Front End Development Libraries' },
@@ -101,10 +100,10 @@ const ShowProjectLinks = (props: ShowProjectLinksProps): JSX.Element => {
         { title: 'Back End Development and APIs' },
         { title: 'Legacy Information Security and Quality Assurance' }
       ] as const;
-      return legacyCerts.map((cert, ind) => {
-        const mapToUse = (projectMap[cert.title] ||
-          legacyProjectMap[cert.title]) as { certSlug: string }[];
-        const { certSlug } = first(mapToUse) as { certSlug: string };
+
+      return certs.map((cert, ind) => {
+        const projects = fullProjectMap[cert.title];
+        const { certSlug } = projects[0];
         const certLocation = `/certification/${username}/${certSlug}`;
         return (
           <tr key={ind}>
@@ -117,12 +116,8 @@ const ShowProjectLinks = (props: ShowProjectLinksProps): JSX.Element => {
         );
       });
     }
-    // @ts-expect-error Error expected until projectMap is typed
-    const project = (projectMap[certName] || legacyProjectMap[certName]) as {
-      link: string;
-      title: string;
-      id: string;
-    }[];
+
+    const project = fullProjectMap[certName];
     return project.map(({ link, title, id }) => (
       <tr key={id}>
         <td>
@@ -151,6 +146,14 @@ const ShowProjectLinks = (props: ShowProjectLinksProps): JSX.Element => {
           null
       }
     : null;
+
+  const isCertName = (
+    maybeCertName: string
+  ): maybeCertName is keyof typeof fullProjectMap | 'Legacy Full Stack' => {
+    if (maybeCertName === 'Legacy Full Stack') return true;
+    return maybeCertName in fullProjectMap;
+  };
+  if (!isCertName(certName)) return <div> Unknown Certification</div>;
 
   return (
     <div>

--- a/client/src/resources/cert-and-project-map.ts
+++ b/client/src/resources/cert-and-project-map.ts
@@ -811,12 +811,9 @@ const fullProjectMap = {
 };
 
 export {
-  certMap,
   certMapWithoutFullStack,
   fullCertMap,
   fullProjectMap,
-  legacyCertMap,
   legacyProjectMap,
-  projectMap,
-  upcomingCertMap
+  projectMap
 };


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Builds on https://github.com/freeCodeCamp/freeCodeCamp/pull/49708, to guarantee that the certification to be rendered is valid.

@ahmadabdolsaheb I wasn't sure how best to handle the error case. Maybe just a translatable message like "We cannot show this certification, email support@freeCodeCamp.org to get help."?

<!-- Feel free to add any additional description of changes below this line -->
