### PR TITLE
docs: correct the seed command mentioned in playwright guide

### DIFF
--- a/docs/how-to-add-playwright-tests.md
+++ b/docs/how-to-add-playwright-tests.md
@@ -171,7 +171,7 @@ describe('The campers landing page', () => {
 
 ### 1. Ensure that MongoDB and Client Applications are Running
 
-- [Start MongoDB and seed the database](how-to-setup-freecodecamp-locally.md#step-3-start-mongodb-and-seed-the-database)
+- [Start MongoDB and seed the database](how-to-setup-freecodecamp-locally.md#step-3-start-mongodb-and-seed-the-database). In order for Playwright tests to work, be sure that you use the `pnpm run seed:certified-user` command.
 
 - [Start the freeCodeCamp client application and API server](how-to-setup-freecodecamp-locally.md#step-4-start-the-freecodecamp-client-application-and-api-server)
 
@@ -318,7 +318,7 @@ If starting the Gitpod environment did not automatically develop the environment
 - Seed the database
 
   ```bash
-  pnpm run seed
+  pnpm run seed:certified-user
   ```
 
 - Develop the server and client

--- a/docs/how-to-setup-freecodecamp-locally.md
+++ b/docs/how-to-setup-freecodecamp-locally.md
@@ -257,7 +257,7 @@ Next, let's seed the database. In this step, we run the below command that fills
 pnpm run seed
 ```
 
-By default, you will be signed in as a new user without any completed certifications. Run the following commands if you need to develop with completed certifications:
+By default, you will be signed in as a new user without any completed certifications. Run the following command if you need to develop with completed certifications or write Playwright tests:
 
 ```bash
 pnpm run seed:certified-user


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

In CI, we are seeding the DB with `seed:certified-user` but the Playwright guide is instructing developers to run `seed`. `seed:certified-user` should be used here since there are test cases that require the user to be certified.

This PR updates the Playwright guide with the correct seed command, as well as adding a note to the setup guide.

Closes #52300

<!-- Feel free to add any additional description of changes below this line -->
