### PR TITLE
fix(tools): move connected to mongo log

### DIFF
--- a/tools/scripts/seed/seed-demo-user.js
+++ b/tools/scripts/seed/seed-demo-user.js
@@ -173,8 +173,6 @@ const blankUser = {
 
 const client = new MongoClient(MONGOHQ_URL, { useNewUrlParser: true });
 
-log('Connected successfully to mongo');
-
 const db = client.db('freecodecamp');
 const user = db.collection('user');
 
@@ -201,6 +199,9 @@ const dropUsers = async function () {
 };
 
 const run = async () => {
+  await client.connect();
+  log('Connected successfully to mongo');
+
   await dropUserTokens();
   await dropUsers();
   if (args.includes('certified-user')) {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #51676

<!-- Feel free to add any additional description of changes below this line -->

This pull request relocates the `log` function into the `run` function. However, the `connect` script is executed first, potentially causing it to throw errors before the `log` function has a chance to run.