### PR TITLE
fix(curriculum): make the test not whitespace sensitive

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f3c866d28d7ad0de6470505.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f3c866d28d7ad0de6470505.md
@@ -16,7 +16,7 @@ Add the class name `flavor` to the `French Vanilla` `p` element.
 You should add the `flavor` class to your `p` element.
 
 ```js
-assert(code.match(/<p\s*class=('|")flavor\1\s*>/i));
+assert(code.match(/<p\s*class\s*=\s*('|")flavor\1\s*>/i));
 ```
 
 You should only have one element with the `flavor` class.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #52541

<!-- Feel free to add any additional description of changes below this line -->
This PR was opened to make the test in [this challenge](https://www.freecodecamp.org/learn/2022/responsive-web-design/learn-basic-css-by-building-a-cafe-menu/step-32) not whitespace sensitive, by adding a `\s*` after and before `=` in regex of test code.

The code was tested locally with windows 11 Home PC using Chrome, Firefox, Edge, and Brave browser.