### PR TITLE
fix(curriculum): updated the control scope C# test question to match Microsoft qu…

### DIFF
--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/add-logic-to-c-sharp-console-applications/control-variable-scope-and-logic-using-code-blocks-in-c-sharp.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/add-logic-to-c-sharp-console-applications/control-variable-scope-and-logic-using-code-blocks-in-c-sharp.md
@@ -16,19 +16,19 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 
 ## --text--
 
-Which of the following describes the affect of a `using` statement?
+Which of the following statements is true about showing/removing the curly braces for code blocks associated with an `if` statement? 
 
 ## --answers--
 
-Affects only the first code block in the code file.
+The curly braces can't be removed from the code block for `else if` and `else` statements.
 
 ---
 
-Affects only the current code block in the code file.
+If the curly braces are removed from the code blocks of an `if-elseif-else`, the white space must also be removed.
 
 ---
 
-Affects all of the code in the code file.
+Always choose a style that improves readability.
 
 ## --video-solution--
 


### PR DESCRIPTION
…estion, replaced irrelevant question

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [ X] My pull request targets the `main` branch of freeCodeCamp.
- [ X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #51497

<!-- Feel free to add any additional description of changes below this line -->

This replaces a question on 'using' statements in C#, but this section does not cover this topic. In all other quiz questions, the question was a copy of one found on Microsoft's C# tutorial. So I've replaced the question about the 'using' statement with a question from the Microsoft tutorial page: https://learn.microsoft.com/en-us/training/modules/csharp-code-blocks/6-knowledge-check


