### PR TITLE
feat(client): add faq section to landing page

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -101,7 +101,66 @@
         "testimony": "\"I've always struggled with learning JavaScript. I've taken many courses but freeCodeCamp's course was the one which stuck. Studying JavaScript as well as data structures and algorithms on <strong>freeCodeCamp gave me the skills</strong> and confidence I needed to land my dream job as a software engineer at Spotify.\""
       }
     },
-    "certification-heading": "Earn free verified certifications in:"
+    "certification-heading": "Earn free verified certifications in:",
+    "faq": "Frequently asked questions:",
+    "faqs": [
+      {
+        "question": "What exactly is freeCodeCamp?",
+        "answer": [
+          "freeCodeCamp is a community of people from all around the world who are learning to code together. We're a 501(c)(3) public charity."
+        ]
+      },
+      {
+        "question": "How will freeCodeCamp help me learn to code?",
+        "answer": [
+          "You will learn to code by building dozens of projects, step-by-step, right in your browser, code editor, or mobile app.",
+          "You will also earn free verified certifications along the way."
+        ]
+      },
+      {
+        "question": "Is freeCodeCamp really free?",
+        "answer": [
+          "Yes. Every aspect of freeCodeCamp is 100% free. The courses, the projects, and even the certifications."
+        ]
+      },
+      {
+        "question": "Can freeCodeCamp help me get a job as a software developer?",
+        "answer": [
+          "Yes. Every year, thousands of people who join the freeCodeCamp community get their first software developer job."
+        ]
+      },
+      {
+        "question": "What skills will I learn?",
+        "answer": [
+          "You will learn the skills most developers use on the job: HTML, CSS, JavaScript, Python, Linux, Git, and SQL, and more. You'll also learn how to use powerful libraries for web development, mobile app development, data science, and artificial intelligence."
+        ]
+      },
+      {
+        "question": "How long does it take to learn all this?",
+        "answer": [
+          "freeCodeCamp is self-paced. Realistically, it may take several years of practicing coding to learn these skills well enough to get a job as a software engineer. Don't quit school or your day job until you feel ready."
+        ]
+      },
+      {
+        "question": "How do I get started?",
+        "answer": [
+          "If you're a beginner, you should start at the beginning of the freeCodeCamp core curriculum. If you're more advanced, we still recommend starting at the beginning, but you can skip to whatever area you wish."
+        ]
+      },
+      {
+        "question": "How do I earn the free verified certifications?",
+        "answer": [
+          "For each certification, you need to build its 5 certification projects, and get all of the project tests to pass to be able to claim your certification."
+        ]
+      },
+      {
+        "question": "I don't see [name of tool] in the freeCodeCamp core curriculum.",
+        "answer": [
+          "Aside from the freeCodeCamp core curriculum, We have thousands of free, full-length books, courses, and programming tutorials. We almost certainly teach whatever programming tools you want to learn. Just use the search bar."
+        ]
+      }
+    ],
+    "happy-coding": "Happy Coding"
   },
   "settings": {
     "share-projects": "Share your non-freeCodeCamp projects, articles or accepted pull requests.",

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -159,8 +159,7 @@
           "Aside from the freeCodeCamp core curriculum, We have thousands of free, full-length books, courses, and programming tutorials. We almost certainly teach whatever programming tools you want to learn. Just use the search bar."
         ]
       }
-    ],
-    "happy-coding": "Happy Coding"
+    ]
   },
   "settings": {
     "share-projects": "Share your non-freeCodeCamp projects, articles or accepted pull requests.",

--- a/client/src/components/landing/components/faq.tsx
+++ b/client/src/components/landing/components/faq.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Col, Row } from '@freecodecamp/react-bootstrap';
+import { Col } from '@freecodecamp/react-bootstrap';
 import { useTranslation } from 'react-i18next';
 import { Spacer } from '../../helpers';
 import BigCallToAction from './big-call-to-action';
@@ -11,29 +11,26 @@ interface FaqItem {
 
 const Faq = (): JSX.Element => {
   const { t } = useTranslation();
-  const faqItems: FaqItem[] = t('landing.faqs', { returnObjects: true });
+  const faqItems = t<string, string & FaqItem[]>('landing.faqs');
 
   return (
-    <Row className='landing-faq'>
-      <Col sm={8} smOffset={2} xs={10} xsOffset={1}>
-        <h1 className='big-heading'>{t('landing.faq')}</h1>
-        <Spacer size='medium' />
-        {faqItems.map((faq, i) => (
-          <div data-test-label='landing-page-faq' key={i}>
-            <h3>{faq.question}</h3>
-            {faq.answer.map((answer, i) => (
-              <p key={i}>{answer}</p>
-            ))}
-            <Spacer size='small' />
-            <Spacer size='small' />
-          </div>
-        ))}
-        <h3>{t('landing.happy-coding')}</h3>
-        <Spacer size='medium' />
-        <BigCallToAction />
-        <Spacer size='large' />
-      </Col>
-    </Row>
+    <Col sm={8} smOffset={2} xs={10} xsOffset={1}>
+      <h1 className='big-heading'>{t('landing.faq')}</h1>
+      <Spacer size='small' />
+      {faqItems.map((faq, i) => (
+        <div data-test-label='landing-page-faq' key={i}>
+          <p className='faq-question'>{faq.question}</p>
+          {faq.answer.map((answer, i) => (
+            <p key={i}>{answer}</p>
+          ))}
+          <Spacer size='small' />
+        </div>
+      ))}
+      <h3>{t('learn.read-this.p12')}</h3>
+      <Spacer size='medium' />
+      <BigCallToAction />
+      <Spacer size='large' />
+    </Col>
   );
 };
 

--- a/client/src/components/landing/components/faq.tsx
+++ b/client/src/components/landing/components/faq.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Col, Row } from '@freecodecamp/react-bootstrap';
+import { useTranslation } from 'react-i18next';
+import { Spacer } from '../../helpers';
+import BigCallToAction from './big-call-to-action';
+
+interface FaqItem {
+  question: string;
+  answer: string[];
+}
+
+const Faq = (): JSX.Element => {
+  const { t } = useTranslation();
+  const faqItems: FaqItem[] = t('landing.faqs', { returnObjects: true });
+
+  return (
+    <Row className='landing-faq'>
+      <Col sm={8} smOffset={2} xs={10} xsOffset={1}>
+        <h1 className='big-heading'>{t('landing.faq')}</h1>
+        <Spacer size='medium' />
+        {faqItems.map((faq, i) => (
+          <div data-test-label='landing-page-faq' key={i}>
+            <h3>{faq.question}</h3>
+            {faq.answer.map((answer, i) => (
+              <p key={i}>{answer}</p>
+            ))}
+            <Spacer size='small' />
+            <Spacer size='small' />
+          </div>
+        ))}
+        <h3>{t('landing.happy-coding')}</h3>
+        <Spacer size='medium' />
+        <BigCallToAction />
+        <Spacer size='large' />
+      </Col>
+    </Row>
+  );
+};
+
+Faq.displayName = 'Faq';
+export default Faq;

--- a/client/src/components/landing/components/testimonials.tsx
+++ b/client/src/components/landing/components/testimonials.tsx
@@ -5,6 +5,7 @@ import emmaImg from '../../../assets/images/landing/Emma.png';
 import sarahImg from '../../../assets/images/landing/Sarah.png';
 import shawnImg from '../../../assets/images/landing/Shawn.png';
 import { LazyImage } from '../../helpers';
+import BigCallToAction from './big-call-to-action';
 
 const Testimonials = (): JSX.Element => {
   const { t } = useTranslation();
@@ -96,6 +97,7 @@ const Testimonials = (): JSX.Element => {
           </div>
         </div>
       </div>
+      <BigCallToAction />
     </div>
   );
 };

--- a/client/src/components/landing/index.tsx
+++ b/client/src/components/landing/index.tsx
@@ -7,6 +7,7 @@ import AsSeenIn from './components/as-seen-in';
 import Certifications from './components/certifications';
 import LandingTop from './components/landing-top';
 import Testimonials from './components/testimonials';
+import Faq from './components/faq';
 
 import './landing.css';
 
@@ -25,6 +26,7 @@ function Landing(): ReactElement {
         </Grid>
         <Testimonials />
         <Certifications />
+        <Faq />
       </main>
     </>
   );

--- a/client/src/components/landing/landing.css
+++ b/client/src/components/landing/landing.css
@@ -66,6 +66,11 @@ figcaption.caption {
   height: 40px;
 }
 
+.faq-question {
+  font-weight: bold;
+  font-size: 1.25rem;
+}
+
 @media (min-width: 370px) {
   .logo-row svg {
     margin: 5px 15px;

--- a/cypress/e2e/default/landing.ts
+++ b/cypress/e2e/default/landing.ts
@@ -3,7 +3,8 @@ const landingPageElements = {
   callToAction: "[data-test-label='landing-big-cta']",
   certifications: "[data-test-label='certifications']",
   testimonials: "[data-test-label='testimonial-cards']",
-  landingPageImage: "[data-test-label='landing-page-figure']"
+  landingPageImage: "[data-test-label='landing-page-figure']",
+  faq: "[data-test-label='landing-page-faq']"
 } as const;
 
 type LandingPageTypes<T> = T[keyof T];
@@ -33,7 +34,7 @@ describe('Landing page', () => {
       'Learn to Code — For Free — Coding Courses for Busy People'
     );
     cy.contains(landingPageElements.callToAction, "Get started (it's free)");
-    cy.get(landingPageElements.callToAction).should('have.length', 2);
+    cy.get(landingPageElements.callToAction).should('have.length', 3);
   });
 
   it('Has visible header and sub-header', () => {
@@ -81,5 +82,9 @@ describe('Landing page', () => {
       .children()
       .its('length')
       .should('eq', 3);
+  });
+
+  it('Has FAQ section', function () {
+    cy.get(landingPageElements.faq).its('length').should('eq', 9);
   });
 });

--- a/cypress/e2e/default/landing.ts
+++ b/cypress/e2e/default/landing.ts
@@ -34,7 +34,7 @@ describe('Landing page', () => {
       'Learn to Code — For Free — Coding Courses for Busy People'
     );
     cy.contains(landingPageElements.callToAction, "Get started (it's free)");
-    cy.get(landingPageElements.callToAction).should('have.length', 3);
+    cy.get(landingPageElements.callToAction).should('have.length', 4);
   });
 
   it('Has visible header and sub-header', () => {


### PR DESCRIPTION
This adds an FAQ section to the landing page per Quincy's request.

<details>
    <summary>Screenshots</summary>
    <img src="https://user-images.githubusercontent.com/20648924/235514621-3f830108-e4ab-4e7c-9273-e449458d5598.png" />
    <img src="https://user-images.githubusercontent.com/20648924/235514636-232f406e-dddf-461a-b32a-5264ee22e7b5.png" />
</details>


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
