### PR TITLE
fix: remove comments again

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/create-strings-using-template-literals.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/create-strings-using-template-literals.md
@@ -69,14 +69,13 @@ assert(
 Template strings and expression interpolation should be used.
 
 ```js
-(getUserInput) => assert(getUserInput('index').match(/(`.*\${.*}.*`)/));
+code.match(/(`.*\${.*}.*`)/);
 ```
 
 An iterator should be used.
 
 ```js
-(getUserInput) =>
-  assert(getUserInput('index').match(/for|map|reduce|forEach|while/));
+assert(code.match(/for|map|reduce|forEach|while/));
 ```
 
 # --seed--

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/create-strings-using-template-literals.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/create-strings-using-template-literals.md
@@ -69,7 +69,7 @@ assert(
 Template strings and expression interpolation should be used.
 
 ```js
-code.match(/(`.*\${.*}.*`)/);
+assert.match(code, /(`.*\${.*}.*`)/);
 ```
 
 An iterator should be used.

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/mutate-an-array-declared-with-const.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/mutate-an-array-declared-with-const.md
@@ -36,24 +36,21 @@ An array is declared as `const s = [5, 7, 2]`. Change the array to `[2, 5, 7]` u
 You should not replace `const` keyword.
 
 ```js
-(getUserInput) => assert(getUserInput('index').match(/const/g));
+assert(code.match(/const/g));
 ```
 
 `s` should be a constant variable (by using `const`).
 
 ```js
-(getUserInput) => assert(getUserInput('index').match(/const\s+s/g));
+assert(code.match(/const\s+s/g));
 ```
 
 You should not change the original array declaration.
 
 ```js
-(getUserInput) =>
-  assert(
-    getUserInput('index').match(
-      /const\s+s\s*=\s*\[\s*5\s*,\s*7\s*,\s*2\s*\]\s*;?/g
-    )
-  );
+assert(code.match(
+/const\s+s\s*=\s*\[\s*5\s*,\s*7\s*,\s*2\s*\]\s*;?/g
+));
 ```
 
 `s` should be equal to `[2, 5, 7]`.

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/prevent-object-mutation.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/prevent-object-mutation.md
@@ -34,25 +34,21 @@ In this challenge you are going to use `Object.freeze` to prevent mathematical c
 You should not replace the `const` keyword.
 
 ```js
-(getUserInput) => assert(getUserInput('index').match(/const/g));
+assert(code.match(/const/g));
 ```
 
 `MATH_CONSTANTS` should be a constant variable (by using `const`).
 
 ```js
-(getUserInput) =>
-  assert(getUserInput('index').match(/const\s+MATH_CONSTANTS/g));
+assert(code.match(/const\s+MATH_CONSTANTS/g));
 ```
 
 You should not change the original declaration of `MATH_CONSTANTS`.
 
 ```js
-(getUserInput) =>
-  assert(
-    getUserInput('index').match(
-      /const\s+MATH_CONSTANTS\s+=\s+{\s+PI:\s+3.14\s+};/g
-    )
-  );
+assert(code.match(
+   /const\s+MATH_CONSTANTS\s+=\s+{\s+PI:\s+3.14\s+};/g
+));
 ```
 
 `PI` should equal `3.14`.

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-with-the-rest-parameter-to-reassign-array-elements.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/use-destructuring-assignment-with-the-rest-parameter-to-reassign-array-elements.md
@@ -49,7 +49,7 @@ assert(testArr_.every((e, i) => e === i + 1) && testArr_.length === 5);
 `Array.slice()` should not be used.
 
 ```js
-(getUserInput) => assert(!getUserInput('index').match(/slice/g));
+assert(!code.match(/slice/g));
 ```
 
 Destructuring on `list` should be used.
@@ -82,6 +82,7 @@ const sourceWithoutFirstTwo = removeFirstTwo(source);
 
 ```js
 function removeFirstTwo(list) {
+  // comment with 'slice' to check comments are removed in tests
   const [, , ...shorterList] = list;
   return shorterList;
 }

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/write-concise-declarative-functions-with-es6.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/write-concise-declarative-functions-with-es6.md
@@ -39,7 +39,7 @@ Refactor the function `setGear` inside the object `bicycle` to use the shorthand
 Traditional function expression should not be used.
 
 ```js
-(getUserInput) => assert(!code.match(/function/));
+assert(!code.match(/function/));
 ```
 
 `setGear` should be a declarative function.
@@ -79,6 +79,7 @@ console.log(bicycle.gear);
 ```js
 const bicycle = {
   gear: 2,
+  // setGear: function(newGear) {
   setGear(newGear) {
     this.gear = newGear;
   }

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/write-concise-object-literal-declarations-using-object-property-shorthand.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/es6/write-concise-object-literal-declarations-using-object-property-shorthand.md
@@ -43,7 +43,7 @@ assert.deepEqual(
 Your code should not use `key:value`.
 
 ```js
-(getUserInput) => assert(!getUserInput('index').match(/:/g));
+assert(!code.match(/:/g))
 ```
 
 # --seed--
@@ -66,10 +66,17 @@ const createPerson = (name, age, gender) => {
 
 ```js
 const createPerson = (name, age, gender) => {
+  // Only change code below this line
+  /*return {
+    name: name,
+    age: age,
+    gender: gender
+  };*/
   return {
     name,
     age,
     gender
   };
+  // Only change code above this line
 };
 ```

--- a/curriculum/get-challenges.js
+++ b/curriculum/get-challenges.js
@@ -334,6 +334,9 @@ Challenges that have been already audited cannot fall back to their English vers
     challenge.translationPending =
       lang !== 'english' && !isAuditedCert(lang, meta.superBlock);
     challenge.usesMultifileEditor = !!meta.usesMultifileEditor;
+  }
+
+  function fixChallengeProperties(challenge) {
     if (challenge.challengeFiles) {
       // The client expects the challengeFiles to be an array of polyvinyls
       challenge.challengeFiles = challengeFilesToPolys(
@@ -344,6 +347,10 @@ Challenges that have been already audited cannot fall back to their English vers
       // The test runner needs the solutions to be arrays of polyvinyls so it
       // can sort them correctly.
       challenge.solutions = challenge.solutions.map(challengeFilesToPolys);
+    }
+    // if removeComments is not explicitly set, default to true
+    if (typeof challenge.removeComments === 'undefined') {
+      challenge.removeComments = true;
     }
   }
 
@@ -371,6 +378,7 @@ Challenges that have been already audited cannot fall back to their English vers
       : parseMD(getFullPath('english', filePath)));
 
     addMetaToChallenge(challenge, meta);
+    fixChallengeProperties(challenge);
 
     return challenge;
   }

--- a/curriculum/schema/challenge-schema.js
+++ b/curriculum/schema/challenge-schema.js
@@ -26,7 +26,7 @@ const schema = Joi.object()
     block: Joi.string().regex(slugRE).required(),
     blockId: Joi.objectId(),
     challengeOrder: Joi.number(),
-    removeComments: Joi.bool(),
+    removeComments: Joi.bool().required(),
     certification: Joi.string().regex(slugRE),
     challengeType: Joi.number().min(0).max(19).required(),
     checksum: Joi.number(),


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Turns out we haven't been removing any comments before running the tests. Now we do.

Also, to help ensure this doesn't happen again, I created a few solutions with comments that will cause the tests to fail. I know this isn't the most bullet-proof method, but writing tests of the tests we use to test our tests is a bit beyond me today.

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/50717

<!-- Feel free to add any additional description of changes below this line -->
