### PR TITLE
fix(curriculum): update border values to include medium

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fadb18058e950c73925279.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fadb18058e950c73925279.md
@@ -16,7 +16,7 @@ Remove the `border`, and add `2rem` of padding only to the top and bottom of eac
 You can use either a value of `none` or `0` to remove the `border`.
 
 ```js
-assert.match(new __helpers.CSSHelp(document).getStyle('fieldset')?.border, /(none)|(0px)/);
+assert.match(new __helpers.CSSHelp(document).getStyle('fieldset')?.border, /(none)|(0px)|(medium)/);
 ```
 
 You should add `padding` of `2rem` to the top and bottom of each `fieldset`.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.


Webkit/Safari reports border `medium` instead of `none` when setting `border: none`

Tested with Webkit using Playwright.

Forum: https://forum.freecodecamp.org/t/code-checker-issue-learn-html-forms-by-building-a-registration-form-step-46/648233