### PR TITLE
feat: remove test that checks for non-translated audited challenges

### DIFF
--- a/curriculum/get-challenges.js
+++ b/curriculum/get-challenges.js
@@ -258,7 +258,7 @@ function generateChallengeCreator(basePath, lang) {
     return path.resolve(__dirname, basePath, pathLang, filePath);
   }
 
-  async function validate(filePath, superBlock) {
+  async function validate(filePath) {
     const invalidLang = !curriculumLangs.includes(lang);
     if (invalidLang)
       throw Error(`${lang} is not a accepted language.
@@ -272,20 +272,6 @@ ${filePath}
 It should be in
 ${getFullPath('english', filePath)}
 `);
-
-    const missingAuditedChallenge =
-      isAuditedCert(lang, superBlock, {
-        showNewCurriculum: process.env.SHOW_NEW_CURRICULUM,
-        showUpcomingChanges: process.env.SHOW_UPCOMING_CHANGES
-      }) && !fs.existsSync(getFullPath(lang, filePath));
-    if (missingAuditedChallenge)
-      throw Error(`Missing ${lang} audited challenge for
-${filePath}
-
-Explanation:
-
-Challenges that have been already audited cannot fall back to their English versions. If you are seeing this, please update, and approve these Challenges on Crowdin first, followed by downloading them to the main branch using the GitHub workflows.
-    `);
   }
 
   function addMetaToChallenge(challenge, meta) {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

I haven't seen this test catch anything OTHER than PRs where we are adding new steps (and thus know that the steps won't have translations yet). It just creates noise and unnecessarily blocks PRs.