### PR TITLE
fix: clean expose_donate_button AB test

### DIFF
--- a/client/src/components/Header/components/nav-links.tsx
+++ b/client/src/components/Header/components/nav-links.tsx
@@ -6,12 +6,9 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React, { Fragment } from 'react';
-import Media from 'react-responsive';
 import { useTranslation, withTranslation } from 'react-i18next';
-import { useFeature } from '@growthbook/growthbook-react';
 import { connect } from 'react-redux';
 import { radioLocation } from '../../../../../config/env.json';
-import { DONATE_NAV_EXPOSED_WIDTH } from '../../../../../config/misc';
 import { openSignoutModal } from '../../../redux/actions';
 import { updateMyTheme } from '../../../redux/settings/actions';
 import { Link } from '../../helpers';
@@ -67,24 +64,13 @@ const DonateButton = ({
   handleMenuKeyDown
 }: DonateButtonProps) => {
   const { t } = useTranslation();
-  const exposeUniversalDonateButton = useFeature('expose_donate_button').on;
   if (isUserDonating) return <ThankYouMessage message={t('donate.thanks')} />;
-  else if (exposeUniversalDonateButton)
-    return (
-      <Media maxWidth={DONATE_NAV_EXPOSED_WIDTH}>
-        <DonateItem
-          handleMenuKeyDown={handleMenuKeyDown}
-          donateText={t('buttons.donate')}
-        />
-      </Media>
-    );
-  else
-    return (
-      <DonateItem
-        handleMenuKeyDown={handleMenuKeyDown}
-        donateText={t('buttons.donate')}
-      />
-    );
+  return (
+    <DonateItem
+      handleMenuKeyDown={handleMenuKeyDown}
+      donateText={t('buttons.donate')}
+    />
+  );
 };
 
 const toggleTheme = (

--- a/client/src/components/Header/components/universal-nav.tsx
+++ b/client/src/components/Header/components/universal-nav.tsx
@@ -1,14 +1,10 @@
 import Loadable from '@loadable/component';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import Media, { useMediaQuery } from 'react-responsive';
-import { useFeature } from '@growthbook/growthbook-react';
+import { useMediaQuery } from 'react-responsive';
 import { isLanding } from '../../../utils/path-parsers';
 import { Link, SkeletonSprite } from '../../helpers';
-import {
-  SEARCH_EXPOSED_WIDTH,
-  DONATE_NAV_EXPOSED_WIDTH
-} from '../../../../../config/misc';
+import { SEARCH_EXPOSED_WIDTH } from '../../../../../config/misc';
 import MenuButton from './menu-button';
 import NavLinks, { type NavLinksProps } from './nav-links';
 import NavLogo from './nav-logo';
@@ -43,8 +39,6 @@ const UniversalNav = ({
     query: `(min-width: ${SEARCH_EXPOSED_WIDTH}px)`
   });
 
-  const exposeDonateButton = useFeature('expose_donate_button').on;
-
   const search =
     typeof window !== `undefined` && isLanding(window.location.pathname) ? (
       <SearchBarOptimized innerRef={searchBarRef} />
@@ -77,18 +71,6 @@ const UniversalNav = ({
           </div>
         ) : (
           <>
-            {!user?.isDonating && exposeDonateButton && (
-              <Media minWidth={DONATE_NAV_EXPOSED_WIDTH + 1}>
-                <Link
-                  sameTab={false}
-                  to='/donate'
-                  data-test-label='nav-donate-button'
-                  className='exposed-button-nav'
-                >
-                  {t('buttons.donate')}
-                </Link>
-              </Media>
-            )}
             <LanguageList />
             <MenuButton
               displayMenu={displayMenu}

--- a/config/misc.ts
+++ b/config/misc.ts
@@ -1,4 +1,3 @@
 export const MAX_MOBILE_WIDTH = 767;
 export const TOOL_PANEL_HEIGHT = 37;
 export const SEARCH_EXPOSED_WIDTH = 980;
-export const DONATE_NAV_EXPOSED_WIDTH = 600;


### PR DESCRIPTION
The first AB test was unsuccessful due to SRM which was most likely caused by calling useFeature in multiple components.

<img width="1375" alt="Screenshot 2023-08-14 at 1 19 57 PM" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/4591597/c053fdb0-989b-44ec-8ff8-1ba55a1ecf42">

To overcome this issue, we would need to pull the feature once, store the variation, and display changes across the client.




Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
