### PR TITLE
fix(curriculum): use helper instead of regex to test css

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f769702e6e33127d14aa120.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f769702e6e33127d14aa120.md
@@ -14,19 +14,15 @@ Now align the text to the `right` for the elements with the `price` class.
 You should have a `price` class selector.
 
 ```js
-assert(code.match(/\.price\s*{/i));
+const hasSelector = new __helpers.CSSHelp(document).getStyle('.price');
+assert.exists(hasSelector);
 ```
 
 Your `price` class selector should set the `text-align` property to `right`.
 
 ```js
-assert(code.match(/\.price\s*{\s*text-align:\s*right;?/i));
-```
-
-Your `.price` element should be aligned to the right.
-
-```js
-assert($('.price').css('text-align') === 'right');
+const priceSelector = new __helpers.CSSHelp(document).getStyle('.price');
+assert.equal(priceSelector?.getPropertyValue('text-align'), 'right');
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The regex wasn't being friendly toward whitespace. 

<!-- Feel free to add any additional description of changes below this line -->
