### PR TITLE
fix: check for margin-left and margin-right not present

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f45a276c093334f0f6e9df4.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f45a276c093334f0f6e9df4.md
@@ -48,14 +48,14 @@ const itemPMarginBottom = new __helpers.CSSHelp(document).getStyle('.item p')?.g
 assert(itemPMarginBottom === '5px');
 ```
 
-Your `p` element nested in your `.item` elements should not have `margin-left`.
+Your `p` elements nested in your `.item` elements should not have a `margin-left` set.
 
 ```js
 const itemPMarginLeft = new __helpers.CSSHelp(document).getStyle('.item p')?.getPropertyValue('margin-left');
 assert(!itemPMarginLeft);
 ```
 
-Your `p` element nested in your `.item` elements should not have `margin-right`.
+Your `p` elements nested in your `.item` elements should not have a `margin-right` set.
 
 ```js
 const itemPMarginRight = new __helpers.CSSHelp(document).getStyle('.item p')?.getPropertyValue('margin-right');

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f45a276c093334f0f6e9df4.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f45a276c093334f0f6e9df4.md
@@ -48,6 +48,20 @@ const itemPMarginBottom = new __helpers.CSSHelp(document).getStyle('.item p')?.g
 assert(itemPMarginBottom === '5px');
 ```
 
+Your `p` element nested in your `.item` elements should not have `margin-left`.
+
+```js
+const itemPMarginLeft = new __helpers.CSSHelp(document).getStyle('.item p')?.getPropertyValue('margin-left');
+assert(!itemPMarginLeft);
+```
+
+Your `p` element nested in your `.item` elements should not have `margin-right`.
+
+```js
+const itemPMarginRight = new __helpers.CSSHelp(document).getStyle('.item p')?.getPropertyValue('margin-right');
+assert(!itemPMarginRight);
+```
+
 # --seed--
 
 ## --seed-contents--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #52181

<!-- Feel free to add any additional description of changes below this line -->
In this code update, I have checked to make sure that  margin-left and margin-right are not present so campers cannot use ```margin: 5px``` or ```margin: 5px 0``` or ```margin: 5px 0 5px 0``` which will set margin-left and margin-right. The campers have to compulsorily use ```margin-top: 5px``` and ```margin-bottom: 5px```. 
