### PR TITLE
chore: move update socials schema

### DIFF
--- a/api/src/routes/settings.ts
+++ b/api/src/routes/settings.ts
@@ -80,24 +80,7 @@ export const settingRoutes: FastifyPluginCallbackTypebox = (
   fastify.put(
     '/update-my-socials',
     {
-      schema: {
-        body: Type.Object({
-          website: Type.Optional(Type.String({ format: 'url' })),
-          twitter: Type.Optional(Type.String({ format: 'url' })),
-          githubProfile: Type.Optional(Type.String({ format: 'url' })),
-          linkedin: Type.Optional(Type.String({ format: 'url' }))
-        }),
-        response: {
-          200: Type.Object({
-            message: Type.Literal('flash.updated-socials'),
-            type: Type.Literal('success')
-          }),
-          500: Type.Object({
-            message: Type.Literal('flash.wrong-updating'),
-            type: Type.Literal('danger')
-          })
-        }
-      }
+      schema: schemas.updateMySocials
     },
     async (req, reply) => {
       try {

--- a/api/src/schemas.ts
+++ b/api/src/schemas.ts
@@ -45,10 +45,12 @@ export const schemas = {
   },
   updateMySocials: {
     body: Type.Object({
-      website: Type.Optional(Type.String({ format: 'url' })),
-      twitter: Type.Optional(Type.String({ format: 'url' })),
-      githubProfile: Type.Optional(Type.String({ format: 'url' })),
-      linkedin: Type.Optional(Type.String({ format: 'url' }))
+      website: Type.Optional(Type.String({ format: 'url', maxLength: 1024 })),
+      twitter: Type.Optional(Type.String({ format: 'url', maxLength: 1024 })),
+      githubProfile: Type.Optional(
+        Type.String({ format: 'url', maxLength: 1024 })
+      ),
+      linkedin: Type.Optional(Type.String({ format: 'url', maxLength: 1024 }))
     }),
     response: {
       200: Type.Object({

--- a/api/src/schemas.ts
+++ b/api/src/schemas.ts
@@ -43,6 +43,24 @@ export const schemas = {
       })
     }
   },
+  updateMySocials: {
+    body: Type.Object({
+      website: Type.Optional(Type.String({ format: 'url' })),
+      twitter: Type.Optional(Type.String({ format: 'url' })),
+      githubProfile: Type.Optional(Type.String({ format: 'url' })),
+      linkedin: Type.Optional(Type.String({ format: 'url' }))
+    }),
+    response: {
+      200: Type.Object({
+        message: Type.Literal('flash.updated-socials'),
+        type: Type.Literal('success')
+      }),
+      500: Type.Object({
+        message: Type.Literal('flash.wrong-updating'),
+        type: Type.Literal('danger')
+      })
+    }
+  },
   updateMyKeyboardShortcuts: {
     body: Type.Object({
       keyboardShortcuts: Type.Boolean()


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Fixes the breaking actions. But the tests break now as we use the `format` property for validating the social endpoint body and goes against the schema security as AJV suggest us to use `maxLength` property if we use `format` property so as to protect our server from longer validation times if long values are submitted.
