### PR TITLE
fix(curriculum): allow valid input elements to pass

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60f805f813eaf2049bc2ceea.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60f805f813eaf2049bc2ceea.md
@@ -26,28 +26,28 @@ assert.equal(document.querySelectorAll('label input')?.length, 4);
 You should add the first `input` after the `label` text `Enter Your First Name:`, and include a space after the colon.
 
 ```js
-const query = /^Enter Your First Name:\s+<input>/
+const query = /^Enter Your First Name:\s+<input/
 assert.match(document.querySelectorAll('label')?.[0]?.innerHTML.trim(), query);
 ```
 
 You should add the second `input` after the `label` text `Enter Your Last Name:`, and include a space after the colon.
 
 ```js
-const query = /^Enter Your Last Name:\s+<input>/
+const query = /^Enter Your Last Name:\s+<input/
 assert.match(document.querySelectorAll('label')?.[1]?.innerHTML.trim(), query);
 ```
 
 You should add the third `input` after the `label` text `Enter Your Email:`, and include a space after the colon.
 
 ```js
-const query = /^Enter Your Email:\s+<input>/
+const query = /^Enter Your Email:\s+<input/
 assert.match(document.querySelectorAll('label')?.[2]?.innerHTML.trim(), query);
 ```
 
 You should add the fourth `input` after the `label` text `Create a New Password:`, and include a space after the colon.
 
 ```js
-const query = /^Create a New Password:\s+<input>/
+const query = /^Create a New Password:\s+<input/
 assert.match(document.querySelectorAll('label')?.[3]?.innerHTML.trim(), query);
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

IF a camper got ahead of themselves and added attributes to the `input` elements, the tests would mysteriously fail:

![image](https://github.com/freeCodeCamp/freeCodeCamp/assets/63889819/d496adec-c8bd-416e-b8d9-5c4d51ebed22)

This change should allow attributes on the `input` elements, as well as self-closing `<input />` syntax.