### PR TITLE
fix(curriculum): headers in forum help message

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -909,8 +909,7 @@
   "forum-help": {
     "browser-info": "**Your browser information:**",
     "user-agent": "User Agent is: <code>{{userAgent}}</code>",
-    "challenge": "**Challenge:**",
-    "challenge-link": "**Link to the challenge:**",
+    "challenge": "**Challenge Information:**",
     "whats-happening": "**Tell us what's happening:**",
     "describe": "Describe your issue in detail here.",
     "camper-project": "**Your project link(s)**",

--- a/client/src/templates/Challenges/redux/create-question-epic.js
+++ b/client/src/templates/Challenges/redux/create-question-epic.js
@@ -95,7 +95,7 @@ function createQuestionEpic(action$, state$, { window }) {
       const challengeHeading = i18next.t('forum-help.challenge');
       const blockTitle = i18next.t(`intro:${superBlock}.blocks.${block}.title`);
       const challengeLinkHeading = i18next.t('forum-help.challenge-link');
-      const endingText = `${browserInfoHeading}\n\n${userAgentHeading}\n\n${challengeHeading} ${blockTitle} - ${challengeTitle}\n\n${challengeLinkHeading}\n${challengeUrl}`;
+      const endingText = `### ${browserInfoHeading}\n\n${userAgentHeading}\n\n### ${challengeHeading} ${blockTitle} - ${challengeTitle}\n\n${challengeLinkHeading}\n${challengeUrl}`;
 
       const camperCodeHeading = i18next.t('forum-help.camper-code');
 
@@ -108,7 +108,7 @@ function createQuestionEpic(action$, state$, { window }) {
         projectFormValues
           ?.map(([key, val]) => `${key}: ${transformEditorLink(val)}\n\n`)
           ?.join('') || filesToMarkdown(challengeFiles);
-      const textMessage = `${whatsHappeningHeading}\n${describe}\n\n${projectOrCodeHeading}\n\n${markdownCodeOrLinks}${endingText}`;
+      const textMessage = `### ${whatsHappeningHeading}\n${describe}\n\n### ${projectOrCodeHeading}\n\n${markdownCodeOrLinks}${endingText}`;
 
       const warning = i18next.t('forum-help.warning');
       const tooLongOne = i18next.t('forum-help.too-long-one');
@@ -117,7 +117,7 @@ function createQuestionEpic(action$, state$, { window }) {
       const addCodeOne = i18next.t('forum-help.add-code-one');
       const addCodeTwo = i18next.t('forum-help.add-code-two');
       const addCodeThree = i18next.t('forum-help.add-code-three');
-      const altTextMessage = `${whatsHappeningHeading}\n\n${camperCodeHeading}\n\n${warning}\n\n${tooLongOne}\n\n${tooLongTwo}\n\n${tooLongThree}\n\n\`\`\`text\n${addCodeOne}\n${addCodeTwo}\n${addCodeThree}\n\`\`\`\n\n${endingText}`;
+      const altTextMessage = `### ${whatsHappeningHeading}\n\n### ${camperCodeHeading}\n\n${warning}\n\n${tooLongOne}\n\n${tooLongTwo}\n\n${tooLongThree}\n\n\`\`\`text\n${addCodeOne}\n${addCodeTwo}\n${addCodeThree}\n\`\`\`\n\n${endingText}`;
 
       const titleText = window.encodeURIComponent(
         `${i18next.t(

--- a/client/src/templates/Challenges/redux/create-question-epic.js
+++ b/client/src/templates/Challenges/redux/create-question-epic.js
@@ -94,8 +94,7 @@ function createQuestionEpic(action$, state$, { window }) {
       });
       const challengeHeading = i18next.t('forum-help.challenge');
       const blockTitle = i18next.t(`intro:${superBlock}.blocks.${block}.title`);
-      const challengeLinkHeading = i18next.t('forum-help.challenge-link');
-      const endingText = `### ${browserInfoHeading}\n\n${userAgentHeading}\n\n### ${challengeHeading} ${blockTitle} - ${challengeTitle}\n\n${challengeLinkHeading}\n${challengeUrl}`;
+      const endingText = `### ${browserInfoHeading}\n\n${userAgentHeading}\n\n### ${challengeHeading}\n${blockTitle} - ${challengeTitle}\n${challengeUrl}`;
 
       const camperCodeHeading = i18next.t('forum-help.camper-code');
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #47452 

<!-- Feel free to add any additional description of changes below this line -->

Adding the semantic headers was the last thing needed to close the issue.

This is how it appears:

![image](https://github.com/freeCodeCamp/freeCodeCamp/assets/26656284/ae986d08-db24-4294-92f1-41ed311c37fe)

![image](https://github.com/freeCodeCamp/freeCodeCamp/assets/26656284/c183fdd7-6718-4915-9732-c19b6f360e00)

