### PR TITLE
docs(i18n): fix links in _translations.md

### DIFF
--- a/docs/_translations.md
+++ b/docs/_translations.md
@@ -8,15 +8,15 @@
 
 <div class='i18n-lang-list'>
 
-- [Chinese](/i18n/chinese/index.md)
-- [Chinese Traditional](/i18n/chinese-traditional/index.md)
-- [English](/index.md)
-- [Español](/i18n/espanol/index.md)
-- [German](/i18n/german/index.md)
-- [Italian](/i18n/italian/index.md)
-- [Japanese](/i18n/japanese/index.md)
-- [Portuguese](/i18n/portuguese/index.md)
-- [Ukrainian](/i18n/ukrainian/index.md)
+- [Chinese](./i18n/chinese/index.md)
+- [Chinese Traditional](./i18n/chinese-traditional/index.md)
+- [English](./index.md)
+- [Español](./i18n/espanol/index.md)
+- [German](./i18n/german/index.md)
+- [Italian](./i18n/italian/index.md)
+- [Japanese](./i18n/japanese/index.md)
+- [Portuguese](./i18n/portuguese/index.md)
+- [Ukrainian](./i18n/ukrainian/index.md)
 
 </div>
 


### PR DESCRIPTION
Fixed broken links in the doc "_translations.md". All the existing links lead to a 404 error.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

No existing issue number.