### PR TITLE
fix(types): four-oh-four props, global i18next definition for returnNull 

### DIFF
--- a/client/i18n/config-for-tests.ts
+++ b/client/i18n/config-for-tests.ts
@@ -12,7 +12,8 @@ i18n
     },
     lng: 'en',
     ns: ['translations'],
-    resources: { en: { translations: {} } }
+    resources: { en: { translations: {} } },
+    returnNull: false
   })
   .catch((error: Error) => {
     throw Error(error.message);

--- a/client/i18n/config.js
+++ b/client/i18n/config.js
@@ -73,7 +73,8 @@ i18n.use(initReactI18next).init({
   },
   react: {
     useSuspense: true
-  }
+  },
+  returnNull: false
 });
 
 i18n.languages = clientLocale;

--- a/client/src/components/FourOhFour/index.tsx
+++ b/client/src/components/FourOhFour/index.tsx
@@ -1,3 +1,4 @@
+import { RouteComponentProps } from '@reach/router';
 import { Link } from 'gatsby';
 import React from 'react';
 import Helmet from 'react-helmet';
@@ -9,7 +10,7 @@ import { Spacer } from '../helpers';
 
 import './404.css';
 
-const FourOhFour = (): JSX.Element => {
+const FourOhFour = (_props: RouteComponentProps): JSX.Element => {
   const { t } = useTranslation();
   const quote = randomQuote();
   return (

--- a/client/src/components/FourOhFour/index.tsx
+++ b/client/src/components/FourOhFour/index.tsx
@@ -9,13 +9,18 @@ import { Spacer } from '../helpers';
 
 import './404.css';
 
-const FourOhFour = (): JSX.Element => {
+interface FourOhFourProps {
+  default?: boolean;
+}
+
+const FourOhFour = (_props: FourOhFourProps): JSX.Element => {
   const { t } = useTranslation();
   const quote = randomQuote();
+
   return (
     <div className='notfound-page-wrapper'>
       <Helmet title={t('404.page-not-found') + '| freeCodeCamp'} />
-      <img alt={t('404.not-found')} src={notFoundLogo} />
+      <img alt={t('404.not-found') || ''} src={notFoundLogo} />
       <Spacer size='medium' />
       <h1>{t('404.page-not-found')}.</h1>
       <Spacer size='medium' />

--- a/client/src/components/FourOhFour/index.tsx
+++ b/client/src/components/FourOhFour/index.tsx
@@ -15,7 +15,7 @@ const FourOhFour = (): JSX.Element => {
   return (
     <div className='notfound-page-wrapper'>
       <Helmet title={t('404.page-not-found') + '| freeCodeCamp'} />
-      <img alt={t('404.not-found') || ''} src={notFoundLogo} />
+      <img alt={t('404.not-found')} src={notFoundLogo} />
       <Spacer size='medium' />
       <h1>{t('404.page-not-found')}.</h1>
       <Spacer size='medium' />

--- a/client/src/components/FourOhFour/index.tsx
+++ b/client/src/components/FourOhFour/index.tsx
@@ -9,14 +9,9 @@ import { Spacer } from '../helpers';
 
 import './404.css';
 
-interface FourOhFourProps {
-  default?: boolean;
-}
-
-const FourOhFour = (_props: FourOhFourProps): JSX.Element => {
+const FourOhFour = (): JSX.Element => {
   const { t } = useTranslation();
   const quote = randomQuote();
-
   return (
     <div className='notfound-page-wrapper'>
       <Helmet title={t('404.page-not-found') + '| freeCodeCamp'} />

--- a/client/src/i18next.d.ts
+++ b/client/src/i18next.d.ts
@@ -1,0 +1,8 @@
+import 'i18next';
+
+// This should not be necessary when upgrading to v23.0.0
+declare module 'i18next' {
+  interface CustomTypeOptions {
+    returnNull: false;
+  }
+}

--- a/client/src/pages/404.tsx
+++ b/client/src/pages/404.tsx
@@ -15,7 +15,7 @@ function FourOhFourPage(): JSX.Element {
       {/* @ts-ignore */}
       <ShowProfileOrFourOhFour path={withPrefix('/:maybeUser')} />
 
-      <FourOhFour default={true} />
+      <FourOhFour />
     </Router>
   );
 }

--- a/client/src/pages/404.tsx
+++ b/client/src/pages/404.tsx
@@ -15,7 +15,7 @@ function FourOhFourPage(): JSX.Element {
       {/* @ts-ignore */}
       <ShowProfileOrFourOhFour path={withPrefix('/:maybeUser')} />
 
-      <FourOhFour />
+      <FourOhFour default />
     </Router>
   );
 }

--- a/client/src/pages/404.tsx
+++ b/client/src/pages/404.tsx
@@ -14,8 +14,7 @@ function FourOhFourPage(): JSX.Element {
       {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
       {/* @ts-ignore */}
       <ShowProfileOrFourOhFour path={withPrefix('/:maybeUser')} />
-      {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
-      {/* @ts-ignore */}
+
       <FourOhFour default={true} />
     </Router>
   );


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Removing non-needed prop types for the `FourOhFour` component to fix a ts-ignore.
Fixing issue with `string | undefined` by adding a proper global i18next definition.
