### PR TITLE
fix(ui-components): default storybook background

### DIFF
--- a/tools/ui-components/.storybook/preview.js
+++ b/tools/ui-components/.storybook/preview.js
@@ -11,6 +11,7 @@ export const parameters = {
     }
   },
   backgrounds: {
+    default: 'light-palette',
     values: [
       {
         name: 'light-palette',
@@ -36,8 +37,8 @@ function renderTheme(Story, context) {
     bg => bg.value === selectedBackgroundValue
   )?.name;
 
-  // There can be no background selected, prevent "undefined" className
-  const className = selectedBackgroundName || '';
+  // Use the value of the default background to prevent "undefined" className
+  const className = selectedBackgroundName || parameters.backgrounds.default;
 
   return (
     <div className={className}>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The Storybook page of the `Button` and `CloseButton` components are currently not displaying the correct styles. This PR updates the Storybook config to allow the components to access the CSS values correctly.

## Steps to test

- Run:
    ```cmd
    cd tools/ui-components
    pnpm run storybook
   ```
- Go to http://localhost:6006/?path=/story/example-button--default and http://localhost:6006/?path=/story/example-closebutton--basic

## Screenshots

| Before | After |
| --- | --- |
| <img width="696" alt="Screenshot 2023-10-25 at 19 02 22" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/15a0a8ab-3060-4078-b8fc-7d3ac74d2b25"> | <img width="797" alt="Screenshot 2023-10-25 at 19 01 20" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/f80cb084-ce7f-4cd8-b40b-847fbbcc588e"> |

<!-- Feel free to add any additional description of changes below this line -->
