### PR TITLE
feat(client): polish the styles for the lang button

### DIFF
--- a/client/src/assets/icons/language-globe.tsx
+++ b/client/src/assets/icons/language-globe.tsx
@@ -6,7 +6,7 @@ function LanguageGlobe(
   return (
     <svg
       aria-hidden={true}
-      height={22}
+      height={24}
       viewBox='0 0 24 24'
       width={24}
       xmlns='http://www.w3.org/2000/svg'

--- a/client/src/components/Header/components/menu-button.tsx
+++ b/client/src/components/Header/components/menu-button.tsx
@@ -44,9 +44,7 @@ const MenuButton = ({
   return (
     <button
       aria-expanded={displayMenu}
-      className={`exposed-button-nav${
-        displayMenu ? ' reverse-toggle-color' : ''
-      }`}
+      className='exposed-button-nav'
       id='toggle-button-nav'
       onBlur={handleBlur}
       onClick={handleClick}

--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -99,7 +99,7 @@
     [aria-expanded='true'],
     [aria-expanded='false'].force-show
   ) {
-  fill: var(--gray-10);
+  fill: var(--gray-00);
 }
 
 .nav-list li {

--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -77,15 +77,28 @@
   top: 100%;
 }
 
+.exposed-button-nav:is(
+    :hover,
+    :hover:focus,
+    [aria-expanded='true'],
+    [aria-expanded='true']:hover
+  ),
 .lang-button-nav:is(
     :hover,
     :hover:focus,
     [aria-expanded='true'],
     [aria-expanded='false'].force-show
   ) {
-  background-color: var(--gray-10);
+  background-color: var(--gray-00);
   color: var(--theme-color);
-  border: 1px solid var(--gray-00);
+}
+
+.lang-button-nav:is(
+    :hover,
+    :hover:focus,
+    [aria-expanded='true'],
+    [aria-expanded='false'].force-show
+  ) {
   fill: var(--gray-10);
 }
 
@@ -173,10 +186,6 @@ li > button.nav-link-signout:not([aria-disabled='true']):is(:hover, :focus) {
   justify-content: space-between;
 }
 
-.nav-link-sign-in {
-  display: none;
-}
-
 .nav-link-dull {
   color: var(--gray-45);
 }
@@ -195,7 +204,6 @@ li > button.nav-link-signout:not([aria-disabled='true']):is(:hover, :focus) {
 
 .exposed-button-nav,
 .lang-button-nav {
-  padding: 2px 14px;
   border: 1px solid var(--gray-00);
   font-size: 18px;
   color: var(--gray-00);
@@ -206,10 +214,16 @@ li > button.nav-link-signout:not([aria-disabled='true']):is(:hover, :focus) {
   align-items: center;
 }
 
+.exposed-button-nav {
+  padding: 2px 14px;
+}
+
+.lang-button-nav {
+  padding: 5px;
+}
+
 .exposed-button-nav:hover,
 .exposed-button-nav:hover:focus {
-  background-color: var(--gray-00);
-  color: var(--gray-90);
   border: 1px solid var(--gray-00);
 }
 
@@ -272,16 +286,6 @@ li > button.nav-link-signout:not([aria-disabled='true']):is(:hover, :focus) {
 
 .display-menu::-webkit-scrollbar {
   display: none;
-}
-
-.exposed-button-nav.reverse-toggle-color {
-  background-color: var(--gray-00);
-  color: var(--theme-color);
-}
-
-.exposed-button-nav.reverse-toggle-color:hover {
-  background-color: var(--gray-00);
-  color: var(--theme-color);
 }
 
 .nav-line {
@@ -433,8 +437,5 @@ li > button.nav-link-signout:not([aria-disabled='true']):is(:hover, :focus) {
   }
   .universal-nav {
     padding: 0 5px;
-  }
-  .nav-link-sign-in {
-    display: flex;
   }
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The hover of the language button was a different color than the one used in the menu, and the height of the button were smaller than the menu button.

I was going to add this in #49860, but I am having a fun bug that is the first time I have seen, so I want to mess with the header refactoring PR a little longer if possible.


Old looks 
![image](https://user-images.githubusercontent.com/88248797/235749302-f652ca4e-6ff4-4dde-b85b-b3526cae7b6c.png)

<!-- Feel free to add any additional description of changes below this line -->

The new one

![image](https://user-images.githubusercontent.com/88248797/235750253-7ff736ac-9e1c-4531-b4f3-4d57e2a6ff07.png)
