### PR TITLE
fix(curriculum): small errors in tests and spelling for JS TODO app project

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64faf0418e828c0114a558a7.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64faf0418e828c0114a558a7.md
@@ -9,7 +9,7 @@ dashedName: step-34
 
 There's a problem. If you add a task, and then add another, the previous task gets duplicated. This means you need to clear out the existing contents of `tasksContainer` before adding a new task.
 
-Set the `innerHTML` of `taskContainer` back to an empty string.
+Set the `innerHTML` of `tasksContainer` back to an empty string.
 
 
 # --hints--

--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb0fa0968f2b113b2d90e9.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-localstorage-by-building-a-todo-app/64fb0fa0968f2b113b2d90e9.md
@@ -28,13 +28,13 @@ assert.match(code, /const\s*editTask\s*=\s*\(buttonEl\)\s*=>\s*\{\s*const dataAr
 You should pass in `item` as the parameter of the `findIndex()` arrow function callback. Don't use curly braces.
 
 ```js
-assert.match(code, /const\s*editTask\s+=\s*\(buttonEl\)\s*=>\s*\{\s*const\s+dataArrIndex\s*=\s*taskData\.findIndex\(\(item\)/)
+assert.match(code, /const\s*editTask\s+=\s*\(buttonEl\)\s*=>\s*\{\s*const\s+dataArrIndex\s*=\s*taskData\.findIndex\(\s*\(?item\)?/)
 ```
 
 Your arrow function callback should check if `item.id === buttonEl.parentElement.id`.
 
 ```js
-assert.match(code, /const\s*editTask\s+=\s*\(buttonEl\)\s*=>\s*\{\s*const\s+dataArrIndex\s*=\s*taskData\.findIndex\(\(item\)\s*=>\s*item\.id\s*===\s*buttonEl\.parentElement\.id\);?\s*\};?/)
+assert.match(code, /const\s*editTask\s+=\s*\(buttonEl\)\s*=>\s*\{\s*const\s+dataArrIndex\s*=\s*taskData\.findIndex\(\s*\(?item\)?\s*=>\s*item\.id\s*===\s*buttonEl\.parentElement\.id\);?\s*\};?/)
 ```
 
 # --seed--


### PR DESCRIPTION
## Summary of changes

- fixed spelling error in step 34 to change it to `tasksContainer` instead of `taskContainer`
- made the parenthesis optional for `item` parameter for step 40

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.
