### PR TITLE
fix(e2e): failing electron tests

### DIFF
--- a/client/src/components/SolutionViewer/project-modal.tsx
+++ b/client/src/components/SolutionViewer/project-modal.tsx
@@ -38,7 +38,12 @@ const ProjectModal = ({
         <SolutionViewer challengeFiles={challengeFiles} solution={solution} />
       </Modal.Body>
       <Modal.Footer>
-        <Button onClick={handleSolutionModalHide}>{t('buttons.close')}</Button>
+        <Button
+          data-cy='solution-viewer-close-btn'
+          onClick={handleSolutionModalHide}
+        >
+          {t('buttons.close')}
+        </Button>
       </Modal.Footer>
     </Modal>
   );

--- a/cypress/e2e/default/learn/challenges/projects.ts
+++ b/cypress/e2e/default/learn/challenges/projects.ts
@@ -147,7 +147,7 @@ describe('project submission', () => {
             // TODO: if we write a test to check that the solution is visible
             // before reloading, we should include that here.
             cy.contains('Solution for');
-            cy.contains('Close').click();
+            cy.get(`[data-cy="solution-viewer-close-btn"]`).click();
           });
 
           // Claim and view solutions on certification page


### PR DESCRIPTION
The electron tests are failing: https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/7103692489/job/19337285409?pr=52472

The footer [added an article with "Close"](https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/7103692489/job/19337285409?pr=52472) and it is messing with the selector.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
