### PR TITLE
fix(client): spacing between sections

### DIFF
--- a/client/src/templates/Challenges/odin/show.tsx
+++ b/client/src/templates/Challenges/odin/show.tsx
@@ -287,11 +287,11 @@ class ShowOdin extends Component<ShowOdinProps, ShowOdinState> {
                       <source
                         src={`https://cdn.freecodecamp.org/${audioPath}`}
                         type='audio/mp3'
-                      ></source>
+                      />
                     </audio>
-                    <Spacer size='medium' />
                   </>
                 )}
+                <Spacer size='medium' />
                 <ObserveKeys>
                   {assignments.length > 0 && (
                     <>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

On C# and Algebra challenge pages, the spacing between the challenge description and the "Assignments" sections was accidentally removed (it was actually moved into a conditional rendering logic: https://github.com/freeCodeCamp/freeCodeCamp/pull/52201/files#diff-bb370cc5944ab162d94f9df7f4790bcdb94c07d706d5052a6d51da1cc7224effR292). This PR simply just adds the `Spacer` back.

## Testing

Tested on the following pages:
- `/learn/college-algebra-with-python/learn-ratios-and-proportions/introduction-to-college-algebra-with-python`
- `/learn/foundational-c-sharp-with-microsoft/write-your-first-code-using-c-sharp/perform-basic-string-formatting-in-c-sharp`

## Screenshots

| Before | After |
| --- | --- |
| <img width="819" alt="Screenshot 2023-11-13 at 11 01 29" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/4a860f6f-8770-46c8-85a3-279c3cc9805c"> | <img width="811" alt="Screenshot 2023-11-13 at 11 01 57" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/9a94d99d-8c0a-4578-b88e-1e77c54e39ac"> |

<!-- Feel free to add any additional description of changes below this line -->
