### PR TITLE
feat: return certSlug on /certificate/showCert

### DIFF
--- a/api-server/src/server/boot/certificate.js
+++ b/api-server/src/server/boot/certificate.js
@@ -506,6 +506,7 @@ function createShowCert(app) {
 
         if (!showName) {
           return res.json({
+            certSlug,
             certTitle,
             username,
             date: completedDate,
@@ -514,6 +515,7 @@ function createShowCert(app) {
         }
 
         return res.json({
+          certSlug,
           certTitle,
           username,
           name,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This will be used by the client so that it can lookup the certs by their keys (certSlug).

`certSlug` should be called `certKey` (since it's only used as (part of) the slug some of the time), but that can wait until the api MVP is live.

<!-- Feel free to add any additional description of changes below this line -->
