### PR TITLE
fix(tools): use download-trending when offline 

### DIFF
--- a/client/tools/download-trending.ts
+++ b/client/tools/download-trending.ts
@@ -1,4 +1,4 @@
-import { writeFileSync } from 'fs';
+import { readFileSync, writeFileSync } from 'fs';
 import path from 'path';
 
 import fetch from 'node-fetch';
@@ -14,24 +14,41 @@ const createCdnUrl = (lang: string) =>
 
 const download = async (clientLocale: string) => {
   const url = createCdnUrl(clientLocale);
-  const res = await fetch(url);
-  if (!res.ok) {
-    throw new Error(
-      `
-      ----------------------------------------------------
-      Error: The CDN is missing the trending YAML file.
-      ----------------------------------------------------
-      Unable to fetch the ${clientLocale} footer: ${res.statusText}
-      `
-    );
-  }
 
-  const data = await res.text();
-  const trendingJSON = JSON.stringify(yaml.load(data));
   const trendingLocation = path.resolve(
     __dirname,
     `../i18n/locales/${clientLocale}/trending.json`
   );
+
+  const loadTrendingJSON = async () => {
+    try {
+      const res = await fetch(url);
+      const data = await res.text();
+      const trendingJSON = JSON.stringify(yaml.load(data));
+
+      return trendingJSON;
+    } catch (error) {
+      const localTrendingJSON = readFileSync(trendingLocation, 'utf8');
+
+      if (!localTrendingJSON) {
+        throw new Error(
+          `
+          ----------------------------------------------------
+          Error: The CDN is missing the trending YAML file.
+          ----------------------------------------------------
+          Unable to fetch the ${clientLocale} error message: ${
+            (error as Error).message
+          }
+          `
+        );
+      }
+
+      return localTrendingJSON;
+    }
+  };
+
+  const trendingJSON = await loadTrendingJSON();
+
   writeFileSync(trendingLocation, trendingJSON);
 
   const trendingObject = JSON.parse(trendingJSON) as Record<string, string>;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
## Issue
`client/tools/download-trending.ts` was attempting to fetch the latest trending data when running the `pnpm develop`  command. This was preventing being able to run without an internet connection after the first initial running of `pnpm develop`

## Fix
- Adjusts `client/tools/download-trending.ts` to attempt to load `trending.json`  on fetch error from the local file system which will exist after running `pnpm develop` the first time with a connection