### PR TITLE
fix(ui-components): improve text readability in Arabic

### DIFF
--- a/client/src/components/layouts/global.css
+++ b/client/src/components/layouts/global.css
@@ -156,6 +156,7 @@ p {
 a {
   color: inherit;
   text-decoration: underline;
+  /* This is required in order to improve text readability in Arabic */
   text-underline-position: under;
 }
 

--- a/tools/ui-components/src/normalize.css
+++ b/tools/ui-components/src/normalize.css
@@ -39,6 +39,14 @@ template {
 }
 a {
   background-color: transparent;
+  text-decoration: underline;
+  /* This is required in order to improve text readability in Arabic */
+  text-underline-position: under;
+}
+@supports not (text-underline-position: under) {
+  a {
+    text-underline-offset: 1em;
+  }
 }
 abbr[title] {
   border-bottom: 1px dotted;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

We previously had an issue with text readability in Arabic (#49453), and the fix was made to `client/src/components/layouts/global.css`. I'm now applying the same change to the `ui-components` library to ensure the display is consistent.

## Testing
Tested on Storybook and confirmed that:
- The `Link` component has the change applied
- `<a>` element rendered in the `Button` and `Dropdown` components is not affected (we want the link to look like a button in these cases, and the link doesn't have an underline)

## Screenshots

### `Link`

| Before | After |
| --- | --- |
| <img width="194" alt="Screenshot 2023-11-15 at 23 16 10" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/fa112a9c-6534-4326-a115-4d62e6ff8d55"> | <img width="190" alt="Screenshot 2023-11-15 at 23 20 21" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/8c9e0e08-8f46-4cf0-90aa-aa838623f97e"> |

### `Button` and `Dropdown`

| Button | Dropdown |
| --- | --- |
| <img width="308" alt="Screenshot 2023-11-15 at 23 22 05" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/ae64d93d-8640-456d-90b3-364d713a40bd"> | <img width="240" alt="Screenshot 2023-11-15 at 23 22 13" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/25715018/d552b84a-2e3c-4a09-9ce1-3c5e1fb4852e"> |

<!-- Feel free to add any additional description of changes below this line -->
