### PR TITLE
fix(curriculum): Added missing full stop after 'entirely'.

### DIFF
--- a/curriculum/challenges/english/03-front-end-development-libraries/jquery/remove-an-element-using-jquery.md
+++ b/curriculum/challenges/english/03-front-end-development-libraries/jquery/remove-an-element-using-jquery.md
@@ -10,7 +10,7 @@ dashedName: remove-an-element-using-jquery
 
 Now let's remove an HTML element from your page using jQuery.
 
-jQuery has a function called `.remove()` that will remove an HTML element entirely
+jQuery has a function called `.remove()` that will remove an HTML element entirely.
 
 Remove the `#target4` element from the page by using the `.remove()` function.
 


### PR DESCRIPTION
Added full stop after 'entirely' in the following challenge: https://www.freecodecamp.org/learn/front-end-development-libraries/jquery/remove-an-element-using-jquery

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!-- Feel free to add any additional description of changes below this line -->
