### PR TITLE
fix: disable flaky codeally e2e tests

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -24,7 +24,8 @@ module.exports = defineConfig({
     // Temporary disable these until we can address the flakiness
     excludeSpecPattern: [
       'cypress/e2e/**/challenge-hot-keys.ts',
-      'cypress/e2e/**/multifile.ts'
+      'cypress/e2e/**/multifile.ts',
+      'cypress/e2e/**/codeally.ts'
     ],
 
     setupNodeEvents(on, config) {


### PR DESCRIPTION
This disables the E2E tests for CodeAlly which are flaky at the moment. 