### PR TITLE
fix(api): require fcc repos for coderoad submissions

### DIFF
--- a/api-server/src/server/boot/challenge.js
+++ b/api-server/src/server/boot/challenge.js
@@ -17,7 +17,6 @@ import isURL from 'validator/lib/isURL';
 import jwt from 'jsonwebtoken';
 import { jwtSecret } from '../../../../config/secrets';
 
-import { environment, deploymentEnv } from '../../../../config/env.json';
 import { fixPartiallyCompletedChallengeItem } from '../../common/utils';
 import { getChallenges } from '../utils/get-curriculum';
 import { ifNoUserSend } from '../utils/middleware';
@@ -543,12 +542,8 @@ function createCoderoadChallengeCompleted(app) {
     const tutorialRepo = tutorialId?.split(':')[0];
     const tutorialOrg = tutorialRepo?.split('/')?.[0];
 
-    // this allows any GH account to host the repo in development or staging
-    // .org submissions should always be from repos hosted on the fCC GH org
-    if (deploymentEnv !== 'staging' && environment !== 'development') {
-      if (tutorialOrg !== 'freeCodeCamp')
-        return res.send('Tutorial not hosted on freeCodeCamp GitHub account');
-    }
+    if (tutorialOrg !== 'freeCodeCamp')
+      return res.send('Tutorial not hosted on freeCodeCamp GitHub account');
 
     // validate tutorial name is in codeRoadChallenges object
     const challenge = codeRoadChallenges.find(challenge =>


### PR DESCRIPTION
The lessons are currently stored as fcc repo and future ones can be too. The endpoint no-longer needs to handle other cases.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Ref: https://github.com/freeCodeCamp/freeCodeCamp/pull/50636#discussion_r1265279406

<!-- Feel free to add any additional description of changes below this line -->
