### PR TITLE
fix: uri encode forum title

### DIFF
--- a/client/src/templates/Challenges/redux/create-question-epic.js
+++ b/client/src/templates/Challenges/redux/create-question-epic.js
@@ -119,9 +119,11 @@ function createQuestionEpic(action$, state$, { window }) {
       const addCodeThree = i18next.t('forum-help.add-code-three');
       const altTextMessage = `${whatsHappeningHeading}\n\n${camperCodeHeading}\n\n${warning}\n\n${tooLongOne}\n\n${tooLongTwo}\n\n${tooLongThree}\n\n\`\`\`text\n${addCodeOne}\n${addCodeTwo}\n${addCodeThree}\n\`\`\`\n\n${endingText}`;
 
-      const titleText = `${i18next.t(
-        `intro:${superBlock}.blocks.${block}.title`
-      )} - ${challengeTitle}`;
+      const titleText = window.encodeURIComponent(
+        `${i18next.t(
+          `intro:${superBlock}.blocks.${block}.title`
+        )} - ${challengeTitle}`
+      );
 
       const category = window.encodeURIComponent(
         i18next.t('links:help.' + helpCategory || 'Help')


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

The C# certification has a `#` in the title, which isn't a valid URI character and [breaks the forum posts](https://forum.freecodecamp.org/t/write-your-first-code-using-c/639686). Encoding the title fixes this issue.