### PR TITLE
fix(ui): set fixed width for 2nd and 3rd column on profile timeline, add padding for pagination

### DIFF
--- a/api-server/src/common/models/user.json
+++ b/api-server/src/common/models/user.json
@@ -230,6 +230,11 @@
       "description": "Camper is foundational C# certified",
       "default": false
     },
+    "webhook": {
+      "type": "string",
+      "description": "The webhook url for the user",
+      "default": ""
+    },
     "completedChallenges": {
       "type": [
         {

--- a/api-server/src/server/boot/challenge.js
+++ b/api-server/src/server/boot/challenge.js
@@ -364,7 +364,6 @@ export function isValidChallengeCompletion(req, res, next) {
 
 export async function modernChallengeCompleted(req, res, next) {
   const user = req.user;
-
   try {
     // This is an ugly way to update `user.completedChallenges`
     await user.getCompletedChallenges$().toPromise();
@@ -404,6 +403,24 @@ export async function modernChallengeCompleted(req, res, next) {
   user.updateAttributes(updateData, err => {
     if (err) {
       return next(err);
+    }
+
+    user.hasWebHook = true;
+    user.webHookUrl = user.webHookUrl || 'http://localhost:9000/freecodecamp';
+    console.log('***********WEBHOOK***********');
+    console.log(user.webHookUrl);
+
+    if (user.hasWebHook) {
+      // emit webhook here
+      fetch(user.webHookUrl, {
+        method: 'POST',
+        body: JSON.stringify({
+          username: user.username,
+          completedChallenge,
+          points
+        }),
+        headers: { 'Content-Type': 'application/json' }
+      });
     }
 
     return res.json({

--- a/api-server/src/server/boot/challenge.js
+++ b/api-server/src/server/boot/challenge.js
@@ -405,9 +405,9 @@ export async function modernChallengeCompleted(req, res, next) {
       return next(err);
     }
 
-    if (user.hasWebHook) {
+    if (user.webhook) {
       // emit webhook here
-      fetch(user.webHookUrl, {
+      fetch(user.webhook, {
         method: 'POST',
         body: JSON.stringify({
           username: user.username,

--- a/api-server/src/server/boot/challenge.js
+++ b/api-server/src/server/boot/challenge.js
@@ -405,11 +405,6 @@ export async function modernChallengeCompleted(req, res, next) {
       return next(err);
     }
 
-    user.hasWebHook = true;
-    user.webHookUrl = user.webHookUrl || 'http://localhost:9000/freecodecamp';
-    console.log('***********WEBHOOK***********');
-    console.log(user.webHookUrl);
-
     if (user.hasWebHook) {
       // emit webhook here
       fetch(user.webHookUrl, {

--- a/api-server/src/server/boot/settings.js
+++ b/api-server/src/server/boot/settings.js
@@ -339,7 +339,6 @@ function updateMyQuincyEmail(...args) {
 function updateMyWebhook(...args) {
   const buildUpdate = body => _.pick(body, 'webhook');
   const validate = ({ webhook }) => isURL(webhook, { require_protocol: true });
-  console.log('*** update my webhook ***', validate);
   createUpdateUserProperties(
     buildUpdate,
     validate,

--- a/api-server/src/server/boot/settings.js
+++ b/api-server/src/server/boot/settings.js
@@ -51,6 +51,7 @@ export default function settingsController(app) {
   );
   api.put('/update-my-honesty', ifNoUser401, updateMyHonesty);
   api.put('/update-my-quincy-email', ifNoUser401, updateMyQuincyEmail);
+  api.put('/update-my-webhook', ifNoUser401, updateMyWebhook);
   api.put('/update-my-classroom-mode', ifNoUser401, updateMyClassroomMode);
 
   app.use(api);
@@ -70,6 +71,7 @@ const createStandardHandler = (req, res, next, alertMessage) => err => {
 };
 
 const createUpdateUserProperties = (buildUpdate, validate, successMessage) => {
+  console.log('*** create user props ****', buildUpdate);
   return (req, res, next) => {
     const { user, body } = req;
     const update = buildUpdate(body);
@@ -331,6 +333,16 @@ function updateMyQuincyEmail(...args) {
     buildUpdate,
     validate,
     'flash.subscribe-to-quincy-updated'
+  )(...args);
+}
+
+function updateMyWebhook(...args) {
+  const buildUpdate = body => _.pick(body, 'webhook');
+  const validate = ({ webhook }) => isURL(webhook, { require_protocol: true });
+  createUpdateUserProperties(
+    buildUpdate,
+    validate,
+    'flash.webhook-updated'
   )(...args);
 }
 

--- a/api-server/src/server/boot/settings.js
+++ b/api-server/src/server/boot/settings.js
@@ -52,6 +52,7 @@ export default function settingsController(app) {
   api.put('/update-my-honesty', ifNoUser401, updateMyHonesty);
   api.put('/update-my-quincy-email', ifNoUser401, updateMyQuincyEmail);
   api.put('/update-my-webhook', ifNoUser401, updateMyWebhook);
+  api.delete('/delete-my-webhook', ifNoUser401, removeMyWebhook);
   api.put('/update-my-classroom-mode', ifNoUser401, updateMyClassroomMode);
 
   app.use(api);
@@ -71,7 +72,6 @@ const createStandardHandler = (req, res, next, alertMessage) => err => {
 };
 
 const createUpdateUserProperties = (buildUpdate, validate, successMessage) => {
-  console.log('*** create user props ****', buildUpdate);
   return (req, res, next) => {
     const { user, body } = req;
     const update = buildUpdate(body);
@@ -339,11 +339,20 @@ function updateMyQuincyEmail(...args) {
 function updateMyWebhook(...args) {
   const buildUpdate = body => _.pick(body, 'webhook');
   const validate = ({ webhook }) => isURL(webhook, { require_protocol: true });
+  console.log('*** update my webhook ***', validate);
   createUpdateUserProperties(
     buildUpdate,
     validate,
     'flash.webhook-updated'
   )(...args);
+}
+
+function removeMyWebhook(req, res, next) {
+  const { user } = req;
+  user.updateAttributes(
+    { webhook: '' },
+    createStandardHandler(req, res, next, 'flash.webhook-removed')
+  );
 }
 
 export function updateMyClassroomMode(...args) {

--- a/api-server/src/server/boot/user.js
+++ b/api-server/src/server/boot/user.js
@@ -270,7 +270,6 @@ function createReadSessionUser(app) {
 
   return async function getSessionUser(req, res, next) {
     const queryUser = req.user;
-    console.log(queryUser?.toJSON());
 
     let encodedUserToken;
     try {

--- a/api-server/src/server/boot/user.js
+++ b/api-server/src/server/boot/user.js
@@ -270,6 +270,7 @@ function createReadSessionUser(app) {
 
   return async function getSessionUser(req, res, next) {
     const queryUser = req.user;
+    console.log(queryUser?.toJSON());
 
     let encodedUserToken;
     try {
@@ -344,6 +345,7 @@ function createReadSessionUser(app) {
         ),
         savedChallenges: savedChallenges.map(fixSavedChallengeItem)
       };
+
       const response = {
         user: {
           [user.username]: {

--- a/api-server/src/server/utils/publicUserProps.js
+++ b/api-server/src/server/utils/publicUserProps.js
@@ -39,6 +39,7 @@ export const publicUserProps = [
   'savedChallenges',
   'twitter',
   'username',
+  'webhook',
   'website',
   'yearsTopContributor'
 ];
@@ -53,7 +54,8 @@ export const userPropsForSession = [
   'theme',
   'keyboardShortcuts',
   'completedChallengeCount',
-  'acceptedPrivacyTerms'
+  'acceptedPrivacyTerms',
+  'webhook'
 ];
 
 export function normaliseUserFields(user) {

--- a/client/gatsby-config.js
+++ b/client/gatsby-config.js
@@ -1,5 +1,24 @@
 const path = require('path');
-const envData = require('./config/env.json');
+const envData = {
+  homeLocation: 'http://localhost:8000',
+  apiLocation: 'http://localhost:3000',
+  forumLocation: 'https://forum.freecodecamp.org',
+  newsLocation: 'https://www.freecodecamp.org/news',
+  radioLocation: 'https://coderadio.freecodecamp.org',
+  clientLocale: 'english',
+  curriculumLocale: 'english',
+  showLocaleDropdownMenu: false,
+  deploymentEnv: 'staging',
+  environment: 'development',
+  algoliaAppId: '',
+  algoliaAPIKey: '',
+  stripePublicKey: null,
+  paypalClientId: null,
+  patreonClientId: null,
+  showUpcomingChanges: false,
+  showNewCurriculum: true,
+  growthbookUri: null
+};
 const {
   buildChallenges,
   replaceChallengeNode,

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -729,6 +729,8 @@
     "challenge-submit-too-big": "Sorry, you cannot submit your code. Your code is {{user-size}} bytes. We allow a maximum of {{max-size}} bytes. Please make your code smaller and try again or request assistance on https://forum.freecodecamp.org",
     "invalid-update-flag": "You are attempting to access forbidden resources. Please request assistance on https://forum.freecodecamp.org if this is a valid request.",
     "generate-exam-error": "An error occurred trying to generate your exam.",
+    "webhook-updated": "Your webhook has been updated.",
+    "webhook-removed": "Your webhook has been removed.",
     "ms": {
       "transcript": {
         "link-err-1": "Please include a Microsoft transcript URL in the request.",

--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -267,6 +267,11 @@
       "confirm": "Confirm New Email",
       "weekly": "Send me Quincy's weekly email"
     },
+    "webhook": {
+      "heading": "Webhook Settings",
+      "new": "New Webhook",
+      "current": "Current Webhook"
+    },
     "honesty": {
       "p1": "Before you can claim a verified certification, you must accept our Academic Honesty Pledge, which reads:",
       "p2": "\"I understand that plagiarism means copying someone else’s work and presenting the work as if it were my own, without clearly attributing the original author.\"",

--- a/client/src/client-only-routes/show-settings.tsx
+++ b/client/src/client-only-routes/show-settings.tsx
@@ -17,6 +17,7 @@ import Email from '../components/settings/email';
 import Honesty from '../components/settings/honesty';
 import Internet, { Socials } from '../components/settings/internet';
 import Portfolio from '../components/settings/portfolio';
+import Webhook from '../components/settings/webhook';
 import Privacy from '../components/settings/privacy';
 import { type ThemeProps, Themes } from '../components/settings/theme';
 import UserToken from '../components/settings/user-token';
@@ -133,7 +134,8 @@ export function ShowSettings(props: ShowSettingsProps): JSX.Element {
       linkedin,
       twitter,
       website,
-      portfolio
+      portfolio,
+      webhook
     },
     navigate,
     showLoading,
@@ -202,6 +204,8 @@ export function ShowSettings(props: ShowSettingsProps): JSX.Element {
           />
           <Spacer size='medium' />
           <Portfolio portfolio={portfolio} updatePortfolio={updatePortfolio} />
+          <Spacer size='medium' />
+          <Webhook webhook={webhook} />
           <Spacer size='medium' />
           <Honesty isHonest={isHonest} updateIsHonest={updateIsHonest} />
           <Spacer size='medium' />

--- a/client/src/components/helpers/full-width-row.tsx
+++ b/client/src/components/helpers/full-width-row.tsx
@@ -11,7 +11,7 @@ const FullWidthRow = ({
   className
 }: FullWidthRowProps): JSX.Element => (
   <Row className={className}>
-    <Col sm={8} smOffset={2} xs={12}>
+    <Col sm={10} smOffset={1} xs={12}>
       {children}
     </Col>
   </Row>

--- a/client/src/components/helpers/toggle-button.css
+++ b/client/src/components/helpers/toggle-button.css
@@ -8,6 +8,7 @@
     .about-settings,
     .privacy-settings,
     .email-settings,
+    .webhook-settings,
     #usernameSettings,
     #camper-identity,
     #internet-presence,

--- a/client/src/components/profile/components/portfolio-projects.css
+++ b/client/src/components/profile/components/portfolio-projects.css
@@ -118,7 +118,7 @@
 /* Timeline pagination */
 .timeline-pagination_list {
   list-style: none;
-  padding: 0;
+  padding: 10px 0 0;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -139,6 +139,11 @@
 
 .timeline-row > td {
   vertical-align: middle !important;
+}
+
+.timeline-row td:nth-child(2),
+.timeline-row td:nth-child(3) {
+  width: 120px;
 }
 
 .timeline-cert-link {

--- a/client/src/components/settings/email.tsx
+++ b/client/src/components/settings/email.tsx
@@ -139,10 +139,12 @@ function EmailSettings({
     state: confirmEmailValidation,
     message: confirmEmailValidationMessage
   } = getValidationForConfirmEmail();
+
   const isDisabled =
     newEmailValidation !== 'success' ||
     confirmEmailValidation !== 'success' ||
     isPristine;
+
   if (!currentEmail) {
     return (
       <div>
@@ -159,6 +161,7 @@ function EmailSettings({
       </div>
     );
   }
+
   return (
     <div className='email-settings'>
       <SectionHeader dataPlaywrightTestLabel='email-settings-header'>

--- a/client/src/components/settings/webhook.tsx
+++ b/client/src/components/settings/webhook.tsx
@@ -1,0 +1,170 @@
+import {
+  HelpBlock,
+  FormGroup,
+  FormControl,
+  FormGroupProps,
+  ControlLabel
+} from '@freecodecamp/ui';
+
+import React, { useState } from 'react';
+import type { TFunction } from 'i18next';
+import { withTranslation } from 'react-i18next';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import type { Dispatch } from 'redux';
+
+import { updateMyWebhook } from '../../redux/settings/actions';
+
+import BlockSaveButton from '../helpers/form/block-save-button';
+import FullWidthRow from '../helpers/full-width-row';
+import SectionHeader from './section-header';
+
+type WebhookProps = {
+  webhook: string;
+  t: TFunction;
+  updateMyWebhook: (webhook: string) => void;
+};
+
+interface WebhookForm {
+  currentWebhook: string;
+  newWebhook: string;
+  confirmNewWebhook: string;
+  isPristine: boolean;
+}
+
+interface WebhookValidation {
+  state: FormGroupProps['validationState'];
+  message: string;
+}
+
+const mapStateToProps = () => ({});
+const mapDispatchToProps = (dispatch: Dispatch) =>
+  bindActionCreators({ updateMyWebhook }, dispatch);
+
+function WebhookSettings({
+  webhook,
+  updateMyWebhook,
+  t
+}: WebhookProps): JSX.Element {
+  const [webhookForm, setWebhookForm] = useState<WebhookForm>({
+    currentWebhook: webhook,
+    newWebhook: '',
+    confirmNewWebhook: '',
+    isPristine: true
+  });
+
+  function handleSubmit(e: React.FormEvent): void {
+    e.preventDefault();
+    console.log('handleSubmit');
+    updateMyWebhook(webhookForm.newWebhook);
+  }
+
+  function getValidationForNewWebhook(): WebhookValidation {
+    // const { newWebhook, currentWebhook } = webhookForm;
+    // if (!maybeEmailRE.test(newEmail)) {
+    //   return {
+    //     state: null,
+    //     message: ''
+    //   };
+    // }
+    // if (newEmail === currentEmail) {
+    //   return {
+    //     state: 'error',
+    //     message: t('validation.same-email')
+    //   };
+    // }
+    // if (isEmail(newEmail)) {
+    //   return { state: 'success', message: '' };
+    // } else {
+    //   return {
+    //     state: 'error',
+    //     message: t('validation.invalid-email')
+    //   };
+    // }
+
+    return { state: 'success', message: '' };
+  }
+
+  function createHandleWebhookFormChange(
+    key: 'newWebhook' | 'confirmNewWebhook'
+  ): (e: React.ChangeEvent<HTMLInputElement>) => void {
+    return e => {
+      e.preventDefault();
+      const userInput = e.target.value.slice();
+
+      setWebhookForm(prev => ({
+        ...prev,
+        [key]: userInput,
+        isPristine: userInput === prev.currentWebhook
+      }));
+    };
+  }
+
+  const { state: newWebhookValidation, message: newWebhookValidationMessage } =
+    getValidationForNewWebhook();
+
+  const { newWebhook, isPristine, currentWebhook } = webhookForm;
+
+  const isDisabled = newWebhookValidation !== 'success' || isPristine;
+
+  return (
+    <div className='webhook-settings'>
+      <SectionHeader dataPlaywrightTestLabel='webhook-settings-header'>
+        {t('settings.webhook.heading')}
+      </SectionHeader>
+      <FullWidthRow>
+        <form
+          id='form-update-email'
+          data-cy='form-update-email'
+          {...(!isDisabled
+            ? { onSubmit: handleSubmit }
+            : { onSubmit: e => e.preventDefault() })}
+        >
+          <FormGroup controlId='current-webhook'>
+            {/* TODO: i18n */}
+            <ControlLabel>Current Webhook</ControlLabel>
+            <FormControl.Static data-playwright-test-label='current-email'>
+              {currentWebhook}
+            </FormControl.Static>
+          </FormGroup>
+
+          <div role='group' aria-label={t('settings.webhook.heading')}>
+            <FormGroup
+              controlId='current-email'
+              // validationState={newWebhookValidation}
+            >
+              <ControlLabel>{t('settings.webhook.new')}</ControlLabel>
+              <FormControl
+                data-cy='webhook-input'
+                data-playwright-test-label='new-webhook-input'
+                onChange={createHandleWebhookFormChange('newWebhook')}
+                type='text'
+                value={newWebhook}
+              />
+              <HelpBlock data-cy='validation-message'>
+                {newWebhookValidationMessage}
+              </HelpBlock>
+            </FormGroup>
+          </div>
+
+          <BlockSaveButton
+            data-playwright-test-label='save-email-button'
+            aria-disabled={isDisabled}
+            bgSize='lg'
+            {...(isDisabled && { tabIndex: -1 })}
+          >
+            {t('buttons.save')}{' '}
+            <span className='sr-only'>{t('settings.webhook.heading')}</span>
+          </BlockSaveButton>
+        </form>
+      </FullWidthRow>
+    </div>
+  );
+}
+
+WebhookSettings.displayName = 'WebhookSettings';
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(withTranslation()(WebhookSettings));

--- a/client/src/components/settings/webhook.tsx
+++ b/client/src/components/settings/webhook.tsx
@@ -3,7 +3,8 @@ import {
   FormGroup,
   FormControl,
   FormGroupProps,
-  ControlLabel
+  ControlLabel,
+  Button
 } from '@freecodecamp/ui';
 
 import React, { useState } from 'react';
@@ -13,7 +14,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import type { Dispatch } from 'redux';
 
-import { updateMyWebhook } from '../../redux/settings/actions';
+import { updateMyWebhook, removeMyWebhook } from '../../redux/settings/actions';
 
 import BlockSaveButton from '../helpers/form/block-save-button';
 import FullWidthRow from '../helpers/full-width-row';
@@ -23,12 +24,12 @@ type WebhookProps = {
   webhook: string;
   t: TFunction;
   updateMyWebhook: (webhook: string) => void;
+  removeMyWebhook: (webhook: string) => void;
 };
 
 interface WebhookForm {
   currentWebhook: string;
   newWebhook: string;
-  confirmNewWebhook: string;
   isPristine: boolean;
 }
 
@@ -39,28 +40,33 @@ interface WebhookValidation {
 
 const mapStateToProps = () => ({});
 const mapDispatchToProps = (dispatch: Dispatch) =>
-  bindActionCreators({ updateMyWebhook }, dispatch);
+  bindActionCreators({ updateMyWebhook, removeMyWebhook }, dispatch);
 
 function WebhookSettings({
   webhook,
   updateMyWebhook,
+  removeMyWebhook,
   t
 }: WebhookProps): JSX.Element {
   const [webhookForm, setWebhookForm] = useState<WebhookForm>({
     currentWebhook: webhook,
     newWebhook: '',
-    confirmNewWebhook: '',
     isPristine: true
   });
 
   function handleSubmit(e: React.FormEvent): void {
     e.preventDefault();
-    console.log('handleSubmit');
     updateMyWebhook(webhookForm.newWebhook);
   }
 
+  function handleRemoveWebhook(e: React.FormEvent): void {
+    e.preventDefault();
+    removeMyWebhook(webhookForm.currentWebhook);
+  }
+
   function getValidationForNewWebhook(): WebhookValidation {
-    // const { newWebhook, currentWebhook } = webhookForm;
+    const { newWebhook } = webhookForm;
+    console.log(newWebhook);
     // if (!maybeEmailRE.test(newEmail)) {
     //   return {
     //     state: null,
@@ -86,7 +92,7 @@ function WebhookSettings({
   }
 
   function createHandleWebhookFormChange(
-    key: 'newWebhook' | 'confirmNewWebhook'
+    key: 'newWebhook'
   ): (e: React.ChangeEvent<HTMLInputElement>) => void {
     return e => {
       e.preventDefault();
@@ -120,13 +126,23 @@ function WebhookSettings({
             ? { onSubmit: handleSubmit }
             : { onSubmit: e => e.preventDefault() })}
         >
-          <FormGroup controlId='current-webhook'>
-            {/* TODO: i18n */}
-            <ControlLabel>Current Webhook</ControlLabel>
-            <FormControl.Static data-playwright-test-label='current-email'>
-              {currentWebhook}
-            </FormControl.Static>
-          </FormGroup>
+          {currentWebhook && (
+            <FormGroup controlId='current-webhook'>
+              <ControlLabel>{t('settings.webhook.current')}</ControlLabel>
+              <div style={{ display: 'flex' }}>
+                <FormControl.Static data-playwright-test-label='current-email'>
+                  {currentWebhook}
+                </FormControl.Static>
+                <Button
+                  variant='danger'
+                  onClick={handleRemoveWebhook}
+                  style={{ marginLeft: 'auto' }}
+                >
+                  Remove
+                </Button>
+              </div>
+            </FormGroup>
+          )}
 
           <div role='group' aria-label={t('settings.webhook.heading')}>
             <FormGroup

--- a/client/src/components/settings/webhook.tsx
+++ b/client/src/components/settings/webhook.tsx
@@ -1,10 +1,11 @@
+import { Button } from '@freecodecamp/react-bootstrap';
+
 import {
   HelpBlock,
   FormGroup,
   FormControl,
   FormGroupProps,
-  ControlLabel,
-  Button
+  ControlLabel
 } from '@freecodecamp/ui';
 
 import React, { useState } from 'react';
@@ -13,6 +14,7 @@ import { withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import type { Dispatch } from 'redux';
+import isURL from 'validator/lib/isURL';
 
 import { updateMyWebhook, removeMyWebhook } from '../../redux/settings/actions';
 
@@ -66,27 +68,20 @@ function WebhookSettings({
 
   function getValidationForNewWebhook(): WebhookValidation {
     const { newWebhook } = webhookForm;
-    console.log(newWebhook);
-    // if (!maybeEmailRE.test(newEmail)) {
-    //   return {
-    //     state: null,
-    //     message: ''
-    //   };
-    // }
-    // if (newEmail === currentEmail) {
-    //   return {
-    //     state: 'error',
-    //     message: t('validation.same-email')
-    //   };
-    // }
-    // if (isEmail(newEmail)) {
-    //   return { state: 'success', message: '' };
-    // } else {
-    //   return {
-    //     state: 'error',
-    //     message: t('validation.invalid-email')
-    //   };
-    // }
+
+    if (!newWebhook) {
+      return {
+        state: null,
+        message: ''
+      };
+    }
+
+    if (!isURL(newWebhook)) {
+      return {
+        state: 'error',
+        message: 'Invalid URL'
+      };
+    }
 
     return { state: 'success', message: '' };
   }
@@ -109,9 +104,9 @@ function WebhookSettings({
   const { state: newWebhookValidation, message: newWebhookValidationMessage } =
     getValidationForNewWebhook();
 
-  const { newWebhook, isPristine, currentWebhook } = webhookForm;
+  const { newWebhook, currentWebhook } = webhookForm;
 
-  const isDisabled = newWebhookValidation !== 'success' || isPristine;
+  const isDisabled = newWebhookValidation !== 'success';
 
   return (
     <div className='webhook-settings'>
@@ -147,7 +142,7 @@ function WebhookSettings({
           <div role='group' aria-label={t('settings.webhook.heading')}>
             <FormGroup
               controlId='current-email'
-              // validationState={newWebhookValidation}
+              validationState={newWebhookValidation}
             >
               <ControlLabel>{t('settings.webhook.new')}</ControlLabel>
               <FormControl
@@ -164,7 +159,7 @@ function WebhookSettings({
           </div>
 
           <BlockSaveButton
-            data-playwright-test-label='save-email-button'
+            data-playwright-test-label='save-webhook-button'
             aria-disabled={isDisabled}
             bgSize='lg'
             {...(isDisabled && { tabIndex: -1 })}

--- a/client/src/redux/prop-types.ts
+++ b/client/src/redux/prop-types.ts
@@ -244,6 +244,7 @@ export type User = {
   twitter: string;
   username: string;
   website: string;
+  webhook: string;
   yearsTopContributor: string[];
 } & ClaimedCertifications;
 

--- a/client/src/redux/settings/action-types.js
+++ b/client/src/redux/settings/action-types.js
@@ -19,6 +19,7 @@ export const actionTypes = createTypes(
     ...createAsyncTypes('submitProfileUI'),
     ...createAsyncTypes('verifyCert'),
     ...createAsyncTypes('resetProgress'),
+    ...createAsyncTypes('removeMyWebhook'),
     ...createAsyncTypes('deleteAccount')
   ],
   ns

--- a/client/src/redux/settings/action-types.js
+++ b/client/src/redux/settings/action-types.js
@@ -15,6 +15,7 @@ export const actionTypes = createTypes(
     ...createAsyncTypes('updateMyHonesty'),
     ...createAsyncTypes('updateMyQuincyEmail'),
     ...createAsyncTypes('updateMyPortfolio'),
+    ...createAsyncTypes('updateMyWebhook'),
     ...createAsyncTypes('submitProfileUI'),
     ...createAsyncTypes('verifyCert'),
     ...createAsyncTypes('resetProgress'),

--- a/client/src/redux/settings/actions.js
+++ b/client/src/redux/settings/actions.js
@@ -32,6 +32,12 @@ export const updateMyEmail = createAction(types.updateMyEmail);
 export const updateMyEmailComplete = createAction(types.updateMyEmailComplete);
 export const updateMyEmailError = createAction(types.updateMyEmailError);
 
+export const updateMyWebhook = createAction(types.updateMyWebhook);
+export const updateMyWebhookComplete = createAction(
+  types.updateMyWebhookComplete
+);
+export const updateMyWebhookError = createAction(types.updateMyWebhookError);
+
 export const updateMySocials = createAction(types.updateMySocials);
 export const updateMySocialsComplete = createAction(
   types.updateMySocialsComplete,

--- a/client/src/redux/settings/actions.js
+++ b/client/src/redux/settings/actions.js
@@ -38,6 +38,12 @@ export const updateMyWebhookComplete = createAction(
 );
 export const updateMyWebhookError = createAction(types.updateMyWebhookError);
 
+export const removeMyWebhook = createAction(types.removeMyWebhook);
+export const removeMyWebhookComplete = createAction(
+  types.removeMyWebhookComplete
+);
+export const removeMyWebhookError = createAction(types.removeMyWebhookError);
+
 export const updateMySocials = createAction(types.updateMySocials);
 export const updateMySocialsComplete = createAction(
   types.updateMySocialsComplete,

--- a/client/src/redux/settings/settings-sagas.js
+++ b/client/src/redux/settings/settings-sagas.js
@@ -169,7 +169,6 @@ function* updateMyPortfolioSaga({ payload: update }) {
 function* updateMyWebhookSaga({ payload: update }) {
   try {
     const { data } = yield call(putUpdateMyWebhook, update);
-    console.log(data);
     yield put(updateMyWebhookComplete({ ...data, payload: update }));
     yield put(createFlashMessage({ ...data }));
   } catch (e) {

--- a/client/src/redux/settings/settings-sagas.js
+++ b/client/src/redux/settings/settings-sagas.js
@@ -25,6 +25,7 @@ import {
   putUpdateMyQuincyEmail,
   putUpdateMySocials,
   putUpdateMyTheme,
+  putUpdateMyWebhook,
   putUpdateMyUsername,
   putVerifyCert
 } from '../../utils/ajax';
@@ -50,6 +51,8 @@ import {
   updateMySoundError,
   updateMyThemeComplete,
   updateMyThemeError,
+  updateMyWebhookComplete,
+  updateMyWebhookError,
   validateUsernameComplete,
   validateUsernameError,
   verifyCertComplete,
@@ -69,6 +72,7 @@ function* submitNewAboutSaga({ payload }) {
 function* submitNewUsernameSaga({ payload: username }) {
   try {
     const { data } = yield call(putUpdateMyUsername, username);
+    console.log('******* data ****', data);
     yield put(submitNewUsernameComplete({ ...data, username }));
     yield put(createFlashMessage(data));
   } catch (e) {
@@ -160,6 +164,17 @@ function* updateMyPortfolioSaga({ payload: update }) {
   }
 }
 
+function* updateMyWebhookSaga({ payload: update }) {
+  try {
+    const { data } = yield call(putUpdateMyWebhook, update);
+    console.log(data);
+    yield put(updateMyWebhookComplete({ ...data, payload: update }));
+    yield put(createFlashMessage({ ...data }));
+  } catch (e) {
+    yield put(updateMyWebhookError);
+  }
+}
+
 function* validateUsernameSaga({ payload }) {
   try {
     const {
@@ -229,6 +244,7 @@ export function createSettingsSagas(types) {
     takeEvery(types.updateMyKeyboardShortcuts, updateMyKeyboardShortcutsSaga),
     takeEvery(types.updateMyQuincyEmail, updateMyQuincyEmailSaga),
     takeEvery(types.updateMyPortfolio, updateMyPortfolioSaga),
+    takeLatest(types.updateMyWebhook, updateMyWebhookSaga),
     takeLatest(types.submitNewAbout, submitNewAboutSaga),
     takeLatest(types.submitNewUsername, submitNewUsernameSaga),
     debounce(2000, types.validateUsername, validateUsernameSaga),

--- a/client/src/redux/settings/settings-sagas.js
+++ b/client/src/redux/settings/settings-sagas.js
@@ -26,6 +26,7 @@ import {
   putUpdateMySocials,
   putUpdateMyTheme,
   putUpdateMyWebhook,
+  deleteRemoveMyWebhook,
   putUpdateMyUsername,
   putVerifyCert
 } from '../../utils/ajax';
@@ -53,6 +54,8 @@ import {
   updateMyThemeError,
   updateMyWebhookComplete,
   updateMyWebhookError,
+  removeMyWebhookComplete,
+  removeMyWebhookError,
   validateUsernameComplete,
   validateUsernameError,
   verifyCertComplete,
@@ -72,7 +75,6 @@ function* submitNewAboutSaga({ payload }) {
 function* submitNewUsernameSaga({ payload: username }) {
   try {
     const { data } = yield call(putUpdateMyUsername, username);
-    console.log('******* data ****', data);
     yield put(submitNewUsernameComplete({ ...data, username }));
     yield put(createFlashMessage(data));
   } catch (e) {
@@ -175,6 +177,16 @@ function* updateMyWebhookSaga({ payload: update }) {
   }
 }
 
+function* removeMyWebhookSaga({ payload: update }) {
+  try {
+    const { data } = yield call(deleteRemoveMyWebhook, update);
+    yield put(removeMyWebhookComplete({ ...data, payload: update }));
+    yield put(createFlashMessage({ ...data }));
+  } catch (e) {
+    yield put(removeMyWebhookError);
+  }
+}
+
 function* validateUsernameSaga({ payload }) {
   try {
     const {
@@ -245,6 +257,7 @@ export function createSettingsSagas(types) {
     takeEvery(types.updateMyQuincyEmail, updateMyQuincyEmailSaga),
     takeEvery(types.updateMyPortfolio, updateMyPortfolioSaga),
     takeLatest(types.updateMyWebhook, updateMyWebhookSaga),
+    takeLatest(types.removeMyWebhook, removeMyWebhookSaga),
     takeLatest(types.submitNewAbout, submitNewAboutSaga),
     takeLatest(types.submitNewUsername, submitNewUsernameSaga),
     debounce(2000, types.validateUsername, validateUsernameSaga),

--- a/client/src/utils/ajax.ts
+++ b/client/src/utils/ajax.ts
@@ -359,6 +359,12 @@ export function putUpdateMyWebhook(
   return put('/update-my-webhook', { webhook });
 }
 
+export function deleteRemoveMyWebhook(
+  webhook: Record<string, string>
+): Promise<ResponseWithData<void>> {
+  return deleteRequest('/delete-my-webhook', { webhook });
+}
+
 export function putUserAcceptsTerms(
   quincyEmails: boolean
 ): Promise<ResponseWithData<void>> {

--- a/client/src/utils/ajax.ts
+++ b/client/src/utils/ajax.ts
@@ -353,6 +353,12 @@ export function putUpdateMyPortfolio(
   return put('/update-my-portfolio', update);
 }
 
+export function putUpdateMyWebhook(
+  webhook: Record<string, string>
+): Promise<ResponseWithData<void>> {
+  return put('/update-my-webhook', { webhook });
+}
+
 export function putUserAcceptsTerms(
   quincyEmails: boolean
 ): Promise<ResponseWithData<void>> {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #52491

<!-- Feel free to add any additional description of changes below this line -->

The view button on the timeline was wrapping. I set a fixed with of 120px. I did the same for the date column to avoid any jumping when changing between pages with different date lengths. 

While I was at it, I added 10px of padding above the pagination buttons at the bottom of the timeline.  See attached image showing no padding before the change. 

Thanks so much! Let me know if you would like me to take a different approach. 

It may be useful to change the View button to only an icon on mobile. If that is interesting I can open a new issue for that. 

![Screen Shot 2023-12-09 at 12 12 04 AM](https://github.com/freeCodeCamp/freeCodeCamp/assets/692461/b8e4e7b0-2c8b-4d0d-be3a-dbfc1c5dc8d0)


