### PR TITLE
chore: update error message for Crash Dumps

### DIFF
--- a/api-server/src/server/middlewares/error-handlers.js
+++ b/api-server/src/server/middlewares/error-handlers.js
@@ -47,7 +47,7 @@ export default function prodErrorHandler() {
     const redirectTo = handled.redirectTo || `${origin}/`;
     const message =
       handled.message ||
-      'Oops! Something went wrong. Please try again in a moment.';
+      'Oops! Something went wrong. Please try again in a moment or contact support@freecodecamp.org if the error persists.';
 
     if (isDev) {
       console.error(errTemplate(err, req));


### PR DESCRIPTION
This should give users some clarity on where to reach when seeing a server crash error, which is helpful in cases where they have duplicate accounts.