### PR TITLE
chore(e2e): reduce retries in open mode

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -10,7 +10,7 @@ module.exports = defineConfig({
   e2e: {
     baseUrl: 'http://localhost:8000',
     projectId: 'ke77ns',
-    retries: 4,
+    retries: { openMode: 1, runMode: 4 },
     chromeWebSecurity: false,
 
     // This is the default spec pattern, that we use on /learn proper


### PR DESCRIPTION
1 retry can be helpful to catch issues where tests do not clean up
sufficiently, but additional retries just waste time.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
