### PR TITLE
feat(client): fetch get-session-user without checking jwt

### DIFF
--- a/client/src/redux/cookie-values.js
+++ b/client/src/redux/cookie-values.js
@@ -1,4 +1,0 @@
-import cookies from 'browser-cookies';
-
-export const jwt =
-  typeof window !== 'undefined' && cookies.get('jwt_access_token');

--- a/client/src/redux/fetch-user-saga.js
+++ b/client/src/redux/fetch-user-saga.js
@@ -6,13 +6,8 @@ import {
   fetchUserComplete,
   fetchUserError
 } from './actions';
-import { jwt } from './cookie-values';
 
 function* fetchSessionUser() {
-  if (!jwt) {
-    yield put(fetchUserComplete({ user: {}, username: '' }));
-    return;
-  }
   try {
     const {
       data: { user = {}, result = '' }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR makes it so the client always tries to fetch the session user (even if the `jwt` cookie is missing).  This is to allow the client to use the new api, since the new api sets httpOnly session cookies that cannot be inspected by the client.

Without these changes the client will never appear to be logged in, even if it has authenticated.

<!-- Feel free to add any additional description of changes below this line -->
