### PR TITLE
fix(a11y): search input

### DIFF
--- a/client/src/components/Header/components/universal-nav.css
+++ b/client/src/components/Header/components/universal-nav.css
@@ -316,8 +316,7 @@ li > button.nav-link-signout:not([aria-disabled='true']):is(:hover, :focus) {
    menu is collapsed. */
 .universal-nav-right
   #toggle-button-nav[aria-expanded='false']
-  + .fcc_searchBar
-  .ais-SearchBox-form {
+  + .fcc_searchBar {
   display: none;
 }
 

--- a/client/src/components/search/searchBar/search-bar.tsx
+++ b/client/src/components/search/searchBar/search-bar.tsx
@@ -72,7 +72,14 @@ export class SearchBar extends Component<SearchBarProps, SearchBarState> {
   }
 
   componentDidMount(): void {
+    const { t } = this.props;
+
     document.addEventListener('click', this.handleFocus);
+
+    const searchInput = document.querySelector('.ais-SearchBox-input');
+    if (searchInput) {
+      searchInput.setAttribute('aria-label', t('search.label'));
+    }
   }
 
   componentWillUnmount(): void {
@@ -198,9 +205,6 @@ export class SearchBar extends Component<SearchBarProps, SearchBarState> {
         >
           <HotKeys handlers={this.keyHandlers} keyMap={this.keyMap}>
             <div className='fcc_search_wrapper'>
-              <label className='fcc_sr_only' htmlFor='fcc_instantsearch'>
-                {t('search.label')}
-              </label>
               <ObserveKeys except={['Space']}>
                 <div onFocus={this.handleFocus} role='textbox'>
                   <SearchBox


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

While working on another PR that involves the search feature, I noticed that the search input did not have a proper accessible name set on it, and it wasn't being completely hidden from screen readers (the label text was still able to be accessed even when the search was hidden). So I got rid of the `label` as it wasn't performing its intended function since its `for` attribute did not point to the search input, and added an `aria-label` to the search input instead.

I know that using `componentDidMount` to add an `aria-label` to the search input is probably causing some of you to roll your eyes, but I wasn't able to find an (easy) way to do this using the API for the search widget. I believe we might be able to create our own custom search widget using the API, but that seems like a lot of work for just adding an attribute. Or, it appears that the most recent versions of algolia React InstantSearch have better accessibility support and we might not need this hack if we upgrade.