### PR TITLE
test: improve output flake by removing chaining

### DIFF
--- a/cypress/e2e/default/learn/challenges/output.ts
+++ b/cypress/e2e/default/learn/challenges/output.ts
@@ -44,19 +44,15 @@ describe('Classic challenge', function () {
     cy.get(outputSelectors.editor, { timeout: 15000 });
     cy.get(outputSelectors.runTestsButton).click();
 
-    cy.get(selectors.dataCy.outputText)
-      .contains(runningOutput)
-      .contains(finishedOutput);
+    cy.get(selectors.dataCy.outputText).contains(runningOutput);
+    cy.get(selectors.dataCy.outputText).contains(finishedOutput);
   });
 
   it('shows test output when the tests are triggered by the keyboard', () => {
-    focusEditor()
-      .type('{ctrl}{enter}')
-      .then(() => {
-        cy.get(selectors.dataCy.outputText)
-          .contains(runningOutput)
-          .contains(finishedOutput);
-      });
+    focusEditor().type('{ctrl}{enter}');
+
+    cy.get(selectors.dataCy.outputText).contains(runningOutput);
+    cy.get(selectors.dataCy.outputText).contains(finishedOutput);
   });
 });
 


### PR DESCRIPTION
This might be a source of flake since 'get' seems to retry until the
first 'contains' is satisfied, but then stops.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
