### PR TITLE
fix(types): adding correct redirect-home props to fix some ts-ignores

### DIFF
--- a/client/src/components/create-redirect.ts
+++ b/client/src/components/create-redirect.ts
@@ -2,7 +2,7 @@ import { navigate } from 'gatsby';
 import type { RouteComponentProps } from "@reach/router"
 
 const createRedirect =
-  (to = '/'): (() => JSX.Element | null) =>
+  (to = '/'): ((_props: RouteComponentProps) => JSX.Element | null) =>
   () => {
     if (typeof window !== 'undefined') {
       void navigate(to);

--- a/client/src/components/create-redirect.ts
+++ b/client/src/components/create-redirect.ts
@@ -1,4 +1,5 @@
 import { navigate } from 'gatsby';
+import type { RouteComponentProps } from "@reach/router"
 
 const createRedirect =
   (to = '/'): (() => JSX.Element | null) =>

--- a/client/src/components/create-redirect.ts
+++ b/client/src/components/create-redirect.ts
@@ -1,5 +1,5 @@
 import { navigate } from 'gatsby';
-import type { RouteComponentProps } from "@reach/router"
+import type { RouteComponentProps } from '@reach/router';
 
 const createRedirect =
   (to = '/'): ((_props: RouteComponentProps) => JSX.Element | null) =>

--- a/client/src/components/create-redirect.ts
+++ b/client/src/components/create-redirect.ts
@@ -1,11 +1,7 @@
 import { navigate } from 'gatsby';
 
-interface RedirectProps {
-  default?: boolean;
-}
-
 const createRedirect =
-  (to = '/'): ((_props: RedirectProps) => JSX.Element | null) =>
+  (to = '/'): (() => JSX.Element | null) =>
   () => {
     if (typeof window !== 'undefined') {
       void navigate(to);

--- a/client/src/components/create-redirect.ts
+++ b/client/src/components/create-redirect.ts
@@ -1,8 +1,11 @@
-/* eslint-disable react/display-name */
 import { navigate } from 'gatsby';
 
+interface RedirectProps {
+  default?: boolean;
+}
+
 const createRedirect =
-  (to = '/'): (() => JSX.Element | null) =>
+  (to = '/'): ((_props: RedirectProps) => JSX.Element | null) =>
   () => {
     if (typeof window !== 'undefined') {
       void navigate(to);

--- a/client/src/pages/certification.tsx
+++ b/client/src/pages/certification.tsx
@@ -17,7 +17,7 @@ function Certification(): JSX.Element {
         path={withPrefix('/certification/:username/:certSlug')}
       />
 
-      <RedirectHome />
+      <RedirectHome default />
     </Router>
   );
 }

--- a/client/src/pages/certification.tsx
+++ b/client/src/pages/certification.tsx
@@ -16,8 +16,7 @@ function Certification(): JSX.Element {
         // @ts-ignore
         path={withPrefix('/certification/:username/:certSlug')}
       />
-      {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
-      {/* @ts-ignore */}
+
       <RedirectHome default={true} />
     </Router>
   );

--- a/client/src/pages/certification.tsx
+++ b/client/src/pages/certification.tsx
@@ -17,7 +17,7 @@ function Certification(): JSX.Element {
         path={withPrefix('/certification/:username/:certSlug')}
       />
 
-      <RedirectHome default={true} />
+      <RedirectHome />
     </Router>
   );
 }

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -9,8 +9,7 @@ function Settings(): JSX.Element {
   return (
     <Router>
       <ShowSettings path={withPrefix('/settings')} />
-      {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
-      {/* @ts-ignore */}
+
       <RedirectHome default={true} />
     </Router>
   );

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -10,7 +10,7 @@ function Settings(): JSX.Element {
     <Router>
       <ShowSettings path={withPrefix('/settings')} />
 
-      <RedirectHome default={true} />
+      <RedirectHome />
     </Router>
   );
 }

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -10,7 +10,7 @@ function Settings(): JSX.Element {
     <Router>
       <ShowSettings path={withPrefix('/settings')} />
 
-      <RedirectHome />
+      <RedirectHome default />
     </Router>
   );
 }

--- a/client/src/pages/unsubscribed.tsx
+++ b/client/src/pages/unsubscribed.tsx
@@ -15,7 +15,7 @@ function Unsubscribed(): JSX.Element {
       {/* @ts-ignore */}
       <ShowUnsubscribed path={withPrefix('/unsubscribed')} />
 
-      <RedirectHome default={true} />
+      <RedirectHome />
     </Router>
   );
 }

--- a/client/src/pages/unsubscribed.tsx
+++ b/client/src/pages/unsubscribed.tsx
@@ -14,8 +14,7 @@ function Unsubscribed(): JSX.Element {
       {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
       {/* @ts-ignore */}
       <ShowUnsubscribed path={withPrefix('/unsubscribed')} />
-      {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
-      {/* @ts-ignore */}
+
       <RedirectHome default={true} />
     </Router>
   );

--- a/client/src/pages/unsubscribed.tsx
+++ b/client/src/pages/unsubscribed.tsx
@@ -15,7 +15,7 @@ function Unsubscribed(): JSX.Element {
       {/* @ts-ignore */}
       <ShowUnsubscribed path={withPrefix('/unsubscribed')} />
 
-      <RedirectHome />
+      <RedirectHome default />
     </Router>
   );
 }

--- a/client/src/pages/user.tsx
+++ b/client/src/pages/user.tsx
@@ -11,7 +11,7 @@ function User(): JSX.Element {
       {/* @ts-expect-error Adding path property breaks username typing */}
       <ShowUser path={withPrefix('/user/:username/report-user')} />
 
-      <RedirectHome default={true} />
+      <RedirectHome />
     </Router>
   );
 }

--- a/client/src/pages/user.tsx
+++ b/client/src/pages/user.tsx
@@ -10,8 +10,7 @@ function User(): JSX.Element {
     <Router>
       {/* @ts-expect-error Adding path property breaks username typing */}
       <ShowUser path={withPrefix('/user/:username/report-user')} />
-      {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
-      {/* @ts-ignore */}
+
       <RedirectHome default={true} />
     </Router>
   );

--- a/client/src/pages/user.tsx
+++ b/client/src/pages/user.tsx
@@ -11,7 +11,7 @@ function User(): JSX.Element {
       {/* @ts-expect-error Adding path property breaks username typing */}
       <ShowUser path={withPrefix('/user/:username/report-user')} />
 
-      <RedirectHome />
+      <RedirectHome default />
     </Router>
   );
 }


### PR DESCRIPTION
Checklist:
- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Removing `RedirectHome` component passed props to fix some ts-ignores