### PR TITLE
refactor: use the sr-only class to visually hide element

### DIFF
--- a/client/src/templates/Challenges/exam/exam.css
+++ b/client/src/templates/Challenges/exam/exam.css
@@ -55,11 +55,6 @@
   margin: 0;
 }
 
-.exam-answer-input-hidden {
-  position: absolute;
-  left: -9999px;
-}
-
 .exam-answer-input-visible {
   margin-inline-end: 15px;
   position: relative;

--- a/client/src/templates/Challenges/exam/show.tsx
+++ b/client/src/templates/Challenges/exam/show.tsx
@@ -423,7 +423,7 @@ class ShowExam extends Component<ShowExamProps, ShowExamState> {
                               userExamQuestions[currentQuestionIndex].answer
                                 .id === id
                             }
-                            className='exam-answer-input-hidden'
+                            className='sr-only'
                             name={id}
                             onChange={() =>
                               this.selectAnswer(


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Changes the approach of visually hiding input elements on the exam page. The current implementation approach uses `position: absolute` and `left: -9999px`, making the elements out of view and resulting a test failure as Playwright is not able to locate the elements. The fix here is to use the existing `sr-only` class, which only adjusts the elements' styles and not position.
- Unblocks #51798 which requires querying and interacting with the input elements.
- Is similar to #51743.

## Screenshots

| Before | After |
| --- | --- |
| <img width="1680" alt="Screenshot 2023-10-12 at 16 32 37" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/5901b60a-3a9d-43be-ab96-559f3f056f01"> | <img width="1680" alt="Screenshot 2023-10-12 at 16 32 04" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/fde2716d-edfe-4245-8619-d3399d076c46"> |

<!-- Feel free to add any additional description of changes below this line -->
