### PR TITLE
fix(types): adding proper yearsTopContributor type

### DIFF
--- a/client/src/components/profile/components/camper.tsx
+++ b/client/src/components/profile/components/camper.tsx
@@ -121,9 +121,7 @@ function Camper({
               {t('profile.contributor')}
             </Link>
           </p>
-          <p className='text-center'>
-            {joinArray(yearsTopContributor as string[], t)}
-          </p>
+          <p className='text-center'>{joinArray(yearsTopContributor, t)}</p>
         </div>
       )}
       <br />

--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -218,8 +218,7 @@ export type User = {
   twitter: string;
   username: string;
   website: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  yearsTopContributor: any[];
+  yearsTopContributor: string[];
 } & ClaimedCertifications;
 
 export type ProfileUI = {


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Removing `any` from the `yearsTopContributor` prop to make it safer, based on its Prisma type.