### PR TITLE
fix(client): show check code button after reset

### DIFF
--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -275,7 +275,8 @@ const LowerJaw = ({
         onClick={tryToExecuteChallenge}
         {...(challengeIsCompleted &&
           !focusManagementCompleted && { tabIndex: -1, className: 'sr-only' })}
-        {...(focusManagementCompleted && { 'aria-hidden': true })}
+        {...(challengeIsCompleted &&
+          focusManagementCompleted && { 'aria-hidden': true })}
         ref={checkYourCodeButtonRef}
       >
         {checkButtonText}

--- a/cypress/e2e/default/learn/challenges/multifile.ts
+++ b/cypress/e2e/default/learn/challenges/multifile.ts
@@ -71,6 +71,26 @@ describe('Challenge with multifile editor', () => {
   );
 
   it(
+    'brings back the check button after reset',
+    { browser: '!firefox' },
+    () => {
+      cy.visit(location);
+      cy.focused().click().type('{end}{enter}<meta charset="UTF-8" />');
+      cy.get(selectors.checkLowerJawButton).should('not.be.focused');
+      cy.get(selectors.checkLowerJawButton).click();
+      // Ready to submit (submit button replaces check button)
+      cy.get(selectors.checkLowerJawButton).should('not.be.visible');
+      cy.get(selectors.submitLowerJawButton).should('be.visible');
+      // Reset
+      cy.get(selectors.resetCodeButton).click();
+      cy.get('[data-cy=reset-modal-confirm').click();
+      // Check button is back
+      cy.get(selectors.checkLowerJawButton).should('be.visible');
+      cy.get(selectors.submitLowerJawButton).should('not.be.visible');
+    }
+  );
+
+  it(
     'checks hotkeys when instruction is focused',
     { browser: '!firefox' },
     () => {

--- a/cypress/e2e/default/learn/challenges/multifile.ts
+++ b/cypress/e2e/default/learn/challenges/multifile.ts
@@ -79,12 +79,14 @@ describe('Challenge with multifile editor', () => {
       cy.get(selectors.checkLowerJawButton).should('not.be.focused');
       cy.get(selectors.checkLowerJawButton).click();
       // Ready to submit (submit button replaces check button)
-      cy.get(selectors.checkLowerJawButton).should('not.be.visible');
       cy.get(selectors.submitLowerJawButton).should('be.visible');
+      cy.get(selectors.checkLowerJawButton).should('not.be.visible');
       // Reset
       cy.get(selectors.resetCodeButton).click();
       cy.get('[data-cy=reset-modal-confirm').click();
-      // Check button is back
+      // First we need to click on the description or Cypress will not be able
+      // to scroll to the button
+      cy.get('.editor-upper-jaw').click();
       cy.get(selectors.checkLowerJawButton).should('be.visible');
       cy.get(selectors.submitLowerJawButton).should('not.be.visible');
     }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This ensures the "Check Your Code" button is displayed after a reset. Previously if you checked valid code then reset, the button would stay hidden.

Steps to reproduce:

1. Go to https://www.freecodecamp.org/learn/2022/responsive-web-design/learn-html-by-building-a-cat-photo-app/step-2
2. Paste `<h2>Cat Photos</h2>` into the editor, below `<h2>Cat Photos</h2>`
3. Click "Check Your Code"
4. See Submit and go to next challenge
5. Click Reset and confirm 
6. See that the lower jaw only contains the Reset button
![image](https://github.com/freeCodeCamp/freeCodeCamp/assets/15801806/9f1c7845-2ae9-479f-8062-2b5c79f41e77)


<!-- Feel free to add any additional description of changes below this line -->
