### PR TITLE
feat(tools, challenge-editor): add script to create challenges

### DIFF
--- a/curriculum/package.json
+++ b/curriculum/package.json
@@ -21,6 +21,7 @@
     "build": "ts-node --project ../tsconfig.json ../tools/scripts/build/build-curriculum",
     "create-empty-steps": "cross-env CALLING_DIR=$INIT_CWD ts-node --project ../tsconfig.json ../tools/challenge-helper-scripts/create-empty-steps",
     "create-next-challenge": "cross-env CALLING_DIR=$INIT_CWD ts-node --project ../tsconfig.json ../tools/challenge-helper-scripts/create-next-challenge",
+    "create-this-challenge": "cross-env CALLING_DIR=$INIT_CWD ts-node --project ../tsconfig.json ../tools/challenge-helper-scripts/create-this-challenge",
     "create-next-step": "cross-env CALLING_DIR=$INIT_CWD ts-node --project ../tsconfig.json ../tools/challenge-helper-scripts/create-next-step",
     "insert-challenge": "cross-env CALLING_DIR=$INIT_CWD ts-node --project ../tsconfig.json ../tools/challenge-helper-scripts/insert-challenge",
     "insert-step": "cross-env CALLING_DIR=$INIT_CWD ts-node --project ../tsconfig.json ../tools/challenge-helper-scripts/insert-step",

--- a/tools/challenge-helper-scripts/create-this-challenge.ts
+++ b/tools/challenge-helper-scripts/create-this-challenge.ts
@@ -1,0 +1,79 @@
+/*
+ * This is a one-off script to create challenges with specific markdown. Fill in
+ * the content below where the comments suggest. When you are done, go to the
+ * English block folder where you want to create the challenge in the terminal,
+ * and run `pnpm create-this-challenge`. It will use the Object ID as the
+ * filename. Change the `challengeId` at the bottom to use the dashed name if
+ * you want that.
+ */
+import ObjectID from 'bson-objectid';
+import { createChallengeFile } from './utils';
+import { getProjectPath } from './helpers/get-project-info';
+import { getMetaData, updateMetaData } from './helpers/project-metadata';
+
+// eslint-disable-next-line @typescript-eslint/no-base-to-string
+const challengeId = new ObjectID().toString();
+
+/***** Only change code below this line *****/
+
+/*
+ * Fill in the variables below with the challenge info. Put the markdown you
+ * want to create in the `template` variable, leaving the frontmatter with the
+ * variables - be sure to escape all backticks in the markdown.
+ */
+const title = 'Temp Title';
+const dashedName = 'temp-title';
+const challengeType = '22';
+const template = `---
+id: ${challengeId}
+title: ${title}
+challengeType: ${challengeType}
+dashedName: ${dashedName}
+audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
+---
+
+# --description--
+
+The word \`I'm\` is a contraction of \`I am\`. Contractions are a way to shorten common combinations of words, especially with verbs.
+
+# --fillInTheBlank--
+
+## --sentence--
+
+\`Hi, that's right! _ Tom McKenzie.\`
+
+## --blanks--
+
+\`I'm\`
+`;
+
+/***** Only change code above this line *****/
+
+const path = getProjectPath();
+if (
+  !/freeCodeCamp\/curriculum\/challenges\/english\/[^/]+\/[^/]+\/$/.test(path)
+) {
+  throw Error(`
+You cannot run this script from anywhere other than a block folder of the English curriculum.
+In the terminal, go to the block folder where you want to create this challenge first.
+For example: 'freeCodeCamp/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/'
+  `);
+}
+
+const meta = getMetaData();
+if (meta.challengeOrder.some(c => c.title === title)) {
+  throw Error(`
+    A challenge with the title ${title} already exists in this block.
+  `);
+}
+
+meta.challengeOrder.push({
+  id: challengeId,
+  title
+});
+
+// write the meta.json file
+updateMetaData(meta);
+
+// write the challenge file, the first argument is the filename
+createChallengeFile(challengeId, template, path);


### PR DESCRIPTION
This adds a script to create challenges with the markdown included. See comments in the script.


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
