### PR TITLE
fix(api): infer if MS profile is private when verifying trophies

### DIFF
--- a/api-server/src/server/boot/challenge.js
+++ b/api-server/src/server/boot/challenge.js
@@ -747,6 +747,13 @@ function createMsTrophyChallengeCompleted(app) {
         });
       }
 
+      if (msGameStatusJson.achievements?.length === 0) {
+        return res.status(403).json({
+          type: 'error',
+          message: 'flash.ms.trophy.err-6'
+        });
+      }
+
       const hasEarnedTrophy = msGameStatusJson.achievements?.some(
         a => a.awardUid === msTrophyId
       );

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -741,6 +741,7 @@
         "err-3": "We could not get your Microsoft profile from your Microsoft ID.",
         "err-4": "It appears that the Microsoft user \"{{msUsername}}\" has not earned this trophy.",
         "err-5": "Something went wrong trying to verify your trophy. Please check and try again.",
+        "err-6": "It looks like your Microsoft account might be private. Set it to public and try again.",
         "verified": "Your trophy from Microsoft's learning platform was verified."
       }
     },

--- a/client/src/components/Flash/redux/flash-messages.ts
+++ b/client/src/components/Flash/redux/flash-messages.ts
@@ -33,6 +33,7 @@ export enum FlashMessages {
   MsTrophyErr3 = 'flash.ms.trophy.err-3',
   MsTrophyErr4 = 'flash.ms.trophy.err-4',
   MsTrophyErr5 = 'flash.ms.trophy.err-5',
+  MsTrophyErr6 = 'flash.ms.trophy.err-6',
   MsTrophyVerified = 'flash.ms.trophy.verified',
   NameNeeded = 'flash.name-needed',
   None = '',

--- a/client/src/utils/tone/index.ts
+++ b/client/src/utils/tone/index.ts
@@ -48,6 +48,7 @@ const toneUrls = {
   [FlashMessages.MsTrophyErr3]: TRY_AGAIN,
   [FlashMessages.MsTrophyErr4]: TRY_AGAIN,
   [FlashMessages.MsTrophyErr5]: TRY_AGAIN,
+  [FlashMessages.MsTrophyErr6]: TRY_AGAIN,
   [FlashMessages.MsTrophyVerified]: CHAL_COMP,
   [FlashMessages.NameNeeded]: TRY_AGAIN,
   // [FlashMessages.None]: '',
@@ -78,13 +79,7 @@ const toneUrls = {
   [FlashMessages.UserNotCertified]: TRY_AGAIN,
   [FlashMessages.WrongName]: TRY_AGAIN,
   [FlashMessages.WrongUpdating]: TRY_AGAIN,
-  [FlashMessages.WentWrong]: TRY_AGAIN,
-  [FlashMessages.MsTrophyErr]: TRY_AGAIN,
-  [FlashMessages.MsTrophyVerified]: CHAL_COMP,
-  [FlashMessages.MsLinked]: CHAL_COMP,
-  [FlashMessages.MsLinkErr]: TRY_AGAIN,
-  [FlashMessages.MsUnlinked]: CHAL_COMP,
-  [FlashMessages.MsUnlinkErr]: TRY_AGAIN
+  [FlashMessages.WentWrong]: TRY_AGAIN
 } as const;
 
 type ToneStates = keyof typeof toneUrls;


### PR DESCRIPTION
This infers if a MS profile is private. See explanation in linked issue.

Also, it removes a few items from the flash message tones that aren't used anymore.

And we will want to add these changes to [this PR](https://github.com/freeCodeCamp/freeCodeCamp/pull/51808) if this is merged, or just to the new API after that PR is merged.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #51866

<!-- Feel free to add any additional description of changes below this line -->
