### PR TITLE
feat(client): show the default 404 page only when profile fails

### DIFF
--- a/client/src/client-only-routes/show-profile-or-four-oh-four.tsx
+++ b/client/src/client-only-routes/show-profile-or-four-oh-four.tsx
@@ -75,9 +75,9 @@ function ShowProfileOrFourOhFour({
   if (!isBrowser()) {
     return null;
   }
-  const hasPorfile = isEmpty(requestedUser) || isEmpty(maybeUser);
+  const hasProfile = isEmpty(requestedUser) || isEmpty(maybeUser);
 
-  return hasPorfile ? (
+  return hasProfile ? (
     <Suspense fallback={<Loader fullScreen={true} />}>
       <FourOhFour />
     </Suspense>

--- a/client/src/client-only-routes/show-profile-or-four-oh-four.tsx
+++ b/client/src/client-only-routes/show-profile-or-four-oh-four.tsx
@@ -75,8 +75,9 @@ function ShowProfileOrFourOhFour({
   if (!isBrowser()) {
     return null;
   }
+  const hasPorfile = isEmpty(requestedUser) || isEmpty(maybeUser);
 
-  return isEmpty(requestedUser) ? (
+  return hasPorfile ? (
     <Suspense fallback={<Loader fullScreen={true} />}>
       <FourOhFour />
     </Suspense>

--- a/client/src/client-only-routes/show-profile-or-four-oh-four.tsx
+++ b/client/src/client-only-routes/show-profile-or-four-oh-four.tsx
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 
 import { isBrowser } from '../../utils/index';
 import Loader from '../components/helpers/loader';
-import Profile from '../components/profile/profile';
 import { fetchProfileForUser } from '../redux/actions';
 import {
   usernameSelector,
@@ -13,6 +12,7 @@ import {
 } from '../redux/selectors';
 import { User } from '../redux/prop-types';
 
+const Profile = lazy(() => import('../components/profile/profile'));
 const FourOhFour = lazy(() => import('../components/FourOhFour'));
 
 interface ShowProfileOrFourOhFourProps {
@@ -56,6 +56,32 @@ const mapDispatchToProps: {
   fetchProfileForUser
 };
 
+type ErrorBoundaryProps = {
+  fallback: React.ReactNode;
+};
+
+class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  { hasError: boolean }
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback;
+    }
+
+    return this.props.children;
+  }
+}
+
 function ShowProfileOrFourOhFour({
   requestedUser,
   maybeUser,
@@ -75,15 +101,11 @@ function ShowProfileOrFourOhFour({
   if (!isBrowser()) {
     return null;
   }
-  const hasProfile = isEmpty(requestedUser) || isEmpty(maybeUser);
-
-  return hasProfile ? (
+  return (
     <Suspense fallback={<Loader fullScreen={true} />}>
-      <FourOhFour />
-    </Suspense>
-  ) : (
-    <Suspense fallback={<Loader fullScreen={true} />}>
-      <Profile isSessionUser={isSessionUser} user={requestedUser} />
+      <ErrorBoundary fallback={<FourOhFour />}>
+        <Profile isSessionUser={isSessionUser} user={requestedUser} />
+      </ErrorBoundary>
     </Suspense>
   );
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Because of the removal of the timer, the page render before the `maybeUser` data is fetched through the useEffect, this aims to delay it, but Idk if it actually will work because it isn't possible to test :(

<!-- Feel free to add any additional description of changes below this line -->


You can find the issue if you visit https://www.freecodecamp.org/Sboonny in private mode