### PR TITLE
fix: allow submissions to complete if signed out

### DIFF
--- a/client/src/templates/Challenges/redux/completion-epic.js
+++ b/client/src/templates/Challenges/redux/completion-epic.js
@@ -211,7 +211,9 @@ export default function completionEpic(action$, state$) {
         block,
         blockHashSlug
       } = challengeMetaSelector(state);
-      let submitter = () => of({ type: 'no-user-signed-in' });
+      // Default to submitChallengeComplete since we do not want the user to
+      // be stuck in the 'isSubmitting' state.
+      let submitter = () => of(submitChallengeComplete());
       if (
         !(challengeType in submitTypes) ||
         !(submitTypes[challengeType] in submitters)

--- a/client/src/templates/Challenges/redux/completion-epic.test.js
+++ b/client/src/templates/Challenges/redux/completion-epic.test.js
@@ -1,0 +1,31 @@
+import { TestScheduler } from 'rxjs/testing';
+import completionEpic from './completion-epic';
+import { submitChallenge, submitChallengeComplete } from './actions';
+
+describe('completionEpic', () => {
+  describe('signed out user', () => {
+    const testScheduler = new TestScheduler((actual, expected) => {
+      it('should dispatch submitChallengeComplete', () => {
+        expect(actual).toEqual(expect.arrayContaining(expected));
+      });
+    });
+
+    testScheduler.run(({ hot, expectObservable }) => {
+      const action$ = hot('a', {
+        a: submitChallenge()
+      });
+      const state$ = {
+        value: {
+          challenge: { challengeMeta: { challengeType: 0 } },
+          app: { user: { username: 'test' } }
+        }
+      };
+
+      const output$ = completionEpic(action$, state$);
+
+      expectObservable(output$).toBe('a', {
+        a: submitChallengeComplete()
+      });
+    });
+  });
+});


### PR DESCRIPTION
The submission does not get sent to the server, but it does need to be
processed correctly by the client to avoid getting stuck in the
isSubmitting state.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
