### PR TITLE
fix(UI): centered flash message

### DIFF
--- a/client/src/components/Flash/flash.css
+++ b/client/src/components/Flash/flash.css
@@ -1,6 +1,6 @@
 div.flash-message {
   display: flex;
-  justify-content: space-around;
+  justify-content: center;
   flex-direction: row;
   margin-bottom: 0px;
   padding-top: 3px;

--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -184,6 +184,7 @@ button.close {
   font-size: 28px;
   opacity: 0.5;
   text-shadow: none;
+  margin: 1px 0px 0px 10px;
 }
 
 button.close:hover,


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #52123 

I have made the flash message to be centered for better alignment.
![image](https://github.com/freeCodeCamp/freeCodeCamp/assets/64531160/79945ebb-930c-4dbf-87ae-9444ffec15b2)


