### PR TITLE
test: stop mocking FREECODECAMP_NODE_ENV

### DIFF
--- a/api/src/server.test.ts
+++ b/api/src/server.test.ts
@@ -1,16 +1,7 @@
 import { setupServer, superRequest } from '../jest.utils';
 import { HOME_LOCATION } from './utils/env';
 
-jest.mock('./utils/env', () => {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-  return {
-    ...jest.requireActual('./utils/env'),
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    FREECODECAMP_NODE_ENV: 'production'
-  };
-});
-
-describe('production', () => {
+describe('server', () => {
   setupServer();
   describe('GET /', () => {
     test('have a 200 response', async () => {
@@ -30,8 +21,11 @@ describe('production', () => {
         'content-security-policy': "frame-ancestors 'none'",
         'content-type': 'application/json; charset=utf-8',
         'x-content-type-options': 'nosniff',
-        'x-frame-options': 'DENY',
-        'strict-transport-security': 'max-age=300; includeSubDomains'
+        'x-frame-options': 'DENY'
+        // In production we also set strict-transport-security, but in order to
+        // test this we would need to mock FREECODECAMP_NODE_ENV to production.
+        // This is possible, but has side effects (like using the normal
+        // database instead of the test ones). On balance it's not worth it.
       });
     });
 
@@ -85,8 +79,7 @@ describe('production', () => {
         'content-security-policy': "frame-ancestors 'none'",
         'content-type': 'text/html; charset=utf-8',
         'x-content-type-options': 'nosniff',
-        'x-frame-options': 'DENY',
-        'strict-transport-security': 'max-age=300; includeSubDomains'
+        'x-frame-options': 'DENY'
       });
     });
   });


### PR DESCRIPTION
While this lets us write slightly better tests, I don't think it's worth
the extra complexity. For example, it interferes with the creation of
test databases. We could work around this, but I'd rather keep things
simple.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
