### PR TITLE
refactor(tools): challenge tests - checks for title and ids

### DIFF
--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -321,11 +321,7 @@ function populateTestsForLang({ lang, challenges, meta }) {
             const pathAndTitle = `${block}/${dashedName}`;
             const idVerificationMessage = mongoIds.check(id, title);
             assert.isNull(idVerificationMessage, idVerificationMessage);
-            const dupeTitleCheck = challengeTitles.check(
-              dashedName,
-              block,
-              pathAndTitle
-            );
+            const dupeTitleCheck = challengeTitles.check(dashedName, block);
             assert.isTrue(
               dupeTitleCheck,
               `All challenges within a block must have a unique dashed name. ${dashedName} (at ${pathAndTitle}) is already assigned`

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -315,8 +315,17 @@ function populateTestsForLang({ lang, challenges, meta }) {
             }
             const { id, title, block, dashedName } = challenge;
             const pathAndTitle = `${block}/${dashedName}`;
-            mongoIds.check(id, title);
-            challengeTitles.check(title, pathAndTitle);
+            const idVerificationMessage = mongoIds.check(id, title);
+            assert.isNull(idVerificationMessage, idVerificationMessage);
+            const dupeTitleCheck = challengeTitles.check(
+              title,
+              block,
+              pathAndTitle
+            );
+            assert.isTrue(
+              dupeTitleCheck,
+              `All challenges within a block must have a unique title. The title ${title} (at ${pathAndTitle}) is already assigned`
+            );
           });
 
           const { challengeType } = challenge;

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -314,17 +314,21 @@ function populateTestsForLang({ lang, challenges, meta }) {
               throw new AssertionError(result.error);
             }
             const { id, title, block, dashedName } = challenge;
+            assert.exists(
+              dashedName,
+              `Missing dashedName for challenge ${id} in ${block}.`
+            );
             const pathAndTitle = `${block}/${dashedName}`;
             const idVerificationMessage = mongoIds.check(id, title);
             assert.isNull(idVerificationMessage, idVerificationMessage);
             const dupeTitleCheck = challengeTitles.check(
-              title,
+              dashedName,
               block,
               pathAndTitle
             );
             assert.isTrue(
               dupeTitleCheck,
-              `All challenges within a block must have a unique title. The title ${title} (at ${pathAndTitle}) is already assigned`
+              `All challenges within a block must have a unique dashed name. ${dashedName} (at ${pathAndTitle}) is already assigned`
             );
           });
 

--- a/curriculum/test/utils/challenge-titles.js
+++ b/curriculum/test/utils/challenge-titles.js
@@ -1,8 +1,11 @@
 class ChallengeTitles {
   constructor() {
-    this.knownTitles = [];
+    /**
+     * Takes the shape of { [block]: title[]}
+     */
+    this.knownTitles = {};
   }
-  check(title, pathAndTitle) {
+  check(title, block) {
     if (typeof title !== 'string') {
       throw new Error(
         `Expected a valid string for ${title}, but got a(n) ${typeof title}`
@@ -12,19 +15,15 @@ class ChallengeTitles {
     if (titleToCheck.length === 0) {
       throw new Error('Expected a title length greater than 0');
     }
-    // reassign titleToCheck if challenge is part of the project
-    // based curriculum
-    const isProjectCurriculumChallenge = title.match(/^Step\s*\d+$/);
-    titleToCheck = isProjectCurriculumChallenge ? pathAndTitle : titleToCheck;
-    const isKnown = this.knownTitles.includes(titleToCheck);
-    // TODO: check for the exceptions or remove the warning.
-    if (isKnown) {
-      console.warn(`
-        All current curriculum challenges must have a unique title.
-        The title ${title} (at ${pathAndTitle}) is already assigned
-      `);
+    if (!this.knownTitles[block]) {
+      this.knownTitles[block] = [];
     }
-    this.knownTitles = [...this.knownTitles, titleToCheck];
+    const isKnown = this.knownTitles[block].includes(title);
+    if (isKnown) {
+      return false;
+    }
+    this.knownTitles[block].push(title);
+    return true;
   }
 }
 

--- a/curriculum/test/utils/mongo-ids.js
+++ b/curriculum/test/utils/mongo-ids.js
@@ -24,16 +24,15 @@ class MongoIds {
     try {
       schema.validate(id);
     } catch {
-      throw Error(`Expected a valid ObjectId for ${title}, but got ${id}`);
+      return `Expected a valid ObjectId for ${title}, but got ${id}`;
     }
 
     const idIndex = findIndex(this.knownIds, existing => id === existing);
     if (idIndex !== -1 && !duplicatedProjectIds.includes(id)) {
-      throw Error(`The id for challenge ${title} appears more than once.
-      With the exception of duplicatedProjectIds this should not happen.
-    `);
+      return `The id for challenge ${title} appears more than once. With the exception of duplicatedProjectIds this should not happen.`;
     }
     this.knownIds = [...this.knownIds, id];
+    return null;
   }
 }
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This originally started because testing the curriculum locally (specifically in non-English) is very noisy:

<img width="940" alt="image" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/63889819/9d44e610-3ca6-4798-9406-995d0791fe4c">

Realistically, challenge names only need to be unique within the same block (because we use the name as the slug). So the first change was to update the tool to track names within blocks.

Then I saw the comments about throwing the errors, so I adjusted both the `ChallengeTitles` and `MongoIds` classes to return values, which are passed into an assert to properly use the test suite:

<img width="953" alt="image" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/63889819/1ae3dd90-007d-4575-97f7-a85d57b39082">

<!-- Feel free to add any additional description of changes below this line -->
