### PR TITLE
fix: type error for solution display widget's dropdown

### DIFF
--- a/client/src/components/solution-display-widget/index.tsx
+++ b/client/src/components/solution-display-widget/index.tsx
@@ -45,7 +45,7 @@ export function SolutionDisplayWidget({
   );
   const ShowProjectAndGithubLinkForCertification = (
     <Dropdown id={`dropdown-for-${id}-${randomIdSuffix}`}>
-      <Dropdown.Toggle block={true} bsStyle='primary' className='btn-invert'>
+      <Dropdown.Toggle className='btn-invert'>
         {viewText}{' '}
         <span className='sr-only'>
           {t('settings.labels.solution-for', { projectTitle })}
@@ -53,7 +53,7 @@ export function SolutionDisplayWidget({
       </Dropdown.Toggle>
       <Dropdown.Menu>
         <MenuItem
-          bsStyle='primary'
+          variant='primary'
           href={solution ?? ''}
           rel='noopener noreferrer'
           target='_blank'
@@ -63,7 +63,7 @@ export function SolutionDisplayWidget({
           <FontAwesomeIcon icon={faExternalLinkAlt} />
         </MenuItem>
         <MenuItem
-          bsStyle='primary'
+          variant='primary'
           href={githubLink}
           rel='noopener noreferrer'
           target='_blank'
@@ -97,7 +97,7 @@ export function SolutionDisplayWidget({
   const ShowUserCode = (
     <Button
       block={true}
-      bsStyle='primary'
+      variant='primary'
       className='btn-invert'
       data-cy={dataCy}
       onClick={showUserCode}
@@ -111,17 +111,17 @@ export function SolutionDisplayWidget({
   const ShowMultifileProjectSolution = (
     <div className='solutions-dropdown'>
       <Dropdown id={`dropdown-for-${id}-${randomIdSuffix}`}>
-        <Dropdown.Toggle block={true} bsStyle='primary' className='btn-invert'>
+        <Dropdown.Toggle className='btn-invert'>
           {viewText}{' '}
           <span className='sr-only'>
             {t('settings.labels.solution-for', { projectTitle })}
           </span>
         </Dropdown.Toggle>
         <Dropdown.Menu>
-          <MenuItem bsStyle='primary' onClick={showUserCode}>
+          <MenuItem variant='primary' onClick={showUserCode}>
             {viewCode}
           </MenuItem>
-          <MenuItem bsStyle='primary' onClick={showProjectPreview}>
+          <MenuItem variant='primary' onClick={showProjectPreview}>
             {viewProject}
           </MenuItem>
         </Dropdown.Menu>
@@ -132,7 +132,7 @@ export function SolutionDisplayWidget({
   const ShowProjectAndGithubLinks = (
     <div className='solutions-dropdown'>
       <Dropdown id={`dropdown-for-${id}-${randomIdSuffix}`}>
-        <Dropdown.Toggle block={true} bsStyle='primary' className='btn-invert'>
+        <Dropdown.Toggle className='btn-invert'>
           {viewText}{' '}
           <span className='sr-only'>
             {t('settings.labels.solution-for', { projectTitle })}
@@ -140,7 +140,7 @@ export function SolutionDisplayWidget({
         </Dropdown.Toggle>
         <Dropdown.Menu>
           <MenuItem
-            bsStyle='primary'
+            variant='primary'
             href={solution}
             rel='noopener noreferrer'
             target='_blank'
@@ -150,7 +150,7 @@ export function SolutionDisplayWidget({
             <FontAwesomeIcon icon={faExternalLinkAlt} />
           </MenuItem>
           <MenuItem
-            bsStyle='primary'
+            variant='primary'
             href={githubLink}
             rel='noopener noreferrer'
             target='_blank'

--- a/tools/ui-components/src/drop-down/drop-down.tsx
+++ b/tools/ui-components/src/drop-down/drop-down.tsx
@@ -25,6 +25,7 @@ type DropdownMenuProps = Props<
 
 export type DropdownProps = DropdownMenuProps & {
   dropup?: boolean;
+  id?: string;
 };
 
 export interface ButtonRenderPropArg {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Similar to #51369

Confused cased by using the component without types.
<!-- Feel free to add any additional description of changes below this line -->
