### PR TITLE
test(api): count userTokens before getting user

### DIFF
--- a/api/src/routes/user.test.ts
+++ b/api/src/routes/user.test.ts
@@ -510,6 +510,9 @@ describe('userRoutes', () => {
           data: tokenData
         });
 
+        const tokens = await fastifyTestInstance.prisma.userToken.count();
+        expect(tokens).toBe(1);
+
         const response = await superRequest('/user/get-session-user', {
           method: 'GET',
           setCookies


### PR DESCRIPTION
This is mostly for debugging since the presense of a second userToken
could explain the intermittent error we're seeing.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
