### PR TITLE
feat(client): move sentence array outside lowerjaw component

### DIFF
--- a/client/src/templates/Challenges/classic/lower-jaw.tsx
+++ b/client/src/templates/Challenges/classic/lower-jaw.tsx
@@ -71,6 +71,18 @@ const mapStateToProps = createSelector(
   })
 );
 
+const sentenceArray = [
+  'learn.sorry-try-again',
+  'learn.sorry-keep-trying',
+  'learn.sorry-getting-there',
+  'learn.sorry-hang-in-there',
+  'learn.sorry-dont-giveup'
+];
+
+const sentencePicker = (currentAttempts: number) => {
+  return sentenceArray[currentAttempts % sentenceArray.length];
+};
+
 const LowerButtonsPanel = ({
   resetButtonText,
   helpButtonText,
@@ -264,17 +276,6 @@ const LowerJaw = ({
     updateContainer();
   });
 
-  const sentencePicker = () => {
-    const sentenceArray = [
-      'learn.sorry-try-again',
-      'learn.sorry-keep-trying',
-      'learn.sorry-getting-there',
-      'learn.sorry-hang-in-there',
-      'learn.sorry-dont-giveup'
-    ];
-    return sentenceArray[currentAttempts % sentenceArray.length];
-  };
-
   const isAttemptsLargerThanTest =
     currentAttempts &&
     testsLength &&
@@ -349,7 +350,7 @@ const LowerJaw = ({
             showFeedback={isFeedbackHidden}
             testText={t('learn.test')}
             htmlDescription={`${hintRef.current}`}
-            learnEncouragementText={t(sentencePicker())}
+            learnEncouragementText={t(sentencePicker(currentAttempts))}
           />
         )}
       </div>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

moved the function outside the component, to stop the component from creating the function every time it's rendered.
moved the array outside the function, for the similar reason.

<!-- Feel free to add any additional description of changes below this line -->
