### PR TITLE
fix(docs): correct typos

### DIFF
--- a/docs/how-to-setup-freecodecamp-locally.md
+++ b/docs/how-to-setup-freecodecamp-locally.md
@@ -148,7 +148,7 @@ Note: `--depth=1` creates a shallow clone of your fork, with only the most recen
 
 Now that you have downloaded a copy of your fork, you will need to set up an `upstream` remote to the parent repository.
 
-[As mentioned earlier](#fork-the-repository-on-github), the main repository is referred `upstream` repository. Your fork referred to as the `origin` repository.
+[As mentioned earlier](#fork-the-repository-on-github), the main repository is referred to as the `upstream` repository. Your fork is referred to as the `origin` repository.
 
 You need a reference from your local clone to the `upstream` repository in addition to the `origin` repository. This is so that you can sync changes from the main repository without the requirement of forking and cloning repeatedly.
 


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Simple typo - no issue was created.

The specific fix was to the second and third sentences of the [Set up Syncing from Parent](https://contribute.freecodecamp.org/#/how-to-setup-freecodecamp-locally?id=set-up-syncing-from-parent) section. They currently read:

> As mentioned earlier, the main repository is referred `upstream` repository. Your fork referred to as the `origin` repository.

This revision reads:

> As mentioned earlier, the main repository is referred to as the `upstream` repository. Your fork is referred to as the `origin` repository.
