### PR TITLE
refactor(client): simplify certification config

### DIFF
--- a/client/config/cert-and-project-map.ts
+++ b/client/config/cert-and-project-map.ts
@@ -850,6 +850,11 @@ const liveCertsToProjects = {
 const certTitles = certs.map(({ title }) => title);
 const legacyCertTitles = legacyCerts.map(({ title }) => title);
 
+export type CertTitle =
+  | (typeof certTitles)[number]
+  | (typeof legacyCertTitles)[number]
+  | 'Legacy Full Stack';
+
 export {
   certTitles,
   legacyCertTitles,

--- a/client/config/cert-and-project-map.ts
+++ b/client/config/cert-and-project-map.ts
@@ -1,5 +1,5 @@
-import { Certification } from '../../../config/certification-settings';
-import config from '../../../config/env.json';
+import { Certification } from '../../config/certification-settings';
+import config from '../../config/env.json';
 
 const { showUpcomingChanges } = config;
 

--- a/client/src/client-only-routes/show-certification.tsx
+++ b/client/src/client-only-routes/show-certification.tsx
@@ -27,7 +27,7 @@ import {
   usernameSelector
 } from '../redux/selectors';
 import { UserFetchState, User } from '../redux/prop-types';
-import { claimableCerts } from '../resources/cert-and-project-map';
+import { liveCerts } from '../resources/cert-and-project-map';
 import {
   certificateMissingErrorMessage,
   reallyWeirdErrorMessage,
@@ -87,7 +87,7 @@ interface ShowCertificationProps {
 const requestedUserSelector = (state: unknown, { username = '' }) =>
   userByNameSelector(username.toLowerCase())(state) as User;
 
-const validCertSlugs = claimableCerts.map(cert => cert.certSlug);
+const validCertSlugs = liveCerts.map(cert => cert.certSlug);
 
 const mapStateToProps = (state: unknown, props: ShowCertificationProps) => {
   const isValidCert = validCertSlugs.some(slug => slug === props.certSlug);

--- a/client/src/client-only-routes/show-certification.tsx
+++ b/client/src/client-only-routes/show-certification.tsx
@@ -27,7 +27,7 @@ import {
   usernameSelector
 } from '../redux/selectors';
 import { UserFetchState, User } from '../redux/prop-types';
-import { liveCerts } from '../resources/cert-and-project-map';
+import { liveCerts } from '../../config/cert-and-project-map';
 import {
   certificateMissingErrorMessage,
   reallyWeirdErrorMessage,

--- a/client/src/client-only-routes/show-certification.tsx
+++ b/client/src/client-only-routes/show-certification.tsx
@@ -27,7 +27,7 @@ import {
   usernameSelector
 } from '../redux/selectors';
 import { UserFetchState, User } from '../redux/prop-types';
-import { fullCertMap } from '../resources/cert-and-project-map';
+import { claimableCerts } from '../resources/cert-and-project-map';
 import {
   certificateMissingErrorMessage,
   reallyWeirdErrorMessage,
@@ -87,7 +87,7 @@ interface ShowCertificationProps {
 const requestedUserSelector = (state: unknown, { username = '' }) =>
   userByNameSelector(username.toLowerCase())(state) as User;
 
-const validCertSlugs = fullCertMap.map(cert => cert.certSlug);
+const validCertSlugs = claimableCerts.map(cert => cert.certSlug);
 
 const mapStateToProps = (state: unknown, props: ShowCertificationProps) => {
   const isValidCert = validCertSlugs.some(slug => slug === props.certSlug);

--- a/client/src/client-only-routes/show-project-links.tsx
+++ b/client/src/client-only-routes/show-project-links.tsx
@@ -7,7 +7,10 @@ import { connect } from 'react-redux';
 import { Link, Spacer } from '../components/helpers';
 import ProjectModal from '../components/SolutionViewer/project-modal';
 import { CompletedChallenge, User } from '../redux/prop-types';
-import { liveCertsToProjects } from '../../config/cert-and-project-map';
+import {
+  liveCertsToProjects,
+  type CertTitle
+} from '../../config/cert-and-project-map';
 
 import { SolutionDisplayWidget } from '../components/solution-display-widget';
 import ProjectPreviewModal from '../templates/Challenges/components/project-preview-modal';
@@ -88,9 +91,7 @@ const ShowProjectLinks = (props: ShowProjectLinksProps): JSX.Element => {
     );
   };
 
-  const renderProjectsFor = (
-    certName: keyof typeof liveCertsToProjects | 'Legacy Full Stack'
-  ) => {
+  const renderProjectsFor = (certName: CertTitle) => {
     if (certName === 'Legacy Full Stack') {
       const certs = [
         { title: 'Responsive Web Design' },
@@ -147,11 +148,7 @@ const ShowProjectLinks = (props: ShowProjectLinksProps): JSX.Element => {
       }
     : null;
 
-  const isCertName = (
-    maybeCertName: string
-  ): maybeCertName is
-    | keyof typeof liveCertsToProjects
-    | 'Legacy Full Stack' => {
+  const isCertName = (maybeCertName: string): maybeCertName is CertTitle => {
     if (maybeCertName === 'Legacy Full Stack') return true;
     return maybeCertName in liveCertsToProjects;
   };

--- a/client/src/client-only-routes/show-project-links.tsx
+++ b/client/src/client-only-routes/show-project-links.tsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import { Link, Spacer } from '../components/helpers';
 import ProjectModal from '../components/SolutionViewer/project-modal';
 import { CompletedChallenge, User } from '../redux/prop-types';
-import { fullProjectMap } from '../resources/cert-and-project-map';
+import { liveCertsToProjects } from '../resources/cert-and-project-map';
 
 import { SolutionDisplayWidget } from '../components/solution-display-widget';
 import ProjectPreviewModal from '../templates/Challenges/components/project-preview-modal';
@@ -89,7 +89,7 @@ const ShowProjectLinks = (props: ShowProjectLinksProps): JSX.Element => {
   };
 
   const renderProjectsFor = (
-    certName: keyof typeof fullProjectMap | 'Legacy Full Stack'
+    certName: keyof typeof liveCertsToProjects | 'Legacy Full Stack'
   ) => {
     if (certName === 'Legacy Full Stack') {
       const certs = [
@@ -102,7 +102,7 @@ const ShowProjectLinks = (props: ShowProjectLinksProps): JSX.Element => {
       ] as const;
 
       return certs.map((cert, ind) => {
-        const projects = fullProjectMap[cert.title];
+        const projects = liveCertsToProjects[cert.title];
         const { certSlug } = projects[0];
         const certLocation = `/certification/${username}/${certSlug}`;
         return (
@@ -117,7 +117,7 @@ const ShowProjectLinks = (props: ShowProjectLinksProps): JSX.Element => {
       });
     }
 
-    const project = fullProjectMap[certName];
+    const project = liveCertsToProjects[certName];
     return project.map(({ link, title, id }) => (
       <tr key={id}>
         <td>
@@ -149,9 +149,11 @@ const ShowProjectLinks = (props: ShowProjectLinksProps): JSX.Element => {
 
   const isCertName = (
     maybeCertName: string
-  ): maybeCertName is keyof typeof fullProjectMap | 'Legacy Full Stack' => {
+  ): maybeCertName is
+    | keyof typeof liveCertsToProjects
+    | 'Legacy Full Stack' => {
     if (maybeCertName === 'Legacy Full Stack') return true;
-    return maybeCertName in fullProjectMap;
+    return maybeCertName in liveCertsToProjects;
   };
   if (!isCertName(certName)) return <div> Unknown Certification</div>;
 

--- a/client/src/client-only-routes/show-project-links.tsx
+++ b/client/src/client-only-routes/show-project-links.tsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import { Link, Spacer } from '../components/helpers';
 import ProjectModal from '../components/SolutionViewer/project-modal';
 import { CompletedChallenge, User } from '../redux/prop-types';
-import { liveCertsToProjects } from '../resources/cert-and-project-map';
+import { liveCertsToProjects } from '../../config/cert-and-project-map';
 
 import { SolutionDisplayWidget } from '../components/solution-display-widget';
 import ProjectPreviewModal from '../templates/Challenges/components/project-preview-modal';

--- a/client/src/components/ProgressBar/progress-bar.tsx
+++ b/client/src/components/ProgressBar/progress-bar.tsx
@@ -9,7 +9,7 @@ import {
   completedChallengesInBlockSelector,
   completedPercentageSelector
 } from '../../templates/Challenges/redux/selectors';
-import { certsWithoutFullStack } from '../../resources/cert-and-project-map';
+import { certsWithoutFullStack } from '../../../config/cert-and-project-map';
 import ProgressBarInner from './progress-bar-inner';
 
 const mapStateToProps = createSelector(

--- a/client/src/components/ProgressBar/progress-bar.tsx
+++ b/client/src/components/ProgressBar/progress-bar.tsx
@@ -9,7 +9,7 @@ import {
   completedChallengesInBlockSelector,
   completedPercentageSelector
 } from '../../templates/Challenges/redux/selectors';
-import { certMapWithoutFullStack } from '../../resources/cert-and-project-map';
+import { certsWithoutFullStack } from '../../resources/cert-and-project-map';
 import ProgressBarInner from './progress-bar-inner';
 
 const mapStateToProps = createSelector(
@@ -55,7 +55,7 @@ function ProgressBar({
   t
 }: ProgressBarProps): JSX.Element {
   const blockTitle = t(`intro:${superBlock}.blocks.${block}.title`);
-  const isCertificationProject = certMapWithoutFullStack.some(cert => {
+  const isCertificationProject = certsWithoutFullStack.some(cert => {
     return cert.projects.some((project: { id: string }) => project.id === id);
   });
 

--- a/client/src/components/settings/certification.tsx
+++ b/client/src/components/settings/certification.tsx
@@ -12,8 +12,8 @@ import { regeneratePathAndHistory } from '../../../../utils/polyvinyl';
 import ProjectPreviewModal from '../../templates/Challenges/components/project-preview-modal';
 import { openModal } from '../../templates/Challenges/redux/actions';
 import {
-  certsToProjects,
-  legacyCertsToProjects,
+  certTitles,
+  legacyCertTitles,
   liveCertsToProjects,
   type CertsToProjects,
   type LegacyCertsToProjects
@@ -43,14 +43,6 @@ const mapDispatchToProps = {
   openModal
 };
 
-// Safety: certToProjects definitely has certToProjects keys, and we are only
-// interested in these keys
-const certTitles = Object.keys(certsToProjects) as Array<keyof CertsToProjects>;
-// Safety: legacyCertsToProjects definitely has legacyCertsToProjects keys, and
-// we are only interested in these keys
-const legacyCertTitles = Object.keys(legacyCertsToProjects) as Array<
-  keyof LegacyCertsToProjects
->;
 const isCertSelector = ({
   is2018DataVisCert,
   isApisMicroservicesCert,

--- a/client/src/components/settings/certification.tsx
+++ b/client/src/components/settings/certification.tsx
@@ -12,11 +12,11 @@ import { regeneratePathAndHistory } from '../../../../utils/polyvinyl';
 import ProjectPreviewModal from '../../templates/Challenges/components/project-preview-modal';
 import { openModal } from '../../templates/Challenges/redux/actions';
 import {
-  projectMap,
-  legacyProjectMap,
-  fullProjectMap,
-  ProjectMap,
-  LegacyProjectMap
+  certsToProjects,
+  legacyCertsToProjects,
+  liveCertsToProjects,
+  type CertsToProjects,
+  type LegacyCertsToProjects
 } from '../../resources/cert-and-project-map';
 import { FlashMessages } from '../Flash/redux/flash-messages';
 import ProjectModal from '../SolutionViewer/project-modal';
@@ -43,13 +43,13 @@ const mapDispatchToProps = {
   openModal
 };
 
-// Safety: projectMap definitely has projectMap keys,
-// and we are only interested in these keys
-const certTitles = Object.keys(projectMap) as Array<keyof ProjectMap>;
-// Safety: legacyProjectMap definitely has legacyProjectMap keys,
-// and we are only interested in these keys
-const legacyCertTitles = Object.keys(legacyProjectMap) as Array<
-  keyof LegacyProjectMap
+// Safety: certToProjects definitely has certToProjects keys, and we are only
+// interested in these keys
+const certTitles = Object.keys(certsToProjects) as Array<keyof CertsToProjects>;
+// Safety: legacyCertsToProjects definitely has legacyCertsToProjects keys, and
+// we are only interested in these keys
+const legacyCertTitles = Object.keys(legacyCertsToProjects) as Array<
+  keyof LegacyCertsToProjects
 >;
 const isCertSelector = ({
   is2018DataVisCert,
@@ -313,7 +313,7 @@ function CertificationSettings(props: CertificationSettingsProps) {
     );
   };
 
-  type CertName = keyof ProjectMap | keyof LegacyProjectMap;
+  type CertName = keyof CertsToProjects | keyof LegacyCertsToProjects;
   const Certification = ({
     certName,
     t
@@ -321,7 +321,7 @@ function CertificationSettings(props: CertificationSettingsProps) {
     certName: CertName;
     t: TFunction;
   }) => {
-    const { certSlug } = fullProjectMap[certName][0];
+    const { certSlug } = liveCertsToProjects[certName][0];
     return (
       <FullWidthRow>
         <Spacer size='medium' />
@@ -353,7 +353,7 @@ function CertificationSettings(props: CertificationSettingsProps) {
     isCert: boolean;
   }) {
     const { username, isHonest, createFlashMessage, t, verifyCert } = props;
-    const { certSlug } = fullProjectMap[certName][0];
+    const { certSlug } = liveCertsToProjects[certName][0];
     const certLocation = `/certification/${username}/${certSlug}`;
     const clickHandler = (e: MouseEvent<HTMLButtonElement>) => {
       e.preventDefault();
@@ -364,7 +364,7 @@ function CertificationSettings(props: CertificationSettingsProps) {
         ? verifyCert(certSlug)
         : createFlashMessage(honestyInfoMessage);
     };
-    return fullProjectMap[certName]
+    return liveCertsToProjects[certName]
       .map(({ link, title, id }) => (
         <tr className='project-row' key={id}>
           <td className='project-title col-sm-8 col-xs-8'>

--- a/client/src/components/settings/certification.tsx
+++ b/client/src/components/settings/certification.tsx
@@ -17,7 +17,7 @@ import {
   liveCertsToProjects,
   type CertsToProjects,
   type LegacyCertsToProjects
-} from '../../resources/cert-and-project-map';
+} from '../../../config/cert-and-project-map';
 import { FlashMessages } from '../Flash/redux/flash-messages';
 import ProjectModal from '../SolutionViewer/project-modal';
 import { FullWidthRow, Spacer } from '../helpers';

--- a/client/src/components/settings/certification.tsx
+++ b/client/src/components/settings/certification.tsx
@@ -45,10 +45,10 @@ const mapDispatchToProps = {
 
 // Safety: projectMap definitely has projectMap keys,
 // and we are only interested in these keys
-const certifications = Object.keys(projectMap) as Array<keyof ProjectMap>;
+const certTitles = Object.keys(projectMap) as Array<keyof ProjectMap>;
 // Safety: legacyProjectMap definitely has legacyProjectMap keys,
 // and we are only interested in these keys
-const legacyCertifications = Object.keys(legacyProjectMap) as Array<
+const legacyCertTitles = Object.keys(legacyProjectMap) as Array<
   keyof LegacyProjectMap
 >;
 const isCertSelector = ({
@@ -402,13 +402,13 @@ function CertificationSettings(props: CertificationSettingsProps) {
     <ScrollableAnchor id='certification-settings'>
       <section className='certification-settings'>
         <SectionHeader>{t('settings.headings.certs')}</SectionHeader>
-        {certifications.map(certName => (
-          <Certification key={certName} certName={certName} t={t} />
+        {certTitles.map(title => (
+          <Certification key={title} certName={title} t={t} />
         ))}
         <SectionHeader>{t('settings.headings.legacy-certs')}</SectionHeader>
         <LegacyFullStack {...props} />
-        {legacyCertifications.map(certName => (
-          <Certification key={certName} certName={certName} t={t} />
+        {legacyCertTitles.map(title => (
+          <Certification key={title} certName={title} t={t} />
         ))}
         <ProjectModal
           {...{

--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -1,7 +1,7 @@
 import { HandlerProps } from 'react-reflex';
 import { SuperBlocks } from '../../../config/superblocks';
 import { Themes } from '../components/settings/theme';
-import { claimableCerts } from '../resources/cert-and-project-map';
+import { liveCerts } from '../resources/cert-and-project-map';
 
 export type Steps = {
   isHonest?: boolean;
@@ -26,7 +26,7 @@ export type MarkdownRemark = {
     superBlock: SuperBlocks;
     // TODO: make enum like superBlock
     certification: string;
-    title: (typeof claimableCerts)[number]['title'];
+    title: (typeof liveCerts)[number]['title'];
   };
   headings: [
     {

--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -1,7 +1,7 @@
 import { HandlerProps } from 'react-reflex';
 import { SuperBlocks } from '../../../config/superblocks';
 import { Themes } from '../components/settings/theme';
-import { liveCerts } from '../resources/cert-and-project-map';
+import { liveCerts } from '../../config/cert-and-project-map';
 
 export type Steps = {
   isHonest?: boolean;

--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -1,7 +1,7 @@
 import { HandlerProps } from 'react-reflex';
 import { SuperBlocks } from '../../../config/superblocks';
 import { Themes } from '../components/settings/theme';
-import { fullCertMap } from '../resources/cert-and-project-map';
+import { claimableCerts } from '../resources/cert-and-project-map';
 
 export type Steps = {
   isHonest?: boolean;
@@ -26,7 +26,7 @@ export type MarkdownRemark = {
     superBlock: SuperBlocks;
     // TODO: make enum like superBlock
     certification: string;
-    title: (typeof fullCertMap)[number]['title'];
+    title: (typeof claimableCerts)[number]['title'];
   };
   headings: [
     {

--- a/client/src/redux/settings/settings-sagas.js
+++ b/client/src/redux/settings/settings-sagas.js
@@ -14,7 +14,7 @@ import {
   certTypes
 } from '../../../../config/certification-settings';
 import { createFlashMessage } from '../../components/Flash/redux';
-import { liveCerts } from '../../resources/cert-and-project-map';
+import { liveCerts } from '../../../config/cert-and-project-map';
 import {
   getUsernameExists,
   putUpdateMyAbout,

--- a/client/src/redux/settings/settings-sagas.js
+++ b/client/src/redux/settings/settings-sagas.js
@@ -14,7 +14,7 @@ import {
   certTypes
 } from '../../../../config/certification-settings';
 import { createFlashMessage } from '../../components/Flash/redux';
-import { fullCertMap } from '../../resources/cert-and-project-map';
+import { claimableCerts } from '../../resources/cert-and-project-map';
 import {
   getUsernameExists,
   putUpdateMyAbout,
@@ -171,7 +171,7 @@ function* validateUsernameSaga({ payload }) {
 
 function* verifyCertificationSaga({ payload }) {
   // check redux if can claim cert before calling backend
-  const currentCert = fullCertMap.find(cert => cert.certSlug === payload);
+  const currentCert = claimableCerts.find(cert => cert.certSlug === payload);
   const completedChallenges = yield select(completedChallengesSelector);
   const certTitle = currentCert?.title || payload;
 

--- a/client/src/redux/settings/settings-sagas.js
+++ b/client/src/redux/settings/settings-sagas.js
@@ -14,7 +14,7 @@ import {
   certTypes
 } from '../../../../config/certification-settings';
 import { createFlashMessage } from '../../components/Flash/redux';
-import { claimableCerts } from '../../resources/cert-and-project-map';
+import { liveCerts } from '../../resources/cert-and-project-map';
 import {
   getUsernameExists,
   putUpdateMyAbout,
@@ -171,7 +171,7 @@ function* validateUsernameSaga({ payload }) {
 
 function* verifyCertificationSaga({ payload }) {
   // check redux if can claim cert before calling backend
-  const currentCert = claimableCerts.find(cert => cert.certSlug === payload);
+  const currentCert = liveCerts.find(cert => cert.certSlug === payload);
   const completedChallenges = yield select(completedChallengesSelector);
   const certTitle = currentCert?.title || payload;
 

--- a/client/src/resources/cert-and-project-map.ts
+++ b/client/src/resources/cert-and-project-map.ts
@@ -43,7 +43,7 @@ const legacyInfosecQaInfosecBase = infoSecBase;
 
 // TODO: generate this automatically in a separate file
 // from the md/meta.json files for each cert and projects
-const legacyCertMap = [
+const legacyCerts = [
   {
     id: '561add10cb82ac38a17513be',
     title: 'Legacy Front End',
@@ -294,7 +294,7 @@ const legacyFullStack = {
   // Requirements are other certs and is
   // handled elsewhere
 } as const;
-const certMap = [
+const certs = [
   {
     id: '561add10cb82ac38a17513bc',
     title: 'Responsive Web Design',
@@ -744,7 +744,7 @@ const certMap = [
   }
 ] as const;
 
-const upcomingCertMap = [
+const upcomingCerts = [
   {
     id: '647e3159823e0ef219c7359b',
     title: 'Foundational C# with Microsoft',
@@ -800,18 +800,19 @@ function getJavaScriptAlgoPath(project: string) {
     : `${jsAlgoBase}/${project}`;
 }
 
-const certMapWithoutFullStack = showUpcomingChanges
-  ? [...upcomingCertMap, ...legacyCertMap, ...certMap]
-  : ([...legacyCertMap, ...certMap] as const);
+const certsWithoutFullStack = showUpcomingChanges
+  ? [...upcomingCerts, ...legacyCerts, ...certs]
+  : ([...legacyCerts, ...certs] as const);
 
-const fullCertMap = [...certMapWithoutFullStack, legacyFullStack] as const;
+const claimableCerts = [...certsWithoutFullStack, legacyFullStack] as const;
 
 export type ProjectMap = Record<
-  (typeof certMap)[number]['title'],
-  (typeof certMap)[number]['projects']
+  (typeof certs)[number]['title'],
+  (typeof certs)[number]['projects']
 >;
 
-const projectMap = certMap.reduce((acc, curr) => {
+// TODO: include upcoming certs when showUpcomingChanges is true
+const projectMap = certs.reduce((acc, curr) => {
   return {
     ...acc,
     [curr.title]: curr.projects
@@ -819,11 +820,11 @@ const projectMap = certMap.reduce((acc, curr) => {
 }, {} as ProjectMap);
 
 export type LegacyProjectMap = Record<
-  (typeof legacyCertMap)[number]['title'],
-  (typeof legacyCertMap)[number]['projects']
+  (typeof legacyCerts)[number]['title'],
+  (typeof legacyCerts)[number]['projects']
 >;
 
-const legacyProjectMap = legacyCertMap.reduce((acc, curr) => {
+const legacyProjectMap = legacyCerts.reduce((acc, curr) => {
   return {
     ...acc,
     [curr.title]: curr.projects
@@ -836,8 +837,8 @@ const fullProjectMap = {
 };
 
 export {
-  certMapWithoutFullStack,
-  fullCertMap,
+  certsWithoutFullStack,
+  claimableCerts,
   fullProjectMap,
   legacyProjectMap,
   projectMap

--- a/client/src/resources/cert-and-project-map.ts
+++ b/client/src/resources/cert-and-project-map.ts
@@ -800,9 +800,7 @@ function getJavaScriptAlgoPath(project: string) {
     : `${jsAlgoBase}/${project}`;
 }
 
-const certsWithoutFullStack = showUpcomingChanges
-  ? [...upcomingCerts, ...legacyCerts, ...certs]
-  : ([...legacyCerts, ...certs] as const);
+const certsWithoutFullStack = [...legacyCerts, ...certs] as const;
 
 const liveCerts = [...certsWithoutFullStack, legacyFullStack] as const;
 
@@ -811,7 +809,16 @@ export type CertsToProjects = Record<
   (typeof certs)[number]['projects']
 >;
 
-// TODO: include upcoming certs when showUpcomingChanges is true
+export type LegacyCertsToProjects = Record<
+  (typeof legacyCerts)[number]['title'],
+  (typeof legacyCerts)[number]['projects']
+>;
+
+export type UpcomingCertsToProjects = Record<
+  (typeof upcomingCerts)[number]['title'],
+  (typeof upcomingCerts)[number]['projects']
+>;
+
 const certsToProjects = certs.reduce((acc, curr) => {
   return {
     ...acc,
@@ -819,17 +826,21 @@ const certsToProjects = certs.reduce((acc, curr) => {
   };
 }, {} as CertsToProjects);
 
-export type LegacyCertsToProjects = Record<
-  (typeof legacyCerts)[number]['title'],
-  (typeof legacyCerts)[number]['projects']
->;
-
 const legacyCertsToProjects = legacyCerts.reduce((acc, curr) => {
   return {
     ...acc,
     [curr.title]: curr.projects
   };
 }, {} as LegacyCertsToProjects);
+
+// TODO: use this (probably in liveCertsToProjects)
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const upcomingCertsToProjects = upcomingCerts.reduce((acc, curr) => {
+  return {
+    ...acc,
+    [curr.title]: curr.projects
+  };
+}, {} as UpcomingCertsToProjects);
 
 const liveCertsToProjects = {
   ...legacyCertsToProjects,

--- a/client/src/resources/cert-and-project-map.ts
+++ b/client/src/resources/cert-and-project-map.ts
@@ -804,42 +804,42 @@ const certsWithoutFullStack = showUpcomingChanges
   ? [...upcomingCerts, ...legacyCerts, ...certs]
   : ([...legacyCerts, ...certs] as const);
 
-const claimableCerts = [...certsWithoutFullStack, legacyFullStack] as const;
+const liveCerts = [...certsWithoutFullStack, legacyFullStack] as const;
 
-export type ProjectMap = Record<
+export type CertsToProjects = Record<
   (typeof certs)[number]['title'],
   (typeof certs)[number]['projects']
 >;
 
 // TODO: include upcoming certs when showUpcomingChanges is true
-const projectMap = certs.reduce((acc, curr) => {
+const certsToProjects = certs.reduce((acc, curr) => {
   return {
     ...acc,
     [curr.title]: curr.projects
   };
-}, {} as ProjectMap);
+}, {} as CertsToProjects);
 
-export type LegacyProjectMap = Record<
+export type LegacyCertsToProjects = Record<
   (typeof legacyCerts)[number]['title'],
   (typeof legacyCerts)[number]['projects']
 >;
 
-const legacyProjectMap = legacyCerts.reduce((acc, curr) => {
+const legacyCertsToProjects = legacyCerts.reduce((acc, curr) => {
   return {
     ...acc,
     [curr.title]: curr.projects
   };
-}, {} as LegacyProjectMap);
+}, {} as LegacyCertsToProjects);
 
-const fullProjectMap = {
-  ...legacyProjectMap,
-  ...projectMap
+const liveCertsToProjects = {
+  ...legacyCertsToProjects,
+  ...certsToProjects
 };
 
 export {
   certsWithoutFullStack,
-  claimableCerts,
-  fullProjectMap,
-  legacyProjectMap,
-  projectMap
+  liveCerts,
+  liveCertsToProjects,
+  legacyCertsToProjects,
+  certsToProjects
 };

--- a/client/src/resources/cert-and-project-map.ts
+++ b/client/src/resources/cert-and-project-map.ts
@@ -847,10 +847,13 @@ const liveCertsToProjects = {
   ...certsToProjects
 };
 
+const certTitles = certs.map(({ title }) => title);
+const legacyCertTitles = legacyCerts.map(({ title }) => title);
+
 export {
+  certTitles,
+  legacyCertTitles,
   certsWithoutFullStack,
   liveCerts,
-  liveCertsToProjects,
-  legacyCertsToProjects,
-  certsToProjects
+  liveCertsToProjects
 };

--- a/client/src/templates/Introduction/components/cert-challenge.tsx
+++ b/client/src/templates/Introduction/components/cert-challenge.tsx
@@ -19,7 +19,7 @@ import {
 } from '../../../redux/selectors';
 import { User, Steps } from '../../../redux/prop-types';
 import { verifyCert } from '../../../redux/settings/actions';
-import { claimableCerts } from '../../../resources/cert-and-project-map';
+import { liveCerts } from '../../../resources/cert-and-project-map';
 
 interface CertChallengeProps {
   // TODO: create enum/reuse SuperBlocks enum somehow
@@ -34,7 +34,7 @@ interface CertChallengeProps {
   isSignedIn: boolean;
   currentCerts: Steps['currentCerts'];
   superBlock: SuperBlocks;
-  title: (typeof claimableCerts)[number]['title'];
+  title: (typeof liveCerts)[number]['title'];
   user: User;
   verifyCert: typeof verifyCert;
 }
@@ -80,7 +80,7 @@ const CertChallenge = ({
   const [isCertified, setIsCertified] = useState(false);
   const [userLoaded, setUserLoaded] = useState(false);
 
-  const cert = claimableCerts.find(x => x.title === title);
+  const cert = liveCerts.find(x => x.title === title);
   if (!cert) throw Error(`Certification ${title} not found`);
   const certSlug = cert.certSlug;
 

--- a/client/src/templates/Introduction/components/cert-challenge.tsx
+++ b/client/src/templates/Introduction/components/cert-challenge.tsx
@@ -19,7 +19,7 @@ import {
 } from '../../../redux/selectors';
 import { User, Steps } from '../../../redux/prop-types';
 import { verifyCert } from '../../../redux/settings/actions';
-import { fullCertMap } from '../../../resources/cert-and-project-map';
+import { claimableCerts } from '../../../resources/cert-and-project-map';
 
 interface CertChallengeProps {
   // TODO: create enum/reuse SuperBlocks enum somehow
@@ -34,7 +34,7 @@ interface CertChallengeProps {
   isSignedIn: boolean;
   currentCerts: Steps['currentCerts'];
   superBlock: SuperBlocks;
-  title: (typeof fullCertMap)[number]['title'];
+  title: (typeof claimableCerts)[number]['title'];
   user: User;
   verifyCert: typeof verifyCert;
 }
@@ -80,7 +80,7 @@ const CertChallenge = ({
   const [isCertified, setIsCertified] = useState(false);
   const [userLoaded, setUserLoaded] = useState(false);
 
-  const cert = fullCertMap.find(x => x.title === title);
+  const cert = claimableCerts.find(x => x.title === title);
   if (!cert) throw Error(`Certification ${title} not found`);
   const certSlug = cert.certSlug;
 

--- a/client/src/templates/Introduction/components/cert-challenge.tsx
+++ b/client/src/templates/Introduction/components/cert-challenge.tsx
@@ -19,7 +19,7 @@ import {
 } from '../../../redux/selectors';
 import { User, Steps } from '../../../redux/prop-types';
 import { verifyCert } from '../../../redux/settings/actions';
-import { liveCerts } from '../../../resources/cert-and-project-map';
+import { liveCerts } from '../../../../config/cert-and-project-map';
 
 interface CertChallengeProps {
   // TODO: create enum/reuse SuperBlocks enum somehow

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -20,7 +20,8 @@
     "plugins/**/*",
     "src/**/*",
     "utils/**/*",
-    "tools/**/*"
+    "tools/**/*",
+    "config/**/*"
   ], // since ts-node compiles ts on the fly and then uses node, it needs to
   // compile the scripts to commonjs (or node will complain about the requires)
   "ts-node": {


### PR DESCRIPTION
- refactor: rename cert data structures
- refactor: more renaming
- feat: add map for upcoming certifications
- refactor: use certification titles directly
- refactor: move to config

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This should be a little less confusing now. Also, I dropped the dependence on `showUpcomingChanges` since this is (should be) a simple config file. In a followup PR I plan to use `showUpcomingChanges` to control which certifications appear on the settings page, but this module's job is just to describe and group the certifications. 

<!-- Feel free to add any additional description of changes below this line -->
