### PR TITLE
fix(curriculum): Changed wording for instructions

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-variables-by-building-a-city-skyline/5d822fd413a79914d39e98fe.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-variables-by-building-a-city-skyline/5d822fd413a79914d39e98fe.md
@@ -7,7 +7,7 @@ dashedName: step-54
 
 # --description--
 
-Add these properties to `.bb2a`:
+Create and add the following properties to `.bb2a`:
 
 ```css
 margin: auto;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!-- Feel free to add any additional description of changes below this line -->

The instructions didn't make it clear you are supposed to create a new class identifier and then add the CSS, so I changed the wording. If anyone has a better idea for the wording, feel free to update it.

Visit the step [here](https://www.freecodecamp.org/learn/2022/responsive-web-design/learn-css-variables-by-building-a-city-skyline/step-54).
