### PR TITLE
refactor(client): replace Bootstrap button component on Show Certification page

### DIFF
--- a/client/src/client-only-routes/show-certification.tsx
+++ b/client/src/client-only-routes/show-certification.tsx
@@ -104,7 +104,7 @@ const mapStateToProps = (state: unknown, props: ShowCertificationProps) => {
       signedInUserName: string,
       userFetchState: UserFetchState,
       isDonating: boolean,
-      user
+      user: User
     ) => ({
       cert,
       fetchState,

--- a/client/src/client-only-routes/show-certification.tsx
+++ b/client/src/client-only-routes/show-certification.tsx
@@ -1,4 +1,3 @@
-import { Button } from '@freecodecamp/react-bootstrap';
 import { isEmpty } from 'lodash-es';
 import { QRCodeSVG } from 'qrcode.react';
 import React, { useEffect, useState } from 'react';
@@ -6,7 +5,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
 import { createSelector } from 'reselect';
-import { Container, Col, Row, Image } from '@freecodecamp/ui';
+import { Container, Col, Row, Image, Button } from '@freecodecamp/ui';
 
 import envData from '../../config/env.json';
 import { getLangCode } from '../../../shared/config/i18n';
@@ -238,8 +237,8 @@ const ShowCertification = (props: ShowCertificationProps): JSX.Element => {
     <div>
       <Button
         block={true}
-        bsSize='sm'
-        bsStyle='primary'
+        size='small'
+        variant='primary'
         onClick={hideDonationSection}
       >
         {t('buttons.close')}
@@ -296,8 +295,8 @@ const ShowCertification = (props: ShowCertificationProps): JSX.Element => {
       <Col xs={12}>
         <Button
           block={true}
-          bsSize='lg'
-          bsStyle='primary'
+          size='large'
+          variant='primary'
           href={`https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME&name=${urlFriendlyCertTitle}&organizationId=4831032&issueYear=${certYear}&issueMonth=${
             certMonth + 1
           }&certUrl=${certURL}`}
@@ -309,8 +308,8 @@ const ShowCertification = (props: ShowCertificationProps): JSX.Element => {
         <Spacer size='medium' />
         <Button
           block={true}
-          bsSize='lg'
-          bsStyle='primary'
+          size='large'
+          variant='primary'
           href={`https://twitter.com/intent/tweet?text=${t('profile.tweet', {
             certTitle: urlFriendlyCertTitle,
             certURL: certURL

--- a/client/src/components/settings/__snapshots__/honesty.test.tsx.snap
+++ b/client/src/components/settings/__snapshots__/honesty.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`<Honesty /> <Honesty /> snapshot when isHonest is false: Honesty 1`] = 
     settings.headings.honesty
   </SectionHeader>
   <FullWidthRow>
-    <p
+    <y
       className="honesty-panel"
     >
       <p>
@@ -42,7 +42,7 @@ exports[`<Honesty /> <Honesty /> snapshot when isHonest is false: Honesty 1`] = 
           </a>
         </Trans>
       </p>
-    </p>
+    </y>
     <Button
       active={false}
       aria-disabled={false}
@@ -66,7 +66,7 @@ exports[`<Honesty /> <Honesty /> snapshot when isHonest is true: HonestyAccepted
     settings.headings.honesty
   </SectionHeader>
   <FullWidthRow>
-    <p
+    <y
       className="honesty-panel"
     >
       <p>
@@ -100,7 +100,7 @@ exports[`<Honesty /> <Honesty /> snapshot when isHonest is true: HonestyAccepted
           </a>
         </Trans>
       </p>
-    </p>
+    </y>
     <Button
       active={false}
       aria-disabled={true}

--- a/tools/ui-components/src/index.ts
+++ b/tools/ui-components/src/index.ts
@@ -1,6 +1,6 @@
 // Use this file as the entry point for component export
 export { Alert, type AlertProps } from './alert';
-// export { Button } from './button';
+export { Button } from './button';
 export { CloseButton } from './close-button';
 export { Image } from './image';
 export { Table } from './table';


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Exports the Button component from `ui-components`
- Migrates the Button component on the Show Certification page
- Is split from https://github.com/freeCodeCamp/freeCodeCamp/pull/51443
- Is related to #52092

The font size and padding values of the `ui-components` Button are greater than the Bootstrap one, so the new buttons are larger compared to the old ones. This is because we changed the default font size (16px) set by browsers to 18px (in the `tools/ui-components/src/global-element-styles.css` file of https://github.com/freeCodeCamp/freeCodeCamp/pull/50465/files#diff-6f798c796a1046a87fe31ef9cafadaf2b84713b39e822eb77b55c67126269bb2R72), and the padding values were increased because they were implemented using the `rem` unit. 

The differences between the Bootstrap and the ui-components Button are:

| | Bootstrap | ui-components |
| --- | --- | --- |
| `font-size` | 23px | 24px |
| `line-height` | 30.6667px | 32px |
| `padding-bottom` | 10px | 11.25px |
| `padding-left` | 16px | 18px |
| `padding-right` | 16px | 18px |
| `padding-top` | 10px | 11.25px |

I'm not sure if we are okay with the new button size or we want to change it. IMHO, the change should be made to the root `font-size` (from 18px to 16px) rather than making Button overriding it, but I'm not 100% certain that this is a safe change.

(Btw, I went back to https://github.com/freeCodeCamp/freeCodeCamp/issues/45357 to check the proposed padding values, and confirmed that we wanted the padding to remain the same.)

## Steps to test

- Go to the Show Certification page. Example: http://localhost:8000/certification/certifieduser/javascript-algorithms-and-data-structures
- Check the "Add this certification to my LinkedIn profile" and "Share this certification on Twitter" buttons
- Check the close button in the donation section

## Screenshots

I don't think it's possible to compare the result with just images, but I'm adding them anyway.

| | Before | After |
| --- | --- | --- |
| Add / share buttons | <img width="1549" alt="Screenshot 2023-11-02 at 13 29 58" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/93be7b6a-284b-483a-ad87-f83c0a63ac50"> | <img width="1642" alt="Screenshot 2023-11-02 at 13 33 20" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/7ed35baa-d6a3-4e1f-9a47-6c82cc0320d0"> |
| Close button | <img width="405" alt="Screenshot 2023-11-02 at 14 28 46" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/ade66932-f0a8-4abc-bae3-36d76876a929"> | <img width="398" alt="Screenshot 2023-11-02 at 14 20 53" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/6f85a304-1ac4-46ae-a9a5-82e1ae485e80"> |

<!-- Feel free to add any additional description of changes below this line -->
