### PR TITLE
docs(playwright): update the recommended locators used in Playwright tests

### DIFF
--- a/docs/how-to-add-playwright-tests.md
+++ b/docs/how-to-add-playwright-tests.md
@@ -10,7 +10,7 @@ pnpm run playwright:install-build-tools
 
 Alternatively you can follow official documentation referenced below:
 
-To install and configure Playwright on your machine check out this [documentation](https://playwright.dev/docs/intro#installing-playwright)
+To install and configure Playwright on your machine check out this [documentation](https://playwright.dev/docs/intro#installing-playwright).
 
 To learn how to write Playwright tests, or 'specs', please see Playwright's official [documentation](https://playwright.dev/docs/writing-tests).
 
@@ -20,141 +20,152 @@ To learn how to write Playwright tests, or 'specs', please see Playwright's offi
 
 - Playwright test files are always with a `.spec.ts` extension.
 
-## Best Practices for writing e2e tests
+## Best Practices for writing E2E tests
 
- This section will explain in detail about best practices for writing and documenting E2E tests based on playwright documentation and our community code-style.
+ This section will explain in detail about best practices for writing and documenting E2E tests based on Playwright documentation and our community code-style.
 
 ### - Identifying a DOM element
 
-  Always use the `data-playwright-test-label` attribute to identify DOM elements. This attribute is used to identify elements in the DOM for testing with playwright only. It is not used for styling or any other purpose.
+Playwright comes with [multiple built-in locators](https://playwright.dev/docs/locators#quick-guide), but we recommend priritizing the following locators:
+  - `getByRole` for querying semantic elements, whose role is important and allows assistive technology to perceive the page correctly. 
+  - `getByText` for querying non-semantic elements such as `div`, `span`, or `p`.
 
-  For example:
+For example:
+```ts
+await expect(page.getByRole('heading', { name: 'Sign up' })).toBeVisible();
+await expect(page.getByText('Hello World')).toBeVisible();
+```
+  
+In cases where the elements cannot be queried using the above-mentioned locators, you can use the `data-playwright-test-label` attribute as the last resort. This attribute is used to identify elements in the DOM for testing with playwright only. It is not used for styling or any other purpose.
 
-  ```html
-  <div data-playwright-test-label="landing-page-figure">
-    <img src="..." alt="..." />
-  </div>
-  ```
+For example:
 
-  Make sure you use the getByTestId method to identify the element in the test file.
+```html
+<div data-playwright-test-label="landing-page-figure">
+  <img src="..." alt="..." />
+</div>
+```
 
-  For example:
+In the test file, you can use the `getByTestId` method to identify the element.
 
-  ```ts
-  const landingPageFigure = page.getByTestId('landing-page-figure');
-  ```
+For example:
+
+```ts
+await expect(page.getByTestId('landing-page-figure')).toBeVisible();
+```
 
 ### - Imports
   
-  Always start with necessary imports at the beginning of the file.
+Always start with necessary imports at the beginning of the file.
   
-  For example:
+For example:
   
-  ```ts
-  import { test, expect, type Page } from '@playwright/test';
-  ```
+```ts
+import { test, expect, type Page } from '@playwright/test';
+```
 
 ### - Constants
 
-  Define any constant elements, data sets, or configurations used throughout your tests for easy reference.
+Define any constant elements, data sets, or configurations used throughout your tests for easy reference.
   
-  For example:
+For example:
   
-  ```ts
-  const landingPageElements = { ... };
-  const superBlocks = [ ... ];
-  ```
+```ts
+const landingPageElements = { ... };
+const superBlocks = [ ... ];
+```
 
 ### - Shared Context
 
- If tests depend on a shared context (like a loaded web page), use beforeAll and afterAll hooks to set up and tear down that context.
+If tests depend on a shared context (like a loaded web page), use beforeAll and afterAll hooks to set up and tear down that context.
 
-  For example:
+For example:
   
-  ```ts
-  let page: Page;
+```ts
+let page: Page;
 
-  beforeAll(async ({ browser }) => {
-    page = await browser.newPage();
-  });
+beforeAll(async ({ browser }) => {
+  page = await browser.newPage();
+});
 
-  afterAll(async () => {
-    await page.close();
-  });
-  ```
+afterAll(async () => {
+  await page.close();
+});
+```
 
 ### - Descriptive test names
 
- Each test block should have a clear and concise name describing exactly what it's testing.
+Each test block should have a clear and concise name describing exactly what it's testing.
 
-  For example:
+For example:
   
-  ```ts
-  test('The component landing-top renders correctly', async ({ page }) => {
-    ...
-  });
-  ```
+```ts
+test('The component landing-top renders correctly', async ({ page }) => {
+ // ...
+});
+```
 
 ### - Human readable assertions
   
-  Each assertion should be as human readable as possible. This makes it easier to understand what the test is doing and what it's expecting.
+Each assertion should be as human readable as possible. This makes it easier to understand what the test is doing and what it's expecting.
 
-  For example:
+For example:
 
-  ```ts
-  await expect(landingHeading1).toHaveText('Learn to code — for free.');
-  ```
+```ts
+await expect(landingHeading1).toHaveText('Learn to code — for free.');
+```
 
 ### - Keep it DRY
 
-  Make sure that the tests are not repeating the same code over and over again. If you find yourself repeating the same code, consider refactoring it as a loop or a function.
+Make sure that the tests are not repeating the same code over and over again. If you find yourself repeating the same code, consider refactoring it as a loop or a function.
 
-  For example:
+For example:
   
-  ```ts
-  for (const logo of await logos.all()) {
-    await expect(logo).toBeVisible();
-  }
-  ```
+```ts
+for (const logo of await logos.all()) {
+  await expect(logo).toBeVisible();
+}
+```
 
 ### - Tests for mobile screens
 
-  Use the 'isMobile' argument to run tests that incude logic that varies for mobile screens.
+Use the `isMobile` argument to run tests that incude logic that varies for mobile screens.
 
-  For example:
+For example:
 
-  ```ts
-  test('The campers landing page figure is visible on desktop and hidden on mobile view', async ({isMobile}) => 
-  {
-    const landingPageImage = page.getByTestId('landing-page-figure');
+```ts
+test('The campers landing page figure is visible on desktop and hidden on mobile view', async ({
+    isMobile
+}) => {
+  const landingPageImage = page.getByTestId('landing-page-figure');
 
-    if (isMobile) {
-      await expect(landingPageImage).toBeHidden();
-    } else {
-      await expect(landingPageImage).toBeVisible();
-    }
-  });
+  if (isMobile) {
+    await expect(landingPageImage).toBeHidden();
+  } else {
+    await expect(landingPageImage).toBeVisible();
+  }
+});
 ```
 
 ### - Group related tests
 
-  Group related tests together using describe blocks. This makes it easier to understand what the tests are doing and what they're testing.
+Group related tests together using describe blocks. This makes it easier to understand what the tests are doing and what they're testing.
 
-  For example:
+For example:
 
-  ```ts
-  describe('The campers landing page', () => {
-    test('The campers landing page figure is visible on desktop and hidden on mobile view', async ({isMobile}) => 
-    {
-      ...
-    });
-
-    test('The campers landing page figure has the correct image', async () => {
-      ...
-    });
+```ts
+describe('The campers landing page', () => {
+  test('The campers landing page figure is visible on desktop and hidden on mobile view', async ({
+    isMobile
+  }) => {
+    // ...
   });
-  ```
 
+  test('The campers landing page figure has the correct image', async () => {
+      // ...
+  });
+});
+```
 
 ## How to Run Tests
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

As mentioned in #51770, we should favor `getByRole` and `getByText` over `getByTestId` in tests so that we can ensure the validity of the DOM.

This PR updates the Playwright best practices guide to reflect this new recommendation. For Hacktoberfest PRs that have already been using test IDs, I think we should still respect the authors' efforts and accept their code addition, and we can always improve the tests later on.

Closes #51770.

<!-- Feel free to add any additional description of changes below this line -->
