### PR TITLE
fix(a11y): give profile link a proper accessible name

### DIFF
--- a/client/src/assets/icons/default-avatar.tsx
+++ b/client/src/assets/icons/default-avatar.tsx
@@ -15,6 +15,7 @@ function DefaultAvatar(
       width='500px'
       xmlns='http://www.w3.org/2000/svg'
       xmlnsXlink='http://www.w3.org/1999/xlink'
+      aria-hidden='true'
       {...props}
     >
       <title>{t('icons.avatar')}</title>

--- a/client/src/components/helpers/avatar-renderer.tsx
+++ b/client/src/components/helpers/avatar-renderer.tsx
@@ -9,12 +9,10 @@ interface AvatarRendererProps {
   isDonating?: boolean;
   isTopContributor?: boolean;
   picture: string;
-  userName: string;
 }
 
 function AvatarRenderer({
   picture,
-  userName,
   isDonating,
   isTopContributor
 }: AvatarRendererProps): JSX.Element {
@@ -44,14 +42,11 @@ function AvatarRenderer({
 
   return (
     <div className={`avatar-container ${borderColor}`}>
+      <span className='sr-only'>{t('buttons.profile')}</span>
       {isPlaceHolderImage ? (
         <DefaultAvatar className='avatar default-avatar' />
       ) : (
-        <Image
-          alt={t('profile.avatar', { username: userName })}
-          className='avatar'
-          src={picture}
-        />
+        <Image alt='' className='avatar' src={picture} />
       )}
     </div>
   );

--- a/client/src/components/profile/__snapshots__/profile.test.tsx.snap
+++ b/client/src/components/profile/__snapshots__/profile.test.tsx.snap
@@ -23,7 +23,13 @@ exports[`<Profile/> renders correctly 1`] = `
           <div
             class="avatar-container default-border"
           >
+            <span
+              class="sr-only"
+            >
+              buttons.profile
+            </span>
             <svg
+              aria-hidden="true"
               class="avatar default-avatar"
               height="500px"
               version="1.1"


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

The profile icon link in the upper right hand corner of the header does not currently follow [best practices for naming links with non-text content](https://www.w3.org/WAI/tutorials/images/functional/#example-4-stand-alone-icon-image-that-has-a-function). It is generally recommended that when non-text content (such as an image) is used as the only content for a link then the accessible name for the link should describe the purpose of the link, not a description of the image (although sometimes it is possible to have both). 

Currently the accessible name for the link is being assigned through the image alt text, which is "[username]'s avatar". Rather, the link should describe where it points to, which in this case is the profile page. We already have a "Profile" link in the main menu, so I think it makes sense to use "Profile" as the accessible name for this link too since they both serve the same purpose. 

Instead of continuing to use the alt text for the accessible name I have added sr-only "Profile" text to the link and hidden the image by giving it empty alt text. I thought this was the easier way to go since we also need to do the same thing for the default avatar svg. So we can simply hide that as well with `aria-hidden` and rely on the sr-only "Profile" text.