### PR TITLE
fix(tools, cypress): skip failed updates test in firefox

### DIFF
--- a/cypress/e2e/default/learn/challenges/failed-updates.ts
+++ b/cypress/e2e/default/learn/challenges/failed-updates.ts
@@ -19,7 +19,7 @@ function getCompletedIds(completedChallenges: ChallengeData[]): string[] {
   return completedChallenges.map((challenge: ChallengeData) => challenge.id);
 }
 
-describe('failed update flushing', function () {
+describe('failed update flushing', { browser: 'chrome' }, function () {
   before(() => {
     cy.task('seed');
     cy.login();


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This seems to be the main flaky test on firefox. As a temporary fix, we can run it only in Chrome.