### PR TITLE
feat(api): DELETE user/user-token

### DIFF
--- a/api/src/routes/user.ts
+++ b/api/src/routes/user.ts
@@ -1,10 +1,7 @@
 import _, { isEmpty } from 'lodash';
 import { ObjectId } from 'mongodb';
 import { customAlphabet } from 'nanoid';
-import {
-  Type,
-  type FastifyPluginCallbackTypebox
-} from '@fastify/type-provider-typebox';
+import { type FastifyPluginCallbackTypebox } from '@fastify/type-provider-typebox';
 
 import { schemas } from '../schemas';
 import {
@@ -268,23 +265,7 @@ export const userRoutes: FastifyPluginCallbackTypebox = (
   fastify.delete(
     '/user/user-token',
     {
-      schema: {
-        response: {
-          200: Type.Object({
-            userToken: Type.Null()
-          }),
-          404: Type.Object({
-            message: Type.Literal('userToken not found'),
-            type: Type.Literal('info')
-          }),
-          500: Type.Object({
-            message: Type.Literal(
-              'Oops! Something went wrong. Please try again in a moment or contact support@freecodecamp.org if the error persists.'
-            ),
-            type: Type.Literal('danger')
-          })
-        }
-      }
+      schema: schemas.deleteUserToken
     },
     async (req, reply) => {
       try {

--- a/api/src/schemas.ts
+++ b/api/src/schemas.ts
@@ -309,6 +309,23 @@ export const schemas = {
       })
     }
   },
+  deleteUserToken: {
+    response: {
+      200: Type.Object({
+        userToken: Type.Null()
+      }),
+      404: Type.Object({
+        message: Type.Literal('userToken not found'),
+        type: Type.Literal('info')
+      }),
+      500: Type.Object({
+        message: Type.Literal(
+          'Oops! Something went wrong. Please try again in a moment or contact support@freecodecamp.org if the error persists.'
+        ),
+        type: Type.Literal('danger')
+      })
+    }
+  },
   // Deprecated endpoints:
   deprecatedEndpoints: {
     response: {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I changed the failure response from status 500 text: 'Error deleting user token' to a 404 JSON response. As per usual, the client doesn't care about the specifics of the error response (it just shows an error unless the response is `{ userToken: anyValue }`).

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/50732

<!-- Feel free to add any additional description of changes below this line -->
