### PR TITLE
revert(client): add react suspense and lazy loading

### DIFF
--- a/client/src/client-only-routes/show-profile-or-four-oh-four.tsx
+++ b/client/src/client-only-routes/show-profile-or-four-oh-four.tsx
@@ -1,8 +1,9 @@
 import { isEmpty } from 'lodash-es';
-import React, { useEffect, Suspense, lazy } from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 
 import { isBrowser } from '../../utils/index';
+import FourOhFour from '../components/FourOhFour';
 import Loader from '../components/helpers/loader';
 import Profile from '../components/profile/profile';
 import { fetchProfileForUser } from '../redux/actions';
@@ -12,8 +13,6 @@ import {
   userProfileFetchStateSelector
 } from '../redux/selectors';
 import { User } from '../redux/prop-types';
-
-const FourOhFour = lazy(() => import('../components/FourOhFour'));
 
 interface ShowProfileOrFourOhFourProps {
   fetchProfileForUser: (username: string) => void;
@@ -25,6 +24,7 @@ interface ShowProfileOrFourOhFourProps {
   isSessionUser: boolean;
   maybeUser?: string;
   requestedUser: User;
+  showLoading: boolean;
 }
 
 const createRequestedUserSelector =
@@ -46,6 +46,7 @@ const makeMapStateToProps =
     return {
       requestedUser: requestedUserSelector(state, props),
       isSessionUser: isSessionUserSelector(state, props),
+      showLoading: fetchState.pending,
       fetchState
     };
   };
@@ -60,7 +61,8 @@ function ShowProfileOrFourOhFour({
   requestedUser,
   maybeUser,
   fetchProfileForUser,
-  isSessionUser
+  isSessionUser,
+  showLoading
 }: ShowProfileOrFourOhFourProps) {
   useEffect(() => {
     // If the user is not already in the store, fetch it
@@ -77,13 +79,13 @@ function ShowProfileOrFourOhFour({
   }
 
   return isEmpty(requestedUser) ? (
-    <Suspense fallback={<Loader fullScreen={true} />}>
+    showLoading ? (
+      <Loader fullScreen={true} />
+    ) : (
       <FourOhFour />
-    </Suspense>
+    )
   ) : (
-    <Suspense fallback={<Loader fullScreen={true} />}>
-      <Profile isSessionUser={isSessionUser} user={requestedUser} />
-    </Suspense>
+    <Profile isSessionUser={isSessionUser} user={requestedUser} />
   );
 }
 


### PR DESCRIPTION
Because https://github.com/freeCodeCamp/freeCodeCamp/pull/50528 revert the breaking change, we can revert the suspense PR which shows the 404 page, while the page is loading.

We can comeback to adding suspense later, when we have another way to access the profile page.