### PR TITLE
fix: translate audited portuguese superblocks

### DIFF
--- a/config/superblocks.ts
+++ b/config/superblocks.ts
@@ -121,8 +121,6 @@ export const notAuditedSuperBlocks: NotAuditedSuperBlocks = {
     SuperBlocks.FoundationalCSharp
   ],
   [Languages.Portuguese]: [
-    SuperBlocks.CollegeAlgebraPy,
-    SuperBlocks.ProjectEuler,
     SuperBlocks.JsAlgoDataStructNew,
     SuperBlocks.FoundationalCSharp
   ],


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Thanks to @DanielRosa74 for spotting that we'd stopped showing these as being translated:
 
![image](https://github.com/freeCodeCamp/freeCodeCamp/assets/15801806/f12f4276-c491-423c-8555-8578f50b58f6)



<!-- Feel free to add any additional description of changes below this line -->
