### PR TITLE
fix: ensure examResults are falsy before starting

### DIFF
--- a/client/src/templates/Challenges/redux/completion-epic.js
+++ b/client/src/templates/Challenges/redux/completion-epic.js
@@ -53,12 +53,7 @@ function postChallenge(update, username) {
   const saveChallenge = postUpdate$(update).pipe(
     retry(3),
     switchMap(({ data }) => {
-      const {
-        savedChallenges,
-        points,
-        isTrophyMissing,
-        examResults = {}
-      } = data;
+      const { savedChallenges, points, isTrophyMissing, examResults } = data;
       const payloadWithClientProperties = {
         ...omit(update.payload, ['files'])
       };


### PR DESCRIPTION
Providing {} as the default value for examResults meant it was truthy,
so the exam page would attempt to display the results.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->



<!-- Feel free to add any additional description of changes below this line -->
