### PR TITLE
fix: use env.ts to get JWT_SECRET

### DIFF
--- a/api/src/routes/challenge.ts
+++ b/api/src/routes/challenge.ts
@@ -1,12 +1,12 @@
 import { type FastifyPluginCallbackTypebox } from '@fastify/type-provider-typebox';
 import jwt from 'jsonwebtoken';
 import { uniqBy } from 'lodash';
-import { jwtSecret } from '../../../api-server/config/secrets';
 import { getChallenges } from '../utils/get-challenges';
 import { updateUserChallengeData } from '../utils/common-challenge-functions';
 import { formatValidationError } from '../utils/error-formatting';
 import { schemas } from '../schemas';
 import { getPoints, ProgressTimestamp } from '../utils/progress';
+import { JWT_SECRET } from '../utils/env';
 import { challengeTypes } from '../../../config/challenge-types';
 import {
   canSubmitCodeRoadCertProject,
@@ -65,8 +65,11 @@ export const challengeRoutes: FastifyPluginCallbackTypebox = (
       }
 
       try {
-        if (typeof encodedUserToken === 'string' && jwtSecret) {
-          const payload = jwt.verify(encodedUserToken, jwtSecret) as JwtPayload;
+        if (typeof encodedUserToken === 'string') {
+          const payload = jwt.verify(
+            encodedUserToken,
+            JWT_SECRET
+          ) as JwtPayload;
           userToken = payload.userToken;
         }
       } catch {


### PR DESCRIPTION
api should not rely on secrets.js (as it is an api-server specific contrivance)

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
