### PR TITLE
feat: remove github prebuild config

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -65,25 +65,6 @@ tasks:
       pnpm run develop:client -- -H '0.0.0.0'
     openMode: split-right
 
-github:
-  prebuilds:
-    # enable for the master/default branch (defaults to true)
-    master: true
-    # enable for all branches in this repo (defaults to false)
-    branches: true
-    # enable for pull requests coming from this repo (defaults to true)
-    pullRequests: true
-    # enable for pull requests coming from forks (defaults to false)
-    pullRequestsFromForks: true
-    # add a check to pull requests (defaults to true)
-    addCheck: false
-    # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
-    addComment: true
-    # add a "Review in Gitpod" button to the pull request's description (defaults to false)
-    addBadge: false
-    # add a label once the prebuild is ready to pull requests (defaults to false)
-    addLabel: false
-
 vscode:
   extensions:
     - dbaeumer.vscode-eslint


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

this is deprecated in favour of the project tab in `https://gitpod.io/projects/[projectName]-[projectId]/prebuilds`

![image](https://github.com/freeCodeCamp/freeCodeCamp/assets/88248797/58250bed-5265-48f0-ae74-51305e9caf84)


<!-- Feel free to add any additional description of changes below this line -->
