### PR TITLE
refactor: move browser-script output into client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,10 +158,6 @@ jspm_packages/
 
 ### Generated config files ###
 config/env.json
-config/client/sass-compile.json
-config/client/frame-runner.json
-config/client/test-evaluator.json
-config/client/python-runner.json
 config/curriculum.json
 config/i18n.js
 config/misc.js
@@ -216,18 +212,11 @@ tags
 *.out
 *.gz
 curriculum/curricula.json
-client/static/js/frame-runner.js
-client/static/js/frame-runner.js.map
 
 ### Additional Folders ###
 api-server/lib/*
 curriculum/dist
 curriculum/build
-client/static/_redirects
-client/static/mobile
-client/static/curriculum-data
-client/i18n/locales/**/trending.json
-client/src/components/Donation/types.js
 
 ### UI Components ###
 tools/ui-components/dist

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@
 **/public
 client/static
 client/**/trending.json
+client/config/browser-scripts/*.json
 **/*fixtures*
 curriculum/challenges/_meta/*/*
 curriculum/challenges/**/*

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -9,3 +9,12 @@ yarn-error.log
 
 /static/js
 ./static/_redirects
+static/curriculum-data
+
+# Generated config
+config/browser-scripts/*.json
+i18n/locales/**/trending.json
+
+# TODO: Remove once you've figured out why it's generated.
+# JS that probably should not be generated
+src/components/Donation/types.js

--- a/client/src/templates/Challenges/rechallenge/transformers.js
+++ b/client/src/templates/Challenges/rechallenge/transformers.js
@@ -11,7 +11,7 @@ import {
   stubTrue
 } from 'lodash-es';
 
-import sassData from '../../../../../config/client/sass-compile.json';
+import sassData from '../../../../../client/config/browser-scripts/sass-compile.json';
 import {
   transformContents,
   transformHeadTailAndContents,

--- a/client/src/templates/Challenges/utils/build.ts
+++ b/client/src/templates/Challenges/utils/build.ts
@@ -1,7 +1,7 @@
 import { challengeTypes } from '../../../../../config/challenge-types';
-import frameRunnerData from '../../../../../config/client/frame-runner.json';
-import testEvaluatorData from '../../../../../config/client/test-evaluator.json';
-import pythonRunnerData from '../../../../../config/client/python-runner.json';
+import frameRunnerData from '../../../../../client/config/browser-scripts/frame-runner.json';
+import testEvaluatorData from '../../../../../client/config/browser-scripts/test-evaluator.json';
+import pythonRunnerData from '../../../../../client/config/browser-scripts/python-runner.json';
 
 import {
   ChallengeFile as PropTypesChallengeFile,

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -34,7 +34,7 @@ const {
 const { challengeTypes } = require('../../config/challenge-types');
 // the config files are created during the build, but not before linting
 const testEvaluator =
-  require('../../config/client/test-evaluator.json').filename;
+  require('../../client/config/browser-scripts/test-evaluator.json').filename;
 
 const { getLines } = require('../../utils/get-lines');
 

--- a/tools/client-plugins/browser-scripts/webpack.config.js
+++ b/tools/client-plugins/browser-scripts/webpack.config.js
@@ -6,7 +6,10 @@ const webpack = require('webpack');
 module.exports = (env = {}) => {
   const __DEV__ = env.production !== true;
   const staticPath = path.join(__dirname, '../../../client/static/js');
-  const configPath = path.join(__dirname, '../../../config/client');
+  const configPath = path.join(
+    __dirname,
+    '../../../client/config/browser-scripts/'
+  );
   return {
     cache: __DEV__ ? { type: 'filesystem' } : false,
     mode: __DEV__ ? 'development' : 'production',


### PR DESCRIPTION
It is used by the curriculum, but frame-runner.json and python-runner.json were implicitly imported via buildDOMChallenge and
buildPythonChallenge. This just makes the dependence explicit.

While I was here I cleaned up the .gitignores a little.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
