### PR TITLE
fix(client): help us translate ribbons

### DIFF
--- a/utils/is-audited.js
+++ b/utils/is-audited.js
@@ -9,8 +9,8 @@ function isAuditedCert(
     throw Error('Both arguments must be provided for auditing');
 
   const auditedSuperBlocks = getAuditedSuperBlocks({
-    showNewCurriculum,
-    showUpcomingChanges,
+    showNewCurriculum: showNewCurriculum.toString(),
+    showUpcomingChanges: showUpcomingChanges.toString(),
     language
   });
   return auditedSuperBlocks.includes(superblock);


### PR DESCRIPTION
There is an issue where the "Help us translate" ribbons on the blocks of upcoming curriculum are shown. This is a quick fix for that. The issue is that the functions in the superblock.js file are used at build time where the env variables are strings, and again at runtime, where they are passed the booleans. This converts those back to strings - this is [similarly done here.](https://github.com/freeCodeCamp/freeCodeCamp/blob/main/client/src/components/Map/index.tsx#L32) The functions probably need some adjusting - we shouldn't be creating them at build time I suppose?

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
