### PR TITLE
fix(curriculum): display C# training URL link appropriately

### DIFF
--- a/client/src/templates/Challenges/components/challenge-description.css
+++ b/client/src/templates/Challenges/components/challenge-description.css
@@ -7,3 +7,7 @@
   margin-bottom: 1.45rem;
   font-size: 0.9rem;
 }
+
+#description ol li a {
+  word-break: break-all;
+}

--- a/client/src/templates/Challenges/ms-trophy/link-ms-user.css
+++ b/client/src/templates/Challenges/ms-trophy/link-ms-user.css
@@ -7,6 +7,10 @@
   margin-bottom: 5px;
 }
 
+.link-ms-user-ol li a {
+  word-break: break-all;
+}
+
 .link-ms-user-ol li:last-child {
   margin-bottom: 0;
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
This PR was opened to set `word-break` property of anchor element under the list element in the description of new C# challenges and in the `LinkMsUser` component to `break-all`. By doing that, on mobile devices (width <= 500px), overflowing the URL links and unnecessarily stretch of the `body` element's viewport width will be prevented and the links will be displayed appropriately as shown in below image.

The code was tested in Chrome, Firefox, Edge, and Brave on windows 11 PC locally, and also Chrome, Firefox, Safari, Opera, and Brave on iPhone SE using the ngrok.

![not_overflowed_URL_in_anchor_tag](https://github.com/freeCodeCamp/freeCodeCamp/assets/44451585/64956487-6b29-4c5d-8951-b51502c84e9b)
