### PR TITLE
fix(api-server): a typo in the info message for resubscribe

### DIFF
--- a/api-server/src/server/boot/randomAPIs.js
+++ b/api-server/src/server/boot/randomAPIs.js
@@ -71,7 +71,7 @@ module.exports = function (app) {
     if (!unsubscribeId) {
       req.flash(
         'info',
-        'We we unable to process this request, please check and try againÍ'
+        'We we unable to process this request, please check and try again'
       );
       res.redirect(origin);
     }
@@ -98,8 +98,7 @@ module.exports = function (app) {
         .then(() => {
           req.flash(
             'success',
-            "We've successfully updated your email preferences. Thank you " +
-              'for resubscribing.'
+            "We've successfully updated your email preferences. Thank you for resubscribing."
           );
           return res.redirectWithFlash(origin);
         })


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

remove operation and typo

<!-- Feel free to add any additional description of changes below this line -->
