### PR TITLE
feat(client): add the missing MSTrophyMissing sound

### DIFF
--- a/client/src/utils/tone/index.ts
+++ b/client/src/utils/tone/index.ts
@@ -61,7 +61,8 @@ const toneUrls = {
   [FlashMessages.UserNotCertified]: TRY_AGAIN,
   [FlashMessages.WrongName]: TRY_AGAIN,
   [FlashMessages.WrongUpdating]: TRY_AGAIN,
-  [FlashMessages.WentWrong]: TRY_AGAIN
+  [FlashMessages.WentWrong]: TRY_AGAIN,
+  [FlashMessages.MSTrophyMissing]: TRY_AGAIN
 } as const;
 
 type ToneStates = keyof typeof toneUrls;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->
if you visit this [section](https://github.com/freeCodeCamp/freeCodeCamp/blob/f18d624d2eb4cd54ccea4e09ca9c35bceebfb891/client/src/components/Flash/redux/index.ts#L38) of the code in the editor, you will get a warning is that the message related to the sound is missing.

this should sort that type error.

>Argument of type 'FlashMessages.AccountDeleted | FlashMessages.AddNameSuccess | FlashMessages.AlreadyClaimed | FlashMessages.CertClaimSuccess | FlashMessages.CertificateMissing | FlashMessages.CertsPrivate | ... 41 more ... | FlashMessages.WentWrong' is not assignable to parameter of type 'Themes | FlashMessages.AccountDeleted | FlashMessages.AddNameSuccess | FlashMessages.AlreadyClaimed | FlashMessages.CertClaimSuccess | FlashMessages.CertificateMissing | ... 46 more ... | "completion"'.
  Type 'FlashMessages.MSTrophyMissing' is not assignable to type 'Themes | FlashMessages.AccountDeleted | FlashMessages.AddNameSuccess | FlashMessages.AlreadyClaimed | FlashMessages.CertClaimSuccess | FlashMessages.CertificateMissing | ... 46 more ... | "completion"'.
<!-- Feel free to add any additional description of changes below this line -->
