### PR TITLE
fix(client): C# survey alert not showing in night mode

### DIFF
--- a/client/src/templates/Challenges/exam/components/foundational-c-sharp-survey-alert.tsx
+++ b/client/src/templates/Challenges/exam/components/foundational-c-sharp-survey-alert.tsx
@@ -1,8 +1,8 @@
-import { Button, Panel } from '@freecodecamp/react-bootstrap';
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
 import { useTranslation } from 'react-i18next';
+import { Panel, Button } from '@freecodecamp/ui';
 import { openModal } from '../../redux/actions';
 import Spacer from '../../../../components/helpers/spacer';
 import SurveyModal from './survey-modal';
@@ -25,17 +25,15 @@ function FoudationalCSharpSurveyAlert({
   const { t } = useTranslation();
 
   return (
-    <Panel data-cy='c-sharp-survey-alert' bsStyle='info'>
+    <Panel variant='info' data-cy='c-sharp-survey-alert'>
       <Panel.Heading>{t('survey.foundational-c-sharp.title')}</Panel.Heading>
       <Panel.Body className='text-center'>
         <p>{t('survey.misc.two-questions')}</p>
         <Spacer size='small' />
         <Button
           block={true}
-          bsSize='md'
-          bsStyle='info'
+          variant='info'
           data-cy='start-csharp-survey-btn'
-          className='btn-invert'
           onClick={openSurveyModal}
           type='button'
         >


### PR DESCRIPTION
I decided to just make a PR for this since I was looking into it. The fix was to replace react-bootstap with the component library.

To test:
-run `pnpm seed --seed-trophy-challenges` (note that this will not work ATM, add changes from [this PR to make this work](https://github.com/freeCodeCamp/freeCodeCamp/pull/52337/files))
-delete the `Survey` collection in mongo so the survey alert shows up
-go to `/learn/foundational-c-sharp-with-microsoft/foundational-c-sharp-with-microsoft-certification-exam/foundational-c-sharp-with-microsoft-certification-exam` to see the alert
-toggle night mode

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #52301

<!-- Feel free to add any additional description of changes below this line -->
