### PR TITLE
test: speed up seeding when testing

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -31,6 +31,11 @@ module.exports = defineConfig({
           execSync('pnpm run build:curriculum');
         }
       });
+      on('task', {
+        seed: () => execSync('node tools/scripts/seed/seed-demo-user'),
+        seedCertified: () =>
+          execSync('node tools/scripts/seed/seed-demo-user certified-user')
+      });
 
       config.env.API_LOCATION = 'http://localhost:3000';
       return config;

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -3,7 +3,7 @@ const { existsSync } = require('fs');
 const { defineConfig } = require('cypress');
 
 function seed(args = []) {
-  execSync('node tools/scripts/seed/seed-demo-user' + args.join(' '));
+  return execSync('node tools/scripts/seed/seed-demo-user' + args.join(' '));
 }
 
 module.exports = defineConfig({

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -3,7 +3,7 @@ const { existsSync } = require('fs');
 const { defineConfig } = require('cypress');
 
 function seed(args = []) {
-  return execSync('node tools/scripts/seed/seed-demo-user' + args.join(' '));
+  return execSync('node tools/scripts/seed/seed-demo-user ' + args.join(' '));
 }
 
 module.exports = defineConfig({

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -2,6 +2,10 @@ const { execSync } = require('child_process');
 const { existsSync } = require('fs');
 const { defineConfig } = require('cypress');
 
+function seed(args = []) {
+  execSync('node tools/scripts/seed/seed-demo-user' + args.join(' '));
+}
+
 module.exports = defineConfig({
   e2e: {
     baseUrl: 'http://localhost:8000',
@@ -32,9 +36,7 @@ module.exports = defineConfig({
         }
       });
       on('task', {
-        seed: () => execSync('node tools/scripts/seed/seed-demo-user'),
-        seedCertified: () =>
-          execSync('node tools/scripts/seed/seed-demo-user certified-user')
+        seed
       });
 
       config.env.API_LOCATION = 'http://localhost:3000';

--- a/cypress/e2e/default/learn/challenges/codeally.ts
+++ b/cypress/e2e/default/learn/challenges/codeally.ts
@@ -19,7 +19,7 @@ describe('CodeAlly cert challenge', function () {
 
   describe('after completing the project', function () {
     before(() => {
-      cy.task('seedCertified');
+      cy.task('seed', ['certified-user']);
       cy.login();
       cy.visit(
         '/learn/relational-database/build-a-celestial-bodies-database-project/build-a-celestial-bodies-database'

--- a/cypress/e2e/default/learn/challenges/codeally.ts
+++ b/cypress/e2e/default/learn/challenges/codeally.ts
@@ -1,7 +1,7 @@
 describe('CodeAlly cert challenge', function () {
   describe('before completing the project', function () {
     before(() => {
-      cy.exec('pnpm run seed');
+      cy.task('seed');
       cy.login();
       cy.visit(
         '/learn/relational-database/build-a-celestial-bodies-database-project/build-a-celestial-bodies-database'
@@ -19,7 +19,7 @@ describe('CodeAlly cert challenge', function () {
 
   describe('after completing the project', function () {
     before(() => {
-      cy.exec('pnpm run seed:certified-user');
+      cy.task('seedCertified');
       cy.login();
       cy.visit(
         '/learn/relational-database/build-a-celestial-bodies-database-project/build-a-celestial-bodies-database'

--- a/cypress/e2e/default/learn/challenges/failed-updates.ts
+++ b/cypress/e2e/default/learn/challenges/failed-updates.ts
@@ -21,7 +21,7 @@ function getCompletedIds(completedChallenges: ChallengeData[]): string[] {
 
 describe('failed update flushing', function () {
   before(() => {
-    cy.exec('pnpm run seed');
+    cy.task('seed');
     cy.login();
   });
 

--- a/cypress/e2e/default/learn/challenges/multifile-cert-project.ts
+++ b/cypress/e2e/default/learn/challenges/multifile-cert-project.ts
@@ -10,7 +10,7 @@ const editorElements = {
 
 describe('multifileCertProjects', function () {
   before(() => {
-    cy.exec('pnpm run seed');
+    cy.task('seed');
     cy.login();
   });
 
@@ -39,7 +39,7 @@ describe('multifileCertProjects', function () {
   it('should save using ctrl+s hotkey and persist through navigation', function () {
     // since rapid clicks will cause the save requests to be ignored, we have to
     // purge the db:
-    cy.exec('pnpm run seed');
+    cy.task('seed');
     // and the redux store:
     cy.reload();
     cy.get(editorElements.container).find(editorElements.editor).click();

--- a/cypress/e2e/default/learn/challenges/navigation.ts
+++ b/cypress/e2e/default/learn/challenges/navigation.ts
@@ -14,7 +14,7 @@ const challenge2 = {
 
 describe('submitting a challenge', () => {
   before(() => {
-    cy.exec('pnpm run seed');
+    cy.task('seed');
     cy.login();
   });
 

--- a/cypress/e2e/default/learn/challenges/progress-bar.ts
+++ b/cypress/e2e/default/learn/challenges/progress-bar.ts
@@ -1,6 +1,6 @@
 describe('progress bar', () => {
   beforeEach(() => {
-    cy.exec('pnpm run seed');
+    cy.task('seed');
     cy.login();
   });
 

--- a/cypress/e2e/default/learn/challenges/projects.ts
+++ b/cypress/e2e/default/learn/challenges/projects.ts
@@ -64,7 +64,7 @@ const pythonProjects = {
 
 describe('project submission', () => {
   beforeEach(() => {
-    cy.exec('pnpm run seed');
+    cy.task('seed');
     cy.login();
   });
   // NOTE: this will fail once challenge tests are added.

--- a/cypress/e2e/default/learn/donate/donate-page-donor.ts
+++ b/cypress/e2e/default/learn/donate/donate-page-donor.ts
@@ -1,6 +1,6 @@
 describe('Donate page', () => {
   beforeEach(() => {
-    cy.exec('pnpm run seed -- --donor');
+    cy.task('seed', ['--donor']);
     cy.login();
   });
 

--- a/cypress/e2e/default/learn/donate/donation-block-completion-modal.ts
+++ b/cypress/e2e/default/learn/donate/donation-block-completion-modal.ts
@@ -1,12 +1,12 @@
 describe('Donate page', () => {
   before(() => {
     cy.clearCookies();
-    cy.exec('pnpm run seed');
+    cy.task('seed');
     cy.login();
   });
 
   after(() => {
-    cy.exec('pnpm run seed');
+    cy.task('seed');
   });
 
   const projects = [

--- a/cypress/e2e/default/learn/header/universal-navigation.ts
+++ b/cypress/e2e/default/learn/header/universal-navigation.ts
@@ -46,7 +46,7 @@ describe('Default Navigation Menu', () => {
 describe('Authenticated Navigation Menu', () => {
   before(() => {
     cy.clearCookies();
-    cy.exec('pnpm run seed');
+    cy.task('seed');
     cy.login();
     cy.get(navigationItems['toggle-button']).should('be.visible').click();
   });
@@ -68,7 +68,7 @@ describe('Authenticated Navigation Menu', () => {
 describe('Authenticated User Sign Out', () => {
   before(() => {
     cy.clearCookies();
-    cy.exec('pnpm run seed');
+    cy.task('seed');
   });
   beforeEach(() => {
     cy.login();

--- a/cypress/e2e/default/learn/header/universal-navigation.ts
+++ b/cypress/e2e/default/learn/header/universal-navigation.ts
@@ -94,7 +94,7 @@ describe('Authenticated User Sign Out', () => {
 describe('Donor Navigation Menu', () => {
   before(() => {
     cy.clearCookies();
-    cy.exec('pnpm run seed -- --donor');
+    cy.task('seed', ['--donor']);
     cy.login();
     cy.visit('/donate');
   });

--- a/cypress/e2e/default/learn/responsive-web-design/intro-page.ts
+++ b/cypress/e2e/default/learn/responsive-web-design/intro-page.ts
@@ -4,7 +4,7 @@ const introPageSelectors = {
 
 describe('Certification intro page', () => {
   before(() => {
-    cy.exec('pnpm run seed');
+    cy.task('seed');
     cy.login();
   });
 

--- a/cypress/e2e/default/learn/responsive-web-design/show-cert-from-superblock.ts
+++ b/cypress/e2e/default/learn/responsive-web-design/show-cert-from-superblock.ts
@@ -29,7 +29,7 @@ const projects = {
 
 describe('Front End Development Libraries Superblock', () => {
   before(() => {
-    cy.exec('pnpm run seed');
+    cy.task('seed');
     cy.login();
     cy.visit('/learn/front-end-development-libraries');
   });
@@ -41,7 +41,7 @@ describe('Front End Development Libraries Superblock', () => {
   });
   describe('After submitting all 5 projects', () => {
     before(() => {
-      cy.exec('pnpm run seed');
+      cy.task('seed');
       cy.login();
       cy.visit('/settings');
       cy.setPrivacyTogglesToPublic();

--- a/cypress/e2e/default/settings/certifications.ts
+++ b/cypress/e2e/default/settings/certifications.ts
@@ -3,7 +3,7 @@ import '@testing-library/cypress/add-commands';
 describe('Settings certifications area', () => {
   describe('initially', () => {
     before(() => {
-      cy.exec('pnpm run seed');
+      cy.task('seed');
       cy.login();
     });
 
@@ -23,7 +23,7 @@ describe('Settings certifications area', () => {
 
   describe('after isHonest', () => {
     before(() => {
-      cy.exec('pnpm run seed');
+      cy.task('seed');
       cy.login();
     });
 

--- a/cypress/e2e/default/settings/email-change.ts
+++ b/cypress/e2e/default/settings/email-change.ts
@@ -1,6 +1,6 @@
 describe('Email input field', () => {
   beforeEach(() => {
-    cy.exec('pnpm run seed');
+    cy.task('seed');
     cy.login();
     cy.visit('/settings');
   });

--- a/cypress/e2e/default/settings/user-token.ts
+++ b/cypress/e2e/default/settings/user-token.ts
@@ -1,7 +1,7 @@
 describe('User token widget on settings page,', function () {
   describe('initially', function () {
     beforeEach(() => {
-      cy.exec('pnpm run seed');
+      cy.task('seed');
       cy.login();
     });
 
@@ -15,7 +15,7 @@ describe('User token widget on settings page,', function () {
 
   describe('after creating token', function () {
     beforeEach(() => {
-      cy.exec('pnpm run seed');
+      cy.task('seed');
       cy.login();
       cy.visit(
         '/learn/relational-database/learn-bash-by-building-a-boilerplate/build-a-boilerplate'

--- a/cypress/e2e/default/show-certification.ts
+++ b/cypress/e2e/default/show-certification.ts
@@ -2,7 +2,7 @@ const certifiedUser = '/certification/certifieduser/responsive-web-design';
 
 describe('A certification,', function () {
   before(() => {
-    cy.task('seedCertified');
+    cy.task('seed', ['certified-user']);
   });
 
   describe('while viewing your own,', function () {

--- a/cypress/e2e/default/show-certification.ts
+++ b/cypress/e2e/default/show-certification.ts
@@ -2,7 +2,7 @@ const certifiedUser = '/certification/certifieduser/responsive-web-design';
 
 describe('A certification,', function () {
   before(() => {
-    cy.exec('pnpm run seed:certified-user');
+    cy.task('seedCertified');
   });
 
   describe('while viewing your own,', function () {

--- a/cypress/e2e/default/top-contributor.ts
+++ b/cypress/e2e/default/top-contributor.ts
@@ -1,7 +1,7 @@
 describe('Top contributor in user profile', () => {
   before(() => {
     cy.clearCookies();
-    cy.exec('pnpm run seed -- --top-contributor');
+    cy.task('seed', ['--top-contributor']);
   });
 
   after(() => {

--- a/cypress/e2e/default/top-contributor.ts
+++ b/cypress/e2e/default/top-contributor.ts
@@ -5,7 +5,7 @@ describe('Top contributor in user profile', () => {
   });
 
   after(() => {
-    cy.exec('pnpm run seed');
+    cy.task('seed');
   });
 
   beforeEach(() => {

--- a/cypress/e2e/default/user/certifications.ts
+++ b/cypress/e2e/default/user/certifications.ts
@@ -1,7 +1,7 @@
 describe('Public profile certifications', () => {
   context('Signed in user viewing their own public profile', () => {
     before(() => {
-      cy.task('seedCertified');
+      cy.task('seed', ['certified-user']);
     });
 
     beforeEach(() => {

--- a/cypress/e2e/default/user/certifications.ts
+++ b/cypress/e2e/default/user/certifications.ts
@@ -1,7 +1,7 @@
 describe('Public profile certifications', () => {
   context('Signed in user viewing their own public profile', () => {
     before(() => {
-      cy.exec('pnpm run seed:certified-user');
+      cy.task('seedCertified');
     });
 
     beforeEach(() => {

--- a/cypress/e2e/default/user/privacy-terms.ts
+++ b/cypress/e2e/default/user/privacy-terms.ts
@@ -8,7 +8,7 @@ describe('Privacy terms', () => {
     }).as('updatePrivacyTerms');
 
     // Seed dev user with `acceptedPrivacyTerms` unset
-    cy.exec('pnpm run seed -- --unset-privacy-terms');
+    cy.task('seed', ['--unset-privacy-terms']);
     // Go to the homepage and log in manually so we can assert the following:
     // 1. Redirection to /email-sign-up works properly
     // 2. The /update-privacy-terms has not been requested
@@ -37,7 +37,7 @@ describe('Privacy terms', () => {
     }).as('updatePrivacyTerms');
 
     // Seed dev user with `acceptedPrivacyTerms` unset
-    cy.exec('pnpm run seed -- --unset-privacy-terms');
+    cy.task('seed', ['--unset-privacy-terms']);
     // Go to the homepage and log in manually so we can assert the following:
     // 1. Redirection to /email-sign-up works properly
     // 2. The /update-privacy-terms has not been requested

--- a/cypress/e2e/default/user/report-user.ts
+++ b/cypress/e2e/default/user/report-user.ts
@@ -1,6 +1,6 @@
 describe('Report User', () => {
   beforeEach(() => {
-    cy.exec('pnpm run seed');
+    cy.task('seed');
     cy.login();
   });
   it('should be possible to report a user from their profile page', () => {

--- a/cypress/e2e/third-party/donate-page.ts
+++ b/cypress/e2e/third-party/donate-page.ts
@@ -1,6 +1,6 @@
 describe('Donate page', () => {
   it('Donation ', () => {
-    cy.exec('pnpm run seed');
+    cy.task('seed');
     cy.login();
     cy.visit('/donate');
     cy.get('.donation-elements', { timeout: 10000 }).within(() => {

--- a/tools/scripts/seed/seed-demo-user.js
+++ b/tools/scripts/seed/seed-demo-user.js
@@ -4,7 +4,28 @@ require('dotenv').config({ path: path.resolve(__dirname, '../../../.env') });
 const { MongoClient, ObjectId } = require('mongodb');
 const fullyCertifiedUser = require('./certified-user-data');
 
-const envVariables = process.argv;
+const args = process.argv.slice(2);
+
+const allowedArgs = [
+  '--donor',
+  '--top-contributor',
+  '--unset-privacy-terms',
+  'certified-user'
+];
+
+// Check for invalid arguments
+args.forEach(arg => {
+  if (!allowedArgs.includes(arg))
+    throw new Error(
+      `Invalid argument ${arg}. Allowed arguments are ${allowedArgs.join(', ')}`
+    );
+});
+
+if (args.includes('certified-user') && args.length > 1) {
+  throw new Error(
+    `Invalid arguments. When using 'certified-user', no other arguments are allowed.`
+  );
+}
 
 const log = debug('fcc:tools:seedLocalAuthUser');
 const { MONGOHQ_URL } = process.env;
@@ -36,9 +57,7 @@ const demoUser = {
   name: 'Development User',
   location: '',
   picture: '',
-  acceptedPrivacyTerms: envVariables.includes('--unset-privacy-terms')
-    ? null
-    : true,
+  acceptedPrivacyTerms: args.includes('--unset-privacy-terms') ? null : true,
   sendQuincyEmail: false,
   currentChallengeId: '',
   isHonest: false,
@@ -62,7 +81,7 @@ const demoUser = {
   isCollegeAlgebraPyCertV8: false,
   completedChallenges: [],
   portfolio: [],
-  yearsTopContributor: envVariables.includes('--top-contributor')
+  yearsTopContributor: args.includes('--top-contributor')
     ? ['2017', '2018', '2019']
     : [],
   rand: 0.6126749173148205,
@@ -82,7 +101,7 @@ const demoUser = {
   badges: {
     coreTeam: []
   },
-  isDonating: envVariables.includes('--donor'),
+  isDonating: args.includes('--donor'),
   emailAuthLinkTTL: null,
   emailVerifyTTL: null,
   keyboardShortcuts: true,
@@ -183,16 +202,12 @@ const dropUsers = async function () {
 const run = async () => {
   await dropUserTokens();
   await dropUsers();
-  if (process.argv[2] === 'certified-user') {
+  if (args.includes('certified-user')) {
     await user.insertOne(fullyCertifiedUser);
     await user.insertOne(blankUser);
-  } else if (!process.argv[2]) {
+  } else {
     await user.insertOne(demoUser);
     await user.insertOne(blankUser);
-  } else {
-    throw new Error(
-      'Invalid argument - This can only be called with zero or one argument. If there is an argument, it must be "certified-user"'
-    );
   }
   log('local auth user seed complete');
 };

--- a/tools/scripts/seed/seed-demo-user.js
+++ b/tools/scripts/seed/seed-demo-user.js
@@ -186,9 +186,13 @@ const run = async () => {
   if (process.argv[2] === 'certified-user') {
     await user.insertOne(fullyCertifiedUser);
     await user.insertOne(blankUser);
-  } else {
+  } else if (!process.argv[2]) {
     await user.insertOne(demoUser);
     await user.insertOne(blankUser);
+  } else {
+    throw new Error(
+      'Invalid argument - This can only be called with zero or one argument. If there is an argument, it must be "certified-user"'
+    );
   }
   log('local auth user seed complete');
 };


### PR DESCRIPTION
- test: speed up seeding
- fix: make seed-demo-user reject bad arguments

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

`pnpm run seed` triggers a bunch of other scripts that it's pointless to run while testing. They only need to be run once before testing, and this happens when the client is started.

<!-- Feel free to add any additional description of changes below this line -->
