### PR TITLE
fix(api): return default values for user fields

### DIFF
--- a/api/src/routes/user.test.ts
+++ b/api/src/routes/user.test.ts
@@ -110,11 +110,8 @@ const minimalUserData: Prisma.userCreateInput = {
 const computedProperties = {
   calendar: {},
   completedChallengeCount: 0,
-  completedChallenges: [], // we don't need to provide an empty array, prisma will create it
   isEmailVerified: minimalUserData.emailVerified,
   points: 1,
-  portfolio: [],
-  yearsTopContributor: [],
   // This is the default value if profileUI is missing. If individual properties
   // are missing from the db, they will be omitted from the response.
   profileUI: {
@@ -540,8 +537,17 @@ describe('userRoutes', () => {
         const publicUser = {
           ..._.omit(minimalUserData, ['externalId', 'unsubscribeId']),
           ...computedProperties,
-          id: testUser?.id,
-          joinDate: new ObjectId(testUser?.id).getTimestamp().toISOString()
+          id: testUser.id,
+          joinDate: new ObjectId(testUser.id).getTimestamp().toISOString(),
+          // the following properties are defaults provided if the field is
+          // missing in the user document.
+          completedChallenges: [],
+          // TODO: add completedExams when /generate-exam is implemented
+          // completedExams: [],
+          partiallyCompletedChallenges: [],
+          portfolio: [],
+          savedChallenges: [],
+          yearsTopContributor: []
         };
 
         const response = await superRequest('/user/get-session-user', {

--- a/api/src/routes/user.ts
+++ b/api/src/routes/user.ts
@@ -1,5 +1,4 @@
 import { type FastifyPluginCallbackTypebox } from '@fastify/type-provider-typebox';
-import { isEmpty } from 'lodash';
 import { ObjectId } from 'mongodb';
 import { customAlphabet } from 'nanoid';
 
@@ -272,8 +271,6 @@ export const userGetRoutes: FastifyPluginCallbackTypebox = (
           progressTimestamps,
           twitter,
           profileUI,
-          savedChallenges,
-          partiallyCompletedChallenges,
           ...publicUser
         } = user;
 
@@ -287,19 +284,11 @@ export const userGetRoutes: FastifyPluginCallbackTypebox = (
               calendar: getCalendar(
                 progressTimestamps as ProgressTimestamp[] | null
               ),
-              partiallyCompletedChallenges: isEmpty(
-                partiallyCompletedChallenges
-              )
-                ? undefined
-                : partiallyCompletedChallenges,
               // This assertion is necessary until the database is normalized.
               points: getPoints(
                 progressTimestamps as ProgressTimestamp[] | null
               ),
               profileUI: normalizeProfileUI(profileUI),
-              savedChallenges: isEmpty(savedChallenges)
-                ? undefined
-                : savedChallenges,
               // TODO(Post-MVP) remove this and just use emailVerified
               isEmailVerified: user.emailVerified,
               joinDate: new ObjectId(user.id).getTimestamp().toISOString(),


### PR DESCRIPTION
The api-server's user/get-session-user route returns [] if an array
field is missing in the underlying user document. These changes should
bring the new api's behaviour into line with api-server's

Thanks to @Nirajn2311 for pointing out the discrepancy.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
