### PR TITLE
feat: warn mobile team if challenge schema updated

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,5 +51,5 @@ pnpm-lock.yaml
 # Files that need attention from the mobile team
 # -------------------------------------------------
 
-/curriculum/schema/challenge-schema.js @freeCodeCamp/mobile
-/client/src/redux/prop-types.ts @freeCodeCamp/mobile
+/curriculum/schema/challenge-schema.js @freeCodeCamp/dev-team @freeCodeCamp/mobile
+/client/src/redux/prop-types.ts @freeCodeCamp/dev-team @freeCodeCamp/mobile

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -46,3 +46,9 @@ pnpm-lock.yaml
 
 # i18n Quotes
 **/motivation.json @freeCodeCamp/staff @freeCodeCamp/i18n
+
+# -------------------------------------------------
+# Files that need attention from the mobile team
+# -------------------------------------------------
+
+/curriculum/schema/challenge-schema.js

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,4 +51,4 @@ pnpm-lock.yaml
 # Files that need attention from the mobile team
 # -------------------------------------------------
 
-/curriculum/schema/challenge-schema.js
+/curriculum/schema/challenge-schema.js @freeCodeCamp/mobile

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -52,3 +52,4 @@ pnpm-lock.yaml
 # -------------------------------------------------
 
 /curriculum/schema/challenge-schema.js @freeCodeCamp/mobile
+/client/src/redux/prop-types.ts @freeCodeCamp/mobile

--- a/curriculum/schema/__snapshots__/challenge-schema.test.js.snap
+++ b/curriculum/schema/__snapshots__/challenge-schema.test.js.snap
@@ -1,0 +1,172 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`challenge schema Notify mobile team BEFORE updating snapshot 1`] = `
+"const Joi = require('joi');
+Joi.objectId = require('joi-objectid')(Joi);
+
+const { challengeTypes } = require('../../shared/config/challenge-types');
+
+const slugRE = new RegExp('^[a-z0-9-]+$');
+const slugWithSlashRE = new RegExp('^[a-z0-9-/]+$');
+
+const fileJoi = Joi.object().keys({
+  fileKey: Joi.string(),
+  ext: Joi.string(),
+  name: Joi.string(),
+  editableRegionBoundaries: [Joi.array().items(Joi.number())],
+  path: Joi.string(),
+  error: Joi.valid(null),
+  head: Joi.string().allow(''),
+  tail: Joi.string().allow(''),
+  seed: Joi.string().allow(''),
+  contents: Joi.string().allow(''),
+  id: Joi.string().allow(''),
+  history: Joi.array().items(Joi.string().allow(''))
+});
+
+const prerequisitesJoi = Joi.object().keys({
+  id: Joi.objectId().required(),
+  title: Joi.string().required()
+});
+
+const schema = Joi.object()
+  .keys({
+    audioPath: Joi.string(),
+    block: Joi.string().regex(slugRE).required(),
+    blockId: Joi.objectId(),
+    challengeOrder: Joi.number(),
+    removeComments: Joi.bool().required(),
+    certification: Joi.string().regex(slugRE),
+    challengeType: Joi.number().min(0).max(22).required(),
+    checksum: Joi.number(),
+    // TODO: require this only for normal challenges, not certs
+    dashedName: Joi.string().regex(slugRE),
+    description: Joi.when('challengeType', {
+      is: [
+        challengeTypes.step,
+        challengeTypes.video,
+        challengeTypes.fillInTheBlank
+      ],
+      then: Joi.string().allow(''),
+      otherwise: Joi.string().required()
+    }),
+    disableLoopProtectTests: Joi.boolean().required(),
+    disableLoopProtectPreview: Joi.boolean().required(),
+    challengeFiles: Joi.array().items(fileJoi),
+    guideUrl: Joi.string().uri({ scheme: 'https' }),
+    hasEditableBoundaries: Joi.boolean(),
+    helpCategory: Joi.valid(
+      'JavaScript',
+      'HTML-CSS',
+      'Python',
+      'Backend Development',
+      'C-Sharp'
+    ),
+    videoUrl: Joi.string().allow(''),
+    fillInTheBlank: Joi.object().keys({
+      sentence: Joi.string().required(),
+      blanks: Joi.array()
+        .items(
+          Joi.object().keys({
+            answer: Joi.string().required(),
+            feedback: Joi.string().allow(null)
+          })
+        )
+        .required()
+    }),
+    forumTopicId: Joi.number(),
+    id: Joi.objectId().required(),
+    instructions: Joi.string().allow(''),
+    isComingSoon: Joi.bool(),
+    isLocked: Joi.bool(),
+    isPrivate: Joi.bool(),
+    msTrophyId: Joi.when('challengeType', {
+      is: [challengeTypes.msTrophy],
+      then: Joi.string().required()
+    }),
+    notes: Joi.string().allow(''),
+    order: Joi.number(),
+    prerequisites: Joi.when('challengeType', {
+      is: [challengeTypes.exam],
+      then: Joi.array().items(prerequisitesJoi)
+    }),
+    // video challenges only:
+    videoId: Joi.when('challengeType', {
+      is: [challengeTypes.video, challengeTypes.dialogue],
+      then: Joi.string().required()
+    }),
+    videoLocaleIds: Joi.when('challengeType', {
+      is: challengeTypes.video,
+      then: Joi.object().keys({
+        espanol: Joi.string(),
+        italian: Joi.string(),
+        portuguese: Joi.string()
+      })
+    }),
+    bilibiliIds: Joi.when('challengeType', {
+      is: challengeTypes.video,
+      then: Joi.object().keys({
+        aid: Joi.number().required(),
+        bvid: Joi.string().required(),
+        cid: Joi.number().required()
+      })
+    }),
+    question: Joi.object().keys({
+      text: Joi.string().required(),
+      answers: Joi.array()
+        .items(
+          Joi.object().keys({
+            answer: Joi.string().required(),
+            feedback: Joi.string().allow(null)
+          })
+        )
+        .required(),
+      solution: Joi.number().required()
+    }),
+    required: Joi.array().items(
+      Joi.object().keys({
+        link: Joi.string(),
+        raw: Joi.bool(),
+        src: Joi.string(),
+        crossDomain: Joi.bool()
+      })
+    ),
+    assignments: Joi.when('challengeType', {
+      is: challengeTypes.dialogue,
+      then: Joi.array().items(Joi.string()).required(),
+      otherwise: Joi.array().items(Joi.string())
+    }),
+    solutions: Joi.array().items(Joi.array().items(fileJoi).min(1)),
+    superBlock: Joi.string().regex(slugWithSlashRE),
+    superOrder: Joi.number(),
+    suborder: Joi.number(),
+    tests: Joi.array().items(
+      // public challenges
+      Joi.object().keys({
+        id: Joi.string().allow(''),
+        text: Joi.string().required(),
+        testString: Joi.string().allow('').required()
+      }),
+      // our tests used in certification verification
+      Joi.object().keys({
+        id: Joi.string().required(),
+        title: Joi.string().required()
+      })
+    ),
+    template: Joi.string().allow(''),
+    time: Joi.string().allow(''),
+    title: Joi.string().required(),
+    translationPending: Joi.bool().required(),
+    url: Joi.when('challengeType', {
+      is: [challengeTypes.codeAllyPractice, challengeTypes.codeAllyCert],
+      then: Joi.string().required()
+    }),
+    usesMultifileEditor: Joi.boolean()
+  })
+  .xor('helpCategory', 'isPrivate');
+
+exports.challengeSchemaValidator = () => {
+  return challenge => schema.validate(challenge);
+};
+"
+`;

--- a/curriculum/schema/challenge-schema.test.js
+++ b/curriculum/schema/challenge-schema.test.js
@@ -1,0 +1,13 @@
+const { readFileSync } = require('fs');
+const path = require('path');
+
+describe('challenge schema', () => {
+  it('Notify mobile team BEFORE updating snapshot', () => {
+    const schemaFile = readFileSync(
+      path.resolve(__dirname, './challenge-schema.js'),
+      'utf8'
+    );
+
+    expect(schemaFile).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This adds a couple of hurdles that should make it harder for us to accidentally change the challenge schema, before the mobile team are read for those changes.

<!-- Feel free to add any additional description of changes below this line -->
