### PR TITLE
fix(e2e, playwright): stabilize page navigation in hotkeys.spec.ts

### DIFF
--- a/e2e/hotkeys.spec.ts
+++ b/e2e/hotkeys.spec.ts
@@ -35,11 +35,20 @@ test('User can interact with the app using the keyboard', async ({
 
   await page.keyboard.press('n');
   const nextCourse = '**/declare-javascript-variables';
+
   await page.waitForURL(nextCourse);
+  // Ensure that the page content is loaded before simulating user interactions.
+  await expect(
+    page.getByRole('heading', { name: 'Declare JavaScript Variables' })
+  ).toBeVisible();
 
   await page.keyboard.press('p');
   const previousCourse = '**/comment-your-javascript-code';
   await page.waitForURL(previousCourse);
+  // Ensure that the page content is loaded before simulating user interactions.
+  await expect(
+    page.getByRole('heading', { name: 'Comment Your JavaScript Code' })
+  ).toBeVisible();
 
   await page.keyboard.press('e');
   await expect(page.getByLabel(editorPaneLabel)).toBeFocused();

--- a/e2e/hotkeys.spec.ts
+++ b/e2e/hotkeys.spec.ts
@@ -35,7 +35,6 @@ test('User can interact with the app using the keyboard', async ({
 
   await page.keyboard.press('n');
   const nextCourse = '**/declare-javascript-variables';
-
   await page.waitForURL(nextCourse);
   // Ensure that the page content is loaded before simulating user interactions.
   await expect(


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR is an attempt to stabilize the navigation flows happen in `hotkeys.spec.ts`.

## Issue

CI failed on #51818 with the following error:

<img width="1111" alt="Screenshot 2023-11-06 at 14 04 17" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/7059b96e-0836-42ff-9d0a-e91635536279">

But the PR doesn't touch that file or any implementation logic.

I think the test is flaky as CI passed on that PR after I pushed a new change. I force-pushed so you can't see in the PR timeline, but here are the build logs:
- Failed: https://github.com/freeCodeCamp/freeCodeCamp/commit/e7d341495601f93089fa538770cc6847d26ae5aa
- Passed: https://github.com/freeCodeCamp/freeCodeCamp/commit/ac11e431c7cf38562e92ba376c2b75ba791a8128

The error is also odd because the navigation that `hotkeys.spec.ts` tries to simulate is just between 2 JS challenges: [Comment Your JavaScript Code](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-javascript/comment-your-javascript-code) and [Declare JavaScript Variables](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-javascript/declare-javascript-variables), so I'm not sure where the RWD navigation comes from.

Coincidentally in #51818 we were discussing how browsers handle navigation. My conclusion was that browsers can handle things differently behind the scene and we should only care about the user flows. So I looked into how to make the flows realistic and stable rather than diving into the rabbit hole, which brings me to the fix.

## Resolution

I'm not 100% sure if this is the right fix, but I'm giving it a try.

My fix here is just adding an element query after each navigation, to ensure that the navigation has completed and the page is loaded before we proceed with user interactions.

## Testing and Result

I ran `npx playwright hotkeys.spec.ts` multiple times and got the following result consistently:

<img width="720" alt="Screenshot 2023-11-06 at 13 51 23" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/526d43d3-1969-4a16-83b6-1e9263caed44">

- Tests consistently passed on Desktop Chrome and Firefox 
- Tests were skipped on Safari (due to a known issue)
- A test failed on Mobile Chrome
  - <img width="699" alt="Screenshot 2023-11-06 at 14 35 10" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/45c05aa8-1599-4a12-a43f-65bf6940a43a">
  - We will need to address this, but we aren't running mobile tests in CI, so this failure is less urgent. I'm deferring this until we get to #52198

<!-- Feel free to add any additional description of changes below this line -->
