### PR TITLE
fix(UI): adjust the behavior of the elements in navbar

### DIFF
--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -33,6 +33,7 @@
   max-inline-size: max-content;
   -webkit-overflow-scrolling: touch;
   -ms-overflow-scrolling: touch;
+  padding-top: 0.2em;
 }
 
 #universal-nav-logo:focus {
@@ -44,7 +45,7 @@
   justify-content: flex-end;
   align-items: center;
   gap: 10px;
-  flex: 1 0 33%;
+  flex: 1 0 auto;
   height: var(--header-height);
 }
 
@@ -271,7 +272,7 @@ li > button.nav-link-signout:not([aria-disabled='true']):is(:hover, :focus) {
 }
 
 .expand-nav {
-  height: var(--header-height);
+  min-height: calc(2 * var(--header-height));
 }
 
 .display-menu {
@@ -357,7 +358,16 @@ li > button.nav-link-signout:not([aria-disabled='true']):is(:hover, :focus) {
 @media (min-width: 980px) {
   #universal-nav-logo {
     height: 100%;
+    padding-top: initial;
     margin-inline: 1em;
+  }
+
+  .expand-nav {
+    min-height: var(--header-height);
+  }
+
+  .universal-nav-right {
+    flex: 1 0 33%;
   }
 }
 
@@ -366,22 +376,8 @@ li > button.nav-link-signout:not([aria-disabled='true']):is(:hover, :focus) {
     display: initial;
   }
 
-  .universal-nav-right {
-    flex: 1 0 auto;
-    display: flex;
-    justify-content: flex-end;
-  }
-
   .fcc_searchBar .ais-SearchBox-form {
     max-width: calc(100vw - 350px);
-  }
-
-  #universal-nav-logo {
-    padding-top: 0.2em;
-  }
-
-  .expand-nav {
-    min-height: calc(2 * var(--header-height));
   }
 }
 
@@ -391,21 +387,18 @@ li > button.nav-link-signout:not([aria-disabled='true']):is(:hover, :focus) {
     margin-top: 0;
   }
 
-  .display-menu {
-    top: calc(var(--header-height) * 2);
-  }
-
   .fcc_searchBar,
   .fcc_searchBar div {
     width: 100%;
   }
 
-  .universal-nav-right .fcc_searchBar .ais-SearchBox-form {
-    width: calc(100% - 30px);
+  .display-menu {
+    top: calc(var(--header-height) * 2);
+    max-height: calc(100vh - var(--header-height) * 2);
   }
 
-  .display-menu {
-    max-height: calc(100vh - var(--header-height) * 2);
+  .universal-nav-right .fcc_searchBar .ais-SearchBox-form {
+    width: calc(100% - 30px);
   }
 
   .universal-nav-right .fcc_searchBar .ais-Hits {

--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -358,7 +358,7 @@ li > button.nav-link-signout:not([aria-disabled='true']):is(:hover, :focus) {
 @media (min-width: 980px) {
   #universal-nav-logo {
     height: 100%;
-    padding-top: initial;
+    padding-top: 0;
     margin-inline: 1em;
   }
 

--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -272,7 +272,7 @@ li > button.nav-link-signout:not([aria-disabled='true']):is(:hover, :focus) {
 }
 
 .expand-nav {
-  min-height: calc(2 * var(--header-height));
+  min-height: calc(var(--header-height) * 2);
 }
 
 .display-menu {

--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -397,11 +397,8 @@ li > button.nav-link-signout:not([aria-disabled='true']):is(:hover, :focus) {
     max-height: calc(100vh - var(--header-height) * 2);
   }
 
+  .universal-nav-right .fcc_searchBar .ais-Hits,
   .universal-nav-right .fcc_searchBar .ais-SearchBox-form {
-    width: calc(100% - 30px);
-  }
-
-  .universal-nav-right .fcc_searchBar .ais-Hits {
     width: calc(100% - 30px);
   }
   #universal-nav .signup-btn {

--- a/client/src/components/Header/components/universal-nav.tsx
+++ b/client/src/components/Header/components/universal-nav.tsx
@@ -1,7 +1,7 @@
 import Loadable from '@loadable/component';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import Media from 'react-responsive';
+import Media, { useMediaQuery } from 'react-responsive';
 import { useFeature } from '@growthbook/growthbook-react';
 import { isLanding } from '../../../utils/path-parsers';
 import { Link, SkeletonSprite } from '../../helpers';
@@ -39,6 +39,9 @@ const UniversalNav = ({
 }: UniversalNavProps): JSX.Element => {
   const { pending } = fetchState;
   const { t } = useTranslation();
+  const isSearchExposedWidth = useMediaQuery({
+    query: `(min-width: ${SEARCH_EXPOSED_WIDTH}px)`
+  });
 
   const exposeDonateButton = useFeature('expose_donate_button').on;
 
@@ -55,7 +58,7 @@ const UniversalNav = ({
       className={`universal-nav${displayMenu ? ' expand-nav' : ''}`}
       id='universal-nav'
     >
-      <Media minWidth={SEARCH_EXPOSED_WIDTH + 1}>
+      {isSearchExposedWidth && (
         <div
           className={`universal-nav-left${
             displayMenu ? ' display-search' : ''
@@ -63,7 +66,7 @@ const UniversalNav = ({
         >
           {search}
         </div>
-      </Media>
+      )}
       <Link id='universal-nav-logo' to='/learn'>
         <NavLogo />
       </Link>
@@ -94,7 +97,7 @@ const UniversalNav = ({
               showMenu={showMenu}
               user={user}
             />
-            <Media maxWidth={SEARCH_EXPOSED_WIDTH}>{search}</Media>
+            {!isSearchExposedWidth && search}
             <NavLinks
               displayMenu={displayMenu}
               hideMenu={hideMenu}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
This PR was opened to adjust the behavior of elements in navbar when the window width is around `SEARCH_EXPOSED_WIDTH`(980px).

This PR solves two issues with the layout of elements in the navbar of current production code as following.

1. Both `universal-nav-left` with the search bar it contains, and the search bar within `universal-nav-right` disappear when the ~~screen~~ window width is greater than 980px and less than 981px on [the page where the navigation bar appears](https://www.freecodecamp.org/).

1. Also, when the ~~screen~~ window width is exactly 980px (equal to `SEARCH_EXPOSED_WIDTH`), the `universal-nav-left` with the search bar it contains will not be displayed, and then If the menu button pressed, the `universal-nav-logo` is displayed with interfering the search bar in `universal-nav-right`.

To solve these issues, the behavior of the elements in the navbar has been adjusted as follows.

- When the ~~screen~~ window width is greater than or equal to `SEARCH_EXPOSED_WIDTH` (980px), `universal-nav-left` with the search bar it contains will be displayed, and the search bar within `universal-nav-right` will not be displayed.

- When the ~~screen~~ window width is less than `SEARCH_EXPOSED_WIDTH` (980px), `universal-nav-left` with the search bar it contains will not be shown, and the search bar inside `universal-nav-right` will be shown.

- The properties in universal-nav.css have been arranged to seamlessly switch between the above two states.