### PR TITLE
fix: create env.json before building curriculum

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "cypress:dev:watch": "pnpm run cypress open",
     "cypress:install": "cypress install && echo 'for use with ./cypress-install.js'",
     "cypress:install-build-tools": "sh ./cypress-install.sh",
-    "predevelop": "npm-run-all -p create:* build:curriculum",
+    "predevelop": "npm-run-all -p create:* -s build:curriculum",
     "develop": "npm-run-all -p develop:*",
     "develop:client": "cd ./client && pnpm run develop",
     "develop:server": "cd ./api-server && pnpm run develop",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

It's a prerequisite, which I hadn't noticed because my env.json already existed.

<!-- Feel free to add any additional description of changes below this line -->
