### PR TITLE
fix(client): separate custom props from svg props attrs

### DIFF
--- a/client/src/assets/icons/superblock-icon.tsx
+++ b/client/src/assets/icons/superblock-icon.tsx
@@ -45,9 +45,9 @@ type SuperBlockIconProps = {
 } & React.SVGProps<SVGSVGElement>;
 
 export function SuperBlockIcon(props: SuperBlockIconProps): JSX.Element {
-  const { superBlock, className } = props;
+  const { superBlock, className, ...iconProps } = props;
   // fallback in case super block doesn't exist and for tests
   const Icon = iconMap[superBlock] ? iconMap[superBlock] : ResponsiveDesign;
 
-  return <Icon className={className} {...props} />;
+  return <Icon className={className} {...iconProps} />;
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Fixes the following error in the browser console:

```console
Warning: React does not recognize the `superBlock` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `superblock` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    in svg (created by ResponsiveDesign)
    in ResponsiveDesign (created by SuperBlockIcon)
    in SuperBlockIcon (created by MapLi)
```