### PR TITLE
fix(curriculum): Check if the element was conditionally rendered

### DIFF
--- a/curriculum/challenges/english/03-front-end-development-libraries/react/use-state-to-toggle-an-element.md
+++ b/curriculum/challenges/english/03-front-end-development-libraries/react/use-state-to-toggle-an-element.md
@@ -65,7 +65,7 @@ assert.strictEqual(
 );
 ```
 
-Clicking the button element should toggle the `visibility` property in state between `true` and `false`.
+Clicking the button element should toggle the `visibility` property in state between `true` and `false` and conditionally render the `h1` element.
 
 ```js
 (() => {
@@ -76,11 +76,11 @@ Clicking the button element should toggle the `visibility` property in state bet
   };
   const second = () => {
     mockedComponent.find('button').simulate('click');
-    return mockedComponent.state('visibility');
+    return mockedComponent.state('visibility') && mockedComponent.find('h1').exists();
   };
   const third = () => {
     mockedComponent.find('button').simulate('click');
-    return mockedComponent.state('visibility');
+    return mockedComponent.state('visibility') && mockedComponent.find('h1').exists();
   };
   const firstValue = first();
   const secondValue = second();


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

You can pass the test with code that mutates the state and doesn't cause a re-render. This is because the test only checks the state update.

---

I was thinking of creating a new test for the rendering but I think it is fine to just combine the state and rendering tests.

As an aside. This change will still let the camper mutate the state and use `this.forceUpdate()` to pass the test (which I guess is fine and expected).

<!-- Feel free to add any additional description of changes below this line -->

Forum: https://forum.freecodecamp.org/t/react-use-state-to-toggle-an-element/641770/3