### PR TITLE
fix(curriculum): cleaning up grammar and adding missing explanations for todo app project

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4e78a7ea4a168de4e6a38.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4e78a7ea4a168de4e6a38.md
@@ -27,7 +27,7 @@ Your event listener should listen for a `click` event.
 assert.match(code, /openTaskFormBtn\.addEventListener\(('|"|`)click\1/)
 ```
 
-Your event listener should include a callback function for the second argument using arrow syntax without curly braces. Then you should use the `classList` property and it's `toggle` method on the `taskForm`, to toggle the class `hidden`. 
+Your event listener should include a callback function for the second argument using arrow syntax without curly braces. Then you should use the `classList` property and its `toggle` method on the `taskForm`, to toggle the class `hidden`. 
 
 ```js
 assert.match(code, /openTaskFormBtn\.addEventListener\(('|"|`)click\1\,\s*\(\)\s*\s*=>\s*taskForm\.classList\.toggle\(\1hidden\1\)\s*\);?/)

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4e78a7ea4a168de4e6a38.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64e4e78a7ea4a168de4e6a38.md
@@ -9,7 +9,7 @@ dashedName: step-6
 
 Now, you will work on opening and closing the form modal.
 
-Add a `click` event listener to the `openTaskFormBtn` variable, and then use `classList` to toggle the `hidden` class on the `taskForm` element.
+Add a `click` event listener to the `openTaskFormBtn` variable, and then use `classList` to toggle the `hidden` class on the `taskForm` element. Make sure not to include curly braces in your arrow function.
 
 Now you can click on the "Add new Task" button and see the form modal.
 
@@ -27,7 +27,7 @@ Your event listener should listen for a `click` event.
 assert.match(code, /openTaskFormBtn\.addEventListener\(('|"|`)click\1/)
 ```
 
-Your event listener should use arrow syntax, then use `classList` property and it's `toggle` method on the `taskForm`, to toggle the class `hidden`. Don't use curly braces.
+Your event listener should include a callback function for the second argument using arrow syntax without curly braces. Then you should use the `classList` property and it's `toggle` method on the `taskForm`, to toggle the class `hidden`. 
 
 ```js
 assert.match(code, /openTaskFormBtn\.addEventListener\(('|"|`)click\1\,\s*\(\)\s*\s*=>\s*taskForm\.classList\.toggle\(\1hidden\1\)\s*\);?/)

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/650300a25b6f72964ab8aca6.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/650300a25b6f72964ab8aca6.md
@@ -7,7 +7,13 @@ dashedName: step-13
 
 # --description--
 
-To make the `id` more unique, add another hyphen and use `Date.now()`.
+To make the `id` more unique, add another hyphen and use <dfn>Date.now()</dfn>.
+
+`Date.now()` returns the number of milliseconds elapsed since January 1, 1970 00:00:00 UTC.
+
+```js
+console.log(Date.now()); // 1628586800000
+```
 
 # --hints--
 


### PR DESCRIPTION
## Summary of changes

- Step 6:  I updated the grammar for the hint text 
- Step 13: `Date.now()` was not explained so I added a brief explanation with a code example. 


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
