### PR TITLE
feat(api): POST /user/ms-username

### DIFF
--- a/api/src/routes/user.test.ts
+++ b/api/src/routes/user.test.ts
@@ -752,7 +752,7 @@ Luke, I am your father
 
 Reported by:
 Username: ${testUser?.username ?? ''}
-Name:
+Name: 
 Email: foo@bar.com
 
 Thanks and regards,

--- a/api/src/routes/user.test.ts
+++ b/api/src/routes/user.test.ts
@@ -5,7 +5,6 @@ import jwt, { JwtPayload } from 'jsonwebtoken';
 import type { Prisma } from '@prisma/client';
 import { ObjectId } from 'mongodb';
 import _ from 'lodash';
-import fetch from 'node-fetch';
 
 import { createUserInput } from '../utils/create-user';
 import {
@@ -18,8 +17,8 @@ import {
 import { JWT_SECRET } from '../utils/env';
 import { getMsTranscriptApiUrl } from './user';
 
-jest.mock('node-fetch');
-const mockedFetch = fetch as unknown as jest.Mock;
+const mockedFetch = jest.fn();
+jest.spyOn(globalThis, 'fetch').mockImplementation(mockedFetch);
 
 // This is used to build a test user.
 const testUserData: Prisma.userCreateInput = {

--- a/api/src/routes/user.test.ts
+++ b/api/src/routes/user.test.ts
@@ -1030,7 +1030,6 @@ Thanks and regards,
           expect(linkedAccounts[1]?.msUsername).toBe(msUsernameTwo);
         });
 
-        // `https://learn.microsoft.com/api/profiles/transcript/share/${msTranscriptId}`;
         it('calls the Microsoft API with the correct url', async () => {
           const msTranscriptUrl =
             'https://learn.microsoft.com/en-us/users/mot01/transcript/8u6awert43q1plo';
@@ -1086,10 +1085,10 @@ describe('Microsoft helpers', () => {
   describe('getMsTranscriptApiUrl', () => {
     const expectedUrl =
       'https://learn.microsoft.com/api/profiles/transcript/share/8u6awert43q1plo';
+
     const urlWithoutSlash =
       'https://learn.microsoft.com/en-us/users/mot01/transcript/8u6awert43q1plo';
     const urlWithSlash = `${urlWithoutSlash}/`;
-
     const urlWithQueryParams = `${urlWithoutSlash}?foo=bar`;
     const urlWithQueryParamsAndSlash = `${urlWithSlash}?foo=bar`;
 

--- a/api/src/routes/user.ts
+++ b/api/src/routes/user.ts
@@ -27,6 +27,24 @@ const nanoid = customAlphabet(
 );
 
 /**
+ * Helper function to get the api url from the shared transcript link.
+ *
+ * @param msTranscript Shared transcript link.
+ * @returns Microsoft transcript api url.
+ */
+export const getMsTranscriptApiUrl = (msTranscript: string) => {
+  // example msTranscriptUrl: https://learn.microsoft.com/en-us/users/mot01/transcript/8u6awert43q1plo
+  const url = new URL(msTranscript);
+
+  // TODO(Post-MVP): throw if it doesn't match?
+  const transcriptUrlRegex = /\/transcript\/([^/]+)\/?/;
+  const id = transcriptUrlRegex.exec(url.pathname)?.[1];
+  return `https://learn.microsoft.com/api/profiles/transcript/share/${
+    id ?? ''
+  }`;
+};
+
+/**
  * Wrapper for endpoints related to user account management,
  * such as account deletion.
  *
@@ -278,7 +296,10 @@ export const userRoutes: FastifyPluginCallbackTypebox = (
         const user = await fastify.prisma.user.findUniqueOrThrow({
           where: { id: req.session.user.id }
         });
-        const msApiRes = await fetch(req.body.msTranscriptUrl);
+
+        const msApiRes = await fetch(
+          getMsTranscriptApiUrl(req.body.msTranscriptUrl)
+        );
 
         if (!msApiRes.ok) {
           void reply.status(404);

--- a/api/src/routes/user.ts
+++ b/api/src/routes/user.ts
@@ -299,14 +299,14 @@ export const userRoutes: FastifyPluginCallbackTypebox = (
           } as const;
         }
 
+        // TODO(Post-MVP): make msUsername unique, then we can simply try to
+        // create the record and catch the error.
         const usernameUsed = !!(await fastify.prisma.msUsername.findFirst({
           where: {
             msUsername: userName
           }
         }));
 
-        // TODO: do we need a specific check? Can we just try to create it and
-        // handle the error?
         if (usernameUsed) {
           void reply.status(403);
           return {
@@ -315,15 +315,17 @@ export const userRoutes: FastifyPluginCallbackTypebox = (
           } as const;
         }
 
+        // TODO(Post-MVP): do we need to store tll in the database? We aren't
+        // storing the creation date, so we can't expire it.
+
         // 900 days in ms
         const ttl = 900 * 24 * 60 * 60 * 1000;
 
         await fastify.prisma.msUsername.create({
           data: { msUsername: userName, userId: user.id, ttl }
         });
-        return { msUsername: 'foobar' };
+        return { msUsername: userName };
       } catch (err) {
-        console.log(err);
         fastify.log.error(err);
         void reply.code(500);
         return {

--- a/api/src/routes/user.ts
+++ b/api/src/routes/user.ts
@@ -281,8 +281,7 @@ export const userRoutes: FastifyPluginCallbackTypebox = (
       schema: schemas.postMsUsername,
       errorHandler(error, request, reply) {
         if (error.validation) {
-          void reply.code(400);
-          void reply.send({
+          void reply.code(400).send({
             message: 'flash.ms.transcript.link-err-1',
             type: 'error'
           });
@@ -302,22 +301,18 @@ export const userRoutes: FastifyPluginCallbackTypebox = (
         );
 
         if (!msApiRes.ok) {
-          void reply.status(404);
-
-          return {
-            type: 'error',
-            message: 'flash.ms.transcript.link-err-2'
-          } as const;
+          return reply
+            .status(404)
+            .send({ type: 'error', message: 'flash.ms.transcript.link-err-2' });
         }
 
         const { userName } = (await msApiRes.json()) as { userName: string };
 
         if (!userName) {
-          void reply.status(500);
-          return {
+          return reply.status(500).send({
             type: 'error',
             message: 'flash.ms.transcript.link-err-3'
-          } as const;
+          });
         }
 
         // TODO(Post-MVP): make msUsername unique, then we can simply try to
@@ -329,11 +324,10 @@ export const userRoutes: FastifyPluginCallbackTypebox = (
         }));
 
         if (usernameUsed) {
-          void reply.status(403);
-          return {
+          return reply.status(403).send({
             type: 'error',
             message: 'flash.ms.transcript.link-err-4'
-          } as const;
+          });
         }
 
         // TODO(Post-MVP): do we need to store tll in the database? We aren't
@@ -359,11 +353,10 @@ export const userRoutes: FastifyPluginCallbackTypebox = (
         return { msUsername: userName };
       } catch (err) {
         fastify.log.error(err);
-        void reply.code(500);
-        return {
+        return reply.code(500).send({
           type: 'error',
           message: 'flash.ms.transcript.link-err-6'
-        } as const;
+        });
       }
     }
   );

--- a/api/src/routes/user.ts
+++ b/api/src/routes/user.ts
@@ -321,9 +321,20 @@ export const userRoutes: FastifyPluginCallbackTypebox = (
         // 900 days in ms
         const ttl = 900 * 24 * 60 * 60 * 1000;
 
-        await fastify.prisma.msUsername.create({
-          data: { msUsername: userName, userId: user.id, ttl }
+        // TODO(Post-MVP): make userId unique and then we can upsert.
+
+        await fastify.prisma.msUsername.deleteMany({
+          where: { userId: user.id }
         });
+
+        await fastify.prisma.msUsername.create({
+          data: {
+            msUsername: userName,
+            ttl,
+            userId: user.id
+          }
+        });
+
         return { msUsername: userName };
       } catch (err) {
         fastify.log.error(err);

--- a/api/src/routes/user.ts
+++ b/api/src/routes/user.ts
@@ -1,7 +1,6 @@
 import { type FastifyPluginCallbackTypebox } from '@fastify/type-provider-typebox';
 import { ObjectId } from 'mongodb';
 import { customAlphabet } from 'nanoid';
-import fetch from 'node-fetch';
 
 import { schemas } from '../schemas';
 import {

--- a/api/src/schemas.ts
+++ b/api/src/schemas.ts
@@ -634,5 +634,33 @@ export const schemas = {
         error: Type.String()
       })
     }
+  },
+  postMsUsername: {
+    body: Type.Object({
+      msTranscriptUrl: Type.String({ maxLength: 1000 })
+    }),
+    response: {
+      200: Type.Object({
+        msUsername: Type.String()
+      }),
+      404: Type.Object({
+        type: Type.Literal('error'),
+        message: Type.Literal('flash.ms.transcript.link-err-2')
+      }),
+      403: Type.Object({
+        type: Type.Literal('error'),
+        message: Type.Literal('flash.ms.transcript.link-err-4')
+      }),
+      500: Type.Union([
+        Type.Object({
+          type: Type.Literal('error'),
+          message: Type.Literal('flash.ms.transcript.link-err-6')
+        }),
+        Type.Object({
+          type: Type.Literal('error'),
+          message: Type.Literal('flash.ms.transcript.link-err-3')
+        })
+      ])
+    }
   }
 };


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

There are a couple of small differences from the api-server implementation

1. There's no way to return `flash.ms.transcript.link-err-5` because prisma guarantees that `msUsername.create` either throws or returns the created record.
2. The api can handle transcript urls with trailing slashes

@moT01 we've got client-side validation for the slashes, so it's not urgent, but I'll create a quick PR so we're not reliant on the client.

Closes: https://github.com/freeCodeCamp/freeCodeCamp/issues/51428

<!-- Feel free to add any additional description of changes below this line -->
