### PR TITLE
fix: dropdown svg margin that move the text from the center

### DIFF
--- a/tools/ui-components/src/drop-down/drop-down.tsx
+++ b/tools/ui-components/src/drop-down/drop-down.tsx
@@ -56,7 +56,7 @@ const DropDownButton = ({
       {children}
       <FontAwesomeIcon
         icon={dropup ? faCaretUp : faCaretDown}
-        className='mt-2 mx-2 h-3'
+        className='mx-2 h-3'
         aria-hidden='true'
       />
     </Menu.Button>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

You can visit [JavaScript challenge](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-javascript/initializing-variables-with-the-assignment-operator) to see the that the text are misaligned
![image](https://github.com/freeCodeCamp/freeCodeCamp/assets/88248797/80ef4d55-52e7-455a-a70b-2152290b80b4)

![image](https://github.com/freeCodeCamp/freeCodeCamp/assets/88248797/a99e9593-b980-467e-8e94-1d9961dd393e)

<!-- Feel free to add any additional description of changes below this line -->
