### PR TITLE
chore(gitpod): move prebuild config to project

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -65,25 +65,6 @@ tasks:
       pnpm run develop:client -- -H '0.0.0.0'
     openMode: split-right
 
-github:
-  prebuilds:
-    # enable for the master/default branch (defaults to true)
-    master: true
-    # enable for all branches in this repo (defaults to false)
-    branches: true
-    # enable for pull requests coming from this repo (defaults to true)
-    pullRequests: true
-    # enable for pull requests coming from forks (defaults to false)
-    pullRequestsFromForks: true
-    # add a check to pull requests (defaults to true)
-    addCheck: false
-    # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
-    addComment: true
-    # add a "Review in Gitpod" button to the pull request's description (defaults to false)
-    addBadge: false
-    # add a label once the prebuild is ready to pull requests (defaults to false)
-    addLabel: false
-
 vscode:
   extensions:
     - dbaeumer.vscode-eslint


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The prebuild settings are deprecated in the `.gitpod.yml` file. Instead, prebuilds are to be configured from https://gitpod.io/projects

I am not sure what I am doing, but I think I have configured a prebuild for this repo:

<img width="488" alt="image" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/51722130/2a39746b-4216-42c2-b23d-635eb5010163">

**More Info**: https://www.gitpod.io/changelog/simplified-prebuilds-defaults
