### PR TITLE
feat: control loop-protect

### DIFF
--- a/client/gatsby-node.js
+++ b/client/gatsby-node.js
@@ -79,6 +79,7 @@ exports.createPages = function createPages({ graphql, actions, reporter }) {
                   challengeType
                   dashedName
                   disableLoopProtect
+                  disableLoopProtectPreview
                   fields {
                     slug
                     blockHashSlug

--- a/client/gatsby-node.js
+++ b/client/gatsby-node.js
@@ -78,6 +78,7 @@ exports.createPages = function createPages({ graphql, actions, reporter }) {
                   certification
                   challengeType
                   dashedName
+                  disableLoopProtect
                   fields {
                     slug
                     blockHashSlug

--- a/client/gatsby-node.js
+++ b/client/gatsby-node.js
@@ -78,7 +78,7 @@ exports.createPages = function createPages({ graphql, actions, reporter }) {
                   certification
                   challengeType
                   dashedName
-                  disableLoopProtect
+                  disableLoopProtectTests
                   disableLoopProtectPreview
                   fields {
                     slug

--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -313,6 +313,7 @@ export type ChallengeMeta = {
   challengeType?: number;
   helpCategory: string;
   disableLoopProtect: boolean;
+  disableLoopProtectPreview: boolean;
 };
 
 export type PortfolioProjectData = {

--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -312,7 +312,7 @@ export type ChallengeMeta = {
   title?: string;
   challengeType?: number;
   helpCategory: string;
-  disableLoopProtect: boolean;
+  disableLoopProtectTests: boolean;
   disableLoopProtectPreview: boolean;
 };
 

--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -312,6 +312,7 @@ export type ChallengeMeta = {
   title?: string;
   challengeType?: number;
   helpCategory: string;
+  disableLoopProtect: boolean;
 };
 
 export type PortfolioProjectData = {

--- a/client/src/templates/Challenges/rechallenge/transformers.js
+++ b/client/src/templates/Challenges/rechallenge/transformers.js
@@ -159,14 +159,16 @@ const babelTransformer = loopProtectOptions => {
 
 function getBabelOptions(
   presets,
-  { preview, disableLoopProtect } = {
+  { preview, disableLoopProtect, disableLoopProtectPreview } = {
     preview: false,
-    disableLoopProtect: false
+    disableLoopProtect: false,
+    disableLoopProtectPreview: false
   }
 ) {
   // we always protect the preview, since it evaluates as the user types and
   // they may briefly have infinite looping code accidentally
-  if (preview) return { ...presets, plugins: ['loopProtection'] };
+  if (preview && !disableLoopProtectPreview)
+    return { ...presets, plugins: ['loopProtection'] };
   if (!disableLoopProtect)
     return { ...presets, plugins: ['testLoopProtection'] };
   return presets;

--- a/client/src/templates/Challenges/rechallenge/transformers.js
+++ b/client/src/templates/Challenges/rechallenge/transformers.js
@@ -159,9 +159,9 @@ const babelTransformer = loopProtectOptions => {
 
 function getBabelOptions(
   presets,
-  { preview, disableLoopProtect, disableLoopProtectPreview } = {
+  { preview, disableLoopProtectTests, disableLoopProtectPreview } = {
     preview: false,
-    disableLoopProtect: false,
+    disableLoopProtectTests: false,
     disableLoopProtectPreview: false
   }
 ) {
@@ -169,7 +169,7 @@ function getBabelOptions(
   // they may briefly have infinite looping code accidentally
   if (preview && !disableLoopProtectPreview)
     return { ...presets, plugins: ['loopProtection'] };
-  if (!disableLoopProtect)
+  if (!disableLoopProtectTests)
     return { ...presets, plugins: ['testLoopProtection'] };
   return presets;
 }

--- a/client/src/templates/Challenges/rechallenge/transformers.js
+++ b/client/src/templates/Challenges/rechallenge/transformers.js
@@ -159,12 +159,16 @@ const babelTransformer = loopProtectOptions => {
 
 function getBabelOptions(
   presets,
-  { preview, protect } = { preview: false, protect: true }
+  { preview, disableLoopProtect } = {
+    preview: false,
+    disableLoopProtect: false
+  }
 ) {
   // we always protect the preview, since it evaluates as the user types and
   // they may briefly have infinite looping code accidentally
   if (preview) return { ...presets, plugins: ['loopProtection'] };
-  if (protect) return { ...presets, plugins: ['testLoopProtection'] };
+  if (!disableLoopProtect)
+    return { ...presets, plugins: ['testLoopProtection'] };
   return presets;
 }
 

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -30,7 +30,6 @@ import {
   challengeHasPreview,
   getTestRunner,
   isJavaScriptChallenge,
-  isLoopProtected,
   updatePreview,
   updateProjectPreview
 } from '../utils/build';
@@ -107,10 +106,9 @@ function* executeChallengeSaga({ payload }) {
 
     const challengeData = yield select(challengeDataSelector);
     const challengeMeta = yield select(challengeMetaSelector);
-    const protect = isLoopProtected(challengeMeta);
     const buildData = yield buildChallengeData(challengeData, {
       preview: false,
-      protect,
+      disableLoopProtect: challengeMeta.disableLoopProtect,
       usesTestRunner: true
     });
     const document = yield getContext('document');
@@ -230,10 +228,9 @@ function* previewChallengeSaga({ flushLogs = true } = {}) {
 
     if (canBuildChallenge(challengeData)) {
       const challengeMeta = yield select(challengeMetaSelector);
-      const protect = isLoopProtected(challengeMeta);
       const buildData = yield buildChallengeData(challengeData, {
         preview: true,
-        protect
+        disableLoopProtect: challengeMeta.disableLoopProtect
       });
       // evaluate the user code in the preview frame or in the worker
       if (challengeHasPreview(challengeData)) {

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -109,6 +109,7 @@ function* executeChallengeSaga({ payload }) {
     const buildData = yield buildChallengeData(challengeData, {
       preview: false,
       disableLoopProtect: challengeMeta.disableLoopProtect,
+      disableLoopProtectPreview: challengeMeta.disableLoopProtectPreview,
       usesTestRunner: true
     });
     const document = yield getContext('document');
@@ -230,7 +231,8 @@ function* previewChallengeSaga({ flushLogs = true } = {}) {
       const challengeMeta = yield select(challengeMetaSelector);
       const buildData = yield buildChallengeData(challengeData, {
         preview: true,
-        disableLoopProtect: challengeMeta.disableLoopProtect
+        disableLoopProtect: challengeMeta.disableLoopProtect,
+        disableLoopProtectPreview: challengeMeta.disableLoopProtectPreview
       });
       // evaluate the user code in the preview frame or in the worker
       if (challengeHasPreview(challengeData)) {

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -108,7 +108,7 @@ function* executeChallengeSaga({ payload }) {
     const challengeMeta = yield select(challengeMetaSelector);
     const buildData = yield buildChallengeData(challengeData, {
       preview: false,
-      disableLoopProtect: challengeMeta.disableLoopProtect,
+      disableLoopProtectTests: challengeMeta.disableLoopProtectTests,
       disableLoopProtectPreview: challengeMeta.disableLoopProtectPreview,
       usesTestRunner: true
     });
@@ -231,7 +231,7 @@ function* previewChallengeSaga({ flushLogs = true } = {}) {
       const challengeMeta = yield select(challengeMetaSelector);
       const buildData = yield buildChallengeData(challengeData, {
         preview: true,
-        disableLoopProtect: challengeMeta.disableLoopProtect,
+        disableLoopProtectTests: challengeMeta.disableLoopProtectTests,
         disableLoopProtectPreview: challengeMeta.disableLoopProtectPreview
       });
       // evaluate the user code in the preview frame or in the worker

--- a/client/src/templates/Challenges/utils/build.ts
+++ b/client/src/templates/Challenges/utils/build.ts
@@ -43,7 +43,7 @@ interface BuildChallengeData extends Context {
 
 interface BuildOptions {
   preview: boolean;
-  disableLoopProtect: boolean;
+  disableLoopProtectTests: boolean;
   disableLoopProtectPreview: boolean;
   usesTestRunner?: boolean;
 }

--- a/client/src/templates/Challenges/utils/build.ts
+++ b/client/src/templates/Challenges/utils/build.ts
@@ -44,7 +44,8 @@ interface BuildChallengeData extends Context {
 interface BuildOptions {
   preview: boolean;
   disableLoopProtect: boolean;
-  usesTestRunner: boolean;
+  disableLoopProtectPreview: boolean;
+  usesTestRunner?: boolean;
 }
 
 const { filename: testEvaluator } = testEvaluatorData;
@@ -211,14 +212,15 @@ type BuildResult = {
 // out of it.
 export function buildDOMChallenge(
   { challengeFiles, required = [], template = '' }: BuildChallengeData,
-  { usesTestRunner } = { usesTestRunner: false }
+  options: BuildOptions
 ): Promise<BuildResult> | undefined {
   const loadEnzyme = challengeFiles?.some(
     challengeFile => challengeFile.ext === 'jsx'
   );
 
-  const pipeLine = composeFunctions(...getTransformers());
+  const pipeLine = composeFunctions(...getTransformers(options));
   const finalFiles = challengeFiles?.map(pipeLine);
+  const usesTestRunner = options.usesTestRunner ?? false;
 
   if (finalFiles) {
     return Promise.all(finalFiles)

--- a/client/src/templates/Challenges/utils/build.ts
+++ b/client/src/templates/Challenges/utils/build.ts
@@ -212,7 +212,7 @@ type BuildResult = {
 // out of it.
 export function buildDOMChallenge(
   { challengeFiles, required = [], template = '' }: BuildChallengeData,
-  options: BuildOptions
+  options?: BuildOptions
 ): Promise<BuildResult> | undefined {
   const loadEnzyme = challengeFiles?.some(
     challengeFile => challengeFile.ext === 'jsx'
@@ -220,7 +220,7 @@ export function buildDOMChallenge(
 
   const pipeLine = composeFunctions(...getTransformers(options));
   const finalFiles = challengeFiles?.map(pipeLine);
-  const usesTestRunner = options.usesTestRunner ?? false;
+  const usesTestRunner = options?.usesTestRunner ?? false;
 
   if (finalFiles) {
     return Promise.all(finalFiles)

--- a/client/src/templates/Challenges/utils/build.ts
+++ b/client/src/templates/Challenges/utils/build.ts
@@ -43,7 +43,7 @@ interface BuildChallengeData extends Context {
 
 interface BuildOptions {
   preview: boolean;
-  protect: boolean;
+  disableLoopProtect: boolean;
   usesTestRunner: boolean;
 }
 
@@ -384,8 +384,4 @@ export function isJavaScriptChallenge({
     challengeType === challengeTypes.js ||
     challengeType === challengeTypes.jsProject
   );
-}
-
-export function isLoopProtected(challengeMeta: ChallengeMeta): boolean {
-  return challengeMeta.superBlock !== 'coding-interview-prep';
 }

--- a/client/utils/gatsby/challenge-page-creator.js
+++ b/client/utils/gatsby/challenge-page-creator.js
@@ -93,6 +93,7 @@ exports.createChallengePages = function (createPage) {
   return function ({ node: { challenge } }, index, allChallengeEdges) {
     const {
       dashedName,
+      disableLoopProtect,
       certification,
       superBlock,
       block,
@@ -113,6 +114,7 @@ exports.createChallengePages = function (createPage) {
           blockHashSlug,
           dashedName,
           certification,
+          disableLoopProtect,
           superBlock,
           block,
           isFirstStep: getIsFirstStepInBlock(index, allChallengeEdges),

--- a/client/utils/gatsby/challenge-page-creator.js
+++ b/client/utils/gatsby/challenge-page-creator.js
@@ -93,7 +93,7 @@ exports.createChallengePages = function (createPage) {
   return function ({ node: { challenge } }, index, allChallengeEdges) {
     const {
       dashedName,
-      disableLoopProtect,
+      disableLoopProtectTests,
       disableLoopProtectPreview,
       certification,
       superBlock,
@@ -115,7 +115,7 @@ exports.createChallengePages = function (createPage) {
           blockHashSlug,
           dashedName,
           certification,
-          disableLoopProtect,
+          disableLoopProtectTests,
           disableLoopProtectPreview,
           superBlock,
           block,

--- a/client/utils/gatsby/challenge-page-creator.js
+++ b/client/utils/gatsby/challenge-page-creator.js
@@ -94,6 +94,7 @@ exports.createChallengePages = function (createPage) {
     const {
       dashedName,
       disableLoopProtect,
+      disableLoopProtectPreview,
       certification,
       superBlock,
       block,
@@ -115,6 +116,7 @@ exports.createChallengePages = function (createPage) {
           dashedName,
           certification,
           disableLoopProtect,
+          disableLoopProtectPreview,
           superBlock,
           block,
           isFirstStep: getIsFirstStepInBlock(index, allChallengeEdges),

--- a/curriculum/challenges/_meta/project-euler-problems-1-to-100/meta.json
+++ b/curriculum/challenges/_meta/project-euler-problems-1-to-100/meta.json
@@ -8,7 +8,7 @@
   "template": "",
   "required": [],
   "superBlock": "project-euler",
-  "disableLoopProtect": true,
+  "disableLoopProtectTests": true,
   "challengeOrder": [
     {
       "id": "5900f36e1000cf542c50fe80",

--- a/curriculum/challenges/_meta/project-euler-problems-1-to-100/meta.json
+++ b/curriculum/challenges/_meta/project-euler-problems-1-to-100/meta.json
@@ -8,6 +8,7 @@
   "template": "",
   "required": [],
   "superBlock": "project-euler",
+  "disableLoopProtect": true,
   "challengeOrder": [
     {
       "id": "5900f36e1000cf542c50fe80",

--- a/curriculum/challenges/_meta/project-euler-problems-101-to-200/meta.json
+++ b/curriculum/challenges/_meta/project-euler-problems-101-to-200/meta.json
@@ -8,6 +8,7 @@
   "template": "",
   "required": [],
   "superBlock": "project-euler",
+  "disableLoopProtect": true,
   "challengeOrder": [
     {
       "id": "5900f3d21000cf542c50fee4",

--- a/curriculum/challenges/_meta/project-euler-problems-101-to-200/meta.json
+++ b/curriculum/challenges/_meta/project-euler-problems-101-to-200/meta.json
@@ -8,7 +8,7 @@
   "template": "",
   "required": [],
   "superBlock": "project-euler",
-  "disableLoopProtect": true,
+  "disableLoopProtectTests": true,
   "challengeOrder": [
     {
       "id": "5900f3d21000cf542c50fee4",

--- a/curriculum/challenges/_meta/project-euler-problems-201-to-300/meta.json
+++ b/curriculum/challenges/_meta/project-euler-problems-201-to-300/meta.json
@@ -8,6 +8,7 @@
   "template": "",
   "required": [],
   "superBlock": "project-euler",
+  "disableLoopProtect": true,
   "challengeOrder": [
     {
       "id": "5900f4361000cf542c50ff48",

--- a/curriculum/challenges/_meta/project-euler-problems-201-to-300/meta.json
+++ b/curriculum/challenges/_meta/project-euler-problems-201-to-300/meta.json
@@ -8,7 +8,7 @@
   "template": "",
   "required": [],
   "superBlock": "project-euler",
-  "disableLoopProtect": true,
+  "disableLoopProtectTests": true,
   "challengeOrder": [
     {
       "id": "5900f4361000cf542c50ff48",

--- a/curriculum/challenges/_meta/project-euler-problems-301-to-400/meta.json
+++ b/curriculum/challenges/_meta/project-euler-problems-301-to-400/meta.json
@@ -8,6 +8,7 @@
   "template": "",
   "required": [],
   "superBlock": "project-euler",
+  "disableLoopProtect": true,
   "challengeOrder": [
     {
       "id": "5900f4991000cf542c50ffab",

--- a/curriculum/challenges/_meta/project-euler-problems-301-to-400/meta.json
+++ b/curriculum/challenges/_meta/project-euler-problems-301-to-400/meta.json
@@ -8,7 +8,7 @@
   "template": "",
   "required": [],
   "superBlock": "project-euler",
-  "disableLoopProtect": true,
+  "disableLoopProtectTests": true,
   "challengeOrder": [
     {
       "id": "5900f4991000cf542c50ffab",

--- a/curriculum/challenges/_meta/project-euler-problems-401-to-480/meta.json
+++ b/curriculum/challenges/_meta/project-euler-problems-401-to-480/meta.json
@@ -8,7 +8,7 @@
   "template": "",
   "required": [],
   "superBlock": "project-euler",
-  "disableLoopProtect": true,
+  "disableLoopProtectTests": true,
   "challengeOrder": [
     {
       "id": "5900f4fd1000cf542c51000f",

--- a/curriculum/challenges/_meta/project-euler-problems-401-to-480/meta.json
+++ b/curriculum/challenges/_meta/project-euler-problems-401-to-480/meta.json
@@ -8,6 +8,7 @@
   "template": "",
   "required": [],
   "superBlock": "project-euler",
+  "disableLoopProtect": true,
   "challengeOrder": [
     {
       "id": "5900f4fd1000cf542c51000f",

--- a/curriculum/challenges/_meta/rosetta-code/meta.json
+++ b/curriculum/challenges/_meta/rosetta-code/meta.json
@@ -8,6 +8,7 @@
   "template": "",
   "required": [],
   "superBlock": "coding-interview-prep",
+  "disableLoopProtect": true,
   "challengeOrder": [
     {
       "id": "594810f028c0303b75339acb",

--- a/curriculum/challenges/_meta/rosetta-code/meta.json
+++ b/curriculum/challenges/_meta/rosetta-code/meta.json
@@ -8,7 +8,7 @@
   "template": "",
   "required": [],
   "superBlock": "coding-interview-prep",
-  "disableLoopProtect": true,
+  "disableLoopProtectTests": true,
   "challengeOrder": [
     {
       "id": "594810f028c0303b75339acb",

--- a/curriculum/get-challenges.js
+++ b/curriculum/get-challenges.js
@@ -327,6 +327,7 @@ ${getFullPath('english', filePath)}
       });
     challenge.usesMultifileEditor = !!meta.usesMultifileEditor;
     challenge.disableLoopProtect = !!meta.disableLoopProtect;
+    challenge.disableLoopProtectPreview = !!meta.disableLoopProtectPreview;
   }
 
   function fixChallengeProperties(challenge) {

--- a/curriculum/get-challenges.js
+++ b/curriculum/get-challenges.js
@@ -326,6 +326,7 @@ ${getFullPath('english', filePath)}
         showUpcomingChanges: process.env.SHOW_UPCOMING_CHANGES === 'true'
       });
     challenge.usesMultifileEditor = !!meta.usesMultifileEditor;
+    challenge.disableLoopProtect = !!meta.disableLoopProtect;
   }
 
   function fixChallengeProperties(challenge) {

--- a/curriculum/get-challenges.js
+++ b/curriculum/get-challenges.js
@@ -326,7 +326,7 @@ ${getFullPath('english', filePath)}
         showUpcomingChanges: process.env.SHOW_UPCOMING_CHANGES === 'true'
       });
     challenge.usesMultifileEditor = !!meta.usesMultifileEditor;
-    challenge.disableLoopProtect = !!meta.disableLoopProtect;
+    challenge.disableLoopProtectTests = !!meta.disableLoopProtectTests;
     challenge.disableLoopProtectPreview = !!meta.disableLoopProtectPreview;
   }
 

--- a/curriculum/schema/challenge-schema.js
+++ b/curriculum/schema/challenge-schema.js
@@ -43,6 +43,7 @@ const schema = Joi.object()
       otherwise: Joi.string().required()
     }),
     disableLoopProtectTests: Joi.boolean().required(),
+    disableLoopProtectPreview: Joi.boolean().required(),
     challengeFiles: Joi.array().items(fileJoi),
     guideUrl: Joi.string().uri({ scheme: 'https' }),
     hasEditableBoundaries: Joi.boolean(),

--- a/curriculum/schema/challenge-schema.js
+++ b/curriculum/schema/challenge-schema.js
@@ -42,6 +42,7 @@ const schema = Joi.object()
       then: Joi.string().allow(''),
       otherwise: Joi.string().required()
     }),
+    disableLoopProtect: Joi.boolean().required(),
     challengeFiles: Joi.array().items(fileJoi),
     guideUrl: Joi.string().uri({ scheme: 'https' }),
     hasEditableBoundaries: Joi.boolean(),

--- a/curriculum/schema/challenge-schema.js
+++ b/curriculum/schema/challenge-schema.js
@@ -42,7 +42,7 @@ const schema = Joi.object()
       then: Joi.string().allow(''),
       otherwise: Joi.string().required()
     }),
-    disableLoopProtect: Joi.boolean().required(),
+    disableLoopProtectTests: Joi.boolean().required(),
     challengeFiles: Joi.array().items(fileJoi),
     guideUrl: Joi.string().uri({ scheme: 'https' }),
     hasEditableBoundaries: Joi.boolean(),

--- a/docs/how-to-work-on-coding-challenges.md
+++ b/docs/how-to-work-on-coding-challenges.md
@@ -566,3 +566,19 @@ pnpm run update-challenge-order
 ```
 
 This will take you through an interactive process to select the order of the challenges.
+
+## Troubleshooting
+
+### Infinite Loop Detected
+
+If you see the following error in the console while previewing a challenge:
+
+```text
+Potential infinite loop detected on line <number>...
+```
+
+This means that the loop-protect plugin has found a long-running loop or recursive function. If your challenge needs to do that (e.g. it contains an event loop that is supposed to run indefinitely), then you can prevent the plugin from being used in the preview. To do so, add `disableLoopProtectPreview: true` to the block's `meta.json` file.
+
+If your tests are computationally intensive, then you may see this error when they run. If this happens then you can add `disableLoopProtect: true` to the block's `meta.json` file.
+
+It's not typically necessary to have both set to true, so only set them as needed.

--- a/docs/how-to-work-on-coding-challenges.md
+++ b/docs/how-to-work-on-coding-challenges.md
@@ -579,6 +579,6 @@ Potential infinite loop detected on line <number>...
 
 This means that the loop-protect plugin has found a long-running loop or recursive function. If your challenge needs to do that (e.g. it contains an event loop that is supposed to run indefinitely), then you can prevent the plugin from being used in the preview. To do so, add `disableLoopProtectPreview: true` to the block's `meta.json` file.
 
-If your tests are computationally intensive, then you may see this error when they run. If this happens then you can add `disableLoopProtect: true` to the block's `meta.json` file.
+If your tests are computationally intensive, then you may see this error when they run. If this happens then you can add `disableLoopProtectTests: true` to the block's `meta.json` file.
 
 It's not typically necessary to have both set to true, so only set them as needed.

--- a/tools/scripts/build/external-data-schema.js
+++ b/tools/scripts/build/external-data-schema.js
@@ -27,8 +27,8 @@ const blockSchema = Joi.object({}).keys({
         title: Joi.string()
       })
     ),
-    disableLoopProtectTests: Joi.boolean().required(),
-    disableLoopProtectPreview: Joi.boolean().required()
+    disableLoopProtectTests: Joi.boolean(),
+    disableLoopProtectPreview: Joi.boolean()
   })
 });
 

--- a/tools/scripts/build/external-data-schema.js
+++ b/tools/scripts/build/external-data-schema.js
@@ -26,7 +26,9 @@ const blockSchema = Joi.object({}).keys({
         id: Joi.string(),
         title: Joi.string()
       })
-    )
+    ),
+    disableLoopProtectTests: Joi.boolean().required(),
+    disableLoopProtectPreview: Joi.boolean().required()
   })
 });
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This allows block-level control over loop-protect for both tests and the preview. Also, project euler should have had loop-protect disabled and this restores that.

Finally, to QA disableLoopProtectPreview, @jdwilkin4's PR https://github.com/freeCodeCamp/freeCodeCamp/pull/50385 has lessons that recursively call `requestAnimationFrame` and so loop forever. It should be enough to add the flag to the meta and run the lessons. Without it the error should appear.

<!-- Feel free to add any additional description of changes below this line -->
