### PR TITLE
fix(client): translate navigation warnings

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -544,7 +544,8 @@
     "iframe-alert": "Normally this link would bring you to another website! It works. This is a link to: {{externalLink}}",
     "iframe-form-submit-alert": "Normally this form would be submitted! It works. This will be submitted to: {{externalLink}}",
     "document-notfound": "document not found",
-    "slow-load-msg": "Looks like this is taking longer than usual, please try refreshing the page."
+    "slow-load-msg": "Looks like this is taking longer than usual, please try refreshing the page.",
+    "navigation-warning": "If you leave this page, you will lose your progress. Are you sure?"
   },
   "icons": {
     "gold-cup": "Gold Cup",

--- a/client/src/templates/Challenges/exam/show.tsx
+++ b/client/src/templates/Challenges/exam/show.tsx
@@ -348,13 +348,13 @@ class ShowExam extends Component<ShowExamProps, ShowExamState> {
 
   stopWindowClose = (event: Event) => {
     event.preventDefault();
-    alert('stop!');
+    alert(this.props.t('misc.navigation-warning'));
   };
 
   stopBrowserBack = (event: Event) => {
     event.preventDefault();
     window.history.forward();
-    alert('stop!');
+    alert(this.props.t('misc.navigation-warning'));
   };
 
   runExam = () => {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

@moT01 it's a bit out of scope for this PR, but I was thinking all the exam translations should be `"exam": "navigation-warning"` etc. rather than the more generic "buttons", "misc" and so on. It should make it marginally easily to find them.  Let me know if that's something you want me to take care of.

<!-- Feel free to add any additional description of changes below this line -->
