### PR TITLE
fix(client): keep logs while executing challenge

### DIFF
--- a/client/src/templates/Challenges/redux/action-types.js
+++ b/client/src/templates/Challenges/redux/action-types.js
@@ -40,13 +40,13 @@ export const actionTypes = createTypes(
     'challengeMounted',
     'sendRenderTime',
     'checkChallenge',
-    'executeChallenge',
     'resetChallenge',
     'stopResetting',
     'resetAttempts',
     'setEditorFocusability',
     'toggleVisibleEditor',
-    ...createAsyncTypes('submitChallenge')
+    ...createAsyncTypes('submitChallenge'),
+    ...createAsyncTypes('executeChallenge')
   ],
   ns
 );

--- a/client/src/templates/Challenges/redux/actions.js
+++ b/client/src/templates/Challenges/redux/actions.js
@@ -70,6 +70,9 @@ export const challengeMounted = createAction(actionTypes.challengeMounted);
 export const sendRenderTime = createAction(actionTypes.sendRenderTime);
 export const checkChallenge = createAction(actionTypes.checkChallenge);
 export const executeChallenge = createAction(actionTypes.executeChallenge);
+export const executeChallengeComplete = createAction(
+  actionTypes.executeChallengeComplete
+);
 export const resetChallenge = createAction(actionTypes.resetChallenge);
 export const stopResetting = createAction(actionTypes.stopResetting);
 export const submitChallenge = createAction(actionTypes.submitChallenge);

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -37,6 +37,7 @@ import { runPythonInFrame, mainPreviewId } from '../utils/frame';
 import { actionTypes } from './action-types';
 import {
   disableBuildOnError,
+  executeChallengeComplete,
   initConsole,
   initLogs,
   logsToConsole,
@@ -50,6 +51,7 @@ import {
   challengeMetaSelector,
   challengeTestsSelector,
   isBuildEnabledSelector,
+  isExecutingSelector,
   portalDocumentSelector
 } from './selectors';
 
@@ -136,6 +138,7 @@ function* executeChallengeSaga({ payload }) {
   } catch (e) {
     yield put(updateConsole(e));
   } finally {
+    yield put(executeChallengeComplete());
     consoleProxy.close();
   }
 }
@@ -219,7 +222,10 @@ function* previewChallengeSaga({ flushLogs = true } = {}) {
   const proxyLogger = args => logProxy.put(args);
 
   try {
-    if (flushLogs) {
+    const isExecuting = yield select(isExecutingSelector);
+    // executeChallengeSaga flushes the logs, so there's no need to if that's
+    // just happened.
+    if (flushLogs && !isExecuting) {
       yield put(initLogs());
       yield put(initConsole(''));
     }

--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -32,6 +32,7 @@ const initialState = {
   userCompletedExam: null,
   hasCompletedBlock: false,
   isBuildEnabled: true,
+  isExecuting: false,
   isResetting: false,
   logsOut: [],
   modal: {
@@ -234,7 +235,12 @@ export const reducer = handleActions(
     [actionTypes.executeChallenge]: state => ({
       ...state,
       currentTab: 3,
-      attempts: state.attempts + 1
+      attempts: state.attempts + 1,
+      isExecuting: true
+    }),
+    [actionTypes.executeChallengeComplete]: state => ({
+      ...state,
+      isExecuting: false
     }),
     [actionTypes.setEditorFocusability]: (state, { payload }) => ({
       ...state,

--- a/client/src/templates/Challenges/redux/selectors.js
+++ b/client/src/templates/Challenges/redux/selectors.js
@@ -40,6 +40,7 @@ export const isSubmittingSelector = state => state[ns].isSubmitting;
 export const isResettingSelector = state => state[ns].isResetting;
 
 export const isBuildEnabledSelector = state => state[ns].isBuildEnabled;
+export const isExecutingSelector = state => state[ns].isExecuting;
 export const successMessageSelector = state => state[ns].successMessage;
 
 export const projectFormValuesSelector = state =>


### PR DESCRIPTION
If the preview happened to start while the challenge is executing, it
could mess up the output. To fix that, this prevents log flushing until
a challenge has finished executing.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
