### PR TITLE
refactor(client): migrate button component in donation form

### DIFF
--- a/client/src/components/Donation/donate-completion.tsx
+++ b/client/src/components/Donation/donate-completion.tsx
@@ -1,8 +1,8 @@
-import { Button } from '@freecodecamp/react-bootstrap';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import Spinner from 'react-spinkit';
 import { Alert } from '@freecodecamp/ui';
+
 import { Spacer } from '../helpers';
 
 type DonateCompletionProps = {
@@ -57,11 +57,9 @@ function DonateCompletion({
       </div>
       <div className='donation-completion-buttons'>
         {error && (
-          <div>
-            <Button bsStyle='primary' onClick={reset}>
-              {t('buttons.try-again')}
-            </Button>
-          </div>
+          <button type='button' className='try-again-button' onClick={reset}>
+            {t('buttons.try-again')}
+          </button>
         )}
       </div>
     </Alert>

--- a/client/src/components/Donation/donate-form.tsx
+++ b/client/src/components/Donation/donate-form.tsx
@@ -6,7 +6,6 @@ import { connect } from 'react-redux';
 import Spinner from 'react-spinkit';
 import { createSelector } from 'reselect';
 import type { TFunction } from 'i18next';
-import { Button } from '@freecodecamp/react-bootstrap';
 
 import {
   defaultDonation,
@@ -222,9 +221,13 @@ class DonateForm extends Component<DonateFormProps, DonateFormComponentState> {
           usd: formattedAmountLabel(donationAmount)
         })}
 
-        <Button bsStyle='primary' className='btn-link' onClick={editAmount}>
+        <button
+          type='button'
+          className='edit-amount-button'
+          onClick={editAmount}
+        >
           {t('donate.edit-amount')}
-        </Button>
+        </button>
       </>
     );
 

--- a/client/src/components/Donation/donation-modal.tsx
+++ b/client/src/components/Donation/donation-modal.tsx
@@ -1,4 +1,4 @@
-import { Modal, Button } from '@freecodecamp/react-bootstrap';
+import { Modal } from '@freecodecamp/react-bootstrap';
 import { Col, Row } from '@freecodecamp/ui';
 import { WindowLocation } from '@reach/router';
 import React, { useEffect, useState } from 'react';
@@ -97,15 +97,13 @@ function CloseButtonRow({
   return (
     <Row>
       <Col sm={4} smOffset={4} xs={8} xsOffset={2}>
-        <Button
-          bsSize='sm'
-          bsStyle='primary'
-          className='btn-link close-button'
+        <button
+          className='close-button'
+          type='button'
           onClick={closeDonationModal}
-          tabIndex='0'
         >
           {donationAttempted ? t('buttons.close') : t('buttons.ask-later')}
-        </Button>
+        </button>
       </Col>
     </Row>
   );

--- a/client/src/components/Donation/donation.css
+++ b/client/src/components/Donation/donation.css
@@ -651,7 +651,6 @@ a.patreon-button:hover {
   border-radius: 0;
   border: 3px solid var(--blue70);
   padding: 6px 12px;
-  margin-bottom: 0;
 }
 .try-again-button:focus,
 .try-again-button:hover,

--- a/client/src/components/Donation/donation.css
+++ b/client/src/components/Donation/donation.css
@@ -485,6 +485,13 @@ button.confirm-donation-btn:hover {
   background-color: #f2ba38;
   border-color: #f2ba38;
 }
+button.confirm-donation-btn:disabled {
+  cursor: not-allowed;
+  background-color: var(--quaternary-background);
+  border-color: var(--quaternary-color);
+  color: var(--quaternary-color);
+  opacity: 0.65;
+}
 
 a.patreon-button {
   border-radius: 5px;

--- a/client/src/components/Donation/donation.css
+++ b/client/src/components/Donation/donation.css
@@ -305,11 +305,28 @@ li.disabled > a {
   justify-content: space-between;
 }
 
+/* 
+ * We currently cannot reuse the Button component from `ui-components`
+ * and are using the native `<button>` with custom CSS.
+ * This implementation is temporary until we can find a solution for this button use case.
+ * Ref: https://github.com/freeCodeCamp/freeCodeCamp/issues/52349
+ */
 .close-button {
   text-align: center;
   margin: 0 auto;
   display: block;
   padding: 0 10px;
+  font-weight: normal;
+  background-color: transparent;
+  border: 0;
+  text-decoration-line: underline;
+  /* This is required in order to improve text readability in Arabic */
+  text-underline-position: under;
+}
+.close-button:hover {
+  text-decoration-line: none;
+  background-color: var(--quaternary-background);
+  color: var(--quaternary-color);
 }
 
 .donation-modal h2 {
@@ -456,13 +473,19 @@ button.confirm-donation-btn {
   display: inline-flex;
   align-items: center;
 }
+button.confirm-donation-btn:focus,
 button.confirm-donation-btn:active,
-button.confirm-donation-btn:active:focus,
+button.confirm-donation-btn:active:focus {
+  background-color: var(--quaternary-background);
+  border-color: var(--secondary-color);
+  color: var(--secondary-color);
+}
 button.confirm-donation-btn:hover {
   color: black;
   background-color: #f2ba38;
   border-color: #f2ba38;
 }
+
 a.patreon-button {
   border-radius: 5px;
   background-color: #ff424d;
@@ -498,9 +521,26 @@ a.patreon-button:hover {
   display: none;
 }
 
-.donation-modal .btn-link:disabled {
-  opacity: 0;
-  cursor: default;
+/* 
+ * We currently cannot reuse the Button component from `ui-components`
+ * and are using the native `<button>` with custom CSS.
+ * This implementation is temporary until we can find a solution for this button use case.
+ * Ref: https://github.com/freeCodeCamp/freeCodeCamp/issues/52349
+ */
+.edit-amount-button {
+  font-weight: normal;
+  background-color: transparent;
+  border: 0;
+  text-decoration-line: underline;
+  /* This is required in order to improve text readability in Arabic */
+  text-underline-position: under;
+  padding: 0;
+}
+
+.edit-amount-button:hover {
+  text-decoration-line: none;
+  background-color: var(--quaternary-background);
+  color: var(--quaternary-color);
 }
 
 .donate-btn-group {
@@ -597,4 +637,26 @@ a.patreon-button:hover {
 
 .confirm-donation-btn svg.svg-inline--fa.fa-lock {
   margin-bottom: 2px;
+}
+
+/* 
+ * We currently cannot reuse the Button component from `ui-components`
+ * and are using the native `<button>` with custom CSS.
+ * This implementation is temporary until we can find a solution for this button use case.
+ * Ref: https://github.com/freeCodeCamp/freeCodeCamp/issues/52349
+ */
+.try-again-button {
+  background-color: var(--blue05);
+  color: var(--blue70);
+  border-radius: 0;
+  border: 3px solid var(--blue70);
+  padding: 6px 12px;
+  margin-bottom: 0;
+}
+.try-again-button:focus,
+.try-again-button:hover,
+.try-again-button:active {
+  color: var(--blue05);
+  background-color: var(--blue70);
+  border-color: var(--blue70);
 }

--- a/client/src/components/Donation/multi-tier-donation-form.tsx
+++ b/client/src/components/Donation/multi-tier-donation-form.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import { Button } from '@freecodecamp/react-bootstrap';
 import {
   Tabs,
   TabsContent,
@@ -89,16 +88,14 @@ function SelectionTabs({
             );
           })}
         </Tabs>
-        <Button
-          block={true}
-          bsStyle='primary'
+        <button
           className='text-center confirm-donation-btn donate-btn-group'
           type='submit'
           data-cy='donation-tier-selection-button'
           onClick={() => setShowDonateForm(true)}
         >
           {t('buttons.donate')}
-        </Button>
+        </button>
         <Spacer size='medium' />
       </Col>
     </Row>

--- a/client/src/components/Donation/stripe-card-form.tsx
+++ b/client/src/components/Donation/stripe-card-form.tsx
@@ -1,4 +1,3 @@
-import { Button } from '@freecodecamp/react-bootstrap';
 import {
   CardNumberElement,
   CardExpiryElement,
@@ -158,16 +157,14 @@ const StripeCardForm = ({
       <div className={'form-status'}>
         {!isSubmissionValid && <p>{t('donate.valid-card')}</p>}
       </div>
-      <Button
-        block={true}
-        bsStyle='primary'
+      <button
         className='confirm-donation-btn'
         disabled={!stripe || !elements || isSubmitting}
         data-cy='donation-confirmation-button'
         type='submit'
       >
         {t('buttons.donate')}
-      </Button>
+      </button>
     </form>
   );
 };


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Migrates Button component in the donation form
- Closes #52349
- Is related to #52092

The issue thread is quite long, so TL;DR: the styling of buttons in the donation form don't match `ui-components`, so instead of replacing the Bootstrap `Button`s with ours and risking CSS collisions, I'm temporarily swapping the buttons with the native `<button>` element to keep the migration moving. We will revisit the component library and clean these up once we know what to do with the one-off components in /learn.

**Notes for reviewers:** I tend to talk a lot on PR, and it's not fair that you have to resolve my self-review comments. So just leave your approval if the PR looks good, I can clear those comments and merge the PR myself 🙂 

## Testing

- Set the `show` prop of `DonationModal` to `true` so that the modal shows up
  - https://github.com/freeCodeCamp/freeCodeCamp/blob/124bf1464039081ac3653716764a65ef9cc28d42/client/src/components/Donation/donation-modal.tsx#L153
- Tweak the rendering logic of `components/Donation/donate-form.tsx` to render the part that you want to test

## Screenshots

### Desktop

<details>
  <summary>Desktop screenshots</summary>

| Button | State | Light | Dark |
| --- | --- | --- | --- |
| Donation | at rest | <img width="922" alt="Screenshot 2023-11-15 at 01 16 06" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/ed31a1d7-e034-4ba3-a28a-24d158af1021"> | <img width="925" alt="Screenshot 2023-11-15 at 01 05 21" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/88bfc0e7-93a6-4e13-aefc-326e9a0c5db5"> |
| Donation | hovered | <img width="925" alt="Screenshot 2023-11-15 at 01 18 29" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/f1ab20b9-552d-49ec-a093-510b98efddbc"> | <img width="923" alt="Screenshot 2023-11-15 at 01 05 36" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/dc2737d3-65bf-46b9-ace7-0b07d9eae949"> |
| Donation | focused | <img width="921" alt="Screenshot 2023-11-15 at 01 23 11" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/5b3a2b55-f67c-409b-833d-a60dfee8ec02"> | <img width="924" alt="Screenshot 2023-11-15 at 01 15 05" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/10b7971d-ed52-4474-b3fe-f5bac28fc68a"> |
| Edit amount | at rest | <img width="918" alt="Screenshot 2023-11-15 at 01 31 47" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/2aaf2446-e9e0-45ea-91f2-32808140320f"> | <img width="920" alt="Screenshot 2023-11-15 at 01 29 13" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/43104acf-0f59-4220-9890-e817488cfadf"> |
| Edit amount | hovered | <img width="920" alt="Screenshot 2023-11-15 at 01 31 54" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/98bff117-e0ab-4add-af6d-8ea6bf9feb96"> | <img width="915" alt="Screenshot 2023-11-15 at 01 29 19" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/33e44c22-88b1-4abd-8c8b-3daa90af973d"> |
| Edit amount | focused | <img width="921" alt="Screenshot 2023-11-15 at 01 32 07" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/a70379f7-ac03-41a8-9e7f-3afe3058e3d9"> | <img width="922" alt="Screenshot 2023-11-15 at 01 29 27" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/17c57156-2824-4558-8ba2-92949905470c"> |
| Close / Ask me later | at rest | <img width="922" alt="Screenshot 2023-11-15 at 01 16 06" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/9cfa0a33-ae77-47ad-94ed-c370eaf0f299"> | <img width="925" alt="Screenshot 2023-11-15 at 01 05 21" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/44a69ba5-5db1-4aa5-9594-aaa51b9a7a70"> |
| Close / Ask me later | hovered | <img width="929" alt="Screenshot 2023-11-15 at 01 26 18" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/360739da-b5bb-4030-9971-856d01cb907f"> | <img width="919" alt="Screenshot 2023-11-15 at 01 27 34" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/3822dce7-39a7-400b-a6bb-b5141282bbd4"> |
| Close / Ask me later | focused | <img width="929" alt="Screenshot 2023-11-15 at 01 26 18" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/c933be10-22a9-4e0f-bc81-d07de0e6cb30"> | <img width="926" alt="Screenshot 2023-11-15 at 01 27 26" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/1da4462f-7eec-47e3-9c13-676bc48108e4"> |
| Try again | at rest | <img width="918" alt="Screenshot 2023-11-15 at 01 34 28" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/98ccde7f-8fd7-4745-aff1-80c48fd22980"> | <img width="918" alt="Screenshot 2023-11-15 at 01 36 27" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/81dcb274-5e47-4d8a-85bb-4954d63a9bb9"> |
| Try again | hovered | <img width="912" alt="Screenshot 2023-11-15 at 01 34 37" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/e3aa55ed-a35f-48ea-87b4-aad29d82cf6e"> | <img width="917" alt="Screenshot 2023-11-15 at 01 36 33" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/ff786a19-28cf-4aa0-be04-2543204854fa"> |
| Try again | focused | <img width="914" alt="Screenshot 2023-11-15 at 01 34 46" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/c909242a-d4db-45e6-b26a-ff9bdad40fb7"> | <img width="915" alt="Screenshot 2023-11-15 at 01 36 41" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/21788864-ba34-4b1b-bc2a-4a1f43821352"> |
</details>

### Mobile
I only checked if the buttons are still displayed properly here.

<details>
  <summary>Mobile screenshots</summary>

| Screen | Screenshot |
| --- | --- |
| tier selection | <img width="452" alt="Screenshot 2023-11-15 at 01 40 54" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/9428f10b-dbb4-43ff-b889-bfe41141534e"> |
| payment method selection | <img width="439" alt="Screenshot 2023-11-15 at 01 47 21" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/ab989542-dcdb-41b9-8263-8ea3cda640ab"> |
| error | <img width="461" alt="Screenshot 2023-11-15 at 01 39 36" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/11620b24-760c-40a1-96d1-2b5b86a33c26"> |
</details>

<!-- Feel free to add any additional description of changes below this line -->
