### PR TITLE
chore(deps): update required pnpm version

### DIFF
--- a/docs/how-to-setup-freecodecamp-locally.md
+++ b/docs/how-to-setup-freecodecamp-locally.md
@@ -69,7 +69,7 @@ We primarily support development on Linux and Unix-based systems like Ubuntu and
 | Prerequisite                                                                                  | Version | Notes                                                                                       |
 | --------------------------------------------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------- |
 | [Node.js](http://nodejs.org)                                                                  | `18.x`  | We use the "Active LTS" version, See [LTS Schedule](https://nodejs.org/en/about/releases/). |
-| [pnpm](https://pnpm.io/installation)                                                          | `8.x`   | -                                                                                            |
+| [pnpm](https://pnpm.io/installation)                                                          | `8.6.x`   | -                                                                                            |
 | [MongoDB Community Server](https://docs.mongodb.com/manual/administration/install-community/) | `5.0.x` | -                                                                                           |
 
 > [!ATTENTION]

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "engines": {
     "node": ">=16",
-    "pnpm": "8"
+    "pnpm": "8.6.x"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [ x] My pull request targets the `main` branch of freeCodeCamp.
- [x ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes na 

<!-- Feel free to add any additional description of changes below this line -->
I think renovate bot and probably github actions are automatically updating to latest pnpm. You can see the bot bumping the lockfile version [here](https://github.com/freeCodeCamp/freeCodeCamp/pull/50597/files#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1) So when I ran pnpm install locally, it failed due to this until i updated pnpm to 8.6.0. This change to package.json will give people a warning when they run `pnpm install` if they their pnpm version is out of date. 

