### PR TITLE
fix(curriculum): Remove quotes from object keys

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-dot-notation.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/accessing-object-properties-with-dot-notation.md
@@ -76,9 +76,9 @@ assert(code.match(/testObj\.\w+/g).length > 1);
 ```js
 // Setup
 const testObj = {
-  "hat": "ballcap",
-  "shirt": "jersey",
-  "shoes": "cleats"
+  hat: "ballcap",
+  shirt: "jersey",
+  shoes: "cleats"
 };
 
 // Only change code below this line
@@ -90,9 +90,9 @@ const shirtValue = testObj;    // Change this line
 
 ```js
 const testObj = {
-  "hat": "ballcap",
-  "shirt": "jersey",
-  "shoes": "cleats"
+  hat: "ballcap",
+  shirt: "jersey",
+  shoes: "cleats"
 };
 
 const hatValue = testObj.hat;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

The quotes are unnecessary and the example code does not use quotes which makes it look inconsistent and possibly confusing.

<!-- Feel free to add any additional description of changes below this line -->

Forum post: https://forum.freecodecamp.org/t/basic-javascript-accessing-object-properties-with-dot-notation/652918