### PR TITLE
fix(api): allow fastify to set content-type dynamically

### DIFF
--- a/api/src/plugins/security.ts
+++ b/api/src/plugins/security.ts
@@ -10,7 +10,6 @@ const securityHeaders: FastifyPluginCallback = (fastify, _options, done) => {
     void reply
       .header('Cache-Control', 'no-store')
       .header('Content-Security-Policy', "frame-ancestors 'none'")
-      .header('Content-Type', 'application/json; charset=utf-8')
       .header('X-Content-Type-Options', 'nosniff')
       .header('X-Frame-Options', 'DENY');
     // TODO: Increase this gradually to 2 years. Include preload once it is

--- a/api/src/server.test.ts
+++ b/api/src/server.test.ts
@@ -11,9 +11,8 @@ jest.mock('./utils/env', () => {
 });
 
 describe('production', () => {
+  setupServer();
   describe('GET /', () => {
-    setupServer();
-
     test('have a 200 response', async () => {
       const res = await superGet('/');
       expect(res.statusCode).toBe(200);
@@ -66,6 +65,20 @@ describe('production', () => {
         'access-control-allow-headers':
           'Origin, X-Requested-With, Content-Type, Accept',
         'access-control-allow-credentials': 'true'
+      });
+    });
+  });
+
+  describe('GET /documentation', () => {
+    test('should have OWASP recommended headers, except content-type', async () => {
+      const res = await superGet('/documentation/static/index.html');
+      expect(res.headers).toMatchObject({
+        'cache-control': 'no-store',
+        'content-security-policy': "frame-ancestors 'none'",
+        'content-type': 'text/html; charset=utf-8',
+        'x-content-type-options': 'nosniff',
+        'x-frame-options': 'DENY',
+        'strict-transport-security': 'max-age=300; includeSubDomains'
       });
     });
   });


### PR DESCRIPTION
We can set content-type: application/json for specific routes, but
doing so ends up with confusing, over-engineered code.

Instead we should take care when auditing the endpoints.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

With this change, the Swagger UI should render again.

<!-- Feel free to add any additional description of changes below this line -->
