### PR TITLE
fix(curriculum): resolving typos and small bugs in JS RPG game

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a8eec45f77bc69e8775294.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a8eec45f77bc69e8775294.md
@@ -17,7 +17,7 @@ You should assign the string `You dodge the attack from the ` to the `text.inner
 assert.match(dodge.toString(), /text\.innerText\s*=\s*('|")You dodge the attack from the \1/);
 ```
 
-You should use the concatenation operator to add the name of the monster to the end of the string. You can get this with `monster[fighting].name`.
+You should use the concatenation operator to add the name of the monster to the end of the string. You can get this with `monsters[fighting].name`.
 
 ```js
 assert.match(dodge.toString(), /text\.innerText\s*=\s*('|")You dodge the attack from the \1\s*\+\s*monsters\[fighting\]\.name/);

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a8f256b813a476cae51f49.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a8f256b813a476cae51f49.md
@@ -9,7 +9,7 @@ dashedName: step-138
 
 Back to your `attack` function - inside the `else if` block, create another `if` and `else` statement. If the player is fighting the dragon (`fighting` would be `2`), call the `winGame` function. Move the `defeatMonster()` call to the `else` block.
 
-For this step, you will need to use the `strict equality (===) operator` to check if `fighting` is equal to `2`. The `strict equality operator` will check if the values are equal and if they are the same data type.
+For this step, you will need to use the strict equality (`===`) operator to check if `fighting` is equal to `2`. The strict equality operator will check if the values are equal and if they are the same data type.
 
 Here is an example that checks if `num` is strictly equal to `5`:
 

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a8f256b813a476cae51f49.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62a8f256b813a476cae51f49.md
@@ -9,7 +9,9 @@ dashedName: step-138
 
 Back to your `attack` function - inside the `else if` block, create another `if` and `else` statement. If the player is fighting the dragon (`fighting` would be `2`), call the `winGame` function. Move the `defeatMonster()` call to the `else` block.
 
-Here is an example that checks if `num` is equal to `5`:
+For this step, you will need to use the `strict equality (===) operator` to check if `fighting` is equal to `2`. The `strict equality operator` will check if the values are equal and if they are the same data type.
+
+Here is an example that checks if `num` is strictly equal to `5`:
 
 ```js
 if (num === 5) {

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62aa20e9cf1be9358f5aceae.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62aa20e9cf1be9358f5aceae.md
@@ -7,7 +7,7 @@ dashedName: step-150
 
 # --description--
 
-Add an `else` statement to the first `if` statement inside you `attack()` function. In the `else` statement, use the `+=` operator to add the text ` You miss.` to the end of `text.innerText`.
+Add an `else` statement to the first `if` statement inside your `attack()` function. In the `else` statement, use the `+=` operator to add the text ` You miss.` to the end of `text.innerText`.
 
 # --hints--
 
@@ -17,7 +17,7 @@ You should add an `else` block after your `if (isMonsterHit())` block.
 assert.match(attack.toString(), /if\s*\(isMonsterHit\(\)\s*\)\s*\{\s*monsterHealth\s*-=\s*weapons\[currentWeapon\]\.power\s*\+\s*Math\.floor\(Math\.random\(\)\s*\*\s*xp\)\s*\+\s*1;\s*\}\s*else/)
 ```
 
-You should add the text ` You miss.` to the end of `text.innerText`. Remember to use compound assignment.
+You should add the text ` You miss.` to the end of `text.innerText`. Remember to use compound assignment and make sure there a space before the word `You`.
 
 ```js
 assert.match(attack.toString(), /if\s*\(isMonsterHit\(\)\s*\)\s*\{\s*monsterHealth\s*-=\s*weapons\[currentWeapon\]\.power\s*\+\s*Math\.floor\(Math\.random\(\)\s*\*\s*xp\)\s*\+\s*1;\s*\}\s*else\s*\{\s*text\.innerText\s*\+=\s*('|")\sYou miss\.\1/)

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62aa20e9cf1be9358f5aceae.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62aa20e9cf1be9358f5aceae.md
@@ -17,7 +17,7 @@ You should add an `else` block after your `if (isMonsterHit())` block.
 assert.match(attack.toString(), /if\s*\(isMonsterHit\(\)\s*\)\s*\{\s*monsterHealth\s*-=\s*weapons\[currentWeapon\]\.power\s*\+\s*Math\.floor\(Math\.random\(\)\s*\*\s*xp\)\s*\+\s*1;\s*\}\s*else/)
 ```
 
-You should add the text ` You miss.` to the end of `text.innerText`. Remember to use compound assignment and make sure there a space before the word `You`.
+You should add the text ` You miss.` to the end of `text.innerText`. Remember to use compound assignment and make sure there is a space before the word `You`.
 
 ```js
 assert.match(attack.toString(), /if\s*\(isMonsterHit\(\)\s*\)\s*\{\s*monsterHealth\s*-=\s*weapons\[currentWeapon\]\.power\s*\+\s*Math\.floor\(Math\.random\(\)\s*\*\s*xp\)\s*\+\s*1;\s*\}\s*else\s*\{\s*text\.innerText\s*\+=\s*('|")\sYou miss\.\1/)

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62aa25fcb5837d43b4d9873d.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62aa25fcb5837d43b4d9873d.md
@@ -207,8 +207,8 @@ const locations = [
         "button text": ["REPLAY?", "REPLAY?", "REPLAY?"], 
         "button functions": [restart, restart, restart], 
         text: "You defeat the dragon! YOU WIN THE GAME! 🎉" 
+    },
 --fcc-editable-region--
-    }
 
 --fcc-editable-region--
 ];

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62aa27560def7048d7b4a095.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62aa27560def7048d7b4a095.md
@@ -7,7 +7,7 @@ dashedName: step-165
 
 # --description--
 
-Before the final quote in that string you added, insert the new line escape character `\n`. This will cause the next part you add to `text.innerText` to appear on a new line.
+At the end of the string, before the final quote, insert the new line escape character `\n`. This will cause the next part you add to `text.innerText` to appear on a new line.
 
 # --hints--
 


### PR DESCRIPTION
## Summary of changes

As I was going through the new JS RPG game, I noticed a couple of typos and extra clarifications needed. 
Here is the list of changes that I made

- [x] fixed a typo for incorrect hint text for step 127
- [x] gave a 1 sentence explanation for strict equality in step 138 since it is not talked about in this project 
- [x] amended the hint text for step 150 to remind campers about spacing
- [x] altered the starting code for step 160 
- [x] clarified instructions for where to add the newline character in the string for step 165

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.


