### PR TITLE
feat(client): change of container & anchor's css on project hover

### DIFF
--- a/client/src/components/profile/components/portfolio-projects.css
+++ b/client/src/components/profile/components/portfolio-projects.css
@@ -6,6 +6,13 @@
   grid-template-columns: repeat(3, 1fr);
   margin-top: 1em;
   margin-bottom: 3em;
+  transition: border-radius 200ms;
+  /* Prevent image overflow while hover */
+  overflow: hidden;
+}
+
+.portfolio-container:hover {
+  border-radius: 20px;
 }
 
 .portfolio-screen-shot {
@@ -36,6 +43,7 @@
   font-size: unset;
   justify-self: end;
   width: 40%;
+  height: 40px; /* Set a fixed height value */
   background-color: var(--primary-color);
   color: var(--primary-background);
   padding: 0.5rem;
@@ -45,6 +53,13 @@
   text-decoration: none;
   /* prevent line breaks in Chinese/Japanese/Korean */
   word-break: keep-all;
+  transition: background-color 200ms, color 200ms;
+}
+
+.portfolio-container:hover a {
+  background-color: var(--quaternary-background);
+  border: 3px solid var(--secondary-color);
+  color: var(--secondary-color);
 }
 
 .portfolio-container a::after {


### PR DESCRIPTION
On User's project hover, we can change the <a> View's background color, border and text color. Also, on project hover, we can show some rounded border on "portfolio-container".

Here's the video preview of what I'm trying to demonstrate:

https://github.com/freeCodeCamp/freeCodeCamp/assets/111045472/c36fbf12-5281-4a79-ad8a-63479f9c27f1

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
