### PR TITLE
feat: show upcoming certifications

### DIFF
--- a/api-server/src/common/models/user.json
+++ b/api-server/src/common/models/user.json
@@ -221,6 +221,11 @@
       "description": "Camper is college algebra with Python certified",
       "default": false
     },
+    "isFoundationalCSharpCertV8": {
+      "type": "boolean",
+      "description": "Camper is foundational C# certified",
+      "default": false
+    },
     "completedChallenges": {
       "type": [
         {

--- a/api-server/src/server/boot/certificate.js
+++ b/api-server/src/server/boot/certificate.js
@@ -397,6 +397,7 @@ function createShowCert(app) {
       isMachineLearningPyCertV7: true,
       isRelationalDatabaseCertV8: true,
       isCollegeAlgebraPyCertV8: true,
+      isFoundationalCSharpCertV8: true,
       isHonest: true,
       username: true,
       name: true,

--- a/api-server/src/server/boot/certificate.js
+++ b/api-server/src/server/boot/certificate.js
@@ -12,7 +12,9 @@ import {
   certTypeTitleMap,
   certTypeIdMap,
   certIds,
-  oldDataVizId
+  oldDataVizId,
+  currentCertifications,
+  upcomingCertifications
 } from '../../../../config/certification-settings';
 import { reportError } from '../middlewares/sentry-error-handler.js';
 
@@ -38,7 +40,8 @@ const {
   dataAnalysisPyV7Id,
   machineLearningPyV7Id,
   relationalDatabaseV8Id,
-  collegeAlgebraPyV8Id
+  collegeAlgebraPyV8Id,
+  foundationalCSharpId
 } = certIds;
 
 const log = debug('fcc:certification');
@@ -51,7 +54,7 @@ export default function bootCertificate(app) {
   const showCert = createShowCert(app);
   const verifyCert = createVerifyCert(certTypeIds, app);
 
-  api.put('/certificate/verify', ifNoUser401, ifNoSuperBlock404, verifyCert);
+  api.put('/certificate/verify', ifNoUser401, ifNoCertification404, verifyCert);
   api.get('/certificate/showCert/:username/:certSlug', showCert);
   api.get('/certificate/verify-can-claim-cert', deprecatedEndpoint);
   app.use(api);
@@ -74,14 +77,17 @@ export function getFallbackFullStackDate(completedChallenges, completedDate) {
   return latestCertDate ? latestCertDate : completedDate;
 }
 
-const certSlugs = Object.keys(certSlugTypeMap);
-
-function ifNoSuperBlock404(req, res, next) {
+function ifNoCertification404(req, res, next) {
   const { certSlug } = req.body;
-  if (certSlug && certSlugs.includes(certSlug)) {
+  if (!certSlug) return res.status(404).end();
+  if (currentCertifications.includes(certSlug)) return next();
+  if (
+    process.env.SHOW_UPCOMING_CHANGES === 'true' &&
+    upcomingCertifications.includes(certSlug)
+  ) {
     return next();
   }
-  return res.status(404).end();
+  res.status(404).end();
 }
 
 const renderCertifiedEmail = loopback.template(
@@ -127,11 +133,15 @@ function createCertTypeIds(allChallenges) {
     [certTypes.collegeAlgebraPyV8]: getCertById(
       collegeAlgebraPyV8Id,
       allChallenges
+    ),
+    [certTypes.foundationalCSharp]: getCertById(
+      foundationalCSharpId,
+      allChallenges
     )
   };
 }
 
-function canClaim(ids, completedChallenges = []) {
+function hasCompletedTests(ids, completedChallenges = []) {
   return _.every(ids, ({ id }) =>
     _.find(completedChallenges, ({ id: completedId }) => completedId === id)
   );
@@ -219,7 +229,8 @@ function getUserIsCertMap(user) {
     isDataAnalysisPyCertV7 = false,
     isMachineLearningPyCertV7 = false,
     isRelationalDatabaseCertV8 = false,
-    isCollegeAlgebraPyCertV8 = false
+    isCollegeAlgebraPyCertV8 = false,
+    isFoundationalCSharpCertV8 = false
   } = user;
 
   return {
@@ -239,7 +250,8 @@ function getUserIsCertMap(user) {
     isDataAnalysisPyCertV7,
     isMachineLearningPyCertV7,
     isRelationalDatabaseCertV8,
-    isCollegeAlgebraPyCertV8
+    isCollegeAlgebraPyCertV8,
+    isFoundationalCSharpCertV8
   };
 }
 
@@ -276,7 +288,7 @@ function createVerifyCert(certTypeIds, app) {
         }
 
         const { id, tests, challengeType } = challenge;
-        if (!canClaim(tests, user.completedChallenges)) {
+        if (!hasCompletedTests(tests, user.completedChallenges)) {
           return Observable.just({
             type: 'info',
             message: 'flash.incomplete-steps',

--- a/api-server/src/server/utils/publicUserProps.js
+++ b/api-server/src/server/utils/publicUserProps.js
@@ -26,6 +26,7 @@ export const publicUserProps = [
   'isDataAnalysisPyCertV7',
   'isMachineLearningPyCertV7',
   'isCollegeAlgebraPyCertV8',
+  'isFoundationalCSharpCertV8',
   'linkedin',
   'location',
   'name',

--- a/client/config/cert-and-project-map.test.ts
+++ b/client/config/cert-and-project-map.test.ts
@@ -1,0 +1,34 @@
+import { uniq } from 'lodash';
+import {
+  currentCertifications,
+  upcomingCertifications,
+  legacyCertifications
+} from '../../config/certification-settings';
+import {
+  currentCertTitles,
+  upcomingCertTitles,
+  legacyCertTitles
+} from './cert-and-project-map';
+
+describe('cert-and-project-map', () => {
+  describe('currentCertTitles', () => {
+    it('should correspond to the currentCertifications config', () => {
+      expect(currentCertTitles).toHaveLength(uniq(currentCertTitles).length);
+      expect(currentCertTitles).toHaveLength(currentCertifications.length);
+    });
+  });
+
+  describe('upcomingCertTitles', () => {
+    it('should correspond to the upcomingCertifications config', () => {
+      expect(upcomingCertTitles).toHaveLength(uniq(upcomingCertTitles).length);
+      expect(upcomingCertTitles).toHaveLength(upcomingCertifications.length);
+    });
+  });
+
+  describe('legacyCertTitles', () => {
+    it('should correspond to the legacyCertifications config', () => {
+      expect(legacyCertTitles).toHaveLength(uniq(legacyCertTitles).length);
+      expect(legacyCertTitles).toHaveLength(legacyCertifications.length);
+    });
+  });
+});

--- a/client/config/cert-and-project-map.ts
+++ b/client/config/cert-and-project-map.ts
@@ -1,4 +1,9 @@
-import { Certification } from '../../config/certification-settings';
+import {
+  Certification,
+  legacyCertifications,
+  upcomingCertifications,
+  currentCertifications
+} from '../../config/certification-settings';
 import config from '../../config/env.json';
 
 const { showUpcomingChanges } = config;
@@ -44,250 +49,7 @@ const legacyInfosecQaInfosecBase = infoSecBase;
 
 // TODO: generate this automatically in a separate file
 // from the md/meta.json files for each cert and projects
-const legacyCerts = [
-  {
-    id: '561add10cb82ac38a17513be',
-    title: 'Legacy Front End',
-    certSlug: Certification.LegacyFrontEnd,
-    projects: [
-      {
-        id: 'bd7158d8c242eddfaeb5bd13',
-        title: 'Build a Personal Portfolio Webpage',
-        link: `${legacyFrontEndResponsiveBase}/build-a-personal-portfolio-webpage`,
-        certSlug: Certification.LegacyFrontEnd
-      },
-      {
-        id: 'bd7158d8c442eddfaeb5bd13',
-        title: 'Build a Random Quote Machine',
-        link: `${legacyFrontEndBase}/build-a-random-quote-machine`,
-        certSlug: Certification.LegacyFrontEnd
-      },
-      {
-        id: 'bd7158d8c442eddfaeb5bd0f',
-        title: 'Build a 25 + 5 Clock',
-        link: `${legacyFrontEndBase}/build-a-25--5-clock`,
-        certSlug: Certification.LegacyFrontEnd
-      },
-      {
-        id: 'bd7158d8c442eddfaeb5bd17',
-        title: 'Build a JavaScript Calculator',
-        link: `${legacyFrontEndBase}/build-a-javascript-calculator`,
-        certSlug: Certification.LegacyFrontEnd
-      },
-      {
-        id: 'bd7158d8c442eddfaeb5bd10',
-        title: 'Show the Local Weather',
-        link: `${legacyFrontEndTakeHomeBase}/show-the-local-weather`,
-        certSlug: Certification.LegacyFrontEnd
-      },
-      {
-        id: 'bd7158d8c442eddfaeb5bd1f',
-        title: 'Use the TwitchTV JSON API',
-        link: `${legacyFrontEndTakeHomeBase}/use-the-twitch-json-api`,
-        certSlug: Certification.LegacyFrontEnd
-      },
-      {
-        id: 'bd7158d8c442eddfaeb5bd18',
-        title: 'Build a Tribute Page',
-        link: `${legacyFrontEndResponsiveBase}/build-a-tribute-page`,
-        certSlug: Certification.LegacyFrontEnd
-      },
-      {
-        id: 'bd7158d8c442eddfaeb5bd19',
-        title: 'Build a Wikipedia Viewer',
-        link: `${legacyFrontEndTakeHomeBase}/build-a-wikipedia-viewer`,
-        certSlug: Certification.LegacyFrontEnd
-      },
-      {
-        id: 'bd7158d8c442eedfaeb5bd1c',
-        title: 'Build a Tic Tac Toe Game',
-        link: `${legacyFrontEndTakeHomeBase}/build-a-tic-tac-toe-game`,
-        certSlug: Certification.LegacyFrontEnd
-      },
-      {
-        id: 'bd7158d8c442eddfaeb5bd1c',
-        title: 'Build a Simon Game',
-        link: `${legacyFrontEndTakeHomeBase}/build-a-simon-game`,
-        certSlug: Certification.LegacyFrontEnd
-      }
-    ]
-  },
-  {
-    id: '660add10cb82ac38a17513be',
-    title: 'Legacy Back End',
-    certSlug: Certification.LegacyBackEnd,
-    projects: [
-      {
-        id: 'bd7158d8c443edefaeb5bdef',
-        title: 'Timestamp Microservice',
-        link: `${legacyBackEndBase}/timestamp-microservice`,
-        certSlug: Certification.LegacyBackEnd
-      },
-      {
-        id: 'bd7158d8c443edefaeb5bdff',
-        title: 'Request Header Parser Microservice',
-        link: `${legacyBackEndBase}/request-header-parser-microservice`,
-        certSlug: Certification.LegacyBackEnd
-      },
-      {
-        id: 'bd7158d8c443edefaeb5bd0e',
-        title: 'URL Shortener Microservice',
-        link: `${legacyBackEndBase}/url-shortener-microservice`,
-        certSlug: Certification.LegacyBackEnd
-      },
-      {
-        id: 'bd7158d8c443edefaeb5bdee',
-        title: 'Image Search Abstraction Layer',
-        link: `${legacyBackEndTakeHomeBase}/build-an-image-search-abstraction-layer`,
-        certSlug: Certification.LegacyBackEnd
-      },
-      {
-        id: 'bd7158d8c443edefaeb5bd0f',
-        title: 'File Metadata Microservice',
-        link: `${legacyBackEndBase}/file-metadata-microservice`,
-        certSlug: Certification.LegacyBackEnd
-      },
-      {
-        id: 'bd7158d8c443eddfaeb5bdef',
-        title: 'Build a Voting App',
-        link: `${legacyBackEndTakeHomeBase}/build-a-voting-app`,
-        certSlug: Certification.LegacyBackEnd
-      },
-      {
-        id: 'bd7158d8c443eddfaeb5bdff',
-        title: 'Build a Nightlife Coordination App',
-        link: `${legacyBackEndTakeHomeBase}/build-a-nightlife-coordination-app`,
-        certSlug: Certification.LegacyBackEnd
-      },
-      {
-        id: 'bd7158d8c443eddfaeb5bd0e',
-        title: 'Chart the Stock Market',
-        link: `${legacyBackEndTakeHomeBase}/chart-the-stock-market`,
-        certSlug: Certification.LegacyBackEnd
-      },
-      {
-        id: 'bd7158d8c443eddfaeb5bd0f',
-        title: 'Manage a Book Trading Club',
-        link: `${legacyBackEndTakeHomeBase}/manage-a-book-trading-club`,
-        certSlug: Certification.LegacyBackEnd
-      },
-      {
-        id: 'bd7158d8c443eddfaeb5bdee',
-        title: 'Build a Pinterest Clone',
-        link: `${legacyBackEndTakeHomeBase}/build-a-pinterest-clone`,
-        certSlug: Certification.LegacyBackEnd
-      }
-    ]
-  },
-
-  {
-    id: '561add10cb82ac39a17513bc',
-    title: 'Legacy Data Visualization',
-    certSlug: Certification.LegacyDataVis,
-    projects: [
-      {
-        id: 'bd7157d8c242eddfaeb5bd13',
-        title: 'Build a Markdown Previewer',
-        link: `${legacyDataVisFrontEndBase}/build-a-markdown-previewer`,
-        certSlug: Certification.LegacyDataVis
-      },
-      {
-        id: 'bd7156d8c242eddfaeb5bd13',
-        title: 'Build a freeCodeCamp Forum Homepage',
-        link: `${legacyDataVisTakeHomeBase}/build-a-freecodecamp-forum-homepage`,
-        certSlug: Certification.LegacyDataVis
-      },
-      {
-        id: 'bd7155d8c242eddfaeb5bd13',
-        title: 'Build a Recipe Box',
-        link: `${legacyDataVisTakeHomeBase}/build-a-recipe-box`,
-        certSlug: Certification.LegacyDataVis
-      },
-      {
-        id: 'bd7154d8c242eddfaeb5bd13',
-        title: 'Build the Game of Life',
-        link: `${legacyDataVisTakeHomeBase}/build-the-game-of-life`,
-        certSlug: Certification.LegacyDataVis
-      },
-      {
-        id: 'bd7153d8c242eddfaeb5bd13',
-        title: 'Build a Roguelike Dungeon Crawler Game',
-        link: `${legacyDataVisTakeHomeBase}/build-a-roguelike-dungeon-crawler-game`,
-        certSlug: Certification.LegacyDataVis
-      },
-      {
-        id: 'bd7168d8c242eddfaeb5bd13',
-        title: 'Visualize Data with a Bar Chart',
-        link: `${legacyDataVisBase}/visualize-data-with-a-bar-chart`,
-        certSlug: Certification.LegacyDataVis
-      },
-      {
-        id: 'bd7178d8c242eddfaeb5bd13',
-        title: 'Visualize Data with a Scatterplot Graph',
-        link: `${legacyDataVisBase}/visualize-data-with-a-scatterplot-graph`,
-        certSlug: Certification.LegacyDataVis
-      },
-      {
-        id: 'bd7188d8c242eddfaeb5bd13',
-        title: 'Visualize Data with a Heat Map',
-        link: `${legacyDataVisBase}/visualize-data-with-a-heat-map`,
-        certSlug: Certification.LegacyDataVis
-      },
-      {
-        id: 'bd7198d8c242eddfaeb5bd13',
-        title: 'Show National Contiguity with a Force Directed Graph',
-        link: `${legacyDataVisTakeHomeBase}/show-national-contiguity-with-a-force-directed-graph`,
-        certSlug: Certification.LegacyDataVis
-      },
-      {
-        id: 'bd7108d8c242eddfaeb5bd13',
-        title: 'Map Data Across the Globe',
-        link: `${legacyDataVisTakeHomeBase}/map-data-across-the-globe`,
-        certSlug: Certification.LegacyDataVis
-      }
-    ]
-  },
-  {
-    id: '561add10cb82ac38a17213bc',
-    title: 'Legacy Information Security and Quality Assurance',
-    // Keep this as information-security-and-quality-assurance
-    certSlug: Certification.LegacyInfoSecQa,
-    projects: [
-      // Keep this as information-security-and-quality-assurance
-      {
-        id: '587d8249367417b2b2512c41',
-        title: 'Metric-Imperial Converter',
-        link: `${legacyInfosecQaQaBase}/metric-imperial-converter`,
-        certSlug: Certification.LegacyInfoSecQa
-      },
-      {
-        id: '587d8249367417b2b2512c42',
-        title: 'Issue Tracker',
-        link: `${legacyInfosecQaQaBase}/issue-tracker`,
-        certSlug: Certification.LegacyInfoSecQa
-      },
-      {
-        id: '587d824a367417b2b2512c43',
-        title: 'Personal Library',
-        link: `${legacyInfosecQaQaBase}/personal-library`,
-        certSlug: Certification.LegacyInfoSecQa
-      },
-      {
-        id: '587d824a367417b2b2512c44',
-        title: 'Stock Price Checker',
-        link: `${legacyInfosecQaInfosecBase}/stock-price-checker`,
-        certSlug: Certification.LegacyInfoSecQa
-      },
-      {
-        id: '587d824a367417b2b2512c45',
-        title: 'Anonymous Message Board',
-        link: `${legacyInfosecQaInfosecBase}/anonymous-message-board`,
-        certSlug: Certification.LegacyInfoSecQa
-      }
-    ]
-  }
-] as const;
-const legacyFullStack = {
+const fullstackCert = {
   id: '561add10cb82ac38a17213bd',
   title: 'Legacy Full Stack',
   certSlug: Certification.LegacyFullStack,
@@ -295,7 +57,7 @@ const legacyFullStack = {
   // Requirements are other certs and is
   // handled elsewhere
 } as const;
-const certs = [
+const allStandardCerts = [
   {
     id: '561add10cb82ac38a17513bc',
     title: 'Responsive Web Design',
@@ -742,10 +504,250 @@ const certs = [
         certSlug: Certification.CollegeAlgebraPy
       }
     ]
-  }
-] as const;
+  },
+  // Legacy certifications
+  {
+    id: '561add10cb82ac38a17513be',
+    title: 'Legacy Front End',
+    certSlug: Certification.LegacyFrontEnd,
+    projects: [
+      {
+        id: 'bd7158d8c242eddfaeb5bd13',
+        title: 'Build a Personal Portfolio Webpage',
+        link: `${legacyFrontEndResponsiveBase}/build-a-personal-portfolio-webpage`,
+        certSlug: Certification.LegacyFrontEnd
+      },
+      {
+        id: 'bd7158d8c442eddfaeb5bd13',
+        title: 'Build a Random Quote Machine',
+        link: `${legacyFrontEndBase}/build-a-random-quote-machine`,
+        certSlug: Certification.LegacyFrontEnd
+      },
+      {
+        id: 'bd7158d8c442eddfaeb5bd0f',
+        title: 'Build a 25 + 5 Clock',
+        link: `${legacyFrontEndBase}/build-a-25--5-clock`,
+        certSlug: Certification.LegacyFrontEnd
+      },
+      {
+        id: 'bd7158d8c442eddfaeb5bd17',
+        title: 'Build a JavaScript Calculator',
+        link: `${legacyFrontEndBase}/build-a-javascript-calculator`,
+        certSlug: Certification.LegacyFrontEnd
+      },
+      {
+        id: 'bd7158d8c442eddfaeb5bd10',
+        title: 'Show the Local Weather',
+        link: `${legacyFrontEndTakeHomeBase}/show-the-local-weather`,
+        certSlug: Certification.LegacyFrontEnd
+      },
+      {
+        id: 'bd7158d8c442eddfaeb5bd1f',
+        title: 'Use the TwitchTV JSON API',
+        link: `${legacyFrontEndTakeHomeBase}/use-the-twitch-json-api`,
+        certSlug: Certification.LegacyFrontEnd
+      },
+      {
+        id: 'bd7158d8c442eddfaeb5bd18',
+        title: 'Build a Tribute Page',
+        link: `${legacyFrontEndResponsiveBase}/build-a-tribute-page`,
+        certSlug: Certification.LegacyFrontEnd
+      },
+      {
+        id: 'bd7158d8c442eddfaeb5bd19',
+        title: 'Build a Wikipedia Viewer',
+        link: `${legacyFrontEndTakeHomeBase}/build-a-wikipedia-viewer`,
+        certSlug: Certification.LegacyFrontEnd
+      },
+      {
+        id: 'bd7158d8c442eedfaeb5bd1c',
+        title: 'Build a Tic Tac Toe Game',
+        link: `${legacyFrontEndTakeHomeBase}/build-a-tic-tac-toe-game`,
+        certSlug: Certification.LegacyFrontEnd
+      },
+      {
+        id: 'bd7158d8c442eddfaeb5bd1c',
+        title: 'Build a Simon Game',
+        link: `${legacyFrontEndTakeHomeBase}/build-a-simon-game`,
+        certSlug: Certification.LegacyFrontEnd
+      }
+    ]
+  },
+  {
+    id: '660add10cb82ac38a17513be',
+    title: 'Legacy Back End',
+    certSlug: Certification.LegacyBackEnd,
+    projects: [
+      {
+        id: 'bd7158d8c443edefaeb5bdef',
+        title: 'Timestamp Microservice',
+        link: `${legacyBackEndBase}/timestamp-microservice`,
+        certSlug: Certification.LegacyBackEnd
+      },
+      {
+        id: 'bd7158d8c443edefaeb5bdff',
+        title: 'Request Header Parser Microservice',
+        link: `${legacyBackEndBase}/request-header-parser-microservice`,
+        certSlug: Certification.LegacyBackEnd
+      },
+      {
+        id: 'bd7158d8c443edefaeb5bd0e',
+        title: 'URL Shortener Microservice',
+        link: `${legacyBackEndBase}/url-shortener-microservice`,
+        certSlug: Certification.LegacyBackEnd
+      },
+      {
+        id: 'bd7158d8c443edefaeb5bdee',
+        title: 'Image Search Abstraction Layer',
+        link: `${legacyBackEndTakeHomeBase}/build-an-image-search-abstraction-layer`,
+        certSlug: Certification.LegacyBackEnd
+      },
+      {
+        id: 'bd7158d8c443edefaeb5bd0f',
+        title: 'File Metadata Microservice',
+        link: `${legacyBackEndBase}/file-metadata-microservice`,
+        certSlug: Certification.LegacyBackEnd
+      },
+      {
+        id: 'bd7158d8c443eddfaeb5bdef',
+        title: 'Build a Voting App',
+        link: `${legacyBackEndTakeHomeBase}/build-a-voting-app`,
+        certSlug: Certification.LegacyBackEnd
+      },
+      {
+        id: 'bd7158d8c443eddfaeb5bdff',
+        title: 'Build a Nightlife Coordination App',
+        link: `${legacyBackEndTakeHomeBase}/build-a-nightlife-coordination-app`,
+        certSlug: Certification.LegacyBackEnd
+      },
+      {
+        id: 'bd7158d8c443eddfaeb5bd0e',
+        title: 'Chart the Stock Market',
+        link: `${legacyBackEndTakeHomeBase}/chart-the-stock-market`,
+        certSlug: Certification.LegacyBackEnd
+      },
+      {
+        id: 'bd7158d8c443eddfaeb5bd0f',
+        title: 'Manage a Book Trading Club',
+        link: `${legacyBackEndTakeHomeBase}/manage-a-book-trading-club`,
+        certSlug: Certification.LegacyBackEnd
+      },
+      {
+        id: 'bd7158d8c443eddfaeb5bdee',
+        title: 'Build a Pinterest Clone',
+        link: `${legacyBackEndTakeHomeBase}/build-a-pinterest-clone`,
+        certSlug: Certification.LegacyBackEnd
+      }
+    ]
+  },
 
-const upcomingCerts = [
+  {
+    id: '561add10cb82ac39a17513bc',
+    title: 'Legacy Data Visualization',
+    certSlug: Certification.LegacyDataVis,
+    projects: [
+      {
+        id: 'bd7157d8c242eddfaeb5bd13',
+        title: 'Build a Markdown Previewer',
+        link: `${legacyDataVisFrontEndBase}/build-a-markdown-previewer`,
+        certSlug: Certification.LegacyDataVis
+      },
+      {
+        id: 'bd7156d8c242eddfaeb5bd13',
+        title: 'Build a freeCodeCamp Forum Homepage',
+        link: `${legacyDataVisTakeHomeBase}/build-a-freecodecamp-forum-homepage`,
+        certSlug: Certification.LegacyDataVis
+      },
+      {
+        id: 'bd7155d8c242eddfaeb5bd13',
+        title: 'Build a Recipe Box',
+        link: `${legacyDataVisTakeHomeBase}/build-a-recipe-box`,
+        certSlug: Certification.LegacyDataVis
+      },
+      {
+        id: 'bd7154d8c242eddfaeb5bd13',
+        title: 'Build the Game of Life',
+        link: `${legacyDataVisTakeHomeBase}/build-the-game-of-life`,
+        certSlug: Certification.LegacyDataVis
+      },
+      {
+        id: 'bd7153d8c242eddfaeb5bd13',
+        title: 'Build a Roguelike Dungeon Crawler Game',
+        link: `${legacyDataVisTakeHomeBase}/build-a-roguelike-dungeon-crawler-game`,
+        certSlug: Certification.LegacyDataVis
+      },
+      {
+        id: 'bd7168d8c242eddfaeb5bd13',
+        title: 'Visualize Data with a Bar Chart',
+        link: `${legacyDataVisBase}/visualize-data-with-a-bar-chart`,
+        certSlug: Certification.LegacyDataVis
+      },
+      {
+        id: 'bd7178d8c242eddfaeb5bd13',
+        title: 'Visualize Data with a Scatterplot Graph',
+        link: `${legacyDataVisBase}/visualize-data-with-a-scatterplot-graph`,
+        certSlug: Certification.LegacyDataVis
+      },
+      {
+        id: 'bd7188d8c242eddfaeb5bd13',
+        title: 'Visualize Data with a Heat Map',
+        link: `${legacyDataVisBase}/visualize-data-with-a-heat-map`,
+        certSlug: Certification.LegacyDataVis
+      },
+      {
+        id: 'bd7198d8c242eddfaeb5bd13',
+        title: 'Show National Contiguity with a Force Directed Graph',
+        link: `${legacyDataVisTakeHomeBase}/show-national-contiguity-with-a-force-directed-graph`,
+        certSlug: Certification.LegacyDataVis
+      },
+      {
+        id: 'bd7108d8c242eddfaeb5bd13',
+        title: 'Map Data Across the Globe',
+        link: `${legacyDataVisTakeHomeBase}/map-data-across-the-globe`,
+        certSlug: Certification.LegacyDataVis
+      }
+    ]
+  },
+  {
+    id: '561add10cb82ac38a17213bc',
+    title: 'Legacy Information Security and Quality Assurance',
+    // Keep this as information-security-and-quality-assurance
+    certSlug: Certification.LegacyInfoSecQa,
+    projects: [
+      // Keep this as information-security-and-quality-assurance
+      {
+        id: '587d8249367417b2b2512c41',
+        title: 'Metric-Imperial Converter',
+        link: `${legacyInfosecQaQaBase}/metric-imperial-converter`,
+        certSlug: Certification.LegacyInfoSecQa
+      },
+      {
+        id: '587d8249367417b2b2512c42',
+        title: 'Issue Tracker',
+        link: `${legacyInfosecQaQaBase}/issue-tracker`,
+        certSlug: Certification.LegacyInfoSecQa
+      },
+      {
+        id: '587d824a367417b2b2512c43',
+        title: 'Personal Library',
+        link: `${legacyInfosecQaQaBase}/personal-library`,
+        certSlug: Certification.LegacyInfoSecQa
+      },
+      {
+        id: '587d824a367417b2b2512c44',
+        title: 'Stock Price Checker',
+        link: `${legacyInfosecQaInfosecBase}/stock-price-checker`,
+        certSlug: Certification.LegacyInfoSecQa
+      },
+      {
+        id: '587d824a367417b2b2512c45',
+        title: 'Anonymous Message Board',
+        link: `${legacyInfosecQaInfosecBase}/anonymous-message-board`,
+        certSlug: Certification.LegacyInfoSecQa
+      }
+    ]
+  },
+  // Upcoming Certifications
   {
     id: '647e3159823e0ef219c7359b',
     title: 'Foundational C# with Microsoft',
@@ -801,74 +803,60 @@ function getJavaScriptAlgoPath(project: string) {
     : `${jsAlgoBase}/${project}`;
 }
 
-// "Standard" certs are those whose prerequisites are not other certs. Currently
-// only the legacy full stack cert is non-standard. Upcoming certs are included,
-// but they are not displayed unless showUpcomingChanges is true.
-const standardCerts = [...legacyCerts, ...certs, ...upcomingCerts] as const;
+type FilteredCert<T, U> = T extends { certSlug: U } ? T : never;
 
-// "Live" certs are those that are currently available to students. Currently
-// this only excludes the upcoming certs.
-const liveCerts = [...standardCerts, legacyFullStack] as const;
+type CurrentCert = FilteredCert<
+  (typeof allStandardCerts)[number],
+  (typeof currentCertifications)[number]
+>;
+
+type LegacyCert = FilteredCert<
+  (typeof allStandardCerts)[number],
+  (typeof legacyCertifications)[number]
+>;
+
+type UpcomingCert = FilteredCert<
+  (typeof allStandardCerts)[number],
+  (typeof upcomingCertifications)[number]
+>;
+
+const currentCerts = allStandardCerts.filter((cert): cert is CurrentCert =>
+  currentCertifications.includes(cert.certSlug)
+);
+const legacyCerts = allStandardCerts.filter((cert): cert is LegacyCert =>
+  legacyCertifications.includes(cert.certSlug)
+);
+const upcomingCerts = allStandardCerts.filter((cert): cert is UpcomingCert =>
+  upcomingCertifications.includes(cert.certSlug)
+);
+const liveCerts = showUpcomingChanges
+  ? [...currentCerts, ...legacyCerts, fullstackCert, ...upcomingCerts]
+  : [...currentCerts, ...legacyCerts, fullstackCert];
 
 type CertsToProjects = Record<
-  (typeof certs)[number]['title'],
-  (typeof certs)[number]['projects']
+  (typeof allStandardCerts)[number]['title'],
+  (typeof allStandardCerts)[number]['projects']
 >;
 
-type LegacyCertsToProjects = Record<
-  (typeof legacyCerts)[number]['title'],
-  (typeof legacyCerts)[number]['projects']
->;
-
-type UpcomingCertsToProjects = Record<
-  (typeof upcomingCerts)[number]['title'],
-  (typeof upcomingCerts)[number]['projects']
->;
-
-const certsToProjects = certs.reduce((acc, curr) => {
+const certsToProjects = allStandardCerts.reduce((acc, curr) => {
   return {
     ...acc,
     [curr.title]: curr.projects
   };
 }, {} as CertsToProjects);
 
-const legacyCertsToProjects = legacyCerts.reduce((acc, curr) => {
-  return {
-    ...acc,
-    [curr.title]: curr.projects
-  };
-}, {} as LegacyCertsToProjects);
-
-// TODO: use this (probably in standardCertsToProjects)
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const upcomingCertsToProjects = upcomingCerts.reduce((acc, curr) => {
-  return {
-    ...acc,
-    [curr.title]: curr.projects
-  };
-}, {} as UpcomingCertsToProjects);
-
-const standardCertsToProjects = {
-  ...upcomingCertsToProjects,
-  ...legacyCertsToProjects,
-  ...certsToProjects
-};
-
-const certTitles = certs.map(({ title }) => title);
+const currentCertTitles = currentCerts.map(({ title }) => title);
 const legacyCertTitles = legacyCerts.map(({ title }) => title);
 const upcomingCertTitles = upcomingCerts.map(({ title }) => title);
 
 export type CertTitle =
-  | (typeof certTitles)[number]
-  | (typeof legacyCertTitles)[number]
-  | (typeof upcomingCertTitles)[number]
+  | (typeof liveCerts)[number]['title']
   | 'Legacy Full Stack';
 
 export {
-  certTitles,
+  currentCertTitles,
   legacyCertTitles,
   upcomingCertTitles,
-  standardCerts,
   liveCerts,
-  standardCertsToProjects
+  certsToProjects
 };

--- a/client/config/cert-and-project-map.ts
+++ b/client/config/cert-and-project-map.ts
@@ -800,21 +800,25 @@ function getJavaScriptAlgoPath(project: string) {
     : `${jsAlgoBase}/${project}`;
 }
 
-const certsWithoutFullStack = [...legacyCerts, ...certs] as const;
+// "Standard" certs are those whose prerequisites are not other certs. Currently
+// only the legacy full stack cert is non-standard.
+const standardCerts = [...legacyCerts, ...certs] as const;
 
-const liveCerts = [...certsWithoutFullStack, legacyFullStack] as const;
+// "Live" certs are those that are currently available to students. Currently
+// this only excludes the upcoming certs.
+const liveCerts = [...standardCerts, legacyFullStack] as const;
 
-export type CertsToProjects = Record<
+type CertsToProjects = Record<
   (typeof certs)[number]['title'],
   (typeof certs)[number]['projects']
 >;
 
-export type LegacyCertsToProjects = Record<
+type LegacyCertsToProjects = Record<
   (typeof legacyCerts)[number]['title'],
   (typeof legacyCerts)[number]['projects']
 >;
 
-export type UpcomingCertsToProjects = Record<
+type UpcomingCertsToProjects = Record<
   (typeof upcomingCerts)[number]['title'],
   (typeof upcomingCerts)[number]['projects']
 >;
@@ -833,7 +837,7 @@ const legacyCertsToProjects = legacyCerts.reduce((acc, curr) => {
   };
 }, {} as LegacyCertsToProjects);
 
-// TODO: use this (probably in liveCertsToProjects)
+// TODO: use this (probably in standardCertsToProjects)
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const upcomingCertsToProjects = upcomingCerts.reduce((acc, curr) => {
   return {
@@ -842,7 +846,7 @@ const upcomingCertsToProjects = upcomingCerts.reduce((acc, curr) => {
   };
 }, {} as UpcomingCertsToProjects);
 
-const liveCertsToProjects = {
+const standardCertsToProjects = {
   ...legacyCertsToProjects,
   ...certsToProjects
 };
@@ -858,7 +862,7 @@ export type CertTitle =
 export {
   certTitles,
   legacyCertTitles,
-  certsWithoutFullStack,
+  standardCerts,
   liveCerts,
-  liveCertsToProjects
+  standardCertsToProjects
 };

--- a/client/config/cert-and-project-map.ts
+++ b/client/config/cert-and-project-map.ts
@@ -27,7 +27,8 @@ const machineLearningPyBase =
   '/learn/machine-learning-with-python/machine-learning-with-python-projects';
 const collegeAlgebraPyBase = '/learn/college-algebra-with-python';
 const takeHomeBase = '/learn/coding-interview-prep/take-home-projects';
-const foundationalCSharpBase = '/learn/foundational-c-sharp-with-microsoft';
+const foundationalCSharpBase =
+  '/learn/foundational-c-sharp-with-microsoft/foundational-c-sharp-with-microsoft-certification-exam';
 const upcomingPythonBase = '/learn/upcoming-python';
 const exampleCertBase = '/learn/example-certification';
 const legacyFrontEndBase = feLibsBase;
@@ -801,8 +802,9 @@ function getJavaScriptAlgoPath(project: string) {
 }
 
 // "Standard" certs are those whose prerequisites are not other certs. Currently
-// only the legacy full stack cert is non-standard.
-const standardCerts = [...legacyCerts, ...certs] as const;
+// only the legacy full stack cert is non-standard. Upcoming certs are included,
+// but they are not displayed unless showUpcomingChanges is true.
+const standardCerts = [...legacyCerts, ...certs, ...upcomingCerts] as const;
 
 // "Live" certs are those that are currently available to students. Currently
 // this only excludes the upcoming certs.
@@ -847,21 +849,25 @@ const upcomingCertsToProjects = upcomingCerts.reduce((acc, curr) => {
 }, {} as UpcomingCertsToProjects);
 
 const standardCertsToProjects = {
+  ...upcomingCertsToProjects,
   ...legacyCertsToProjects,
   ...certsToProjects
 };
 
 const certTitles = certs.map(({ title }) => title);
 const legacyCertTitles = legacyCerts.map(({ title }) => title);
+const upcomingCertTitles = upcomingCerts.map(({ title }) => title);
 
 export type CertTitle =
   | (typeof certTitles)[number]
   | (typeof legacyCertTitles)[number]
+  | (typeof upcomingCertTitles)[number]
   | 'Legacy Full Stack';
 
 export {
   certTitles,
   legacyCertTitles,
+  upcomingCertTitles,
   standardCerts,
   liveCerts,
   standardCertsToProjects

--- a/client/src/client-only-routes/show-certification.tsx
+++ b/client/src/client-only-routes/show-certification.tsx
@@ -87,10 +87,10 @@ interface ShowCertificationProps {
 const requestedUserSelector = (state: unknown, { username = '' }) =>
   userByNameSelector(username.toLowerCase())(state) as User;
 
-const validCertSlugs = liveCerts.map(cert => cert.certSlug);
-
 const mapStateToProps = (state: unknown, props: ShowCertificationProps) => {
-  const isValidCert = validCertSlugs.some(slug => slug === props.certSlug);
+  const isValidCert = liveCerts.some(
+    ({ certSlug }) => certSlug === props.certSlug
+  );
   return createSelector(
     showCertSelector,
     showCertFetchStateSelector,

--- a/client/src/client-only-routes/show-project-links.tsx
+++ b/client/src/client-only-routes/show-project-links.tsx
@@ -8,7 +8,7 @@ import { Link, Spacer } from '../components/helpers';
 import ProjectModal from '../components/SolutionViewer/project-modal';
 import { CompletedChallenge, User } from '../redux/prop-types';
 import {
-  liveCertsToProjects,
+  standardCertsToProjects,
   type CertTitle
 } from '../../config/cert-and-project-map';
 
@@ -103,7 +103,7 @@ const ShowProjectLinks = (props: ShowProjectLinksProps): JSX.Element => {
       ] as const;
 
       return certs.map((cert, ind) => {
-        const projects = liveCertsToProjects[cert.title];
+        const projects = standardCertsToProjects[cert.title];
         const { certSlug } = projects[0];
         const certLocation = `/certification/${username}/${certSlug}`;
         return (
@@ -118,7 +118,7 @@ const ShowProjectLinks = (props: ShowProjectLinksProps): JSX.Element => {
       });
     }
 
-    const project = liveCertsToProjects[certName];
+    const project = standardCertsToProjects[certName];
     return project.map(({ link, title, id }) => (
       <tr key={id}>
         <td>
@@ -150,7 +150,7 @@ const ShowProjectLinks = (props: ShowProjectLinksProps): JSX.Element => {
 
   const isCertName = (maybeCertName: string): maybeCertName is CertTitle => {
     if (maybeCertName === 'Legacy Full Stack') return true;
-    return maybeCertName in liveCertsToProjects;
+    return maybeCertName in standardCertsToProjects;
   };
   if (!isCertName(certName)) return <div> Unknown Certification</div>;
 

--- a/client/src/client-only-routes/show-project-links.tsx
+++ b/client/src/client-only-routes/show-project-links.tsx
@@ -8,7 +8,7 @@ import { Link, Spacer } from '../components/helpers';
 import ProjectModal from '../components/SolutionViewer/project-modal';
 import { CompletedChallenge, User } from '../redux/prop-types';
 import {
-  standardCertsToProjects,
+  certsToProjects,
   type CertTitle
 } from '../../config/cert-and-project-map';
 
@@ -103,7 +103,7 @@ const ShowProjectLinks = (props: ShowProjectLinksProps): JSX.Element => {
       ] as const;
 
       return certs.map((cert, ind) => {
-        const projects = standardCertsToProjects[cert.title];
+        const projects = certsToProjects[cert.title];
         const { certSlug } = projects[0];
         const certLocation = `/certification/${username}/${certSlug}`;
         return (
@@ -118,7 +118,7 @@ const ShowProjectLinks = (props: ShowProjectLinksProps): JSX.Element => {
       });
     }
 
-    const project = standardCertsToProjects[certName];
+    const project = certsToProjects[certName];
     return project.map(({ link, title, id }) => (
       <tr key={id}>
         <td>
@@ -150,7 +150,7 @@ const ShowProjectLinks = (props: ShowProjectLinksProps): JSX.Element => {
 
   const isCertName = (maybeCertName: string): maybeCertName is CertTitle => {
     if (maybeCertName === 'Legacy Full Stack') return true;
-    return maybeCertName in standardCertsToProjects;
+    return maybeCertName in certsToProjects;
   };
   if (!isCertName(certName)) return <div> Unknown Certification</div>;
 

--- a/client/src/client-only-routes/show-settings.tsx
+++ b/client/src/client-only-routes/show-settings.tsx
@@ -117,6 +117,7 @@ export function ShowSettings(props: ShowSettingsProps): JSX.Element {
       isMachineLearningPyCertV7,
       isRelationalDatabaseCertV8,
       isCollegeAlgebraPyCertV8,
+      isFoundationalCSharpCertV8,
       isEmailVerified,
       isHonest,
       sendQuincyEmail,
@@ -224,6 +225,7 @@ export function ShowSettings(props: ShowSettingsProps): JSX.Element {
             isRelationalDatabaseCertV8={isRelationalDatabaseCertV8}
             isRespWebDesignCert={isRespWebDesignCert}
             isSciCompPyCertV7={isSciCompPyCertV7}
+            isFoundationalCSharpCertV8={isFoundationalCSharpCertV8}
             username={username}
             verifyCert={verifyCert}
           />

--- a/client/src/components/ProgressBar/progress-bar.tsx
+++ b/client/src/components/ProgressBar/progress-bar.tsx
@@ -9,7 +9,7 @@ import {
   completedChallengesInBlockSelector,
   completedPercentageSelector
 } from '../../templates/Challenges/redux/selectors';
-import { certsWithoutFullStack } from '../../../config/cert-and-project-map';
+import { standardCerts } from '../../../config/cert-and-project-map';
 import ProgressBarInner from './progress-bar-inner';
 
 const mapStateToProps = createSelector(
@@ -55,7 +55,7 @@ function ProgressBar({
   t
 }: ProgressBarProps): JSX.Element {
   const blockTitle = t(`intro:${superBlock}.blocks.${block}.title`);
-  const isCertificationProject = certsWithoutFullStack.some(cert => {
+  const isCertificationProject = standardCerts.some(cert => {
     return cert.projects.some((project: { id: string }) => project.id === id);
   });
 

--- a/client/src/components/ProgressBar/progress-bar.tsx
+++ b/client/src/components/ProgressBar/progress-bar.tsx
@@ -9,7 +9,7 @@ import {
   completedChallengesInBlockSelector,
   completedPercentageSelector
 } from '../../templates/Challenges/redux/selectors';
-import { standardCerts } from '../../../config/cert-and-project-map';
+import { liveCerts } from '../../../config/cert-and-project-map';
 import ProgressBarInner from './progress-bar-inner';
 
 const mapStateToProps = createSelector(
@@ -55,9 +55,10 @@ function ProgressBar({
   t
 }: ProgressBarProps): JSX.Element {
   const blockTitle = t(`intro:${superBlock}.blocks.${block}.title`);
-  const isCertificationProject = standardCerts.some(cert => {
-    return cert.projects.some((project: { id: string }) => project.id === id);
-  });
+  // Always false for legacy full stack, since it has no projects.
+  const isCertificationProject = liveCerts.some(cert =>
+    cert.projects?.some((project: { id: string }) => project.id === id)
+  );
 
   const totalChallengesInBlock = currentBlockIds?.length ?? 0;
   const meta =

--- a/client/src/components/settings/certification.tsx
+++ b/client/src/components/settings/certification.tsx
@@ -14,6 +14,7 @@ import { openModal } from '../../templates/Challenges/redux/actions';
 import {
   certTitles,
   legacyCertTitles,
+  upcomingCertTitles,
   standardCertsToProjects,
   type CertTitle
 } from '../../../config/cert-and-project-map';
@@ -25,8 +26,8 @@ import {
   Certification,
   certSlugTypeMap
 } from '../../../../config/certification-settings';
+import env from '../../../../config/env.json';
 
-import './certification.css';
 import {
   ClaimedCertifications,
   CompletedChallenge,
@@ -35,6 +36,10 @@ import {
 import { createFlashMessage } from '../Flash/redux';
 import { verifyCert } from '../../redux/settings/actions';
 import SectionHeader from './section-header';
+
+import './certification.css';
+
+const { showUpcomingChanges } = env;
 
 configureAnchors({ offset: -40, scrollDuration: 0 });
 
@@ -59,7 +64,8 @@ const isCertSelector = ({
   isDataAnalysisPyCertV7,
   isMachineLearningPyCertV7,
   isRelationalDatabaseCertV8,
-  isCollegeAlgebraPyCertV8
+  isCollegeAlgebraPyCertV8,
+  isFoundationalCSharpCertV8
 }: ClaimedCertifications) => ({
   is2018DataVisCert,
   isApisMicroservicesCert,
@@ -77,7 +83,8 @@ const isCertSelector = ({
   isDataAnalysisPyCertV7,
   isMachineLearningPyCertV7,
   isRelationalDatabaseCertV8,
-  isCollegeAlgebraPyCertV8
+  isCollegeAlgebraPyCertV8,
+  isFoundationalCSharpCertV8
 });
 
 const isCertMapSelector = createSelector(
@@ -98,7 +105,8 @@ const isCertMapSelector = createSelector(
     isDataAnalysisPyCertV7,
     isMachineLearningPyCertV7,
     isRelationalDatabaseCertV8,
-    isCollegeAlgebraPyCertV8
+    isCollegeAlgebraPyCertV8,
+    isFoundationalCSharpCertV8
   }) => ({
     'Responsive Web Design': isRespWebDesignCert,
     'JavaScript Algorithms and Data Structures': isJsAlgoDataStructCert,
@@ -115,7 +123,12 @@ const isCertMapSelector = createSelector(
     'Legacy Front End': isFrontEndCert,
     'Legacy Data Visualization': isDataVisCert,
     'Legacy Back End': isBackEndCert,
-    'Legacy Information Security and Quality Assurance': isInfosecQaCert
+    'Legacy Information Security and Quality Assurance': isInfosecQaCert,
+    'Foundational C# with Microsoft': isFoundationalCSharpCertV8,
+    // TODO: remove Example Certification? Also, include Upcoming Python
+    // Certification.
+    'Example Certification': false,
+    'Upcoming Python Certification': false
   })
 );
 
@@ -400,6 +413,10 @@ function CertificationSettings(props: CertificationSettingsProps) {
         {legacyCertTitles.map(title => (
           <Certification key={title} certName={title} t={t} />
         ))}
+        {showUpcomingChanges &&
+          upcomingCertTitles.map(title => (
+            <Certification key={title} certName={title} t={t} />
+          ))}
         <ProjectModal
           {...{
             projectTitle,

--- a/client/src/components/settings/certification.tsx
+++ b/client/src/components/settings/certification.tsx
@@ -12,10 +12,10 @@ import { regeneratePathAndHistory } from '../../../../utils/polyvinyl';
 import ProjectPreviewModal from '../../templates/Challenges/components/project-preview-modal';
 import { openModal } from '../../templates/Challenges/redux/actions';
 import {
-  certTitles,
+  currentCertTitles,
   legacyCertTitles,
   upcomingCertTitles,
-  standardCertsToProjects,
+  certsToProjects,
   type CertTitle
 } from '../../../config/cert-and-project-map';
 import { FlashMessages } from '../Flash/redux/flash-messages';
@@ -324,7 +324,7 @@ function CertificationSettings(props: CertificationSettingsProps) {
     certName: Exclude<CertTitle, 'Legacy Full Stack'>;
     t: TFunction;
   }) => {
-    const { certSlug } = standardCertsToProjects[certName][0];
+    const { certSlug } = certsToProjects[certName][0];
     return (
       <FullWidthRow>
         <Spacer size='medium' />
@@ -356,7 +356,7 @@ function CertificationSettings(props: CertificationSettingsProps) {
     isCert: boolean;
   }) {
     const { username, isHonest, createFlashMessage, t, verifyCert } = props;
-    const { certSlug } = standardCertsToProjects[certName][0];
+    const { certSlug } = certsToProjects[certName][0];
     const certLocation = `/certification/${username}/${certSlug}`;
     const clickHandler = (e: MouseEvent<HTMLButtonElement>) => {
       e.preventDefault();
@@ -367,7 +367,7 @@ function CertificationSettings(props: CertificationSettingsProps) {
         ? verifyCert(certSlug)
         : createFlashMessage(honestyInfoMessage);
     };
-    return standardCertsToProjects[certName]
+    return certsToProjects[certName]
       .map(({ link, title, id }) => (
         <tr className='project-row' key={id}>
           <td className='project-title col-sm-8 col-xs-8'>
@@ -405,7 +405,7 @@ function CertificationSettings(props: CertificationSettingsProps) {
     <ScrollableAnchor id='certification-settings'>
       <section className='certification-settings'>
         <SectionHeader>{t('settings.headings.certs')}</SectionHeader>
-        {certTitles.map(title => (
+        {currentCertTitles.map(title => (
           <Certification key={title} certName={title} t={t} />
         ))}
         <SectionHeader>{t('settings.headings.legacy-certs')}</SectionHeader>

--- a/client/src/components/settings/certification.tsx
+++ b/client/src/components/settings/certification.tsx
@@ -14,9 +14,8 @@ import { openModal } from '../../templates/Challenges/redux/actions';
 import {
   certTitles,
   legacyCertTitles,
-  liveCertsToProjects,
-  type CertsToProjects,
-  type LegacyCertsToProjects
+  standardCertsToProjects,
+  type CertTitle
 } from '../../../config/cert-and-project-map';
 import { FlashMessages } from '../Flash/redux/flash-messages';
 import ProjectModal from '../SolutionViewer/project-modal';
@@ -305,15 +304,14 @@ function CertificationSettings(props: CertificationSettingsProps) {
     );
   };
 
-  type CertName = keyof CertsToProjects | keyof LegacyCertsToProjects;
   const Certification = ({
     certName,
     t
   }: {
-    certName: CertName;
+    certName: Exclude<CertTitle, 'Legacy Full Stack'>;
     t: TFunction;
   }) => {
-    const { certSlug } = liveCertsToProjects[certName][0];
+    const { certSlug } = standardCertsToProjects[certName][0];
     return (
       <FullWidthRow>
         <Spacer size='medium' />
@@ -341,11 +339,11 @@ function CertificationSettings(props: CertificationSettingsProps) {
     certName,
     isCert
   }: {
-    certName: CertName;
+    certName: Exclude<CertTitle, 'Legacy Full Stack'>;
     isCert: boolean;
   }) {
     const { username, isHonest, createFlashMessage, t, verifyCert } = props;
-    const { certSlug } = liveCertsToProjects[certName][0];
+    const { certSlug } = standardCertsToProjects[certName][0];
     const certLocation = `/certification/${username}/${certSlug}`;
     const clickHandler = (e: MouseEvent<HTMLButtonElement>) => {
       e.preventDefault();
@@ -356,7 +354,7 @@ function CertificationSettings(props: CertificationSettingsProps) {
         ? verifyCert(certSlug)
         : createFlashMessage(honestyInfoMessage);
     };
-    return liveCertsToProjects[certName]
+    return standardCertsToProjects[certName]
       .map(({ link, title, id }) => (
         <tr className='project-row' key={id}>
           <td className='project-title col-sm-8 col-xs-8'>

--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -264,6 +264,7 @@ export type ClaimedCertifications = {
   isSciCompPyCertV7: boolean;
   isDataAnalysisPyCertV7: boolean;
   isMachineLearningPyCertV7: boolean;
+  isFoundationalCSharpCertV8: boolean;
 };
 
 type SavedChallenges = SavedChallenge[];

--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -1,7 +1,7 @@
 import { HandlerProps } from 'react-reflex';
 import { SuperBlocks } from '../../../config/superblocks';
 import { Themes } from '../components/settings/theme';
-import { liveCerts } from '../../config/cert-and-project-map';
+import { type CertTitle } from '../../config/cert-and-project-map';
 
 export type Steps = {
   isHonest?: boolean;
@@ -26,7 +26,7 @@ export type MarkdownRemark = {
     superBlock: SuperBlocks;
     // TODO: make enum like superBlock
     certification: string;
-    title: (typeof liveCerts)[number]['title'];
+    title: CertTitle;
   };
   headings: [
     {

--- a/client/src/templates/Introduction/components/cert-challenge.tsx
+++ b/client/src/templates/Introduction/components/cert-challenge.tsx
@@ -19,7 +19,10 @@ import {
 } from '../../../redux/selectors';
 import { User, Steps } from '../../../redux/prop-types';
 import { verifyCert } from '../../../redux/settings/actions';
-import { liveCerts } from '../../../../config/cert-and-project-map';
+import {
+  type CertTitle,
+  liveCerts
+} from '../../../../config/cert-and-project-map';
 
 interface CertChallengeProps {
   // TODO: create enum/reuse SuperBlocks enum somehow
@@ -34,7 +37,7 @@ interface CertChallengeProps {
   isSignedIn: boolean;
   currentCerts: Steps['currentCerts'];
   superBlock: SuperBlocks;
-  title: (typeof liveCerts)[number]['title'];
+  title: CertTitle;
   user: User;
   verifyCert: typeof verifyCert;
 }

--- a/config/certification-settings.ts
+++ b/config/certification-settings.ts
@@ -35,6 +35,8 @@ export enum Certification {
   LegacyFullStack = 'full-stack'
 }
 
+// "Current" certifications are the subset of standard certifications that are
+// live and not legacy.
 export const currentCertifications = [
   Certification.RespWebDesign,
   Certification.JsAlgoDataStruct,
@@ -47,18 +49,24 @@ export const currentCertifications = [
   Certification.DataAnalysisPy,
   Certification.InfoSec,
   Certification.MachineLearningPy,
-  Certification.CollegeAlgebraPy,
+  Certification.CollegeAlgebraPy
+] as const;
+
+// "Legacy" certifications are another class of standard certifications. They're
+// still live and claimable, but some parts of the UI handle them differently.
+export const legacyCertifications = [
   Certification.LegacyFrontEnd,
   Certification.LegacyBackEnd,
   Certification.LegacyDataVis,
-  Certification.LegacyInfoSecQa,
-  Certification.LegacyFullStack
-];
+  Certification.LegacyInfoSecQa
+] as const;
 
+// "Upcoming" certifications are standard certifications that are not live unless
+// showUpcomingChanges is true.
 export const upcomingCertifications = [
   Certification.UpcomingPython,
   Certification.FoundationalCSharp
-];
+] as const;
 
 export const certTypes = {
   frontEnd: 'isFrontEndCert',

--- a/config/certification-settings.ts
+++ b/config/certification-settings.ts
@@ -24,6 +24,7 @@ export enum Certification {
   InfoSec = 'information-security-v7',
   MachineLearningPy = 'machine-learning-with-python-v7',
   CollegeAlgebraPy = 'college-algebra-with-python-v8',
+  // Upcoming certifications
   FoundationalCSharp = 'foundational-c-sharp-with-microsoft',
   UpcomingPython = 'upcoming-python-v8',
   // Legacy certifications
@@ -33,6 +34,31 @@ export enum Certification {
   LegacyInfoSecQa = 'information-security-and-quality-assurance',
   LegacyFullStack = 'full-stack'
 }
+
+export const currentCertifications = [
+  Certification.RespWebDesign,
+  Certification.JsAlgoDataStruct,
+  Certification.FrontEndDevLibs,
+  Certification.DataVis,
+  Certification.RelationalDb,
+  Certification.BackEndDevApis,
+  Certification.QualityAssurance,
+  Certification.SciCompPy,
+  Certification.DataAnalysisPy,
+  Certification.InfoSec,
+  Certification.MachineLearningPy,
+  Certification.CollegeAlgebraPy,
+  Certification.LegacyFrontEnd,
+  Certification.LegacyBackEnd,
+  Certification.LegacyDataVis,
+  Certification.LegacyInfoSecQa,
+  Certification.LegacyFullStack
+];
+
+export const upcomingCertifications = [
+  Certification.UpcomingPython,
+  Certification.FoundationalCSharp
+];
 
 export const certTypes = {
   frontEnd: 'isFrontEndCert',
@@ -52,7 +78,7 @@ export const certTypes = {
   fullStack: 'isFullStackCert',
   relationalDatabaseV8: 'isRelationalDatabaseCertV8',
   collegeAlgebraPyV8: 'isCollegeAlgebraPyCertV8',
-  foundationalCSharp: 'isFoundationalCSharp'
+  foundationalCSharp: 'isFoundationalCSharpCertV8'
 } as const;
 
 export const certIds = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1344,6 +1344,9 @@ importers:
 
   tools/scripts/build:
     devDependencies:
+      '@total-typescript/ts-reset':
+        specifier: ^0.4.0
+        version: 0.4.2
       chai:
         specifier: 4.3.7
         version: 4.3.7
@@ -19649,7 +19652,6 @@ packages:
         optional: true
     dependencies:
       debug: 2.2.0
-    dev: false
 
   /follow-redirects@1.15.2(debug@3.2.7):
     resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
@@ -21703,7 +21705,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.2(debug@4.3.4)
+      follow-redirects: 1.15.2(debug@2.2.0)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug

--- a/tools/scripts/build/package.json
+++ b/tools/scripts/build/package.json
@@ -19,6 +19,7 @@
   "author": "freeCodeCamp <team@freecodecamp.org>",
   "main": "none",
   "devDependencies": {
+    "@total-typescript/ts-reset": "^0.4.0",
     "chai": "4.3.7",
     "joi": "17.9.2",
     "readdirp": "3.6.0"

--- a/tools/scripts/build/reset.d.ts
+++ b/tools/scripts/build/reset.d.ts
@@ -1,0 +1,1 @@
+import '@total-typescript/ts-reset';

--- a/tools/scripts/seed/certified-user-data.js
+++ b/tools/scripts/seed/certified-user-data.js
@@ -35,6 +35,7 @@ module.exports = {
   isMachineLearningPyCertV7: true,
   isRelationalDatabaseCertV8: true,
   isCollegeAlgebraPyCertV8: true,
+  isFoundationalCSharpCertV8: true,
   completedChallenges: [
     { id: 'bd7123c8c441eddfaeb5bdef', completedDate: 1475094716730, files: [] },
     { id: '5895f70bf9fc0f352b528e64', completedDate: 1537207306322, files: [] },

--- a/tools/scripts/seed/seed-demo-user.js
+++ b/tools/scripts/seed/seed-demo-user.js
@@ -79,6 +79,7 @@ const demoUser = {
   isMachineLearningPyCertV7: false,
   isRelationalDatabaseCertV8: false,
   isCollegeAlgebraPyCertV8: false,
+  isFoundationalCSharpCertV8: false,
   completedChallenges: [],
   portfolio: [],
   yearsTopContributor: args.includes('--top-contributor')


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

It took me a while before I settled on a way of organizing the config that keeps it (relatively) simple, while making it easy to use in the client. I'm not entirely happy with this, but I also don't see any simple improvements to make.

Everything will be a lot nicer once we stop using the certification titles as keys, but I think this is good enough for now.

The main thing, from a QA perspective, is what happens with `SHOW_UPCOMING_CHANGES=true`. Hopefully "nothing", but that needs confirming before we merge.

<!-- Feel free to add any additional description of changes below this line -->
