### PR TITLE
fix(scripts): arguments not working when seeding demo user

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "preseed": "npm-run-all create:shared",
     "playwright:install-build-tools": "cd ./e2e && npm i && npx playwright install && npx playwright install-deps",
     "playwright:install-build-tools-linux": "sh ./playwright-install.sh",
-    "seed": "cross-env DEBUG=fcc:* node ./tools/scripts/seed/seed-demo-user && pnpm seed:surveys && pnpm seed:exams",
+    "seed": "cross-env DEBUG=fcc:* && pnpm seed:surveys && pnpm seed:exams && node ./tools/scripts/seed/seed-demo-user",
     "seed:certified-user": "cross-env DEBUG=fcc:* node ./tools/scripts/seed/seed-demo-user certified-user && pnpm seed:surveys && pnpm seed:exams",
     "seed:exams": "cross-env DEBUG=fcc:* node tools/scripts/seed-exams/create-exams",
     "seed:surveys": "cross-env DEBUG=fcc:* node ./tools/scripts/seed/seed-surveys",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "preseed": "npm-run-all create:shared",
     "playwright:install-build-tools": "cd ./e2e && npm i && npx playwright install && npx playwright install-deps",
     "playwright:install-build-tools-linux": "sh ./playwright-install.sh",
-    "seed": "cross-env DEBUG=fcc:* && pnpm seed:surveys && pnpm seed:exams && node ./tools/scripts/seed/seed-demo-user",
+    "seed": "pnpm seed:surveys && pnpm seed:exams && cross-env DEBUG=fcc:* node ./tools/scripts/seed/seed-demo-user",
     "seed:certified-user": "cross-env DEBUG=fcc:* node ./tools/scripts/seed/seed-demo-user certified-user && pnpm seed:surveys && pnpm seed:exams",
     "seed:exams": "cross-env DEBUG=fcc:* node tools/scripts/seed-exams/create-exams",
     "seed:surveys": "cross-env DEBUG=fcc:* node ./tools/scripts/seed/seed-surveys",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "playwright:install-build-tools": "cd ./e2e && npm i && npx playwright install && npx playwright install-deps",
     "playwright:install-build-tools-linux": "sh ./playwright-install.sh",
     "seed": "pnpm seed:surveys && pnpm seed:exams && cross-env DEBUG=fcc:* node ./tools/scripts/seed/seed-demo-user",
-    "seed:certified-user": "cross-env DEBUG=fcc:* node ./tools/scripts/seed/seed-demo-user certified-user && pnpm seed:surveys && pnpm seed:exams",
+    "seed:certified-user": "pnpm seed:surveys && pnpm seed:exams && cross-env DEBUG=fcc:* node ./tools/scripts/seed/seed-demo-user certified-user",
     "seed:exams": "cross-env DEBUG=fcc:* node tools/scripts/seed-exams/create-exams",
     "seed:surveys": "cross-env DEBUG=fcc:* node ./tools/scripts/seed/seed-surveys",
     "serve:client": "cd ./client && pnpm run serve",


### PR DESCRIPTION
When we [added the surveys and exams to the seed script,](https://github.com/freeCodeCamp/freeCodeCamp/pull/52269) it broke the ability to pass arguments to the seed command. e.g. `pnpm seed --top-contributor` The command runs, but the arguments don't work. This changes the order the commands run so the arguments work.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
