### PR TITLE
test(e2e,playwright): Challenges

### DIFF
--- a/e2e/challenges.test.ts
+++ b/e2e/challenges.test.ts
@@ -1,0 +1,47 @@
+import { test, expect, Page } from '@playwright/test';
+import translations from '../client/i18n/locales/english/translations.json';
+
+let page: Page;
+const pathsToTest = [{ input: '/challenges', expected: '/learn' }];
+
+test.beforeAll(async ({ browser }) => {
+  page = await browser.newPage();
+});
+
+test.afterAll(async () => {
+  await page.close();
+});
+
+test.describe('Legacy Challenge Path Redirection Tests', () => {
+  const testLearnPageTitle = async () => {
+    await expect(page).toHaveTitle(
+      'Learn to Code — For Free — Coding Courses for Busy People'
+    );
+  };
+
+  const testLearnPageHeader = async () => {
+    const header = page.getByTestId('learn-heading');
+    await expect(header).toBeVisible();
+    await expect(header).toContainText(translations.learn.heading);
+  };
+
+  const runLearnTests = async () => {
+    await testLearnPageTitle();
+    await testLearnPageHeader();
+  };
+
+  for (const { input, expected } of pathsToTest) {
+    test(`should redirect from ${input} to ${expected}, if it fails runs a DOM test`, async () => {
+      try {
+        await page.goto(input);
+        const currentPath = new URL(page.url()).pathname;
+        expect(currentPath).toBe(expected);
+      } catch (error) {
+        console.log(
+          `Failed to redirect from ${input} to ${expected}. Running DOM tests.`
+        );
+        await runLearnTests();
+      }
+    });
+  }
+});

--- a/e2e/challenges.test.ts
+++ b/e2e/challenges.test.ts
@@ -36,6 +36,10 @@ test.describe('Legacy Challenge Path Redirection Tests', () => {
         await page.goto(input);
         const currentPath = new URL(page.url()).pathname;
         expect(currentPath).toBe(expected);
+        // Due to inconsistent URL behavior in WebKit & Mobile Safari.
+        // The URL may not correctly reflect the page.
+        // Fallback to running a DOM test and validate page content.
+        // Ensures we are on the expected page despite URL.
       } catch (error) {
         console.log(
           `Failed to redirect from ${input} to ${expected}. Running DOM tests.`


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Refers #51705

<!-- Feel free to add any additional description of changes below this line -->
camperbot cant code

In initial tests, WebKit and mobile Safari failed to reflect the correct URL after redirection, showing "challenges" instead of "learn". As a workaround, I now perform a DOM check to verify the page content. Though I intended to validate specific URL patterns, the inconsistent URL behavior on WebKit and Safari made me reconsider.

I.E
I didn't do checks for sub-pages because of this
challenges/some-course
learn/some-course

If I understand GitPod correctly, it could be the reason webkit and mobile safari specifically fail with this method when using GitPod.