### PR TITLE
chore: remove old babel-core + plugins

### DIFF
--- a/api-server/.babelrc
+++ b/api-server/.babelrc
@@ -10,7 +10,6 @@
     ]
   ],
   "plugins": [
-    "babel-plugin-transform-function-bind",
     "@babel/plugin-proposal-object-rest-spread",
     "@babel/plugin-proposal-optional-chaining"
   ]

--- a/api-server/package.json
+++ b/api-server/package.json
@@ -24,9 +24,6 @@
     "develop": "node src/development-start.js",
     "start": "cross-env DEBUG=fcc* node lib/production-start.js"
   },
-  "resolutions": {
-    "babel-core": "7.0.0-bridge.0"
-  },
   "dependencies": {
     "@freecodecamp/loopback-component-passport": "1.2.0",
     "@sentry/node": "7.37.1",
@@ -85,9 +82,6 @@
     "@babel/plugin-proposal-optional-chaining": "7.17.12",
     "@babel/preset-env": "7.18.0",
     "@babel/register": "7.17.7",
-    "babel-core": "7.0.0-bridge.0",
-    "babel-plugin-transform-function-bind": "6.22.0",
-    "babel-plugin-transform-imports": "1.5.1",
     "loopback-component-explorer": "6.4.0",
     "nodemon": "2.0.16",
     "smee-client": "1.2.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -419,15 +419,6 @@ importers:
       '@babel/register':
         specifier: 7.17.7
         version: 7.17.7(@babel/core@7.18.0)
-      babel-core:
-        specifier: 7.0.0-bridge.0
-        version: 7.0.0-bridge.0(@babel/core@7.18.0)
-      babel-plugin-transform-function-bind:
-        specifier: 6.22.0
-        version: 6.22.0
-      babel-plugin-transform-imports:
-        specifier: 1.5.1
-        version: 1.5.1
       loopback-component-explorer:
         specifier: 6.4.0
         version: 6.4.0
@@ -2407,7 +2398,7 @@ packages:
       '@babel/traverse': 7.21.2
       '@babel/types': 7.20.7
       convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.0
@@ -2785,7 +2776,7 @@ packages:
       '@babel/core': 7.18.0
       '@babel/helper-compilation-targets': 7.22.5(@babel/core@7.18.0)
       '@babel/helper-plugin-utils': 7.22.5
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       lodash.debounce: 4.0.8
       resolve: 1.22.2
       semver: 6.3.0
@@ -6269,7 +6260,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.5
       '@babel/parser': 7.22.5
       '@babel/types': 7.22.5
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -6286,7 +6277,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.5
       '@babel/parser': 7.22.5
       '@babel/types': 7.22.5
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -11681,7 +11672,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
 
@@ -12393,14 +12384,6 @@ packages:
       chalk: 1.1.3
       esutils: 2.0.3
       js-tokens: 3.0.2
-    dev: true
-
-  /babel-core@7.0.0-bridge.0(@babel/core@7.18.0):
-    resolution: {integrity: sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.0
     dev: true
 
   /babel-eslint@10.1.0(eslint@7.32.0):
@@ -13315,17 +13298,6 @@ packages:
     dependencies:
       babel-plugin-syntax-function-bind: 6.13.0
       babel-runtime: 6.26.0
-    dev: true
-
-  /babel-plugin-transform-imports@1.5.1:
-    resolution: {integrity: sha512-Jkb0tjqye8kjOD7GdcKJTGB3dC9fruQhwRFZCeYS0sZO2otyjG6SohKR8nZiSm/OvhY+Ny2ktzVE59XKgIqskA==}
-    dependencies:
-      babel-types: 6.26.0
-      is-valid-path: 0.1.1
-      lodash.camelcase: 4.3.0
-      lodash.findkey: 4.6.0
-      lodash.kebabcase: 4.1.1
-      lodash.snakecase: 4.1.1
     dev: true
 
   /babel-plugin-transform-imports@2.0.0:
@@ -15945,6 +15917,17 @@ packages:
     dependencies:
       ms: 2.1.2
     dev: true
+
+  /debug@4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
 
   /debug@4.3.4(supports-color@8.1.1):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -20712,7 +20695,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
 
@@ -23432,10 +23415,6 @@ packages:
   /lodash.every@4.6.0:
     resolution: {integrity: sha512-isF82d+65/sNvQ3aaQAW7LLHnnTxSN/2fm4rhYyuufLzA4VtHz6y6S5vFwe6PQVr2xdqUOyxBbTNKDpnmeu50w==}
 
-  /lodash.findkey@4.6.0:
-    resolution: {integrity: sha512-Y+f2R8KsUDJVqdfeai01P5A1IQeMWsMG1p0rghzdhIl7TIap47Y2Z5UJK8x4pstixNL56KVHFRE1IW9jvRwy4g==}
-    dev: true
-
   /lodash.flatten@4.4.0:
     resolution: {integrity: sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==}
 
@@ -23481,10 +23460,6 @@ packages:
     resolution: {integrity: sha512-yv3cSQZmfpbIKo4Yo45B1taEvxjNvcpF1CEOc0Y6dEyvhPIfEJE3twDwPgWTPQubcSgXyBwBKG6wpQvWMDOf6Q==}
     dev: false
 
-  /lodash.kebabcase@4.1.1:
-    resolution: {integrity: sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==}
-    dev: true
-
   /lodash.map@4.6.0:
     resolution: {integrity: sha512-worNHGKLDetmcEYDvh2stPCrrQRkP20E4l0iIS7F8EvzMqBBi7ltvFN5m1HvTf1P7Jk1txKhvFcmYsCr8O2F1Q==}
 
@@ -23503,10 +23478,6 @@ packages:
 
   /lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
-
-  /lodash.snakecase@4.1.1:
-    resolution: {integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==}
-    dev: true
 
   /lodash.sortby@4.7.0:
     resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
@@ -23564,7 +23535,7 @@ packages:
     dependencies:
       async: 0.9.2
       commondir: 1.0.1
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@5.5.0)
       lodash: 4.17.21
       semver: 5.7.1
       strong-globalize: 4.1.3
@@ -23577,7 +23548,7 @@ packages:
     resolution: {integrity: sha512-vDRR4gqkvGOEXh5yL383xGuGxUW9xtF+NCY6/lJu1VAgupKltZxEx3Vw+L3nsGvQrlkJTSmiK3jk72qxkoBtbw==}
     engines: {node: '>=6'}
     dependencies:
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@5.5.0)
       lodash: 4.17.21
       loopback-swagger: 5.9.0
       strong-globalize: 4.1.3
@@ -23592,7 +23563,7 @@ packages:
     dependencies:
       async: 2.6.4
       bson: 1.1.6
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@5.5.0)
       loopback-connector: 4.11.1
       mongodb: 3.7.3
       strong-globalize: 4.1.3
@@ -23622,7 +23593,7 @@ packages:
     dependencies:
       async: 3.2.4
       bluebird: 3.7.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       msgpack5: 4.5.1
       strong-globalize: 5.1.0
       uuid: 7.0.3
@@ -23636,7 +23607,7 @@ packages:
     dependencies:
       async: 2.6.4
       bluebird: 3.7.2
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@5.5.0)
       depd: 1.1.2
       inflection: 1.13.4
       lodash: 4.17.21
@@ -23660,7 +23631,7 @@ packages:
     resolution: {integrity: sha512-p0qSzuuX7eATe5Bxy+RqCj3vSfSFfdCtqyf3yuC+DpchMvgal33XlhEi2UmywyK/Ym28oVnZxxWmfrwFMzSwLQ==}
     engines: {node: '>=4.0.0'}
     dependencies:
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -23670,7 +23641,7 @@ packages:
     engines: {node: '>=8.9'}
     dependencies:
       async: 2.6.4
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@5.5.0)
       strong-globalize: 4.1.3
     transitivePeerDependencies:
       - supports-color
@@ -23681,7 +23652,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       async: 2.6.4
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@5.5.0)
       ejs: 2.7.4
       lodash: 4.17.21
       strong-globalize: 4.1.3
@@ -31128,7 +31099,7 @@ packages:
     dependencies:
       '@types/express': 4.17.17
       accepts: 1.3.8
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       ejs: 3.1.8
       fast-safe-stringify: 2.1.1
       http-status: 1.6.2
@@ -31143,7 +31114,7 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       accept-language: 3.0.18
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       globalize: 1.7.0
       lodash: 4.17.21
       md5: 2.3.0
@@ -31158,7 +31129,7 @@ packages:
     engines: {node: '>=8.9'}
     dependencies:
       accept-language: 3.0.18
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       globalize: 1.7.0
       lodash: 4.17.21
       md5: 2.3.0
@@ -31174,7 +31145,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       accept-language: 3.0.18
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       globalize: 1.7.0
       lodash: 4.17.21
       md5: 2.3.0
@@ -31191,7 +31162,7 @@ packages:
     dependencies:
       async: 3.2.4
       body-parser: 1.20.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       depd: 2.0.0
       escape-string-regexp: 2.0.0
       eventemitter2: 5.0.1
@@ -31325,7 +31296,7 @@ packages:
     dependencies:
       component-emitter: 1.3.0
       cookiejar: 2.1.4
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       fast-safe-stringify: 2.1.1
       form-data: 4.0.0
       formidable: 2.1.1


### PR DESCRIPTION
We don't use the :: operator, so transform-function-bind is unnecessary.
    
transform-imports was not part of the config, so wasn't being used.
    
Without those plugins, the bridge is not necessary.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
