### PR TITLE
fix(api): handle the case where there are multiple users with the same email

### DIFF
--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -88,19 +88,21 @@ const getEmailFromAuth0 = async (req: FastifyRequest) => {
 };
 
 const findOrCreateUser = async (fastify: FastifyInstance, email: string) => {
-  // TODO: handle the case where there are multiple users with the same email.
-  // e.g. use findMany and throw an error if more than one is found.
-  const existingUser = await fastify.prisma.user.findFirst({
+  const existingUsers = await fastify.prisma.user.findMany({
     where: { email },
     select: { id: true }
   });
-  return (
-    existingUser ??
-    (await fastify.prisma.user.create({
+
+  if (existingUsers.length > 1) {
+    throw new Error('Multiple users found with the same email address');
+  }
+
+  return existingUsers.length
+    ? existingUsers[0]
+    : await fastify.prisma.user.create({
       data: { ...defaultUser, email },
       select: { id: true }
-    }))
-  );
+    });
 };
 
 export const devLoginCallback: FastifyPluginCallback = (

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -97,12 +97,13 @@ const findOrCreateUser = async (fastify: FastifyInstance, email: string) => {
     throw new Error('Multiple users found with the same email address');
   }
 
-  return existingUsers.length
-    ? { id: existingUsers[0].id }
-    : await fastify.prisma.user.create({
-        data: { ...defaultUser, email },
-        select: { id: true }
-      });
+  if (existingUsers.length) {
+    return { id: existingUsers[0].id };
+  }
+  return await fastify.prisma.user.create({
+    data: { ...defaultUser, email },
+    select: { id: true }
+  });
 };
 
 export const devLoginCallback: FastifyPluginCallback = (

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -97,12 +97,12 @@ const findOrCreateUser = async (fastify: FastifyInstance, email: string) => {
     throw new Error('Multiple users found with the same email address');
   }
 
-  return existingUsers.length > 0
-    ? { id: existingUsers[0].id }
-    : await fastify.prisma.user.create({
+  return !existingUsers.length
+    ? await fastify.prisma.user.create({
         data: { ...defaultUser, email },
         select: { id: true }
-      });
+      })
+    : { id: existingUsers[0].id };
 };
 
 export const devLoginCallback: FastifyPluginCallback = (

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -100,9 +100,9 @@ const findOrCreateUser = async (fastify: FastifyInstance, email: string) => {
   return existingUsers.length
     ? existingUsers[0]
     : await fastify.prisma.user.create({
-      data: { ...defaultUser, email },
-      select: { id: true }
-    });
+        data: { ...defaultUser, email },
+        select: { id: true }
+      });
 };
 
 export const devLoginCallback: FastifyPluginCallback = (

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -98,7 +98,7 @@ const findOrCreateUser = async (fastify: FastifyInstance, email: string) => {
   }
 
   return existingUsers.length
-    ? existingUsers[0]
+    ? { id: existingUsers[0].id }
     : await fastify.prisma.user.create({
         data: { ...defaultUser, email },
         select: { id: true }

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -98,7 +98,7 @@ const findOrCreateUser = async (fastify: FastifyInstance, email: string) => {
   }
 
   return existingUsers && existingUsers.length > 0
-    ? { id: existingUsers ?? existingUsers[0]?.id }
+    ? { id: existingUsers[0]?.id }
     : await fastify.prisma.user.create({
         data: { ...defaultUser, email },
         select: { id: true }

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -98,7 +98,7 @@ const findOrCreateUser = async (fastify: FastifyInstance, email: string) => {
   }
 
   return existingUsers && existingUsers.length > 0
-    ? { id: existingUsers[0].id }
+    ? { id: existingUsers ?? existingUsers[0].id }
     : await fastify.prisma.user.create({
         data: { ...defaultUser, email },
         select: { id: true }

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -98,7 +98,7 @@ const findOrCreateUser = async (fastify: FastifyInstance, email: string) => {
   }
 
   return existingUsers && existingUsers.length > 0
-    ? { id: existingUsers ?? existingUsers[0].id }
+    ? { id: existingUsers ?? existingUsers[0]?.id }
     : await fastify.prisma.user.create({
         data: { ...defaultUser, email },
         select: { id: true }

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -97,12 +97,12 @@ const findOrCreateUser = async (fastify: FastifyInstance, email: string) => {
     throw new Error('Multiple users found with the same email address');
   }
 
-  return !existingUsers.length
-    ? await fastify.prisma.user.create({
+  return existingUsers && existingUsers.length > 0
+    ? { id: existingUsers[0].id }
+    : await fastify.prisma.user.create({
         data: { ...defaultUser, email },
         select: { id: true }
-      })
-    : { id: existingUsers[0].id };
+      });
 };
 
 export const devLoginCallback: FastifyPluginCallback = (

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -97,13 +97,12 @@ const findOrCreateUser = async (fastify: FastifyInstance, email: string) => {
     throw new Error('Multiple users found with the same email address');
   }
 
-  if (existingUsers.length) {
-    return { id: existingUsers[0].id };
-  }
-  return await fastify.prisma.user.create({
-    data: { ...defaultUser, email },
-    select: { id: true }
-  });
+  return existingUsers.length > 0
+    ? { id: existingUsers[0].id }
+    : await fastify.prisma.user.create({
+        data: { ...defaultUser, email },
+        select: { id: true }
+      });
 };
 
 export const devLoginCallback: FastifyPluginCallback = (


### PR DESCRIPTION
What has been done:
- In `findOrCreateUser` function of `auth.ts` file, the case for when there are multiple users with same email was not handled. It was kept as a todo for later. 
- I checked for multiple users with same mail using `findMany` and if more than one is found then throw an error, or else return the first user found `existingUsers[0]` or create a new user using the `fastify.prisma.user.create method`.

Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes: None
 