### PR TITLE
style(docs): tab text is hidden in lightmode

### DIFF
--- a/docs/_theme.css
+++ b/docs/_theme.css
@@ -506,7 +506,7 @@ body.close .github-corner {
 }
 
 .docsify-tabs__tab:not(.docsify-tabs__tab--active) {
-  color: var(--secondary-background) !important;
+  color: var(--primary-color) !important;
 }
 
 .docsify-tabs__tab:not(.docsify-tabs__tab--active):hover {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #51958

<!-- Feel free to add any additional description of changes below this line -->
### Issue
On the Contribution Guide Page, there is a UI issue. Tab text for unselected tabs is not displayed. Here is the screenshot:

### Expected behavior
The text must appear for Tab either it is selected or not

## Screenshots
### Tab 1
<img width="935" alt="old-1" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/58172661/50eea5b6-71ac-4400-bd3e-db602618b5e0">
<img width="935" alt="new-1" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/58172661/aeec6160-63e8-4586-8744-10944b9f5830">

### Tab 2
<img width="946" alt="old-2" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/58172661/ca9edc2a-fb43-4df7-931e-912bbff0d2ab">
<img width="946" alt="new-2" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/58172661/c7621bab-fd3b-4e6f-af7b-d6d6bc2bdd30">

