### PR TITLE
feat(client): remove the height from the space component

### DIFF
--- a/client/src/components/helpers/spacer.tsx
+++ b/client/src/components/helpers/spacer.tsx
@@ -16,10 +16,7 @@ interface SpacerProps {
 }
 
 const Spacer = ({ size, children }: SpacerProps): JSX.Element => (
-  <div
-    className='spacer'
-    style={{ padding: `${Padding[size]}px 0`, height: '1px' }}
-  >
+  <div className='spacer' style={{ padding: `${Padding[size]}px 0` }}>
     {children}
   </div>
 );

--- a/client/src/components/profile/__snapshots__/profile.test.tsx.snap
+++ b/client/src/components/profile/__snapshots__/profile.test.tsx.snap
@@ -4,14 +4,14 @@ exports[`<Profile/> renders correctly 1`] = `
 <div>
   <div
     class="spacer"
-    style="padding: 15px 0px; height: 1px;"
+    style="padding: 15px 0px;"
   />
   <div
     class="container"
   >
     <div
       class="spacer"
-      style="padding: 15px 0px; height: 1px;"
+      style="padding: 15px 0px;"
     />
     <div>
       <div
@@ -276,7 +276,7 @@ exports[`<Profile/> renders correctly 1`] = `
     </div>
     <div
       class="spacer"
-      style="padding: 15px 0px; height: 1px;"
+      style="padding: 15px 0px;"
     />
     <div
       class="text-center row"
@@ -289,7 +289,7 @@ exports[`<Profile/> renders correctly 1`] = `
     </div>
     <div
       class="spacer"
-      style="padding: 15px 0px; height: 1px;"
+      style="padding: 15px 0px;"
     />
   </div>
 </div>

--- a/client/src/pages/__snapshots__/email-sign-up.test.js.snap
+++ b/client/src/pages/__snapshots__/email-sign-up.test.js.snap
@@ -16,7 +16,6 @@ exports[`<EmailSignUp /> Non-Authenticated user "not accepted terms and conditio
         className="spacer"
         style={
           {
-            "height": "1px",
             "padding": "15px 0",
           }
         }
@@ -31,7 +30,6 @@ exports[`<EmailSignUp /> Non-Authenticated user "not accepted terms and conditio
           className="spacer"
           style={
             {
-              "height": "1px",
               "padding": "15px 0",
             }
           }
@@ -100,7 +98,6 @@ exports[`<EmailSignUp /> Non-Authenticated user "not accepted terms and conditio
         className="spacer"
         style={
           {
-            "height": "1px",
             "padding": "15px 0",
           }
         }
@@ -112,7 +109,6 @@ exports[`<EmailSignUp /> Non-Authenticated user "not accepted terms and conditio
         className="spacer"
         style={
           {
-            "height": "1px",
             "padding": "15px 0",
           }
         }
@@ -125,7 +121,6 @@ exports[`<EmailSignUp /> Non-Authenticated user "not accepted terms and conditio
         className="spacer"
         style={
           {
-            "height": "1px",
             "padding": "5px 0",
           }
         }
@@ -142,7 +137,6 @@ exports[`<EmailSignUp /> Non-Authenticated user "not accepted terms and conditio
         className="spacer"
         style={
           {
-            "height": "1px",
             "padding": "5px 0",
           }
         }
@@ -155,7 +149,6 @@ exports[`<EmailSignUp /> Non-Authenticated user "not accepted terms and conditio
         className="spacer"
         style={
           {
-            "height": "1px",
             "padding": "15px 0",
           }
         }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #49828

With the existance of height having a child inside the component will require us to set height to the spacer every time we use it, this remove the needs for that.

<!-- Feel free to add any additional description of changes below this line -->
