### PR TITLE
fix(UI): make page layout able to change seamlessly

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -112,7 +112,7 @@
     "react-monaco-editor": "0.40.0",
     "react-redux": "7.2.9",
     "react-reflex": "4.1.0",
-    "react-responsive": "6.1.2",
+    "react-responsive": "9.0.2",
     "react-scrollable-anchor": "0.6.1",
     "react-spinkit": "3.0.0",
     "react-tooltip": "4.5.1",

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -4,7 +4,7 @@ import Helmet from 'react-helmet';
 import { useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { HandlerProps } from 'react-reflex';
-import Media from 'react-responsive';
+import { useMediaQuery } from 'react-responsive';
 import { bindActionCreators, Dispatch } from 'redux';
 import { createStructuredSelector } from 'reselect';
 import store from 'store';
@@ -214,6 +214,9 @@ function ShowClassic({
   const containerRef = useRef<HTMLElement>();
   const editorRef = useRef<editor.IStandaloneCodeEditor>();
   const instructionsPanelRef = useRef<HTMLDivElement>(null);
+  const isMobile = useMediaQuery({
+    query: `(max-width: ${MAX_MOBILE_WIDTH}px)`
+  });
 
   const blockNameTitle = `${t(
     `intro:${superBlock}.blocks.${block}.title`
@@ -422,7 +425,7 @@ function ShowClassic({
     >
       <LearnLayout hasEditableBoundaries={hasEditableBoundaries}>
         <Helmet title={windowTitle} />
-        <Media maxWidth={MAX_MOBILE_WIDTH}>
+        {isMobile && (
           <MobileLayout
             editor={renderEditor({
               isMobileLayout: true,
@@ -450,8 +453,8 @@ function ShowClassic({
             usesMultifileEditor={usesMultifileEditor}
             videoUrl={videoUrl}
           />
-        </Media>
-        <Media minWidth={MAX_MOBILE_WIDTH + 1}>
+        )}
+        {!isMobile && (
           <DesktopLayout
             challengeFiles={reduxChallengeFiles}
             challengeType={challengeType}
@@ -480,7 +483,7 @@ function ShowClassic({
             }
             windowTitle={windowTitle}
           />
-        </Media>
+        )}
         <CompletionModal />
         <HelpModal challengeTitle={title} challengeBlock={blockName} />
         <VideoModal videoUrl={videoUrl} />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -666,8 +666,8 @@ importers:
         specifier: 4.1.0
         version: 4.1.0(react-dom@16.14.0)(react@16.14.0)
       react-responsive:
-        specifier: 6.1.2
-        version: 6.1.2(react@16.14.0)
+        specifier: 9.0.2
+        version: 9.0.2(react@16.14.0)
       react-scrollable-anchor:
         specifier: 0.6.1
         version: 0.6.1(react-dom@16.14.0)(react@16.14.0)
@@ -26745,16 +26745,17 @@ packages:
     resolution: {integrity: sha512-Gvzk7OZpiqKSkxsQvO/mbTN1poglhmAV7gR/DdIrRrSMXraRQQlfikRJOr3Nb9GTMPC5kof948Zy6jJZIFtDvQ==}
     engines: {node: '>=0.10.0'}
 
-  /react-responsive@6.1.2(react@16.14.0):
-    resolution: {integrity: sha512-AXentVC/kN3KED9zhzJv2pu4vZ0i6cSHdTtbCScVV1MT6F5KXaG2qs5D7WLmhdaOvmiMX8UfmS4ZSO+WPwDt4g==}
-    engines: {node: '>= 0.10'}
+  /react-responsive@9.0.2(react@16.14.0):
+    resolution: {integrity: sha512-+4CCab7z8G8glgJoRjAwocsgsv6VA2w7JPxFWHRc7kvz8mec1/K5LutNC2MG28Mn8mu6+bu04XZxHv5gyfT7xQ==}
+    engines: {node: '>=0.10'}
     peerDependencies:
-      react: ^16.3.0
+      react: '>=16.8.0'
     dependencies:
       hyphenate-style-name: 1.0.4
       matchmediaquery: 0.3.1
       prop-types: 15.8.1
       react: 16.14.0
+      shallow-equal: 1.2.1
     dev: false
 
   /react-router-dom@6.14.0(react-dom@16.14.0)(react@16.14.0):
@@ -28296,6 +28297,10 @@ packages:
 
   /shallow-compare@1.2.2:
     resolution: {integrity: sha512-LUMFi+RppPlrHzbqmFnINTrazo0lPNwhcgzuAXVVcfy/mqPDrQmHAyz5bvV0gDAuRFrk804V0HpQ6u9sZ0tBeg==}
+
+  /shallow-equal@1.2.1:
+    resolution: {integrity: sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==}
+    dev: false
 
   /shallowequal@1.1.0:
     resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
This PR was opened to allow seamless transitions between Mobile Layout and Desktop Layout when changing the browser window width.

In the current [steps](https://www.freecodecamp.org/learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-2)/[challenges](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-javascript/comment-your-javascript-code) page, both Mobile Layout and Desktop Layout in the [`show.tsx`](https://github.com/freeCodeCamp/freeCodeCamp/blob/main/client/src/templates/Challenges/classic/show.tsx) will disappear when browser window width is adjusted at more than 767px and less than 768px, so there is a slight gap between two layouts during changing the window width.
Current production code has `ShowClassic` functional component, so `useMediaQuery` hook (instead of `Media` component) can be used to address this issue and will allow seamless transitions.