### PR TITLE
feat(github): add waiting triage label to feature request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/04--feature-request-for-freecodecamp-org-s-platforms.yml
+++ b/.github/ISSUE_TEMPLATE/04--feature-request-for-freecodecamp-org-s-platforms.yml
@@ -1,6 +1,6 @@
 name: New Feature - Request a new feature for our Platforms
 description: Suggest an idea for freeCodeCamp.org's /learn, /news, Community Forum, Code Radio, or other platforms.
-labels: ['type: feature request']
+labels: ['type: feature request', 'status: waiting triage']
 body:
   - type: textarea
     attributes:


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I'm not sure why the feature request template doesn't have the `waiting triage` label automatically added like the other templates, so here I'm adding it in. I personally find it helpful to have the label added as I can tell which issue is new / needs attention. But usually feature requests are triaged by staff members though, so I'm not sure if this is useful for you.

<!-- Feel free to add any additional description of changes below this line -->
