### PR TITLE
fix(curriculum): Use child combinator for label location

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60f5d2776c854e069560fbe6.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60f5d2776c854e069560fbe6.md
@@ -33,7 +33,7 @@ The last two `fieldset` elements should be empty.
 
 ```js
 const LastTwoFieldsetElements = Array.from(document.querySelectorAll("form fieldset:not(fieldset:first-child)"));
-assert.isTrue(LastTwoFieldsetElements.filter((ele) => ele?.innerHTML?.replace(/\s*/g, ""))?.length === 0);
+assert.isTrue(LastTwoFieldsetElements.filter((ele) => ele.innerHTML?.replace(/\s/g, ""))?.length === 0);
 ```
 
 Make sure you close the `label` elements.

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60f5d2776c854e069560fbe6.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60f5d2776c854e069560fbe6.md
@@ -20,7 +20,7 @@ assert.equal(document.querySelectorAll('label')?.length, 4);
 You should add the `label` elements as direct children to the first `fieldset`. Make sure to close the `label` elements.
 
 ```js
-assert.equal(document.querySelectorAll('fieldset > label')?.length, 4);
+assert.equal(document.querySelectorAll('form fieldset:first-child > label')?.length, 4);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60f5d2776c854e069560fbe6.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60f5d2776c854e069560fbe6.md
@@ -11,17 +11,38 @@ The first `fieldset` will hold name, email, and password fields. Start by adding
 
 # --hints--
 
-You should add four `label` elements.
+There should be three `fieldset` elements in total.
 
 ```js
-assert.equal(document.querySelectorAll('label')?.length, 4);
+assert.equal(document.querySelectorAll('fieldset')?.length, 3);
 ```
 
-You should add the `label` elements as direct children to the first `fieldset`. Make sure to close the `label` elements.
+The `fieldset` elements should all be direct children of the `form` element.
+
+```js
+assert.equal(document.querySelectorAll('form > fieldset')?.length, 3);
+```
+
+The four `label` elements should all be direct children of the first `fieldset` element. Make sure you close the `label` elements.
 
 ```js
 assert.equal(document.querySelectorAll('form fieldset:first-child > label')?.length, 4);
 ```
+
+The last two `fieldset` elements should be empty.
+
+```js
+const LastTwoFieldsetElements = Array.from(document.querySelectorAll("form fieldset:not(fieldset:first-child)"));
+assert.isTrue(LastTwoFieldsetElements.filter((ele) => ele?.innerHTML?.replace(/\s*/g, ""))?.length === 0);
+```
+
+Make sure you close the `label` elements.
+
+```js
+assert.lengthOf(document.querySelector('fieldset')?.innerHTML?.match(/<\/label>/g), 4)
+```
+
+
 
 # --seed--
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60f5d2776c854e069560fbe6.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60f5d2776c854e069560fbe6.md
@@ -17,10 +17,10 @@ You should add four `label` elements.
 assert.equal(document.querySelectorAll('label')?.length, 4);
 ```
 
-You should add the `label` elements to the first `fieldset`.
+You should add the `label` elements as direct children to the first `fieldset`. Make sure to close the `label` elements.
 
 ```js
-assert.equal(document.querySelector('fieldset')?.querySelectorAll('label')?.length, 4);
+assert.equal(document.querySelectorAll('fieldset > label')?.length, 4);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Use the child combinator selector to catch incorrectly auto-closing elements. The test will still allow correctly auto-closed elements, i.e. the last `label` element can be auto-closed and still pass the test.

Closes #51059 

<!-- Feel free to add any additional description of changes below this line -->

Forum thread for context
https://forum.freecodecamp.org/t/responsive-web-design-bug-learn-html-forms-step-14/625080

Challenge:
https://www.freecodecamp.org/learn/2022/responsive-web-design/learn-html-forms-by-building-a-registration-form/step-14
