### PR TITLE
fix:center-success-popup

### DIFF
--- a/client/src/components/Flash/flash.css
+++ b/client/src/components/Flash/flash.css
@@ -1,6 +1,6 @@
 .flash-message {
   display: flex;
-  justify-content: space-around;
+  justify-content: center;
   flex-direction: row-reverse;
   margin-bottom: 0px;
   padding-top: 3px;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #51151

<!-- Feel free to add any additional description of changes below this line -->
Centered both text and the 'x' button, instead of aligning the 'x' button on the right side. And here is the result :
![image](https://github.com/freeCodeCamp/freeCodeCamp/assets/54121483/ccd0f5ae-9ef6-4c18-a994-f1cfc79fae6b)

