### PR TITLE
feat(tools): add tests for language selector

### DIFF
--- a/cypress/e2e/default/learn/header/lang-selector.ts
+++ b/cypress/e2e/default/learn/header/lang-selector.ts
@@ -1,0 +1,43 @@
+const langSelectors = {
+  button: '#toggle-lang-button',
+  english: '[data-value="english"]',
+  espanol: '[data-value="espanol"]',
+  chinese: '[data-value="chinese"]'
+};
+
+const langOpts = [
+  'english',
+  'espanol',
+  'chinese',
+  'chinese-traditional',
+  'italian',
+  'portuguese',
+  'ukrainian',
+  'japanese',
+  'german'
+];
+
+describe('language selector', () => {
+  it('should render the button', () => {
+    cy.visit('/learn');
+    cy.get(langSelectors.button).should('be.visible');
+  });
+
+  it('should render all lang options', () => {
+    cy.visit('/learn');
+    cy.get(langSelectors.button).click();
+    langOpts.forEach(lang => {
+      cy.get(`[data-value="${lang}"]`).should('be.visible');
+    });
+  });
+
+  it('should navigate to another language', () => {
+    cy.visit('/learn');
+    cy.get(langSelectors.button).click();
+    cy.get(langSelectors.espanol).click();
+    cy.url().should('include', '/espanol');
+    cy.get(langSelectors.button).click();
+    cy.get(langSelectors.chinese).click();
+    cy.url().should('include', '/chinese');
+  });
+});


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This is a regression test for #50268 

<!-- Feel free to add any additional description of changes below this line -->

Passes locally: 
<img width="1364" alt="image" src="https://user-images.githubusercontent.com/63889819/236291828-f29c9281-22a0-43e3-b99a-17f12e7430bc.png">
