### PR TITLE
fix(a11y): prevent monaco tab key status from announcing on page load

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -409,10 +409,13 @@ const Editor = (props: EditorProps): JSX.Element => {
       return accessibility;
     };
 
-    const setTabTrapped = (trapped: boolean, announce = true) => {
+    const setTabTrapped = (
+      trapped: boolean,
+      opts: { announce: boolean } = { announce: true }
+    ) => {
       setMonacoTabTrapped(trapped);
       store.set('monacoTabTrapped', trapped);
-      if (announce) {
+      if (opts.announce) {
         ariaAlert(
           `${
             trapped
@@ -426,7 +429,7 @@ const Editor = (props: EditorProps): JSX.Element => {
     // By default, Tab will be trapped in the monaco editor, so we only need to
     // check if the user has turned this off.
     if (!isTabTrapped()) {
-      setTabTrapped(false, false);
+      setTabTrapped(false, { announce: false });
     }
 
     const accessibilityMode = storedAccessibilityMode();

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -615,7 +615,6 @@ const Editor = (props: EditorProps): JSX.Element => {
       document.querySelectorAll('.monaco-alert');
     if (ariaLive.length > 0) {
       const liveText = ariaLive[0];
-      liveText.dataset.timestamp = time;
       liveText.textContent = message;
       // Hack used by monaco to force older browsers to announce the update to
       // the live region.

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -623,7 +623,11 @@ const Editor = (props: EditorProps): JSX.Element => {
       liveText.style.visibility = 'visible';
       // Need to remove message after a few seconds so screen readers don't
       // run into it.
+      // First, track the latest message so it is shown for the full duration.
+      const time = `t${Date.now()}`;
+      liveText.dataset.timestamp = time;
       setTimeout(function () {
+        // Now, only the latest message will have this timestamp.
         if (liveText.dataset.timestamp === time) {
           liveText.textContent = '';
         }

--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -613,7 +613,6 @@ const Editor = (props: EditorProps): JSX.Element => {
   const ariaAlert = (message: string) => {
     const ariaLive: NodeListOf<HTMLDivElement> =
       document.querySelectorAll('.monaco-alert');
-    const time = `t${Date.now()}`;
     if (ariaLive.length > 0) {
       const liveText = ariaLive[0];
       liveText.dataset.timestamp = time;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This one has been bugging me for a while and it's a supplemental fix to a bigger accessibility issue I'm currently working on.

If the user changes the functionality of the Tab key in the monaco editor using `Ctrl-m` then the message that is announced (via a live region) to screen reader users hangs around and is announced on subsequent page loads. This PR fixes that issue and also removes the message after a short period of time so screen reader users don't accidentally stumble upon it.