### PR TITLE
fix(UI): Improve help modal heading

### DIFF
--- a/client/src/templates/Challenges/components/help-modal.css
+++ b/client/src/templates/Challenges/components/help-modal.css
@@ -7,6 +7,12 @@
   padding-bottom: 10px;
 }
 
+.help-modal-heading {
+  line-height: 1.5;
+  font-weight: 400;
+  word-spacing: -0.4ch;
+}
+
 @media screen and (max-width: 767px) {
   .help-modal .btn-lg {
     font-size: 16px;

--- a/client/src/templates/Challenges/components/help-modal.tsx
+++ b/client/src/templates/Challenges/components/help-modal.tsx
@@ -64,7 +64,7 @@ function HelpModal({
         </Modal.Title>
       </Modal.Header>
       <Modal.Body className='help-modal-body text-center'>
-        <h3>
+        <h3 className='help-modal-heading'>
           <Trans i18nKey='learn.tried-rsa'>
             <a
               href={RSA}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #52273

<!-- Feel free to add any additional description of changes below this line -->

Made a few changes to the CSS for the help modal heading. It should improve the legibility and overall look of the text.

This might also help with #52233 but we may still need the changes from the open PR for that as well.

Edit: I forgot the add the images.

![help-modal-dark](https://github.com/freeCodeCamp/freeCodeCamp/assets/28780271/01b23f5e-b806-469f-8dbe-cb48235edf45)
![help-modal](https://github.com/freeCodeCamp/freeCodeCamp/assets/28780271/847415c7-b4d7-4bb4-a51c-12d310b51c5e)

---

An aside. I tried testing it with different languages but when switching the language it didn't apply the class and broke the CSS. I'm not sure what is going on but I have seen it happen before where the CSS is wonky in dev mode. Opening the browser dev tools seems to make it worse I have noticed. Not sure what is going on but I assume it is a caching issue or something.