### PR TITLE
fix(a11y): mobile tab navigation

### DIFF
--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -103,7 +103,7 @@
 }
 
 /* Need to narrow width of tabs to make room for preview toggle button */
-#mobile-layout [data-haspreview='true'] [role='tablist'] {
+#mobile-layout[data-haspreview='true'] [role='tablist'] {
   width: calc(100% - 2rem);
 }
 

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -108,6 +108,10 @@
 #mobile-layout .nav-lists > button {
   height: 100%;
   font-size: 0.8em;
+  /* Need to override radix-ui defaults on side padding to allow room for
+     four tabs and a preview toggle button at narrow view ports */
+  padding-left: 0.2rem;
+  padding-right: 0.2rem;
 }
 
 #mobile-layout .nav-lists button[data-state='active'] {

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -103,7 +103,7 @@
 }
 
 /* Need to narrow width of tabs to make room for preview toggle button */
-#mobile-layout [role='tablist'] {
+#mobile-layout [data-haspreview='true'] [role='tablist'] {
   width: calc(100% - 2rem);
 }
 

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -134,6 +134,8 @@
   border: 0;
   padding: 0;
   background-color: inherit;
+  font-size: 0.8rem;
+  height: 100%;
 }
 
 .portal-button[aria-expanded='true'] {
@@ -183,16 +185,6 @@
   right: 0;
   height: 2rem;
   border-bottom: 1px solid var(--quaternary-color);
-}
-
-#mobile-layout .portal-button {
-  font-size: 0.8rem;
-  height: 100%;
-}
-
-#mobile-layout .portal-button svg {
-  height: 18px;
-  padding-block-start: 3px;
 }
 
 #mobile-layout #mobile-layout-pane-instructions {

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -89,22 +89,26 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  /* for placing the preview toggle button */
+  position: relative;
 }
 
 #mobile-layout .nav-lists {
-  margin: 0 1px;
+  margin: 0;
   padding: 0;
   display: flex;
   border-bottom: 1px solid var(--quaternary-color);
+  height: 2rem;
+  flex-shrink: 0;
 }
 
-/* Need to narrow width to make room for preview toggle button */
-#mobile-layout .nav-lists[data-haspreview='true'] {
-  width: calc(100% - 2rem - 2px);
+/* Need to narrow width of tabs to make room for preview toggle button */
+#mobile-layout [role='tablist'] {
+  width: calc(100% - 2rem);
 }
 
 #mobile-layout .nav-lists > button {
-  height: 2.5em;
+  height: 100%;
   font-size: 0.8em;
 }
 
@@ -172,8 +176,17 @@
   flex-direction: column;
 }
 
+#mobile-layout .portal-button-wrap {
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 2rem;
+  border-bottom: 1px solid var(--quaternary-color);
+}
+
 #mobile-layout .portal-button {
-  top: calc(var(--header-height) + var(--breadcrumbs-height));
+  font-size: 0.8rem;
+  height: 100%;
 }
 
 #mobile-layout .portal-button svg {

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -89,8 +89,6 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  /* for placing the preview toggle button */
-  position: relative;
 }
 
 #mobile-layout .nav-lists {
@@ -181,7 +179,7 @@
 
 #mobile-layout .portal-button-wrap {
   position: absolute;
-  top: 0;
+  top: calc(var(--header-height) + var(--breadcrumbs-height));
   right: 0;
   height: 2rem;
   border-bottom: 1px solid var(--quaternary-color);

--- a/client/src/templates/Challenges/classic/classic.css
+++ b/client/src/templates/Challenges/classic/classic.css
@@ -133,6 +133,7 @@
   width: 2rem;
   border: 0;
   padding: 0;
+  background-color: inherit;
 }
 
 .portal-button[aria-expanded='true'] {

--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -278,14 +278,16 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
               value={Tab.Preview}
               forceMount
             >
-              <button
-                className='portal-button'
-                aria-expanded={!!showPreviewPortal}
-                onClick={() => togglePane('showPreviewPortal')}
-              >
-                <span className='sr-only'>{getPortalBtnSrText()}</span>
-                <FontAwesomeIcon icon={faWindowRestore} />
-              </button>
+              <div className='portal-button-wrap'>
+                <button
+                  className='portal-button'
+                  aria-expanded={!!showPreviewPortal}
+                  onClick={() => togglePane('showPreviewPortal')}
+                >
+                  <span className='sr-only'>{getPortalBtnSrText()}</span>
+                  <FontAwesomeIcon icon={faWindowRestore} />
+                </button>
+              </div>
               {displayPreviewPane && preview}
               {showPreviewPortal && (
                 <p className='preview-external-window'>
@@ -302,14 +304,16 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
             />
           )}
           {hasPreview && this.state.currentTab !== 'preview' && (
-            <button
-              className='portal-button'
-              aria-expanded={!!showPreviewPortal}
-              onClick={() => togglePane('showPreviewPortal')}
-            >
-              <span className='sr-only'>{getPortalBtnSrText()}</span>
-              <FontAwesomeIcon icon={faWindowRestore} />
-            </button>
+            <div className='portal-button-wrap'>
+              <button
+                className='portal-button'
+                aria-expanded={!!showPreviewPortal}
+                onClick={() => togglePane('showPreviewPortal')}
+              >
+                <span className='sr-only'>{getPortalBtnSrText()}</span>
+                <FontAwesomeIcon icon={faWindowRestore} />
+              </button>
+            </div>
           )}
         </Tabs>
         {displayPreviewPortal && (

--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -86,9 +86,9 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
     currentTab: this.props.hasEditableBoundaries ? Tab.Editor : Tab.Instructions
   };
 
-  switchTab = (tab: Tab): void => {
+  switchTab = (tab: string): void => {
     this.setState({
-      currentTab: tab
+      currentTab: tab as Tab
     });
   };
 
@@ -215,6 +215,7 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
           onMouseDown={this.handleClick}
           onTouchStart={this.handleClick}
           defaultValue={currentTab}
+          onValueChange={this.switchTab}
           {...(hasPreview && { 'data-haspreview': 'true' })}
         >
           <TabsList className='nav-lists'>
@@ -239,14 +240,6 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
                 {i18next.t('learn.editor-tabs.preview')}
               </TabsTrigger>
             )}
-            <button
-              className='portal-button'
-              aria-expanded={!!showPreviewPortal}
-              onClick={() => togglePane('showPreviewPortal')}
-            >
-              <span className='sr-only'>{getPortalBtnSrText()}</span>
-              <FontAwesomeIcon icon={faWindowRestore} />
-            </button>
           </TabsList>
 
           <TabsContent tabIndex={-1} className='tab-content' value={Tab.Editor}>
@@ -285,6 +278,14 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
               value={Tab.Preview}
               forceMount
             >
+              <button
+                className='portal-button'
+                aria-expanded={!!showPreviewPortal}
+                onClick={() => togglePane('showPreviewPortal')}
+              >
+                <span className='sr-only'>{getPortalBtnSrText()}</span>
+                <FontAwesomeIcon icon={faWindowRestore} />
+              </button>
               {displayPreviewPane && preview}
               {showPreviewPortal && (
                 <p className='preview-external-window'>
@@ -299,6 +300,16 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
               isMobile={true}
               videoUrl={videoUrl}
             />
+          )}
+          {hasPreview && this.state.currentTab !== 'preview' && (
+            <button
+              className='portal-button'
+              aria-expanded={!!showPreviewPortal}
+              onClick={() => togglePane('showPreviewPortal')}
+            >
+              <span className='sr-only'>{getPortalBtnSrText()}</span>
+              <FontAwesomeIcon icon={faWindowRestore} />
+            </button>
           )}
         </Tabs>
         {displayPreviewPortal && (

--- a/client/src/templates/Challenges/classic/mobile-layout.tsx
+++ b/client/src/templates/Challenges/classic/mobile-layout.tsx
@@ -277,6 +277,9 @@ class MobileLayout extends Component<MobileLayoutProps, MobileLayoutState> {
               className='tab-content'
               value={Tab.Preview}
               forceMount
+              // forceMount causes the preview tabpanel to never be hidden,
+              // so we need to manually add it when preview is not active.
+              {...(this.state.currentTab === 'preview' ? {} : { hidden: true })}
             >
               <div className='portal-button-wrap'>
                 <button


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

PR #51361 sort of upset the mobile tab navigation just a little, so this PR is just making it all better.

- Moved the preview pane toggle button out of the tablist. Only tabs should be in the tablist. Also, when focus is on a tab, the `Tab` key should put focus on its associated tabpanel, or the first focusable element in the tabpanel if appropriate. Having the preview pane toggle button in the tablist put it in the tab order between the tabs and the tabpanels and thus if either the code or console tab had focus, hitting `Tab` would put focus on the toggle button instead of the tabpanel. See my original PR #50961 for a more in depth discussion.
- Due to the `forceMount` property on the Preview tab, the Preview tabpanel was not being hidden properly when it was not active and thus it was navigable to screen readers when it shouldn't have been. I manually added the `hidden` property to the Preview tab when it is not active. We could also solve this using CSS `display: none` but I went with the `hidden` attribute since that's what the other tabpanels are using.
- I cleaned up the CSS a little.