### PR TITLE
fix(curriculum): allow whitespace in attr declarations

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f331e55dfab7a896e53c3a1.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f331e55dfab7a896e53c3a1.md
@@ -22,13 +22,13 @@ assert(code.match(/<meta.*?\/?>/is));
 Your `meta` tag should have a `charset` attribute.
 
 ```js
-assert(code.match(/<meta charset=/i));
+assert(code.match(/<meta\s+charset\s*=/i));
 ```
 
 Your `charset` attribute should have a value of `utf-8`.
 
 ```js
-assert(code.match(/charset=('|")utf-8\1/i));
+assert(code.match(/charset\s*=\s*('|")utf-8\1/i));
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Allows valid syntax like this to pass:

```html
<meta charset = "utf8" />
```

HTML Spec Ref: https://html.spec.whatwg.org/#attributes-2
Forum post that brought this to attention: https://forum.freecodecamp.org/t/learn-basic-css-by-building-a-cafe-menu-step-3/651787