### PR TITLE
fix(api): move settings schema to schema file

### DIFF
--- a/api/src/routes/settings.ts
+++ b/api/src/routes/settings.ts
@@ -80,24 +80,7 @@ export const settingRoutes: FastifyPluginCallbackTypebox = (
   fastify.put(
     '/update-my-socials',
     {
-      schema: {
-        body: Type.Object({
-          website: Type.Optional(Type.String({ format: 'url' })),
-          twitter: Type.Optional(Type.String({ format: 'url' })),
-          githubProfile: Type.Optional(Type.String({ format: 'url' })),
-          linkedin: Type.Optional(Type.String({ format: 'url' }))
-        }),
-        response: {
-          200: Type.Object({
-            message: Type.Literal('flash.updated-socials'),
-            type: Type.Literal('success')
-          }),
-          500: Type.Object({
-            message: Type.Literal('flash.wrong-updating'),
-            type: Type.Literal('danger')
-          })
-        }
-      }
+      schema: schemas.updateMySocials
     },
     async (req, reply) => {
       try {

--- a/api/src/schemas.ts
+++ b/api/src/schemas.ts
@@ -103,6 +103,24 @@ export const schemas = {
       })
     }
   },
+  updateMySocials: {
+    body: Type.Object({
+      website: Type.Optional(Type.String({ format: 'url' })),
+      twitter: Type.Optional(Type.String({ format: 'url' })),
+      githubProfile: Type.Optional(Type.String({ format: 'url' })),
+      linkedin: Type.Optional(Type.String({ format: 'url' }))
+    }),
+    response: {
+      200: Type.Object({
+        message: Type.Literal('flash.updated-socials'),
+        type: Type.Literal('success')
+      }),
+      500: Type.Object({
+        message: Type.Literal('flash.wrong-updating'),
+        type: Type.Literal('danger')
+      })
+    }
+  },
   // Deprecated endpoints:
   deprecatedEndpoints: {
     response: {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

After moving the schema to its own file, old PR with schema to it needs to adapt, one merged before it rebased which casing eslint to complain
<!-- Feel free to add any additional description of changes below this line -->

https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/5071679235/jobs/9108366728?pr=50497
