### PR TITLE
fix(curriculum): check individual properties instead of shorthand

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-css-animation-by-building-a-ferris-wheel/614100d7d335bb2a5ff74f1f.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-css-animation-by-building-a-ferris-wheel/614100d7d335bb2a5ff74f1f.md
@@ -16,7 +16,13 @@ Set the `animation` property of the `.cabin` rule to `cabins 10s linear infinite
 Your `.cabin` selector should have an `animation` property set to `cabins 10s linear infinite`.
 
 ```js
-assert(new __helpers.CSSHelp(document).getStyle('.cabin')?.animation === '10s linear 0s infinite normal none running cabins');
+const cabinElementStyles = new __helpers.CSSHelp(document).getStyle('.cabin');
+assert(
+  cabinElementStyles?.animationName === "cabins" &&
+    cabinElementStyles?.animationDuration === "10s" &&
+    cabinElementStyles?.animationTimingFunction === "linear" &&
+    cabinElementStyles?.animationIterationCount === "infinite"
+);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

This should fix the test for the reported browser incompatibility.

The only issue I can see with this approach is that we can't check if other properties were added incorrectly (like an animation delay or whatnot). But that seems beyond the requirements anyway.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #51225

<!-- Feel free to add any additional description of changes below this line -->
