### PR TITLE
feat(api): allow client to signin/signout

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -30,7 +30,11 @@ import mailer from './plugins/mailer';
 import redirectWithMessage from './plugins/redirect-with-message';
 import security from './plugins/security';
 import sessionAuth from './plugins/session-auth';
-import { auth0Routes, devLoginCallback } from './routes/auth';
+import {
+  auth0Routes,
+  devLoginCallback,
+  devLegacyAuthRoutes
+} from './routes/auth';
 import { challengeRoutes } from './routes/challenge';
 import { deprecatedEndpoints } from './routes/deprecated-endpoints';
 import { unsubscribeDeprecated } from './routes/deprecated-unsubscribe';
@@ -208,6 +212,7 @@ export const build = async (
   void fastify.register(auth0Routes, { prefix: '/auth' });
   if (FCC_ENABLE_DEV_LOGIN_MODE) {
     void fastify.register(devLoginCallback, { prefix: '/auth' });
+    void fastify.register(devLegacyAuthRoutes);
   }
   void fastify.register(challengeRoutes);
   void fastify.register(settingRoutes);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Combined with https://github.com/freeCodeCamp/freeCodeCamp/pull/51615 this allows the current client to signin/out of the new api and use any endpoint that we've migrated. That means we can finally QA the api in the way it's intended to be used (at least for the MVP!).

WIthout https://github.com/freeCodeCamp/freeCodeCamp/pull/51678 you'll need a jwt_access_token cookie (any value, doesn't matter) to signin properly, but as long as you don't delete that, it'll work.

<!-- Feel free to add any additional description of changes below this line -->
