### PR TITLE
docs: troubleshooting Gitpod ports

### DIFF
--- a/docs/how-to-setup-freecodecamp-locally.md
+++ b/docs/how-to-setup-freecodecamp-locally.md
@@ -39,6 +39,18 @@ There are various ways to launch an GitPod workspace:
 
 That's it, you can now skip to the 'syncing up from parent' section after you have launched a GitPod workspace. Most parts of this guide applies to GitPod workspaces, but be mindful of [how the URLs & Ports work within a GitPod](https://www.gitpod.io/docs/configure/workspaces/ports) workspace.
 
+**Note: Troubleshooting port issues on GitPod**
+
+Sometimes the service on `port:8000` doesn't go live. This is common when you are restarting an inactive workspace.
+
+If the service is not coming up on `port:8000`, you can troubleshoot using these steps:
+
+- **Start the server**: Run `pnpm run develop:server` in one terminal window from the root project directory (`/workspace/freeCodeCamp`) to start the server.
+
+- **Start the client**: In another terminal window, run `pnpm run develop -- -H '0.0.0.0'` from the client directory (`/workspace/freeCodeCamp/client`) to start the client.
+
+This should make the `port:8000` avaialable and you can preview the rendered pages in a new tab.
+
 ### How to Prepare your Local Machine
 
 Here is a minimum system requirement for running freeCodeCamp locally:

--- a/docs/how-to-setup-freecodecamp-locally.md
+++ b/docs/how-to-setup-freecodecamp-locally.md
@@ -49,7 +49,7 @@ If the service is not coming up on `port:8000`, you can troubleshoot using these
 
 - **Start the client**: In another terminal window, run `pnpm run develop -- -H '0.0.0.0'` from the client directory (`/workspace/freeCodeCamp/client`) to start the client.
 
-This should make the `port:8000` avaialable and you can preview the rendered pages in a new tab.
+This should make port `8000` available.
 
 ### How to Prepare your Local Machine
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This should be useful when the service is not coming up on `port:8000`.

<!-- Feel free to add any additional description of changes below this line -->
