### PR TITLE
fix(curriculum): Explicitly tell campers to use the > selector

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614090d5a22b6f0a5a6b464c.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614090d5a22b6f0a5a6b464c.md
@@ -9,7 +9,7 @@ dashedName: step-13
 
 # --description--
 
-Target unordered list elements within `nav` elements, and use _Flexbox_ to evenly space the children.
+Use the `>` selector to target unordered list elements within `nav` elements, and use _Flexbox_ to evenly space the children.
 
 # --hints--
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614090d5a22b6f0a5a6b464c.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614090d5a22b6f0a5a6b464c.md
@@ -9,7 +9,7 @@ dashedName: step-13
 
 # --description--
 
-Use the `>` selector to target unordered list elements within `nav` elements, and use _Flexbox_ to evenly space the children.
+Use the `>` selector to target the unordered list elements within the `nav` elements, and use _Flexbox_ to evenly space the children.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to #47554

<!-- Feel free to add any additional description of changes below this line -->

It explicitly states to use the greater than selector. 
