### PR TITLE
fix(api): trim trailing space if no reporter name

### DIFF
--- a/api/src/routes/user.test.ts
+++ b/api/src/routes/user.test.ts
@@ -719,9 +719,11 @@ describe('userRoutes', () => {
       });
 
       test('POST returns 200 status code with "success" message', async () => {
-        const testUser = await fastifyTestInstance.prisma.user.findFirst({
-          where: { email: testUserData.email }
-        });
+        const testUser = await fastifyTestInstance.prisma.user.findFirstOrThrow(
+          {
+            where: { email: testUserData.email }
+          }
+        );
         const response = await superRequest('/user/report-user', {
           method: 'POST',
           setCookies
@@ -747,8 +749,8 @@ Luke, I am your father
 
 
 Reported by:
-Username: ${testUser?.username ?? ''}
-Name: 
+Username: ${testUser.username}
+Name:
 Email: foo@bar.com
 
 Thanks and regards,

--- a/api/src/utils/email-templates.ts
+++ b/api/src/utils/email-templates.ts
@@ -24,7 +24,7 @@ ${reportDesc}
 
 Reported by:
 Username: ${reporter.username}
-Name: ${reporter.name ?? ''}
+Name:${reporter.name ? ' ' + reporter.name : ''}
 Email: ${reporter.email}
 
 Thanks and regards,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This is mostly because my editor deletes trailing spaces on save, but also because there shouldn't be one!

<!-- Feel free to add any additional description of changes below this line -->
