### PR TITLE
fix(test): confirm the decoded token is correct

### DIFF
--- a/api/src/routes/user.test.ts
+++ b/api/src/routes/user.test.ts
@@ -15,7 +15,6 @@ import {
   superRequest
 } from '../../jest.utils';
 import { JWT_SECRET } from '../utils/env';
-import { encodeUserToken } from '../utils/user-token';
 
 // This is used to build a test user.
 const testUserData: Prisma.userCreateInput = {
@@ -504,8 +503,6 @@ describe('userRoutes', () => {
           created: new Date()
         };
 
-        const encodedToken = encodeUserToken(tokenData.id);
-
         await fastifyTestInstance.prisma.userToken.create({
           data: tokenData
         });
@@ -518,13 +515,11 @@ describe('userRoutes', () => {
           setCookies
         });
 
-        const {
-          user: { foobar }
-        } = response.body as unknown as {
-          user: { foobar: unknown };
-        };
+        const { userToken } = jwt.decode(
+          response.body.user.foobar.userToken
+        ) as { userToken: string };
 
-        expect(foobar).toMatchObject({ userToken: encodedToken });
+        expect(tokenData.id).toBe(userToken);
       });
       test('GET returns a minimal user when all optional properties are missing', async () => {
         // To get a minimal test user we first delete the existing one...


### PR DESCRIPTION
We're only interested in the payload, not the issued at time.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This test would often fail in CI (e.g. https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/5750663731/job/15588105041?pr=51140) because `jwt.sign({ userToken: 'value'}, secret)` actually encodes

```
{ 
  userToken: 'value',
  iat: 'date in seconds'
 }
 ```

and so the encoded value could change between `jwt.sign` calls.

<!-- Feel free to add any additional description of changes below this line -->
