### PR TITLE
refactor: DRY using Certification enum

### DIFF
--- a/client/src/components/settings/certification.tsx
+++ b/client/src/components/settings/certification.tsx
@@ -22,7 +22,10 @@ import { FlashMessages } from '../Flash/redux/flash-messages';
 import ProjectModal from '../SolutionViewer/project-modal';
 import { FullWidthRow, Spacer } from '../helpers';
 import { SolutionDisplayWidget } from '../solution-display-widget';
-import { certSlugTypeMap } from '../../../../config/certification-settings';
+import {
+  Certification,
+  certSlugTypeMap
+} from '../../../../config/certification-settings';
 
 import './certification.css';
 import {
@@ -162,9 +165,7 @@ const LegacyFullStack = (props: CertificationSettingsProps) => {
     isJsAlgoDataStructCert &&
     isRespWebDesignCert;
 
-  // Keep the settings page certSlug as full-stack rather than
-  // legacy-full-stack so we don't break existing links
-  const certSlug = 'full-stack';
+  const certSlug = Certification.LegacyFullStack;
   const certLocation = `/certification/${username}/${certSlug}`;
 
   const buttonStyle = {

--- a/client/src/redux/selectors.js
+++ b/client/src/redux/selectors.js
@@ -1,4 +1,4 @@
-import { SuperBlocks } from '../../../config/superblocks';
+import { Certification } from '../../../config/certification-settings';
 import { ns as MainApp } from './action-types';
 
 export const savedChallengesSelector = state =>
@@ -49,7 +49,7 @@ export const shouldRequestDonationSelector = state => {
   // a block has been completed
   if (recentlyClaimedBlock) return true;
 
-  /* 
+  /*
   When AB testing for showing multiple progress modals is active,
   show a donation modal every 30 challenges after the first 50
    */
@@ -138,91 +138,91 @@ export const certificatesByNameSelector = username => state => {
       {
         show: isRespWebDesignCert,
         title: 'Responsive Web Design Certification',
-        certSlug: SuperBlocks.RespWebDesign
+        certSlug: Certification.RespWebDesign
       },
       {
         show: isJsAlgoDataStructCert,
         title: 'JavaScript Algorithms and Data Structures Certification',
-        certSlug: SuperBlocks.JsAlgoDataStruct
+        certSlug: Certification.JsAlgoDataStruct
       },
       {
         show: isFrontEndLibsCert,
         title: 'Front End Development Libraries Certification',
-        certSlug: SuperBlocks.FrontEndDevLibs
+        certSlug: Certification.FrontEndDevLibs
       },
       {
         show: is2018DataVisCert,
         title: 'Data Visualization Certification',
-        certSlug: SuperBlocks.DataVis
+        certSlug: Certification.DataVis
       },
       {
         show: isApisMicroservicesCert,
         title: 'Back End Development and APIs Certification',
-        certSlug: SuperBlocks.BackEndDevApis
+        certSlug: Certification.BackEndDevApis
       },
       {
         show: isQaCertV7,
         title: ' Quality Assurance Certification',
-        certSlug: 'quality-assurance-v7'
+        certSlug: Certification.QualityAssurance
       },
       {
         show: isInfosecCertV7,
         title: 'Information Security Certification',
-        certSlug: 'information-security-v7'
+        certSlug: Certification.InfoSec
       },
       {
         show: isSciCompPyCertV7,
         title: 'Scientific Computing with Python Certification',
-        certSlug: 'scientific-computing-with-python-v7'
+        certSlug: Certification.SciCompPy
       },
       {
         show: isDataAnalysisPyCertV7,
         title: 'Data Analysis with Python Certification',
-        certSlug: 'data-analysis-with-python-v7'
+        certSlug: Certification.DataAnalysisPy
       },
       {
         show: isMachineLearningPyCertV7,
         title: 'Machine Learning with Python Certification',
-        certSlug: 'machine-learning-with-python-v7'
+        certSlug: Certification.MachineLearningPy
       },
       {
         show: isRelationalDatabaseCertV8,
         title: 'Relational Database Certification',
-        certSlug: 'relational-database-v8'
+        certSlug: Certification.RelationalDb
       },
       {
         show: isCollegeAlgebraPyCertV8,
         title: 'College Algebra with Python Certification',
-        certSlug: 'college-algebra-with-python-v8'
+        certSlug: Certification.CollegeAlgebraPy
       }
     ],
     legacyCerts: [
       {
         show: isFrontEndCert,
         title: 'Front End Certification',
-        certSlug: 'legacy-front-end'
+        certSlug: Certification.LegacyFrontEnd
       },
       {
         show: isBackEndCert,
         title: 'Back End Certification',
-        certSlug: 'legacy-back-end'
+        certSlug: Certification.LegacyBackEnd
       },
       {
         show: isDataVisCert,
         title: 'Data Visualization Certification',
-        certSlug: 'legacy-data-visualization'
+        certSlug: Certification.LegacyDataVis
       },
       {
         show: isInfosecQaCert,
         title: 'Information Security and Quality Assurance Certification',
         // Keep the current public profile cert slug
-        certSlug: 'information-security-and-quality-assurance'
+        certSlug: Certification.LegacyInfoSecQa
       },
       {
         show: isFullStackCert,
         title: 'Full Stack Certification',
         // Keep the current public profile cert slug
-        certSlug: 'full-stack'
+        certSlug: Certification.LegacyFullStack
       }
     ]
   };

--- a/client/src/resources/cert-and-project-map.ts
+++ b/client/src/resources/cert-and-project-map.ts
@@ -1,4 +1,4 @@
-import { SuperBlocks } from '../../../config/superblocks';
+import { Certification } from '../../../config/certification-settings';
 import config from '../../../config/env.json';
 
 const { showUpcomingChanges } = config;
@@ -47,134 +47,134 @@ const legacyCertMap = [
   {
     id: '561add10cb82ac38a17513be',
     title: 'Legacy Front End',
-    certSlug: 'legacy-front-end',
+    certSlug: Certification.LegacyFrontEnd,
     projects: [
       {
         id: 'bd7158d8c242eddfaeb5bd13',
         title: 'Build a Personal Portfolio Webpage',
         link: `${legacyFrontEndResponsiveBase}/build-a-personal-portfolio-webpage`,
-        certSlug: 'legacy-front-end'
+        certSlug: Certification.LegacyFrontEnd
       },
       {
         id: 'bd7158d8c442eddfaeb5bd13',
         title: 'Build a Random Quote Machine',
         link: `${legacyFrontEndBase}/build-a-random-quote-machine`,
-        certSlug: 'legacy-front-end'
+        certSlug: Certification.LegacyFrontEnd
       },
       {
         id: 'bd7158d8c442eddfaeb5bd0f',
         title: 'Build a 25 + 5 Clock',
         link: `${legacyFrontEndBase}/build-a-25--5-clock`,
-        certSlug: 'legacy-front-end'
+        certSlug: Certification.LegacyFrontEnd
       },
       {
         id: 'bd7158d8c442eddfaeb5bd17',
         title: 'Build a JavaScript Calculator',
         link: `${legacyFrontEndBase}/build-a-javascript-calculator`,
-        certSlug: 'legacy-front-end'
+        certSlug: Certification.LegacyFrontEnd
       },
       {
         id: 'bd7158d8c442eddfaeb5bd10',
         title: 'Show the Local Weather',
         link: `${legacyFrontEndTakeHomeBase}/show-the-local-weather`,
-        certSlug: 'legacy-front-end'
+        certSlug: Certification.LegacyFrontEnd
       },
       {
         id: 'bd7158d8c442eddfaeb5bd1f',
         title: 'Use the TwitchTV JSON API',
         link: `${legacyFrontEndTakeHomeBase}/use-the-twitch-json-api`,
-        certSlug: 'legacy-front-end'
+        certSlug: Certification.LegacyFrontEnd
       },
       {
         id: 'bd7158d8c442eddfaeb5bd18',
         title: 'Build a Tribute Page',
         link: `${legacyFrontEndResponsiveBase}/build-a-tribute-page`,
-        certSlug: 'legacy-front-end'
+        certSlug: Certification.LegacyFrontEnd
       },
       {
         id: 'bd7158d8c442eddfaeb5bd19',
         title: 'Build a Wikipedia Viewer',
         link: `${legacyFrontEndTakeHomeBase}/build-a-wikipedia-viewer`,
-        certSlug: 'legacy-front-end'
+        certSlug: Certification.LegacyFrontEnd
       },
       {
         id: 'bd7158d8c442eedfaeb5bd1c',
         title: 'Build a Tic Tac Toe Game',
         link: `${legacyFrontEndTakeHomeBase}/build-a-tic-tac-toe-game`,
-        certSlug: 'legacy-front-end'
+        certSlug: Certification.LegacyFrontEnd
       },
       {
         id: 'bd7158d8c442eddfaeb5bd1c',
         title: 'Build a Simon Game',
         link: `${legacyFrontEndTakeHomeBase}/build-a-simon-game`,
-        certSlug: 'legacy-front-end'
+        certSlug: Certification.LegacyFrontEnd
       }
     ]
   },
   {
     id: '660add10cb82ac38a17513be',
     title: 'Legacy Back End',
-    certSlug: 'legacy-back-end',
+    certSlug: Certification.LegacyBackEnd,
     projects: [
       {
         id: 'bd7158d8c443edefaeb5bdef',
         title: 'Timestamp Microservice',
         link: `${legacyBackEndBase}/timestamp-microservice`,
-        certSlug: 'legacy-back-end'
+        certSlug: Certification.LegacyBackEnd
       },
       {
         id: 'bd7158d8c443edefaeb5bdff',
         title: 'Request Header Parser Microservice',
         link: `${legacyBackEndBase}/request-header-parser-microservice`,
-        certSlug: 'legacy-back-end'
+        certSlug: Certification.LegacyBackEnd
       },
       {
         id: 'bd7158d8c443edefaeb5bd0e',
         title: 'URL Shortener Microservice',
         link: `${legacyBackEndBase}/url-shortener-microservice`,
-        certSlug: 'legacy-back-end'
+        certSlug: Certification.LegacyBackEnd
       },
       {
         id: 'bd7158d8c443edefaeb5bdee',
         title: 'Image Search Abstraction Layer',
         link: `${legacyBackEndTakeHomeBase}/build-an-image-search-abstraction-layer`,
-        certSlug: 'legacy-back-end'
+        certSlug: Certification.LegacyBackEnd
       },
       {
         id: 'bd7158d8c443edefaeb5bd0f',
         title: 'File Metadata Microservice',
         link: `${legacyBackEndBase}/file-metadata-microservice`,
-        certSlug: 'legacy-back-end'
+        certSlug: Certification.LegacyBackEnd
       },
       {
         id: 'bd7158d8c443eddfaeb5bdef',
         title: 'Build a Voting App',
         link: `${legacyBackEndTakeHomeBase}/build-a-voting-app`,
-        certSlug: 'legacy-back-end'
+        certSlug: Certification.LegacyBackEnd
       },
       {
         id: 'bd7158d8c443eddfaeb5bdff',
         title: 'Build a Nightlife Coordination App',
         link: `${legacyBackEndTakeHomeBase}/build-a-nightlife-coordination-app`,
-        certSlug: 'legacy-back-end'
+        certSlug: Certification.LegacyBackEnd
       },
       {
         id: 'bd7158d8c443eddfaeb5bd0e',
         title: 'Chart the Stock Market',
         link: `${legacyBackEndTakeHomeBase}/chart-the-stock-market`,
-        certSlug: 'legacy-back-end'
+        certSlug: Certification.LegacyBackEnd
       },
       {
         id: 'bd7158d8c443eddfaeb5bd0f',
         title: 'Manage a Book Trading Club',
         link: `${legacyBackEndTakeHomeBase}/manage-a-book-trading-club`,
-        certSlug: 'legacy-back-end'
+        certSlug: Certification.LegacyBackEnd
       },
       {
         id: 'bd7158d8c443eddfaeb5bdee',
         title: 'Build a Pinterest Clone',
         link: `${legacyBackEndTakeHomeBase}/build-a-pinterest-clone`,
-        certSlug: 'legacy-back-end'
+        certSlug: Certification.LegacyBackEnd
       }
     ]
   },
@@ -182,67 +182,67 @@ const legacyCertMap = [
   {
     id: '561add10cb82ac39a17513bc',
     title: 'Legacy Data Visualization',
-    certSlug: 'legacy-data-visualization',
+    certSlug: Certification.LegacyDataVis,
     projects: [
       {
         id: 'bd7157d8c242eddfaeb5bd13',
         title: 'Build a Markdown Previewer',
         link: `${legacyDataVisFrontEndBase}/build-a-markdown-previewer`,
-        certSlug: 'legacy-data-visualization'
+        certSlug: Certification.LegacyDataVis
       },
       {
         id: 'bd7156d8c242eddfaeb5bd13',
         title: 'Build a freeCodeCamp Forum Homepage',
         link: `${legacyDataVisTakeHomeBase}/build-a-freecodecamp-forum-homepage`,
-        certSlug: 'legacy-data-visualization'
+        certSlug: Certification.LegacyDataVis
       },
       {
         id: 'bd7155d8c242eddfaeb5bd13',
         title: 'Build a Recipe Box',
         link: `${legacyDataVisTakeHomeBase}/build-a-recipe-box`,
-        certSlug: 'legacy-data-visualization'
+        certSlug: Certification.LegacyDataVis
       },
       {
         id: 'bd7154d8c242eddfaeb5bd13',
         title: 'Build the Game of Life',
         link: `${legacyDataVisTakeHomeBase}/build-the-game-of-life`,
-        certSlug: 'legacy-data-visualization'
+        certSlug: Certification.LegacyDataVis
       },
       {
         id: 'bd7153d8c242eddfaeb5bd13',
         title: 'Build a Roguelike Dungeon Crawler Game',
         link: `${legacyDataVisTakeHomeBase}/build-a-roguelike-dungeon-crawler-game`,
-        certSlug: 'legacy-data-visualization'
+        certSlug: Certification.LegacyDataVis
       },
       {
         id: 'bd7168d8c242eddfaeb5bd13',
         title: 'Visualize Data with a Bar Chart',
         link: `${legacyDataVisBase}/visualize-data-with-a-bar-chart`,
-        certSlug: 'legacy-data-visualization'
+        certSlug: Certification.LegacyDataVis
       },
       {
         id: 'bd7178d8c242eddfaeb5bd13',
         title: 'Visualize Data with a Scatterplot Graph',
         link: `${legacyDataVisBase}/visualize-data-with-a-scatterplot-graph`,
-        certSlug: 'legacy-data-visualization'
+        certSlug: Certification.LegacyDataVis
       },
       {
         id: 'bd7188d8c242eddfaeb5bd13',
         title: 'Visualize Data with a Heat Map',
         link: `${legacyDataVisBase}/visualize-data-with-a-heat-map`,
-        certSlug: 'legacy-data-visualization'
+        certSlug: Certification.LegacyDataVis
       },
       {
         id: 'bd7198d8c242eddfaeb5bd13',
         title: 'Show National Contiguity with a Force Directed Graph',
         link: `${legacyDataVisTakeHomeBase}/show-national-contiguity-with-a-force-directed-graph`,
-        certSlug: 'legacy-data-visualization'
+        certSlug: Certification.LegacyDataVis
       },
       {
         id: 'bd7108d8c242eddfaeb5bd13',
         title: 'Map Data Across the Globe',
         link: `${legacyDataVisTakeHomeBase}/map-data-across-the-globe`,
-        certSlug: 'legacy-data-visualization'
+        certSlug: Certification.LegacyDataVis
       }
     ]
   },
@@ -250,38 +250,38 @@ const legacyCertMap = [
     id: '561add10cb82ac38a17213bc',
     title: 'Legacy Information Security and Quality Assurance',
     // Keep this as information-security-and-quality-assurance
-    certSlug: 'information-security-and-quality-assurance',
+    certSlug: Certification.LegacyInfoSecQa,
     projects: [
       // Keep this as information-security-and-quality-assurance
       {
         id: '587d8249367417b2b2512c41',
         title: 'Metric-Imperial Converter',
         link: `${legacyInfosecQaQaBase}/metric-imperial-converter`,
-        certSlug: 'information-security-and-quality-assurance'
+        certSlug: Certification.LegacyInfoSecQa
       },
       {
         id: '587d8249367417b2b2512c42',
         title: 'Issue Tracker',
         link: `${legacyInfosecQaQaBase}/issue-tracker`,
-        certSlug: 'information-security-and-quality-assurance'
+        certSlug: Certification.LegacyInfoSecQa
       },
       {
         id: '587d824a367417b2b2512c43',
         title: 'Personal Library',
         link: `${legacyInfosecQaQaBase}/personal-library`,
-        certSlug: 'information-security-and-quality-assurance'
+        certSlug: Certification.LegacyInfoSecQa
       },
       {
         id: '587d824a367417b2b2512c44',
         title: 'Stock Price Checker',
         link: `${legacyInfosecQaInfosecBase}/stock-price-checker`,
-        certSlug: 'information-security-and-quality-assurance'
+        certSlug: Certification.LegacyInfoSecQa
       },
       {
         id: '587d824a367417b2b2512c45',
         title: 'Anonymous Message Board',
         link: `${legacyInfosecQaInfosecBase}/anonymous-message-board`,
-        certSlug: 'information-security-and-quality-assurance'
+        certSlug: Certification.LegacyInfoSecQa
       }
     ]
   }
@@ -289,7 +289,7 @@ const legacyCertMap = [
 const legacyFullStack = {
   id: '561add10cb82ac38a17213bd',
   title: 'Legacy Full Stack',
-  certSlug: 'full-stack',
+  certSlug: Certification.LegacyFullStack,
   projects: null
   // Requirements are other certs and is
   // handled elsewhere
@@ -298,19 +298,19 @@ const certMap = [
   {
     id: '561add10cb82ac38a17513bc',
     title: 'Responsive Web Design',
-    certSlug: SuperBlocks.RespWebDesign,
+    certSlug: Certification.RespWebDesign,
     projects: [
       {
         id: '587d78af367417b2b2512b03',
         title: 'Build a Survey Form',
         link: getResponsiveWebDesignPath('build-a-survey-form'),
-        certSlug: SuperBlocks.RespWebDesign
+        certSlug: Certification.RespWebDesign
       },
       {
         id: 'bd7158d8c442eddfaeb5bd18',
         title: 'Build a Tribute Page',
         link: getResponsiveWebDesignPath('build-a-tribute-page'),
-        certSlug: SuperBlocks.RespWebDesign
+        certSlug: Certification.RespWebDesign
       },
       {
         id: '587d78b0367417b2b2512b05',
@@ -318,315 +318,315 @@ const certMap = [
         link: getResponsiveWebDesignPath(
           'build-a-technical-documentation-page'
         ),
-        certSlug: SuperBlocks.RespWebDesign
+        certSlug: Certification.RespWebDesign
       },
       {
         id: '587d78af367417b2b2512b04',
         title: 'Build a Product Landing Page',
         link: getResponsiveWebDesignPath('build-a-product-landing-page'),
-        certSlug: SuperBlocks.RespWebDesign
+        certSlug: Certification.RespWebDesign
       },
       {
         id: 'bd7158d8c242eddfaeb5bd13',
         title: 'Build a Personal Portfolio Webpage',
         link: getResponsiveWebDesignPath('build-a-personal-portfolio-webpage'),
-        certSlug: SuperBlocks.RespWebDesign
+        certSlug: Certification.RespWebDesign
       }
     ]
   },
   {
     id: '561abd10cb81ac38a17513bc',
     title: 'JavaScript Algorithms and Data Structures',
-    certSlug: SuperBlocks.JsAlgoDataStruct,
+    certSlug: Certification.JsAlgoDataStruct,
     projects: [
       {
         id: 'aaa48de84e1ecc7c742e1124',
         title: 'Palindrome Checker',
         link: getJavaScriptAlgoPath('palindrome-checker'),
-        certSlug: SuperBlocks.JsAlgoDataStruct
+        certSlug: Certification.JsAlgoDataStruct
       },
       {
         id: 'a7f4d8f2483413a6ce226cac',
         title: 'Roman Numeral Converter',
         link: getJavaScriptAlgoPath('roman-numeral-converter'),
-        certSlug: SuperBlocks.JsAlgoDataStruct
+        certSlug: Certification.JsAlgoDataStruct
       },
       {
         id: '56533eb9ac21ba0edf2244e2',
         title: 'Caesars Cipher',
         link: getJavaScriptAlgoPath('caesars-cipher'),
-        certSlug: SuperBlocks.JsAlgoDataStruct
+        certSlug: Certification.JsAlgoDataStruct
       },
       {
         id: 'aff0395860f5d3034dc0bfc9',
         title: 'Telephone Number Validator',
         link: getJavaScriptAlgoPath('telephone-number-validator'),
-        certSlug: SuperBlocks.JsAlgoDataStruct
+        certSlug: Certification.JsAlgoDataStruct
       },
       {
         id: 'aa2e6f85cab2ab736c9a9b24',
         title: 'Cash Register',
         link: getJavaScriptAlgoPath('cash-register'),
-        certSlug: SuperBlocks.JsAlgoDataStruct
+        certSlug: Certification.JsAlgoDataStruct
       }
     ]
   },
   {
     id: '561acd10cb82ac38a17513bc',
     title: 'Front End Development Libraries',
-    certSlug: SuperBlocks.FrontEndDevLibs,
+    certSlug: Certification.FrontEndDevLibs,
     projects: [
       {
         id: 'bd7158d8c442eddfaeb5bd13',
         title: 'Build a Random Quote Machine',
         link: `${feLibsBase}/build-a-random-quote-machine`,
-        certSlug: SuperBlocks.FrontEndDevLibs
+        certSlug: Certification.FrontEndDevLibs
       },
       {
         id: 'bd7157d8c242eddfaeb5bd13',
         title: 'Build a Markdown Previewer',
         link: `${feLibsBase}/build-a-markdown-previewer`,
-        certSlug: SuperBlocks.FrontEndDevLibs
+        certSlug: Certification.FrontEndDevLibs
       },
       {
         id: '587d7dbc367417b2b2512bae',
         title: 'Build a Drum Machine',
         link: `${feLibsBase}/build-a-drum-machine`,
-        certSlug: SuperBlocks.FrontEndDevLibs
+        certSlug: Certification.FrontEndDevLibs
       },
       {
         id: 'bd7158d8c442eddfaeb5bd17',
         title: 'Build a JavaScript Calculator',
         link: `${feLibsBase}/build-a-javascript-calculator`,
-        certSlug: SuperBlocks.FrontEndDevLibs
+        certSlug: Certification.FrontEndDevLibs
       },
       {
         id: 'bd7158d8c442eddfaeb5bd0f',
         title: 'Build a 25 + 5 Clock',
         link: `${feLibsBase}/build-a-25--5-clock`,
-        certSlug: SuperBlocks.FrontEndDevLibs
+        certSlug: Certification.FrontEndDevLibs
       }
     ]
   },
   {
     id: '5a553ca864b52e1d8bceea14',
     title: 'Data Visualization',
-    certSlug: SuperBlocks.DataVis,
+    certSlug: Certification.DataVis,
     projects: [
       {
         id: 'bd7168d8c242eddfaeb5bd13',
         title: 'Visualize Data with a Bar Chart',
         link: `${dataVisBase}/visualize-data-with-a-bar-chart`,
-        certSlug: SuperBlocks.DataVis
+        certSlug: Certification.DataVis
       },
       {
         id: 'bd7178d8c242eddfaeb5bd13',
         title: 'Visualize Data with a Scatterplot Graph',
         link: `${dataVisBase}/visualize-data-with-a-scatterplot-graph`,
-        certSlug: SuperBlocks.DataVis
+        certSlug: Certification.DataVis
       },
       {
         id: 'bd7188d8c242eddfaeb5bd13',
         title: 'Visualize Data with a Heat Map',
         link: `${dataVisBase}/visualize-data-with-a-heat-map`,
-        certSlug: SuperBlocks.DataVis
+        certSlug: Certification.DataVis
       },
       {
         id: '587d7fa6367417b2b2512bbf',
         title: 'Visualize Data with a Choropleth Map',
         link: `${dataVisBase}/visualize-data-with-a-choropleth-map`,
-        certSlug: SuperBlocks.DataVis
+        certSlug: Certification.DataVis
       },
       {
         id: '587d7fa6367417b2b2512bc0',
         title: 'Visualize Data with a Treemap Diagram',
         link: `${dataVisBase}/visualize-data-with-a-treemap-diagram`,
-        certSlug: SuperBlocks.DataVis
+        certSlug: Certification.DataVis
       }
     ]
   },
   {
     id: '606243f50267e718b1e755f4',
     title: 'Relational Database',
-    certSlug: 'relational-database-v8',
+    certSlug: Certification.RelationalDb,
     projects: [
       {
         id: '5f1a4ef5d5d6b5ab580fc6ae',
         title: 'Celestial Bodies Database',
         link: `${relationalDatabaseBase}/build-a-celestial-bodies-database-project/build-a-celestial-bodies-database`,
-        certSlug: 'relational-database-v8'
+        certSlug: Certification.RelationalDb
       },
       {
         id: '5f9771307d4d22b9d2b75a94',
         title: 'World Cup Database',
         link: `${relationalDatabaseBase}/build-a-world-cup-database-project/build-a-world-cup-database`,
-        certSlug: 'relational-database-v8'
+        certSlug: Certification.RelationalDb
       },
       {
         id: '5f87ac112ae598023a42df1a',
         title: 'Salon Appointment Scheduler',
         link: `${relationalDatabaseBase}/build-a-salon-appointment-scheduler-project/build-a-salon-appointment-scheduler`,
-        certSlug: 'relational-database-v8'
+        certSlug: Certification.RelationalDb
       },
       {
         id: '602d9ff222201c65d2a019f2',
         title: 'Periodic Table Database',
         link: `${relationalDatabaseBase}/build-a-periodic-table-database-project/build-a-periodic-table-database`,
-        certSlug: 'relational-database-v8'
+        certSlug: Certification.RelationalDb
       },
       {
         id: '602da04c22201c65d2a019f4',
         title: 'Number Guessing Game',
         link: `${relationalDatabaseBase}/build-a-number-guessing-game-project/build-a-number-guessing-game`,
-        certSlug: 'relational-database-v8'
+        certSlug: Certification.RelationalDb
       }
     ]
   },
   {
     id: '561add10cb82ac38a17523bc',
     title: 'Back End Development and APIs',
-    certSlug: SuperBlocks.BackEndDevApis,
+    certSlug: Certification.BackEndDevApis,
     projects: [
       {
         id: 'bd7158d8c443edefaeb5bdef',
         title: 'Timestamp Microservice',
         link: `${apiMicroBase}/timestamp-microservice`,
-        certSlug: SuperBlocks.BackEndDevApis
+        certSlug: Certification.BackEndDevApis
       },
       {
         id: 'bd7158d8c443edefaeb5bdff',
         title: 'Request Header Parser Microservice',
         link: `${apiMicroBase}/request-header-parser-microservice`,
-        certSlug: SuperBlocks.BackEndDevApis
+        certSlug: Certification.BackEndDevApis
       },
       {
         id: 'bd7158d8c443edefaeb5bd0e',
         title: 'URL Shortener Microservice',
         link: `${apiMicroBase}/url-shortener-microservice`,
-        certSlug: SuperBlocks.BackEndDevApis
+        certSlug: Certification.BackEndDevApis
       },
       {
         id: '5a8b073d06fa14fcfde687aa',
         title: 'Exercise Tracker',
         link: `${apiMicroBase}/exercise-tracker`,
-        certSlug: SuperBlocks.BackEndDevApis
+        certSlug: Certification.BackEndDevApis
       },
       {
         id: 'bd7158d8c443edefaeb5bd0f',
         title: 'File Metadata Microservice',
         link: `${apiMicroBase}/file-metadata-microservice`,
-        certSlug: SuperBlocks.BackEndDevApis
+        certSlug: Certification.BackEndDevApis
       }
     ]
   },
   {
     id: '5e611829481575a52dc59c0e',
     title: 'Quality Assurance',
-    certSlug: 'quality-assurance-v7',
+    certSlug: Certification.QualityAssurance,
     projects: [
       {
         id: '587d8249367417b2b2512c41',
         title: 'Metric-Imperial Converter',
         link: `${qaBase}/metric-imperial-converter`,
-        certSlug: 'quality-assurance-v7'
+        certSlug: Certification.QualityAssurance
       },
       {
         id: '587d8249367417b2b2512c42',
         title: 'Issue Tracker',
         link: `${qaBase}/issue-tracker`,
-        certSlug: 'quality-assurance-v7'
+        certSlug: Certification.QualityAssurance
       },
       {
         id: '587d824a367417b2b2512c43',
         title: 'Personal Library',
         link: `${qaBase}/personal-library`,
-        certSlug: 'quality-assurance-v7'
+        certSlug: Certification.QualityAssurance
       },
       {
         id: '5e601bf95ac9d0ecd8b94afd',
         title: 'Sudoku Solver',
         link: `${qaBase}/sudoku-solver`,
-        certSlug: 'quality-assurance-v7'
+        certSlug: Certification.QualityAssurance
       },
       {
         id: '5e601c0d5ac9d0ecd8b94afe',
         title: 'American British Translator',
         link: `${qaBase}/american-british-translator`,
-        certSlug: 'quality-assurance-v7'
+        certSlug: Certification.QualityAssurance
       }
     ]
   },
   {
     id: '5e44431b903586ffb414c951',
     title: 'Scientific Computing with Python',
-    certSlug: 'scientific-computing-with-python-v7',
+    certSlug: Certification.SciCompPy,
     projects: [
       {
         id: '5e44412c903586ffb414c94c',
         title: 'Arithmetic Formatter',
         link: `${sciCompPyBase}/arithmetic-formatter`,
-        certSlug: 'scientific-computing-with-python-v7'
+        certSlug: Certification.SciCompPy
       },
       {
         id: '5e444136903586ffb414c94d',
         title: 'Time Calculator',
         link: `${sciCompPyBase}/time-calculator`,
-        certSlug: 'scientific-computing-with-python-v7'
+        certSlug: Certification.SciCompPy
       },
       {
         id: '5e44413e903586ffb414c94e',
         title: 'Budget App',
         link: `${sciCompPyBase}/budget-app`,
-        certSlug: 'scientific-computing-with-python-v7'
+        certSlug: Certification.SciCompPy
       },
       {
         id: '5e444147903586ffb414c94f',
         title: 'Polygon Area Calculator',
         link: `${sciCompPyBase}/polygon-area-calculator`,
-        certSlug: 'scientific-computing-with-python-v7'
+        certSlug: Certification.SciCompPy
       },
       {
         id: '5e44414f903586ffb414c950',
         title: 'Probability Calculator',
         link: `${sciCompPyBase}/probability-calculator`,
-        certSlug: 'scientific-computing-with-python-v7'
+        certSlug: Certification.SciCompPy
       }
     ]
   },
   {
     id: '5e46fc95ac417301a38fb934',
     title: 'Data Analysis with Python',
-    certSlug: 'data-analysis-with-python-v7',
+    certSlug: Certification.DataAnalysisPy,
     projects: [
       {
         id: '5e46f7e5ac417301a38fb928',
         title: 'Mean-Variance-Standard Deviation Calculator',
         link: `${dataAnalysisPyBase}/mean-variance-standard-deviation-calculator`,
-        certSlug: 'data-analysis-with-python-v7'
+        certSlug: Certification.DataAnalysisPy
       },
       {
         id: '5e46f7e5ac417301a38fb929',
         title: 'Demographic Data Analyzer',
         link: `${dataAnalysisPyBase}/demographic-data-analyzer`,
-        certSlug: 'data-analysis-with-python-v7'
+        certSlug: Certification.DataAnalysisPy
       },
       {
         id: '5e46f7f8ac417301a38fb92a',
         title: 'Medical Data Visualizer',
         link: `${dataAnalysisPyBase}/medical-data-visualizer`,
-        certSlug: 'data-analysis-with-python-v7'
+        certSlug: Certification.DataAnalysisPy
       },
       {
         id: '5e46f802ac417301a38fb92b',
         title: 'Page View Time Series Visualizer',
         link: `${dataAnalysisPyBase}/page-view-time-series-visualizer`,
-        certSlug: 'data-analysis-with-python-v7'
+        certSlug: Certification.DataAnalysisPy
       },
       {
         id: '5e4f5c4b570f7e3a4949899f',
         title: 'Sea Level Predictor',
         link: `${dataAnalysisPyBase}/sea-level-predictor`,
-        certSlug: 'data-analysis-with-python-v7'
+        certSlug: Certification.DataAnalysisPy
       }
     ]
   },
@@ -634,111 +634,111 @@ const certMap = [
   {
     id: '5e6021435ac9d0ecd8b94b00',
     title: 'Information Security',
-    certSlug: 'information-security-v7',
+    certSlug: Certification.InfoSec,
     projects: [
       {
         id: '587d824a367417b2b2512c44',
         title: 'Stock Price Checker',
         link: `${infoSecBase}/stock-price-checker`,
-        certSlug: 'information-security-v7'
+        certSlug: Certification.InfoSec
       },
       {
         id: '587d824a367417b2b2512c45',
         title: 'Anonymous Message Board',
         link: `${infoSecBase}/anonymous-message-board`,
-        certSlug: 'information-security-v7'
+        certSlug: Certification.InfoSec
       },
       {
         id: '5e46f979ac417301a38fb932',
         title: 'Port Scanner',
         link: `${infoSecBase}/port-scanner`,
-        certSlug: 'information-security-v7'
+        certSlug: Certification.InfoSec
       },
       {
         id: '5e46f983ac417301a38fb933',
         title: 'SHA-1 Password Cracker',
         link: `${infoSecBase}/sha-1-password-cracker`,
-        certSlug: 'information-security-v7'
+        certSlug: Certification.InfoSec
       },
       {
         id: '5e601c775ac9d0ecd8b94aff',
         title: 'Secure Real Time Multiplayer Game',
         link: `${infoSecBase}/secure-real-time-multiplayer-game`,
-        certSlug: 'information-security-v7'
+        certSlug: Certification.InfoSec
       }
     ]
   },
   {
     id: '5e46fc95ac417301a38fb935',
     title: 'Machine Learning with Python',
-    certSlug: 'machine-learning-with-python-v7',
+    certSlug: Certification.MachineLearningPy,
     projects: [
       {
         id: '5e46f8d6ac417301a38fb92d',
         title: 'Rock Paper Scissors',
         link: `${machineLearningPyBase}/rock-paper-scissors`,
-        certSlug: 'machine-learning-with-python-v7'
+        certSlug: Certification.MachineLearningPy
       },
       {
         id: '5e46f8dcac417301a38fb92e',
         title: 'Cat and Dog Image Classifier',
         link: `${machineLearningPyBase}/cat-and-dog-image-classifier`,
-        certSlug: 'machine-learning-with-python-v7'
+        certSlug: Certification.MachineLearningPy
       },
       {
         id: '5e46f8e3ac417301a38fb92f',
         title: 'Book Recommendation Engine using KNN',
         link: `${machineLearningPyBase}/book-recommendation-engine-using-knn`,
-        certSlug: 'machine-learning-with-python-v7'
+        certSlug: Certification.MachineLearningPy
       },
       {
         id: '5e46f8edac417301a38fb930',
         title: 'Linear Regression Health Costs Calculator',
         link: `${machineLearningPyBase}/linear-regression-health-costs-calculator`,
-        certSlug: 'machine-learning-with-python-v7'
+        certSlug: Certification.MachineLearningPy
       },
       {
         id: '5e46f8edac417301a38fb931',
         title: 'Neural Network SMS Text Classifier',
         link: `${machineLearningPyBase}/neural-network-sms-text-classifier`,
-        certSlug: 'machine-learning-with-python-v7'
+        certSlug: Certification.MachineLearningPy
       }
     ]
   },
   {
     id: '61531b20cc9dfa2741a5b800',
     title: 'College Algebra with Python',
-    certSlug: 'college-algebra-with-python-v8',
+    certSlug: Certification.CollegeAlgebraPy,
     projects: [
       {
         id: '63d83ff239c73468b059cd3f',
         title: 'Build a Multi-Function Calculator',
         link: getCollegeAlgebraPyPath('build-a-multi-function-calculator'),
-        certSlug: 'college-algebra-with-python-v8'
+        certSlug: Certification.CollegeAlgebraPy
       },
       {
         id: '63d83ffd39c73468b059cd40',
         title: 'Build a Graphing Calculator',
         link: getCollegeAlgebraPyPath('build-a-graphing-calculator'),
-        certSlug: 'college-algebra-with-python-v8'
+        certSlug: Certification.CollegeAlgebraPy
       },
       {
         id: '63d8401039c73468b059cd41',
         title: 'Build Three Math Games',
         link: getCollegeAlgebraPyPath('build-three-math-games'),
-        certSlug: 'college-algebra-with-python-v8'
+        certSlug: Certification.CollegeAlgebraPy
       },
       {
         id: '63d8401e39c73468b059cd42',
         title: 'Build a Financial Calculator',
         link: getCollegeAlgebraPyPath('build-a-financial-calculator'),
-        certSlug: 'college-algebra-with-python-v8'
+        certSlug: Certification.CollegeAlgebraPy
       },
       {
         id: '63d8402e39c73468b059cd43',
         title: 'Build a Data Graph Explorer',
         link: getCollegeAlgebraPyPath('build-a-data-graph-explorer'),
-        certSlug: 'college-algebra-with-python-v8'
+        certSlug: Certification.CollegeAlgebraPy
       }
     ]
   }
@@ -748,13 +748,13 @@ const upcomingCertMap = [
   {
     id: '647e3159823e0ef219c7359b',
     title: 'Foundational C# with Microsoft',
-    certSlug: 'foundational-c-sharp-with-microsoft',
+    certSlug: Certification.FoundationalCSharp,
     projects: [
       {
         id: '647e22d18acb466c97ccbef8',
         title: 'Foundational C# with Microsoft Certification Exam',
         link: `${foundationalCSharpBase}/foundational-c-sharp-with-microsoft-certification-exam`,
-        certSlug: 'foundational-c-sharp-with-microsoft'
+        certSlug: Certification.FoundationalCSharp
       }
     ]
   },
@@ -774,13 +774,13 @@ const upcomingCertMap = [
   {
     id: '64afc4e8f3b37856e035b85f',
     title: 'Upcoming Python Certification',
-    certSlug: 'upcoming-python-v8',
+    certSlug: Certification.UpcomingPython,
     projects: [
       {
         id: '64afc37bf3b37856e035b85e',
         title: 'Upcoming Python Project',
         link: `${upcomingPythonBase}/upcoming-python-project`,
-        certSlug: 'upcoming-python-v8'
+        certSlug: Certification.UpcomingPython
       }
     ]
   }

--- a/client/utils/index.ts
+++ b/client/utils/index.ts
@@ -1,20 +1,22 @@
+import { Certification } from '../../config/certification-settings';
+
 const idToPath = new Map(
   Object.entries({
-    '561add10cb82ac38a17523bc': 'back-end-development-and-apis',
-    '5a553ca864b52e1d8bceea14': 'data-visualization',
-    '561acd10cb82ac38a17513bc': 'front-end-development-libraries',
-    '5e611829481575a52dc59c0e': 'quality-assurance-v7',
-    '5e6021435ac9d0ecd8b94b00': 'information-security-v7',
-    '561abd10cb81ac38a17513bc': 'javascript-algorithms-and-data-structures',
-    '561add10cb82ac38a17513bc': 'responsive-web-design',
-    '660add10cb82ac38a17513be': 'legacy-back-end',
-    '561add10cb82ac39a17513bc': 'legacy-data-visualization',
-    '561add10cb82ac38a17513be': 'legacy-front-end',
-    '561add10cb82ac38a17213bc': 'information-security-and-quality-assurance',
-    '561add10cb82ac38a17213bd': 'full-stack',
-    '5e44431b903586ffb414c951': 'scientific-computing-with-python-v7',
-    '5e46fc95ac417301a38fb934': 'data-analysis-with-python-v7',
-    '5e46fc95ac417301a38fb935': 'machine-learning-with-python-v7'
+    '561add10cb82ac38a17523bc': Certification.BackEndDevApis,
+    '5a553ca864b52e1d8bceea14': Certification.DataVis,
+    '561acd10cb82ac38a17513bc': Certification.FrontEndDevLibs,
+    '5e611829481575a52dc59c0e': Certification.QualityAssurance,
+    '5e6021435ac9d0ecd8b94b00': Certification.InfoSec,
+    '561abd10cb81ac38a17513bc': Certification.JsAlgoDataStruct,
+    '561add10cb82ac38a17513bc': Certification.RespWebDesign,
+    '660add10cb82ac38a17513be': Certification.LegacyBackEnd,
+    '561add10cb82ac39a17513bc': Certification.LegacyDataVis,
+    '561add10cb82ac38a17513be': Certification.LegacyFrontEnd,
+    '561add10cb82ac38a17213bc': Certification.LegacyInfoSecQa,
+    '561add10cb82ac38a17213bd': Certification.LegacyFullStack,
+    '5e44431b903586ffb414c951': Certification.SciCompPy,
+    '5e46fc95ac417301a38fb934': Certification.DataAnalysisPy,
+    '5e46fc95ac417301a38fb935': Certification.MachineLearningPy
   })
 );
 

--- a/config/certification-settings.ts
+++ b/config/certification-settings.ts
@@ -102,8 +102,6 @@ export const certSlugTypeMap = {
   [Certification.LegacyFrontEnd]: certTypes.frontEnd,
   [Certification.LegacyBackEnd]: certTypes.backEnd,
   [Certification.LegacyDataVis]: certTypes.dataVis,
-  // Keep these slugs the same so we don't
-  // break existing links
   [Certification.LegacyInfoSecQa]: certTypes.infosecQa,
   [Certification.LegacyFullStack]: certTypes.fullStack,
 

--- a/config/certification-settings.ts
+++ b/config/certification-settings.ts
@@ -1,5 +1,39 @@
 import { SuperBlocks } from './superblocks';
 
+/**
+ * Certifications are not equivalent to superblocks. Each superblock corresponds
+ * to 0 or 1 certifications, but a certification may not correspond to a
+ * superblock.
+ *
+ * As an example of the former: the CodingInterviewPrep superblock does not
+ * correspond to a certification. As an example of the latter: the legacy
+ * front-end certification no longer has a corresponding superblock.
+ *
+ * The value of each enum member is the slug of the corresponding certification.
+ */
+export enum Certification {
+  RespWebDesign = 'responsive-web-design',
+  JsAlgoDataStruct = 'javascript-algorithms-and-data-structures',
+  FrontEndDevLibs = 'front-end-development-libraries',
+  DataVis = 'data-visualization',
+  RelationalDb = 'relational-database-v8',
+  BackEndDevApis = 'back-end-development-and-apis',
+  QualityAssurance = 'quality-assurance-v7',
+  SciCompPy = 'scientific-computing-with-python-v7',
+  DataAnalysisPy = 'data-analysis-with-python-v7',
+  InfoSec = 'information-security-v7',
+  MachineLearningPy = 'machine-learning-with-python-v7',
+  CollegeAlgebraPy = 'college-algebra-with-python-v8',
+  FoundationalCSharp = 'foundational-c-sharp-with-microsoft',
+  UpcomingPython = 'upcoming-python-v8',
+  // Legacy certifications
+  LegacyFrontEnd = 'legacy-front-end',
+  LegacyBackEnd = 'legacy-back-end',
+  LegacyDataVis = 'legacy-data-visualization',
+  LegacyInfoSecQa = 'information-security-and-quality-assurance',
+  LegacyFullStack = 'full-stack'
+}
+
 export const certTypes = {
   frontEnd: 'isFrontEndCert',
   backEnd: 'isBackEndCert',
@@ -65,30 +99,28 @@ export const completionHours = {
 
 export const certSlugTypeMap = {
   // legacy
-  'legacy-front-end': certTypes.frontEnd,
-  'legacy-back-end': certTypes.backEnd,
-  'legacy-data-visualization': certTypes.dataVis,
+  [Certification.LegacyFrontEnd]: certTypes.frontEnd,
+  [Certification.LegacyBackEnd]: certTypes.backEnd,
+  [Certification.LegacyDataVis]: certTypes.dataVis,
   // Keep these slugs the same so we don't
   // break existing links
-  'information-security-and-quality-assurance': certTypes.infosecQa,
-  'full-stack': certTypes.fullStack,
+  [Certification.LegacyInfoSecQa]: certTypes.infosecQa,
+  [Certification.LegacyFullStack]: certTypes.fullStack,
 
   // modern
-  [SuperBlocks.RespWebDesign]: certTypes.respWebDesign,
-  [SuperBlocks.RespWebDesignNew]: certTypes.respWebDesign,
-  [SuperBlocks.JsAlgoDataStruct]: certTypes.jsAlgoDataStruct,
-  [SuperBlocks.JsAlgoDataStructNew]: certTypes.jsAlgoDataStruct,
-  [SuperBlocks.FrontEndDevLibs]: certTypes.frontEndDevLibs,
-  [SuperBlocks.DataVis]: certTypes.dataVis2018,
-  [SuperBlocks.BackEndDevApis]: certTypes.apisMicroservices,
-  'quality-assurance-v7': certTypes.qaV7,
-  'information-security-v7': certTypes.infosecV7,
-  'scientific-computing-with-python-v7': certTypes.sciCompPyV7,
-  'data-analysis-with-python-v7': certTypes.dataAnalysisPyV7,
-  'machine-learning-with-python-v7': certTypes.machineLearningPyV7,
-  'relational-database-v8': certTypes.relationalDatabaseV8,
-  'college-algebra-with-python-v8': certTypes.collegeAlgebraPyV8,
-  'foundational-c-sharp-with-microsoft': certTypes.foundationalCSharp
+  [Certification.RespWebDesign]: certTypes.respWebDesign,
+  [Certification.JsAlgoDataStruct]: certTypes.jsAlgoDataStruct,
+  [Certification.FrontEndDevLibs]: certTypes.frontEndDevLibs,
+  [Certification.DataVis]: certTypes.dataVis2018,
+  [Certification.BackEndDevApis]: certTypes.apisMicroservices,
+  [Certification.QualityAssurance]: certTypes.qaV7,
+  [Certification.InfoSec]: certTypes.infosecV7,
+  [Certification.SciCompPy]: certTypes.sciCompPyV7,
+  [Certification.DataAnalysisPy]: certTypes.dataAnalysisPyV7,
+  [Certification.MachineLearningPy]: certTypes.machineLearningPyV7,
+  [Certification.RelationalDb]: certTypes.relationalDatabaseV8,
+  [Certification.CollegeAlgebraPy]: certTypes.collegeAlgebraPyV8,
+  [Certification.FoundationalCSharp]: certTypes.foundationalCSharp
 };
 
 export const superBlockCertTypeMap = {


### PR DESCRIPTION
- refactor: DRY out cert ids/slugs via enum
- fix: use new enum in certification.tsx

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This also disentangles superblocks and certifications (in at least some of the cases). We often use them interchangeably, but they're only equivalent by coincidence - i.e. the slug happens to have the same name for some of the superblocks and corresponding certifications.

<!-- Feel free to add any additional description of changes below this line -->
