### PR TITLE
fix(client): unify challenge titles and headings

### DIFF
--- a/client/src/templates/Challenges/codeally/show.tsx
+++ b/client/src/templates/Challenges/codeally/show.tsx
@@ -294,7 +294,7 @@ class ShowCodeAlly extends Component<ShowCodeAllyProps> {
                       <Spacer size='medium' />
                       <ChallengeHeading
                         heading={'learn.step-1'}
-                        isCompleted={!isPartiallyCompleted || isCompleted}
+                        isCompleted={isPartiallyCompleted || isCompleted}
                       />
                       <Spacer size='medium' />
                       <div className='ca-description'>
@@ -326,7 +326,7 @@ class ShowCodeAlly extends Component<ShowCodeAllyProps> {
                       <Spacer size='medium' />
                       <ChallengeHeading
                         heading={'learn.step-2'}
-                        isCompleted={!isCompleted}
+                        isCompleted={isCompleted}
                       />
                       <Spacer size='medium' />
                       <div className='ca-description'>

--- a/client/src/templates/Challenges/codeally/show.tsx
+++ b/client/src/templates/Challenges/codeally/show.tsx
@@ -18,7 +18,6 @@ import ChallengeTitle from '../components/challenge-title';
 import PrismFormatted from '../components/prism-formatted';
 import { challengeTypes } from '../../../../../shared/config/challenge-types';
 import CompletionModal from '../components/completion-modal';
-import GreenPass from '../../../assets/icons/green-pass';
 import HelpModal from '../components/help-modal';
 import Hotkeys from '../components/hotkeys';
 import { hideCodeAlly, tryToShowCodeAlly } from '../../../redux/actions';
@@ -49,6 +48,7 @@ import { SuperBlocks } from '../../../../../shared/config/superblocks';
 import { CodeAllyDown } from '../../../components/growth-book/codeally-down';
 
 import './codeally.css';
+import ChallengeHeading from '../components/challenge-heading';
 
 // Redux
 const mapStateToProps = createSelector(
@@ -292,16 +292,10 @@ class ShowCodeAlly extends Component<ShowCodeAllyProps> {
                       </div>
                       <hr />
                       <Spacer size='medium' />
-                      <b>{t('learn.step-1')}</b>
-                      {(isPartiallyCompleted || isCompleted) && (
-                        <GreenPass
-                          style={{
-                            height: '15px',
-                            width: '15px',
-                            marginInlineEnd: '7px'
-                          }}
-                        />
-                      )}
+                      <ChallengeHeading
+                        heading={'learn.step-1'}
+                        isCompleted={!isPartiallyCompleted || isCompleted}
+                      />
                       <Spacer size='medium' />
                       <div className='ca-description'>
                         {t('learn.runs-in-vm')}
@@ -330,16 +324,10 @@ class ShowCodeAlly extends Component<ShowCodeAllyProps> {
                     <>
                       <hr />
                       <Spacer size='medium' />
-                      <b>{t('learn.step-2')}</b>
-                      {isCompleted && (
-                        <GreenPass
-                          style={{
-                            height: '15px',
-                            width: '15px',
-                            marginInlineStart: '7px'
-                          }}
-                        />
-                      )}
+                      <ChallengeHeading
+                        heading={'learn.step-2'}
+                        isCompleted={!isCompleted}
+                      />
                       <Spacer size='medium' />
                       <div className='ca-description'>
                         {t('learn.submit-public-url')}

--- a/client/src/templates/Challenges/components/challenge-heading.css
+++ b/client/src/templates/Challenges/components/challenge-heading.css
@@ -1,0 +1,10 @@
+.challenge-heading-wrap {
+  display: flex;
+  gap: 7px;
+  align-items: center;
+  justify-content: center;
+}
+
+.challenge-heading {
+  font-size: 16px;
+}

--- a/client/src/templates/Challenges/components/challenge-heading.tsx
+++ b/client/src/templates/Challenges/components/challenge-heading.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import GreenPass from '../../../assets/icons/green-pass';
+
+import './challenge-heading.css';
+
+interface ChallengeTitleProps {
+  heading: string;
+  isI18nKey?: boolean;
+  isCompleted?: boolean;
+}
+
+function ChallengeHeading({
+  heading,
+  isI18nKey = true,
+  isCompleted = false
+}: ChallengeTitleProps): JSX.Element {
+  const { t } = useTranslation();
+
+  return (
+    <div className='challenge-heading-wrap'>
+      <h2 className='challenge-heading'>{isI18nKey ? t(heading) : heading}</h2>
+      {isCompleted && <GreenPass />}
+    </div>
+  );
+}
+
+ChallengeHeading.displayName = 'ChallengeHeading';
+
+export default ChallengeHeading;

--- a/client/src/templates/Challenges/components/challenge-heading.tsx
+++ b/client/src/templates/Challenges/components/challenge-heading.tsx
@@ -4,7 +4,7 @@ import GreenPass from '../../../assets/icons/green-pass';
 
 import './challenge-heading.css';
 
-interface ChallengeTitleProps {
+interface ChallengeHeadingProps {
   heading: string;
   isI18nKey?: boolean;
   isCompleted?: boolean;
@@ -14,7 +14,7 @@ function ChallengeHeading({
   heading,
   isI18nKey = true,
   isCompleted = false
-}: ChallengeTitleProps): JSX.Element {
+}: ChallengeHeadingProps): JSX.Element {
   const { t } = useTranslation();
 
   return (

--- a/client/src/templates/Challenges/dialogue/show.tsx
+++ b/client/src/templates/Challenges/dialogue/show.tsx
@@ -20,6 +20,7 @@ import { ChallengeNode, ChallengeMeta } from '../../../redux/prop-types';
 import Hotkeys from '../components/hotkeys';
 import VideoPlayer from '../components/video-player';
 import CompletionModal from '../components/completion-modal';
+import ChallengeTitle from '../components/challenge-title';
 import HelpModal from '../components/help-modal';
 import PrismFormatted from '../components/prism-formatted';
 import {
@@ -32,6 +33,7 @@ import { isChallengeCompletedSelector } from '../redux/selectors';
 // Styles
 import '../odin/show.css';
 import '../video.css';
+import ChallengeHeading from '../components/challenge-heading';
 
 // Redux Setup
 const mapStateToProps = createSelector(
@@ -182,11 +184,13 @@ class ShowDialogue extends Component<ShowDialogueProps, ShowDialogueState> {
             block,
             videoId,
             fields: { blockName },
+            translationPending,
             assignments
           }
         }
       },
       openHelpModal,
+      isChallengeCompleted,
       pageContext: {
         challengeMeta: { nextChallengePath, prevChallengePath }
       },
@@ -210,6 +214,13 @@ class ShowDialogue extends Component<ShowDialogueProps, ShowDialogueState> {
           />
           <Container>
             <Row>
+              <Spacer size='medium' />
+              <ChallengeTitle
+                isCompleted={isChallengeCompleted}
+                translationPending={translationPending}
+              >
+                {title}
+              </ChallengeTitle>
               {videoId && (
                 <Col lg={10} lgOffset={1} md={10} mdOffset={1}>
                   <Spacer size='medium' />
@@ -230,11 +241,10 @@ class ShowDialogue extends Component<ShowDialogueProps, ShowDialogueState> {
               )}
               <Col md={8} mdOffset={2} sm={10} smOffset={1} xs={12}>
                 <Spacer size='medium' />
-                <h2>{title}</h2>
                 <PrismFormatted className={'line-numbers'} text={description} />
                 <Spacer size='medium' />
                 <ObserveKeys>
-                  <h2>{t('learn.assignments')}</h2>
+                  <ChallengeHeading heading={'learn.assignments'} />
                   <div className='video-quiz-options'>
                     {assignments.map((assignment, index) => (
                       <label className='video-quiz-option-label' key={index}>

--- a/client/src/templates/Challenges/fill-in-the-blank/show.tsx
+++ b/client/src/templates/Challenges/fill-in-the-blank/show.tsx
@@ -18,6 +18,7 @@ import LearnLayout from '../../../components/layouts/learn';
 import { ChallengeNode, ChallengeMeta } from '../../../redux/prop-types';
 import Hotkeys from '../components/hotkeys';
 import ChallengeTitle from '../components/challenge-title';
+import ChallengeHeading from '../components/challenge-heading';
 import CompletionModal from '../components/completion-modal';
 import HelpModal from '../components/help-modal';
 import PrismFormatted from '../components/prism-formatted';
@@ -315,7 +316,7 @@ class ShowFillInTheBlank extends Component<
                 <Spacer size='medium' />
                 <PrismFormatted text={instructions} />
                 <Spacer size='medium' />
-                <h2>{t('learn.fill-in-the-blank')}</h2>
+                <ChallengeHeading heading={'learn.fill-in-the-blank'} />
                 <Spacer size='small' />
                 <ObserveKeys>
                   <div>

--- a/client/src/templates/Challenges/ms-trophy/link-ms-user.css
+++ b/client/src/templates/Challenges/ms-trophy/link-ms-user.css
@@ -1,8 +1,3 @@
-.link-ms-user-title {
-  text-align: center;
-  font-size: inherit;
-}
-
 .link-ms-user-ol li {
   margin-bottom: 5px;
 }

--- a/client/src/templates/Challenges/ms-trophy/link-ms-user.tsx
+++ b/client/src/templates/Challenges/ms-trophy/link-ms-user.tsx
@@ -12,6 +12,7 @@ import {
   HelpBlock
 } from '@freecodecamp/ui';
 
+import ChallengeHeading from '../components/challenge-heading';
 import { Spacer } from '../../../components/helpers';
 import { isMicrosoftTranscriptLink } from '../../../../../shared/utils/validate';
 import {
@@ -86,7 +87,7 @@ function LinkMsUser({
 
   return !isSignedIn ? (
     <>
-      <h2 className='link-ms-user-title'>{t('learn.ms.link-header')}</h2>
+      <ChallengeHeading heading={'learn.ms.link-header'} />
       <Spacer size='small' />
 
       <p data-playwright-test-label='link-signin-text'>
@@ -111,7 +112,7 @@ function LinkMsUser({
         </>
       ) : (
         <div>
-          <h2 className='link-ms-user-title'>{t('learn.ms.link-header')}</h2>
+          <ChallengeHeading heading={'learn.ms.link-header'} />
           <Spacer size='small' />
 
           <p data-playwright-test-label='unlinked-text'>

--- a/client/src/templates/Challenges/odin/show.tsx
+++ b/client/src/templates/Challenges/odin/show.tsx
@@ -20,6 +20,8 @@ import { ChallengeNode, ChallengeMeta } from '../../../redux/prop-types';
 import Hotkeys from '../components/hotkeys';
 import VideoPlayer from '../components/video-player';
 import CompletionModal from '../components/completion-modal';
+import ChallengeTitle from '../components/challenge-title';
+import ChallengeHeading from '../components/challenge-heading';
 import HelpModal from '../components/help-modal';
 import PrismFormatted from '../components/prism-formatted';
 import {
@@ -216,11 +218,13 @@ class ShowOdin extends Component<ShowOdinProps, ShowOdinState> {
             bilibiliIds,
             fields: { blockName },
             question: { text, answers, solution },
+            translationPending,
             assignments,
             audioPath
           }
         }
       },
+      isChallengeCompleted,
       openCompletionModal,
       openHelpModal,
       pageContext: {
@@ -253,6 +257,13 @@ class ShowOdin extends Component<ShowOdinProps, ShowOdinState> {
           />
           <Container>
             <Row>
+              <Spacer size='medium' />
+              <ChallengeTitle
+                isCompleted={isChallengeCompleted}
+                translationPending={translationPending}
+              >
+                {title}
+              </ChallengeTitle>
               {videoId && (
                 <Col lg={10} lgOffset={1} md={10} mdOffset={1}>
                   <Spacer size='medium' />
@@ -275,7 +286,6 @@ class ShowOdin extends Component<ShowOdinProps, ShowOdinState> {
               )}
               <Col md={8} mdOffset={2} sm={10} smOffset={1} xs={12}>
                 <Spacer size='medium' />
-                <h2>{title}</h2>
                 <PrismFormatted className={'line-numbers'} text={description} />
                 {audioPath && (
                   <>
@@ -295,7 +305,7 @@ class ShowOdin extends Component<ShowOdinProps, ShowOdinState> {
                 <ObserveKeys>
                   {assignments.length > 0 && (
                     <>
-                      <h2>{t('learn.assignments')}</h2>
+                      <ChallengeHeading heading={'learn.assignments'} />
                       <div className='video-quiz-options'>
                         {assignments.map((assignment, index) => (
                           <label
@@ -325,7 +335,7 @@ class ShowOdin extends Component<ShowOdinProps, ShowOdinState> {
                     </>
                   )}
 
-                  <h2>{t('learn.question')}</h2>
+                  <ChallengeHeading heading={'learn.question'} />
                   <PrismFormatted className={'line-numbers'} text={text} />
                   <div className='video-quiz-options'>
                     {answers.map(({ answer }, index) => (


### PR DESCRIPTION
I was a little annoyed with some inconsistencies in the challenge titles and headings. This adds a `ChallengeHeading` component for the h2's on challenge pages and uses the `ChallengeTitle` component where it wasn't being used.

MS Trophy challenges
-changed to use challenge header

Odin (multiple choice) - used in English/Odin/Algebra/C# curriculum:
-used ChallengeTitle and moved title above video
-used challengeHeading for assignment and question headings

English Dialogue:
-used ChallengeTitle and moved title above video
-used challengeHeading for assignment and question headings

CodeAlly project
-used challengeHeading

<details>
<summary>images</summary>
Before on the left, After on the right:

<img width="1750" alt="Screenshot 2023-12-05 at 11 02 08 AM" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/20648924/9d867309-0734-4958-8b93-2d8a6aee5248">

<img width="1762" alt="Screenshot 2023-12-05 at 10 59 38 AM" src="https://github.com/freeCodeCamp/freeCodeCamp/assets/20648924/87613d24-0ae6-44bf-9b49-a5b1966ec4ac">

</details>
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX


<!-- Feel free to add any additional description of changes below this line -->

TODO: Add ChallengeHeader to playwright issue if this gets merged. Or. I will add it here if I get to it before it gets reviewed.