### PR TITLE
chore(ci): remove seed:exams from playwright workflow

### DIFF
--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -129,9 +129,7 @@ jobs:
           pnpm run build:server
 
       - name: Seed Database with Certified User
-        run: |
-          pnpm run seed:certified-user
-          pnpm run seed:exams
+        run: pnpm run seed:certified-user
 
       # start-ci uses pm2, so it needs to be installed globally
       - name: Install pm2


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

We are currently running both `seed:certified-user` and `seed:exams` in the Playwright workflow:

https://github.com/freeCodeCamp/freeCodeCamp/blob/14f9dbf9656266fc14dffc53b19563258a189cc1/.github/workflows/e2e-playwright.yml#L132-L134

This is redundant now that we have merged `seed:exams` into `seed:certified-user`:

https://github.com/freeCodeCamp/freeCodeCamp/blob/14f9dbf9656266fc14dffc53b19563258a189cc1/package.json#L73

This PR removes the execution of `seed:exams` from the Playwright workflow.

<!-- Feel free to add any additional description of changes below this line -->
