### PR TITLE
fix(client): show upcoming curriculum on maps

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -119,6 +119,7 @@
     "core-certs-heading": "Earn free verified certifications with freeCodeCamp's core curriculum:",
     "professional-certs-heading": "Earn free professional certifications:",
     "interview-prep-heading": "Prepare for the developer interview job search:",
+    "upcoming-heading": "Upcoming curriculum:",
     "faq": "Frequently asked questions:",
     "faqs": [
       {

--- a/client/src/components/Map/index.tsx
+++ b/client/src/components/Map/index.tsx
@@ -115,6 +115,19 @@ function Map({ forLanding = false }: MapProps): React.ReactElement {
           <MapLi key={i} superBlock={superBlock} landing={forLanding} />
         ))}
       </ul>
+      {showUpcomingChanges && (
+        <>
+          <Spacer size='medium' />
+          <h1 className={forLanding ? 'big-heading' : ''}>
+            {t('landing.upcoming-heading')}
+          </h1>
+          <ul>
+            {superBlockOrder[SuperBlockStages.Upcoming].map((superBlock, i) => (
+              <MapLi key={i} superBlock={superBlock} landing={forLanding} />
+            ))}
+          </ul>
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
I accidentally removed the upcoming stuff from the map when making C# changes. This adds it back.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
