### PR TITLE
docs: add Michal to hall of fame

### DIFF
--- a/docs/security-hall-of-fame.md
+++ b/docs/security-hall-of-fame.md
@@ -7,5 +7,6 @@ While we do not offer any bounties or swags at the moment, we are grateful to th
 - Mehul Mohan from [codedamn](https://codedamn.com) ([@mehulmpt](https://twitter.com/mehulmpt)) - [Vulnerability Fix](https://github.com/freeCodeCamp/freeCodeCamp/blob/bb5a9e815313f1f7c91338e171bfe5acb8f3e346/client/src/components/Flash/index.js)
 - Peter Samir https://www.linkedin.com/in/peter-samir/
 - Laurence Tennant ([@hyperreality](https://github.com/hyperreality)) working with IncludeSecurity.com - [GHSA-cc3r-grh4-27gj](https://github.com/freeCodeCamp/freeCodeCamp/security/advisories/GHSA-cc3r-grh4-27gj)
+- Michal Biesiada ([@mbiesiad](https://github.com/mbiesiad)) - [GHSA-6c37-r62q-7xf4](https://github.com/freeCodeCamp/freeCodeCamp/security/advisories/GHSA-6c37-r62q-7xf4)
 
 > **Thank you for your contributions :pray:**


### PR DESCRIPTION
This PR adds @mbiesiad to the hall of fame page: https://contribute.freecodecamp.org/#/security-hall-of-fame 
