### PR TITLE
fix(ui-components): styling issues in CloseButton

### DIFF
--- a/tools/ui-components/src/close-button/close-button.test.tsx
+++ b/tools/ui-components/src/close-button/close-button.test.tsx
@@ -10,6 +10,12 @@ describe('<CloseButton>', () => {
     expect(screen.getByRole('button')).toBeInTheDocument();
   });
 
+  it('should have "Close" as the default label', () => {
+    render(<CloseButton onClick={jest.fn()} />);
+
+    expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
+  });
+
   it('should set "aria-label" to "label" prop', () => {
     const expectedLabel = 'Close me please';
     render(<CloseButton label={expectedLabel} onClick={jest.fn()} />);

--- a/tools/ui-components/src/close-button/close-button.tsx
+++ b/tools/ui-components/src/close-button/close-button.tsx
@@ -33,8 +33,8 @@ export function CloseButton({
     'active:before:opacity-20',
     // Focus state
     'focus:outline-none', // Hide the default browser outline
-    'focus:ring',
-    'focus:ring-focus-outline-color',
+    'focus-visible:ring',
+    'focus-visible:ring-focus-outline-color',
     // Content positioning
     'flex',
     'justify-center',

--- a/tools/ui-components/src/close-button/close-button.tsx
+++ b/tools/ui-components/src/close-button/close-button.tsx
@@ -15,18 +15,41 @@ export function CloseButton({
   onClick
 }: CloseButtonProps): JSX.Element {
   const classes = [
-    'text-xl font-bold leading-none appearance-none opacity-20',
-    'hover:opacity-50 focus:opacity-50',
+    // Remove browser's default styles
+    'bg-transparent',
+    'border-none',
+    // Text styles
+    'text-lg',
+    'font-bold',
+    'text-foreground-primary',
+    // Active state
+    'active:before:w-full',
+    'active:before:h-full',
+    'active:before:absolute',
+    'active:before:inset-0',
+    'active:before:border-3',
+    'active:before:border-transparent',
+    'active:before:bg-gray-900',
+    'active:before:opacity-20',
+    // Focus state
+    'focus:outline-none', // Hide the default browser outline
+    'focus:ring',
+    'focus:ring-focus-outline-color',
+    // Content positioning
+    'flex',
+    'justify-center',
+    'items-center',
+    // Others
+    'w-[24px]',
+    'h-[24px]',
+    'opacity-50',
     className
   ].join(' ');
+
   return (
-    <button
-      aria-label={label ?? 'Close'}
-      className={classes}
-      onClick={onClick}
-      type='button'
-    >
-      ×
+    <button className={classes} onClick={onClick} type='button'>
+      <span className='sr-only'>{label ?? 'Close'}</span>
+      <span aria-hidden>×</span>
     </button>
   );
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Fixes styling issues in the CloseButton component
- Improves the implementation of the component to ensure screen readers won't announce the `x` symbol to the users (screen readers are currently read the button as "times button", tested with VoiceOver)

## Screenshots

| | Before | After |
| --- | --- | --- |
| Light theme - at rest | <img width="1680" alt="Screenshot 2023-10-09 at 23 05 11" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/c34cf12b-1d3d-4225-b3a5-250b4d5e71ee"> | <img width="1680" alt="Screenshot 2023-10-09 at 23 01 48" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/9c918487-9fa7-4313-a6c4-4f1eac619cba"> |
| Light theme - focused | <img width="1680" alt="Screenshot 2023-10-09 at 23 05 57" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/1b66217f-1d73-4c51-ad2f-382c16cca96e"> | <img width="1680" alt="Screenshot 2023-10-09 at 23 02 12" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/16095f72-186e-44b1-9f44-d2712211d291"> |
| Dark theme - at rest | <img width="1680" alt="Screenshot 2023-10-09 at 23 05 19" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/a0585186-a03e-489c-9529-727949ebafb4"> | <img width="1680" alt="Screenshot 2023-10-09 at 23 01 56" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/be955894-85e7-43de-b26c-e4382bfeb53e"> |
| Dark theme - focused | <img width="1680" alt="Screenshot 2023-10-09 at 23 05 34" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/90114485-d88a-4692-94dd-f01af047bd95"> | <img width="1680" alt="Screenshot 2023-10-09 at 23 02 04" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/28cc5d8d-d6c1-4345-9153-e9ac7494b29a"> |

<!-- Feel free to add any additional description of changes below this line -->
