### PR TITLE
chore: remove mock-fs from the dependency list

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,6 @@
     "lint-staged": "^13.1.0",
     "lodash": "4.17.21",
     "markdownlint": "0.31.0",
-    "mock-fs": "5.2.0",
     "npm-run-all": "4.1.5",
     "prettier": "3.0.3",
     "prismjs": "1.29.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,9 +135,6 @@ importers:
       markdownlint:
         specifier: 0.31.0
         version: 0.31.0
-      mock-fs:
-        specifier: 5.2.0
-        version: 5.2.0
       npm-run-all:
         specifier: 4.1.5
         version: 4.1.5
@@ -1142,9 +1139,6 @@ importers:
       '@types/inquirer':
         specifier: ^8.2.5
         version: 8.2.5
-      '@types/mock-fs':
-        specifier: 4.13.2
-        version: 4.13.2
       bson-objectid:
         specifier: 2.0.4
         version: 2.0.4
@@ -9594,12 +9588,6 @@ packages:
     resolution: {integrity: sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==}
     dependencies:
       '@types/node': 20.8.0
-
-  /@types/mock-fs@4.13.2:
-    resolution: {integrity: sha512-mSIMAOjrNTVUFmZgJEigSIm+GlS4hbrk8U5+M8EB45uMrykKdN9TidjjSaOY1yFph2+TD7bsIfB4r+IrMYVyPQ==}
-    dependencies:
-      '@types/node': 20.8.0
-    dev: true
 
   /@types/ms@0.7.32:
     resolution: {integrity: sha512-xPSg0jm4mqgEkNhowKgZFBNtwoEwF6gJ4Dhww+GFpm3IgtNseHQZ5IqdNwnquZEoANxyDAKDRAdVo4Z72VvD/g==}
@@ -23196,11 +23184,6 @@ packages:
       yargs: 16.2.0
       yargs-parser: 20.2.4
       yargs-unparser: 2.0.0
-    dev: true
-
-  /mock-fs@5.2.0:
-    resolution: {integrity: sha512-2dF2R6YMSZbpip1V1WHKGLNjr/k48uQClqMVb5H3MOvwc9qhYis3/IWbj02qIg/Y8MDXKFF4c5v0rxx2o6xTZw==}
-    engines: {node: '>=12.0.0'}
     dev: true
 
   /mock-require@3.0.3:

--- a/tools/challenge-helper-scripts/package.json
+++ b/tools/challenge-helper-scripts/package.json
@@ -25,7 +25,6 @@
   "devDependencies": {
     "@types/glob": "^8.0.1",
     "@types/inquirer": "^8.2.5",
-    "@types/mock-fs": "4.13.2",
     "bson-objectid": "2.0.4",
     "cross-env": "7.0.3",
     "glob": "^8.1.0",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Follows up to https://github.com/freeCodeCamp/freeCodeCamp/pull/51980.

There were issues in `mock-fs` that caused tests to fail on Node 20, and we (or actually, Naomi) resolved the issues by rewriting the test setup without `mock-fs`. The library is now unused and can be removed.

<!-- Feel free to add any additional description of changes below this line -->
