### PR TITLE
Updated grammer mistake in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Our full-stack web development and machine learning curriculum is completely fre
 
 ### Certifications
 
-freeCodeCamp.org offers several free developer certifications. Each of these certifications involves building 5 required web app projects, along with hundreds of optional coding challenges to help you prepare for those projects. We estimate that each certification will take a beginner programmer around 300 hours to earn.
+The freeCodeCamp.org offers several free developer certifications. Each of these certifications involves building 5 required web app projects, along with hundreds of optional coding challenges to help you prepare for those projects. We estimate that each certification will take a beginner programmer around 300 hours to earn.
 
 Each of these 50 projects in the freeCodeCamp.org curriculum has its own agile user stories and automated tests. These help you build up your project incrementally and ensure you've fulfilled all the user stories before you submit it.
 


### PR DESCRIPTION
CheckList:
- [x] I have read [freeCodeCamp's contribution guidelines.](https://contribute.freecodecamp.org/#/) 
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`) 
- [x] My pull request targets the `master` branch of freeCodeCamp. 
- [x] I have tested these changes either locally on my machine, or GitPod.
- [x] All files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

What I changed.
**Before**
The line started with 
```diff
-freecodecamp.org offers certifications...
``` 
**After**
I introduced the article `"The"` (used in English grammar) an now its looks like 
```diff
+The freecodecamp.org offers...
```
