### PR TITLE
Update security.md, in the guideline section spelling mistake happene…

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -12,7 +12,7 @@ This document outlines our security policy for the codebases, platforms that we 
 We appreciate responsible disclosure of vulnerabilities that might impact the integrity of our platforms and users. In the interest of saving everyone time, we encourage you to report vulnerabilities with these in mind:
 
 1. Ensure that you are using the **latest**, **stable**, and **updated** versions of the Operating System and Web Browser(s) available to you on your machine.
-2. We consider using tools & online utilities to report issues with SPF & DKIM configs, SSL Server tests, etc., in the category of ["beg bounties"](https://www.troyhunt.com/beg-bounties) and are unable to respond to these reports.
+2. We consider using tools & online utilities to report issues with SPF & DKIM configs, SSL Server tests, etc., in the category of ["bUg bounties"](https://www.troyhunt.com/beg-bounties) and are unable to respond to these reports.
 3. While we do not offer any bounties or swags at the moment, we'll be happy to list your name in our [Hall of Fame](security-hall-of-fame.md) list, provided the reports are not low-effort.
 
 ### Reporting


### PR DESCRIPTION
A spelling mistake happened in https://contribute.freecodecamp.org/#/security i corrected it

in the [Guidelines] (https://contribute.freecodecamp.org/#/security?id=guidelines)  section , insted of word "bug bounties" written as "beg bounties " ,i corrected it.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #50075 

<!-- Feel free to add any additional description of changes below this line -->

<img width="698" alt="bug" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/106869525/6b8372e6-05a5-4de1-a34a-df6cb6bdbbbd">
