### PR TITLE
chore: clean up form validator type defs

### DIFF
--- a/client/src/components/formHelpers/form-validators.tsx
+++ b/client/src/components/formHelpers/form-validators.tsx
@@ -17,24 +17,25 @@ function isPathRoot(urlString: string): boolean {
   }
 }
 
-export const editorValidator = (value: string): React.ReactElement | null =>
+type Validator = (value: string) => React.ReactElement | null;
+
+export const editorValidator: Validator = value =>
   editorRegex.test(value) ? <Trans>validation.editor-url</Trans> : null;
 
-export const fCCValidator = (value: string): React.ReactElement | null =>
+export const fCCValidator: Validator = value =>
   fCCRegex.test(value) ? <Trans>validation.own-work-url</Trans> : null;
 
-export const localhostValidator = (value: string): React.ReactElement | null =>
+export const localhostValidator: Validator = value =>
   localhostRegex.test(value) ? (
     <Trans>validation.publicly-visible-url</Trans>
   ) : null;
 
-export const httpValidator = (value: string): React.ReactElement | null =>
+export const httpValidator: Validator = value =>
   httpRegex.test(value) ? <Trans>validation.http-url</Trans> : null;
 
-export const pathValidator = (value: string): React.ReactElement | null =>
+export const pathValidator: Validator = value =>
   isPathRoot(value) ? <Trans>validation.path-url</Trans> : null;
 
-type Validator = (value: string) => React.ReactElement | null;
 export function composeValidators(...validators: (Validator | null)[]) {
   return (value: string): ReturnType<Validator> | null =>
     validators.reduce(


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Noticed this when reviewing #51008 - it doesn't make sense to have a type definition for the validators and then not use it on the validators. 😁 

<!-- Feel free to add any additional description of changes below this line -->
