### PR TITLE
fix(tools): allow long-form of language id

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-algorithm-scripting/boo-who.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-algorithm-scripting/boo-who.md
@@ -78,7 +78,7 @@ assert.strictEqual(booWho('false'), false);
 
 ## --seed-contents--
 
-```javascript
+```js
 function booWho(bool) {
   return bool;
 }
@@ -88,7 +88,7 @@ booWho(null);
 
 # --solutions--
 
-```javascript
+```js
 function booWho(bool) {
   return typeof bool === "boolean";
 }

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-algorithm-scripting/boo-who.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-algorithm-scripting/boo-who.md
@@ -78,7 +78,7 @@ assert.strictEqual(booWho('false'), false);
 
 ## --seed-contents--
 
-```js
+```javascript
 function booWho(bool) {
   return bool;
 }
@@ -88,7 +88,7 @@ booWho(null);
 
 # --solutions--
 
-```js
+```javascript
 function booWho(bool) {
   return typeof bool === "boolean";
 }

--- a/tools/challenge-parser/parser/plugins/utils/get-file-visitor.js
+++ b/tools/challenge-parser/parser/plugins/utils/get-file-visitor.js
@@ -9,6 +9,10 @@ const keyToSection = {
   tail: 'after-user-code'
 };
 const supportedLanguages = ['js', 'css', 'html', 'jsx', 'py'];
+const longToShortLanguages = {
+  javascript: 'js',
+  python: 'py'
+};
 
 function defaultFile(lang, id) {
   return {
@@ -25,8 +29,7 @@ function getFilenames(lang) {
   const langToFilename = {
     js: 'script',
     css: 'styles',
-    py: 'main',
-    python: 'main'
+    py: 'main'
   };
   return langToFilename[lang] ?? 'index';
 }
@@ -45,19 +48,20 @@ function getFileVisitor(seeds, seedKey, validate) {
 function codeToData(node, seeds, seedKey, validate) {
   if (validate) validate(node);
   const lang = node.lang;
-  if (!supportedLanguages.includes(lang))
+  const shortLang = longToShortLanguages[lang] ?? lang;
+  if (!supportedLanguages.includes(shortLang))
     throw Error(`On line ${
       position.start(node).line
-    } '${lang}' is not a supported language.
+    } '${shortLang}' is not a supported language.
  Please use one of js, css, html, jsx or py
 `);
 
-  const fileId = `index${lang}`;
+  const fileId = `index${shortLang}`;
   const id = seeds[fileId] ? seeds[fileId].id : '';
   // the contents will be missing if there is an id preceding this code
   // block.
   if (!seeds[fileId]) {
-    seeds[fileId] = defaultFile(lang, id);
+    seeds[fileId] = defaultFile(shortLang, id);
   }
   if (isEmpty(node.value) && seedKey !== 'contents') {
     const section = keyToSection[seedKey];
@@ -82,9 +86,10 @@ function idToData(node, index, parent, seeds) {
   }
   const codeNode = parent.children[index + 1];
   if (codeNode && is(codeNode, 'code')) {
-    const fileKey = `index${codeNode.lang}`;
+    const shortLang = longToShortLanguages[codeNode.lang] ?? codeNode.lang;
+    const fileKey = `index${shortLang}`;
     if (seeds[fileKey]) throw Error('::id{#id}s must come before code blocks');
-    seeds[fileKey] = defaultFile(codeNode.lang, id);
+    seeds[fileKey] = defaultFile(shortLang, id);
   } else {
     throw Error('::id{#id}s must come before code blocks');
   }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I do not know why, but I default to writing the full name after backticks in markdown 🤷‍♂️ 

I removed the long name from `langToFilename`, because it would just be duplication.