### PR TITLE
feat: remove abstraction in formFields

### DIFF
--- a/client/src/components/formHelpers/form-fields.tsx
+++ b/client/src/components/formHelpers/form-fields.tsx
@@ -5,7 +5,6 @@ import {
   FormGroup,
   HelpBlock
 } from '@freecodecamp/react-bootstrap';
-import { kebabCase } from 'lodash-es';
 import normalizeUrl from 'normalize-url';
 import React from 'react';
 import { Field } from 'react-final-form';
@@ -35,9 +34,8 @@ type FormFieldsProps = {
   options: FormOptions;
 };
 
-function FormFields(props: FormFieldsProps): JSX.Element {
+function FormFields({ formFields, options }: FormFieldsProps): JSX.Element {
   const { t } = useTranslation();
-  const { formFields, options = {} }: FormFieldsProps = props;
   const {
     ignored = [],
     placeholders = {},
@@ -96,27 +94,22 @@ function FormFields(props: FormFieldsProps): JSX.Element {
         .filter(formField => !ignored.includes(formField.name))
         .map(({ name, label }) => (
           // TODO: verify if the value is always a string
-          <Field key={`${kebabCase(name)}-field`} name={name}>
+          <Field key={`${name}-field`} name={name}>
             {({ input: { value, onChange }, meta: { pristine, error } }) => {
-              const key = kebabCase(name);
-              const type = name in types ? types[name] : 'text';
               const placeholder =
                 name in placeholders ? placeholders[name] : '';
               const isURL = types[name] === 'url';
               return (
-                <FormGroup key={key}>
-                  {type === 'hidden' ? null : (
-                    <ControlLabel htmlFor={key}>{label}</ControlLabel>
-                  )}
+                <FormGroup key={name}>
+                  <ControlLabel htmlFor={name}>{label}</ControlLabel>
                   <FormControl
-                    componentClass={type === 'textarea' ? type : 'input'}
-                    id={key}
+                    id={name}
                     name={name}
                     onChange={onChange}
                     placeholder={placeholder}
                     required={required.includes(name)}
                     rows={4}
-                    type={type}
+                    type='url'
                     value={value as string}
                   />
                   {nullOrWarning(

--- a/client/src/components/formHelpers/form.test.tsx
+++ b/client/src/components/formHelpers/form.test.tsx
@@ -23,10 +23,6 @@ const defaultTestProps: StrictSolutionFormProps = {
 test('should render', () => {
   render(<StrictSolutionForm {...defaultTestProps} />);
 
-  const nameInput = screen.getByLabelText(/name Label/);
-  expect(nameInput).not.toBeRequired();
-  expect(nameInput).toHaveAttribute('type', 'text');
-
   const websiteInput = screen.getByLabelText(/WebSite label/);
   expect(websiteInput).toBeRequired();
   expect(websiteInput).toHaveAttribute('type', 'url');


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

One of the issues faced while finishing #51204, was this abstraction.

it checks for values that are never passed, use `type`  to define the component and its type at the same time, change the value of label's `for` attribute, so it never links to the right input's `name` attribute, when it's two word aka `githubLink` changes to `github-link`.

I have checked backend and front end project, here are their URL respectively

- /learn/back-end-development-and-apis/back-end-development-and-apis-projects/timestamp-microservice
- /learn/front-end-development-libraries/front-end-development-libraries-projects/build-a-markdown-previewer



<!-- Feel free to add any additional description of changes below this line -->
