### PR TITLE
fix: only run one previewChallengeSaga at once

### DIFF
--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -231,7 +231,7 @@ function* executeTests(testRunner, tests, testTimeout = 5000) {
 }
 
 // updates preview frame and the fcc console.
-function* previewChallengeSaga(action) {
+export function* previewChallengeSaga(action) {
   const flushLogs = action?.type !== actionTypes.previewMounted;
   yield delay(700);
 

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -231,7 +231,8 @@ function* executeTests(testRunner, tests, testTimeout = 5000) {
 }
 
 // updates preview frame and the fcc console.
-function* previewChallengeSaga({ flushLogs = true } = {}) {
+function* previewChallengeSaga(action) {
+  const flushLogs = action?.type !== actionTypes.previewMounted;
   yield delay(700);
 
   const isBuildEnabled = yield select(isBuildEnabledSelector);
@@ -296,13 +297,16 @@ function* previewChallengeSaga({ flushLogs = true } = {}) {
   }
 }
 
-function* updatePreviewSaga() {
+// TODO: refactor this so that we can use a single saga for all challenge
+// updates (then they can all go in the same `takeLatest` call and be cancelled
+// appropriately)
+function* updatePreviewSaga(action) {
   const challengeData = yield select(challengeDataSelector);
   if (challengeData.challengeType === challengeTypes.python) {
     yield updatePython(challengeData);
   } else {
     // all other challenges have to recreate the preview
-    yield previewChallengeSaga();
+    yield previewChallengeSaga(action);
   }
 }
 
@@ -345,12 +349,9 @@ export function createExecuteChallengeSaga(types) {
     takeLatest(types.executeChallenge, executeCancellableChallengeSaga),
     takeLatest(types.updateFile, updatePreviewSaga),
     takeLatest(
-      [types.challengeMounted, types.resetChallenge],
+      [types.challengeMounted, types.resetChallenge, types.previewMounted],
       previewChallengeSaga
     ),
-    takeLatest(types.previewMounted, previewChallengeSaga, {
-      flushLogs: false
-    }),
     takeLatest(types.projectPreviewMounted, previewProjectSolutionSaga)
   ];
 }

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.test.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.test.js
@@ -1,0 +1,44 @@
+import { expectSaga } from 'redux-saga-test-plan';
+
+jest.mock('redux-saga/effects', () => ({
+  ...jest.requireActual('redux-saga/effects'),
+  delay: jest.fn()
+}));
+
+const initialState = {
+  challenge: { isBuildEnabled: true, isExecuting: false, challengeMeta: {} }
+};
+
+// We're not testing the reducer here, so just return the initial state
+function reducer(state = initialState, _action) {
+  return state;
+}
+
+import { previewChallengeSaga } from './execute-challenge-saga';
+
+const challengeMounted = { type: 'challenge.challengeMounted' };
+const previewMounted = { type: 'challenge.previewMounted' };
+const resetChallenge = { type: 'challenge.resetChallenge' };
+
+describe('execute-challenge-saga', () => {
+  it('flushes logs on challengeMounted', () => {
+    return expectSaga(previewChallengeSaga, challengeMounted)
+      .withReducer(reducer)
+      .put({ type: 'challenge.initLogs' })
+      .silentRun();
+    // TODO: figure out why silentRun is necessary. Without it, we get timeout
+    // warnings. Increasing the timeout just makes the tests take longer.
+  });
+  it('flushes logs on reset', () => {
+    return expectSaga(previewChallengeSaga, resetChallenge)
+      .withReducer(reducer)
+      .put({ type: 'challenge.initLogs' })
+      .silentRun();
+  });
+  it('does not flush logs on previewMounted', () => {
+    return expectSaga(previewChallengeSaga, previewMounted)
+      .withReducer(reducer)
+      .not.put({ type: 'challenge.initLogs' })
+      .silentRun();
+  });
+});


### PR DESCRIPTION
takeLatest allows us to cancel already running sagas, meaning that less
time is wasted and effects that are triggered by the preview saga should
only be triggered once.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Ref: https://github.com/freeCodeCamp/freeCodeCamp/pull/51104
closes #50113

<!-- Feel free to add any additional description of changes below this line -->
