### PR TITLE
test(e2e): session validation

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,9 +1,20 @@
 const login = (user?: string) => {
-  cy.session(user ?? 'new-user', () => {
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-    cy.visit(`${Cypress.env('API_LOCATION')}/signin`);
-    cy.contains('Welcome back');
-  });
+  cy.session(
+    user ?? 'new-user',
+    () => {
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+      cy.visit(`${Cypress.env('API_LOCATION')}/signin`);
+      cy.contains('Welcome back');
+    },
+    {
+      validate() {
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+        cy.request(`${Cypress.env('API_LOCATION')}/user/get-session-user`)
+          .its('status')
+          .should('eq', 200);
+      }
+    }
+  );
 };
 
 const setPrivacyTogglesToPublic = () => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -4,6 +4,7 @@ const login = (user?: string) => {
     () => {
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       cy.visit(`${Cypress.env('API_LOCATION')}/signin`);
+      cy.url().should('include', '/learn');
       cy.contains('Welcome back');
     },
     {


### PR DESCRIPTION
- test: add session validation
- test: check the browser is redirected to learn

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Since https://github.com/freeCodeCamp/freeCodeCamp/pull/51678 went in we've started seeing intermittent Cypress test failures like https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/6719831607/job/18262616518

The tests are failing because a `/user/get-session-user` request fails. I'd like to rule out the case where the session does not get created when `cy.login()` is called and this PR should help with that.

<!-- Feel free to add any additional description of changes below this line -->
