### PR TITLE
fix: stop generating prisma client during tests

### DIFF
--- a/api/src/db/prisma.ts
+++ b/api/src/db/prisma.ts
@@ -21,7 +21,7 @@ const isTest = (workerId: string | undefined): workerId is string =>
 const prismaPlugin: FastifyPluginAsync = fp(async (server, _options) => {
   if (isTest(process.env.JEST_WORKER_ID)) {
     // push the schema to the test db to setup indexes, unique constraints, etc
-    execSync('pnpm prisma db push', {
+    execSync('pnpm prisma db push -- --skip-generate', {
       env: {
         ...process.env,
         MONGOHQ_URL: createTestConnectionURL(


### PR DESCRIPTION
It will be generated before the tests are run so there's no need to keep
regenerating it.

Skipping it should improve testing performance substantially.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
