### PR TITLE
docs: moved imports section

### DIFF
--- a/docs/how-to-add-playwright-tests.md
+++ b/docs/how-to-add-playwright-tests.md
@@ -24,9 +24,19 @@ To learn how to write Playwright tests, or 'specs', please see Playwright's offi
 
  This section will explain in detail about best practices for writing and documenting E2E tests based on Playwright documentation and our community code-style.
 
+### - Imports
+  
+Always start with necessary imports at the beginning of the file.
+  
+For example:
+  
+```ts
+import { test, expect, type Page } from '@playwright/test';
+```
+
 ### - Identifying a DOM element
 
-Playwright comes with [multiple built-in locators](https://playwright.dev/docs/locators#quick-guide), but we recommend priritizing the following locators:
+Playwright comes with [multiple built-in locators](https://playwright.dev/docs/locators#quick-guide), but we recommend prioritizing the following locators:
   - `getByRole` for querying semantic elements, whose role is important and allows assistive technology to perceive the page correctly. 
   - `getByText` for querying non-semantic elements such as `div`, `span`, or `p`.
 
@@ -52,16 +62,6 @@ For example:
 
 ```ts
 await expect(page.getByTestId('landing-page-figure')).toBeVisible();
-```
-
-### - Imports
-  
-Always start with necessary imports at the beginning of the file.
-  
-For example:
-  
-```ts
-import { test, expect, type Page } from '@playwright/test';
 ```
 
 ### - Constants


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->

Proposal to move the section `Imports` above section `Identifying a DOM Element` for the sake of continuity. It would make better sense to introduce readers to what needs to be imported first, then diving into what those imports provide. Also, a minor spell fix.
