### PR TITLE
feat(client): AB test loading donation elements individually

### DIFF
--- a/client/src/components/Donation/donation-modal.tsx
+++ b/client/src/components/Donation/donation-modal.tsx
@@ -79,13 +79,17 @@ const RenderIlustration = ({
 }) => {
   const showModalBears = useFeature('show-modal-bears').on;
   if (showModalBears) {
-    if (recentlyClaimedBlock !== null)
-      return <BearBlockCompletion className='donation-icon' />;
-    else return <BearProgressModal className='donation-icon' />;
-  } else if (recentlyClaimedBlock !== null) {
-    return <Cup className='donation-icon' />;
+    return recentlyClaimedBlock ? (
+      <BearBlockCompletion className='donation-icon' />
+    ) : (
+      <BearProgressModal className='donation-icon' />
+    );
   } else {
-    return <Heart className='donation-icon' />;
+    return recentlyClaimedBlock ? (
+      <Cup className='donation-icon' />
+    ) : (
+      <Heart className='donation-icon' />
+    );
   }
 };
 
@@ -186,7 +190,7 @@ function DonateModal({
         <Row>
           <Col
             xs={12}
-            className={loadElementsIdividually && 'two-seconds-delay-fade-in'}
+            className={loadElementsIndividually && 'two-seconds-delay-fade-in'}
           >
             <DonateForm
               handleProcessing={handleProcessing}

--- a/client/src/components/Donation/donation-modal.tsx
+++ b/client/src/components/Donation/donation-modal.tsx
@@ -106,24 +106,24 @@ function DonateModal({
   const [ctaNumber, setCtaNumber] = useState(0);
   const [isDisabled, setIsDisabled] = useState(true);
   const [showSkipButton, setShowSkipButton] = useState(false);
-  const loadElementsIdividually = useFeature('load_elements_individually').on;
+  const loadElementsIndividually = useFeature('load_elements_individually').on;
   const { t } = useTranslation();
   const handleProcessing = () => {
     setCloseLabel(true);
   };
 
   useEffect(() => {
-    if (!loadElementsIdividually) {
+    if (loadElementsIndividually) {
+      const timer = setTimeout(() => {
+        setIsDisabled(false);
+        setShowSkipButton(true);
+      }, 4000);
+      return () => clearTimeout(timer);
+    } else {
       setIsDisabled(false);
       setShowSkipButton(true);
-      return;
     }
-    const timer = setTimeout(() => {
-      setIsDisabled(false);
-      setShowSkipButton(true);
-    }, 4000);
-    return () => clearTimeout(timer);
-  }, [loadElementsIdividually]);
+  }, [loadElementsIndividually]);
 
   useEffect(() => {
     if (show) {

--- a/client/src/components/Donation/donation-modal.tsx
+++ b/client/src/components/Donation/donation-modal.tsx
@@ -1,6 +1,6 @@
 import { Modal, Button, Col, Row } from '@freecodecamp/react-bootstrap';
 import { WindowLocation } from '@reach/router';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { useFeature } from '@growthbook/growthbook-react';
@@ -79,8 +79,9 @@ const RenderIlustration = ({
 }) => {
   const showModalBears = useFeature('show-modal-bears').on;
   if (showModalBears) {
-    if (recentlyClaimedBlock !== null) return <BearBlockCompletion />;
-    else return <BearProgressModal />;
+    if (recentlyClaimedBlock !== null)
+      return <BearBlockCompletion className='donation-icon' />;
+    else return <BearProgressModal className='donation-icon' />;
   } else if (recentlyClaimedBlock !== null) {
     return <Cup className='donation-icon' />;
   } else {
@@ -101,12 +102,28 @@ function DonateModal({
   location,
   recentlyClaimedBlock
 }: DonateModalProps): JSX.Element {
-  const [closeLabel, setCloseLabel] = React.useState(false);
-  const [ctaNumber, setCtaNumber] = React.useState(0);
+  const [closeLabel, setCloseLabel] = useState(false);
+  const [ctaNumber, setCtaNumber] = useState(0);
+  const [isDisabled, setIsDisabled] = useState(true);
+  const [showSkipButton, setShowSkipButton] = useState(false);
+  const loadElementsIdividually = useFeature('load_elements_individually').on;
   const { t } = useTranslation();
   const handleProcessing = () => {
     setCloseLabel(true);
   };
+
+  useEffect(() => {
+    if (!loadElementsIdividually) {
+      setIsDisabled(false);
+      setShowSkipButton(true);
+      return;
+    }
+    const timer = setTimeout(() => {
+      setIsDisabled(false);
+      setShowSkipButton(true);
+    }, 4000);
+    return () => clearTimeout(timer);
+  }, [loadElementsIdividually]);
 
   useEffect(() => {
     if (show) {
@@ -163,11 +180,14 @@ function DonateModal({
       onExited={handleModalHide}
       show={show}
     >
-      <Modal.Body>
+      <Modal.Body className={'no-delay-fade-in'}>
         {donationText}
         <Spacer size='medium' />
         <Row>
-          <Col xs={12}>
+          <Col
+            xs={12}
+            className={loadElementsIdividually && 'two-seconds-delay-fade-in'}
+          >
             <DonateForm
               handleProcessing={handleProcessing}
               isMinimalForm={true}
@@ -177,7 +197,13 @@ function DonateModal({
         </Row>
         <Spacer size='medium' />
         <Row>
-          <Col sm={4} smOffset={4} xs={8} xsOffset={2}>
+          <Col
+            sm={4}
+            smOffset={4}
+            xs={8}
+            xsOffset={2}
+            className={showSkipButton ? 'no-delay-fade-in' : 'no-opacity'}
+          >
             <Button
               block={true}
               bsSize='sm'
@@ -185,6 +211,7 @@ function DonateModal({
               className='btn-link'
               onClick={closeDonationModal}
               tabIndex='0'
+              disabled={isDisabled}
             >
               {closeLabel ? t('buttons.close') : t('buttons.ask-later')}
             </Button>

--- a/client/src/components/Donation/donation.css
+++ b/client/src/components/Donation/donation.css
@@ -254,23 +254,31 @@ li.disabled > a {
 }
 
 .donation-icon {
-  width: 150px;
-  height: auto;
-  transform: scale(1.5);
-  opacity: 0;
-  animation: donation-icon-animation 1s linear 100ms forwards;
+  height: 150px;
+  width: auto;
 }
 
-@keyframes donation-icon-animation {
-  33% {
-    transform: scale(1.2);
-  }
-  66% {
-    transform: scale(1.25);
+.two-seconds-delay-fade-in {
+  opacity: 0;
+  pointer-events: none;
+  animation: opacity-animation 1s linear 100ms forwards;
+  animation-delay: 2s;
+}
+
+.no-delay-fade-in {
+  opacity: 0;
+  pointer-events: none;
+  animation: opacity-animation 1s linear 100ms forwards;
+}
+
+@keyframes opacity-animation {
+  0% {
+    pointer-events: none;
+    opacity: 0;
   }
   100% {
+    pointer-events: auto;
     opacity: 1;
-    transform: scale(1);
   }
 }
 
@@ -459,6 +467,11 @@ a.patreon-button:hover {
 
 .hide {
   display: none;
+}
+
+.donation-modal .btn-link:disabled {
+  opacity: 0;
+  cursor: default;
 }
 
 .donate-btn-group {


### PR DESCRIPTION
This pr AB tests loading the modal elements with a delay.

If the feature is on, the following should happen:

1. illustration and CTA should appear immediately with a 1 sec fade in animation
2. payment confirmation and form should appear 1 second after that ( 2 second delay from the start) with a 1 sec fade in animation
3. skip button (maybe later) should appear 1 second later ( 4 seconds delay from the start) with a 1 sec fade in animation

All of the modal contents should appear with 1 sec fade in animation on the control variation.

To test, enter random strings instead of user email until the illustrations show up. The odds are 50/50. [freecodecamp/freeCodeCamp@b325b4b/client/src/components/growth-book/growth-book-wrapper.tsx#L78](https://github.com/freecodecamp/freeCodeCamp/blob/b325b4b5dcb0b23cc390c099bc0991093d36aa73/client/src/components/growth-book/growth-book-wrapper.tsx#L78)

Make sure to try the control and test.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
