### PR TITLE
fix: allow csrf_token to expire with session

### DIFF
--- a/client/gatsby-browser.js
+++ b/client/gatsby-browser.js
@@ -33,6 +33,8 @@ export const wrapPageElement = layoutSelector;
 export const disableCorePrefetching = () => true;
 
 export const onClientEntry = () => {
-  // the token must be erased since it is only valid for the old _csrf secret
+  // Letting the users' browsers expire the cookie seems to have caused issues
+  // for some users. Until we have time to investigate further, we should remove
+  // the cookie on every page load.
   cookies.erase('csrf_token');
 };

--- a/client/gatsby-browser.js
+++ b/client/gatsby-browser.js
@@ -1,4 +1,3 @@
-import cookies from 'browser-cookies';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { I18nextProvider } from 'react-i18next';
@@ -31,8 +30,3 @@ wrapRootElement.propTypes = {
 export const wrapPageElement = layoutSelector;
 
 export const disableCorePrefetching = () => true;
-
-export const onClientEntry = () => {
-  // the token must be erased since it is only valid for the old _csrf secret
-  cookies.erase('csrf_token');
-};

--- a/client/gatsby-browser.js
+++ b/client/gatsby-browser.js
@@ -1,3 +1,4 @@
+import cookies from 'browser-cookies';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { I18nextProvider } from 'react-i18next';
@@ -30,3 +31,8 @@ wrapRootElement.propTypes = {
 export const wrapPageElement = layoutSelector;
 
 export const disableCorePrefetching = () => true;
+
+export const onClientEntry = () => {
+  // the token must be erased since it is only valid for the old _csrf secret
+  cookies.erase('csrf_token');
+};


### PR DESCRIPTION
In order for _csrf and csrf_token to not match, a user would have to
manually modify one or the other. In addition, the api-server generates
a new csrf_token in this case so subsequent requests will succeed.

As such, manually erasing cookies seems excessive.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Also related: https://github.com/freeCodeCamp/freeCodeCamp/pull/51754. It is failing because, for some reason, webkit is triggering the cookie erasure. No idea why that's happening, but this change fixes the issue.

<!-- Feel free to add any additional description of changes below this line -->
