### PR TITLE
fix(curriculum): improve typography challenge step-55

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-typography-by-building-a-nutrition-label/615f7ecb09de9a938ef94756.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-typography-by-building-a-nutrition-label/615f7ecb09de9a938ef94756.md
@@ -7,7 +7,7 @@ dashedName: step-55
 
 # --description--
 
-Add another `p` element with the text `Total Carbohydrate 37g 13%`. Like before, use `span` elements to make the text `Total Carbohydrate` and `13%` bold. Also add an additional `span` element to wrap the `Total Carbohydrate 37g` text in a span element so to have it aligned to the left, and `13%` to the right.
+Below your last `p` element, add another `p` element with the text `Total Carbohydrate 37g 13%`. Like before, use `span` elements to make the text `Total Carbohydrate` and `13%` bold. Also add an additional `span` element around the `Total Carbohydrate 37g` text, to have it aligned to the left, and `13%` to the right.
 
 # --hints--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #52376 

<!-- Feel free to add any additional description of changes below this line -->
As per the issue, I've updated the step-55 challenge at learn typography in the responsive web design curriculum, to now include the "Below your last `p` element ... ", and fixed the typo by removing the word `to` from the following line, as suggested:
```diff
--- Also add an additional `span` element to wrap the `Total Carbohydrate 37g` text in a span element so to have it aligned to the left, and `13%` to the right.
+++ Also add an additional `span` element around the `Total Carbohydrate 37g` text, to have it aligned to the left, and `13%` to the right.
```
Also changed the structure of the sentence a bit, as the phrase `span element` was being repeated twice.