### PR TITLE
refactor(api): simplify user tests

### DIFF
--- a/api/src/routes/challenge.test.ts
+++ b/api/src/routes/challenge.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { challengeTypes } from '../../../config/challenge-types';
-import { setupServer, superRequest } from '../../jest.utils';
+import { devLogin, setupServer, superRequest } from '../../jest.utils';
 
 const isValidChallengeCompletionErrorMsg = {
   type: 'error',
@@ -43,9 +43,7 @@ describe('challengeRoutes', () => {
 
     // Authenticate user
     beforeAll(async () => {
-      const res = await superRequest('/auth/dev-callback', { method: 'GET' });
-      expect(res.status).toBe(200);
-      setCookies = res.get('Set-Cookie');
+      setCookies = await devLogin();
     });
 
     describe('/project-completed', () => {

--- a/api/src/routes/donate.test.ts
+++ b/api/src/routes/donate.test.ts
@@ -1,6 +1,4 @@
-import request from 'supertest';
-
-import { setupServer, superRequest } from '../../jest.utils';
+import { devLogin, setupServer, superRequest } from '../../jest.utils';
 
 describe('Donate', () => {
   setupServer();
@@ -9,14 +7,7 @@ describe('Donate', () => {
     let setCookies: string[];
 
     beforeEach(async () => {
-      await fastifyTestInstance.prisma.user.updateMany({
-        where: { email: 'foo@bar.com' },
-        data: { isDonating: false }
-      });
-      const res = await request(fastifyTestInstance.server).get(
-        '/auth/dev-callback'
-      );
-      setCookies = res.get('Set-Cookie');
+      setCookies = await devLogin();
     });
 
     describe('POST /donate/add-donation', () => {

--- a/api/src/routes/settings.test.ts
+++ b/api/src/routes/settings.test.ts
@@ -1,6 +1,4 @@
-import request from 'supertest';
-
-import { setupServer, superRequest } from '../../jest.utils';
+import { devLogin, setupServer, superRequest } from '../../jest.utils';
 
 const baseProfileUI = {
   isLocked: false,
@@ -83,15 +81,14 @@ describe('settingRoutes', () => {
 
     // Authenticate user
     beforeAll(async () => {
+      setCookies = await devLogin();
+      // This is not strictly necessary, since the defaultUser has this
+      // profileUI, but we're interested in how the profileUI is updated. As
+      // such, setting this explicitly isolates these tests.
       await fastifyTestInstance.prisma.user.updateMany({
         where: { email: 'foo@bar.com' },
         data: { profileUI: baseProfileUI }
       });
-      const res = await request(fastifyTestInstance.server).get(
-        '/auth/dev-callback'
-      );
-      expect(res.status).toBe(200);
-      setCookies = res.get('Set-Cookie');
     });
 
     describe('/update-my-profileui', () => {

--- a/api/src/routes/user.test.ts
+++ b/api/src/routes/user.test.ts
@@ -251,6 +251,8 @@ const modifiedProgressData = {
   needsModeration: true
 };
 
+const userTokenId = 'dummy-id';
+
 describe('userRoutes', () => {
   setupServer();
 
@@ -271,7 +273,7 @@ describe('userRoutes', () => {
         });
 
         const userCount = await fastifyTestInstance.prisma.user.count({
-          where: { email: 'foo@bar.com' }
+          where: { email: testUserData.email }
         });
 
         expect(response.body).toStrictEqual({});
@@ -283,12 +285,12 @@ describe('userRoutes', () => {
     describe('/account/reset-progress', () => {
       afterAll(async () => {
         await fastifyTestInstance.prisma.user.deleteMany({
-          where: { email: 'foo@bar.com' }
+          where: { email: testUserData.email }
         });
       });
       test('POST returns 200 status code with empty object', async () => {
         await fastifyTestInstance.prisma.user.updateMany({
-          where: { email: 'foo@bar.com' },
+          where: { email: testUserData.email },
           data: modifiedProgressData
         });
 
@@ -298,7 +300,7 @@ describe('userRoutes', () => {
         });
 
         const user = await fastifyTestInstance.prisma.user.findFirst({
-          where: { email: 'foo@bar.com' }
+          where: { email: testUserData.email }
         });
 
         expect(response.body).toStrictEqual({});
@@ -309,12 +311,13 @@ describe('userRoutes', () => {
       });
     });
     describe('/user/user-token', () => {
-      let userId: string | undefined;
+      let userId: string;
       beforeEach(async () => {
         const user = await fastifyTestInstance.prisma.user.findFirstOrThrow({
-          where: { email: 'foo@bar.com' }
+          where: { email: testUserData.email },
+          select: { id: true }
         });
-        userId = user?.id;
+        userId = user.id;
 
         await fastifyTestInstance.prisma.userToken.create({
           data: {
@@ -443,12 +446,12 @@ describe('userRoutes', () => {
 
       afterEach(async () => {
         await fastifyTestInstance.prisma.userToken.deleteMany({
-          where: { id: 'dummy-id' }
+          where: { id: userTokenId }
         });
       });
 
       test('GET rejects with 500 status code if the username is missing', async () => {
-        await fastifyTestInstance?.prisma.user.updateMany({
+        await fastifyTestInstance.prisma.user.updateMany({
           where: { email: testUserData.email },
           data: { username: '' }
         });
@@ -511,7 +514,7 @@ describe('userRoutes', () => {
         const tokenData = {
           userId: testUser.id,
           ttl: 123,
-          id: 'dummy-id',
+          id: userTokenId,
           created: new Date()
         };
 
@@ -622,7 +625,7 @@ describe('userRoutes', () => {
           setCookies
         });
 
-        expect(response?.statusCode).toBe(401);
+        expect(response.statusCode).toBe(401);
       });
 
       test('POST returns 401 status code with error message', async () => {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Hopefully this will eliminate failures like https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/5712204307/job/15475399296. My working hypothesis is that the `userId` used to delete the `UserTokens` is not always the same as the one used to create them and so the cleanup is not working correctly. I've yet to recreate the bug, though, so this is just my best guess.

<!-- Feel free to add any additional description of changes below this line -->
