### PR TITLE
feat(tools/challenge-parser): Add tests to fill-in-the-blank parser

### DIFF
--- a/tools/challenge-parser/parser/__fixtures__/ast-fill-in-the-blank-one-blank.json
+++ b/tools/challenge-parser/parser/__fixtures__/ast-fill-in-the-blank-one-blank.json
@@ -1,0 +1,592 @@
+{
+    "type": "root",
+    "children": [
+      {
+        "type": "heading",
+        "depth": 1,
+        "children": [
+          {
+            "type": "text",
+            "value": "--description--",
+            "position": {
+              "start": {
+                "line": 9,
+                "column": 3,
+                "offset": 159
+              },
+              "end": {
+                "line": 9,
+                "column": 18,
+                "offset": 174
+              }
+            }
+          }
+        ],
+        "position": {
+          "start": {
+            "line": 9,
+            "column": 1,
+            "offset": 157
+          },
+          "end": {
+            "line": 9,
+            "column": 18,
+            "offset": 174
+          }
+        }
+      },
+      {
+        "type": "paragraph",
+        "children": [
+          {
+            "type": "text",
+            "value": "In English, when making introductions or identifying someone, you use the verb ",
+            "position": {
+              "start": {
+                "line": 11,
+                "column": 1,
+                "offset": 176
+              },
+              "end": {
+                "line": 11,
+                "column": 80,
+                "offset": 255
+              }
+            }
+          },
+          {
+            "type": "inlineCode",
+            "value": "to be",
+            "position": {
+              "start": {
+                "line": 11,
+                "column": 80,
+                "offset": 255
+              },
+              "end": {
+                "line": 11,
+                "column": 87,
+                "offset": 262
+              }
+            }
+          },
+          {
+            "type": "text",
+            "value": ". In this case, ",
+            "position": {
+              "start": {
+                "line": 11,
+                "column": 87,
+                "offset": 262
+              },
+              "end": {
+                "line": 11,
+                "column": 103,
+                "offset": 278
+              }
+            }
+          },
+          {
+            "type": "inlineCode",
+            "value": "You are",
+            "position": {
+              "start": {
+                "line": 11,
+                "column": 103,
+                "offset": 278
+              },
+              "end": {
+                "line": 11,
+                "column": 112,
+                "offset": 287
+              }
+            }
+          },
+          {
+            "type": "text",
+            "value": " is used to address the person Maria is talking to and affirmatively identify their occupation.",
+            "position": {
+              "start": {
+                "line": 11,
+                "column": 112,
+                "offset": 287
+              },
+              "end": {
+                "line": 11,
+                "column": 207,
+                "offset": 382
+              }
+            }
+          }
+        ],
+        "position": {
+          "start": {
+            "line": 11,
+            "column": 1,
+            "offset": 176
+          },
+          "end": {
+            "line": 11,
+            "column": 207,
+            "offset": 382
+          }
+        }
+      },
+      {
+        "type": "paragraph",
+        "children": [
+          {
+            "type": "text",
+            "value": "Maria is introducing herself and confirming Tom's job role. ",
+            "position": {
+              "start": {
+                "line": 13,
+                "column": 1,
+                "offset": 384
+              },
+              "end": {
+                "line": 13,
+                "column": 61,
+                "offset": 444
+              }
+            }
+          },
+          {
+            "type": "inlineCode",
+            "value": "Are",
+            "position": {
+              "start": {
+                "line": 13,
+                "column": 61,
+                "offset": 444
+              },
+              "end": {
+                "line": 13,
+                "column": 66,
+                "offset": 449
+              }
+            }
+          },
+          {
+            "type": "text",
+            "value": " is used in the present affirmative to make a statement.",
+            "position": {
+              "start": {
+                "line": 13,
+                "column": 66,
+                "offset": 449
+              },
+              "end": {
+                "line": 13,
+                "column": 122,
+                "offset": 505
+              }
+            }
+          }
+        ],
+        "position": {
+          "start": {
+            "line": 13,
+            "column": 1,
+            "offset": 384
+          },
+          "end": {
+            "line": 13,
+            "column": 122,
+            "offset": 505
+          }
+        }
+      },
+      {
+        "type": "heading",
+        "depth": 1,
+        "children": [
+          {
+            "type": "text",
+            "value": "--fillInTheBlank--",
+            "position": {
+              "start": {
+                "line": 15,
+                "column": 3,
+                "offset": 509
+              },
+              "end": {
+                "line": 15,
+                "column": 21,
+                "offset": 527
+              }
+            }
+          }
+        ],
+        "position": {
+          "start": {
+            "line": 15,
+            "column": 1,
+            "offset": 507
+          },
+          "end": {
+            "line": 15,
+            "column": 21,
+            "offset": 527
+          }
+        }
+      },
+      {
+        "type": "heading",
+        "depth": 2,
+        "children": [
+          {
+            "type": "text",
+            "value": "--sentence--",
+            "position": {
+              "start": {
+                "line": 17,
+                "column": 4,
+                "offset": 532
+              },
+              "end": {
+                "line": 17,
+                "column": 16,
+                "offset": 544
+              }
+            }
+          }
+        ],
+        "position": {
+          "start": {
+            "line": 17,
+            "column": 1,
+            "offset": 529
+          },
+          "end": {
+            "line": 17,
+            "column": 16,
+            "offset": 544
+          }
+        }
+      },
+      {
+        "type": "paragraph",
+        "children": [
+          {
+            "type": "inlineCode",
+            "value": "Hello, You _ the new graphic designer, right?",
+            "position": {
+              "start": {
+                "line": 19,
+                "column": 1,
+                "offset": 546
+              },
+              "end": {
+                "line": 19,
+                "column": 48,
+                "offset": 593
+              }
+            }
+          }
+        ],
+        "position": {
+          "start": {
+            "line": 19,
+            "column": 1,
+            "offset": 546
+          },
+          "end": {
+            "line": 19,
+            "column": 48,
+            "offset": 593
+          }
+        }
+      },
+      {
+        "type": "heading",
+        "depth": 2,
+        "children": [
+          {
+            "type": "text",
+            "value": "--blanks--",
+            "position": {
+              "start": {
+                "line": 21,
+                "column": 4,
+                "offset": 598
+              },
+              "end": {
+                "line": 21,
+                "column": 14,
+                "offset": 608
+              }
+            }
+          }
+        ],
+        "position": {
+          "start": {
+            "line": 21,
+            "column": 1,
+            "offset": 595
+          },
+          "end": {
+            "line": 21,
+            "column": 14,
+            "offset": 608
+          }
+        }
+      },
+      {
+        "type": "paragraph",
+        "children": [
+          {
+            "type": "inlineCode",
+            "value": "are",
+            "position": {
+              "start": {
+                "line": 23,
+                "column": 1,
+                "offset": 610
+              },
+              "end": {
+                "line": 23,
+                "column": 6,
+                "offset": 615
+              }
+            }
+          }
+        ],
+        "position": {
+          "start": {
+            "line": 23,
+            "column": 1,
+            "offset": 610
+          },
+          "end": {
+            "line": 23,
+            "column": 6,
+            "offset": 615
+          }
+        }
+      },
+      {
+        "type": "heading",
+        "depth": 3,
+        "children": [
+          {
+            "type": "text",
+            "value": "--feedback--",
+            "position": {
+              "start": {
+                "line": 25,
+                "column": 5,
+                "offset": 621
+              },
+              "end": {
+                "line": 25,
+                "column": 17,
+                "offset": 633
+              }
+            }
+          }
+        ],
+        "position": {
+          "start": {
+            "line": 25,
+            "column": 1,
+            "offset": 617
+          },
+          "end": {
+            "line": 25,
+            "column": 17,
+            "offset": 633
+          }
+        }
+      },
+      {
+        "type": "paragraph",
+        "children": [
+          {
+            "type": "text",
+            "value": "The verb ",
+            "position": {
+              "start": {
+                "line": 27,
+                "column": 1,
+                "offset": 635
+              },
+              "end": {
+                "line": 27,
+                "column": 10,
+                "offset": 644
+              }
+            }
+          },
+          {
+            "type": "inlineCode",
+            "value": "to be",
+            "position": {
+              "start": {
+                "line": 27,
+                "column": 10,
+                "offset": 644
+              },
+              "end": {
+                "line": 27,
+                "column": 17,
+                "offset": 651
+              }
+            }
+          },
+          {
+            "type": "text",
+            "value": " is an irregular verb. When conjugated with the pronoun ",
+            "position": {
+              "start": {
+                "line": 27,
+                "column": 17,
+                "offset": 651
+              },
+              "end": {
+                "line": 27,
+                "column": 73,
+                "offset": 707
+              }
+            }
+          },
+          {
+            "type": "inlineCode",
+            "value": "you",
+            "position": {
+              "start": {
+                "line": 27,
+                "column": 73,
+                "offset": 707
+              },
+              "end": {
+                "line": 27,
+                "column": 78,
+                "offset": 712
+              }
+            }
+          },
+          {
+            "type": "text",
+            "value": ", ",
+            "position": {
+              "start": {
+                "line": 27,
+                "column": 78,
+                "offset": 712
+              },
+              "end": {
+                "line": 27,
+                "column": 80,
+                "offset": 714
+              }
+            }
+          },
+          {
+            "type": "inlineCode",
+            "value": "be",
+            "position": {
+              "start": {
+                "line": 27,
+                "column": 80,
+                "offset": 714
+              },
+              "end": {
+                "line": 27,
+                "column": 84,
+                "offset": 718
+              }
+            }
+          },
+          {
+            "type": "text",
+            "value": " becomes ",
+            "position": {
+              "start": {
+                "line": 27,
+                "column": 84,
+                "offset": 718
+              },
+              "end": {
+                "line": 27,
+                "column": 93,
+                "offset": 727
+              }
+            }
+          },
+          {
+            "type": "inlineCode",
+            "value": "are",
+            "position": {
+              "start": {
+                "line": 27,
+                "column": 93,
+                "offset": 727
+              },
+              "end": {
+                "line": 27,
+                "column": 98,
+                "offset": 732
+              }
+            }
+          },
+          {
+            "type": "text",
+            "value": ". For example: ",
+            "position": {
+              "start": {
+                "line": 27,
+                "column": 98,
+                "offset": 732
+              },
+              "end": {
+                "line": 27,
+                "column": 113,
+                "offset": 747
+              }
+            }
+          },
+          {
+            "type": "inlineCode",
+            "value": "You are an English learner.",
+            "position": {
+              "start": {
+                "line": 27,
+                "column": 113,
+                "offset": 747
+              },
+              "end": {
+                "line": 27,
+                "column": 142,
+                "offset": 776
+              }
+            }
+          }
+        ],
+        "position": {
+          "start": {
+            "line": 27,
+            "column": 1,
+            "offset": 635
+          },
+          "end": {
+            "line": 27,
+            "column": 142,
+            "offset": 776
+          }
+        }
+      }
+    ],
+    "position": {
+      "start": {
+        "line": 1,
+        "column": 1,
+        "offset": 0
+      },
+      "end": {
+        "line": 28,
+        "column": 1,
+        "offset": 777
+      }
+    }
+  }

--- a/tools/challenge-parser/parser/__fixtures__/ast-fill-in-the-blank.json
+++ b/tools/challenge-parser/parser/__fixtures__/ast-fill-in-the-blank.json
@@ -7,18 +7,195 @@
       "children": [
         {
           "type": "text",
-          "value": "--description--"
+          "value": "--description--",
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 3,
+              "offset": 2
+            },
+            "end": {
+              "line": 1,
+              "column": 18,
+              "offset": 17
+            }
+          }
         }
-      ]
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 18,
+          "offset": 17
+        }
+      }
     },
     {
       "type": "paragraph",
       "children": [
         {
           "type": "text",
-          "value": "Description for a fill in the blank test."
+          "value": "In English, when making introductions or identifying someone, you use the verb ",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 1,
+              "offset": 19
+            },
+            "end": {
+              "line": 3,
+              "column": 80,
+              "offset": 98
+            }
+          }
+        },
+        {
+          "type": "inlineCode",
+          "value": "to be",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 80,
+              "offset": 98
+            },
+            "end": {
+              "line": 3,
+              "column": 87,
+              "offset": 105
+            }
+          }
+        },
+        {
+          "type": "text",
+          "value": ". In this case, ",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 87,
+              "offset": 105
+            },
+            "end": {
+              "line": 3,
+              "column": 103,
+              "offset": 121
+            }
+          }
+        },
+        {
+          "type": "inlineCode",
+          "value": "You are",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 103,
+              "offset": 121
+            },
+            "end": {
+              "line": 3,
+              "column": 112,
+              "offset": 130
+            }
+          }
+        },
+        {
+          "type": "text",
+          "value": " is used to address the person Maria is talking to and affirmatively identify their occupation.",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 112,
+              "offset": 130
+            },
+            "end": {
+              "line": 3,
+              "column": 207,
+              "offset": 225
+            }
+          }
         }
-      ]
+      ],
+      "position": {
+        "start": {
+          "line": 3,
+          "column": 1,
+          "offset": 19
+        },
+        "end": {
+          "line": 3,
+          "column": 207,
+          "offset": 225
+        }
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Maria is introducing herself and confirming Tom's job role. ",
+          "position": {
+            "start": {
+              "line": 5,
+              "column": 1,
+              "offset": 227
+            },
+            "end": {
+              "line": 5,
+              "column": 61,
+              "offset": 287
+            }
+          }
+        },
+        {
+          "type": "inlineCode",
+          "value": "Are",
+          "position": {
+            "start": {
+              "line": 5,
+              "column": 61,
+              "offset": 287
+            },
+            "end": {
+              "line": 5,
+              "column": 66,
+              "offset": 292
+            }
+          }
+        },
+        {
+          "type": "text",
+          "value": " is used in the present affirmative to make a statement.",
+          "position": {
+            "start": {
+              "line": 5,
+              "column": 66,
+              "offset": 292
+            },
+            "end": {
+              "line": 5,
+              "column": 122,
+              "offset": 348
+            }
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 5,
+          "column": 1,
+          "offset": 227
+        },
+        "end": {
+          "line": 5,
+          "column": 122,
+          "offset": 348
+        }
+      }
     },
     {
       "type": "heading",
@@ -26,37 +203,33 @@
       "children": [
         {
           "type": "text",
-          "value": "--instructions--"
+          "value": "--fillInTheBlank--",
+          "position": {
+            "start": {
+              "line": 7,
+              "column": 3,
+              "offset": 352
+            },
+            "end": {
+              "line": 7,
+              "column": 21,
+              "offset": 370
+            }
+          }
         }
-      ]
-    },
-    {
-      "type": "paragraph",
-      "children": [
-        {
-          "type": "text",
-          "value": "Instructions for a fill in the blank test."
+      ],
+      "position": {
+        "start": {
+          "line": 7,
+          "column": 1,
+          "offset": 350
+        },
+        "end": {
+          "line": 7,
+          "column": 21,
+          "offset": 370
         }
-      ]
-    },
-    {
-      "type": "heading",
-      "depth": 1,
-      "children": [
-        {
-          "type": "text",
-          "value": "--fillInTheBlank--"
-        }
-      ]
-    },
-    {
-      "type": "paragraph",
-      "children": [
-        {
-          "type": "text",
-          "value": "These are for the English curriculum challenges."
-        }
-      ]
+      }
     },
     {
       "type": "heading",
@@ -64,14 +237,133 @@
       "children": [
         {
           "type": "text",
-          "value": "--sentence--"
+          "value": "--sentence--",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 4,
+              "offset": 375
+            },
+            "end": {
+              "line": 9,
+              "column": 16,
+              "offset": 387
+            }
+          }
         }
-      ]
+      ],
+      "position": {
+        "start": {
+          "line": 9,
+          "column": 1,
+          "offset": 372
+        },
+        "end": {
+          "line": 9,
+          "column": 16,
+          "offset": 387
+        }
+      }
     },
     {
-      "type": "code",
-      "lang": "plaintext",
-      "value": "Hello, You _ the new graphic designer, _? _ to meet you!"
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "inlineCode",
+          "value": "Hello, You _ the new graphic designer, _? _ to meet you!",
+          "position": {
+            "start": {
+              "line": 11,
+              "column": 1,
+              "offset": 389
+            },
+            "end": {
+              "line": 11,
+              "column": 59,
+              "offset": 447
+            }
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 11,
+          "column": 1,
+          "offset": 389
+        },
+        "end": {
+          "line": 11,
+          "column": 59,
+          "offset": 447
+        }
+      }
+    },
+    {
+      "type": "heading",
+      "depth": 2,
+      "children": [
+        {
+          "type": "text",
+          "value": "--blanks--",
+          "position": {
+            "start": {
+              "line": 13,
+              "column": 4,
+              "offset": 452
+            },
+            "end": {
+              "line": 13,
+              "column": 14,
+              "offset": 462
+            }
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 13,
+          "column": 1,
+          "offset": 449
+        },
+        "end": {
+          "line": 13,
+          "column": 14,
+          "offset": 462
+        }
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "inlineCode",
+          "value": "are",
+          "position": {
+            "start": {
+              "line": 15,
+              "column": 1,
+              "offset": 464
+            },
+            "end": {
+              "line": 15,
+              "column": 6,
+              "offset": 469
+            }
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 15,
+          "column": 1,
+          "offset": 464
+        },
+        "end": {
+          "line": 15,
+          "column": 6,
+          "offset": 469
+        }
+      }
     },
     {
       "type": "heading",
@@ -79,68 +371,385 @@
       "children": [
         {
           "type": "text",
-          "value": "--blanks--"
+          "value": "--feedback--",
+          "position": {
+            "start": {
+              "line": 17,
+              "column": 5,
+              "offset": 475
+            },
+            "end": {
+              "line": 17,
+              "column": 17,
+              "offset": 487
+            }
+          }
         }
-      ]
-    },
-    {
-      "type": "code",
-      "lang": "plaintext",
-      "value": "are"
-    },
-    {
-      "type": "heading",
-      "depth": 4,
-      "children": [
-        {
-          "type": "text",
-          "value": "--feedback--"
+      ],
+      "position": {
+        "start": {
+          "line": 17,
+          "column": 1,
+          "offset": 471
+        },
+        "end": {
+          "line": 17,
+          "column": 17,
+          "offset": 487
         }
-      ]
+      }
     },
     {
       "type": "paragraph",
       "children": [
         {
           "type": "text",
-          "value": "Feedback 1"
+          "value": "The verb ",
+          "position": {
+            "start": {
+              "line": 19,
+              "column": 1,
+              "offset": 489
+            },
+            "end": {
+              "line": 19,
+              "column": 10,
+              "offset": 498
+            }
+          }
+        },
+        {
+          "type": "inlineCode",
+          "value": "to be",
+          "position": {
+            "start": {
+              "line": 19,
+              "column": 10,
+              "offset": 498
+            },
+            "end": {
+              "line": 19,
+              "column": 17,
+              "offset": 505
+            }
+          }
+        },
+        {
+          "type": "text",
+          "value": " is an irregular verb. When conjugated with the pronoun ",
+          "position": {
+            "start": {
+              "line": 19,
+              "column": 17,
+              "offset": 505
+            },
+            "end": {
+              "line": 19,
+              "column": 73,
+              "offset": 561
+            }
+          }
+        },
+        {
+          "type": "inlineCode",
+          "value": "you",
+          "position": {
+            "start": {
+              "line": 19,
+              "column": 73,
+              "offset": 561
+            },
+            "end": {
+              "line": 19,
+              "column": 78,
+              "offset": 566
+            }
+          }
+        },
+        {
+          "type": "text",
+          "value": ", ",
+          "position": {
+            "start": {
+              "line": 19,
+              "column": 78,
+              "offset": 566
+            },
+            "end": {
+              "line": 19,
+              "column": 80,
+              "offset": 568
+            }
+          }
+        },
+        {
+          "type": "inlineCode",
+          "value": "be",
+          "position": {
+            "start": {
+              "line": 19,
+              "column": 80,
+              "offset": 568
+            },
+            "end": {
+              "line": 19,
+              "column": 84,
+              "offset": 572
+            }
+          }
+        },
+        {
+          "type": "text",
+          "value": " becomes ",
+          "position": {
+            "start": {
+              "line": 19,
+              "column": 84,
+              "offset": 572
+            },
+            "end": {
+              "line": 19,
+              "column": 93,
+              "offset": 581
+            }
+          }
+        },
+        {
+          "type": "inlineCode",
+          "value": "are",
+          "position": {
+            "start": {
+              "line": 19,
+              "column": 93,
+              "offset": 581
+            },
+            "end": {
+              "line": 19,
+              "column": 98,
+              "offset": 586
+            }
+          }
+        },
+        {
+          "type": "text",
+          "value": ". For example: ",
+          "position": {
+            "start": {
+              "line": 19,
+              "column": 98,
+              "offset": 586
+            },
+            "end": {
+              "line": 19,
+              "column": 113,
+              "offset": 601
+            }
+          }
+        },
+        {
+          "type": "inlineCode",
+          "value": "You are an English learner.",
+          "position": {
+            "start": {
+              "line": 19,
+              "column": 113,
+              "offset": 601
+            },
+            "end": {
+              "line": 19,
+              "column": 142,
+              "offset": 630
+            }
+          }
         }
-      ]
+      ],
+      "position": {
+        "start": {
+          "line": 19,
+          "column": 1,
+          "offset": 489
+        },
+        "end": {
+          "line": 19,
+          "column": 142,
+          "offset": 630
+        }
+      }
     },
     {
-      "type": "thematicBreak"
+      "type": "thematicBreak",
+      "position": {
+        "start": {
+          "line": 21,
+          "column": 1,
+          "offset": 632
+        },
+        "end": {
+          "line": 21,
+          "column": 4,
+          "offset": 635
+        }
+      }
     },
     {
-      "type": "code",
-      "lang": "plaintext",
-      "value": "right"
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "inlineCode",
+          "value": "right",
+          "position": {
+            "start": {
+              "line": 23,
+              "column": 1,
+              "offset": 637
+            },
+            "end": {
+              "line": 23,
+              "column": 8,
+              "offset": 644
+            }
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 23,
+          "column": 1,
+          "offset": 637
+        },
+        "end": {
+          "line": 23,
+          "column": 8,
+          "offset": 644
+        }
+      }
     },
     {
       "type": "heading",
-      "depth": 4,
+      "depth": 3,
       "children": [
         {
           "type": "text",
-          "value": "--feedback--"
+          "value": "--feedback--",
+          "position": {
+            "start": {
+              "line": 25,
+              "column": 5,
+              "offset": 650
+            },
+            "end": {
+              "line": 25,
+              "column": 17,
+              "offset": 662
+            }
+          }
         }
-      ]
+      ],
+      "position": {
+        "start": {
+          "line": 25,
+          "column": 1,
+          "offset": 646
+        },
+        "end": {
+          "line": 25,
+          "column": 17,
+          "offset": 662
+        }
+      }
     },
     {
       "type": "paragraph",
       "children": [
         {
           "type": "text",
-          "value": "Feedback 2"
+          "value": "Feedback 2",
+          "position": {
+            "start": {
+              "line": 27,
+              "column": 1,
+              "offset": 664
+            },
+            "end": {
+              "line": 27,
+              "column": 11,
+              "offset": 674
+            }
+          }
         }
-      ]
+      ],
+      "position": {
+        "start": {
+          "line": 27,
+          "column": 1,
+          "offset": 664
+        },
+        "end": {
+          "line": 27,
+          "column": 11,
+          "offset": 674
+        }
+      }
     },
     {
-      "type": "thematicBreak"
+      "type": "thematicBreak",
+      "position": {
+        "start": {
+          "line": 29,
+          "column": 1,
+          "offset": 676
+        },
+        "end": {
+          "line": 29,
+          "column": 4,
+          "offset": 679
+        }
+      }
     },
     {
-      "type": "code",
-      "lang": "plaintext",
-      "value": "Nice"
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "inlineCode",
+          "value": "Nice",
+          "position": {
+            "start": {
+              "line": 31,
+              "column": 1,
+              "offset": 681
+            },
+            "end": {
+              "line": 31,
+              "column": 7,
+              "offset": 687
+            }
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 31,
+          "column": 1,
+          "offset": 681
+        },
+        "end": {
+          "line": 31,
+          "column": 7,
+          "offset": 687
+        }
+      }
     }
-  ]
+  ],
+  "position": {
+    "start": {
+      "line": 1,
+      "column": 1,
+      "offset": 0
+    },
+    "end": {
+      "line": 31,
+      "column": 7,
+      "offset": 687
+    }
+  }
 }

--- a/tools/challenge-parser/parser/__fixtures__/ast-fill-in-the-blank.json
+++ b/tools/challenge-parser/parser/__fixtures__/ast-fill-in-the-blank.json
@@ -1,0 +1,146 @@
+{
+  "type": "root",
+  "children": [
+    {
+      "type": "heading",
+      "depth": 1,
+      "children": [
+        {
+          "type": "text",
+          "value": "--description--"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Description for a fill in the blank test."
+        }
+      ]
+    },
+    {
+      "type": "heading",
+      "depth": 1,
+      "children": [
+        {
+          "type": "text",
+          "value": "--instructions--"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Instructions for a fill in the blank test."
+        }
+      ]
+    },
+    {
+      "type": "heading",
+      "depth": 1,
+      "children": [
+        {
+          "type": "text",
+          "value": "--fillInTheBlank--"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "These are for the English curriculum challenges."
+        }
+      ]
+    },
+    {
+      "type": "heading",
+      "depth": 2,
+      "children": [
+        {
+          "type": "text",
+          "value": "--sentence--"
+        }
+      ]
+    },
+    {
+      "type": "code",
+      "lang": "plaintext",
+      "value": "Hello, You _ the new graphic designer, _? _ to meet you!"
+    },
+    {
+      "type": "heading",
+      "depth": 3,
+      "children": [
+        {
+          "type": "text",
+          "value": "--blanks--"
+        }
+      ]
+    },
+    {
+      "type": "code",
+      "lang": "plaintext",
+      "value": "are"
+    },
+    {
+      "type": "heading",
+      "depth": 4,
+      "children": [
+        {
+          "type": "text",
+          "value": "--feedback--"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Feedback 1"
+        }
+      ]
+    },
+    {
+      "type": "thematicBreak"
+    },
+    {
+      "type": "code",
+      "lang": "plaintext",
+      "value": "right"
+    },
+    {
+      "type": "heading",
+      "depth": 4,
+      "children": [
+        {
+          "type": "text",
+          "value": "--feedback--"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Feedback 2"
+        }
+      ]
+    },
+    {
+      "type": "thematicBreak"
+    },
+    {
+      "type": "code",
+      "lang": "plaintext",
+      "value": "Nice"
+    }
+  ]
+}

--- a/tools/challenge-parser/parser/__fixtures__/with-fill-in-the-blank-one-blank.md
+++ b/tools/challenge-parser/parser/__fixtures__/with-fill-in-the-blank-one-blank.md
@@ -1,0 +1,19 @@
+# --description--
+
+In English, when making introductions or identifying someone, you use the verb `to be`. In this case, `You are` is used to address the person Maria is talking to and affirmatively identify their occupation.
+
+Maria is introducing herself and confirming Tom's job role. `Are` is used in the present affirmative to make a statement.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Hello, You _ the new graphic designer, right?`
+
+## --blanks--
+
+`are`
+
+### --feedback--
+
+The verb `to be` is an irregular verb. When conjugated with the pronoun `you`, `be` becomes `are`. For example: `You are an English learner.`

--- a/tools/challenge-parser/parser/__fixtures__/with-fill-in-the-blank.md
+++ b/tools/challenge-parser/parser/__fixtures__/with-fill-in-the-blank.md
@@ -1,0 +1,31 @@
+# --description--
+
+In English, when making introductions or identifying someone, you use the verb `to be`. In this case, `You are` is used to address the person Maria is talking to and affirmatively identify their occupation.
+
+Maria is introducing herself and confirming Tom's job role. `Are` is used in the present affirmative to make a statement.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+`Hello, You _ the new graphic designer, _? _ to meet you!`
+
+## --blanks--
+
+`are`
+
+### --feedback--
+
+The verb `to be` is an irregular verb. When conjugated with the pronoun `you`, `be` becomes `are`. For example: `You are an English learner.`
+
+---
+
+`right`
+
+### --feedback--
+
+Feedback 2
+
+---
+
+`Nice`

--- a/tools/challenge-parser/parser/plugins/add-fill-in-the-blank.js
+++ b/tools/challenge-parser/parser/plugins/add-fill-in-the-blank.js
@@ -49,12 +49,12 @@ function getBlanks(blanksNodes) {
       const feedbackNodes = getAllBetween(blanksTree, '--feedback--');
 
       return {
-        answer: blanksNodes[0].children[0].value,
+        answer: blanksNodes[0].value,
         feedback: mdastToHtml(feedbackNodes)
       };
     }
 
-    return { answer: blanksGroup[0].children[0].value, feedback: null };
+    return { answer: blanksTree.children[0].value, feedback: null };
   });
 }
 

--- a/tools/challenge-parser/parser/plugins/add-fill-in-the-blank.js
+++ b/tools/challenge-parser/parser/plugins/add-fill-in-the-blank.js
@@ -49,12 +49,12 @@ function getBlanks(blanksNodes) {
       const feedbackNodes = getAllBetween(blanksTree, '--feedback--');
 
       return {
-        answer: blanksNodes[0].value,
+        answer: blanksNodes[0].children[0].value,
         feedback: mdastToHtml(feedbackNodes)
       };
     }
 
-    return { answer: blanksTree.children[0].value, feedback: null };
+    return { answer: blanksGroup[0].children[0].value, feedback: null };
   });
 }
 

--- a/tools/challenge-parser/parser/plugins/add-fill-in-the-blank.test.js
+++ b/tools/challenge-parser/parser/plugins/add-fill-in-the-blank.test.js
@@ -1,4 +1,5 @@
 const mockFillInTheBlankAST = require('../__fixtures__/ast-fill-in-the-blank.json');
+const mockFillInTheBlankYouAreAST = require('../__fixtures__/ast-fill-in-the-blank-one-blank.json');
 const addFillInTheBlankQuestion = require('./add-fill-in-the-blank');
 
 describe('fill-in-the-blanks plugin', () => {
@@ -42,13 +43,16 @@ describe('fill-in-the-blanks plugin', () => {
     expect(testObject.blanks[2].feedback).toBeNull();
   });
 
-  it('should convert question and answer markdown into html', () => {
+  it('should convert feedback markdown into html', () => {
     plugin(mockFillInTheBlankAST, file);
     const testObject = file.data.fillInTheBlank;
 
     expect(testObject.blanks[0]).toStrictEqual({
       answer: 'are',
-      feedback: '<p>Feedback 1</p>'
+      feedback:
+        '<p>The verb <code>to be</code> is an irregular verb. ' +
+        'When conjugated with the pronoun <code>you</code>, <code>be</code> ' +
+        'becomes <code>are</code>. For example: <code>You are an English learner.</code></p>'
     });
 
     expect(testObject.blanks[1]).toStrictEqual({
@@ -59,6 +63,17 @@ describe('fill-in-the-blanks plugin', () => {
     expect(testObject.blanks[2]).toStrictEqual({
       answer: 'Nice',
       feedback: null
+    });
+  });
+
+  it('should handle one blank', () => {
+    plugin(mockFillInTheBlankYouAreAST, file);
+    const testObject = file.data.fillInTheBlank;
+
+    expect(testObject.blanks[0]).toStrictEqual({
+      answer: 'are',
+      feedback:
+        '<p>The verb <code>to be</code> is an irregular verb. When conjugated with the pronoun <code>you</code>, <code>be</code> becomes <code>are</code>. For example: <code>You are an English learner.</code></p>'
     });
   });
 });

--- a/tools/challenge-parser/parser/plugins/add-fill-in-the-blank.test.js
+++ b/tools/challenge-parser/parser/plugins/add-fill-in-the-blank.test.js
@@ -1,0 +1,64 @@
+const mockFillInTheBlankAST = require('../__fixtures__/ast-fill-in-the-blank.json');
+const addFillInTheBlankQuestion = require('./add-fill-in-the-blank');
+
+describe('fill-in-the-blanks plugin', () => {
+  const plugin = addFillInTheBlankQuestion();
+  let file = { data: {} };
+
+  beforeEach(() => {
+    file = { data: {} };
+  });
+
+  it('returns a function', () => {
+    expect(typeof plugin).toEqual('function');
+  });
+
+  it('adds a `fillInTheBlank` property to `file.data`', () => {
+    plugin(mockFillInTheBlankAST, file);
+    expect('fillInTheBlank' in file.data).toBe(true);
+  });
+
+  it('should generate a fillInTheBlank object from a fill-in-the-blank challenge AST', () => {
+    plugin(mockFillInTheBlankAST, file);
+    const testObject = file.data.fillInTheBlank;
+
+    expect(Object.keys(testObject).length).toBe(2);
+    expect(testObject).toHaveProperty('sentence');
+    expect(typeof testObject.sentence).toBe('string');
+    expect(testObject).toHaveProperty('blanks');
+    expect(Array.isArray(testObject.blanks)).toBe(true);
+    expect(testObject.blanks.length).toBe(3);
+    expect(testObject.blanks[0]).toHaveProperty('answer');
+    expect(typeof testObject.blanks[0].answer).toBe('string');
+    expect(testObject.blanks[0]).toHaveProperty('feedback');
+    expect(typeof testObject.blanks[0].feedback).toBe('string');
+    expect(testObject.blanks[1]).toHaveProperty('answer');
+    expect(typeof testObject.blanks[1].answer).toBe('string');
+    expect(testObject.blanks[1]).toHaveProperty('feedback');
+    expect(typeof testObject.blanks[1].feedback).toBe('string');
+    expect(testObject.blanks[2]).toHaveProperty('answer');
+    expect(typeof testObject.blanks[2].answer).toBe('string');
+    expect(testObject.blanks[2]).toHaveProperty('feedback');
+    expect(testObject.blanks[2].feedback).toBeNull();
+  });
+
+  it('should convert question and answer markdown into html', () => {
+    plugin(mockFillInTheBlankAST, file);
+    const testObject = file.data.fillInTheBlank;
+
+    expect(testObject.blanks[0]).toStrictEqual({
+      answer: 'are',
+      feedback: '<p>Feedback 1</p>'
+    });
+
+    expect(testObject.blanks[1]).toStrictEqual({
+      answer: 'right',
+      feedback: '<p>Feedback 2</p>'
+    });
+
+    expect(testObject.blanks[2]).toStrictEqual({
+      answer: 'Nice',
+      feedback: null
+    });
+  });
+});


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #52309

<!-- Feel free to add any additional description of changes below this line -->

Hello, I've added a test file related to the parser for the Fill In The Blanks challenge.

This needed minor changes to the original fill-in-the-blanks.js file, since the blank answers are in `code` blocks, i.e. not considered a child of itself in the syntax tree.

I based tests expected on what I saw in #52305, i.e. I'd expect the markdown to be in the format of:

```markdown
# --description--

Description for a fill in the blank test.

# --instructions--

Instructions for a fill in the blank test.

# --fillInTheBlank--

These are for the English curriculum challenges.

## --sentence--

`Hello, You _ the new graphic designer, _? _ to meet you!`


## --blanks--

`are`

### --feedback--

Feedback 1

---

`right`

### --feedback--

Feedback 2

---

`Nice`

```

I'm new here and getting acquainted with the codebase, so I'm happy to take some feedback or suggestions :)