### PR TITLE
fix(curriculum): correct lesson wording registration-form step-28

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fab4a123ce4b04526b082b.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fab4a123ce4b04526b082b.md
@@ -9,7 +9,7 @@ dashedName: step-28
 
 Currently when someone submit the form, they can submit it without checking the radio inputs. Although you had used `required` attribute to indicate the the input is required previously, this can't work in this case, because adding required to both inputs, will convey the wrong information to the form users.
 
-To solve this, you can provide context of what is needed by adding `legend` element below the second `fieldset` with text `Account type (required)`, then add `checked` attribute to the `Personal` input to make sure that the form is submitted with the required data in it.
+To solve this, you can provide context of what is needed by adding a `legend` element below the second `label` with text `Account type (required)`, then add `checked` attribute to the `Personal` input to make sure that the form is submitted with the required data in it.
 
 # --hints--
 

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fab4a123ce4b04526b082b.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/60fab4a123ce4b04526b082b.md
@@ -9,7 +9,7 @@ dashedName: step-28
 
 Currently when someone submit the form, they can submit it without checking the radio inputs. Although you had used `required` attribute to indicate the the input is required previously, this can't work in this case, because adding required to both inputs, will convey the wrong information to the form users.
 
-To solve this, you can provide context of what is needed by adding a `legend` element below the second `label` with text `Account type (required)`, then add `checked` attribute to the `Personal` input to make sure that the form is submitted with the required data in it.
+To solve this, you can provide context of what is needed by adding a `legend` element with text `Account type (required)` before the `label` elements within the second `fieldset`. Then add the `checked` attribute to the `Personal` input to ensure the form is submitted with the required data in it.
 
 # --hints--
 


### PR DESCRIPTION
Correction to incorrect/confusing wording

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Currently the challege text is:

To solve this, you can provide context of what is needed by adding legend element below the second fieldset with text Account type (required)

and the code:
```
<fieldset>

        <label><input type="radio" name="account-type" checked/> Personal</label>
        <label><input type="radio" name="account-type" /> Business</label>
      </fieldset>
```

but it should read "below the second label" or "above the second fieldset"
