### PR TITLE
fix(curriculum): fixed Incorrect pre-existing code in step 30 in RWD 22 curriculum registration form

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/62ff8e998d3e7eae14d6ae3b.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/62ff8e998d3e7eae14d6ae3b.md
@@ -82,7 +82,6 @@ assert(document.querySelector('fieldset:nth-child(3) + label')?.matches('label[f
 --fcc-editable-region--
 
 --fcc-editable-region--
-      <label><input type="checkbox" required /></label>
       <input type="submit" value="Submit" />
     </form>
   </body>

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/62ff8e998d3e7eae14d6ae3b.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/62ff8e998d3e7eae14d6ae3b.md
@@ -9,9 +9,9 @@ dashedName: step-30
 
 You need to confirm that the user has read the terms and conditions.
 
-Add `label` element after the third `fieldset`, and a `input` element with `type` attribute of `checkbox` inside the newly added `label` element. Make this `input` element `required` because users should not sign up without reading the terms and conditions.
+Add a `label` element. Inside the newly created `label` element add an `input` element and set the `type` attribute to `checkbox`. Make this `input` element `required` so users can not sign up without agreeing to the terms and conditions.
 
-Don't forget to add an `id` attribute of `terms-and-conditions` for accessibility.
+Add an `id` and `for` attribute with the value &nbsp; &nbsp; &nbsp; &nbsp; `terms-and-conditions` to the elements for accessibility.
 
 # --hints--
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/62ff8e998d3e7eae14d6ae3b.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/62ff8e998d3e7eae14d6ae3b.md
@@ -11,7 +11,7 @@ You need to confirm that the user has read the terms and conditions.
 
 Add a `label` element. Inside the newly created `label` element add an `input` element and set the `type` attribute to `checkbox`. Make this `input` element `required` so users can not sign up without agreeing to the terms and conditions.
 
-Add an `id` and `for` attribute with the value &nbsp; &nbsp; &nbsp; &nbsp; `terms-and-conditions` to the elements for accessibility.
+Add an `id` and `for` attribute with the value `terms-and-conditions` to the elements for accessibility.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #52029 

<!-- Feel free to add any additional description of changes below this line -->
I have fixed the incorrect pre-written code in responsive web design 22 where it was told to implement a check box but i was present there already.