### PR TITLE
feat: add aa test in react component

### DIFF
--- a/client/src/components/Donation/donation-modal.tsx
+++ b/client/src/components/Donation/donation-modal.tsx
@@ -94,7 +94,7 @@ function DonateModal({
   const { t } = useTranslation();
 
   // test wheather the conversions are being distributed properly
-  useFeature('aa-test-in-component').on;
+  useFeature('aa-test-in-component');
 
   const handleProcessing = () => {
     setCloseLabel(true);

--- a/client/src/components/Donation/donation-modal.tsx
+++ b/client/src/components/Donation/donation-modal.tsx
@@ -92,6 +92,10 @@ function DonateModal({
   const [showSkipButton, setShowSkipButton] = useState(false);
   const loadElementsIndividually = useFeature('load_elements_individually').on;
   const { t } = useTranslation();
+
+  // test wheather the conversions are being distributed properly
+  useFeature('aa-test-in-component').on;
+
   const handleProcessing = () => {
     setCloseLabel(true);
   };


### PR DESCRIPTION
The aa test in that lives in growth-book-redux-connector.tsx still running, but it shows inconsistency in conversion distribution between the variations. 

This is another aa-test to measure the integrity of the tests executed in react components (donation modal)

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
