### PR TITLE
docs: revising typos and adding clarity to steps for creating a PR

### DIFF
--- a/docs/how-to-open-a-pull-request.md
+++ b/docs/how-to-open-a-pull-request.md
@@ -32,12 +32,12 @@ Whenever you open a Pull Request(PR), you can use the below to determine the typ
 
 **Type:**
 
-| Type  | When to select                                                                   |
-| :---- | :------------------------------------------------------------------------------- |
+| Type  | When to select                                                                  |
+|:------|:--------------------------------------------------------------------------------|
 | fix   | Changed or updated/improved functionality, tests, the wording of a lesson, etc. |
-| feat  | Only if you are adding new functionality, tests, etc.                            |
-| chore | Changes that are not related to code, tests, or verbiage of a lesson.            |
-| docs  | Changes to `/docs` directory or the contributing guidelines, etc.                |
+| feat  | Only if you are adding new functionality, tests, etc.                           |
+| chore | Changes that are not related to code, tests, or verbiage of a lesson.           |
+| docs  | Changes to `/docs` directory or the contributing guidelines, etc.               |
 
 **Scope:**
 
@@ -93,7 +93,7 @@ Some examples of good PR titles would be:
 
    - This is very important when making changes that are not just edits to text content like documentation or a challenge description. Examples of changes that need local testing include JavaScript, CSS, or HTML, which could change the functionality or layout of a page.
 
-   - If your PR affects the behaviour of a page it should be accompanied by corresponding [Cypress integration tests](how-to-add-cypress-tests.md).
+   - If your PR affects the behaviour of a page, it should be accompanied by corresponding [Cypress integration tests](how-to-add-cypress-tests.md).
 
 ## Feedback on Pull Requests
 
@@ -110,7 +110,7 @@ And as always, feel free to ask questions on the ['Contributors' category on our
 
 Conflicts can arise because many contributors work on the repository, and changes can break your PR which is pending a review and merge.
 
-More often than not you may not require a rebase, because we squash all commits, however, if a rebase is requested, here is what you should do.
+Since we squash all commits, you may not need to do a rebase.  However, if a rebase is requested, check our [For Usual Bug Fixes and Features](#for-usual-bug-fixes-and-features) or [For Upcoming Curriculum and Features](#for-upcoming-curriculum-and-features) guides to learn how to do this process for your corresponding PR.
 
 ### For Usual Bug Fixes and Features
 
@@ -188,7 +188,7 @@ When you are working on features for our upcoming curriculum `next-*` branches, 
    git cherry-pick <commit-hash>
    ```
 
-4. Resolve any conflicts, cleanup, install dependencies and run tests
+4. Resolve any conflicts, cleanup, and install dependencies and run tests
 
    ```console
    pnpm run clean
@@ -202,7 +202,7 @@ When you are working on features for our upcoming curriculum `next-*` branches, 
 
    ```
 
-5. If everything looks good push back to the PR
+5. If everything looks good, push back to the PR
 
    ```console
    git push --force origin <pr-branch-name>


### PR DESCRIPTION
## Description
This PR revises some typos "How to Open a Pull Request" documentation. It also elaborates on some steps(e.g., how to solve merge conflicts).  

## Benefits
1. Revising the typos will help contributors gain a better understanding of what the directions are describing.
2. Linking the [For Usual Bug Fixes and Features](http://localhost:3400/#/how-to-open-a-pull-request?id=for-usual-bug-fixes-and-features) and [For Upcoming Curriculum and Features](http://localhost:3400/#/how-to-open-a-pull-request?id=for-upcoming-curriculum-and-features) guides in the second paragraph of the section on solving merge conflicts would make it easier for contributors to get the help they need.   
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
