### PR TITLE
fix(a11y): keyboard navigation on mobile tabs

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -403,7 +403,8 @@
     "building-a-university": "We're Building a Free Computer Science University Degree Program",
     "if-help-university": "We've already made a ton of progress. Support our charity with the long road ahead.",
     "qualified-for-exam": "Congratulations, you have completed all the requirements to qualify for the exam.",
-    "not-qualified-for-exam": "You have not met the requirements to be eligible for the exam. To qualify, please complete the following challenges:"
+    "not-qualified-for-exam": "You have not met the requirements to be eligible for the exam. To qualify, please complete the following challenges:",
+    "preview-external-window": "Preview currently showing in external window."
   },
   "donate": {
     "title": "Support our charity",

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -111,10 +111,10 @@
   text-decoration: none;
   font-size: 0.8em;
   border: 0;
-}
-
-#mobile-layout .nav-tabs > li > a {
-  padding: 8px 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 2rem;
 }
 
 #mobile-layout .nav-tabs > li.active > a {
@@ -129,15 +129,18 @@
   color: var(--secondary-color);
 }
 
+#mobile-layout [aria-controls='mobile-layout-pane-preview'] {
+  width: calc(100% - 35px);
+}
+
 .portal-button {
   position: absolute;
-  right: 3px;
-  top: 2px;
-  height: 32px;
-  width: 32px;
-  border: 1px solid black;
-  padding: 1px;
-  background: white;
+  right: 1px;
+  top: 0px;
+  height: 2rem;
+  width: 2rem;
+  border: 0;
+  padding: 0;
 }
 
 .portal-button > span {
@@ -157,6 +160,10 @@
 .portal-button[aria-expanded='true'] {
   border-color: var(--primary-color);
   background-color: var(--primary-color);
+}
+
+.portal-button:focus-visible {
+  outline-offset: -3px;
 }
 
 #mobile-layout .tab-content {

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -89,6 +89,8 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  /* for positioning preview display button */
+  position: relative;
 }
 
 #mobile-layout .nav-tabs {
@@ -111,7 +113,7 @@
   border: 0;
 }
 
-#mobile-layout .nav-tabs > li > a:not(#mobile-layout-tab-preview) {
+#mobile-layout .nav-tabs > li > a {
   padding: 8px 10px;
 }
 
@@ -127,24 +129,34 @@
   color: var(--secondary-color);
 }
 
-#mobile-layout-tab-preview {
-  position: relative;
-  padding: 8px 46px 8px 10px;
-}
-
 #portal-button {
   position: absolute;
-  right: 0;
-  top: 0;
+  right: 3px;
+  top: 2px;
+  height: 32px;
+  width: 32px;
+  border: 1px solid black;
+  padding: 1px;
+  background: white;
+}
+
+#portal-button > span {
+  padding: 1px;
+  display: flex;
   height: 100%;
-  width: 36px;
-  border: 0;
+  width: 100%;
+  background: var(--quaternary-background);
+  justify-content: center;
+  align-items: center;
+}
+
+#portal-button:hover > span {
+  background: var(--secondary-color);
 }
 
 #portal-button[aria-expanded='true'] {
   border-color: var(--primary-color);
   background-color: var(--primary-color);
-  color: var(--secondary-background);
 }
 
 #mobile-layout .tab-content {
@@ -153,6 +165,11 @@
   flex-grow: 1;
   overflow-y: hidden;
   padding-block-end: 37px;
+}
+
+#mobile-layout-pane-preview .preview-external-window {
+  text-align: center;
+  margin-top: 60px;
 }
 
 #mobile-layout-pane-editor {

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -98,6 +98,7 @@
   padding: 0;
   display: flex;
   border-bottom: 1px solid var(--quaternary-color);
+  height: 2rem;
 }
 
 /* Need to narrow width to make room for preview toggle button */
@@ -119,7 +120,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 2rem;
+  height: calc(2rem - 1px);
   padding: 0;
 }
 
@@ -128,6 +129,7 @@
   background-color: var(--quaternary-color);
   border: 0;
   font-weight: 900;
+  height: 100%;
 }
 
 #mobile-layout .nav-tabs > li:not(.active) > a:hover {
@@ -139,30 +141,17 @@
   position: absolute;
   right: 1px;
   top: 0;
-  height: calc(2rem + 1px);
+  height: 2rem;
   width: 2rem;
   border: 0;
   border-bottom: 1px solid var(--quaternary-color);
   padding: 0;
 }
 
-.portal-button > span {
-  padding: 1px;
-  display: flex;
-  height: 100%;
-  width: 100%;
-  background: var(--quaternary-background);
-  justify-content: center;
-  align-items: center;
-}
-
-.portal-button:hover > span {
-  background: var(--secondary-color);
-}
-
 .portal-button[aria-expanded='true'] {
   border-color: var(--primary-color);
   background-color: var(--primary-color);
+  color: var(--secondary-background);
 }
 
 .portal-button:focus-visible {

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -129,7 +129,7 @@
   color: var(--secondary-color);
 }
 
-#portal-button {
+.portal-button {
   position: absolute;
   right: 3px;
   top: 2px;
@@ -140,7 +140,7 @@
   background: white;
 }
 
-#portal-button > span {
+.portal-button > span {
   padding: 1px;
   display: flex;
   height: 100%;
@@ -150,11 +150,11 @@
   align-items: center;
 }
 
-#portal-button:hover > span {
+.portal-button:hover > span {
   background: var(--secondary-color);
 }
 
-#portal-button[aria-expanded='true'] {
+.portal-button[aria-expanded='true'] {
   border-color: var(--primary-color);
   background-color: var(--primary-color);
 }

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -100,6 +100,11 @@
   border-bottom: 1px solid var(--quaternary-color);
 }
 
+/* Need to narrow width to make room for preview toggle button */
+#mobile-layout .nav-tabs[data-haspreview='true'] {
+  width: calc(100% - 2rem - 2px);
+}
+
 #mobile-layout .nav-tabs > li {
   flex: 1;
   text-align: center;
@@ -115,6 +120,7 @@
   align-items: center;
   justify-content: center;
   height: 2rem;
+  padding: 0;
 }
 
 #mobile-layout .nav-tabs > li.active > a {
@@ -129,17 +135,14 @@
   color: var(--secondary-color);
 }
 
-#mobile-layout [aria-controls='mobile-layout-pane-preview'] {
-  width: calc(100% - 35px);
-}
-
 .portal-button {
   position: absolute;
   right: 1px;
-  top: 0px;
-  height: 2rem;
+  top: 0;
+  height: calc(2rem + 1px);
   width: 2rem;
   border: 0;
+  border-bottom: 1px solid var(--quaternary-color);
   padding: 0;
 }
 

--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -212,6 +212,7 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
       <>
         <Tabs
           activeKey={currentTab}
+          animation={false}
           defaultActiveKey={currentTab}
           id='mobile-layout'
           onKeyDown={this.handleKeyDown}

--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -269,7 +269,7 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
               {displayPreviewPane && preview}
               {showPreviewPortal && (
                 <p className='preview-external-window'>
-                  Preview currently showing in external window
+                  Preview currently showing in external window.
                 </p>
               )}
             </TabPane>
@@ -281,7 +281,7 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
               videoUrl={videoUrl}
             />
           )}
-          {this.state.currentTab !== 'preview' && (
+          {hasPreview && this.state.currentTab !== 'preview' && (
             <button
               className='portal-button'
               aria-expanded={!!showPreviewPortal}

--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -263,10 +263,8 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
                 aria-expanded={!!showPreviewPortal}
                 onClick={() => togglePane('showPreviewPortal')}
               >
-                <span>
-                  <span className='sr-only'>{getPortalBtnSrText()}</span>
-                  <FontAwesomeIcon icon={faWindowRestore} />
-                </span>
+                <span className='sr-only'>{getPortalBtnSrText()}</span>
+                <FontAwesomeIcon icon={faWindowRestore} />
               </button>
               {displayPreviewPane && preview}
               {showPreviewPortal && (
@@ -289,10 +287,8 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
               aria-expanded={!!showPreviewPortal}
               onClick={() => togglePane('showPreviewPortal')}
             >
-              <span>
-                <span className='sr-only'>{getPortalBtnSrText()}</span>
-                <FontAwesomeIcon icon={faWindowRestore} />
-              </span>
+              <span className='sr-only'>{getPortalBtnSrText()}</span>
+              <FontAwesomeIcon icon={faWindowRestore} />
             </button>
           )}
         </Tabs>

--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -269,7 +269,7 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
               {displayPreviewPane && preview}
               {showPreviewPortal && (
                 <p className='preview-external-window'>
-                  Preview currently showing in external window.
+                  {i18next.t('learn.preview-external-window')}
                 </p>
               )}
             </TabPane>

--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -1,6 +1,6 @@
 import { TabPane, Tabs } from '@freecodecamp/react-bootstrap';
 import i18next from 'i18next';
-import React, { Component, ReactElement, SyntheticEvent } from 'react';
+import React, { Component, ReactElement } from 'react';
 import { faWindowRestore } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { createSelector } from 'reselect';
@@ -85,14 +85,7 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
     currentTab: this.props.hasEditableBoundaries ? Tab.Editor : Tab.Instructions
   };
 
-  switchTab = (tab: Tab, e: SyntheticEvent): void => {
-    const portalButton = document.getElementById('portal-button');
-    // prevent switching to preview tab if pressing portal button
-    if (portalButton?.contains(e.target as Node)) {
-      e.preventDefault();
-      return;
-    }
-
+  switchTab = (tab: Tab): void => {
     this.setState({
       currentTab: tab
     });
@@ -261,21 +254,25 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
           {hasPreview && (
             <TabPane
               eventKey={Tab.Preview}
-              title={
-                <>
-                  {i18next.t('learn.editor-tabs.preview')}
-                  <button
-                    id='portal-button'
-                    aria-expanded={!!showPreviewPortal}
-                    onClick={() => togglePane('showPreviewPortal')}
-                  >
-                    <span className='sr-only'>{getPortalBtnSrText()}</span>
-                    <FontAwesomeIcon icon={faWindowRestore} />
-                  </button>
-                </>
-              }
+              title={i18next.t('learn.editor-tabs.preview')}
             >
+              <button
+                id='portal-button'
+                aria-expanded={!!showPreviewPortal}
+                onClick={() => togglePane('showPreviewPortal')}
+                tabIndex={this.state.currentTab === 'preview' ? 0 : -1}
+              >
+                <span>
+                  <span className='sr-only'>{getPortalBtnSrText()}</span>
+                  <FontAwesomeIcon icon={faWindowRestore} />
+                </span>
+              </button>
               {displayPreviewPane && preview}
+              {showPreviewPortal && (
+                <p className='preview-external-window'>
+                  Preview currently showing in external window
+                </p>
+              )}
             </TabPane>
           )}
           {!hasEditableBoundaries && (

--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -219,6 +219,7 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
           onMouseDown={this.handleClick}
           onSelect={this.switchTab}
           onTouchStart={this.handleClick}
+          {...(hasPreview && { 'data-haspreview': 'true' })}
         >
           {!hasEditableBoundaries && (
             <TabPane

--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -257,10 +257,9 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
               title={i18next.t('learn.editor-tabs.preview')}
             >
               <button
-                id='portal-button'
+                className='portal-button'
                 aria-expanded={!!showPreviewPortal}
                 onClick={() => togglePane('showPreviewPortal')}
-                tabIndex={this.state.currentTab === 'preview' ? 0 : -1}
               >
                 <span>
                   <span className='sr-only'>{getPortalBtnSrText()}</span>
@@ -281,6 +280,18 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
               isMobile={true}
               videoUrl={videoUrl}
             />
+          )}
+          {this.state.currentTab !== 'preview' && (
+            <button
+              className='portal-button'
+              aria-expanded={!!showPreviewPortal}
+              onClick={() => togglePane('showPreviewPortal')}
+            >
+              <span>
+                <span className='sr-only'>{getPortalBtnSrText()}</span>
+                <FontAwesomeIcon icon={faWindowRestore} />
+              </span>
+            </button>
           )}
         </Tabs>
         {displayPreviewPortal && (


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

PR #50389 accidentally broke keyboard navigation for the mobile tabs in the steps. Additionally, it nested the toggle preview button inside the Preview tab which is not allowed since the tab itself is an interactive element. This PR aims to fix these accessibility issues.

There really isn't an established pattern for adding a button to a tab like this. The accessible keyboard behavior for tabs dictates that when focus is on a tab item, pressing the `Tab` key should move focus onto its tab panel, or it can move focus to the first element inside its tab panel if that element is focusable. So I moved the toggle button to be the first element in the Preview tab panel and then used absolute positioning to move it to the right side of the Preview tab. Now when the keyboard focus is on the Preview tab item, pressing `Tab` will focus the toggle button (which is the first element in the tab panel, so we are good here).

Of course since the toggle button is now in the tab panel then it will only show when the Preview tab is selected, so I added a duplicate toggle button (after all of the tab panel content in the DOM) that will only show when the Preview tab isn't selected. This way, the toggle button is always visible but the keyboard behavior for the non-Preview tab items will work properly. 

It's not perfect. Because the toggle button is at the bottom of the DOM when the Preview tab is not active, it can appear to be out of the natural tab order. For example, if you are on the Code tab, after you `Tab` through all of the focusable items in the code tab panel then you will visually go back up to the toggle button. It may also be a little disconcerting for screen reader users that the toggle button is at the bottom of the DOM when the Preview tab isn't selected, as it might seem a little out of place since the current selected tab has nothing to do with the Preview feature. I think the solution to these issues is to only show the toggle button when the Preview tab is active (that way we can get rid of the duplicate toggle button). But since the preview button is currently showing at all times, I'm assuming that is what we want.


