### PR TITLE
fix(curriculum): duplicate ids in RWD accessibility quiz

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6145f59029474c0d3dc1c8b8.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6145f59029474c0d3dc1c8b8.md
@@ -11,13 +11,26 @@ As with the other `input` and `label` elements, link the `textarea` to its corre
 
 # --hints--
 
-You should give the `label` element a `for` attribute.
+You should give the `textarea` element an `id` attribute.
 
 ```js
-assert.notEmpty(document.querySelectorAll('.formrow > .question-block')?.[1]?.querySelector('label')?.htmlFor);
+assert.notEmpty(document.querySelectorAll('.answer')?.[1]?.querySelector('textarea')?.id);
 ```
 
-You should give the `textarea` element an `id` attribute matching the `for` attribute of the `label` element.
+You cannot include spaces in the `id` for the `textarea` element.
+
+```js
+assert.match(document.querySelectorAll('.answer')?.[1]?.querySelector('textarea')?.id, /^\S+$/);
+```
+
+You must choose a different `id` for the `textarea` element because another element is using that `id`.
+
+```js
+const textareaId = document.querySelectorAll('.answer')?.[1]?.querySelector('textarea')?.id;
+assert.equal(document.querySelectorAll(`[id='${textareaId.replaceAll(/(['\\])/g, "\\$1")}']`).length, 1);
+```
+
+You should give the `label` element a `for` attribute matching the `id` of the `textarea` element.
 
 ```js
 assert.equal(document.querySelectorAll('.formrow > .question-block')?.[1]?.querySelector('label')?.htmlFor, document.querySelectorAll('.answer')?.[1]?.querySelector('textarea')?.id);
@@ -27,6 +40,12 @@ You should give the `textarea` element a `name` attribute.
 
 ```js
 assert.notEmpty(document.querySelectorAll('.answer')?.[1]?.querySelector('textarea')?.name);
+```
+
+You should use at least one non-space character in the `name` attribute for the `textarea`.
+
+```js
+assert.match(document.querySelectorAll('.answer')?.[1]?.querySelector('textarea')?.name, /\S/);
 ```
 
 # --seed--

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6145f685797bd30df9784e8c.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6145f685797bd30df9784e8c.md
@@ -148,10 +148,10 @@ assert.equal(document.querySelector('button[type="submit"]')?.textContent ?? doc
               </select>
             </div>
             <div class="question-block">
-              <label for="css-questions">Do you have any questions:</label>
+              <label for="css-textarea">Do you have any questions:</label>
             </div>
             <div class="answer">
-              <textarea id="css-questions" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
+              <textarea id="css-textarea" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
             </div>
           </div>
         </section>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6145f829ac6a920ebf5797d7.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6145f829ac6a920ebf5797d7.md
@@ -131,10 +131,10 @@ assert.exists(document.querySelector('footer > address'));
               </select>
             </div>
             <div class="question-block">
-              <label for="css-questions">Do you have any questions:</label>
+              <label for="css-textarea">Do you have any questions:</label>
             </div>
             <div class="answer">
-              <textarea id="css-questions" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
+              <textarea id="css-textarea" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
             </div>
           </div>
         </section>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6145f8f8bcd4370f6509078e.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6145f8f8bcd4370f6509078e.md
@@ -132,10 +132,10 @@ assert.equal(document.querySelector('address')?.innerText, 'freeCodeCamp\nSan Fr
               </select>
             </div>
             <div class="question-block">
-              <label for="css-questions">Do you have any questions:</label>
+              <label for="css-textarea">Do you have any questions:</label>
             </div>
             <div class="answer">
-              <textarea id="css-questions" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
+              <textarea id="css-textarea" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
             </div>
           </div>
         </section>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6145fb5018cb5b100cb2a88c.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6145fb5018cb5b100cb2a88c.md
@@ -138,10 +138,10 @@ assert.equal(document.querySelector('address')?.innerHTML?.match(/freeCodeCamp/g
               </select>
             </div>
             <div class="question-block">
-              <label for="css-questions">Do you have any questions:</label>
+              <label for="css-textarea">Do you have any questions:</label>
             </div>
             <div class="answer">
-              <textarea id="css-questions" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
+              <textarea id="css-textarea" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
             </div>
           </div>
         </section>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6145fc3707fc3310c277f5c8.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6145fc3707fc3310c277f5c8.md
@@ -163,10 +163,10 @@ assert.equal(display, 'block');
               </select>
             </div>
             <div class="question-block">
-              <label for="css-questions">Do you have any questions:</label>
+              <label for="css-textarea">Do you have any questions:</label>
             </div>
             <div class="answer">
-              <textarea id="css-questions" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
+              <textarea id="css-textarea" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
             </div>
           </div>
         </section>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614796cb8086be482d60e0ac.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614796cb8086be482d60e0ac.md
@@ -160,10 +160,10 @@ for (let elem of document.querySelectorAll('li > a')) {
               </select>
             </div>
             <div class="question-block">
-              <label for="css-questions">Do you have any questions:</label>
+              <label for="css-textarea">Do you have any questions:</label>
             </div>
             <div class="answer">
-              <textarea id="css-questions" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
+              <textarea id="css-textarea" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
             </div>
           </div>
         </section>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6147a14ef5668b5881ef2297.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6147a14ef5668b5881ef2297.md
@@ -156,10 +156,10 @@ assert.equal(cursor, 'pointer');
               </select>
             </div>
             <div class="question-block">
-              <label for="css-questions">Do you have any questions:</label>
+              <label for="css-textarea">Do you have any questions:</label>
             </div>
             <div class="answer">
-              <textarea id="css-questions" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
+              <textarea id="css-textarea" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
             </div>
           </div>
         </section>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614878f7a412310647873015.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614878f7a412310647873015.md
@@ -143,10 +143,10 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('header')?.top, '0px');
               </select>
             </div>
             <div class="question-block">
-              <label for="css-questions">Do you have any questions:</label>
+              <label for="css-textarea">Do you have any questions:</label>
             </div>
             <div class="answer">
-              <textarea id="css-questions" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
+              <textarea id="css-textarea" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
             </div>
           </div>
         </section>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/61487b77d4a37707073a64e5.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/61487b77d4a37707073a64e5.md
@@ -145,10 +145,10 @@ assert.isEmpty(new __helpers.CSSHelp(document).getStyle('main')?.paddingRight);
               </select>
             </div>
             <div class="question-block">
-              <label for="css-questions">Do you have any questions:</label>
+              <label for="css-textarea">Do you have any questions:</label>
             </div>
             <div class="answer">
-              <textarea id="css-questions" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
+              <textarea id="css-textarea" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
             </div>
           </div>
         </section>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/61487da611a65307e78d2c20.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/61487da611a65307e78d2c20.md
@@ -156,10 +156,10 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('nav > ul')?.height, '100%
               </select>
             </div>
             <div class="question-block">
-              <label for="css-questions">Do you have any questions:</label>
+              <label for="css-textarea">Do you have any questions:</label>
             </div>
             <div class="answer">
-              <textarea id="css-questions" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
+              <textarea id="css-textarea" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
             </div>
           </div>
         </section>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/61487f703571b60899055cf9.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/61487f703571b60899055cf9.md
@@ -161,10 +161,10 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('section')?.maxWidth, '600
               </select>
             </div>
             <div class="question-block">
-              <label for="css-questions">Do you have any questions:</label>
+              <label for="css-textarea">Do you have any questions:</label>
             </div>
             <div class="answer">
-              <textarea id="css-questions" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
+              <textarea id="css-textarea" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
             </div>
           </div>
         </section>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614880dc16070e093e29bc56.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614880dc16070e093e29bc56.md
@@ -129,10 +129,10 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('h2')?.paddingTop, '60px')
               </select>
             </div>
             <div class="question-block">
-              <label for="css-questions">Do you have any questions:</label>
+              <label for="css-textarea">Do you have any questions:</label>
             </div>
             <div class="answer">
-              <textarea id="css-questions" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
+              <textarea id="css-textarea" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
             </div>
           </div>
         </section>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614883b6fa720e09fb167de9.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614883b6fa720e09fb167de9.md
@@ -147,10 +147,10 @@ assert.isAtLeast(Number(new __helpers.CSSHelp(document).getStyle('.info')?.paddi
               </select>
             </div>
             <div class="question-block">
-              <label for="css-questions">Do you have any questions:</label>
+              <label for="css-textarea">Do you have any questions:</label>
             </div>
             <div class="answer">
-              <textarea id="css-questions" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
+              <textarea id="css-textarea" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
             </div>
           </div>
         </section>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614884c1f5d6f30ab3d78cde.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/614884c1f5d6f30ab3d78cde.md
@@ -227,10 +227,10 @@ assert.isAtLeast(valInPx, 13);
               </select>
             </div>
             <div class="question-block">
-              <label for="css-questions">Do you have any questions:</label>
+              <label for="css-textarea">Do you have any questions:</label>
             </div>
             <div class="answer">
-              <textarea id="css-questions" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
+              <textarea id="css-textarea" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
             </div>
           </div>
         </section>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/61488ecfd05e290b5712e6da.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/61488ecfd05e290b5712e6da.md
@@ -140,10 +140,10 @@ assert.equal(textAlign, 'left');
               </select>
             </div>
             <div class="question-block">
-              <label for="css-questions">Do you have any questions:</label>
+              <label for="css-textarea">Do you have any questions:</label>
             </div>
             <div class="answer">
-              <textarea id="css-questions" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
+              <textarea id="css-textarea" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
             </div>
           </div>
         </section>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148d99cdc7acd0c519862cb.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148d99cdc7acd0c519862cb.md
@@ -140,10 +140,10 @@ assert.equal(minWidth, '55px');
               </select>
             </div>
             <div class="question-block">
-              <label for="css-questions">Do you have any questions:</label>
+              <label for="css-textarea">Do you have any questions:</label>
             </div>
             <div class="answer">
-              <textarea id="css-questions" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
+              <textarea id="css-textarea" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
             </div>
           </div>
         </section>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148da157cc0bd0d06df5c0a.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148da157cc0bd0d06df5c0a.md
@@ -144,10 +144,10 @@ document.querySelectorAll('.info label').forEach(el => {
               </select>
             </div>
             <div class="question-block">
-              <label for="css-questions">Do you have any questions:</label>
+              <label for="css-textarea">Do you have any questions:</label>
             </div>
             <div class="answer">
-              <textarea id="css-questions" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
+              <textarea id="css-textarea" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
             </div>
           </div>
         </section>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148dc095264000dce348bf5.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148dc095264000dce348bf5.md
@@ -161,10 +161,10 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('.question-block')?.textAl
               </select>
             </div>
             <div class="question-block">
-              <label for="css-questions">Do you have any questions:</label>
+              <label for="css-textarea">Do you have any questions:</label>
             </div>
             <div class="answer">
-              <textarea id="css-questions" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
+              <textarea id="css-textarea" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
             </div>
           </div>
         </section>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148dcaaf2e8750e6cb4501a.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148dcaaf2e8750e6cb4501a.md
@@ -147,10 +147,10 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('p')?.fontSize, '20px');
               </select>
             </div>
             <div class="question-block">
-              <label for="css-questions">Do you have any questions:</label>
+              <label for="css-textarea">Do you have any questions:</label>
             </div>
             <div class="answer">
-              <textarea id="css-questions" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
+              <textarea id="css-textarea" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
             </div>
           </div>
         </section>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148dd31d210990f0fb140f8.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148dd31d210990f0fb140f8.md
@@ -137,10 +137,10 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('.question')?.paddingBotto
               </select>
             </div>
             <div class="question-block">
-              <label for="css-questions">Do you have any questions:</label>
+              <label for="css-textarea">Do you have any questions:</label>
             </div>
             <div class="answer">
-              <textarea id="css-questions" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
+              <textarea id="css-textarea" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
             </div>
           </div>
         </section>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148defa9c01520fb9d178a0.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148defa9c01520fb9d178a0.md
@@ -143,10 +143,10 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('.answers-list')?.padding,
               </select>
             </div>
             <div class="question-block">
-              <label for="css-questions">Do you have any questions:</label>
+              <label for="css-textarea">Do you have any questions:</label>
             </div>
             <div class="answer">
-              <textarea id="css-questions" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
+              <textarea id="css-textarea" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
             </div>
           </div>
         </section>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148dfab9b54c110577de165.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148dfab9b54c110577de165.md
@@ -175,10 +175,10 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('button')?.border, '3px so
               </select>
             </div>
             <div class="question-block">
-              <label for="css-questions">Do you have any questions:</label>
+              <label for="css-textarea">Do you have any questions:</label>
             </div>
             <div class="answer">
-              <textarea id="css-questions" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
+              <textarea id="css-textarea" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
             </div>
           </div>
         </section>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148e0bcc13efd10f7d7a6a9.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148e0bcc13efd10f7d7a6a9.md
@@ -141,10 +141,10 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('footer')?.justifyContent,
               </select>
             </div>
             <div class="question-block">
-              <label for="css-questions">Do you have any questions:</label>
+              <label for="css-textarea">Do you have any questions:</label>
             </div>
             <div class="answer">
-              <textarea id="css-questions" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
+              <textarea id="css-textarea" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
             </div>
           </div>
         </section>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148e161ecec9511941f8833.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148e161ecec9511941f8833.md
@@ -155,10 +155,10 @@ assert.isAtLeast(contrast(backgroundColour, aColour), 7);
               </select>
             </div>
             <div class="question-block">
-              <label for="css-questions">Do you have any questions:</label>
+              <label for="css-textarea">Do you have any questions:</label>
             </div>
             <div class="answer">
-              <textarea id="css-questions" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
+              <textarea id="css-textarea" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
             </div>
           </div>
         </section>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148e28706b34912340fd042.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148e28706b34912340fd042.md
@@ -153,10 +153,10 @@ assert.isAtLeast(Number(window.getComputedStyle(document.querySelector('address'
               </select>
             </div>
             <div class="question-block">
-              <label for="css-questions">Do you have any questions:</label>
+              <label for="css-textarea">Do you have any questions:</label>
             </div>
             <div class="answer">
-              <textarea id="css-questions" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
+              <textarea id="css-textarea" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
             </div>
           </div>
         </section>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148e335c1edd512d00e4691.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148e335c1edd512d00e4691.md
@@ -131,10 +131,10 @@ assert.equal(new __helpers.CSSHelp(document).getStyle('*')?.scrollBehavior, 'smo
               </select>
             </div>
             <div class="question-block">
-              <label for="css-questions">Do you have any questions:</label>
+              <label for="css-textarea">Do you have any questions:</label>
             </div>
             <div class="answer">
-              <textarea id="css-questions" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
+              <textarea id="css-textarea" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
             </div>
           </div>
         </section>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148e41c728f65138addf9cc.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148e41c728f65138addf9cc.md
@@ -147,10 +147,10 @@ assert.notExists(new __helpers.CSSHelp(document).getStyle('*'));
               </select>
             </div>
             <div class="question-block">
-              <label for="css-questions">Do you have any questions:</label>
+              <label for="css-textarea">Do you have any questions:</label>
             </div>
             <div class="answer">
-              <textarea id="css-questions" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
+              <textarea id="css-textarea" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
             </div>
           </div>
         </section>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148e5aeb102e3142de026a2.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-accessibility-by-building-a-quiz/6148e5aeb102e3142de026a2.md
@@ -149,10 +149,10 @@ assert.equal(document.querySelectorAll('a')?.[2]?.getAttribute('accesskey')?.len
               </select>
             </div>
             <div class="question-block">
-              <label for="css-questions">Do you have any questions:</label>
+              <label for="css-textarea">Do you have any questions:</label>
             </div>
             <div class="answer">
-              <textarea id="css-questions" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
+              <textarea id="css-textarea" name="css-questions" rows="5" cols="24" placeholder="Who is flexbox..."></textarea>
             </div>
           </div>
         </section>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Partial fix for #47827

<!-- Feel free to add any additional description of changes below this line -->

Someone in the help forum brought this up a few days ago and it reminded me that I had opened an issue for it just over a year ago. So I decided it was time to fix it.

The `textarea` in the accessibility quiz has the same `id` value as the `h2` heading above it. Sometimes duplicate `id`s don't cause an accessibility issue, but in this case it does since the `label` for the `textarea` is pointing to an `id` shared by two elements, which causes ambiguity about which element to use for the `textarea`'s accessible name. And of course, `id`s are supposed to be unique in the first place. So we should probably not have this issue in a course specifically about accessibility :slightly_smiling_face:

I've added some extra tests to step 40 to make sure they pick a proper `id` for the `textarea`. Basically, it can't contain spaces and it can't already exist. And then I picked a new value for the `id` and updated the remaining steps.