### PR TITLE
fix(a11y): input not having associated label on MS trophy page

### DIFF
--- a/client/src/templates/Challenges/exam/show.tsx
+++ b/client/src/templates/Challenges/exam/show.tsx
@@ -420,7 +420,6 @@ class ShowExam extends Component<ShowExamProps, ShowExamState> {
                       ({ answer, id }) => (
                         <label className='exam-answer-label' key={id}>
                           <input
-                            aria-label={t('aria.answer')}
                             checked={
                               userExamQuestions[currentQuestionIndex].answer
                                 .id === id

--- a/client/src/templates/Challenges/ms-trophy/link-ms-user.tsx
+++ b/client/src/templates/Challenges/ms-trophy/link-ms-user.tsx
@@ -151,10 +151,11 @@ function LinkMsUser({
           <Spacer size='medium' />
           <form onSubmit={handleLinkUsername}>
             <FormGroup validationState={isValid ? 'success' : 'error'}>
-              <ControlLabel>
+              <ControlLabel htmlFor='transcript-link'>
                 <strong>{t('learn.ms.transcript-label')}</strong>
               </ControlLabel>
               <FormControl
+                id='transcript-link'
                 type='url'
                 onChange={handleInputChange}
                 placeholder='https://learn.microsoft.com/en-us/users/username/transcript/transcriptId'

--- a/e2e/link-ms-user.spec.ts
+++ b/e2e/link-ms-user.spec.ts
@@ -64,5 +64,14 @@ test.describe('Link MS user component (unlinked signedIn user)', () => {
     const linkText6 = page.getByTestId('link-li-6-text');
     await expect(linkText6).toBeVisible();
     await expect(linkText6).toHaveText(translations.learn.ms['link-li-6']);
+
+    const transcriptLinkInput = page.getByLabel(
+      translations.learn.ms['transcript-label']
+    );
+    await expect(transcriptLinkInput).toBeVisible();
+    await expect(transcriptLinkInput).toHaveAttribute(
+      'placeholder',
+      'https://learn.microsoft.com/en-us/users/username/transcript/transcriptId'
+    );
   });
 });


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

We have an `<input>` and a `<label>` on the MS Trophy page but they aren't associated, resulting the input not having a proper label. 

This PR:
- Addresses the issue by adding an `id` to the input and passing the ID to the `label` element
- Adds an assertion to the e2e test to ensure the input always has an associated label

## Steps to test

- Go to a trophy page: https://www.freecodecamp.org/learn/foundational-c-sharp-with-microsoft/write-your-first-code-using-c-sharp/trophy-write-your-first-code-using-c-sharp
- Ensure that your MS account is not linked (so that the page renders a text input)
- Check if the input has a proper label

## Results

| Before | After |
| --- | --- |
| <img width="1180" alt="Screenshot 2023-10-31 at 10 34 51" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/0387613c-4d5f-49dc-a8dc-ec8553f9b54c"> | <img width="1155" alt="Screenshot 2023-10-31 at 10 37 05" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/5d1d6a39-02e5-402c-918d-04cf9e496ffc"> |

<!-- Feel free to add any additional description of changes below this line -->
