### PR TITLE
fix(client): error flash when toggling send quincy email in settings

### DIFF
--- a/client/src/components/settings/email.tsx
+++ b/client/src/components/settings/email.tsx
@@ -227,7 +227,7 @@ function EmailSettings({
       </FullWidthRow>
       <Spacer size='medium' />
       <FullWidthRow>
-        <form id='form-quincy-email' onSubmit={handleSubmit}>
+        <form id='form-quincy-email' onSubmit={e => e.preventDefault()}>
           <ToggleButtonSetting
             action={t('settings.email.weekly')}
             flag={sendQuincyEmail}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #50335 

<!-- Feel free to add any additional description of changes below this line -->

The rapid error flash is shown because of the `handleSubmit` function which would try to update the user email.
