### PR TITLE
fix(curriculum): better user understanding in Step-93

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/619d2f0e9440bc27caee1cec.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/619d2f0e9440bc27caee1cec.md
@@ -9,7 +9,7 @@ dashedName: step-93
 
 Fun fact: Most, if not all, flippers are not naturally rectangles.
 
-Give the `.arm` elements top-left, top-right, and bottom-right corners a radius of `30%`, and the bottom-left corner a radius of `120%`.
+Give the `.arm` elements' top-left, top-right, and bottom-right corners a radius of `30%`, and the bottom-left corner a radius of `120%`.
 
 # --hints--
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/619d2f0e9440bc27caee1cec.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/619d2f0e9440bc27caee1cec.md
@@ -9,7 +9,7 @@ dashedName: step-93
 
 Fun fact: Most, if not all, flippers are not naturally rectangles.
 
-Give the `.arm` elements top -left, -right, and bottom-right corners a radius of `30%`, and the bottom-left corner a radius of `120%`.
+Give the `.arm` elements top-left, top-right, and bottom-right corners a radius of `30%`, and the bottom-left corner a radius of `120%`.
 
 # --hints--
 

--- a/curriculum/challenges/german/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/619d2f0e9440bc27caee1cec.md
+++ b/curriculum/challenges/german/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/619d2f0e9440bc27caee1cec.md
@@ -9,7 +9,7 @@ dashedName: step-93
 
 Fun fact: Most, if not all, flippers are not naturally rectangles.
 
-Give the `.arm` elements top-left, top-right, and bottom-right corners a radius of `30%`, and the bottom-left corner a radius of `120%`.
+Give the `.arm` elements top -left, -right, and bottom-right corners a radius of `30%`, and the bottom-left corner a radius of `120%`.
 
 # --hints--
 

--- a/curriculum/challenges/german/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/619d2f0e9440bc27caee1cec.md
+++ b/curriculum/challenges/german/14-responsive-web-design-22/learn-css-transforms-by-building-a-penguin/619d2f0e9440bc27caee1cec.md
@@ -9,7 +9,7 @@ dashedName: step-93
 
 Fun fact: Most, if not all, flippers are not naturally rectangles.
 
-Give the `.arm` elements top -left, -right, and bottom-right corners a radius of `30%`, and the bottom-left corner a radius of `120%`.
+Give the `.arm` elements top-left, top-right, and bottom-right corners a radius of `30%`, and the bottom-left corner a radius of `120%`.
 
 # --hints--
 


### PR DESCRIPTION
Instead of `top -left, -right`, it's better to show user to change `top-left, top-right` border radius.
Here's the current one:
![Screenshot (386)](https://github.com/freeCodeCamp/freeCodeCamp/assets/111045472/5ebccf69-ffe0-4dd4-84f7-da343b94376a)

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
