### PR TITLE
fix(client): underline links for all languages

### DIFF
--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -690,3 +690,13 @@ blockquote .small {
   color: white;
   background-color: black;
 }
+
+a {
+  text-underline-position: under;
+}
+
+@supports not (text-underline-position: under) {
+  a {
+    text-underline-offset: 1em;
+  }
+}

--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -163,6 +163,13 @@ p {
 a {
   color: inherit;
   text-decoration: underline;
+  text-underline-position: under;
+}
+
+@supports not (text-underline-position: under) {
+  a {
+    text-underline-offset: 1em;
+  }
 }
 
 a:hover,
@@ -689,14 +696,4 @@ blockquote .small {
 .sr-only {
   color: white;
   background-color: black;
-}
-
-a {
-  text-underline-position: under;
-}
-
-@supports not (text-underline-position: under) {
-  a {
-    text-underline-offset: 1em;
-  }
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #49453

<!-- Feel free to add any additional description of changes below this line -->
Because the problem affects all languages, not only Arabic, I added a solution to global.css. You can verify this by checking at the page footer.
