### PR TITLE
fix(client): window title in rdb challenges

### DIFF
--- a/client/src/templates/Challenges/codeally/show.tsx
+++ b/client/src/templates/Challenges/codeally/show.tsx
@@ -207,6 +207,11 @@ class ShowCodeAlly extends Component<ShowCodeAllyProps> {
       userToken = null
     } = this.props;
 
+    const blockNameTitle = `${t(
+      `intro:${superBlock}.blocks.${blockName}.title`
+    )}: ${title}`;
+    const windowTitle = `${blockNameTitle} | freeCodeCamp.org`;
+
     // Initial CodeAlly login includes a tempToken in redirect URL
     const queryParams = new URLSearchParams(window.location.search);
     const codeAllyTempToken: string | null = queryParams.get('tempToken');
@@ -234,7 +239,7 @@ class ShowCodeAlly extends Component<ShowCodeAllyProps> {
 
     return showCodeAlly ? (
       <LearnLayout>
-        <Helmet title={`${blockName}: ${title} | freeCodeCamp.org`} />
+        <Helmet title={windowTitle} />
         <iframe
           className='codeally-frame'
           data-cy='codeally-frame'
@@ -251,7 +256,7 @@ class ShowCodeAlly extends Component<ShowCodeAllyProps> {
         prevChallengePath={prevChallengePath}
       >
         <LearnLayout>
-          <Helmet title={`${blockName}: ${title} | freeCodeCamp.org`} />
+          <Helmet title={windowTitle} />
           <Grid>
             {superBlock === SuperBlocks.RelationalDb && <CodeAllyDown />}
             <Row>


### PR DESCRIPTION
The window titles had a dasherized version of the block in the rdb challenges. This undasherizes it.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
