### PR TITLE
fix(curriculum):  add info to description

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-typography-by-building-a-nutrition-label/615f6b2d164f81809efd9bdc.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-typography-by-building-a-nutrition-label/615f6b2d164f81809efd9bdc.md
@@ -7,7 +7,7 @@ dashedName: step-43
 
 # --description--
 
-After your last `.divider` element, create a `p` element and give it the text `Total Fat 8g 10%`. Wrap the text `Total Fat` in a `span` element with the `class` of `bold`. Wrap the text `10%` in another `span` element with the `class` of `bold`. Finally, nest the `Total Fat` `span` element and the text `8g` in an additional `span` element for alignment.
+After your last `.divider` element, create a `p` element and give it the text `Total Fat 8g 10%`. Wrap the text `Total Fat` in a `span` element with the `class` of `bold`. Wrap the text `10%` in another `span` element with the `class` of `bold`. Finally, nest the `Total Fat` `span` element and the text `8g` in an additional `span` element for alignment. Make sure there is a space between the `span` element with the `class` of `bold` and the text `8g`.
 
 # --hints--
 


### PR DESCRIPTION
I had trouble in this step because I forgot to add space between the `span` element with the `class` of `bold` and the text `8g`.

```
<span><span class="bold">Total Fat</span>8g</span>
```
 
As it's already visually confusing because of all the span elements, it might make sense to add this in the description.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
