### PR TITLE
fix(client/api): ms trophy validation

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -732,11 +732,15 @@
         "unlinked": "The link to your Microsoft username has been removed.",
         "unlink-err": "Something went wrong trying to remove the link to your Microsoft username."
       },
+      "profile": {
+        "err": "We could not find a Microsoft user ID for Microsoft user \"{{msUsername}}\""
+      },
       "trophy": {
         "err-1": "We could not find a Microsoft username associated with your freeCodeCamp account.",
         "err-2": "You are trying to submit a challenge that does not appear to be a trophy challenge.",
-        "err-3": "It appears that the Microsoft user \"{{msUsername}}\" has not earned this trophy.",
-        "err-4": "Something went wrong trying to verify your trophy. Please check and try again.",
+        "err-3": "We could not get your Microsoft profile from your Microsoft ID.",
+        "err-4": "It appears that the Microsoft user \"{{msUsername}}\" has not earned this trophy.",
+        "err-5": "Something went wrong trying to verify your trophy. Please check and try again.",
         "verified": "Your trophy from Microsoft's learning platform was verified."
       }
     }

--- a/client/src/components/Flash/index.tsx
+++ b/client/src/components/Flash/index.tsx
@@ -16,7 +16,8 @@ function Flash({ flashMessage, removeFlashMessage }: FlashProps): JSX.Element {
   const { type, message, id, variables } = flashMessage;
   const { t } = useTranslation();
 
-  const flashStyle = type as AlertProps['variant'];
+  const flashStyle =
+    type === 'error' ? 'danger' : (type as AlertProps['variant']);
 
   function handleClose() {
     removeFlashMessage();

--- a/client/src/components/Flash/redux/flash-messages.ts
+++ b/client/src/components/Flash/redux/flash-messages.ts
@@ -32,6 +32,7 @@ export enum FlashMessages {
   MsTrophyErr2 = 'flash.ms.trophy.err-2',
   MsTrophyErr3 = 'flash.ms.trophy.err-3',
   MsTrophyErr4 = 'flash.ms.trophy.err-4',
+  MsTrophyErr5 = 'flash.ms.trophy.err-5',
   MsTrophyVerified = 'flash.ms.trophy.verified',
   NameNeeded = 'flash.name-needed',
   None = '',

--- a/client/src/components/Flash/redux/flash-messages.ts
+++ b/client/src/components/Flash/redux/flash-messages.ts
@@ -27,6 +27,7 @@ export enum FlashMessages {
   MsTranscriptLinked = 'flash.ms.transcript.linked',
   MsTranscriptUnlinked = 'flash.ms.transcript.unlinked',
   MsTranscriptUnlinkErr = 'flash.ms.transcript.unlink-err',
+  MsProfileErr = 'flash.ms.profile.err',
   MsTrophyErr1 = 'flash.ms.trophy.err-1',
   MsTrophyErr2 = 'flash.ms.trophy.err-2',
   MsTrophyErr3 = 'flash.ms.trophy.err-3',

--- a/client/src/utils/tone/index.ts
+++ b/client/src/utils/tone/index.ts
@@ -47,6 +47,7 @@ const toneUrls = {
   [FlashMessages.MsTrophyErr2]: TRY_AGAIN,
   [FlashMessages.MsTrophyErr3]: TRY_AGAIN,
   [FlashMessages.MsTrophyErr4]: TRY_AGAIN,
+  [FlashMessages.MsTrophyErr5]: TRY_AGAIN,
   [FlashMessages.MsTrophyVerified]: CHAL_COMP,
   [FlashMessages.NameNeeded]: TRY_AGAIN,
   // [FlashMessages.None]: '',

--- a/client/src/utils/tone/index.ts
+++ b/client/src/utils/tone/index.ts
@@ -42,6 +42,7 @@ const toneUrls = {
   [FlashMessages.MsTranscriptLinked]: CHAL_COMP,
   [FlashMessages.MsTranscriptUnlinked]: CHAL_COMP,
   [FlashMessages.MsTranscriptUnlinkErr]: TRY_AGAIN,
+  [FlashMessages.MsProfileErr]: TRY_AGAIN,
   [FlashMessages.MsTrophyErr1]: TRY_AGAIN,
   [FlashMessages.MsTrophyErr2]: TRY_AGAIN,
   [FlashMessages.MsTrophyErr3]: TRY_AGAIN,


### PR DESCRIPTION
From MS: "they are or have already changed the API that we are using to verify trophies. That means that this will no longer work soon for new users: https://learn.microsoft.com/api/gamestatus/achievements/learn.wwl.get-started-c-sharp-part-6.trophy?username=moT01&locale=en-us" This is the URL we use to check if campers have earned the trophy. They suggested this alternative.

It gets an MS profile from a username - e.g. https://learn.microsoft.com/api/profiles/moT01
That response includes a user ID. Which we can use to get their achievements - e.g. https://learn.microsoft.com/api/gamestatus/60fd13c3-1c9d-4149-940e-7c2a4450ca45

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
