### PR TITLE
chore(api-server): remove unused `is*` fields

### DIFF
--- a/api-server/src/common/models/user.js
+++ b/api-server/src/common/models/user.js
@@ -815,10 +815,6 @@ export default function initializeUser(User) {
           user;
         const allUser = {
           ..._.pick(user, publicUserProps),
-          isGithub: !!user.githubProfile,
-          isLinkedIn: !!user.linkedin,
-          isTwitter: !!user.twitter,
-          isWebsite: !!user.website,
           points: progressTimestamps.length,
           completedChallenges,
           ...getProgress(progressTimestamps, timezone),

--- a/api-server/src/server/boot/settings.js
+++ b/api-server/src/server/boot/settings.js
@@ -307,16 +307,7 @@ function handleInvalidUpdate(res) {
 
 function updateUserFlag(req, res, next) {
   const { user, body: update } = req;
-  const allowedKeys = [
-    'isGithub',
-    'isLinkedIn',
-    'isTwitter',
-    'isWebsite',
-    'githubProfile',
-    'linkedin',
-    'twitter',
-    'website'
-  ];
+  const allowedKeys = ['githubProfile', 'linkedin', 'twitter', 'website'];
   if (Object.keys(update).every(key => allowedKeys.includes(key))) {
     return user.updateAttributes(
       update,

--- a/api-server/src/server/boot/user.js
+++ b/api-server/src/server/boot/user.js
@@ -149,10 +149,6 @@ function createReadSessionUser(app) {
             ...pick(user, userPropsForSession),
             username: user.usernameDisplay || user.username,
             isEmailVerified: !!user.emailVerified,
-            isGithub: !!user.githubProfile,
-            isLinkedIn: !!user.linkedin,
-            isTwitter: !!user.twitter,
-            isWebsite: !!user.website,
             ...normaliseUserFields(user),
             joinDate: user.id.getTimestamp(),
             userToken: encodedUserToken


### PR DESCRIPTION
Related #50344 

These fields are no longer used in either the client or the server. This PR is not even needed, because it does not look like the fields are being set anywhere on the DB anymore. That being said, it is a simple PR that reduces the crud sent to the client.