### PR TITLE
docs: mention the seed:exams command in the setup guide

### DIFF
--- a/docs/how-to-contribute-to-the-codebase.md
+++ b/docs/how-to-contribute-to-the-codebase.md
@@ -4,7 +4,7 @@ Ignoring these steps may soil your copy which makes the contributing, maintainin
 
 ## Contributing to the Codebase
 
-You can now make changes to files and commit your changes to your fork, which you can prepare by reading [how to set up freeCodeCamp](how-to-setup-freecodecamp-locally.md).
+You can now make changes to files and commit your changes to your fork, which you can prepare by reading [how to set up freeCodeCamp locally](how-to-setup-freecodecamp-locally.md).
 
 Follow these steps:
 

--- a/docs/how-to-contribute-to-the-codebase.md
+++ b/docs/how-to-contribute-to-the-codebase.md
@@ -4,7 +4,7 @@ Ignoring these steps may soil your copy which makes the contributing, maintainin
 
 ## Contributing to the Codebase
 
-You can now make changes to files and commit your changes to your fork, which you can prepare by reading [how to set up freecodecamp](how-to-setup-freecodecamp-locally.md).
+You can now make changes to files and commit your changes to your fork, which you can prepare by reading [how to set up freeCodeCamp](how-to-setup-freecodecamp-locally.md).
 
 Follow these steps:
 

--- a/docs/how-to-setup-freecodecamp-locally.md
+++ b/docs/how-to-setup-freecodecamp-locally.md
@@ -257,10 +257,11 @@ Next, let's seed the database. In this step, we run the below command that fills
 pnpm run seed
 ```
 
-By default, you will be signed in as a new user without any completed certifications. Run the following command if you need to develop with completed certifications:
+By default, you will be signed in as a new user without any completed certifications. Run the following commands if you need to develop with completed certifications:
 
 ```console
 pnpm run seed:certified-user
+pnpm run seed:exams
 ```
 
 > [!WARNING]
@@ -296,5 +297,6 @@ A quick reference to the commands that you will need when working locally.
 | `pnpm install`          | Installs / re-installs all dependencies and bootstraps the different services. |
 | `pnpm run seed`    | Creates authorized test users and inserts them into MongoDB.        |
 | `pnpm run seed:certified-user`    | Creates authorized test users with certifications fully completed, and inserts them into MongoDB.        |
+| `pnpm run seed:exams`    | Creates exams and inserts them into MongoDB.        |
 | `pnpm run develop` | Starts the freeCodeCamp API Server and Client Applications.                   |
 | `pnpm run clean`   | Uninstalls all dependencies and cleans up caches.                             |


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The `seed:exams` command is needed in order to develop and test courses that have exams. Without it, we will get the following error when we access an exam, even as a certified user:

<img width="1680" alt="Screenshot 2023-11-02 at 22 46 21" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/347b2c5f-1913-4ce3-9834-a8edcc2fdc66">

The command was added to our CI pipeline via https://github.com/freeCodeCamp/freeCodeCamp/pull/51842, and I'm now just mentioning it in the setup guide.

<!-- Feel free to add any additional description of changes below this line -->
