### PR TITLE
feat(api): allow redirection with message

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -5,8 +5,8 @@
   },
   "dependencies": {
     "@fastify/cookie": "^8.3.0",
-    "@fastify/middie": "8.3",
     "@fastify/csrf-protection": "6.3.0",
+    "@fastify/middie": "8.3",
     "@fastify/session": "^10.1.1",
     "@fastify/swagger": "^8.3.1",
     "@fastify/swagger-ui": "^1.5.0",
@@ -16,7 +16,8 @@
     "fastify": "4.17.0",
     "fastify-auth0-verify": "^1.0.0",
     "fastify-plugin": "^4.3.0",
-    "nodemon": "2.0.22"
+    "nodemon": "2.0.22",
+    "query-string": "^7.1.3"
   },
   "description": "The freeCodeCamp.org open-source codebase and curriculum",
   "devDependencies": {

--- a/api/src/plugins/redirect-with-message.test.ts
+++ b/api/src/plugins/redirect-with-message.test.ts
@@ -9,6 +9,10 @@ async function setupServer() {
   return fastify;
 }
 
+const isString = (value: unknown): value is string => {
+  return typeof value === 'string';
+};
+
 describe('redirectWithMessage plugin', () => {
   it('should decorate reply object with redirectWithMessage method', async () => {
     expect.assertions(3);
@@ -80,10 +84,6 @@ describe('redirectWithMessage plugin', () => {
         method: 'GET',
         url: '/'
       });
-
-      const isString = (value: unknown): value is string => {
-        return typeof value === 'string';
-      };
       if (!isString(res.headers.location))
         throw new Error('Location is not a string');
       const { search } = new URL(res.headers.location, 'http://localhost');

--- a/api/src/plugins/redirect-with-message.test.ts
+++ b/api/src/plugins/redirect-with-message.test.ts
@@ -1,0 +1,101 @@
+import Fastify, { FastifyInstance } from 'fastify';
+import qs from 'query-string';
+
+import redirectWithMessage from './redirect-with-message';
+
+async function setupServer() {
+  const fastify = Fastify();
+  await fastify.register(redirectWithMessage);
+  return fastify;
+}
+
+describe('redirectWithMessage plugin', () => {
+  it('should decorate reply object with redirectWithMessage method', async () => {
+    expect.assertions(3);
+
+    const fastify = await setupServer();
+
+    fastify.get('/', (_req, reply) => {
+      expect(reply).toHaveProperty('redirectWithMessage');
+      expect(reply.redirectWithMessage).toBeInstanceOf(Function);
+      return { foo: 'bar' };
+    });
+
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/'
+    });
+
+    expect(res.statusCode).toEqual(200);
+  });
+
+  describe('redirectWithMessage method', () => {
+    let fastify: FastifyInstance;
+    beforeEach(async () => {
+      fastify = await setupServer();
+    });
+
+    it('should redirect to the first argument', async () => {
+      fastify.get('/', (_req, reply) => {
+        return reply.redirectWithMessage('/target', {
+          type: 'info',
+          content: 'foo'
+        });
+      });
+      const res = await fastify.inject({
+        method: 'GET',
+        url: '/'
+      });
+
+      expect(res.headers.location).toMatch(/^\/target/);
+      expect(res.statusCode).toEqual(302);
+    });
+
+    it('should convert the second argument into a query string', async () => {
+      fastify.get('/', (_req, reply) => {
+        return reply.redirectWithMessage('/target', {
+          type: 'info',
+          content: 'foo'
+        });
+      });
+      const res = await fastify.inject({
+        method: 'GET',
+        url: '/'
+      });
+
+      expect(res.headers.location).toMatch(/^\/target\?messages=info/);
+    });
+
+    it('should encode the message twice when creating the query string', async () => {
+      const expectedMessage = { danger: ['foo bar'] };
+
+      fastify.get('/', (_req, reply) => {
+        return reply.redirectWithMessage('/target', {
+          type: 'danger',
+          content: 'foo bar'
+        });
+      });
+
+      const res = await fastify.inject({
+        method: 'GET',
+        url: '/'
+      });
+
+      const isString = (value: unknown): value is string => {
+        return typeof value === 'string';
+      };
+      if (!isString(res.headers.location))
+        throw new Error('Location is not a string');
+      const { search } = new URL(res.headers.location, 'http://localhost');
+
+      // The query string itself is encoded:
+      const { messages } = qs.parse(search, { arrayFormat: 'index' });
+      if (!isString(messages)) throw new Error('Messages is not a string');
+
+      // As is the message embedded in it:
+      expect(qs.parse(messages, { arrayFormat: 'index' })).toEqual(
+        expectedMessage
+      );
+    });
+  });
+});

--- a/api/src/plugins/redirect-with-message.ts
+++ b/api/src/plugins/redirect-with-message.ts
@@ -1,0 +1,54 @@
+import { FastifyPluginCallback, type FastifyReply } from 'fastify';
+import fp from 'fastify-plugin';
+// TODO: (POST MVP)use node's querystring and just JSON stringify the message.
+// No need for query-string on either side.
+
+import qs from 'query-string';
+
+declare module 'fastify' {
+  interface FastifyReply {
+    redirectWithMessage: typeof redirectWithMessage;
+  }
+}
+
+type Message = {
+  type: 'info' | 'danger' | 'success' | 'errors';
+  content: string;
+};
+
+type MessageQuery = {
+  info?: string[];
+  danger?: string[];
+  success?: string[];
+  errors?: string[];
+};
+
+// The client expects a message like { info: ['foo'] }, { danger: ['bar'] } etc.
+const prepareMessage = (message: Message): MessageQuery => ({
+  [message.type]: [message.content]
+});
+
+function redirectWithMessage(
+  this: FastifyReply,
+  url: string,
+  message: Message
+) {
+  return this.redirect(
+    `${url}?${qs.stringify(
+      {
+        messages: qs.stringify(prepareMessage(message), {
+          arrayFormat: 'index'
+        })
+      },
+      { arrayFormat: 'index' }
+    )}`
+  );
+}
+
+const plugin: FastifyPluginCallback = (fastify, _options, done) => {
+  fastify.decorateReply('redirectWithMessage', redirectWithMessage);
+
+  done();
+};
+
+export default fp(plugin);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,6 +203,9 @@ importers:
       nodemon:
         specifier: 2.0.22
         version: 2.0.22
+      query-string:
+        specifier: ^7.1.3
+        version: 7.1.3
     devDependencies:
       '@fastify/type-provider-typebox':
         specifier: 3.2.0


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Ref: https://github.com/freeCodeCamp/freeCodeCamp/pull/50497#issuecomment-1563075784

The functionality should be identical to the api-server's `redirectWithFlash`, but with two key differences in how it's used. Firstly, flash isn't used at all and secondly, only one message can be sent per redirect.

The reasons for first change is simply that the api-server approach almost always ended up with code like

```
req.flash('info', 'helpful message');
res.redirectWithFlash('/exciting-url');
```

and now we can just write

```
res.redirectWithMessage('/exciting-url', { type: 'info', content: 'helpful message' });
```

but, more usefully, it's no longer possible to have

```
req.flash('info', 'irrelevant message');
// big gap
res.redirectWithFlash('/'); // surprise message!
```

Finally, I restricted the number of messages to 1, because I couldn't find a case where the api-server sent more than one message and I don't think the client can handle multiple messages at the moment.

<!-- Feel free to add any additional description of changes below this line -->
