### PR TITLE
chore(client): remove unused prop

### DIFF
--- a/client/src/client-only-routes/show-settings.tsx
+++ b/client/src/client-only-routes/show-settings.tsx
@@ -123,7 +123,6 @@ export function ShowSettings(props: ShowSettingsProps): JSX.Element {
       username,
       about,
       picture,
-      points,
       theme,
       sound,
       keyboardShortcuts,
@@ -174,7 +173,6 @@ export function ShowSettings(props: ShowSettingsProps): JSX.Element {
             location={location}
             name={name}
             picture={picture}
-            points={points}
             sound={sound}
             keyboardShortcuts={keyboardShortcuts}
             submitNewAbout={submitNewAbout}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

There is a TS error in `show-settings.tsx`

<img width="876" alt="Screenshot 2023-07-30 at 14 32 03" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/1468e8df-5fc7-4e3b-9d67-fac688b6b237">

The error occurs because the component that `ShowSettings` is passing the `points` prop to (`About`) doesn't have the prop listed in the props interface.

I'm resolving the error by simply removing the `points` prop as the prop isn't used by the `About` component.

<!-- Feel free to add any additional description of changes below this line -->
