### PR TITLE
refactor: stop storing sessionMeta in redux

### DIFF
--- a/client/src/redux/fetch-user-saga.js
+++ b/client/src/redux/fetch-user-saga.js
@@ -16,7 +16,7 @@ function* fetchSessionUser() {
   }
   try {
     const {
-      data: { user = {}, result = '', sessionMeta = {} }
+      data: { user = {}, result = '' }
     } = yield call(getSessionUser);
     const appUser = user[result] || {};
 
@@ -26,9 +26,7 @@ function* fetchSessionUser() {
 
     store.set('fcc-sound', sound);
 
-    yield put(
-      fetchUserComplete({ user: appUser, username: result, sessionMeta })
-    );
+    yield put(fetchUserComplete({ user: appUser, username: result }));
   } catch (e) {
     console.log('failed to fetch user', e);
     yield put(fetchUserError(e));

--- a/client/src/redux/index.js
+++ b/client/src/redux/index.js
@@ -64,7 +64,6 @@ const initialState = {
   userProfileFetchState: {
     ...defaultFetchState
   },
-  sessionMeta: { activeDonations: 0 },
   showDonationModal: false,
   showSignoutModal: false,
   isOnline: true,
@@ -179,7 +178,7 @@ export const reducer = handleActions(
     }),
     [actionTypes.fetchUserComplete]: (
       state,
-      { payload: { user, username, sessionMeta } }
+      { payload: { user, username } }
     ) => ({
       ...state,
       user: {
@@ -193,10 +192,6 @@ export const reducer = handleActions(
         complete: true,
         errored: false,
         error: null
-      },
-      sessionMeta: {
-        ...state.sessionMeta,
-        ...sessionMeta
       }
     }),
     [actionTypes.fetchUserError]: (state, { payload }) => ({

--- a/client/src/redux/types.ts
+++ b/client/src/redux/types.ts
@@ -22,9 +22,6 @@ export interface State {
     user: Record<string, unknown>;
     userFetchState: DefaultFetchState;
     userProfileFetchState: DefaultFetchState;
-    sessionMeta: {
-      activeDonations: number;
-    };
     showDonationModal: boolean;
     showSignoutModal: boolean;
     isOnline: boolean;

--- a/client/src/utils/ajax.ts
+++ b/client/src/utils/ajax.ts
@@ -88,7 +88,6 @@ async function request<T>(
 
 interface SessionUser {
   user?: { [username: string]: User };
-  sessionMeta: { activeDonations: number };
 }
 
 type CompleteChallengeFromApi = {
@@ -163,7 +162,6 @@ export function getSessionUser(): Promise<ResponseWithData<SessionUser>> {
     return {
       response,
       data: {
-        sessionMeta: data.sessionMeta,
         result,
         user
       }


### PR DESCRIPTION
It's only stored, never read.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

PR to remove from API to follow, but this should be deployed first.

<!-- Feel free to add any additional description of changes below this line -->
