### PR TITLE
fixed text on landing page call to action button

### DIFF
--- a/client/src/components/landing/components/big-call-to-action.tsx
+++ b/client/src/components/landing/components/big-call-to-action.tsx
@@ -1,13 +1,10 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 import Login from '../../Header/components/login';
 
 const BigCallToAction = (): JSX.Element => {
-  const { t } = useTranslation();
-
   return (
     <Login block={true} data-test-label='landing-big-cta'>
-      {t('buttons.logged-in-cta-btn')}
+      Create Account (it&apos;s free!)
     </Login>
   );
 };


### PR DESCRIPTION
…alkthrough findings

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x ] My pull request targets the `main` branch of freeCodeCamp.
- [ x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

I did a cognitive walkthrough of the website from going from the landing page to eventually starting a new course. My main findings were that it was somewhat confusing as the expected out of the action "Get Started" would bring me to a list of courses but instead it brought me to a log in. I was thinking that a way to fix this would be to change the button to "Create Account" to solve this problem.
