### PR TITLE
Changed the navbar to 60px and changed other properties (listed in the description) to suit the new navbar height

### DIFF
--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -219,7 +219,7 @@ li > button.nav-link-signout:not([aria-disabled='true']):is(:hover, :focus) {
 }
 
 .lang-button-nav {
-  padding: 5px;
+  padding: 3px;
 }
 
 .exposed-button-nav:hover,
@@ -294,7 +294,7 @@ li > button.nav-link-signout:not([aria-disabled='true']):is(:hover, :focus) {
 
 .signup-btn {
   max-height: calc(var(--header-height) - 6px);
-  padding: 4px 12px;
+  padding: 0.6px 12px;
   margin-inline-start: 2px;
   display: flex;
   align-items: center;
@@ -414,7 +414,7 @@ li > button.nav-link-signout:not([aria-disabled='true']):is(:hover, :focus) {
     width: calc(100% - 30px);
   }
   #universal-nav .signup-btn {
-    padding: 4px 6px;
+    padding: 0.5px 6px;
   }
   #toggle-button-nav .menu-btn-text,
   #universal-nav .login-btn-text {

--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -354,7 +354,7 @@ li > button.nav-link-signout:not([aria-disabled='true']):is(:hover, :focus) {
   display: none;
 }
 
-@media (min-width: 980px) {
+@media (min-width: 981px) {
   #universal-nav-logo {
     height: 100%;
     margin-inline: 1em;
@@ -375,9 +375,11 @@ li > button.nav-link-signout:not([aria-disabled='true']):is(:hover, :focus) {
   .fcc_searchBar .ais-SearchBox-form {
     max-width: calc(100vw - 350px);
   }
-
+  
   #universal-nav-logo {
-    padding-top: 0.2em;
+    margin: 0px;
+    max-height: 60px;
+    padding-top: 0.8em;
   }
 
   .expand-nav {
@@ -425,9 +427,6 @@ li > button.nav-link-signout:not([aria-disabled='true']):is(:hover, :focus) {
   }
   .exposed-button-nav {
     padding: 2px 8px;
-  }
-  #universal-nav-logo {
-    padding-block: 0.2em 0.1em;
   }
 }
 

--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -9,7 +9,7 @@ body {
   font-family: var(--font-family-sans-serif);
   color: var(--secondary-color);
   background: var(--secondary-background);
-  --header-height: 38px;
+  --header-height: 60px;
 }
 
 #___gatsby {

--- a/client/src/components/search/searchBar/searchbar.css
+++ b/client/src/components/search/searchBar/searchbar.css
@@ -129,7 +129,7 @@ and arrow keys */
   grid-template-areas: 'submit input reset';
   margin-bottom: 0;
   gap: 0.25em;
-  margin-top: 6px;
+  margin-top: 17px;
   background-color: var(--gray-75);
 }
 


### PR DESCRIPTION
Changed the --header-height in global.css from 38px to 60px so the navbar's height reflects as 60px.

Changed the margin-top of the searchBar so it fits the new navbar height.

Changed the nav-logo positioning that was mentioned by bbsmooth in the comment. Now, when max-width:980px is triggered it does not have any awkward state where FCC logo is out of position and the FCC logo and search bar spacing is proper.  

Checklist:
- [x ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [ x] My pull request targets the `main` branch of freeCodeCamp.
- [ x] I have tested these changes either locally on my machine, or GitPod.