### PR TITLE
fix(curriculum): Update instructions and add a space to the editable region

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f45a276c093334f0f6e9df4.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f45a276c093334f0f6e9df4.md
@@ -9,7 +9,7 @@ dashedName: step-73
 
 Focusing on the menu items and prices, there is a fairly large gap between each line.
 
-Target all the `p` elements nested in elements with the `class` named `item` and set their top and bottom margin to be `5px`.
+Use the existing selector that targets all the `p` elements nested in elements with the class named `item` and set their top and bottom margin to be `5px`.
 
 # --hints--
 
@@ -151,16 +151,15 @@ hr {
   border-color: brown;
 }
 
+--fcc-editable-region--
 h1, h2 {
   font-family: Impact, serif;
 }
 
-  --fcc-editable-region--
 .item p {
   display: inline-block;
-  
+
 }
-  --fcc-editable-region--
 
 .flavor, .dessert {
   text-align: left;
@@ -171,5 +170,6 @@ h1, h2 {
   text-align: right;
   width: 25%
 }
+--fcc-editable-region--
 ```
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f45a276c093334f0f6e9df4.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f45a276c093334f0f6e9df4.md
@@ -151,14 +151,16 @@ hr {
   border-color: brown;
 }
 
---fcc-editable-region--
 h1, h2 {
   font-family: Impact, serif;
 }
 
+  --fcc-editable-region--
 .item p {
   display: inline-block;
+  
 }
+  --fcc-editable-region--
 
 .flavor, .dessert {
   text-align: left;
@@ -169,6 +171,5 @@ h1, h2 {
   text-align: right;
   width: 25%
 }
---fcc-editable-region--
 ```
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Make it more clear what needs to be edited.

<!-- Feel free to add any additional description of changes below this line -->

Forum: https://forum.freecodecamp.org/t/learn-basic-css-by-building-a-cafe-menu-step-73/643080

---

Edit: I guess the current region might be intentional to force the camper to more carefully read and understand the requirement of using an existing selector. But then I would expect it to be part of the requirements and not just the test assert.

> Target all the `p` elements nested in elements with the class named `item` and set their top and bottom `margin` to be `5px`.

It is already targeted for them as the selector already exists. It makes it sound like a new selector has to be created.

---

> Use the existing selector that targets all the `p` elements nested in elements with the class named `item` and set their top and bottom `margin` to be `5px`.

Or something to that effect.
