### PR TITLE
fix(a11y): minimal fixes for MC questions

### DIFF
--- a/client/src/templates/Challenges/components/prism-formatted.tsx
+++ b/client/src/templates/Challenges/components/prism-formatted.tsx
@@ -5,10 +5,22 @@ import { enhancePrismAccessibility } from '../utils';
 interface PrismFormattedProps {
   className?: string;
   text: string;
+  useSpan?: boolean;
+  noAria?: boolean;
 }
 
-function PrismFormatted({ className, text }: PrismFormattedProps): JSX.Element {
+function PrismFormatted({
+  className,
+  text,
+  useSpan,
+  noAria
+}: PrismFormattedProps): JSX.Element {
   const instructionsRef = useRef<HTMLDivElement>(null);
+  const ElementName = useSpan ? 'span' : 'div';
+
+  if (noAria) {
+    text = text.replace(/<pre( [^>]+)?>/, '<pre$1 data-no-aria="true">');
+  }
 
   useEffect(() => {
     // Just in case 'current' has not been created, though it should have been.
@@ -19,7 +31,7 @@ function PrismFormatted({ className, text }: PrismFormattedProps): JSX.Element {
   }, []);
 
   return (
-    <div
+    <ElementName
       className={className}
       dangerouslySetInnerHTML={{ __html: text }}
       ref={instructionsRef}

--- a/client/src/templates/Challenges/utils/index.ts
+++ b/client/src/templates/Challenges/utils/index.ts
@@ -33,6 +33,7 @@ export function transformEditorLink(url: string): string {
     );
 }
 
+// Adds region role and accessible name to PrismJS code blocks
 export function enhancePrismAccessibility(
   prismEnv: Prism.hooks.ElementHighlightedEnvironment
 ): void {
@@ -52,17 +53,24 @@ export function enhancePrismAccessibility(
     pug: 'pug'
   };
   const parent = prismEnv?.element?.parentElement;
-  if (parent && parent.nodeName === 'PRE' && parent.tabIndex === 0) {
-    parent.setAttribute('role', 'region');
-    const codeType = prismEnv.element?.className
-      .replace(/language-(.*)/, '$1')
-      .toLowerCase();
-    const codeName = langs[codeType] || '';
-    parent.setAttribute(
-      'aria-label',
-      i18next.t('aria.code-example', {
-        codeName
-      })
-    );
+  if (
+    !parent ||
+    parent.nodeName !== 'PRE' ||
+    parent.tabIndex !== 0 ||
+    parent.dataset.noAria === 'true'
+  ) {
+    return;
   }
+
+  parent.setAttribute('role', 'region');
+  const codeType = prismEnv.element?.className
+    .replace(/language-(.*)/, '$1')
+    .toLowerCase();
+  const codeName = langs[codeType] || '';
+  parent.setAttribute(
+    'aria-label',
+    i18next.t('aria.code-example', {
+      codeName
+    })
+  );
 }

--- a/client/src/templates/Challenges/video.css
+++ b/client/src/templates/Challenges/video.css
@@ -91,7 +91,7 @@
   border: 2px solid var(--primary-color);
 }
 
-input.video-quiz-input-hidden:focus-visible + .video-quiz-input-visible {
+input:focus-visible + .video-quiz-input-visible {
   outline: 3px solid var(--focus-outline-color);
   outline-offset: 2px;
 }

--- a/client/src/templates/Challenges/video.css
+++ b/client/src/templates/Challenges/video.css
@@ -91,6 +91,11 @@
   border: 2px solid var(--primary-color);
 }
 
+input.video-quiz-input-hidden:focus-visible + .video-quiz-input-visible {
+  outline: 3px solid var(--focus-outline-color);
+  outline-offset: 2px;
+}
+
 .video-quiz-selected-input {
   width: 10px;
   height: 10px;

--- a/client/src/templates/Challenges/video/show.tsx
+++ b/client/src/templates/Challenges/video/show.tsx
@@ -260,15 +260,19 @@ class ShowVideo extends Component<ShowVideoProps, ShowVideoState> {
                     {answers.map((option, index) => (
                       // answers are static and have no natural id property, so
                       // index should be fine as a key:
-                      <label className='video-quiz-option-label' key={index}>
+                      <label
+                        className='video-quiz-option-label'
+                        key={index}
+                        htmlFor={`mc-question-${index}`}
+                      >
                         <input
-                          aria-label={t('aria.answer')}
                           checked={this.state.selectedOption === index}
                           className='video-quiz-input-hidden'
                           name='quiz'
                           onChange={this.handleOptionChange}
                           type='radio'
                           value={index}
+                          id={`mc-question-${index}`}
                         />{' '}
                         <span className='video-quiz-input-visible'>
                           {this.state.selectedOption === index ? (
@@ -277,7 +281,9 @@ class ShowVideo extends Component<ShowVideoProps, ShowVideoState> {
                         </span>
                         <PrismFormatted
                           className={'video-quiz-option'}
-                          text={option}
+                          text={option.replace(/^<p>|<\/p>$/g, '')}
+                          useSpan
+                          noAria
                         />
                       </label>
                     ))}

--- a/client/src/templates/Challenges/video/show.tsx
+++ b/client/src/templates/Challenges/video/show.tsx
@@ -267,7 +267,7 @@ class ShowVideo extends Component<ShowVideoProps, ShowVideoState> {
                       >
                         <input
                           checked={this.state.selectedOption === index}
-                          className='video-quiz-input-hidden'
+                          className='sr-only'
                           name='quiz'
                           onChange={this.handleOptionChange}
                           type='radio'


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

As I mentioned in my previous PR #50267 about the MC questions, truly making these accessible is going to take a broader effort. The aim of this PR is to provide some quick urgent fixes that will make these at least usable for screen reader users and people using other assistive tech.

Apparently, the ODIN project MC questions use their own `show.tsx` file to display the MC questions, which I did not realize when I started working on this PR. So this PR only targets MC questions displayed with `video/show.tsx`. Once we have this working the way we want, it shouldn't be too hard to add these fixes to the ODIN project.

- Remove `aria-label` from `input`. This was causing the accessible name to always be "Answer" instead of the text in the `label`. 
- Added `for` attribute to `label` since this is a best practice.
- Replaced `video-quiz-input-hidden` class on `input` with `sr-only` since it was merely trying to replicate `sr-only` but not doing it as well as `sr-only` does. Also, `sr-only` might be needed for Playwright tests (see PR #51743).
- Added options to PrismFormatted to use a `span` instead of a `div` and also to suppress giving the code block a role and accessible name. Technically, `div`s are not allowed in a `label` and thus we need PrismFormatted to use a `span`. Giving the code block a role and accessible name inside the `label` was causing NVDA and JAWS to not read the entire `label` text properly.
- Remove the `p` element wrapped around the option text since technically `p` elements should not be in a `label`.
- Add visible focus indicator to the visible radio button. (This one does touch the ODIN project MC questions since they rely on the same CSS.)
