### PR TITLE
fix(a11y): heading structure on landing page

### DIFF
--- a/client/src/components/landing/components/as-seen-in.tsx
+++ b/client/src/components/landing/components/as-seen-in.tsx
@@ -12,12 +12,12 @@ const AsSeenIn = (): JSX.Element => {
       className='as-seen-in text-center'
       data-playwright-test-label='landing-as-seen-in-container'
     >
-      <p
+      <h2
         className='big-heading'
         data-playwright-test-label='landing-as-seen-in-text'
       >
         {t('landing.as-seen-in')}
-      </p>
+      </h2>
       <AsSeenInText fill='light' />
     </Container>
   );

--- a/client/src/components/landing/components/faq.tsx
+++ b/client/src/components/landing/components/faq.tsx
@@ -24,7 +24,7 @@ const Faq = (): JSX.Element => {
           data-playwright-test-label='landing-page-faq'
           key={i}
         >
-          <p className='faq-question'>{faq.question}</p>
+          <h3 className='faq-question'>{faq.question}</h3>
           {faq.answer.map((answer, i) => (
             <p key={i}>{answer}</p>
           ))}

--- a/client/src/components/landing/components/faq.tsx
+++ b/client/src/components/landing/components/faq.tsx
@@ -31,7 +31,7 @@ const Faq = (): JSX.Element => {
           <Spacer size='small' />
         </div>
       ))}
-      <h3>{t('learn.read-this.p12')}</h3>
+      <h2 className='landing-page-happy'>{t('learn.read-this.p12')}</h2>
       <Spacer size='medium' />
       <BigCallToAction />
       <Spacer size='large' />

--- a/client/src/components/landing/components/testimonials.tsx
+++ b/client/src/components/landing/components/testimonials.tsx
@@ -45,9 +45,11 @@ const Testimonials = (): JSX.Element => {
               </p>
             </div>
             <div className='testimony'>
-              <p data-playwright-test-label='testimonials-endorser-testimony'>
-                <Trans>landing.testimonials.shawn.testimony</Trans>
-              </p>
+              <blockquote>
+                <p data-playwright-test-label='testimonials-endorser-testimony'>
+                  <Trans>landing.testimonials.shawn.testimony</Trans>
+                </p>
+              </blockquote>
             </div>
           </div>
         </div>
@@ -78,9 +80,11 @@ const Testimonials = (): JSX.Element => {
               </p>
             </div>
             <div className='testimony'>
-              <p data-playwright-test-label='testimonials-endorser-testimony'>
-                <Trans>landing.testimonials.sarah.testimony</Trans>
-              </p>
+              <blockquote>
+                <p data-playwright-test-label='testimonials-endorser-testimony'>
+                  <Trans>landing.testimonials.sarah.testimony</Trans>
+                </p>
+              </blockquote>
             </div>
           </div>
         </div>
@@ -111,9 +115,11 @@ const Testimonials = (): JSX.Element => {
               </p>
             </div>
             <div className='testimony'>
-              <p data-playwright-test-label='testimonials-endorser-testimony'>
-                <Trans>landing.testimonials.emma.testimony</Trans>
-              </p>
+              <blockquote>
+                <p data-playwright-test-label='testimonials-endorser-testimony'>
+                  <Trans>landing.testimonials.emma.testimony</Trans>
+                </p>
+              </blockquote>
             </div>
           </div>
         </div>

--- a/client/src/components/landing/components/testimonials.tsx
+++ b/client/src/components/landing/components/testimonials.tsx
@@ -36,10 +36,10 @@ const Testimonials = (): JSX.Element => {
 
           <div className='testimonials-footer'>
             <div className='testimonial-meta'>
-              <p data-playwright-test-label='testimonials-endorser-location'>
+              <h3 data-playwright-test-label='testimonials-endorser-location'>
                 {' '}
                 <Trans>landing.testimonials.shawn.location</Trans>
-              </p>
+              </h3>
               <p data-playwright-test-label='testimonials-endorser-occupation'>
                 <Trans>landing.testimonials.shawn.occupation</Trans>
               </p>
@@ -69,10 +69,10 @@ const Testimonials = (): JSX.Element => {
 
           <div className='testimonials-footer'>
             <div className='testimonial-meta'>
-              <p data-playwright-test-label='testimonials-endorser-location'>
+              <h3 data-playwright-test-label='testimonials-endorser-location'>
                 {' '}
                 <Trans>landing.testimonials.sarah.location</Trans>
-              </p>
+              </h3>
               <p data-playwright-test-label='testimonials-endorser-occupation'>
                 <Trans>landing.testimonials.sarah.occupation</Trans>
               </p>
@@ -102,10 +102,10 @@ const Testimonials = (): JSX.Element => {
 
           <div className='testimonials-footer'>
             <div className='testimonial-meta'>
-              <p data-playwright-test-label='testimonials-endorser-location'>
+              <h3 data-playwright-test-label='testimonials-endorser-location'>
                 {' '}
                 <Trans>landing.testimonials.emma.location</Trans>
-              </p>
+              </h3>
               <p data-playwright-test-label='testimonials-endorser-occupation'>
                 <Trans>landing.testimonials.emma.occupation</Trans>
               </p>

--- a/client/src/components/landing/landing.css
+++ b/client/src/components/landing/landing.css
@@ -143,6 +143,13 @@ figcaption.caption {
   padding: 10px 0 30px;
 }
 
+.testimonial-meta h3 {
+  font-family: var(--font-family-sans-serif);
+  font-size: 1.3rem;
+  font-weight: normal;
+  margin-bottom: 0;
+}
+
 .testimonial-meta p,
 .testimonial-meta strong {
   font-size: 1.2rem;

--- a/client/src/components/landing/landing.css
+++ b/client/src/components/landing/landing.css
@@ -30,7 +30,7 @@
   font-family: var(--font-family-sans-serif);
 }
 
-.landing-page h2.landing-page-happy {
+.landing-page .landing-page-happy {
   font-family: var(--font-family-monospace);
   font-size: 1.1rem;
   margin-top: 0;

--- a/client/src/components/landing/landing.css
+++ b/client/src/components/landing/landing.css
@@ -169,6 +169,11 @@ figcaption.caption {
   justify-content: center;
 }
 
+.testimony blockquote {
+  padding: 0;
+  border: 0;
+}
+
 .landing-top,
 .as-seen-in,
 .certification-section,

--- a/client/src/components/landing/landing.css
+++ b/client/src/components/landing/landing.css
@@ -70,6 +70,8 @@ figcaption.caption {
 .faq-question {
   font-weight: bold;
   font-size: 1.25rem;
+  font-family: var(--font-family-sans-serif);
+  margin-bottom: 1.2rem;
 }
 
 @media (min-width: 370px) {

--- a/client/src/components/landing/landing.css
+++ b/client/src/components/landing/landing.css
@@ -51,6 +51,7 @@ figcaption.caption {
 
 .as-seen-in .big-heading {
   color: var(--gray-15);
+  margin-top: 0;
 }
 
 .landing-page .big-heading {

--- a/client/src/components/landing/landing.css
+++ b/client/src/components/landing/landing.css
@@ -30,6 +30,12 @@
   font-family: var(--font-family-sans-serif);
 }
 
+.landing-page h2.landing-page-happy {
+  font-family: var(--font-family-monospace);
+  font-size: 1.1rem;
+  margin-top: 0;
+}
+
 figcaption.caption {
   margin: 10px 0 0;
   font-weight: 600;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Just some minor updates to make the heading structure a little more accessible on the landing page. You shouldn't notice any difference in the styling of the page.

Also, wrapped each testimonial quote in a `blockquote` because it seemed to be a perfect use for it. Some screen readers (NVDA and JAWS for sure) will announce that it is a blockquote.