### PR TITLE
feat: disable submission until it's done

### DIFF
--- a/client/src/templates/Challenges/components/completion-modal.tsx
+++ b/client/src/templates/Challenges/components/completion-modal.tsx
@@ -21,7 +21,8 @@ import {
   isCompletionModalOpenSelector,
   successMessageSelector,
   challengeFilesSelector,
-  challengeMetaSelector
+  challengeMetaSelector,
+  isSubmittingSelector
 } from '../redux/selectors';
 import ProgressBar from '../../../components/ProgressBar';
 import GreenPass from '../../../assets/icons/green-pass';
@@ -36,7 +37,7 @@ const mapStateToProps = createSelector(
   isSignedInSelector,
   allChallengesInfoSelector,
   successMessageSelector,
-
+  isSubmittingSelector,
   (
     challengeFiles: ChallengeFiles,
     { dashedName }: { dashedName: string },
@@ -44,7 +45,8 @@ const mapStateToProps = createSelector(
     isOpen: boolean,
     isSignedIn: boolean,
     allChallengesInfo: AllChallengesInfo,
-    message: string
+    message: string,
+    isSubmitting: boolean
   ) => ({
     challengeFiles,
     dashedName,
@@ -52,7 +54,8 @@ const mapStateToProps = createSelector(
     isOpen,
     isSignedIn,
     allChallengesInfo,
-    message
+    message,
+    isSubmitting
   })
 );
 
@@ -147,6 +150,7 @@ class CompletionModal extends Component<
       close,
       isOpen,
       isSignedIn,
+      isSubmitting,
       message,
       t,
       dashedName,
@@ -193,6 +197,7 @@ class CompletionModal extends Component<
             block={true}
             bsSize='large'
             bsStyle='primary'
+            disabled={isSubmitting}
             onClick={() => submitChallenge()}
           >
             {isSignedIn ? t('buttons.submit-and-go') : t('buttons.go-to-next')}

--- a/client/src/templates/Challenges/components/completion-modal.tsx
+++ b/client/src/templates/Challenges/components/completion-modal.tsx
@@ -163,6 +163,7 @@ class CompletionModal extends Component<
 
     return (
       <Modal
+        data-cy='completion-modal'
         animation={false}
         bsSize='lg'
         dialogClassName='challenge-success-modal'
@@ -198,6 +199,7 @@ class CompletionModal extends Component<
             bsSize='large'
             bsStyle='primary'
             disabled={isSubmitting}
+            data-cy='submit-challenge'
             onClick={() => submitChallenge()}
           >
             {isSignedIn ? t('buttons.submit-and-go') : t('buttons.go-to-next')}

--- a/client/src/templates/Challenges/redux/action-types.js
+++ b/client/src/templates/Challenges/redux/action-types.js
@@ -1,4 +1,4 @@
-import { createTypes } from '../../../utils/create-types';
+import { createAsyncTypes, createTypes } from '../../../utils/create-types';
 
 export const CURRENT_CHALLENGE_KEY = 'currentChallengeId';
 
@@ -43,10 +43,10 @@ export const actionTypes = createTypes(
     'executeChallenge',
     'resetChallenge',
     'stopResetting',
-    'submitChallenge',
     'resetAttempts',
     'setEditorFocusability',
-    'toggleVisibleEditor'
+    'toggleVisibleEditor',
+    ...createAsyncTypes('submitChallenge')
   ],
   ns
 );

--- a/client/src/templates/Challenges/redux/actions.js
+++ b/client/src/templates/Challenges/redux/actions.js
@@ -71,6 +71,12 @@ export const executeChallenge = createAction(actionTypes.executeChallenge);
 export const resetChallenge = createAction(actionTypes.resetChallenge);
 export const stopResetting = createAction(actionTypes.stopResetting);
 export const submitChallenge = createAction(actionTypes.submitChallenge);
+export const submitChallengeComplete = createAction(
+  actionTypes.submitChallengeComplete
+);
+export const submitChallengeError = createAction(
+  actionTypes.submitChallengeError
+);
 export const resetAttempts = createAction(actionTypes.resetAttempts);
 
 export const setEditorFocusability = createAction(

--- a/client/src/templates/Challenges/redux/completion-epic.js
+++ b/client/src/templates/Challenges/redux/completion-epic.js
@@ -36,7 +36,9 @@ import { actionTypes } from './action-types';
 import {
   closeModal,
   updateSolutionFormValues,
-  setIsAdvancing
+  setIsAdvancing,
+  submitChallengeComplete,
+  submitChallengeError
 } from './actions';
 import {
   challengeFilesSelector,
@@ -73,14 +75,15 @@ function postChallenge(update, username) {
           },
           savedChallenges: mapFilesToChallengeFiles(savedChallenges)
         }),
-        updateComplete()
+        updateComplete(),
+        submitChallengeComplete()
       ];
       // TODO(Post-MVP): separate endpoint for trophy submission?
       if (isTrophyMissing)
         actions.push(createFlashMessage(trophyMissingMessage));
       return of(...actions);
     }),
-    catchError(() => of(updateFailed(update)))
+    catchError(() => of(updateFailed(update), submitChallengeError()))
   );
   return saveChallenge;
 }

--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -52,7 +52,8 @@ const initialState = {
   projectFormValues: {},
   successMessage: 'Happy Coding!',
   isAdvancing: false,
-  chapterSlug: ''
+  chapterSlug: '',
+  isSubmitting: false
 };
 
 export const epics = [completionEpic, createQuestionEpic, codeStorageEpic];
@@ -64,6 +65,18 @@ export const sagas = [
 
 export const reducer = handleActions(
   {
+    [actionTypes.submitChallenge]: state => ({
+      ...state,
+      isSubmitting: true
+    }),
+    [actionTypes.submitChallengeComplete]: state => ({
+      ...state,
+      isSubmitting: false
+    }),
+    [actionTypes.submitChallengeError]: state => ({
+      ...state,
+      isSubmitting: false
+    }),
     [actionTypes.createFiles]: (state, { payload }) => ({
       ...state,
       challengeFiles: payload,

--- a/client/src/templates/Challenges/redux/selectors.js
+++ b/client/src/templates/Challenges/redux/selectors.js
@@ -33,6 +33,7 @@ export const isFinishExamModalOpenSelector = state =>
 export const isProjectPreviewModalOpenSelector = state =>
   state[ns].modal.projectPreview;
 export const isShortcutsModalOpenSelector = state => state[ns].modal.shortcuts;
+export const isSubmittingSelector = state => state[ns].isSubmitting;
 export const isResettingSelector = state => state[ns].isResetting;
 
 export const isBuildEnabledSelector = state => state[ns].isBuildEnabled;


### PR DESCRIPTION
- feat(client): track submission state
- feat: disable submit button while submitting

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The original motivation was that @moT01 spotted that it was easy to submit MS learn links multiple times, since the validation is relatively slow. However, this is more generally applicable: there's no reason a learner would want to submit twice in quick succession and this PR should prevent that.

<!-- Feel free to add any additional description of changes below this line -->
