### PR TITLE
docs: mention the seed:certified-user command in the setup guide

### DIFF
--- a/docs/how-to-setup-freecodecamp-locally.md
+++ b/docs/how-to-setup-freecodecamp-locally.md
@@ -283,6 +283,15 @@ Next, let's seed the database. In this step, we run the below command that fills
 pnpm run seed
 ```
 
+By default, you will be signed in as a new user without any completed certifications. Run the following command if you need to develop with completed certifications:
+
+```console
+pnpm run seed:certified-user
+```
+
+> [!WARNING]
+> Running `pnpm run seed:certified-user` will log you out. You will have to clear your browser cookies and sign in again.
+
 #### Step 4: Start the freeCodeCamp Client Application and API Server
 
 You can now start up the API server and the client applications.
@@ -312,5 +321,6 @@ A quick reference to the commands that you will need when working locally.
 | ----------------- | ----------------------------------------------------------------------------- |
 | `pnpm install`          | Installs / re-installs all dependencies and bootstraps the different services. |
 | `pnpm run seed`    | Creates authorized test users and inserts them into MongoDB.        |
+| `pnpm run seed:certified-user`    | Creates authorized test users with certifications fully completed, and inserts them into MongoDB.        |
 | `pnpm run develop` | Starts the freeCodeCamp API Server and Client Applications.                   |
 | `pnpm run clean`   | Uninstalls all dependencies and cleans up caches.                             |


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I found that the `pnpm run seed:certified-user` command is mentioned in a warning message and in the troubleshooting guide, but not in the setup guide, so I decided to add it in.

<!-- Feel free to add any additional description of changes below this line -->
