### PR TITLE
fix(curriculum): added tests for the nested objects challenge in basic Js curriculum

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-objects.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-objects.md
@@ -54,7 +54,7 @@ assert.match(code, /myStorage\.car\.inside/);
 `gloveBoxContents` should still be declared with `const`.
 
 ```js
-assert.match(code, /const\s+gloveBoxContents\s*=\s*.*;\s*$/);
+assert.match(code, /const\s+gloveBoxContents\s*=/);
 ```
 
 You should not change the `myStorage` object.

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-objects.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-objects.md
@@ -57,7 +57,7 @@ assert.match(code, /myStorage\.car\.inside/);
 assert.match(code, /const\s+gloveBoxContents\s*=\s*.*;\s*$/);
 ```
 
-Do not modify the shape of the `myStorage` object.
+You should not change the `myStorage` object.
 
 ```js
 const expectedMyStorage = {

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-objects.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-objects.md
@@ -61,15 +61,16 @@ Do not modify the shape of the `myStorage` object.
 
 ```js
 const expectedMyStorage = {
-  "car": {
-    "inside": {
-      "glove box": "maps",
-      "passenger seat": "crumbs"
+  "car":{
+    "inside":{
+      "glove box":"maps",
+      "passenger seat":"crumbs"
     },
-    "outside": {
-      "trunk": "jack"
+    "outside":{
+      "trunk":"jack"
     }
-  };
+  }
+};
 assert.deepStrictEqual(myStorage, expectedMyStorage);
 ```
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-objects.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-nested-objects.md
@@ -54,7 +54,23 @@ assert.match(code, /myStorage\.car\.inside/);
 `gloveBoxContents` should still be declared with `const`.
 
 ```js
-assert.match(code, /const\s+gloveBoxContents\s*=\s*myStorage\.car\.inside\[\s*("|')glove box\1\s*\]|const\s*{\s*('|")glove box\2:\s*gloveBoxContents\s*}\s*=\s*myStorage\.car\.inside;/);
+assert.match(code, /const\s+gloveBoxContents\s*=\s*.*;\s*$/);
+```
+
+Do not modify the shape of the `myStorage` object.
+
+```js
+const expectedMyStorage = {
+  "car": {
+    "inside": {
+      "glove box": "maps",
+      "passenger seat": "crumbs"
+    },
+    "outside": {
+      "trunk": "jack"
+    }
+  };
+assert.deepStrictEqual(myStorage, expectedMyStorage);
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #51870

<!-- Feel free to add any additional description of changes below this line -->
- Added a test in the Nested Objects challenge that checks that the camper didn't alter the object shape. Uses deep object compare.
- Also optimized the regular expression test for ensuring `const` type casting for `gloveBoxContents` variable. Previously, the regex wouldn't match the statement `const gloveBoxContents = myStorage.car.inside.glove_box;`. But the test case says nothing about the property or its naming convention. It just needs the variable gloveBoxContents to be a const.