### PR TITLE
fix: only show loader message on layout

### DIFF
--- a/client/src/components/helpers/__snapshots__/loader.test.tsx.snap
+++ b/client/src/components/helpers/__snapshots__/loader.test.tsx.snap
@@ -14,12 +14,6 @@ exports[`<Loader /> matches the fullScreen render snapshot 1`] = `
     <div />
     <div />
   </div>
-  <br />
-  <p
-    class="text-center"
-  >
-    misc.slow-load-msg
-  </p>
 </div>
 `;
 

--- a/client/src/components/helpers/loader.tsx
+++ b/client/src/components/helpers/loader.tsx
@@ -17,7 +17,7 @@ function Loader({
   const { t } = useTranslation();
 
   const [showSpinner, setShowSpinner] = useState(!loaderDelay);
-  const [showMessage, setShowMessage] = useState(!messageDelay);
+  const [showMessage, setShowMessage] = useState(false);
   useEffect(() => {
     if (loaderDelay) {
       const timerId = setTimeout(() => setShowSpinner(true), loaderDelay);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

No other `Loader` is passed `messageDelay` so they were all displaying the message immediately.

<!-- Feel free to add any additional description of changes below this line -->
