### PR TITLE
refactor(curriculum): Move assignments to their own heading

### DIFF
--- a/curriculum/challenges/english/16-the-odin-project/top-learn-html-foundations/html-foundations-question-a.md
+++ b/curriculum/challenges/english/16-the-odin-project/top-learn-html-foundations/html-foundations-question-a.md
@@ -25,12 +25,12 @@ HTML has a vast list of predefined tags that you can use to create all kinds of 
 
 Using the correct elements for content is called semantic HTML. You will explore this in much more depth later on in the curriculum.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Watch Kevin Powell’s [Introduction to HTML video](https://www.youtube.com/watch?v=LGQuIIv2RVA&list=PL4-IK0AVhVjM0xE0K2uZRvsM7LkIhsPT-)
-    
+
+# --question--
+
 ## --text--
 
 What are HTML tags?

--- a/curriculum/challenges/english/16-the-odin-project/top-learn-html-foundations/html-foundations-question-e.md
+++ b/curriculum/challenges/english/16-the-odin-project/top-learn-html-foundations/html-foundations-question-e.md
@@ -11,11 +11,11 @@ HTML and CSS are two languages that work together to create everything that you 
 
 Many helpful resources out there keep referring to HTML and CSS as programming languages, but if you want to get technical, labeling them as such is not quite accurate. This is because they are only concerned with presenting information. They are not used to program logic. JavaScript, which you will learn in the next section, is a programming language because it’s used to make webpages do things. Yet, there is quite a lot you can do with just HTML and CSS, and you will definitely need them both. Throughout our curriculum, the following lessons focus on giving you the tools you need to succeed once you reach JavaScript content.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Read <a href="https://brytdesigns.com/html-css-javascript-whats-the-difference#What_is_HTML" target="_blank">the HTML vs CSS vs JavaScript article</a>. It is a quick overview of the relationships between HTML, CSS, and JavaScript.
+
+# --question--
     
 ## --text--
 
@@ -37,5 +37,3 @@ HTML and CSS are used to add style to a webpage, and JavaScript is used to creat
 ## --video-solution--
 
 2
-
-

--- a/curriculum/challenges/english/16-the-odin-project/top-learn-html-foundations/html-foundations-question-g.md
+++ b/curriculum/challenges/english/16-the-odin-project/top-learn-html-foundations/html-foundations-question-g.md
@@ -11,9 +11,7 @@ The final element needed to complete the HTML boilerplate is the `<body>` elemen
 
 To complete the boilerplate, add a `body` element to the `index.html` file. The `body` element also goes within the `html` element and is always below the `head` element, like so:
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Watch and follow along to Kevin Powell’s brilliant Building your first web page video above.
 
@@ -24,7 +22,9 @@ Build some muscle memory by deleting the contents of the `index.html` file and t
 ---
 
 Run your boilerplate through this [HTML validator](https://www.freeformatter.com/html-validator.html). Validators ensure your markup is correct and are an excellent learning tool, as they provide feedback on syntax errors you may be making often and aren’t aware of, such as missing closing tags and extra spaces in your HTML.
-    
+
+# --question--
+
 ## --text--
 
 What is the purpose of the `body` element?

--- a/curriculum/challenges/english/16-the-odin-project/top-links-and-images/links-and-images-question-a.md
+++ b/curriculum/challenges/english/16-the-odin-project/top-links-and-images/links-and-images-question-a.md
@@ -39,11 +39,11 @@ By default, any text wrapped with an anchor tag without a `href` attribute will 
 
 It’s worth noting you can use anchor tags to link to any kind of resource on the internet, not just other HTML documents. You can link to videos, pdf files, images, and so on, but for the most part, you will be linking to other HTML documents.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Watch Kevin Powell’s HTML Links video above.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/16-the-odin-project/top-links-and-images/links-and-images-question-d.md
+++ b/curriculum/challenges/english/16-the-odin-project/top-links-and-images/links-and-images-question-d.md
@@ -84,12 +84,12 @@ In many cases, this will work just fine; however, you can still run into unexpec
 </body>
 ```
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Watch Kevin Powell’s HTML File Structure video above.
-    
+
+# --question--
+
 ## --text--
 
 What is the difference between an absolute and a relative link?

--- a/curriculum/challenges/english/16-the-odin-project/top-links-and-images/links-and-images-question-e.md
+++ b/curriculum/challenges/english/16-the-odin-project/top-links-and-images/links-and-images-question-e.md
@@ -70,12 +70,12 @@ The `alt` attribute is used to describe an image. It will be used in place of th
 This is how the The Odin Project logo example you used earlier looks with an `alt` attribute included:
 <iframe allowfullscreen="true" allowpaymentrequest="true" allowtransparency="true" class="cp_embed_iframe " frameborder="0" height="300" width="100%" name="cp_embed_2" scrolling="no" src="https://codepen.io/TheOdinProjectExamples/embed/ExXjoEp?height=300&amp;theme-id=dark&amp;default-tab=html%2Cresult&amp;slug-hash=ExXjoEp&amp;user=TheOdinProjectExamples&amp;name=cp_embed_2" style="width: 100%; overflow:hidden; display:block;" title="CodePen Embed" loading="lazy" id="cp_embed_ExXjoEp"></iframe>
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Watch Kevin Powell’s HTML Images Video above.
-    
+
+# --question--
+
 ## --text--
 
 Which tag is used to display an image?

--- a/curriculum/challenges/english/16-the-odin-project/top-links-and-images/links-and-images-question-h.md
+++ b/curriculum/challenges/english/16-the-odin-project/top-links-and-images/links-and-images-question-h.md
@@ -69,12 +69,12 @@ The `alt` attribute is used to describe an image. It will be used in place of th
 This is how the The Odin Project logo example you used earlier looks with an alt attribute included:
 <iframe allowfullscreen="true" allowpaymentrequest="true" allowtransparency="true" class="cp_embed_iframe " frameborder="0" height="300" width="100%" name="cp_embed_2" scrolling="no" src="https://codepen.io/TheOdinProjectExamples/embed/ExXjoEp?height=300&amp;theme-id=dark&amp;default-tab=html%2Cresult&amp;slug-hash=ExXjoEp&amp;user=TheOdinProjectExamples&amp;name=cp_embed_2" style="width: 100%; overflow:hidden; display:block;" title="CodePen Embed" loading="lazy" id="cp_embed_ExXjoEp"></iframe>
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Read about the  <a href="https://www.internetingishard.com/html-and-css/links-and-images/#image-formats" target="_blank">four main image formats</a> that can be used on the web.
-    
+
+# --question--
+
 ## --text--
 
 What are the four main image formats that you can use for images on the web?

--- a/curriculum/challenges/english/16-the-odin-project/top-the-box-model/the-box-model-question-a.md
+++ b/curriculum/challenges/english/16-the-odin-project/top-the-box-model/the-box-model-question-a.md
@@ -12,11 +12,11 @@ To open up the inspector, you can right-click on any element of a webpage and cl
 
 Don’t get overwhelmed with all the tools you’re now seeing! For this lesson, we want to focus on the Elements and Styles panes.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Play around with Chrome Dev Tools and see if you can answer the following question.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/16-the-odin-project/top-the-box-model/the-box-model-question-c.md
+++ b/curriculum/challenges/english/16-the-odin-project/top-the-box-model/the-box-model-question-c.md
@@ -14,11 +14,11 @@ When an element is selected, the Styles tab will show all the currently applied 
 
 ![Overwritten style](https://cdn.statically.io/gh/TheOdinProject/curriculum/f8fd38fc62578d8e8368f5303126215a492847f0/foundations/html_css/inspecting-html-and-css/imgs/03.png)
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Play around with Chrome Dev Tools and see if you can answer the following question.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/16-the-odin-project/top-the-box-model/the-box-model-question-d.md
+++ b/curriculum/challenges/english/16-the-odin-project/top-the-box-model/the-box-model-question-d.md
@@ -14,12 +14,11 @@ When an element is selected, the Styles tab will show all the currently applied 
 
 ![Overwritten style](https://cdn.statically.io/gh/TheOdinProject/curriculum/f8fd38fc62578d8e8368f5303126215a492847f0/foundations/html_css/inspecting-html-and-css/imgs/03.png)
 
-
-# --question--
-
-## --assignment--
+# --assignment--
 
 Play around with Chrome Dev Tools and see if you can answer the following question.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/16-the-odin-project/top-the-box-model/the-box-model-question-f.md
+++ b/curriculum/challenges/english/16-the-odin-project/top-the-box-model/the-box-model-question-f.md
@@ -16,12 +16,11 @@ Every single thing on a webpage is a rectangular box. These boxes can have other
 }
 ```
 
-
-# --question--
-
-## --assignment--
+# --assignment--
 
 Add a border to every element on the page and see how the boxes are laid out.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/16-the-odin-project/top-the-box-model/the-box-model-question-g.md
+++ b/curriculum/challenges/english/16-the-odin-project/top-the-box-model/the-box-model-question-g.md
@@ -20,11 +20,11 @@ Be sure to study the diagrams carefully.
 
 ![the box model](https://cdn.statically.io/gh/TheOdinProject/curriculum/main/foundations/html_css/css-foundations/the-box-model/imgs/box-model.png)
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Add a border to every element on the page and see how the boxes are laid out.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/16-the-odin-project/top-working-with-text/working-with-text-question-a.md
+++ b/curriculum/challenges/english/16-the-odin-project/top-working-with-text/working-with-text-question-a.md
@@ -31,12 +31,12 @@ Changing our example from before to use paragraph elements fixes the issue:
 
 <iframe allowfullscreen="true" allowpaymentrequest="true" allowtransparency="true" class="cp_embed_iframe " frameborder="0" height="300" width="100%" name="cp_embed_2" scrolling="no" src="https://codepen.io/TheOdinProjectExamples/embed/mdwbmdp?height=300&amp;theme-id=dark&amp;default-tab=html%2Cresult&amp;slug-hash=mdwbmdp&amp;user=TheOdinProjectExamples&amp;name=cp_embed_2" style="width: 100%; overflow:hidden; display:block;" title="CodePen Embed" loading="lazy" id="cp_embed_mdwbmdp"></iframe>
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Watch and follow along to Kevin Powell’s HTML Paragraph and Headings Video above.
-    
+
+# --question--
+
 ## --text--
 
 How do you create a paragraph in HTML?

--- a/curriculum/challenges/english/16-the-odin-project/top-working-with-text/working-with-text-question-c.md
+++ b/curriculum/challenges/english/16-the-odin-project/top-working-with-text/working-with-text-question-c.md
@@ -19,11 +19,11 @@ But you will probably find yourself using the `strong` element much more in comb
 
 Sometimes you will want to make text bold without giving it an important meaning. You’ll learn how to do that in the CSS lessons later in the curriculum.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Watch Kevin Powell’s HTML Bold and Italic Text Video above.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/16-the-odin-project/top-working-with-text/working-with-text-question-g.md
+++ b/curriculum/challenges/english/16-the-odin-project/top-working-with-text/working-with-text-question-g.md
@@ -20,12 +20,12 @@ Writing an HTML comment is simple: You just enclose the comment with `<!--` and 
 <!-- I am another html comment -->
 ```
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 To get some practice working with text in HTML, create a plain blog article page which uses different headings, uses paragraphs, and has some text in the paragraphs bolded and italicized. You can use [Lorem Ipsum](https://loremipsum.io) to generate dummy text, in place of real text as you build your sites.
-    
+
+# --question--
+  
 ## --text--
 
 How do you create HTML comments?

--- a/curriculum/challenges/english/16-the-odin-project/top-working-with-text/working-with-text-question-h.md
+++ b/curriculum/challenges/english/16-the-odin-project/top-working-with-text/working-with-text-question-h.md
@@ -21,9 +21,7 @@ Ordered lists are created using the `<ol>` element. Each individual item in them
 
 <iframe allowfullscreen="true" allowpaymentrequest="true" allowtransparency="true" class="cp_embed_iframe " frameborder="0" height="300" width="100%" name="cp_embed_2" scrolling="no" src="https://codepen.io/TheOdinProjectExamples/embed/yLXYvYp?height=300&amp;theme-id=dark&amp;default-tab=html%2Cresult&amp;slug-hash=yLXYvYp&amp;user=TheOdinProjectExamples&amp;name=cp_embed_2" style="width: 100%; overflow:hidden; display:block;" title="CodePen Embed" loading="lazy" id="cp_embed_yLXYvYp"></iframe>
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Watch the first three minutes of Kevin Powell's video on Ordered and Unordered lists above.
 
@@ -42,7 +40,9 @@ Make an unordered list of places you’d like to visit someday.
 ---
 
 Make an ordered list of your all time top 5 favorite video games or movies.
-    
+  
+# --question--
+  
 ## --text--
 
 What HTML tag is used to create an unordered list?

--- a/curriculum/challenges/english/17-college-algebra-with-python/learn-applications-of-linear-systems/word-problems.md
+++ b/curriculum/challenges/english/17-college-algebra-with-python/learn-applications-of-linear-systems/word-problems.md
@@ -16,15 +16,15 @@ This first video will look at key words that tell you what math operation to use
 
 \- <a href="https://openstax.org/details/books/algebra-and-trigonometry" target="_blank" rel="noopener noreferrer nofollow">Algebra and Trigonometry by Jay Abramson</a>
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the problems on pages 63, 75, 85, and 118 from "Business Math, a Step-by-Step Handbook (2021)".
 
 ---
 
 Complete the problems on pages 304, 308, and 321 from "Algebra and Trigonometry".
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/17-college-algebra-with-python/learn-business-applications-of-college-algebra/demand-and-revenue.md
+++ b/curriculum/challenges/english/17-college-algebra-with-python/learn-business-applications-of-college-algebra/demand-and-revenue.md
@@ -16,11 +16,11 @@ Here is the <a href="https://colab.research.google.com/drive/1foxkSd90q1tHCSqyY6
 
 \- <a href="https://lyryx.com/subjects/business/business-mathematics/" target="_blank" rel="noopener noreferrer nofollow">Business Math, a Step-by-Step Handbook (2021) by Jean-Paul Oliver</a>
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the problems on pages 155 and 163 from "Business Math, a Step-by-Step Handbook (2021)".
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/17-college-algebra-with-python/learn-fractions-and-decimals/converting-fractions-and-decimals.md
+++ b/curriculum/challenges/english/17-college-algebra-with-python/learn-fractions-and-decimals/converting-fractions-and-decimals.md
@@ -12,11 +12,11 @@ The first video will show you how to convert between fractions, decimals, and pe
 
 Here is the <a href="https://colab.research.google.com/drive/1dgeEEODP7cwm_96_JqbjxxJhVpZcFfGe?usp=sharing#scrollTo=NkMTAVF0BlqE" target="_blank" rel="noopener noreferrer nofollow">Colab notebook used in the video.</a> Use this code as a model, and write your own code to convert fractions and decimals.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Add the code to convert fractions and decimals to your algebra Colab notebook.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/17-college-algebra-with-python/learn-fractions-and-decimals/fractions-and-decimals-extra.md
+++ b/curriculum/challenges/english/17-college-algebra-with-python/learn-fractions-and-decimals/fractions-and-decimals-extra.md
@@ -12,15 +12,15 @@ The following video will show you one way to set up your Google Colaboratory not
 
 Here is <a href="https://colab.research.google.com/drive/1a_RtRtVfeO0m2528T4V-bCXozWf3HpM7?usp=sharing" target="_blank" rel="noopener noreferrer nofollow">the Colab notebook used in this video</a> so you can use it as a model.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Add the code to factor and solve for a variable to your algebra Colab notebook.
 
 ---
 
 Run the code in the following notebook to get <a href="https://colab.research.google.com/drive/1qON4GYbMkaZJA7MYd7-RcDROOkuuBJg9?usp=sharing" target="_blank" rel="noopener noreferrer nofollow">practice converting fractions and decimals.</a> As a bonus, look at the code used to generate the practice problems.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/17-college-algebra-with-python/learn-functions-and-graphing/functions-and-graphing-extra.md
+++ b/curriculum/challenges/english/17-college-algebra-with-python/learn-functions-and-graphing/functions-and-graphing-extra.md
@@ -12,11 +12,11 @@ This next video will show you the connection between functions and graphing. Not
 
 Here is the <a href="https://colab.research.google.com/drive/1UYorWd9-Btf_ZQyA9YdUzxzKR8rnVrSV" target="_blank" rel="noopener noreferrer nofollow">Colab notebook to go with this video.</a>
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Add code to your algebra Colab notebook for functions and graphing.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/17-college-algebra-with-python/learn-functions-and-graphing/functions.md
+++ b/curriculum/challenges/english/17-college-algebra-with-python/learn-functions-and-graphing/functions.md
@@ -12,11 +12,11 @@ This first video will show you what it means to be a function, and then it will 
 
 Here is the <a href="https://colab.research.google.com/drive/1d0e55NoKjKILIum34POv04h0OLpE_pkn" target="_blank" rel="noopener noreferrer nofollow">Colab notebook used in this and the next videos.</a>
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Add code to your algebra Colab notebook that creates Python functions for decimal-to-fraction conversions
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/17-college-algebra-with-python/learn-functions-and-graphing/graphing.md
+++ b/curriculum/challenges/english/17-college-algebra-with-python/learn-functions-and-graphing/graphing.md
@@ -12,15 +12,15 @@ This next video will show you the connection between functions and graphing. Not
 
 Here is the <a href="https://colab.research.google.com/drive/1UYorWd9-Btf_ZQyA9YdUzxzKR8rnVrSV#scrollTo=yJiVB8wdHRxS" target="_blank" rel="noopener noreferrer nofollow">Colab notebook to go with the last two videos</a> so you can start making your own graphs.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Add code to your algebra Colab notebook for functions and graphing.
 
 ---
 
 Run the following notebook to see <a href="https://colab.research.google.com/drive/1UYorWd9-Btf_ZQyA9YdUzxzKR8rnVrSV#scrollTo=yJiVB8wdHRxS" target="_blank" rel="noopener noreferrer nofollow">more ways to create graphs using algebra and Python.</a>
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/17-college-algebra-with-python/learn-how-to-graph-systems-of-equations/graphing-systems.md
+++ b/curriculum/challenges/english/17-college-algebra-with-python/learn-how-to-graph-systems-of-equations/graphing-systems.md
@@ -12,11 +12,11 @@ This first video will show you how to graph systems of equations with written ma
 
 Here is the <a href="https://colab.research.google.com/drive/1N1JEZJctODxsntROnmg0VqMSHXYdIlFD?usp=sharing" target="_blank" rel="noopener noreferrer nofollow">Colab notebook used in this video.</a>
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Add code from the video to the algebra notebook you are building, and test it with different functions.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/17-college-algebra-with-python/learn-how-to-solve-for-x/how-to-solve-for-x-extra.md
+++ b/curriculum/challenges/english/17-college-algebra-with-python/learn-how-to-solve-for-x/how-to-solve-for-x-extra.md
@@ -12,15 +12,15 @@ This video will go deeper, with more examples of how to use SymPy solve. It will
 
 Here is the <a href="https://colab.research.google.com/drive/1Jv6WxW93J_1GZao8DkNb4X0D93oVibbs" target="_blank" rel="noopener noreferrer nofollow">Colab notebook to go along with this video.</a> Use it to add more to the algebra Colab notebook that you are building.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Add the code for more ways to solve for x from the video to your algebra Colab notebook.
 
 ---
 
 Open the following Colab notebook, run the cell, and <a href="https://colab.research.google.com/drive/1XjmHoERFKcvol7FPidQE-wgdvR82HV45" target="_blank" rel="noopener noreferrer nofollow">practice solving one and two-step algebra problems.</a> As a bonus, look at the code that generates the practice problems.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/17-college-algebra-with-python/learn-how-to-solve-for-x/solving-for-x.md
+++ b/curriculum/challenges/english/17-college-algebra-with-python/learn-how-to-solve-for-x/solving-for-x.md
@@ -12,11 +12,11 @@ This first video will show you the essence of algebra and then how Python code d
 
 Here is the <a href="https://colab.research.google.com/drive/11Zi77gs1FKoEqfPqYa2HtTENiWZyQAO2?usp=sharing" target="_blank" rel="noopener noreferrer nofollow">Colab notebook to go along with this video.</a> Add the code from the video to your algebra Colab notebook to see how to solve for X using Python. Then change the code if you want, test it, and compare it to paper-and-pencil solving. Remember the equation input needs to be in Python syntax.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Add the code to solve for x from the video to your algebra Colab notebook.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/17-college-algebra-with-python/learn-how-to-solve-systems-of-equations/solving-systems.md
+++ b/curriculum/challenges/english/17-college-algebra-with-python/learn-how-to-solve-systems-of-equations/solving-systems.md
@@ -12,11 +12,11 @@ The first video will show you the math behind solving a system of two equations 
 
 Here is the <a href="https://colab.research.google.com/drive/1UfyQiXCedAAv5kcqgi_pGYV-HkSgN8YD?usp=sharing" target="_blank" rel="noopener noreferrer nofollow">Colab notebook used in this video.</a>
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Add code to your notebook to solve and graph systems of equations
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/17-college-algebra-with-python/learn-linear-functions/linear-equations.md
+++ b/curriculum/challenges/english/17-college-algebra-with-python/learn-linear-functions/linear-equations.md
@@ -12,11 +12,11 @@ This video will show you the math behind finding the y-intercept in a linear fun
 
 Here is the <a href="https://colab.research.google.com/drive/1UJ1w-XFTuCfK6FI3H2GT0lbxd2HO3tQ6?usp=sharing" target="_blank" rel="noopener noreferrer nofollow">Colab notebook to go with the last two videos,</a> so you can see the formulas.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Add code to your algebra Colab notebook to graph a function from points or from equation input.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/17-college-algebra-with-python/learn-ratios-and-proportions/introduction-to-college-algebra-with-python.md
+++ b/curriculum/challenges/english/17-college-algebra-with-python/learn-ratios-and-proportions/introduction-to-college-algebra-with-python.md
@@ -16,11 +16,11 @@ This first video includes an introduction to the course, how it will work, and h
 
 \- <a href="https://openstax.org/details/books/algebra-and-trigonometry" target="_blank" rel="noopener noreferrer nofollow">Algebra and Trigonometry by Jay Abramson</a>
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Create an algebra <a href="https://drive.google.com/" target="_blank" rel="noopener noreferrer nofollow">Colab notebook on your google drive</a> so you can follow along with the videos.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/17-college-algebra-with-python/learn-ratios-and-proportions/ratios-and-proportions-extra.md
+++ b/curriculum/challenges/english/17-college-algebra-with-python/learn-ratios-and-proportions/ratios-and-proportions-extra.md
@@ -10,12 +10,12 @@ dashedName: ratios-and-proportions-extra
 
 The last video in this section will show you how to use proportions in other applications, such as currency exchange rates and unit conversion. It will also show you more about setting up your notebook and working through the practice assignment.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Open the following Colab notebook, run the cell, and <a href="https://colab.research.google.com/drive/1XjmHoERFKcvol7FPidQE-wgdvR82HV45" target="_blank" rel="noopener noreferrer nofollow">practice solving one-step algebra problems.</a> As a bonus, look at the code that generates the practice problems.
- 
+
+# --question--
+
 ## --text--
 
 What is another way to write 0.9999... (repeating 9)?

--- a/curriculum/challenges/english/17-college-algebra-with-python/learn-ratios-and-proportions/solving-proportions.md
+++ b/curriculum/challenges/english/17-college-algebra-with-python/learn-ratios-and-proportions/solving-proportions.md
@@ -12,11 +12,11 @@ Now we get to the math content. This video will show you how to set up and solve
 
 Here is the <a href="https://colab.research.google.com/drive/1Q7nCcbrnoYttkwiHB_nQ-X1JuLpUmtRD?usp=sharing" target="_blank" rel="noopener noreferrer nofollow">Colab notebook to go along with this video.</a> If you have not done so yet, set up your algebra Colab notebook from the last video. Then, add the code from this video to it.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Add the code from the video to the algebra Colab notebook you created in the first step.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/add-logic-to-c-sharp-console-applications/add-looping-logic-to-your-code-using-the-do-while-and-while-statements-in-c-sharp.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/add-logic-to-c-sharp-console-applications/add-looping-logic-to-your-code-using-the-do-while-and-while-statements-in-c-sharp.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/csharp-do-while/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/csharp-do-while/</a> and complete all the tasks for the "Add Looping Logic to Your Code Using the do-while and while Statements in C#" module. This is **required** to earn the "Add Logic to C# Console Applications" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/csharp-do-while/" target="_blank" rel="noreferrer">Add Looping Logic to Your Code Using the `do`-`while` and `while` Statements in C#</a> module on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/add-logic-to-c-sharp-console-applications/branch-the-flow-of-code-using-the-switch-case-construct-in-c-sharp.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/add-logic-to-c-sharp-console-applications/branch-the-flow-of-code-using-the-switch-case-construct-in-c-sharp.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/csharp-switch-case/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/csharp-switch-case/</a> and complete all the tasks for the "Branch the Flow of Code Using the switch-case Construct in C#" module. This is **required** to earn the "Add Logic to C# Console Applications" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/csharp-switch-case/" target="_blank" rel="noreferrer">Branch the Flow of Code Using the `switch`-`case` Construct in C#</a> module on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/add-logic-to-c-sharp-console-applications/challenge-project-develop-branching-and-looping-structures-in-c-sharp.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/add-logic-to-c-sharp-console-applications/challenge-project-develop-branching-and-looping-structures-in-c-sharp.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/challenge-project-develop-branching-looping-structures-c-sharp/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/challenge-project-develop-branching-looping-structures-c-sharp/</a> and complete all the tasks for the "Challenge Project - Develop Branching and Looping Structures in C#" module. This is **required** to earn the "Add Logic to C# Console Applications" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/challenge-project-develop-branching-looping-structures-c-sharp/" target="_blank" rel="noreferrer">Develop Branching and Looping Structures in C#</a> challenge project on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/add-logic-to-c-sharp-console-applications/control-variable-scope-and-logic-using-code-blocks-in-c-sharp.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/add-logic-to-c-sharp-console-applications/control-variable-scope-and-logic-using-code-blocks-in-c-sharp.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/csharp-code-blocks/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/csharp-code-blocks/</a> and complete all the tasks for the "Control Variable Scope and Logic Using Code Blocks in C#" module. This is **required** to earn the "Add Logic to C# Console Applications" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/csharp-code-blocks/" target="_blank" rel="noreferrer">Control Variable Scope and Logic Using Code Blocks in C#</a> module on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/add-logic-to-c-sharp-console-applications/evaluate-boolean-expressions-to-make-decisions-in-c-sharp.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/add-logic-to-c-sharp-console-applications/evaluate-boolean-expressions-to-make-decisions-in-c-sharp.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/csharp-evaluate-boolean-expressions/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/csharp-evaluate-boolean-expressions/</a> and complete all the tasks for the "Evaluate Boolean Expressions to Make Decisions in C#" module. This is **required** to earn the "Add Logic to C# Console Applications" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/csharp-evaluate-boolean-expressions/" target="_blank" rel="noreferrer">Evaluate Boolean Expressions to Make Decisions in C#</a> module on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/add-logic-to-c-sharp-console-applications/guided-project-develop-conditional-branching-and-looping-structures-in-c-sharp.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/add-logic-to-c-sharp-console-applications/guided-project-develop-conditional-branching-and-looping-structures-in-c-sharp.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/guided-project-develop-conditional-branching-looping/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/guided-project-develop-conditional-branching-looping/</a> and complete all the tasks for the "Guided Project - Develop Conditional Branching and Looping Structures in C#" module. This is **required** to earn the "Add Logic to C# Console Applications" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/guided-project-develop-conditional-branching-looping/" target="_blank" rel="noreferrer">Develop Conditional Branching and Looping Structures in C#</a> guided project on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/add-logic-to-c-sharp-console-applications/iterate-through-a-code-block-using-the-for-statement-in-c-sharp.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/add-logic-to-c-sharp-console-applications/iterate-through-a-code-block-using-the-for-statement-in-c-sharp.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/csharp-for/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/csharp-for/</a> and complete all the tasks for the "Iterate Through a Code Block Using the for Statement in C#" module. This is **required** to earn the "Add Logic to C# Console Applications" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/csharp-for/" target="_blank" rel="noreferrer">Iterate Through a Code Block Using the `for` Statement in C#</a> module on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/create-and-run-simple-c-sharp-console-applications/add-decision-logic-to-your-code-using-if-else-and-else-if-statements-in-c-sharp.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/create-and-run-simple-c-sharp-console-applications/add-decision-logic-to-your-code-using-if-else-and-else-if-statements-in-c-sharp.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/csharp-if-elseif-else/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/csharp-if-elseif-else/</a> and complete all the tasks for the "Add Decision Logic to Your Code Using if, else, and else if statements in C#" module. This is **required** to earn the "Create and Run Simple C# Console Applications" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/csharp-if-elseif-else/" target="_blank" rel="noreferrer">Add Decision Logic to Your Code Using `if`, `else`, and `else if` Statements in C#</a> module on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/create-and-run-simple-c-sharp-console-applications/call-methods-from-the-dot-net-class-library-using-c-sharp.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/create-and-run-simple-c-sharp-console-applications/call-methods-from-the-dot-net-class-library-using-c-sharp.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/csharp-call-methods/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/csharp-call-methods/</a> and complete all the tasks for the "Call Methods From the .NET Class Library Using C#" module. This is **required** to earn the "Create and Run Simple C# Console Applications" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/csharp-call-methods/" target="_blank" rel="noreferrer">Call Methods from the .NET Class Library Using C#</a> module on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/create-and-run-simple-c-sharp-console-applications/challenge-project-develop-foreach-and-if-elseif-else-structures-to-process-array-data-in-c-sharp.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/create-and-run-simple-c-sharp-console-applications/challenge-project-develop-foreach-and-if-elseif-else-structures-to-process-array-data-in-c-sharp.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/challenge-project-arrays-iteration-selection/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/challenge-project-arrays-iteration-selection/</a> and complete all the tasks for the "Challenge Project - Develop foreach and if-elseif-else Structures to Process Array Data in C#" module. This is **required** to earn the "Create and Run Simple C# Console Applications" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/challenge-project-arrays-iteration-selection/" target="_blank" rel="noreferrer">Develop `foreach` and `if`-`elseif`-`else` Structures to Process Array Data in C#</a> challenge project on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/create-and-run-simple-c-sharp-console-applications/create-readable-code-with-conventions-whitespace-and-comments-in-c-sharp.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/create-and-run-simple-c-sharp-console-applications/create-readable-code-with-conventions-whitespace-and-comments-in-c-sharp.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/csharp-readable-code/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/csharp-readable-code/</a> and complete all the tasks for the "Create Readable Code with Conventions, Whitespace, and Comments in C#" module. This is **required** to earn the "Create and Run Simple C# Console Applications" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/csharp-readable-code/" target="_blank" rel="noreferrer">Create Readable Code with Conventions, Whitespace, and Comments in C#</a> module on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/create-and-run-simple-c-sharp-console-applications/guided-project-develop-foreach-and-if-elseif-else-structures-to-process-array-data-in-c-sharp.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/create-and-run-simple-c-sharp-console-applications/guided-project-develop-foreach-and-if-elseif-else-structures-to-process-array-data-in-c-sharp.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/guided-project-arrays-iteration-selection/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/guided-project-arrays-iteration-selection/</a> and complete all the tasks for the "Guided Project - Develop foreach and if-elseif-else Structures to Process Array Data in C#" module. This is **required** to earn the "Create and Run Simple C# Console Applications" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/guided-project-arrays-iteration-selection/" target="_blank" rel="noreferrer">Develop `foreach` and `if`-`elseif`-`else` Structures to Process Array Data in C#</a> guided project on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/create-and-run-simple-c-sharp-console-applications/install-and-configure-visual-studio-code.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/create-and-run-simple-c-sharp-console-applications/install-and-configure-visual-studio-code.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/install-configure-visual-studio-code/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/install-configure-visual-studio-code/</a> and complete all the tasks for the "Install and Configure Visual Studio Code" module. This is **required** to earn the "Create and Run Simple C# Console Applications" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/install-configure-visual-studio-code/" target="_blank" rel="noreferrer">Install and Configure Visual Studio Code</a> module on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/create-and-run-simple-c-sharp-console-applications/store-and-iterate-through-sequences-of-data-using-arrays-and-the-foreach-statement-in-c-sharp.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/create-and-run-simple-c-sharp-console-applications/store-and-iterate-through-sequences-of-data-using-arrays-and-the-foreach-statement-in-c-sharp.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/csharp-arrays/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/csharp-arrays/</a> and complete all the tasks for the "Store and Iterate Through Sequences of Data Using Arrays and the foreach Statement in C#" module. This is **required** to earn the "Create and Run Simple C# Console Applications" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/csharp-arrays/" target="_blank" rel="noreferrer">Store and Iterate Through Sequences of Data Using Arrays and the `foreach` Statement in C#</a> module on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/create-methods-in-c-sharp-console-applications/challenge-project-create-a-mini-game.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/create-methods-in-c-sharp-console-applications/challenge-project-create-a-mini-game.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/challenge-project-create-mini-game/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/challenge-project-create-mini-game/</a> and complete all the tasks for the "Challenge Project - Create a Mini-Game" module. This is **required** to earn the "Create Methods in C# Console Applications" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/challenge-project-create-mini-game/" target="_blank" rel="noreferrer">Create a Mini-Game</a> challenge project on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/create-methods-in-c-sharp-console-applications/create-c-sharp-methods-that-return-values.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/create-methods-in-c-sharp-console-applications/create-c-sharp-methods-that-return-values.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/create-c-sharp-methods-return-values/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/create-c-sharp-methods-return-values/</a> and complete all the tasks for the "Create C# Methods that Return Values" module. This is **required** to earn the "Create Methods in C# Console Applications" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/create-c-sharp-methods-return-values/" target="_blank" rel="noreferrer">Create C# Methods that Return Values</a> module on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/create-methods-in-c-sharp-console-applications/create-c-sharp-methods-with-parameters.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/create-methods-in-c-sharp-console-applications/create-c-sharp-methods-with-parameters.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/create-c-sharp-methods-parameters/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/create-c-sharp-methods-parameters/</a> and complete all the tasks for the "Create C# Methods with Parameters" module. This is **required** to earn the "Create Methods in C# Console Applications" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/create-c-sharp-methods-parameters/" target="_blank" rel="noreferrer">Create C# Methods with Parameters</a> module on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/create-methods-in-c-sharp-console-applications/guided-project-plan-a-petting-zoo-visit.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/create-methods-in-c-sharp-console-applications/guided-project-plan-a-petting-zoo-visit.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/guided-project-visit-petting-zoo/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/guided-project-visit-petting-zoo/</a> and complete all the tasks for the "Guided Project - Plan a Petting Zoo Visit" module. This is **required** to earn the "Create Methods in C# Console Applications" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/guided-project-visit-petting-zoo/" target="_blank" rel="noreferrer">Plan a Petting Zoo Visit</a> guided project on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/create-methods-in-c-sharp-console-applications/write-your-first-c-sharp-method.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/create-methods-in-c-sharp-console-applications/write-your-first-c-sharp-method.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/write-first-c-sharp-method/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/write-first-c-sharp-method/</a> and complete all the tasks for the "Write Your First C# Method" module. This is **required** to earn the "Create Methods in C# Console Applications" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/write-first-c-sharp-method/" target="_blank" rel="noreferrer">Write Your First C# Method</a> module on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/debug-c-sharp-console-applications/challenge-project-debug-a-c-sharp-console-application-using-visual-studio-code.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/debug-c-sharp-console-applications/challenge-project-debug-a-c-sharp-console-application-using-visual-studio-code.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/challenge-project-debug-c-sharp-console-application/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/challenge-project-debug-c-sharp-console-application/</a> and complete all the tasks for the "Challenge Project - Debug a C# Console Application Using Visual Studio Code" module. This is **required** to earn the "Debug C# Console Applications" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/challenge-project-debug-c-sharp-console-application/" target="_blank" rel="noreferrer">Debug a C# Console Application Using Visual Studio Code</a> challenge project on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/debug-c-sharp-console-applications/create-and-throw-exceptions-in-c-sharp-console-applications.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/debug-c-sharp-console-applications/create-and-throw-exceptions-in-c-sharp-console-applications.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/create-throw-exceptions-c-sharp/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/create-throw-exceptions-c-sharp/</a> and complete all the tasks for the "Create and Throw Exceptions in C# Console Applications" module. This is **required** earn to the "Debug C# Console Applications" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/create-throw-exceptions-c-sharp/" target="_blank" rel="noreferrer">Create and Throw Exceptions in C# Console Applications</a> module on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/debug-c-sharp-console-applications/guided-project-debug-and-handle-exceptions-in-a-c-sharp-console-application-using-visual-studio-code.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/debug-c-sharp-console-applications/guided-project-debug-and-handle-exceptions-in-a-c-sharp-console-application-using-visual-studio-code.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/guided-project-debug-handle-exceptions-c-sharp-console-application/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/guided-project-debug-handle-exceptions-c-sharp-console-application/</a> and complete all the tasks for the "Guided Project - Debug and Handle Exceptions in a C# Console Application Using Visual Studio Code" module. This is **required** to earn the "Debug C# Console Applications" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/guided-project-debug-handle-exceptions-c-sharp-console-application/" target="_blank" rel="noreferrer">Debug and Handle Exceptions in a C# Console Application Using Visual Studio Code</a> guided project on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/debug-c-sharp-console-applications/implement-exception-handling-in-c-sharp-console-applications.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/debug-c-sharp-console-applications/implement-exception-handling-in-c-sharp-console-applications.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/implement-exception-handling-c-sharp/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/implement-exception-handling-c-sharp/</a> and complete all the tasks for the "Implement Exception Handling in C# Console Applications" module. This is **required** to earn the "Debug C# Console Applications" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/implement-exception-handling-c-sharp/" target="_blank" rel="noreferrer">Implement Exception Handling in C# Console Applications</a> module on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/debug-c-sharp-console-applications/implement-the-visual-studio-code-debugging-tools-for-c-sharp.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/debug-c-sharp-console-applications/implement-the-visual-studio-code-debugging-tools-for-c-sharp.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/implement-visual-studio-code-debugging-tools/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/implement-visual-studio-code-debugging-tools/</a> and complete all the tasks for the "Implement the Visual Studio Code Debugging Tools for C#" module. This is **required** to earn the "Debug C# Console Applications" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/implement-visual-studio-code-debugging-tools/" target="_blank" rel="noreferrer">Implement the Visual Studio Code Debugging Tools for C#</a> module on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/debug-c-sharp-console-applications/review-the-principles-of-code-debugging-and-exception-handling.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/debug-c-sharp-console-applications/review-the-principles-of-code-debugging-and-exception-handling.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/review-principles-code-debugging-exception-handling-c-sharp/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/review-principles-code-debugging-exception-handling-c-sharp/</a> and complete all the tasks for the "Review the Principles of Code Debugging and Exception Handling" module. This is **required** to earn the "Debug C# Console Applications" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/review-principles-code-debugging-exception-handling-c-sharp/" target="_blank" rel="noreferrer">Review the Principles of Code Debugging and Exception Handling</a> module on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/work-with-variable-data-in-c-sharp-console-applications/challenge-project-work-with-variable-data-in-c-sharp.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/work-with-variable-data-in-c-sharp-console-applications/challenge-project-work-with-variable-data-in-c-sharp.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/challenge-project-work-variable-data-c-sharp/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/challenge-project-work-variable-data-c-sharp/</a> and complete all the tasks for the "Challenge Project - Work with Variable Data in C#" module. This is **required** to earn the "Work with Variable Data in C# Console Applications" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/challenge-project-work-variable-data-c-sharp/" target="_blank" rel="noreferrer">Work with Variable Data in C#</a> challenge project on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/work-with-variable-data-in-c-sharp-console-applications/choose-the-correct-data-type-in-your-c-sharp-code.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/work-with-variable-data-in-c-sharp-console-applications/choose-the-correct-data-type-in-your-c-sharp-code.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/csharp-choose-data-type/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/csharp-choose-data-type/</a> and complete all the tasks for the "Choose the Correct Data Type in Your C# Code" module. This is **required** to earn the "Work with Variable Data in C# Console Applications" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/csharp-choose-data-type/" target="_blank" rel="noreferrer">Choose the Correct Data Type in Your C# Code</a> module on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/work-with-variable-data-in-c-sharp-console-applications/convert-data-types-using-casting-and-conversion-techniques-in-c-sharp.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/work-with-variable-data-in-c-sharp-console-applications/convert-data-types-using-casting-and-conversion-techniques-in-c-sharp.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/csharp-convert-cast/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/csharp-convert-cast/</a> and complete all the tasks for the "Convert Data Types Using Casting and Conversion Techniques in C#" module. This is **required** to earn the "Work with Variable Data in C# Console Applications" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/csharp-convert-cast/" target="_blank" rel="noreferrer">Convert Data Types Using Casting and Conversion Techniques in C#</a> module on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/work-with-variable-data-in-c-sharp-console-applications/format-alphanumeric-data-for-presentation-in-c-sharp.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/work-with-variable-data-in-c-sharp-console-applications/format-alphanumeric-data-for-presentation-in-c-sharp.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/csharp-format-strings/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/csharp-format-strings/</a> and complete all the tasks for the "Format Alphanumeric Data for Presentation in C#" module. This is **required** to earn the "Work with Variable Data in C# Console Applications" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/csharp-format-strings/" target="_blank" rel="noreferrer">Format Alphanumeric Data for Presentation in C#</a> module on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/work-with-variable-data-in-c-sharp-console-applications/guided-project-work-with-variable-data-in-c-sharp.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/work-with-variable-data-in-c-sharp-console-applications/guided-project-work-with-variable-data-in-c-sharp.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/guided-project-work-variable-data-c-sharp/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/guided-project-work-variable-data-c-sharp/</a> and complete all the tasks for the "Guided Project - Work with Variable Data in C#" module. This is **required** to earn the "Work with Variable Data in C# Console Applications" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/guided-project-work-variable-data-c-sharp/" target="_blank" rel="noreferrer">Work with Variable Data in C#</a> guided project on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/work-with-variable-data-in-c-sharp-console-applications/modify-the-content-of-string-using-built-in-string-data-type-methods-in-c-sharp.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/work-with-variable-data-in-c-sharp-console-applications/modify-the-content-of-string-using-built-in-string-data-type-methods-in-c-sharp.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/csharp-modify-content/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/csharp-modify-content/</a> and complete all the tasks for the "Modify the Content of Strings Using Built-In String Data Type Methods in C#" module. This is **required** to earn the "Work with Variable Data in C# Console Applications" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/csharp-modify-content/" target="_blank" rel="noreferrer">Modify the Content of Strings Using Built-In String Data Type Methods in C#</a> module on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/work-with-variable-data-in-c-sharp-console-applications/perform-operations-on-arrays-using-helpers-methods-in-c-sharp.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/work-with-variable-data-in-c-sharp-console-applications/perform-operations-on-arrays-using-helpers-methods-in-c-sharp.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/csharp-arrays-operations/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/csharp-arrays-operations/</a> and complete all the tasks for the "Perform Operations on Arrays Using Helper Methods in C#" module. This is **required** to earn the "Work with Variable Data in C# Console Applications" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/csharp-arrays-operations/" target="_blank" rel="noreferrer">Perform Operations on Arrays Using Helper Methods in C#</a> module on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/write-your-first-code-using-c-sharp/guided-project-calculate-and-print-student-grades.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/write-your-first-code-using-c-sharp/guided-project-calculate-and-print-student-grades.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/guided-project-calculate-print-student-grades/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/guided-project-calculate-print-student-grades/</a> and complete all the tasks for the "Guided Project - Calculate and Print Student Grades" module. This is **required** to earn the "Write Your First Code Using C#" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/guided-project-calculate-print-student-grades/" target="_blank" rel="noreferrer">Calculate and Print Student Grades</a> guided project on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/write-your-first-code-using-c-sharp/guided-project-calculate-final-gpa.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/write-your-first-code-using-c-sharp/guided-project-calculate-final-gpa.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/guided-project-calculate-final-gpa/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/guided-project-calculate-final-gpa/</a> and complete all the tasks for the "Guided Project - Calculate Final GPA" module. This is **required** to earn the "Write Your First Code Using C#" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/guided-project-calculate-final-gpa/" target="_blank" rel="noreferrer">Calculate Final GPA</a> guided project on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/write-your-first-code-using-c-sharp/perform-basic-operations-on-numbers-in-c-sharp.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/write-your-first-code-using-c-sharp/perform-basic-operations-on-numbers-in-c-sharp.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/csharp-basic-operations/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/csharp-basic-operations/</a> and complete all the tasks for the "Perform Basic Operations on Numbers in C#" module. This is **required** to earn the "Write Your First Code Using C#" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/csharp-basic-operations/" target="_blank" rel="noreferrer">Perform Basic Operations on Numbers in C#</a> module on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/write-your-first-code-using-c-sharp/perform-basic-string-formatting-in-c-sharp.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/write-your-first-code-using-c-sharp/perform-basic-string-formatting-in-c-sharp.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/csharp-basic-formatting/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/csharp-basic-formatting/</a> and complete all the tasks for the "Perform Basic String Formatting in C#" module. This is **required** to earn the "Write Your First Code Using C#" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/csharp-basic-formatting/" target="_blank" rel="noreferrer">Perform Basic String Formatting in C#</a> module on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/write-your-first-code-using-c-sharp/store-and-retrieve-data-using-literal-and-variable-values-in-c-sharp.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/write-your-first-code-using-c-sharp/store-and-retrieve-data-using-literal-and-variable-values-in-c-sharp.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/csharp-literals-variables/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/csharp-literals-variables/</a> and complete all the tasks for the "Store and Retrieve Data Using Literal and Variable Values in C#" module. This is **required** to earn the "Write Your First Code Using C#" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/csharp-literals-variables/" target="_blank" rel="noreferrer">Store and Retrieve Data Using Literal and Variable Values in C#</a> module on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 

--- a/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/write-your-first-code-using-c-sharp/write-your-first-c-sharp-code.md
+++ b/curriculum/challenges/english/19-foundational-c-sharp-with-microsoft/write-your-first-code-using-c-sharp/write-your-first-c-sharp-code.md
@@ -12,11 +12,11 @@ This challenge will be partially completed on the Microsoft Learn platform. Foll
 1. Go to <a href="https://learn.microsoft.com/training/modules/csharp-write-first/" target="_blank" rel="noreferrer">https://learn.microsoft.com/training/modules/csharp-write-first/</a> and complete all the tasks in the "Write Your First C# Code" module. This is **required** to earn the "Write Your First Code Using C#" trophy on Microsoft Learn, and qualify for the certification exam.
 1. When you are finished, come back and correctly answer the question below.
 
-# --question--
-
-## --assignment--
+# --assignment--
 
 Complete the <a href="https://learn.microsoft.com/training/modules/csharp-write-first/" target="_blank" rel="noreferrer">Write Your First C# Code</a> module on Microsoft Learn. Then, answer the question below.
+
+# --question--
 
 ## --text--
 


### PR DESCRIPTION
This moves the `assignments` in challenge markdown files into their own heading outside of the `question` tree. This isn't explicitly necessary as it functionally seems to be the same - but, the assignments don't seem specifically related to the questions. I am working on adding some stuff for the English challenges and this was annoying me a little.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
