### PR TITLE
fix(client): handle normal tests in python runner

### DIFF
--- a/curriculum/challenges/english/20-upcoming-python/learn-python-by-building-a-blackjack-game/5daa813381b9e3db6c126b43.md
+++ b/curriculum/challenges/english/20-upcoming-python/learn-python-by-building-a-blackjack-game/5daa813381b9e3db6c126b43.md
@@ -13,6 +13,12 @@ Set the `hello` variable to "world". Then print the value.
 
 # --hints--
 
+The source code should include `one = 2`
+
+```js
+assert(code.match(/one\s*=\s*2/))
+```
+
 The `hello` variable should equal "world".
 
 ```js
@@ -27,12 +33,6 @@ The `hello` variable should equal "world".
 --fcc-editable-region--
 one = 1
 hello = "goodbye"
-def a_function():
-    local_thing = "world"
-    print(local_thing)
-
-a_function()
-
 print(hello)
 --fcc-editable-region--
 ```
@@ -40,7 +40,7 @@ print(hello)
 # --solutions--
 
 ```py
-one = 1
+one = 2
 hello = "world"
 print(hello)
 ```

--- a/tools/client-plugins/browser-scripts/python-runner.ts
+++ b/tools/client-plugins/browser-scripts/python-runner.ts
@@ -54,6 +54,10 @@ async function setupPyodide() {
 type Input = (text: string) => Promise<string>;
 type Print = (...args: unknown[]) => void;
 type ResetTerminal = () => void;
+type EvaluatedTeststring = {
+  input: string[];
+  test: () => Promise<unknown>;
+};
 
 function createJSFunctionsForPython(
   term: Terminal,
@@ -219,23 +223,36 @@ async function initTestFrame(e: InitTestFrameArg) {
     // debugger;
     try {
       // eval test string to get the dummy input and actual test
-      const { input, test } = await new Promise<{
-        input: string[];
-        test: () => Promise<unknown>;
-      }>((resolve, reject) =>
-        // To avoid race conditions, we have to run the test in a final
-        // frameDocument ready:
-        $(() => {
-          try {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-            const test: { input: string[]; test: () => Promise<unknown> } =
-              eval(testString);
-            resolve(test);
-          } catch (err) {
-            reject(err);
-          }
-        })
+      const evaluatedTestString = await new Promise<unknown>(
+        (resolve, reject) =>
+          // To avoid race conditions, we have to run the test in a final
+          // frameDocument ready:
+          $(() => {
+            try {
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+              const test: { input: string[]; test: () => Promise<unknown> } =
+                eval(testString);
+              resolve(test);
+            } catch (err) {
+              reject(err);
+            }
+          })
       );
+
+      // If the test string does not evaluate to an object, then we assume that
+      // it's a standard JS test and any assertions have already passed.
+      if (typeof evaluatedTestString !== 'object') {
+        return { pass: true };
+      }
+
+      if (!evaluatedTestString || !('test' in evaluatedTestString)) {
+        throw new Error(
+          'Test string did not evaluate to an object with the test property'
+        );
+      }
+
+      const { input, test } = evaluatedTestString as EvaluatedTeststring;
+
       // TODO: throw helpful error if we run out of input values, since it's likely
       // that the user added too many input statements.
       const inputIterator = input ? input.values() : null;
@@ -253,10 +270,13 @@ async function initTestFrame(e: InitTestFrameArg) {
         resetTerminal: () => void 0
       });
 
-      // Make __pyodide available to the test code
-      const __pyodide: PyodideInterface = await this.__runPython(code);
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
-      const __userGlobals = __pyodide.globals.get('__locals');
+      // We have to declare these variables in the scope of 'eval', so that they
+      // exist when the `testString` is evaluated. Otherwise, they will be
+      // undefined when `test` is called and the tests will not be able to use
+      // __pyodide or __userGlobals.
+      const __pyodide = await this.__runPython(code);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      const __userGlobals = __pyodide.globals.get('__locals') as unknown;
       await test();
 
       return { pass: true };


### PR DESCRIPTION
Normal in the sense that they just invoke some assertions and do not
return a { test: () => {...} } object.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
