### PR TITLE
fix(landing): fixed trending guides breakpoint and spacing

### DIFF
--- a/client/src/components/Footer/footer.css
+++ b/client/src/components/Footer/footer.css
@@ -53,10 +53,29 @@
 
 .trending-guides-articles {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(12.7em, 1fr));
-  grid-column-gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(11em, 1fr));
+  grid-column-gap: 3rem;
   grid-row-gap: 0.5rem;
 }
+
+@media (max-width: 1400px) {
+  .trending-guides-articles {
+    grid-template-columns: repeat(auto-fit, minmax(12em, 1fr));
+  }
+}
+
+@media (max-width: 800px) {
+  .trending-guides-articles {
+    grid-template-columns: repeat(auto-fit, minmax(13em, 1fr));
+  }
+}
+
+/* .trending-guides-articles {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(11em, 1fr));
+  grid-column-gap: 3rem;
+  grid-row-gap: 0.5rem;
+} */
 
 .trending-guides-articles {
   white-space: pre;

--- a/client/src/components/Footer/footer.css
+++ b/client/src/components/Footer/footer.css
@@ -54,7 +54,7 @@
 .trending-guides-articles {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(12.7em, 1fr));
-  grid-column-gap: 1rem;
+  grid-column-gap: 1.75rem;
   grid-row-gap: 0.5rem;
 }
 

--- a/client/src/components/Footer/footer.css
+++ b/client/src/components/Footer/footer.css
@@ -54,7 +54,8 @@
 .trending-guides-articles {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(12.7em, 1fr));
-  gap: 0.5rem;
+  grid-column-gap: 1rem;
+  grid-row-gap: 0.5rem;
 }
 
 .trending-guides-articles {

--- a/client/src/components/Footer/footer.css
+++ b/client/src/components/Footer/footer.css
@@ -70,13 +70,6 @@
   }
 }
 
-/* .trending-guides-articles {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(11em, 1fr));
-  grid-column-gap: 3rem;
-  grid-row-gap: 0.5rem;
-} */
-
 .trending-guides-articles {
   white-space: pre;
 }

--- a/client/src/components/Footer/footer.css
+++ b/client/src/components/Footer/footer.css
@@ -52,6 +52,12 @@
 }
 
 .trending-guides-articles {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(12em, 1fr));
+  gap: 1rem;
+}
+
+.trending-guides-articles {
   white-space: pre;
 }
 

--- a/client/src/components/Footer/footer.css
+++ b/client/src/components/Footer/footer.css
@@ -52,12 +52,6 @@
 }
 
 .trending-guides-articles {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(12em, 1fr));
-  gap: 0.5rem;
-}
-
-.trending-guides-articles {
   white-space: pre;
 }
 

--- a/client/src/components/Footer/footer.css
+++ b/client/src/components/Footer/footer.css
@@ -53,8 +53,8 @@
 
 .trending-guides-articles {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(12em, 1fr));
-  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(12.7em, 1fr));
+  gap: 0.5rem;
 }
 
 .trending-guides-articles {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #51025

<!-- Feel free to add any additional description of changes below this line -->

Element controlling the columns:
![image](https://github.com/freeCodeCamp/freeCodeCamp/assets/109321774/29016a73-fe65-4c94-9d3f-559c67b6a65b)


So, we go to the `footer.ts` file and look for `trending-guides-articles` where we can increase the gap from 0.5rem to 1rem
![image](https://github.com/freeCodeCamp/freeCodeCamp/assets/109321774/3b3a6b2c-743b-4d05-9e50-d123f6cf24d7)


Fixed:
![image](https://github.com/freeCodeCamp/freeCodeCamp/assets/109321774/97a0dabe-b171-4733-86bf-55843bf3ced3)


This fix results in the breakpoint to increase, before the length reaches 1234px, it breaks into a smaller vp.
