### PR TITLE
fix: allow at least 100 loops before breaking out

### DIFF
--- a/client/src/templates/Challenges/rechallenge/transformers.js
+++ b/client/src/templates/Challenges/rechallenge/transformers.js
@@ -25,7 +25,8 @@ const { filename: sassCompile } = sassData;
 
 const protectTimeout = 100;
 const testProtectTimeout = 1500;
-const loopsPerTimeoutCheck = 2000;
+const loopsPerTimeoutCheck = 20;
+const testLoopsPerTimeoutCheck = 2000;
 
 function loopProtectCB(line) {
   console.log(
@@ -54,11 +55,11 @@ async function loadBabel() {
   /* eslint-enable no-inline-comments */
   Babel.registerPlugin(
     'loopProtection',
-    protect(protectTimeout, loopProtectCB)
+    protect(protectTimeout, loopProtectCB, loopsPerTimeoutCheck)
   );
   Babel.registerPlugin(
     'testLoopProtection',
-    protect(testProtectTimeout, testLoopProtectCB, loopsPerTimeoutCheck)
+    protect(testProtectTimeout, testLoopProtectCB, testLoopsPerTimeoutCheck)
   );
 }
 
@@ -165,8 +166,8 @@ function getBabelOptions(
     disableLoopProtectPreview: false
   }
 ) {
-  // we always protect the preview, since it evaluates as the user types and
-  // they may briefly have infinite looping code accidentally
+  // we protect the preview unless specifically disabled, since it evaluates as
+  // the user types and they may briefly have infinite looping code accidentally
   if (preview && !disableLoopProtectPreview)
     return { ...presets, plugins: ['loopProtection'] };
   if (!disableLoopProtectTests)

--- a/client/src/templates/Challenges/rechallenge/transformers.js
+++ b/client/src/templates/Challenges/rechallenge/transformers.js
@@ -25,7 +25,7 @@ const { filename: sassCompile } = sassData;
 
 const protectTimeout = 100;
 const testProtectTimeout = 1500;
-const loopsPerTimeoutCheck = 20;
+const loopsPerTimeoutCheck = 100;
 const testLoopsPerTimeoutCheck = 2000;
 
 function loopProtectCB(line) {


### PR DESCRIPTION
This allows React renders more leeway, since they often render so slowly
that their first render can exceed the loop-protect timeout

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/51656

<!-- Feel free to add any additional description of changes below this line -->
