### PR TITLE
fix(client): ensure __runTest is used

### DIFF
--- a/client/src/templates/Challenges/rechallenge/builders.ts
+++ b/client/src/templates/Challenges/rechallenge/builders.ts
@@ -33,8 +33,9 @@ A required file can not have both a src and a link: src = ${src}, link = ${link}
     })
     .join('\n');
 
+  // The script has an id so that tests can look for it, if needed.
   const testRunnerScript = testRunner
-    ? `<script src='${testRunner}' type='text/javascript'></script>`
+    ? `<script id="fcc-test-runner" src='${testRunner}' type='text/javascript'></script>`
     : '';
 
   return `<head>${head}</head>${

--- a/client/src/templates/Challenges/rechallenge/builders.ts
+++ b/client/src/templates/Challenges/rechallenge/builders.ts
@@ -1,15 +1,17 @@
 import { template as _template } from 'lodash-es';
 
 interface ConcatHTMLOptions {
-  required: { src: string; link?: string }[];
+  required?: { src: string; link?: string }[];
   template?: string;
   contents?: string;
+  testRunner?: string;
 }
 
 export function concatHtml({
   required = [],
   template,
-  contents
+  contents,
+  testRunner
 }: ConcatHTMLOptions): string {
   const embedSource = template
     ? _template(template)
@@ -31,5 +33,11 @@ A required file can not have both a src and a link: src = ${src}, link = ${link}
     })
     .join('\n');
 
-  return `<head>${head}</head>${embedSource({ source: contents }) || ''}`;
+  const testRunnerScript = testRunner
+    ? `<script src='${testRunner}' type='text/javascript'></script>`
+    : '';
+
+  return `<head>${head}</head>${
+    embedSource({ source: contents }) || ''
+  }${testRunnerScript}`;
 }

--- a/client/src/templates/Challenges/utils/build.ts
+++ b/client/src/templates/Challenges/utils/build.ts
@@ -44,11 +44,7 @@ interface BuildOptions {
 const { filename: runner } = frameRunnerData;
 const { filename: testEvaluator } = testEvaluatorData;
 
-const frameRunner = [
-  {
-    src: `/js/${runner}.js`
-  }
-];
+const frameRunnerSrc = `/js/${runner}.js`;
 
 type ApplyFunctionProps = (file: ChallengeFile) => Promise<ChallengeFile>;
 
@@ -200,9 +196,6 @@ export function buildDOMChallenge(
   { challengeFiles, required = [], template = '' }: BuildChallengeData,
   { usesTestRunner } = { usesTestRunner: false }
 ): Promise<BuildResult> | undefined {
-  const finalRequires = [...required];
-  if (usesTestRunner) finalRequires.push(...frameRunner);
-
   const loadEnzyme = challengeFiles?.some(
     challengeFile => challengeFile.ext === 'jsx'
   );
@@ -222,9 +215,10 @@ export function buildDOMChallenge(
           challengeType:
             challengeTypes.html || challengeTypes.multifileCertProject,
           build: concatHtml({
-            required: finalRequires,
+            required,
             template,
-            contents
+            contents,
+            ...(usesTestRunner && { testRunner: frameRunnerSrc })
           }),
           sources: buildSourceMap(challengeFiles),
           loadEnzyme
@@ -264,7 +258,7 @@ export function buildJSChallenge(
 function buildBackendChallenge({ url }: BuildChallengeData) {
   return {
     challengeType: challengeTypes.backend,
-    build: concatHtml({ required: frameRunner }),
+    build: concatHtml({ testRunner: frameRunnerSrc }),
     sources: { url }
   };
 }

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62b46e3a8d4be31be5af793d.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62b46e3a8d4be31be5af793d.md
@@ -25,7 +25,10 @@ Your `script` element should come at the end of your `body` element.
 ```js
 const script = document.querySelector('script[data-src$="script.js"]');
 assert.equal(script.previousElementSibling.tagName, "DIV");
-assert.isNull(script.nextElementSibling);
+// When building the test frame, the runner script is always inserted after user
+// code. This means the learner's script should be the penultimate element in 
+// the body.
+assert.equal(script.nextElementSibling.id, "fcc-test-runner");
 assert.equal(script.parentElement.tagName, "BODY");
 ```
 


### PR DESCRIPTION
- fix: load framerunner after learner code
- fix: add script id for testing

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The motivation was to prevent __runTest getting overwritten, but I also like the distinction between test runner and dependencies. I think separating them makes their roles clearer.

<!-- Feel free to add any additional description of changes below this line -->
