### PR TITLE
fix(curriculum): 6537e0be715fcb57d31ba8c3 assertions

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/6537e0be715fcb57d31ba8c3.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-html-forms-by-building-a-registration-form/6537e0be715fcb57d31ba8c3.md
@@ -17,13 +17,17 @@ Well done! You have completed the final part of the _Registration Form_ practice
 You should use an `a` element selector.
 
 ```js
-assert.exists(new __helpers.CSSHelp(document).getStyle('a'));
+const cssHelp = new __helpers.CSSHelp(document);
+const selectors = cssHelp.selectorsFromSelector('a');
+assert.exists(cssHelp.getStyleAny(selectors));
 ```
 
 You should give the `a` element a `color` of `#dfdfe2`.
 
 ```js
-assert.equal(new __helpers.CSSHelp(document).getStyle('a')?.color, 'rgb(223, 223, 226)');
+const cssHelp = new __helpers.CSSHelp(document);
+const selectors = cssHelp.selectorsFromSelector('a');
+assert.equal(cssHelp.getStyleAny(selectors)?.color, 'rgb(223, 223, 226)');
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #52381 

<!-- Feel free to add any additional description of changes below this line -->
In Step 65 of the _Learn HTML Forms by Building a Registration Form_ course, multiple CSS selectors are valid, but only one is currently accepted.

I changed the assertions to test for all valid CSS selectors using two new methods, which I'll add [in another PR](https://github.com/freeCodeCamp/curriculum-helpers/pull/96).