### PR TITLE
refactor: use process.env in node environments

### DIFF
--- a/api-server/src/common/models/user.js
+++ b/api-server/src/common/models/user.js
@@ -16,7 +16,6 @@ import uuid from 'uuid/v4';
 import { isEmail } from 'validator';
 
 import { blocklistedUsernames } from '../../../../config/constants';
-import { apiLocation } from '../../../../config/env.json';
 
 import { wrapHandledError } from '../../server/utils/create-handled-error.js';
 import {
@@ -202,7 +201,7 @@ export default function initializeUser(User) {
           exists => {
             if (exists) {
               throw wrapHandledError(new Error('user already exists'), {
-                redirectTo: `${apiLocation}/signin`,
+                redirectTo: `${process.env.API_LOCATION}/signin`,
                 message: dedent`
         The ${user.email} email address is already associated with an account.
         Try signing in with it here instead.
@@ -502,7 +501,7 @@ export default function initializeUser(User) {
         }
         const { id: loginToken, created: emailAuthLinkTTL } = token;
         const loginEmail = getEncodedEmail(newEmail ? newEmail : null);
-        const host = apiLocation;
+        const host = process.env.API_LOCATION;
         const mailOptions = {
           type: 'email',
           to: newEmail ? newEmail : this.email,

--- a/api-server/src/server/middlewares/constant-headers.js
+++ b/api-server/src/server/middlewares/constant-headers.js
@@ -1,5 +1,4 @@
 import { allowedOrigins } from '../../../../config/cors-settings';
-import { homeLocation } from '../../../../config/env.json';
 
 export default function constantHeaders() {
   return function (req, res, next) {
@@ -10,7 +9,7 @@ export default function constantHeaders() {
     ) {
       res.header('Access-Control-Allow-Origin', req.headers.origin);
     } else {
-      res.header('Access-Control-Allow-Origin', homeLocation);
+      res.header('Access-Control-Allow-Origin', process.env.HOME_LOCATION);
     }
     res.header('Access-Control-Allow-Credentials', true);
     res.header(

--- a/api-server/src/server/middlewares/csp.js
+++ b/api-server/src/server/middlewares/csp.js
@@ -1,11 +1,9 @@
 import helmet from 'helmet';
 
-import { homeLocation } from '../../../../config/env.json';
-
 let trusted = [
   "'self'",
   'https://search.freecodecamp.org',
-  homeLocation,
+  process.env.HOME_LOCATION,
   'https://' + process.env.AUTH0_DOMAIN
 ];
 

--- a/api-server/src/server/middlewares/request-authorization.test.js
+++ b/api-server/src/server/middlewares/request-authorization.test.js
@@ -1,9 +1,13 @@
+import path from 'path';
 import jwt from 'jsonwebtoken';
+import { config } from 'dotenv';
 
 import { mockReq as mockRequest, mockRes } from '../boot_tests/challenge.test';
 import createRequestAuthorization, {
   isAllowedPath
 } from './request-authorization';
+
+config({ path: path.resolve(__dirname, '../../../../.env') });
 
 const validJWTSecret = 'this is a super secret string';
 const invalidJWTSecret = 'This is not correct secret';

--- a/api-server/src/server/middlewares/request-authorization.test.js
+++ b/api-server/src/server/middlewares/request-authorization.test.js
@@ -1,6 +1,5 @@
 import jwt from 'jsonwebtoken';
 
-import { homeLocation } from '../../../../config/env.json';
 import { mockReq as mockRequest, mockRes } from '../boot_tests/challenge.test';
 import createRequestAuthorization, {
   isAllowedPath
@@ -27,7 +26,7 @@ const mockGetUserById = id =>
 
 const mockReq = args => {
   const mock = mockRequest(args);
-  mock.header = () => homeLocation;
+  mock.header = () => process.env.HOME_LOCATION;
   return mock;
 };
 

--- a/api-server/src/server/passport-providers.js
+++ b/api-server/src/server/passport-providers.js
@@ -1,11 +1,10 @@
-import { homeLocation, apiLocation } from '../../../config/env.json';
 import { auth0 } from '../../../config/secrets';
 
 const { clientID, clientSecret, domain } = auth0;
 
 // These don't seem to be used, can they go?
-const successRedirect = `${homeLocation}/learn`;
-const failureRedirect = `${homeLocation}/signin`;
+const successRedirect = `${process.env.HOME_LOCATION}/learn`;
+const failureRedirect = `${process.env.HOME_LOCATION}/signin`;
 
 // TODO: can we remove passport-mock-strategy entirely in prod? That would let
 // us make passport-mock-strategy a dev dep, as it should be.
@@ -33,7 +32,7 @@ const passportProviders = {
     clientSecret,
     domain,
     cookieDomain: process.env.COOKIE_DOMAIN || 'localhost',
-    callbackURL: `${apiLocation}/auth/auth0/callback`,
+    callbackURL: `${process.env.API_LOCATION}/auth/auth0/callback`,
     authPath: '/auth/auth0',
     callbackPath: '/auth/auth0/callback',
     useCustomCallback: true,

--- a/api-server/src/server/utils/redirection.js
+++ b/api-server/src/server/utils/redirection.js
@@ -1,11 +1,14 @@
 const jwt = require('jsonwebtoken');
 const { allowedOrigins } = require('../../../../config/cors-settings');
-// homeLocation is being used as a fallback here. If the one provided by the
-// client is invalid we default to this.
-const { homeLocation } = require('../../../../config/env.json');
+// process.env.HOME_LOCATION is being used as a fallback here. If the one
+// provided by the client is invalid we default to this.
 const { availableLangs } = require('../../../../config/i18n');
 
-function getReturnTo(encryptedParams, secret, _homeLocation = homeLocation) {
+function getReturnTo(
+  encryptedParams,
+  secret,
+  _homeLocation = process.env.HOME_LOCATION
+) {
   let params;
   try {
     params = jwt.verify(encryptedParams, secret);
@@ -25,7 +28,7 @@ function getReturnTo(encryptedParams, secret, _homeLocation = homeLocation) {
 
 function normalizeParams(
   { returnTo, origin, pathPrefix },
-  _homeLocation = homeLocation
+  _homeLocation = process.env.HOME_LOCATION
 ) {
   // coerce to strings, just in case something weird and nefarious is happening
   returnTo = '' + returnTo;
@@ -59,7 +62,7 @@ function getRedirectParams(req, _normalizeParams = normalizeParams) {
   const url = req.header('Referer');
   // since we do not always redirect the user back to the page they were on
   // we need client locale and origin to construct the redirect url.
-  const returnUrl = new URL(url ? url : homeLocation);
+  const returnUrl = new URL(url ? url : process.env.HOME_LOCATION);
   const origin = returnUrl.origin;
   // if this is not one of the client languages, validation will convert
   // this to '' before it is used.

--- a/api-server/src/server/utils/redirection.test.js
+++ b/api-server/src/server/utils/redirection.test.js
@@ -67,7 +67,7 @@ describe('redirection', () => {
       expect(keys.length).toBe(3);
       expect(keys).toEqual(expect.arrayContaining(expectedKeys));
     });
-    it('should default to homeLocation', () => {
+    it('should default to process.env.HOME_LOCATION', () => {
       expect.assertions(1);
       expect(normalizeParams({}, defaultOrigin)).toEqual(defaultObject);
     });
@@ -92,9 +92,9 @@ describe('redirection', () => {
       );
     });
     // we *could*, in principle, grab the path and send them to
-    // homeLocation/path, but if the origin is wrong something unexpected is
+    // process.env.HOME_LOCATION/path, but if the origin is wrong something unexpected is
     // going on. In that case it's probably best to just send them to
-    // homeLocation/learn.
+    // process.env.HOME_LOCATION/learn.
     it('should return default parameters if the origin is unknown', () => {
       expect.assertions(1);
       const exampleOrigin = {

--- a/client/src/templates/Introduction/components/block.tsx
+++ b/client/src/templates/Introduction/components/block.tsx
@@ -30,7 +30,7 @@ import {
 import Challenges from './challenges';
 import '../intro.css';
 
-const { curriculumLocale } = envData;
+const { curriculumLocale, showUpcomingChanges, showNewCurriculum } = envData;
 
 const mapStateToProps = (
   state: unknown,
@@ -130,6 +130,11 @@ class Block extends Component<BlockProps> {
       );
     });
 
+    const isAudited = isAuditedCert(curriculumLocale, superBlock, {
+      showNewCurriculum,
+      showUpcomingChanges
+    });
+
     const blockTitle = t(`intro:${superBlock}.blocks.${blockDashedName}.title`);
     // the real type of TFunction is the type below, because intro can be an array of strings
     // type RealTypeOFTFunction = TFunction & ((key: string) => string[]);
@@ -160,7 +165,7 @@ class Block extends Component<BlockProps> {
           <div className={`block ${isExpanded ? 'open' : ''}`}>
             <div className='block-header'>
               <h3 className='big-block-title'>{blockTitle}</h3>
-              {!isAuditedCert(curriculumLocale, superBlock) && (
+              {isAudited && (
                 <div className='block-cta-wrapper'>
                   <Link
                     className='block-title-translation-cta'
@@ -217,7 +222,7 @@ class Block extends Component<BlockProps> {
           <div className='block'>
             <div className='block-header'>
               <h3 className='big-block-title'>{blockTitle}</h3>
-              {!isAuditedCert(curriculumLocale, superBlock) && (
+              {isAudited && (
                 <div className='block-cta-wrapper'>
                   <Link
                     className='block-title-translation-cta'
@@ -280,7 +285,7 @@ class Block extends Component<BlockProps> {
               </button>
             </h3>
             <div className='tags-wrapper'>
-              {!isAuditedCert(curriculumLocale, superBlock) && (
+              {isAudited && (
                 <Link
                   className='cert-tag'
                   to={t('links:help-translate-link-url')}
@@ -310,7 +315,7 @@ class Block extends Component<BlockProps> {
             <span className='cert-tag' aria-hidden='true'>
               {t('misc.certification-project')}
             </span>
-            {!isAuditedCert(curriculumLocale, superBlock) && (
+            {isAudited && (
               <Link
                 className='cert-tag'
                 to={t('links:help-translate-link-url')}

--- a/curriculum/get-challenges.js
+++ b/curriculum/get-challenges.js
@@ -274,8 +274,10 @@ ${getFullPath('english', filePath)}
 `);
 
     const missingAuditedChallenge =
-      isAuditedCert(lang, superBlock) &&
-      !fs.existsSync(getFullPath(lang, filePath));
+      isAuditedCert(lang, superBlock, {
+        showNewCurriculum: process.env.SHOW_NEW_CURRICULUM,
+        showUpcomingChanges: process.env.SHOW_UPCOMING_CHANGES
+      }) && !fs.existsSync(getFullPath(lang, filePath));
     if (missingAuditedChallenge)
       throw Error(`Missing ${lang} audited challenge for
 ${filePath}

--- a/curriculum/get-challenges.js
+++ b/curriculum/get-challenges.js
@@ -4,7 +4,7 @@ const util = require('util');
 const yaml = require('js-yaml');
 const { findIndex } = require('lodash');
 const readDirP = require('readdirp');
-const { showUpcomingChanges } = require('../config/env.json');
+
 const { curriculum: curriculumLangs } =
   require('../config/i18n').availableLangs;
 const { parseMD } = require('../tools/challenge-parser/parser');
@@ -183,7 +183,7 @@ async function buildBlocks({ basename: blockName }, curriculum, superBlock) {
       throw Error(`meta file at ${metaPath} is missing 'helpCategory'`);
     }
 
-    if (!isUpcomingChange || showUpcomingChanges) {
+    if (!isUpcomingChange || process.env.SHOW_UPCOMING_CHANGES === 'true') {
       // add the block to the superBlock
       const blockInfo = { meta: blockMeta, challenges: [] };
       curriculum[superBlock].blocks[blockName] = blockInfo;

--- a/curriculum/get-challenges.js
+++ b/curriculum/get-challenges.js
@@ -334,7 +334,11 @@ Challenges that have been already audited cannot fall back to their English vers
     challenge.time = meta.time;
     challenge.helpCategory = challenge.helpCategory || meta.helpCategory;
     challenge.translationPending =
-      lang !== 'english' && !isAuditedCert(lang, meta.superBlock);
+      lang !== 'english' &&
+      !isAuditedCert(lang, meta.superBlock, {
+        showNewCurriculum: process.env.SHOW_NEW_CURRICULUM,
+        showUpcomingChanges: process.env.SHOW_UPCOMING_CHANGES
+      });
     challenge.usesMultifileEditor = !!meta.usesMultifileEditor;
   }
 
@@ -368,8 +372,10 @@ Challenges that have been already audited cannot fall back to their English vers
 
     // We always try to translate comments (even English ones) to confirm that translations exist.
     const translateComments =
-      isAuditedCert(lang, meta.superBlock) &&
-      fs.existsSync(getFullPath(lang, filePath));
+      isAuditedCert(lang, meta.superBlock, {
+        showNewCurriculum: process.env.SHOW_NEW_CURRICULUM,
+        showUpcomingChanges: process.env.SHOW_UPCOMING_CHANGES
+      }) && fs.existsSync(getFullPath(lang, filePath));
 
     const challenge = await (translateComments
       ? parseTranslation(

--- a/tools/scripts/build/download-trending.ts
+++ b/tools/scripts/build/download-trending.ts
@@ -1,10 +1,13 @@
 import { writeFileSync } from 'fs';
+import path from 'path';
+
 import fetch from 'node-fetch';
 import yaml from 'js-yaml';
-import envData from '../../../config/env.json';
+import { config } from 'dotenv';
+
 import { trendingSchemaValidator } from './schema/trending-schema';
 
-const { clientLocale } = envData;
+config({ path: path.resolve(__dirname, '../../../.env') });
 
 const createCdnUrl = (lang: string) =>
   `https://cdn.freecodecamp.org/universal/trending/${lang}.yaml`;
@@ -44,7 +47,11 @@ const download = async (clientLocale: string) => {
   }
 };
 
-void download(clientLocale);
+const locale = process.env.CLIENT_LOCALE;
+
+if (!locale) throw Error('CLIENT_LOCALE must be set to a valid locale');
+
+void download(locale);
 // TODO: remove the need to fallback to english once we're confident it's
 // unnecessary (client/i18n/config.js will need all references to 'en' removing)
-if (clientLocale !== 'english') void download('english');
+if (locale !== 'english') void download('english');

--- a/utils/is-audited.js
+++ b/utils/is-audited.js
@@ -1,16 +1,16 @@
 const { getAuditedSuperBlocks } = require('../config/superblocks');
-const {
-  showNewCurriculum,
-  showUpcomingChanges
-} = require('../config/env.json');
 
-function isAuditedCert(language, superblock) {
+function isAuditedCert(
+  language,
+  superblock,
+  { showNewCurriculum, showUpcomingChanges }
+) {
   if (!language || !superblock)
     throw Error('Both arguments must be provided for auditing');
 
   const auditedSuperBlocks = getAuditedSuperBlocks({
-    showNewCurriculum: showNewCurriculum.toString(),
-    showUpcomingChanges: showUpcomingChanges.toString(),
+    showNewCurriculum,
+    showUpcomingChanges,
     language
   });
   return auditedSuperBlocks.includes(superblock);


### PR DESCRIPTION
env.json is only necessary for code that runs in the browser and does not have access to process.

Using env.json in other workspaces creates more coupling between them and the client.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
