### PR TITLE
fix(api-server): check type of email to prevent throw

### DIFF
--- a/api-server/src/server/boot/authentication.js
+++ b/api-server/src/server/boot/authentication.js
@@ -220,7 +220,7 @@ function mobileLogin(app) {
 
       const { email } = await auth0Res.json();
 
-      if (!isEmail(email)) {
+      if (typeof email === 'string' && !isEmail(email)) {
         return next(
           wrapHandledError(new TypeError('decoded email is invalid'), {
             type: 'danger',

--- a/api-server/src/server/boot/authentication.js
+++ b/api-server/src/server/boot/authentication.js
@@ -220,7 +220,7 @@ function mobileLogin(app) {
 
       const { email } = await auth0Res.json();
 
-      if (typeof email === 'string' && !isEmail(email)) {
+      if (typeof email !== 'string' || !isEmail(email)) {
         return next(
           wrapHandledError(new TypeError('decoded email is invalid'), {
             type: 'danger',


### PR DESCRIPTION
Sentry complained because of a new error.

Turns out, `isEmail` only accepts type `string` as an argument, otherwise throws. If only we had strong typings...