### PR TITLE
refactor(api): stop returning streak

### DIFF
--- a/api-server/src/common/models/user.js
+++ b/api-server/src/common/models/user.js
@@ -755,7 +755,6 @@ export default function initializeUser(User) {
       name,
       points,
       portfolio,
-      streak,
       username,
       yearsTopContributor
     } = user;
@@ -800,7 +799,6 @@ export default function initializeUser(User) {
       name: showName ? name : '',
       points: showPoints ? points : null,
       portfolio: showPortfolio ? portfolio : [],
-      streak: showHeatMap ? streak : {},
       yearsTopContributor: yearsTopContributor
     };
   }
@@ -811,13 +809,12 @@ export default function initializeUser(User) {
         if (!user) {
           return Observable.of({});
         }
-        const { completedChallenges, progressTimestamps, timezone, profileUI } =
-          user;
+        const { completedChallenges, progressTimestamps, profileUI } = user;
         const allUser = {
           ..._.pick(user, publicUserProps),
           points: progressTimestamps.length,
           completedChallenges,
-          ...getProgress(progressTimestamps, timezone),
+          ...getProgress(progressTimestamps),
           ...normaliseUserFields(user),
           joinDate: user.id.getTimestamp()
         };

--- a/api-server/src/server/boot/user.js
+++ b/api-server/src/server/boot/user.js
@@ -133,10 +133,10 @@ function createReadSessionUser(app) {
         ].map(obs => obs.toPromise())
       );
 
-      const progress = getProgress(progressTimestamps, queryUser.timezone);
+      const { calendar } = getProgress(progressTimestamps);
       const user = {
         ...queryUser.toJSON(),
-        ...progress,
+        calendar,
         completedChallenges: completedChallenges.map(fixCompletedChallengeItem),
         partiallyCompletedChallenges: partiallyCompletedChallenges.map(
           fixPartiallyCompletedChallengeItem

--- a/api-server/src/server/utils/publicUserProps.js
+++ b/api-server/src/server/utils/publicUserProps.js
@@ -1,11 +1,5 @@
 import { isURL } from 'validator';
 
-import {
-  prepUniqueDaysByHours,
-  calcCurrentStreak,
-  calcLongestStreak
-} from '../utils/user-stats';
-
 export const publicUserProps = [
   'about',
   'calendar',
@@ -40,7 +34,6 @@ export const publicUserProps = [
   'profileUI',
   'projects',
   'savedChallenges',
-  'streak',
   'twitter',
   'username',
   'website',
@@ -76,17 +69,12 @@ export function normaliseUserFields(user) {
   return { about, picture, twitter };
 }
 
-export function getProgress(progressTimestamps, timezone = 'EST') {
+export function getProgress(progressTimestamps) {
   const calendar = progressTimestamps
     .filter(Boolean)
     .reduce((data, timestamp) => {
       data[Math.floor(timestamp / 1000)] = 1;
       return data;
     }, {});
-  const uniqueHours = prepUniqueDaysByHours(progressTimestamps, timezone);
-  const streak = {
-    longest: calcLongestStreak(uniqueHours, timezone),
-    current: calcCurrentStreak(uniqueHours, timezone)
-  };
-  return { calendar, streak };
+  return { calendar };
 }

--- a/client/src/components/profile/profile.test.tsx
+++ b/client/src/components/profile/profile.test.tsx
@@ -25,10 +25,6 @@ const userProps = {
       showDonation: false
     },
     calendar: {},
-    streak: {
-      current: 1,
-      longest: 1
-    },
     completedChallenges: [],
     portfolio: [],
     progressTimestamps: [],


### PR DESCRIPTION
The client does not use them. It calculates streaks from the calendar
property.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
