### PR TITLE
fix(a11y): completed-step focus accessibility

### DIFF
--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -285,6 +285,10 @@ button.map-title {
   position: relative;
 }
 
+.challenge-completed:focus-visible {
+  outline-color: var(--secondary-color);
+}
+
 .challenge-completed span {
   font-weight: 700;
   font-size: 1.3rem;

--- a/client/src/templates/Introduction/intro.css
+++ b/client/src/templates/Introduction/intro.css
@@ -290,8 +290,8 @@ button.map-title {
 }
 
 .challenge-completed span {
-  font-weight: 700;
-  font-size: 1.3rem;
+  font-weight: 900;
+  font-size: 1.5rem;
   margin-top: -0.05rem;
 }
 


### PR DESCRIPTION
Changed completed-step outline color to secondary color on focus

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #50023

<!-- Feel free to add any additional description of changes below this line -->
