### PR TITLE
feat: better lang selector tests

### DIFF
--- a/cypress/e2e/default/learn/header/lang-selector.ts
+++ b/cypress/e2e/default/learn/header/lang-selector.ts
@@ -1,43 +1,34 @@
-const langSelectors = {
-  button: '#toggle-lang-button',
-  english: '[data-value="english"]',
-  espanol: '[data-value="espanol"]',
-  chinese: '[data-value="chinese"]'
-};
+import { availableLangs, hiddenLangs } from '../../../../../config/i18n';
 
-const langOpts = [
-  'english',
-  'espanol',
-  'chinese',
-  'chinese-traditional',
-  'italian',
-  'portuguese',
-  'ukrainian',
-  'japanese',
-  'german'
-];
+const buttonSelector = '#toggle-lang-button';
+const toLangSelector = (lang: string) => `[data-value="${lang}"]`;
+
+const langOpts = availableLangs.client.filter(
+  lang => !hiddenLangs.includes(lang)
+);
 
 describe('language selector', () => {
+  beforeEach(() => {
+    cy.visit('/learn');
+  });
+
   it('should render the button', () => {
-    cy.visit('/learn');
-    cy.get(langSelectors.button).should('be.visible');
+    cy.get(buttonSelector).should('be.visible');
   });
 
-  it('should render all lang options', () => {
-    cy.visit('/learn');
-    cy.get(langSelectors.button).click();
-    langOpts.forEach(lang => {
-      cy.get(`[data-value="${lang}"]`).should('be.visible');
+  langOpts.forEach(lang => {
+    it(`should render the ${lang} option`, () => {
+      cy.get(buttonSelector).click();
+      cy.get(toLangSelector(lang)).should('be.visible');
     });
-  });
 
-  it('should navigate to another language', () => {
-    cy.visit('/learn');
-    cy.get(langSelectors.button).click();
-    cy.get(langSelectors.espanol).click();
-    cy.url().should('include', '/espanol');
-    cy.get(langSelectors.button).click();
-    cy.get(langSelectors.chinese).click();
-    cy.url().should('include', '/chinese');
+    if (lang === 'english') {
+      return;
+    }
+    it(`should navigate to ${lang}`, () => {
+      cy.get(buttonSelector).click();
+      cy.get(toLangSelector(lang)).click();
+      cy.url().should('include', `/${lang}`);
+    });
   });
 });


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

It occurred to me that this could be both more robust and more programmatic. Now it grabs the list of available languages from the config, filters the hidden ones, and tests that each language is both in the navbar and navigates correctly. This should help us catch any potential issues. 