### PR TITLE
input clears after search

### DIFF
--- a/client/src/components/search/searchBar/search-bar-optimized.tsx
+++ b/client/src/components/search/searchBar/search-bar-optimized.tsx
@@ -20,6 +20,7 @@ const SearchBarOptimized = ({
     if (value && value.length > 1) {
       window.open(`${searchUrl}?query=${encodeURIComponent(value)}`, '_blank');
     }
+    setValue('');
   };
   const onClick = () => {
     setValue('');


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #52322

When we search on [news page](https://www.freecodecamp.org/news), the search field gets cleared on search. But, when we search on [home page](https://www.freecodecamp.org/) results will open on a separate tab "/news" with the search query and the origin tab still has the searched query.

This pull request resets the value in the search box after searching



<!-- Feel free to add any additional description of changes below this line -->
