### PR TITLE
feat(tools/challenge-editor): add challenge tools for working with English challenges

### DIFF
--- a/tools/challenge-editor/api/configs/super-block-list.ts
+++ b/tools/challenge-editor/api/configs/super-block-list.ts
@@ -74,5 +74,9 @@ export const superBlockList = [
   {
     name: 'Upcoming Python',
     path: '20-upcoming-python'
+  },
+  {
+    name: 'A2 English for Developers (Beta)',
+    path: '21-a2-english-for-developers'
   }
 ];

--- a/tools/challenge-editor/client/src/components/block/block.tsx
+++ b/tools/challenge-editor/client/src/components/block/block.tsx
@@ -4,6 +4,11 @@ import { ChallengeData } from '../../../interfaces/challenge-data';
 import { API_LOCATION } from '../../utils/handle-request';
 import './block.css';
 
+const stepBasedSuperblocks = [
+  '14-responsive-web-design-22',
+  '15-javascript-algorithms-and-data-structures-22'
+];
+
 const Block = () => {
   const [error, setError] = useState<Error | null>(null);
   const [loading, setLoading] = useState(false);
@@ -37,13 +42,19 @@ const Block = () => {
   if (loading) {
     return <div>Loading...</div>;
   }
+
+  const isStepBasedSuperblock = stepBasedSuperblocks.includes(
+    params.superblock
+  );
+
   return (
     <div>
       <h1>{params.block}</h1>
       <span className='breadcrumb'>{params.superblock}</span>
       <ul className='step-grid'>
-        {items.map(challenge => (
+        {items.map((challenge, i) => (
           <li key={challenge.name}>
+            {!isStepBasedSuperblock && <span>{`${i + 1}: `}</span>}
             <Link
               to={`/${params.superblock}/${params.block}/${challenge.path}`}
             >
@@ -57,12 +68,44 @@ const Block = () => {
       </p>
       <hr />
       <h2>Project Controls</h2>
-      <p>
-        Looking to add, remove, or edit steps?{' '}
-        <Link to={`/${params.superblock}/${params.block}/_tools`}>
-          Use the step tools.
-        </Link>
-      </p>
+      {isStepBasedSuperblock ? (
+        <p>
+          Looking to add, remove, or edit steps?{' '}
+          <Link to={`/${params.superblock}/${params.block}/_tools`}>
+            Use the step tools.
+          </Link>
+        </p>
+      ) : (
+        <>
+          <p>
+            Looking to add or remove challenges? Navigate to <br />
+            <code>
+              freeCodeCamp/curriculum/challenges/english
+              {`/${params.superblock}/${params.block}/`}
+            </code>
+            <br />
+            in your terminal and run the following commands:
+          </p>
+          <ul>
+            <li>
+              <code>pnpm create-next-challenge</code>: Create a new challenge at
+              the end of this block.
+            </li>
+            <li>
+              <code>pnpm insert-challenge</code>: Create a new challenge in the
+              middle of this block.
+            </li>
+            <li>
+              <code>pnpm delete-challenge</code>: Delete a challenge in this
+              block.
+            </li>
+          </ul>
+          <p>
+            Refresh the page after running a command to see the changes
+            reflected.
+          </p>
+        </>
+      )}
     </div>
   );
 };

--- a/tools/challenge-helper-scripts/helpers/get-challenge-template.ts
+++ b/tools/challenge-helper-scripts/helpers/get-challenge-template.ts
@@ -1,6 +1,10 @@
 /* eslint-disable @typescript-eslint/no-base-to-string */
 import ObjectID from 'bson-objectid';
 
+const sanitizeTitle = (title: string) => {
+  return title.includes(':') ? `"${title}"` : title;
+};
+
 export interface ChallengeOptions {
   challengeId: ObjectID;
   title: string;
@@ -15,7 +19,7 @@ const buildFrontMatter = ({
   challengeType
 }: ChallengeOptions) => `---
 id: ${challengeId.toString()}
-title: ${title}
+title: ${sanitizeTitle(title)}
 challengeType: ${challengeType}
 dashedName: ${dashedName}
 ---`;
@@ -28,9 +32,22 @@ const buildFrontMatterWithVideo = ({
 }: ChallengeOptions) => `---
 id: ${challengeId.toString()}
 videoId: ADD YOUR VIDEO ID HERE!!!
-title: ${title}
+title: ${sanitizeTitle(title)}
 challengeType: ${challengeType}
 dashedName: ${dashedName}
+---`;
+
+const buildFrontMatterWithAudio = ({
+  challengeId,
+  title,
+  dashedName,
+  challengeType
+}: ChallengeOptions) => `---
+id: ${challengeId.toString()}
+title: ${sanitizeTitle(title)}
+challengeType: ${challengeType}
+dashedName: ${dashedName}
+audioPath: Add the path to the audio file here. Or, delete this if you don't have audio.
 ---`;
 
 export const getLegacyChallengeTemplate = (
@@ -163,6 +180,77 @@ Answer 3
 1
 `;
 
+export const getMultipleChoiceChallengeTemplate = (
+  options: ChallengeOptions
+): string => `${buildFrontMatterWithAudio(options)}
+
+# --description--
+
+${options.title} description.
+
+# --question--
+
+## --text--
+
+${options.title} question?
+
+## --answers--
+
+Answer 1
+
+---
+
+Answer 2
+
+---
+
+Answer 3
+
+## --video-solution--
+
+1
+`;
+
+export const getFillInTheBlankChallengeTemplate = (
+  options: ChallengeOptions
+): string => `${buildFrontMatterWithAudio(options)}
+
+# --description--
+
+${options.title} description.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+\`Fill _ the _ sentence.\`
+
+## --blanks--
+
+\`in\`
+
+### --feedback--
+
+It's \`in\`
+
+---
+
+\`blank\`
+`;
+
+export const getDialogueChallengeTemplate = (
+  options: ChallengeOptions
+): string => `${buildFrontMatterWithVideo(options)}
+
+# --description--
+
+${options.title} description.
+
+## --assignment--
+
+${options.title} assignment!
+`;
+
 /**
  * This should be kept in parity with the challengeTypes in the
  * client.
@@ -192,5 +280,8 @@ export const challengeTypeToTemplate: {
   16: null,
   17: null,
   18: null,
-  19: null
+  19: getMultipleChoiceChallengeTemplate,
+  20: null,
+  21: getDialogueChallengeTemplate,
+  22: getFillInTheBlankChallengeTemplate
 };

--- a/tools/challenge-helper-scripts/helpers/get-challenge-template.ts
+++ b/tools/challenge-helper-scripts/helpers/get-challenge-template.ts
@@ -2,7 +2,7 @@
 import ObjectID from 'bson-objectid';
 
 const sanitizeTitle = (title: string) => {
-  return title.includes(':') ? `"${title}"` : title;
+  return title.includes(':') || title.includes("'") ? `"${title}"` : title;
 };
 
 export interface ChallengeOptions {


### PR DESCRIPTION
This adds a few things to the challenge editor and challenge helper scripts for the English challenges:

-A few new templates (used when creating challenges) for the new challenge types
-Adds instructions at the bottom of the block pages to create/delete challenges - for non-step-based superblocks. New RWD & JS still have the UI
-Adds numbers by the challenge titles on the block pages

To test:
-run `pnpm challenge-editor` from the `freeCodeCamp` folder
-go to `localhost:3300/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office`
-follow the instructions at the bottom to create/delete challenges
-after that, play around if you want - there's a few differences between step based superblocks and non-step based.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
