### PR TITLE
feat(tools): test single challenge by id

### DIFF
--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -107,8 +107,16 @@ setup()
   .catch(err => handleRejection(err));
 
 async function setup() {
-  if (process.env.FCC_SUPERBLOCK && process.env.FCC_BLOCK) {
-    throw new Error(`Please do not use both a block and superblock as input.`);
+  if (
+    [
+      process.env.FCC_BLOCK,
+      process.env.FCC_ID,
+      process.env.FCC_SUPERBLOCK
+    ].filter(Boolean).length > 1
+  ) {
+    throw new Error(
+      `Please use at most single input from: block, id, superblock.`
+    );
   }
 
   // liveServer starts synchronously
@@ -179,6 +187,25 @@ async function setup() {
     }
   }
 
+  if (process.env.FCC_ID) {
+    console.log(`\nId being tested: ${process.env.FCC_ID}`);
+    const challengeIndex = challenges.findIndex(
+      challenge => challenge.id === process.env.FCC_ID
+    );
+    if (challengeIndex === -1) {
+      throw new Error(`No challenge found with id "${process.env.FCC_ID}"`);
+    }
+    const { solutions = [] } = challenges[challengeIndex];
+    if (isEmpty(solutions)) {
+      // Project based curriculum usually has solution for current challenge in
+      // next challenge's seed.
+      challenges = challenges.slice(challengeIndex, challengeIndex + 2);
+    } else {
+      // Only one challenge is tested, but tests assume challenges is an array.
+      challenges = [challenges[challengeIndex]];
+    }
+  }
+
   const meta = {};
   for (const challenge of challenges) {
     const dashedBlockName = challenge.block;
@@ -238,7 +265,7 @@ function populateTestsForLang({ lang, challenges, meta }) {
   const challengeTitles = new ChallengeTitles();
   const validateChallenge = challengeSchemaValidator();
 
-  if (!process.env.FCC_BLOCK) {
+  if (!process.env.FCC_BLOCK && !process.env.FCC_ID) {
     describe('Assert meta order', function () {
       /** This array can be used to skip a superblock - we'll use this
        * when we are working on the new project-based curriculum for
@@ -287,6 +314,12 @@ function populateTestsForLang({ lang, challenges, meta }) {
   describe(`Check challenges (${lang})`, function () {
     this.timeout(5000);
     challenges.forEach((challenge, id) => {
+      // When testing single challenge, in project based curriculum,
+      // challenge to test (current challenge) might not have solution.
+      // Instead seed from next challenge is tested against tests from
+      // current challenge. Next challenge is skipped from testing.
+      if (process.env.FCC_ID && id > 0) return;
+
       const dashedBlockName = challenge.block;
       // TODO: once certifications are not included in the list of challenges,
       // stop returning early here.

--- a/curriculum/test/test-challenges.js
+++ b/curriculum/test/test-challenges.js
@@ -110,12 +110,12 @@ async function setup() {
   if (
     [
       process.env.FCC_BLOCK,
-      process.env.FCC_ID,
+      process.env.FCC_CHALLENGE_ID,
       process.env.FCC_SUPERBLOCK
     ].filter(Boolean).length > 1
   ) {
     throw new Error(
-      `Please use at most single input from: block, id, superblock.`
+      `Please use at most single input from: block, challenge id, superblock.`
     );
   }
 
@@ -187,13 +187,15 @@ async function setup() {
     }
   }
 
-  if (process.env.FCC_ID) {
-    console.log(`\nId being tested: ${process.env.FCC_ID}`);
+  if (process.env.FCC_CHALLENGE_ID) {
+    console.log(`\nChallenge Id being tested: ${process.env.FCC_CHALLENGE_ID}`);
     const challengeIndex = challenges.findIndex(
-      challenge => challenge.id === process.env.FCC_ID
+      challenge => challenge.id === process.env.FCC_CHALLENGE_ID
     );
     if (challengeIndex === -1) {
-      throw new Error(`No challenge found with id "${process.env.FCC_ID}"`);
+      throw new Error(
+        `No challenge found with id "${process.env.FCC_CHALLENGE_ID}"`
+      );
     }
     const { solutions = [] } = challenges[challengeIndex];
     if (isEmpty(solutions)) {
@@ -265,7 +267,7 @@ function populateTestsForLang({ lang, challenges, meta }) {
   const challengeTitles = new ChallengeTitles();
   const validateChallenge = challengeSchemaValidator();
 
-  if (!process.env.FCC_BLOCK && !process.env.FCC_ID) {
+  if (!process.env.FCC_BLOCK && !process.env.FCC_CHALLENGE_ID) {
     describe('Assert meta order', function () {
       /** This array can be used to skip a superblock - we'll use this
        * when we are working on the new project-based curriculum for
@@ -318,7 +320,7 @@ function populateTestsForLang({ lang, challenges, meta }) {
       // challenge to test (current challenge) might not have solution.
       // Instead seed from next challenge is tested against tests from
       // current challenge. Next challenge is skipped from testing.
-      if (process.env.FCC_ID && id > 0) return;
+      if (process.env.FCC_CHALLENGE_ID && id > 0) return;
 
       const dashedBlockName = challenge.block;
       // TODO: once certifications are not included in the list of challenges,

--- a/docs/how-to-work-on-coding-challenges.md
+++ b/docs/how-to-work-on-coding-challenges.md
@@ -460,7 +460,13 @@ Before you [create a pull request](how-to-open-a-pull-request.md) for your chang
 pnpm run test:curriculum
 ```
 
-2. You can also test a block or a superblock of challenges with these commands
+2. To test single challenge, you can use it challenge id with following command
+
+```
+FCC_ID=646cf6cbca98e258da65c979 pnpm run test:curriculum
+```
+
+3. You can also test a block or a superblock of challenges with these commands
 
 ```
 FCC_BLOCK='Basic HTML and HTML5' pnpm run test:curriculum
@@ -470,7 +476,7 @@ FCC_BLOCK='Basic HTML and HTML5' pnpm run test:curriculum
 FCC_SUPERBLOCK='responsive-web-design' pnpm run test:curriculum
 ```
 
-You are also able to test one challenge individually by performing the following steps:
+You are also able to test challenges by title by performing the following steps:
 
 1. Switch to the `curriculum` directory:
 

--- a/docs/how-to-work-on-coding-challenges.md
+++ b/docs/how-to-work-on-coding-challenges.md
@@ -463,7 +463,7 @@ pnpm run test:curriculum
 2. To test single challenge, you can use it challenge id with following command
 
 ```
-FCC_ID=646cf6cbca98e258da65c979 pnpm run test:curriculum
+FCC_CHALLENGE_ID=646cf6cbca98e258da65c979 pnpm run test:curriculum
 ```
 
 3. You can also test a block or a superblock of challenges with these commands


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #47057

---
- Allows using ~~`FCC_ID`~~ `FCC_CHALLENGE_ID` to test single challenge in curriculum.
- For project based curriculum challenges, which might not have solution, the seed of next step is used in test, as necessary.
- Added usage information to documentation.