### PR TITLE
fix(CI): adjust job queue and remove wasteful runs

### DIFF
--- a/.github/workflows/e2e-mobile.yml
+++ b/.github/workflows/e2e-mobile.yml
@@ -1,17 +1,6 @@
 name: CI - E2E - Mobile (webview) Browser
 on:
   workflow_dispatch:
-  # push:
-  #   paths-ignore:
-  #     - 'docs/**'
-  #   branches:
-  #     - 'main'
-  # pull_request:
-  #   paths-ignore:
-  #     - 'docs/**'
-  #   branches:
-  #     - 'main'
-  #     - 'next-**'
 
 jobs:
   mobile-test:

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -1,11 +1,11 @@
 name: CI - E2E - Playwright
 on:
-  push:
-    paths-ignore:
-      - 'docs/**'
-    branches:
-      - 'main'
-      - 'e2e-**'
+  workflow_dispatch:
+  workflow_run:
+    workflows: ['CI - Node.js']
+    types:
+      - completed
+  # TODO: refactor with a workflow_call
   pull_request:
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -1,16 +1,18 @@
 name: CI - E2E - Web browser
 on:
-  push:
-    paths-ignore:
-      - 'docs/**'
-    branches:
-      - 'main'
+  workflow_dispatch:
+  workflow_run:
+    workflows: ['CI - Node.js']
+    types:
+      - completed
+  # TODO: refactor with a workflow_call
   pull_request:
     paths-ignore:
       - 'docs/**'
     branches:
       - 'main'
       - 'next-**'
+      - 'e2e-**'
 
 jobs:
   build-client:

--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -70,9 +70,47 @@ jobs:
           pnpm run build:curriculum
           pnpm run lint
 
+  # DONT REMOVE THIS JOB, you dont know what it does
+  build:
+    name: Build
+    needs: lint
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        node-version: [18.x]
+
+    steps:
+      - name: Checkout Source Files
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+
+      - name: Checkout client-config
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          repository: freeCodeCamp/client-config
+          path: client-config
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+
+      - name: Set freeCodeCamp Environment Variables
+        run: cp sample.env .env
+
+      - name: Install and Build
+        run: |
+          pnpm install
+          pnpm run build
+
   test:
     name: Test
-    needs: lint
+    needs: build
     runs-on: ubuntu-20.04
 
     strategy:
@@ -117,46 +155,9 @@ jobs:
       - name: Run Tests
         run: pnpm test
 
-  # DONT REMOVE THIS JOB, you dont know what it does
-  build:
-    name: Build
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        node-version: [18.x]
-
-    steps:
-      - name: Checkout Source Files
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
-
-      - name: Checkout client-config
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
-        with:
-          repository: freeCodeCamp/client-config
-          path: client-config
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8
-
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: pnpm
-
-      - name: Set freeCodeCamp Environment Variables
-        run: cp sample.env .env
-
-      - name: Install and Build
-        run: |
-          pnpm install
-          pnpm run build
-
   test-upcoming:
-    name: Test Upcoming Changes
-    needs: lint
+    name: Test - Upcoming Changes
+    needs: build
     runs-on: ubuntu-20.04
 
     strategy:
@@ -203,8 +204,8 @@ jobs:
         run: pnpm test
 
   test-new:
-    name: Test New Curriculum
-    needs: lint
+    name: Test - New Curriculum
+    needs: build
     runs-on: ubuntu-20.04
 
     strategy:
@@ -252,8 +253,8 @@ jobs:
         run: pnpm test
 
   test-localization:
-    name: Localize
-    needs: lint
+    name: Test - i18n
+    needs: build
     runs-on: ubuntu-20.04
 
     strategy:
@@ -304,29 +305,3 @@ jobs:
           CURRICULUM_LOCALE: ${{ matrix.locale }}
           CLIENT_LOCALE: ${{ matrix.locale }}
         run: pnpm test
-
-  failure-comment:
-    name: Comment on i18n Failure
-    needs: ['test', 'test-localization']
-    runs-on: ubuntu-20.04
-    if: ${{ always() && needs.test.result == 'success' && needs.test-localization.result == 'failure' }}
-    steps:
-      - uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
-        with:
-          github-token: ${{ secrets.CAMPERBOT_NO_TRANSLATE }}
-          script: |
-            const isDev = await github.rest.teams.getMembershipForUserInOrg({
-              org: "freeCodeCamp",
-              team_slug: "dev-team",
-              username: context.payload.pull_request.user.login
-            }).catch(() => ({status: 404}));
-            if (context.payload.pull_request.user.login !== "camperbot" && isDev.status !== 200) {
-              github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: "Hi,\n\nIt looks like the localization tests have failed. This is expected when there are significant curriculum changes in the English version.\n\nThis could mean a Crowdin sync is required to address the scenario. Please check with our staff developer team, either on [Discord](https://discord.gg/KVUmVXA) or our [forums](https://forum.freecodecamp.org). They will confirm and take over helping you through the PR.\n\nThanks for your understanding and contribution."
-              })
-            } else if (isDev.status === 200) {
-              core.setFailed('This PR appears to touch translated curriculum files, but since you are on the dev team there is no message.');
-            }

--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -83,12 +83,6 @@ jobs:
       - name: Checkout Source Files
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
-      - name: Checkout client-config
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
-        with:
-          repository: freeCodeCamp/client-config
-          path: client-config
-
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:

--- a/.github/workflows/node.js-tests.yml
+++ b/.github/workflows/node.js-tests.yml
@@ -70,7 +70,8 @@ jobs:
           pnpm run build:curriculum
           pnpm run lint
 
-  # DONT REMOVE THIS JOB, you dont know what it does
+  # DONT REMOVE THIS JOB.
+  # TODO: Refactor and use re-usable workflow and shared artifacts
   build:
     name: Build
     needs: lint


### PR DESCRIPTION
The order is now tuned in for the job sequence.

This also uses `workflow_run` to execute only when linting, building, and unit testing are done—fewer jobs in general and forces pacing the order of needs for checks.

In the future, I will probably refactor this further so the E2E workflows use `workflow_call` as well, reducing the runs even more, but for now, here is the behavior:

1. On PR events: "Lint --> Build --> Test" and parallel run E2E.
2. On push events (main, etc.): Lint --> Build --> Test (5 different kinds of jobs) --> E2E
