### PR TITLE
fix: add build jobs to CI to make renovate behave

### DIFF
--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build-client:
-    name: Build
+    name: Build Client
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build-client:
-    name: Build
+    name: Build Client
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -117,6 +117,43 @@ jobs:
       - name: Run Tests
         run: pnpm test
 
+  # DONT REMOVE THIS JOB, you dont know what it does
+  build:
+    name: Build
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        node-version: [18.x]
+
+    steps:
+      - name: Checkout Source Files
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+
+      - name: Checkout client-config
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          repository: freeCodeCamp/client-config
+          path: client-config
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+
+      - name: Set freeCodeCamp Environment Variables
+        run: cp sample.env .env
+
+      - name: Install and Build
+        run: |
+          pnpm install
+          pnpm run build
+
   test-upcoming:
     name: Test Upcoming Changes
     needs: lint


### PR DESCRIPTION
Someone decided to remove the build job (let git blame Mr.O) from the CI for some reason, making renovate run wild. It's not renovate's fault if you chose to remove the E-Brake from your car.