### PR TITLE
fix(curriculum): change hint for opening anchor tags

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dfa30b9eacea3f48c6300ad.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-by-building-a-cat-photo-app/5dfa30b9eacea3f48c6300ad.md
@@ -29,7 +29,7 @@ Your anchor (`a`) element should have an opening tag. Opening tags have this syn
 assert(document.querySelectorAll('a').length >= 2);
 ```
 
-You should only add one opening anchor (`a`) tag. Please remove any extras.
+You are missing a closing (`a`) tag after the image.
 
 ```js
 assert(document.querySelectorAll('a').length === 2);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #50705

<!-- Feel free to add any additional description of changes below this line -->

Change this line:
"You should only add one opening anchor (a) tag. Please remove any extras."

For that:
"You are missing a closing (a) tag after the image."

To be more clearly and directly.