### PR TITLE
fix(curriculum): attribute validation to be order insensitive

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-intermediate-css-by-building-a-cat-painting/646c48df8674cf2b91020ecc.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-intermediate-css-by-building-a-cat-painting/646c48df8674cf2b91020ecc.md
@@ -20,7 +20,7 @@ assert.match(code, /<link/)
 Your `link` element should have a `rel` and `href` attribute set to `stylesheet` and `./styles.css`.
 
 ```js
-assert.match(code, /<link\s+(rel=("|'|`)stylesheet\2\s+href=("|'|`)\.\/styles\.css\3|href=("|'|`)\.\/styles\.css\4\s+rel=("|'|`)stylesheet\5)\s*\/?>/)
+assert.match(code, /<link\s+(rel=("|')stylesheet\2\s+href=("|')\.\/styles\.css\3|href=("|')\.\/styles\.css\4\s+rel=("|')stylesheet\5)\s*\/?>/)
 ```
 
 # --seed--

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-intermediate-css-by-building-a-cat-painting/646c48df8674cf2b91020ecc.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-intermediate-css-by-building-a-cat-painting/646c48df8674cf2b91020ecc.md
@@ -17,18 +17,11 @@ Your should have a `link` element.
 assert.match(code, /<link/)
 ```
 
-Your `link` element should have a `rel` attribute set to `stylesheet`.
+Your `link` element should have a `rel` and `href` attribute set to `stylesheet` and `./styles.css`.
 
 ```js
-assert.match(code, /<link\s+rel=("|'|`)stylesheet\1/)
+assert.match(code, /<link\s+(rel=("|'|`)stylesheet\2\s+href=("|'|`)\.\/styles\.css\3|href=("|'|`)\.\/styles\.css\4\s+rel=("|'|`)stylesheet\5)\s*\/?>/)
 ```
-
-Your `link` element should have an `href` attribute with the value `./styles.css`.
-
-```js
-assert.match(code, /<link\s+rel=("|'|`)stylesheet\1\s+href=\1\.\/styles\.css\1\s*\/?>/)
-```
-
 
 # --seed--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #52057

<!-- Feel free to add any additional description of changes below this line -->
Description:
The updated code makes sure that both rel and href are present but order doesnot matter.
