### PR TITLE
fix(client): remove use of jwt_access_token

### DIFF
--- a/api-server/src/server/utils/getSetAccessToken.js
+++ b/api-server/src/server/utils/getSetAccessToken.js
@@ -20,7 +20,9 @@ export function setAccessTokenToResponse(
 ) {
   const cookieConfig = {
     ...createCookieConfig(req),
-    maxAge: accessToken.ttl || 77760000000
+    maxAge: accessToken.ttl || 77760000000,
+    httpOnly: true,
+    secure: process.env.ENV === 'production'
   };
   const jwtAccess = jwt.sign({ accessToken }, jwtSecret);
   res.cookie(jwtCookieNS, jwtAccess, cookieConfig);

--- a/api-server/src/server/utils/getSetAccessToken.js
+++ b/api-server/src/server/utils/getSetAccessToken.js
@@ -22,7 +22,7 @@ export function setAccessTokenToResponse(
     ...createCookieConfig(req),
     maxAge: accessToken.ttl || 77760000000,
     httpOnly: true,
-    secure: process.env.ENV === 'production'
+    secure: process.env.FREECODECAMP_NODE_ENV === 'production'
   };
   const jwtAccess = jwt.sign({ accessToken }, jwtSecret);
   res.cookie(jwtCookieNS, jwtAccess, cookieConfig);

--- a/client/src/redux/cookie-values.js
+++ b/client/src/redux/cookie-values.js
@@ -1,4 +1,0 @@
-import cookies from 'browser-cookies';
-
-export const jwt =
-  typeof window !== 'undefined' && cookies.get('jwt_access_token');

--- a/client/src/redux/fetch-user-saga.js
+++ b/client/src/redux/fetch-user-saga.js
@@ -7,13 +7,8 @@ import {
   fetchUserComplete,
   fetchUserError
 } from './actions';
-import { jwt } from './cookie-values';
 
 function* fetchSessionUser() {
-  if (!jwt) {
-    yield put(fetchUserComplete({ user: {}, username: '' }));
-    return;
-  }
   try {
     const {
       data: { user = {}, result = '' }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

**Notes:**
- API changes to be reverted before merge
  - Client to be deployed before API changes
  - Token has also been set to secure for production
- Should we add `res.setCookie('jwt_access_token', JRRTolkien, { httpOnly: true });` to `/get-session-user` on the api to force/update this for all?