### PR TITLE
fix(UI): Prevent new quote generation on page click in FourOhFour page 

### DIFF
--- a/client/src/components/FourOhFour/index.tsx
+++ b/client/src/components/FourOhFour/index.tsx
@@ -1,6 +1,6 @@
 import { RouteComponentProps } from '@reach/router';
 import { Link } from 'gatsby';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Helmet from 'react-helmet';
 import { useTranslation } from 'react-i18next';
 
@@ -11,8 +11,12 @@ import { Spacer } from '../helpers';
 import './404.css';
 
 const FourOhFour = (_props: RouteComponentProps): JSX.Element => {
+  const [quote, setQuote] = useState(randomQuote());
   const { t } = useTranslation();
-  const quote = randomQuote();
+
+  useEffect(() => {
+    setQuote(randomQuote());
+  }, []);
 
   return (
     <div className='notfound-page-wrapper'>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Addresses only part of #52205:

- Generating a new quote on the 404 page when it is clicked or when the search box is focused.  The desired result is achieved without the useEffect as well. 

<!-- Feel free to add any additional description of changes below this line -->
