### PR TITLE
refactor(client): replace button in unsubscribed and report user pages

### DIFF
--- a/client/src/client-only-routes/show-unsubscribed.tsx
+++ b/client/src/client-only-routes/show-unsubscribed.tsx
@@ -1,9 +1,8 @@
-import { Button } from '@freecodecamp/react-bootstrap';
 import type { RouteComponentProps } from '@reach/router';
 import React from 'react';
 import Helmet from 'react-helmet';
 import { useTranslation } from 'react-i18next';
-import { Container, Panel } from '@freecodecamp/ui';
+import { Container, Panel, Button } from '@freecodecamp/ui';
 
 import envData from '../../config/env.json';
 import { Spacer } from '../components/helpers';
@@ -42,8 +41,8 @@ function ShowUnsubscribed({
             <FullWidthRow>
               <Button
                 block={true}
-                bsSize='lg'
-                bsStyle='primary'
+                size='large'
+                variant='primary'
                 href={`${apiLocation}/resubscribe/${unsubscribeId}`}
               >
                 {t('buttons.resubscribe')}

--- a/client/src/client-only-routes/show-user.tsx
+++ b/client/src/client-only-routes/show-user.tsx
@@ -1,4 +1,3 @@
-import { Button } from '@freecodecamp/react-bootstrap';
 import React, { useState } from 'react';
 import Helmet from 'react-helmet';
 import type { TFunction } from 'i18next';
@@ -11,7 +10,8 @@ import {
   ControlLabel,
   Panel,
   Col,
-  Row
+  Row,
+  Button
 } from '@freecodecamp/ui';
 
 import Login from '../components/Header/components/login';
@@ -131,7 +131,7 @@ function ShowUser({
                 value={textarea}
               />
             </FormGroup>
-            <Button block={true} bsStyle='primary' type='submit'>
+            <Button block={true} variant='primary' type='submit'>
               {t('report.submit')}
             </Button>
             <Spacer size='medium' />


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Replaces Bootstrap Button with `ui-components` Button in the Unsubscribed and Report User pages
- Is split from #51443
- Is related to #52092

## Screenshots

| Page | Result |
| --- | --- |
| `/unsubscribed/:id` | <img width="802" alt="Screenshot 2023-11-13 at 09 33 25" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/8f748356-e08b-420c-8e6d-5d686103b4b8"> |
| `/user/:username/report-user` | <img width="877" alt="Screenshot 2023-11-13 at 09 35 28" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/e6cb4289-db80-4712-996a-9658859cc150"> |

<!-- Feel free to add any additional description of changes below this line -->
