### PR TITLE
fix(a11y): announce percent completed for screen readers

### DIFF
--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -47,7 +47,7 @@ interface LowerJawStatusProps {
   testText: string;
 }
 
-export interface LowerJawProps {
+interface LowerJawProps {
   challengeMeta: ChallengeMeta;
   completedPercent: number;
   hint?: string;
@@ -342,6 +342,9 @@ const LowerJaw = ({
               )}
             </LowerJawStatus>
             <LowerJawQuote quote={quote} />
+            <span className='sr-only'>
+              {t('learn.percent-complete', { percent: completedPercent })}
+            </span>
           </>
         )}
         {hintRef.current && !challengeIsCompleted && (


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

When a user completes a step, a progress bar appears in the lower jaw. The percent completed text under the progress bar is not automatically announced by screen readers because that text is not in the aria live region (the congrats message and inspirational quote are in the live region). This PR adds the percent completed text as sr-only text at the end of the live region.

Another option is to move the entire progress bar into the live region but then both the title of the course and the percent completed text would be announced by the screen reader. I don't think the title needs to be announced every time as the user will already know what course they are in, so adding just the percent completed text in the live region avoids this unnecessary verbosity.
