### PR TITLE
fix: content misalignment on the profile page #51955

### DIFF
--- a/client/src/components/profile/components/certifications.tsx
+++ b/client/src/components/profile/components/certifications.tsx
@@ -49,7 +49,7 @@ function CertButton({ username, cert }: CertButtonProps): JSX.Element {
   return (
     <>
       <Row>
-        <Col className='certifications' sm={10} smPush={1}>
+        <Col className='certifications'>
           <Link
             className='btn btn-lg btn-primary btn-block'
             to={`/certification/${username}/${cert.certSlug}`}


### PR DESCRIPTION
Closes #51955

**Additional Description :**
By removing the sm and smPush properties from the Col containing the link, the problem was resolved. I have tested it with different resolutions. Take a look at these screenshots.
![image](https://github.com/freeCodeCamp/freeCodeCamp/assets/118912986/07b2eb77-5da7-4628-a0f4-a1cc434de156)
![image](https://github.com/freeCodeCamp/freeCodeCamp/assets/118912986/29a94e92-8700-4611-aaeb-65e1411d9c27)
![image](https://github.com/freeCodeCamp/freeCodeCamp/assets/118912986/328b682d-712d-4282-9e33-5c580cdfaba7)
![image](https://github.com/freeCodeCamp/freeCodeCamp/assets/118912986/e9ff3e5b-4f1b-4160-8782-f9afe221b41f)

**To Test:**
1. Visit homepage
2. Click on profile page

Note: Unless the Settings are set to show Certifications, this content will not appear.

**Checklist:**
- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.
