### PR TITLE
fix(ui): remove horizontal scrollbar from text only code elements

### DIFF
--- a/client/src/components/layouts/prism.css
+++ b/client/src/components/layouts/prism.css
@@ -18,6 +18,11 @@ pre[class*='language-'] {
   text-shadow: none !important;
 }
 
+/* remove horizontal scrollbars for text-only code */
+code[class='language-markup'] {
+  white-space: normal !important;
+}
+
 /* a11y color adjustments */
 :not(.dark-palette) .token.comment,
 :not(.dark-palette) .token.prolog,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #50845 

<!-- Feel free to add any additional description of changes below this line -->

I tested all of the current challenges/steps that are using `markup` for the code examples and they all line wrap naturally with this change and it doesn't seem to cause any side effects. If you want me to list them all out here, let me know (there are 11 of them).

I'm not super happy about using `!important` but it seems to me that this is the most logical CSS file to add this change and so `!important` is going to have to do.