### PR TITLE
chore: codesee ignores gitignore

### DIFF
--- a/.github/workflows/codesee-diagram.yml
+++ b/.github/workflows/codesee-diagram.yml
@@ -7,6 +7,7 @@ on:
   pull_request_target:
     paths-ignore:
       - 'docs/**'
+      - '.gitignore'
     types: [opened, synchronize, reopened]
 
 permissions: read-all


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

99% of the PRs that touch `.gitignore` get closed by our spam integration - doesn't make sense to run codesee on those it's just extra noise.