### PR TITLE
docs: warn about hardware and Windows setups

### DIFF
--- a/docs/how-to-setup-freecodecamp-locally.md
+++ b/docs/how-to-setup-freecodecamp-locally.md
@@ -2,8 +2,10 @@ Follow these guidelines for setting up a development environment for freeCodeCam
 
 ## Choose between Gitpod or your Own Machine (local setup)
 
-> [!ATTENTION]
-> **Note:** freeCodeCamp does NOT run natively on Windows 10 or 11, you will need to use WSL2. You can follow [this guide](how-to-setup-wsl.md) to set up WSL2. You can't use Command Prompt, Git Bash or PowerShell to run freeCodeCamp natively within windows.
+> [!ATTENTION] 
+> - freeCodeCamp does not build and run natively on Windows, you will [need to use WSL2](how-to-setup-wsl.md) for a Linux-like setup on Windows. 
+> - You can't use Windows Command Prompt, Git Bash or PowerShell to build and run the codebase.
+> - Note that if using Windows, the hardware requirements need to be more than [what we mention](how-to-setup-freecodecamp-locally?id=how-to-prepare-your-local-machine) to accomodate for WSL-based setup. 
 
 If you are looking to make a one-off contribution, you should use Gitpod to make changes. The Gitpod setup launches a ready-to-code environment in a few minutes in your web browser. For contributing long-term, we recommend you setup freeCodeCamp on your local machine.
 


### PR DESCRIPTION
A good chunk of the developers are on Windows, and hopefully, this change gets the point across better.

Before:

<img width="809" alt="image" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/1884376/c16fdccd-6a86-479f-b5ef-7f263454ae31">


After:

<img width="807" alt="image" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/1884376/e104b4b1-5a1c-4bc7-a630-b7ef4768e0cc">
