### PR TITLE
fix(api): specify use of Int32 for small ints

### DIFF
--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -19,7 +19,7 @@ type File {
 }
 
 type CompletedChallenge {
-  challengeType      Int? // Null | Undefined
+  challengeType      Int?     @db.Int // Null | Undefined
   completedDate      Float // TODO(Post-MVP): Change to DateTime
   files              File[]
   githubLink         String? // Undefined
@@ -156,7 +156,7 @@ model AuthToken {
 
 model Donation {
   id             String            @id @default(auto()) @map("_id") @db.ObjectId
-  amount         Int
+  amount         Int               @db.Int
   customerId     String
   duration       String?
   email          String


### PR DESCRIPTION
We know that challengeType and amount are both small numbers, nowhere
near the max of 32 bit ints, so we can make that explicit.

Other ints are less obviously below the limit so it seemed safer to
default to Int64s.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Ref: https://github.com/freeCodeCamp/freeCodeCamp/pull/50701#pullrequestreview-1529151141

<!-- Feel free to add any additional description of changes below this line -->
