### PR TITLE
test(e2e,playwright): email-settings section on settings page

### DIFF
--- a/client/src/components/Flash/index.tsx
+++ b/client/src/components/Flash/index.tsx
@@ -26,7 +26,7 @@ function Flash({ flashMessage, removeFlashMessage }: FlashProps): JSX.Element {
   return (
     <TransitionGroup>
       <CSSTransition classNames='flash-message' key={id} timeout={500}>
-        <Alert variant={flashStyle} className='flash-message'>
+        <Alert variant={flashStyle} className='flash-message' data-playwright-test-label='flash-message'>
           {t(message, variables)}
           <CloseButton
             onClick={handleClose}

--- a/client/src/components/Flash/index.tsx
+++ b/client/src/components/Flash/index.tsx
@@ -26,7 +26,11 @@ function Flash({ flashMessage, removeFlashMessage }: FlashProps): JSX.Element {
   return (
     <TransitionGroup>
       <CSSTransition classNames='flash-message' key={id} timeout={500}>
-        <Alert variant={flashStyle} className='flash-message' data-playwright-test-label='flash-message'>
+        <Alert
+          variant={flashStyle}
+          className='flash-message'
+          data-playwright-test-label='flash-message'
+        >
           {t(message, variables)}
           <CloseButton
             onClick={handleClose}

--- a/client/src/components/settings/email.tsx
+++ b/client/src/components/settings/email.tsx
@@ -165,7 +165,10 @@ function EmailSettings({
               {t('settings.email.not-verified')}
               <br />
               <Trans i18nKey='settings.email.check'>
-                <Link to='/update-email' />
+                <Link
+                  data-playwright-test-label='email-verification-link'
+                  to='/update-email'
+                />
               </Trans>
             </Alert>
           </HelpBlock>

--- a/client/src/components/settings/email.tsx
+++ b/client/src/components/settings/email.tsx
@@ -155,11 +155,13 @@ function EmailSettings({
   }
   return (
     <div className='email-settings'>
-      <SectionHeader>{t('settings.email.heading')}</SectionHeader>
+      <SectionHeader dataPlaywrightTestLabel='email-settings-header'>
+        {t('settings.email.heading')}
+      </SectionHeader>
       {isEmailVerified ? null : (
         <FullWidthRow>
           <HelpBlock>
-            <Alert variant='info' className='text-center'>
+            <Alert variant='info' className='text-center' data-playwright-test-label='email-verification-alert'>
               {t('settings.email.not-verified')}
               <br />
               <Trans i18nKey='settings.email.check'>
@@ -178,7 +180,9 @@ function EmailSettings({
         >
           <FormGroup controlId='current-email'>
             <ControlLabel>{t('settings.email.current')}</ControlLabel>
-            <FormControl.Static>{currentEmail}</FormControl.Static>
+            <FormControl.Static data-playwright-test-label='current-email'>
+              {currentEmail}
+            </FormControl.Static>
           </FormGroup>
           <div role='group' aria-label={t('settings.email.heading')}>
             <FormGroup
@@ -187,6 +191,7 @@ function EmailSettings({
             >
               <ControlLabel>{t('settings.email.new')}</ControlLabel>
               <FormControl
+                data-playwright-test-label='new-email-input'
                 onChange={createHandleEmailFormChange('newEmail')}
                 type='email'
                 value={newEmail}
@@ -201,6 +206,7 @@ function EmailSettings({
             >
               <ControlLabel>{t('settings.email.confirm')}</ControlLabel>
               <FormControl
+                data-playwright-test-label='confirm-email-input'
                 onChange={createHandleEmailFormChange('confirmNewEmail')}
                 type='email'
                 value={confirmNewEmail}
@@ -211,6 +217,7 @@ function EmailSettings({
             </FormGroup>
           </div>
           <BlockSaveButton
+            data-playwright-test-label='save-email-button'
             aria-disabled={isDisabled}
             bgSize='lg'
             {...(isDisabled && { tabIndex: -1 })}
@@ -227,7 +234,9 @@ function EmailSettings({
           flag={sendQuincyEmail}
           flagName='sendQuincyEmail'
           offLabel={t('buttons.no-thanks')}
+          dataPlaywrightTestOffLabel='no-thanks-button'
           onLabel={t('buttons.yes-please')}
+          dataPlaywrightTestOnLabel='yes-please-button'
           toggleFlag={() => updateQuincyEmail(!sendQuincyEmail)}
         />
       </FullWidthRow>

--- a/client/src/components/settings/email.tsx
+++ b/client/src/components/settings/email.tsx
@@ -161,7 +161,11 @@ function EmailSettings({
       {isEmailVerified ? null : (
         <FullWidthRow>
           <HelpBlock>
-            <Alert variant='info' className='text-center' data-playwright-test-label='email-verification-alert'>
+            <Alert
+              variant='info'
+              className='text-center'
+              data-playwright-test-label='email-verification-alert'
+            >
               {t('settings.email.not-verified')}
               <br />
               <Trans i18nKey='settings.email.check'>

--- a/client/src/components/settings/section-header.tsx
+++ b/client/src/components/settings/section-header.tsx
@@ -4,12 +4,21 @@ import FullWidthRow from '../helpers/full-width-row';
 
 type SectionHeaderProps = {
   children: string | React.ReactNode | React.ReactElement;
+  dataPlaywrightTestLabel?: string;
 };
 
-function SectionHeader({ children }: SectionHeaderProps): JSX.Element {
+function SectionHeader({
+  children,
+  dataPlaywrightTestLabel
+}: SectionHeaderProps): JSX.Element {
   return (
     <FullWidthRow>
-      <h2 className='text-center'>{children}</h2>
+      <h2
+        data-playwright-test-label={dataPlaywrightTestLabel}
+        className='text-center'
+      >
+        {children}
+      </h2>
       <hr />
     </FullWidthRow>
   );

--- a/client/src/components/settings/toggle-button-setting.tsx
+++ b/client/src/components/settings/toggle-button-setting.tsx
@@ -11,7 +11,9 @@ export default function ToggleButtonSetting({
   flagName,
   toggleFlag,
   offLabel,
-  onLabel
+  onLabel,
+  dataPlaywrightTestOffLabel,
+  dataPlaywrightTestOnLabel
 }: ToggleSettingProps): JSX.Element {
   return (
     <fieldset
@@ -29,6 +31,7 @@ export default function ToggleButtonSetting({
       </div>
       <div className='toggle-button-group'>
         <button
+          data-playwright-test-label={dataPlaywrightTestOnLabel}
           aria-pressed={flag}
           {...(!flag && { onClick: toggleFlag })}
           value='1'
@@ -40,6 +43,7 @@ export default function ToggleButtonSetting({
           </span>
         </button>
         <button
+          data-playwright-test-label={dataPlaywrightTestOffLabel}
           aria-pressed={!flag}
           {...(flag && { onClick: toggleFlag })}
           value='2'

--- a/client/src/components/settings/toggle-radio-setting.tsx
+++ b/client/src/components/settings/toggle-radio-setting.tsx
@@ -10,6 +10,8 @@ export type ToggleSettingProps = {
   toggleFlag: () => void;
   offLabel: string;
   onLabel: string;
+  dataPlaywrightTestOffLabel?: string;
+  dataPlaywrightTestOnLabel?: string;
 };
 
 export default function ToggleRadioSetting({

--- a/e2e/email-settings.spec.ts
+++ b/e2e/email-settings.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 
 const settingsPageElement = {
   emailSettingsSectionHeader: 'email-settings-header',
@@ -13,34 +13,33 @@ const settingsPageElement = {
   flashMessageAlert: 'flash-message'
 } as const;
 
+let page: Page;
+
 test.use({ storageState: 'playwright/.auth/certified-user.json' });
 
-test.beforeEach(async ({ page }) => {
+test.beforeAll(async ({ browser }) => {
+  page = await browser.newPage();
   await page.goto('/settings');
 });
 
-test.afterEach(async ({ page }) => {
+test.afterAll(async () => {
   await page.close();
 });
 
 test.describe('Email Settings', () => {
-  test('should display email settings section header on settings page', async ({
-    page
-  }) => {
+  test('should display email settings section header on settings page', async () => {
     await expect(
       page.getByTestId(settingsPageElement.emailSettingsSectionHeader)
     ).toHaveText('Email Settings');
   });
 
-  test('should display current email address', async ({ page }) => {
+  test('should display current email address', async () => {
     await expect(
       page.getByTestId(settingsPageElement.currentEmailText)
     ).toHaveText('foo@bar.com');
   });
 
-  test('should display email verification alert after email update', async ({
-    page
-  }) => {
+  test('should display email verification alert after email update', async () => {
     const newEmailAddress = 'foo-update@bar.com';
 
     await page
@@ -59,16 +58,20 @@ test.describe('Email Settings', () => {
       page.getByTestId(settingsPageElement.emailVerificationAlert)
     ).toBeVisible();
 
-    await page.getByTestId(settingsPageElement.emailVerificationLink).click();
-    await expect(page).toHaveURL(/update-email/);
+    const emailVerificationLink = page.getByTestId(
+      settingsPageElement.emailVerificationLink
+    );
+    await expect(emailVerificationLink).toHaveAttribute(
+      'href',
+      '/update-email'
+    );
   });
 
-  test('should display flash message when email subscription is toggled', async ({
-    page
-  }) => {
+  test('should display flash message when email subscription is toggled', async () => {
     await page
       .getByTestId(settingsPageElement.emailSubscriptionYesPleaseButton)
       .click();
+
     await expect(
       page.getByTestId(settingsPageElement.flashMessageAlert)
     ).toContainText("We have updated your subscription to Quincy's email");

--- a/e2e/email-settings.spec.ts
+++ b/e2e/email-settings.spec.ts
@@ -53,19 +53,7 @@ test.describe('Email Settings', () => {
       page.getByTestId(settingsPageElement.flashMessageAlert)
     ).toBeVisible();
 
-    const getSessionUserResponsePromise = page.waitForResponse(response =>
-      response.url().includes('get-session-user')
-    );
     await page.reload();
-    const getSessionUserResponse = await getSessionUserResponsePromise;
-    const getSessionUserResponseBody = await getSessionUserResponse.json();
-    const isEmailVerified =
-      getSessionUserResponseBody.user.certifieduser.isEmailVerified;
-    expect(
-      isEmailVerified,
-      JSON.stringify(await page.context().cookies(), null, 2)
-    ).toBe(false);
-
     await expect(
       page.getByTestId(settingsPageElement.emailVerificationAlert)
     ).toBeVisible();
@@ -80,20 +68,9 @@ test.describe('Email Settings', () => {
   });
 
   test('should display flash message when email subscription is toggled', async () => {
-    const subscriptionResponsePromise = page.waitForResponse(response =>
-      response.url().includes('update-my-quincy-email')
-    );
     await page
       .getByTestId(settingsPageElement.emailSubscriptionYesPleaseButton)
       .click();
-    const subscriptionResponse = await subscriptionResponsePromise;
-    const subscriptionRequestHeaders = JSON.stringify(
-      await subscriptionResponse.request().allHeaders(),
-      null,
-      2
-    );
-
-    expect(subscriptionResponse.status(), subscriptionRequestHeaders).toBe(200);
 
     await expect(
       page.getByTestId(settingsPageElement.flashMessageAlert)

--- a/e2e/email-settings.spec.ts
+++ b/e2e/email-settings.spec.ts
@@ -61,9 +61,10 @@ test.describe('Email Settings', () => {
     const getSessionUserResponseBody = await getSessionUserResponse.json();
     const isEmailVerified =
       getSessionUserResponseBody.user.certifieduser.isEmailVerified;
-    expect(isEmailVerified, JSON.stringify(getSessionUserResponseBody)).toBe(
-      false
-    );
+    expect(
+      isEmailVerified,
+      JSON.stringify(await page.context().cookies(), null, 2)
+    ).toBe(false);
 
     await expect(
       page.getByTestId(settingsPageElement.emailVerificationAlert)
@@ -87,7 +88,9 @@ test.describe('Email Settings', () => {
       .click();
     const subscriptionResponse = await subscriptionResponsePromise;
     const subscriptionRequestHeaders = JSON.stringify(
-      await subscriptionResponse.request().allHeaders()
+      await subscriptionResponse.request().allHeaders(),
+      null,
+      2
     );
 
     expect(subscriptionResponse.status(), subscriptionRequestHeaders).toBe(200);

--- a/e2e/email-settings.spec.ts
+++ b/e2e/email-settings.spec.ts
@@ -74,8 +74,15 @@ test.describe('Email Settings', () => {
     ).toContainText("We have updated your subscription to Quincy's email");
 
     // Undo subscription change
-    await page
-      .getByTestId(settingsPageElement.emailSubscriptionNoThanksButton)
-      .click();
+    await Promise.all([
+      page.waitForResponse(
+        response =>
+          response.url().includes('update-my-quincy-email') &&
+          response.status() === 200
+      ),
+      page
+        .getByTestId(settingsPageElement.emailSubscriptionNoThanksButton)
+        .click()
+    ]);
   });
 });

--- a/e2e/email-settings.spec.ts
+++ b/e2e/email-settings.spec.ts
@@ -53,7 +53,18 @@ test.describe('Email Settings', () => {
       page.getByTestId(settingsPageElement.flashMessageAlert)
     ).toBeVisible();
 
+    const getSessionUserResponsePromise = page.waitForResponse(response =>
+      response.url().includes('get-session-user')
+    );
     await page.reload();
+    const getSessionUserResponse = await getSessionUserResponsePromise;
+    const getSessionUserResponseBody = await getSessionUserResponse.json();
+    const isEmailVerified =
+      getSessionUserResponseBody.user.certifieduser.isEmailVerified;
+    expect(isEmailVerified, JSON.stringify(getSessionUserResponseBody)).toBe(
+      false
+    );
+
     await expect(
       page.getByTestId(settingsPageElement.emailVerificationAlert)
     ).toBeVisible();
@@ -68,9 +79,18 @@ test.describe('Email Settings', () => {
   });
 
   test('should display flash message when email subscription is toggled', async () => {
+    const subscriptionResponsePromise = page.waitForResponse(response =>
+      response.url().includes('update-my-quincy-email')
+    );
     await page
       .getByTestId(settingsPageElement.emailSubscriptionYesPleaseButton)
       .click();
+    const subscriptionResponse = await subscriptionResponsePromise;
+    const subscriptionRequestHeaders = JSON.stringify(
+      await subscriptionResponse.request().allHeaders()
+    );
+
+    expect(subscriptionResponse.status(), subscriptionRequestHeaders).toBe(200);
 
     await expect(
       page.getByTestId(settingsPageElement.flashMessageAlert)

--- a/e2e/email-settings.spec.ts
+++ b/e2e/email-settings.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 
 const settingsPageElement = {
   emailSettingsSectionHeader: 'email-settings-header',
@@ -13,33 +13,37 @@ const settingsPageElement = {
   flashMessageAlert: 'flash-message'
 } as const;
 
-let page: Page;
-
 test.use({ storageState: 'playwright/.auth/certified-user.json' });
 
-test.beforeAll(async ({ browser }) => {
-  page = await browser.newPage();
+test.beforeEach(async ({ page }) => {
   await page.goto('/settings');
 });
 
-test.afterAll(async () => {
+test.afterEach(async ({ page }) => {
   await page.close();
 });
 
 test.describe('Email Settings', () => {
-  test('should display email settings section header on settings page', async () => {
+  test('should display email settings section header on settings page', async ({
+    page
+  }) => {
     await expect(
       page.getByTestId(settingsPageElement.emailSettingsSectionHeader)
     ).toHaveText('Email Settings');
   });
 
-  test('should display current email address', async () => {
+  test('should display current email address', async ({ page }) => {
     await expect(
       page.getByTestId(settingsPageElement.currentEmailText)
     ).toHaveText('foo@bar.com');
   });
 
-  test('should display email verification alert after email update', async () => {
+  test('should display email verification alert after email update', async ({
+    page,
+    browserName
+  }) => {
+    test.skip(browserName === 'webkit', 'csrf_token cookie is being deleted');
+
     const newEmailAddress = 'foo-update@bar.com';
 
     await page
@@ -67,7 +71,12 @@ test.describe('Email Settings', () => {
     );
   });
 
-  test('should display flash message when email subscription is toggled', async () => {
+  test('should display flash message when email subscription is toggled', async ({
+    page,
+    browserName
+  }) => {
+    test.skip(browserName === 'webkit', 'csrf_token cookie is being deleted');
+
     await page
       .getByTestId(settingsPageElement.emailSubscriptionYesPleaseButton)
       .click();

--- a/e2e/email-settings.spec.ts
+++ b/e2e/email-settings.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect, type Page } from '@playwright/test';
+
+let page: Page;
+
+const settingsPageElement = {
+  emailSettingsSectionHeader: 'email-settings-header',
+  emailVerificationAlert: 'email-verification-alert',
+  currentEmailText: 'current-email',
+  newEmailInput: 'new-email-input',
+  confirmEmailInput: 'confirm-email-input',
+  saveButton: 'save-email-button',
+  emailSubscriptionYesPleaseButton: 'yes-please-button',
+  emailSubscriptionNoThanksButton: 'no-thanks-button',
+  flashMessageAlert: 'flash-message'
+} as const;
+
+test.use({ storageState: 'playwright/.auth/certified-user.json' });
+
+test.beforeAll(async ({ browser }) => {
+  page = await browser.newPage();
+  await page.goto('/settings');
+});
+
+test.afterAll(async () => {
+  await page.close();
+});
+
+test.describe('Email Settings', () => {
+  test('should display email settings section header on settings page', async () => {
+    await expect(
+      page.getByTestId(settingsPageElement.emailSettingsSectionHeader)
+    ).toHaveText('Email Settings');
+  });
+
+  test('should display current email address', async () => {
+    await expect(
+      page.getByTestId(settingsPageElement.currentEmailText)
+    ).toHaveText('foo@bar.com');
+  });
+
+  test('should display email verification alert after email update', async () => {
+    const newEmailAddress = 'foo-update@bar.com';
+
+    await page
+      .getByTestId(settingsPageElement.newEmailInput)
+      .fill(newEmailAddress);
+    await page
+      .getByTestId(settingsPageElement.confirmEmailInput)
+      .fill(newEmailAddress);
+    await page.getByTestId(settingsPageElement.saveButton).click();
+    await expect(
+      page.getByTestId(settingsPageElement.flashMessageAlert)
+    ).toBeVisible();
+
+    await page.reload();
+    await expect(
+      page.getByTestId(settingsPageElement.emailVerificationAlert)
+    ).toBeVisible();
+  });
+
+  test('should display flash message when email subscription is toggled', async () => {
+    let subscriptionButton: string =
+      settingsPageElement.emailSubscriptionYesPleaseButton;
+
+    const isSubscribed =
+      (await page
+        .getByTestId(settingsPageElement.emailSubscriptionYesPleaseButton)
+        .getAttribute('aria-pressed')) === 'true';
+
+    if (isSubscribed) {
+      subscriptionButton = settingsPageElement.emailSubscriptionNoThanksButton;
+    }
+
+    await page.getByTestId(subscriptionButton).click();
+
+    await expect(
+      page.getByTestId(settingsPageElement.flashMessageAlert)
+    ).toContainText("We have updated your subscription to Quincy's email");
+  });
+});

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,4 +1,4 @@
-import { expect, test as setup } from '@playwright/test';
+import { test as setup } from '@playwright/test';
 
 setup('Login', async ({ page }) => {
   await page.goto('/');
@@ -6,11 +6,4 @@ setup('Login', async ({ page }) => {
   await page
     .context()
     .storageState({ path: 'playwright/.auth/certified-user.json' });
-
-  const cookies = await page.context().cookies();
-  const cookieNames = cookies.map(cookie => cookie.name);
-  expect(cookieNames).toEqual(expect.arrayContaining(['csrf_token']));
-
-  const tokenCookie = cookies.find(({ name }) => name === 'csrf_token');
-  expect(tokenCookie?.value).not.toBe('');
 });

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,4 +1,4 @@
-import { test as setup } from '@playwright/test';
+import { expect, test as setup } from '@playwright/test';
 
 setup('Login', async ({ page }) => {
   await page.goto('/');
@@ -6,4 +6,11 @@ setup('Login', async ({ page }) => {
   await page
     .context()
     .storageState({ path: 'playwright/.auth/certified-user.json' });
+
+  const cookies = await page.context().cookies();
+  const cookieNames = cookies.map(cookie => cookie.name);
+  expect(cookieNames).toEqual(expect.arrayContaining(['csrf_token']));
+
+  const tokenCookie = cookies.find(({ name }) => name === 'csrf_token');
+  expect(tokenCookie?.value).not.toBe('');
 });


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

#51705: Implements e2e tests for "Email Settings" section on Settings page
⚠️ Note that implementing e2e tests for the entire Settings page would be too big for a single PR. If this accepted by the team, other sections would be covered in separate individual PRs

<!-- Feel free to add any additional description of changes below this line -->
