### PR TITLE
feat(curriculum): add all english block 1 animations

### DIFF
--- a/client/src/templates/Challenges/components/scene/character.tsx
+++ b/client/src/templates/Challenges/components/scene/character.tsx
@@ -48,17 +48,22 @@ export function Character({
     }
 
     if (isTalking) {
-      talkInterval = setInterval(() => {
-        const openDuration = getRandomInt(100, 200);
-        const closeDuration = getRandomInt(300, 400);
+      const talk = () => {
+        const openTimeout = getRandomInt(0, 100);
+        const closeTimeout = getRandomInt(150, 300);
 
         setTimeout(() => {
           setMouthIsOpen(true);
-        }, openDuration);
+        }, openTimeout);
 
         setTimeout(() => {
           setMouthIsOpen(false);
-        }, closeDuration);
+        }, closeTimeout);
+      };
+
+      talk();
+      talkInterval = setInterval(() => {
+        talk();
       }, 300);
     }
 

--- a/client/src/templates/Challenges/dialogue/show.tsx
+++ b/client/src/templates/Challenges/dialogue/show.tsx
@@ -216,7 +216,7 @@ class ShowDialogue extends Component<ShowDialogueProps, ShowDialogueState> {
                 <Spacer size='medium' />
               </Col>
 
-              <Scene scene={scene} />
+              {scene && <Scene scene={scene} />}
 
               <Col md={8} mdOffset={2} sm={10} smOffset={1} xs={12}>
                 <ObserveKeys>

--- a/curriculum/challenges/_meta/learn-greetings-in-your-first-day-at-the-office/meta.json
+++ b/curriculum/challenges/_meta/learn-greetings-in-your-first-day-at-the-office/meta.json
@@ -534,6 +534,10 @@
       "title": "Task 127"
     },
     {
+      "id": "657e0d0037192f3d9e3d5417",
+      "title": "Task 128"
+    },
+    {
       "id": "656cd63a45146d1c2c51e682",
       "title": "Task 129"
     },

--- a/curriculum/challenges/_meta/learn-greetings-in-your-first-day-at-the-office/meta.json
+++ b/curriculum/challenges/_meta/learn-greetings-in-your-first-day-at-the-office/meta.json
@@ -122,6 +122,10 @@
       "title": "Task 27"
     },
     {
+      "id": "657bcf58b87d01890f9bdc93",
+      "title": "Task 28"
+    },
+    {
       "id": "656a137523a9bc0f9d3bae01",
       "title": "Task 29"
     },

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/651dd5296ffb500e3f2ce479.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/651dd5296ffb500e3f2ce479.md
@@ -39,7 +39,7 @@ In the audio, `you're` is used, which is a contraction of `you are`. The verb `t
     "characters": [
       {
         "character": "Maria",
-        "position": { "x": 50, "y": 0, "z": 1.5 },
+        "position": {"x":50,"y":0,"z":1.5},
         "opacity": 0
       }
     ],
@@ -47,7 +47,7 @@ In the audio, `you're` is used, which is a contraction of `you are`. The verb `t
       "filename": "1.1-1.mp3",
       "startTime": 1,
       "startTimestamp": 0,
-      "finishTimestamp": 2.5
+      "finishTimestamp": 2.38
     }
   },
   "commands": [
@@ -58,17 +58,17 @@ In the audio, `you're` is used, which is a contraction of `you are`. The verb `t
     },
     {
       "character": "Maria",
-      "startTime": 0.5,
-      "finishTime": 2.9,
+      "startTime": 1,
+      "finishTime": 2.88,
       "dialogue": {
-        "text": "Hello! You're the new graphic designer, right?",
+        "text": "Hello. You're the new graphic designer, right?",
         "align": "center"
       }
     },
     {
       "character": "Maria",
       "opacity": 0,
-      "startTime": 3.4
+      "startTime": 3.38
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/651dd5386ffb500e3f2ce47a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/651dd5386ffb500e3f2ce47a.md
@@ -37,7 +37,7 @@ Pay attention to the verb in the sentence.
     "characters": [
       {
         "character": "Maria",
-        "position": { "x": 50, "y": 0, "z": 1.5 },
+        "position": {"x":50,"y":0,"z":1.5},
         "opacity": 0
       }
     ],
@@ -45,7 +45,7 @@ Pay attention to the verb in the sentence.
       "filename": "1.1-1.mp3",
       "startTime": 1,
       "startTimestamp": 0,
-      "finishTimestamp": 2.5
+      "finishTimestamp": 2.38
     }
   },
   "commands": [
@@ -56,17 +56,17 @@ Pay attention to the verb in the sentence.
     },
     {
       "character": "Maria",
-      "startTime": 0.5,
-      "finishTime": 2.9,
+      "startTime": 1,
+      "finishTime": 2.88,
       "dialogue": {
-        "text": "Hello! You're the new graphic designer, right?",
+        "text": "Hello. You're the new graphic designer, right?",
         "align": "center"
       }
     },
     {
       "character": "Maria",
       "opacity": 0,
-      "startTime": 3.4
+      "startTime": 3.38
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6537e6ece93e5724eeb27c54.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6537e6ece93e5724eeb27c54.md
@@ -84,7 +84,7 @@ Focus on the term Maria used to describe herself.
     },
     {
       "character": "Maria",
-      "startTime": 0.5,
+      "startTime": 1,
       "finishTime": 2.2,
       "dialogue": {
         "text": "I'm Maria, the team lead.",

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6543aa3df5f028dba112f275.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6543aa3df5f028dba112f275.md
@@ -64,7 +64,7 @@ Focus on the term Maria used to describe herself.
     },
     {
       "character": "Maria",
-      "startTime": 0.5,
+      "startTime": 1,
       "finishTime": 2.2,
       "dialogue": {
         "text": "I'm Maria, the team lead.",

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6543aaa9f5f028dba112f276.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6543aaa9f5f028dba112f276.md
@@ -51,3 +51,47 @@ Which phrase does Tom use to confirm Maria's statement about him?
 ## --video-solution--
 
 3
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-1.mp3",
+      "startTime": 1,
+      "startTimestamp": 4.5,
+      "finishTimestamp": 8.46
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 0.5,
+      "finishTime": 4.7,
+      "dialogue": {
+        "text": "Hi, that's right. I'm Tom McKenzie. It's a pleasure to meet you.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 5.2
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6543aaa9f5f028dba112f276.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6543aaa9f5f028dba112f276.md
@@ -61,14 +61,14 @@ Which phrase does Tom use to confirm Maria's statement about him?
     "characters": [
       {
         "character": "Tom",
-        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "position": {"x":50,"y":15,"z":1.2},
         "opacity": 0
       }
     ],
     "audio": {
       "filename": "1.1-1.mp3",
       "startTime": 1,
-      "startTimestamp": 4.5,
+      "startTimestamp": 4.62,
       "finishTimestamp": 8.46
     }
   },
@@ -80,8 +80,8 @@ Which phrase does Tom use to confirm Maria's statement about him?
     },
     {
       "character": "Tom",
-      "startTime": 0.5,
-      "finishTime": 4.7,
+      "startTime": 1,
+      "finishTime": 4.34,
       "dialogue": {
         "text": "Hi, that's right. I'm Tom McKenzie. It's a pleasure to meet you.",
         "align": "center"
@@ -90,7 +90,7 @@ Which phrase does Tom use to confirm Maria's statement about him?
     {
       "character": "Tom",
       "opacity": 0,
-      "startTime": 5.2
+      "startTime": 4.84
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6543aae6f5f028dba112f277.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6543aae6f5f028dba112f277.md
@@ -37,14 +37,14 @@ Listen to the audio and complete the sentence below.
     "characters": [
       {
         "character": "Tom",
-        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "position": {"x":50,"y":15,"z":1.2},
         "opacity": 0
       }
     ],
     "audio": {
       "filename": "1.1-1.mp3",
       "startTime": 1,
-      "startTimestamp": 4.5,
+      "startTimestamp": 4.62,
       "finishTimestamp": 8.46
     }
   },
@@ -56,8 +56,8 @@ Listen to the audio and complete the sentence below.
     },
     {
       "character": "Tom",
-      "startTime": 0.5,
-      "finishTime": 4.7,
+      "startTime": 1,
+      "finishTime": 4.34,
       "dialogue": {
         "text": "Hi, that's right. I'm Tom McKenzie. It's a pleasure to meet you.",
         "align": "center"
@@ -66,7 +66,7 @@ Listen to the audio and complete the sentence below.
     {
       "character": "Tom",
       "opacity": 0,
-      "startTime": 5.2
+      "startTime": 4.84
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6543aae6f5f028dba112f277.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6543aae6f5f028dba112f277.md
@@ -3,7 +3,6 @@ id: 6543aae6f5f028dba112f277
 title: Task 6
 challengeType: 22
 dashedName: task-6
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--
@@ -28,3 +27,47 @@ Listen to the audio and complete the sentence below.
 ---
 
 `right`
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-1.mp3",
+      "startTime": 1,
+      "startTimestamp": 4.5,
+      "finishTimestamp": 8.46
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 0.5,
+      "finishTime": 4.7,
+      "dialogue": {
+        "text": "Hi, that's right. I'm Tom McKenzie. It's a pleasure to meet you.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 5.2
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6543abeff5f028dba112f278.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6543abeff5f028dba112f278.md
@@ -3,7 +3,6 @@ id: 6543abeff5f028dba112f278
 title: Task 7
 challengeType: 19
 dashedName: task-7
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--
@@ -52,3 +51,47 @@ Think about which verb form would correctly fit with `I` to talk about oneself i
 ## --video-solution--
 
 2
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-1.mp3",
+      "startTime": 1,
+      "startTimestamp": 4.5,
+      "finishTimestamp": 8.46
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 0.5,
+      "finishTime": 4.7,
+      "dialogue": {
+        "text": "Hi, that's right. I'm Tom McKenzie. It's a pleasure to meet you.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 5.2
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6543abeff5f028dba112f278.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6543abeff5f028dba112f278.md
@@ -68,8 +68,8 @@ Think about which verb form would correctly fit with `I` to talk about oneself i
     "audio": {
       "filename": "1.1-1.mp3",
       "startTime": 1,
-      "startTimestamp": 4.62,
-      "finishTimestamp": 8.46
+      "startTimestamp": 4.5,
+      "finishTimestamp": 7
     }
   },
   "commands": [
@@ -81,16 +81,16 @@ Think about which verb form would correctly fit with `I` to talk about oneself i
     {
       "character": "Tom",
       "startTime": 1,
-      "finishTime": 4.34,
+      "finishTime": 3.3,
       "dialogue": {
-        "text": "Hi, that's right. I'm Tom McKenzie. It's a pleasure to meet you.",
+        "text": "Hi, that's right. I'm Tom McKenzie.",
         "align": "center"
       }
     },
     {
       "character": "Tom",
       "opacity": 0,
-      "startTime": 4.84
+      "startTime": 3.8
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6543abeff5f028dba112f278.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6543abeff5f028dba112f278.md
@@ -61,14 +61,14 @@ Think about which verb form would correctly fit with `I` to talk about oneself i
     "characters": [
       {
         "character": "Tom",
-        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "position": {"x":50,"y":15,"z":1.2},
         "opacity": 0
       }
     ],
     "audio": {
       "filename": "1.1-1.mp3",
       "startTime": 1,
-      "startTimestamp": 4.5,
+      "startTimestamp": 4.62,
       "finishTimestamp": 8.46
     }
   },
@@ -80,8 +80,8 @@ Think about which verb form would correctly fit with `I` to talk about oneself i
     },
     {
       "character": "Tom",
-      "startTime": 0.5,
-      "finishTime": 4.7,
+      "startTime": 1,
+      "finishTime": 4.34,
       "dialogue": {
         "text": "Hi, that's right. I'm Tom McKenzie. It's a pleasure to meet you.",
         "align": "center"
@@ -90,7 +90,7 @@ Think about which verb form would correctly fit with `I` to talk about oneself i
     {
       "character": "Tom",
       "opacity": 0,
-      "startTime": 5.2
+      "startTime": 4.84
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6543abf5f5f028dba112f279.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6543abf5f5f028dba112f279.md
@@ -3,7 +3,6 @@ id: 6543abf5f5f028dba112f279
 title: Task 8
 challengeType: 22
 dashedName: task-8
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--
@@ -24,3 +23,47 @@ The word `I'm` is a contraction of `I am`. Contractions are a way to shorten com
 ## --blanks--
 
 `I'm`
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-1.mp3",
+      "startTime": 1,
+      "startTimestamp": 4.5,
+      "finishTimestamp": 8.46
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 0.5,
+      "finishTime": 4.7,
+      "dialogue": {
+        "text": "Hi, that's right. I'm Tom McKenzie. It's a pleasure to meet you.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 5.2
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6543abf5f5f028dba112f279.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6543abf5f5f028dba112f279.md
@@ -40,8 +40,8 @@ The word `I'm` is a contraction of `I am`. Contractions are a way to shorten com
     "audio": {
       "filename": "1.1-1.mp3",
       "startTime": 1,
-      "startTimestamp": 4.62,
-      "finishTimestamp": 8.46
+      "startTimestamp": 4.5,
+      "finishTimestamp": 7
     }
   },
   "commands": [
@@ -53,16 +53,16 @@ The word `I'm` is a contraction of `I am`. Contractions are a way to shorten com
     {
       "character": "Tom",
       "startTime": 1,
-      "finishTime": 4.34,
+      "finishTime": 3.3,
       "dialogue": {
-        "text": "Hi, that's right. I'm Tom McKenzie. It's a pleasure to meet you.",
+        "text": "Hi, that's right. I'm Tom McKenzie.",
         "align": "center"
       }
     },
     {
       "character": "Tom",
       "opacity": 0,
-      "startTime": 4.84
+      "startTime": 3.8
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6543abf5f5f028dba112f279.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6543abf5f5f028dba112f279.md
@@ -33,14 +33,14 @@ The word `I'm` is a contraction of `I am`. Contractions are a way to shorten com
     "characters": [
       {
         "character": "Tom",
-        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "position": {"x":50,"y":15,"z":1.2},
         "opacity": 0
       }
     ],
     "audio": {
       "filename": "1.1-1.mp3",
       "startTime": 1,
-      "startTimestamp": 4.5,
+      "startTimestamp": 4.62,
       "finishTimestamp": 8.46
     }
   },
@@ -52,8 +52,8 @@ The word `I'm` is a contraction of `I am`. Contractions are a way to shorten com
     },
     {
       "character": "Tom",
-      "startTime": 0.5,
-      "finishTime": 4.7,
+      "startTime": 1,
+      "finishTime": 4.34,
       "dialogue": {
         "text": "Hi, that's right. I'm Tom McKenzie. It's a pleasure to meet you.",
         "align": "center"
@@ -62,7 +62,7 @@ The word `I'm` is a contraction of `I am`. Contractions are a way to shorten com
     {
       "character": "Tom",
       "opacity": 0,
-      "startTime": 5.2
+      "startTime": 4.84
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/655283c039eb38f51e0e6f7e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/655283c039eb38f51e0e6f7e.md
@@ -3,7 +3,6 @@ id: 655283c039eb38f51e0e6f7e
 title: Task 9
 challengeType: 19
 dashedName: task-9
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--
@@ -52,3 +51,47 @@ Tom is providing both his first name and surname in a formal way. Choose the opt
 ## --video-solution--
 
 1
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-1.mp3",
+      "startTime": 1,
+      "startTimestamp": 4.5,
+      "finishTimestamp": 8.46
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 0.5,
+      "finishTime": 4.7,
+      "dialogue": {
+        "text": "Hi, that's right. I'm Tom McKenzie. It's a pleasure to meet you.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 5.2
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/655283c039eb38f51e0e6f7e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/655283c039eb38f51e0e6f7e.md
@@ -68,8 +68,8 @@ Tom is providing both his first name and surname in a formal way. Choose the opt
     "audio": {
       "filename": "1.1-1.mp3",
       "startTime": 1,
-      "startTimestamp": 4.62,
-      "finishTimestamp": 8.46
+      "startTimestamp": 4.5,
+      "finishTimestamp": 7
     }
   },
   "commands": [
@@ -81,16 +81,16 @@ Tom is providing both his first name and surname in a formal way. Choose the opt
     {
       "character": "Tom",
       "startTime": 1,
-      "finishTime": 4.34,
+      "finishTime": 3.3,
       "dialogue": {
-        "text": "Hi, that's right. I'm Tom McKenzie. It's a pleasure to meet you.",
+        "text": "Hi, that's right. I'm Tom McKenzie.",
         "align": "center"
       }
     },
     {
       "character": "Tom",
       "opacity": 0,
-      "startTime": 4.84
+      "startTime": 3.8
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/655283c039eb38f51e0e6f7e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/655283c039eb38f51e0e6f7e.md
@@ -61,14 +61,14 @@ Tom is providing both his first name and surname in a formal way. Choose the opt
     "characters": [
       {
         "character": "Tom",
-        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "position": {"x":50,"y":15,"z":1.2},
         "opacity": 0
       }
     ],
     "audio": {
       "filename": "1.1-1.mp3",
       "startTime": 1,
-      "startTimestamp": 4.5,
+      "startTimestamp": 4.62,
       "finishTimestamp": 8.46
     }
   },
@@ -80,8 +80,8 @@ Tom is providing both his first name and surname in a formal way. Choose the opt
     },
     {
       "character": "Tom",
-      "startTime": 0.5,
-      "finishTime": 4.7,
+      "startTime": 1,
+      "finishTime": 4.34,
       "dialogue": {
         "text": "Hi, that's right. I'm Tom McKenzie. It's a pleasure to meet you.",
         "align": "center"
@@ -90,7 +90,7 @@ Tom is providing both his first name and surname in a formal way. Choose the opt
     {
       "character": "Tom",
       "opacity": 0,
-      "startTime": 5.2
+      "startTime": 4.84
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/65528a7c39eb38f51e0e6f7f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/65528a7c39eb38f51e0e6f7f.md
@@ -61,14 +61,14 @@ Tom is being introduced to Maria for the first time. Listen to his choice of wor
     "characters": [
       {
         "character": "Tom",
-        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "position": {"x":50,"y":15,"z":1.2},
         "opacity": 0
       }
     ],
     "audio": {
       "filename": "1.1-1.mp3",
       "startTime": 1,
-      "startTimestamp": 4.5,
+      "startTimestamp": 4.62,
       "finishTimestamp": 8.46
     }
   },
@@ -80,8 +80,8 @@ Tom is being introduced to Maria for the first time. Listen to his choice of wor
     },
     {
       "character": "Tom",
-      "startTime": 0.5,
-      "finishTime": 4.7,
+      "startTime": 1,
+      "finishTime": 4.34,
       "dialogue": {
         "text": "Hi, that's right. I'm Tom McKenzie. It's a pleasure to meet you.",
         "align": "center"
@@ -90,7 +90,7 @@ Tom is being introduced to Maria for the first time. Listen to his choice of wor
     {
       "character": "Tom",
       "opacity": 0,
-      "startTime": 5.2
+      "startTime": 4.84
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/65528a7c39eb38f51e0e6f7f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/65528a7c39eb38f51e0e6f7f.md
@@ -68,7 +68,7 @@ Tom is being introduced to Maria for the first time. Listen to his choice of wor
     "audio": {
       "filename": "1.1-1.mp3",
       "startTime": 1,
-      "startTimestamp": 4.62,
+      "startTimestamp": 7,
       "finishTimestamp": 8.46
     }
   },
@@ -81,16 +81,16 @@ Tom is being introduced to Maria for the first time. Listen to his choice of wor
     {
       "character": "Tom",
       "startTime": 1,
-      "finishTime": 4.34,
+      "finishTime": 2.34,
       "dialogue": {
-        "text": "Hi, that's right. I'm Tom McKenzie. It's a pleasure to meet you.",
+        "text": "It's a pleasure to meet you.",
         "align": "center"
       }
     },
     {
       "character": "Tom",
       "opacity": 0,
-      "startTime": 4.84
+      "startTime": 2.84
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/65528a7c39eb38f51e0e6f7f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/65528a7c39eb38f51e0e6f7f.md
@@ -3,7 +3,6 @@ id: 65528a7c39eb38f51e0e6f7f
 title: Task 10
 challengeType: 19
 dashedName: task-10
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--
@@ -52,3 +51,47 @@ Tom is being introduced to Maria for the first time. Listen to his choice of wor
 ## --video-solution--
 
 2
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-1.mp3",
+      "startTime": 1,
+      "startTimestamp": 4.5,
+      "finishTimestamp": 8.46
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 0.5,
+      "finishTime": 4.7,
+      "dialogue": {
+        "text": "Hi, that's right. I'm Tom McKenzie. It's a pleasure to meet you.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 5.2
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6552939414fdaa21fc734788.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6552939414fdaa21fc734788.md
@@ -3,7 +3,6 @@ id: 6552939414fdaa21fc734788
 title: Task 11
 challengeType: 19
 dashedName: task-11
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--
@@ -52,3 +51,47 @@ Incorrect. Maria isn't introducing Tom to any board of directors.
 ## --video-solution--
 
 3
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Maria",
+        "position": { "x": 50, "y": 0, "z": 1.5 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-1.mp3",
+      "startTime": 1,
+      "startTimestamp": 8.46,
+      "finishTimestamp": 11.9
+    }
+  },
+  "commands": [
+    {
+      "character": "Maria",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Maria",
+      "startTime": 1,
+      "finishTime": 3.89,
+      "dialogue": {
+        "text": "Welcome aboard, Tom. How do you like California so far?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Maria",
+      "opacity": 0,
+      "startTime": 4.39
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6552939414fdaa21fc734788.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6552939414fdaa21fc734788.md
@@ -69,7 +69,7 @@ Incorrect. Maria isn't introducing Tom to any board of directors.
       "filename": "1.1-1.mp3",
       "startTime": 1,
       "startTimestamp": 8.46,
-      "finishTimestamp": 11.9
+      "finishTimestamp": 11.85
     }
   },
   "commands": [

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/65529784e7cb6e24eb03a1af.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/65529784e7cb6e24eb03a1af.md
@@ -47,7 +47,7 @@ The verb in the blank refers to a way of asking someone's opinion or feelings ab
       "filename": "1.1-1.mp3",
       "startTime": 1,
       "startTimestamp": 8.46,
-      "finishTimestamp": 11.9
+      "finishTimestamp": 11.85
     }
   },
   "commands": [

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/65529784e7cb6e24eb03a1af.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/65529784e7cb6e24eb03a1af.md
@@ -3,7 +3,6 @@ id: 65529784e7cb6e24eb03a1af
 title: Task 12
 challengeType: 22
 dashedName: task-12
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--
@@ -30,3 +29,47 @@ Maria is asking Tom about his impressions of California.
 ### --feedback--
 
 The verb in the blank refers to a way of asking someone's opinion or feelings about something.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Maria",
+        "position": { "x": 50, "y": 0, "z": 1.5 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-1.mp3",
+      "startTime": 1,
+      "startTimestamp": 8.46,
+      "finishTimestamp": 11.9
+    }
+  },
+  "commands": [
+    {
+      "character": "Maria",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Maria",
+      "startTime": 1,
+      "finishTime": 3.89,
+      "dialogue": {
+        "text": "Welcome aboard, Tom. How do you like California so far?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Maria",
+      "opacity": 0,
+      "startTime": 4.39
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6568bf620d3e770ea770123f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6568bf620d3e770ea770123f.md
@@ -3,7 +3,6 @@ id: 6568bf620d3e770ea770123f
 title: Task 13
 challengeType: 22
 dashedName: task-13
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--
@@ -12,6 +11,7 @@ Maria: Welcome aboard, Tom! How do you like California so far?
 -->
 
 # --description--
+
 The phrase `so far` is used in English to indicate the time up to the present moment or up to a certain point. Maria is asking Tom about his feelings or impressions of California from the time he arrived up until now.
 
 # --fillInTheBlank--
@@ -35,3 +35,47 @@ The phrase in the blanks refers to a period of time up to the present moment.
 ### --feedback--
 
 The phrase in the blanks refers to a period of time up to the present moment.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Maria",
+        "position": { "x": 50, "y": 0, "z": 1.5 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-1.mp3",
+      "startTime": 1,
+      "startTimestamp": 8.46,
+      "finishTimestamp": 11.9
+    }
+  },
+  "commands": [
+    {
+      "character": "Maria",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Maria",
+      "startTime": 1,
+      "finishTime": 3.89,
+      "dialogue": {
+        "text": "Welcome aboard, Tom. How do you like California so far?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Maria",
+      "opacity": 0,
+      "startTime": 4.39
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6568bf620d3e770ea770123f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6568bf620d3e770ea770123f.md
@@ -53,7 +53,7 @@ The phrase in the blanks refers to a period of time up to the present moment.
       "filename": "1.1-1.mp3",
       "startTime": 1,
       "startTimestamp": 8.46,
-      "finishTimestamp": 11.9
+      "finishTimestamp": 11.85
     }
   },
   "commands": [

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6568c0f3792d990efe47949e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6568c0f3792d990efe47949e.md
@@ -3,7 +3,6 @@ id: 6568c0f3792d990efe47949e
 title: Task 14
 challengeType: 22
 dashedName: task-14
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6568c181c8a1420f262b698b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6568c181c8a1420f262b698b.md
@@ -37,14 +37,14 @@ When talking about preferences or feelings towards something, the phrase `I like
     "characters": [
       {
         "character": "Tom",
-        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "position": {"x":50,"y":15,"z":1.2},
         "opacity": 0
       }
     ],
     "audio": {
       "filename": "1.1-1.mp3",
-      "startTime": 0.5,
-      "startTimestamp": 11.45,
+      "startTime": 1,
+      "startTimestamp": 11.9,
       "finishTimestamp": 15.18
     }
   },
@@ -56,8 +56,8 @@ When talking about preferences or feelings towards something, the phrase `I like
     },
     {
       "character": "Tom",
-      "startTime": 0.5,
-      "finishTime": 3.83,
+      "startTime": 1,
+      "finishTime": 3.78,
       "dialogue": {
         "text": "I like it. It's different from Texas, but I like it here.",
         "align": "center"
@@ -66,7 +66,7 @@ When talking about preferences or feelings towards something, the phrase `I like
     {
       "character": "Tom",
       "opacity": 0,
-      "startTime": 4.33
+      "startTime": 4.28
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6568c181c8a1420f262b698b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6568c181c8a1420f262b698b.md
@@ -3,7 +3,6 @@ id: 6568c181c8a1420f262b698b
 title: Task 15
 challengeType: 22
 dashedName: task-15
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--
@@ -28,3 +27,47 @@ When talking about preferences or feelings towards something, the phrase `I like
 ---
 
 `it`
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-1.mp3",
+      "startTime": 0.5,
+      "startTimestamp": 11.45,
+      "finishTimestamp": 15.18
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 0.5,
+      "finishTime": 3.83,
+      "dialogue": {
+        "text": "I like it. It's different from Texas, but I like it here.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 4.33
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6568c3539307ad0f902d20e7.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6568c3539307ad0f902d20e7.md
@@ -61,14 +61,14 @@ Listen again.
     "characters": [
       {
         "character": "Tom",
-        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "position": {"x":50,"y":15,"z":1.2},
         "opacity": 0
       }
     ],
     "audio": {
       "filename": "1.1-1.mp3",
-      "startTime": 0.5,
-      "startTimestamp": 11.45,
+      "startTime": 1,
+      "startTimestamp": 11.9,
       "finishTimestamp": 15.18
     }
   },
@@ -80,8 +80,8 @@ Listen again.
     },
     {
       "character": "Tom",
-      "startTime": 0.5,
-      "finishTime": 3.83,
+      "startTime": 1,
+      "finishTime": 3.78,
       "dialogue": {
         "text": "I like it. It's different from Texas, but I like it here.",
         "align": "center"
@@ -90,7 +90,7 @@ Listen again.
     {
       "character": "Tom",
       "opacity": 0,
-      "startTime": 4.33
+      "startTime": 4.28
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6568c3539307ad0f902d20e7.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6568c3539307ad0f902d20e7.md
@@ -3,7 +3,6 @@ id: 6568c3539307ad0f902d20e7
 title: Task 16
 challengeType: 19
 dashedName: task-16
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--
@@ -52,3 +51,47 @@ Listen again.
 ## --video-solution--
 
 1
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-1.mp3",
+      "startTime": 0.5,
+      "startTimestamp": 11.45,
+      "finishTimestamp": 15.18
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 0.5,
+      "finishTime": 3.83,
+      "dialogue": {
+        "text": "I like it. It's different from Texas, but I like it here.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 4.33
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6568c3d772f1460fc81f40e9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6568c3d772f1460fc81f40e9.md
@@ -45,14 +45,14 @@ What words does Tom use to compare California and Texas?
     "characters": [
       {
         "character": "Tom",
-        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "position": {"x":50,"y":15,"z":1.2},
         "opacity": 0
       }
     ],
     "audio": {
       "filename": "1.1-1.mp3",
-      "startTime": 0.5,
-      "startTimestamp": 11.45,
+      "startTime": 1,
+      "startTimestamp": 11.9,
       "finishTimestamp": 15.18
     }
   },
@@ -64,8 +64,8 @@ What words does Tom use to compare California and Texas?
     },
     {
       "character": "Tom",
-      "startTime": 0.5,
-      "finishTime": 3.83,
+      "startTime": 1,
+      "finishTime": 3.78,
       "dialogue": {
         "text": "I like it. It's different from Texas, but I like it here.",
         "align": "center"
@@ -74,7 +74,7 @@ What words does Tom use to compare California and Texas?
     {
       "character": "Tom",
       "opacity": 0,
-      "startTime": 4.33
+      "startTime": 4.28
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6568c3d772f1460fc81f40e9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6568c3d772f1460fc81f40e9.md
@@ -3,7 +3,6 @@ id: 6568c3d772f1460fc81f40e9
 title: Task 17
 challengeType: 22
 dashedName: task-17
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--
@@ -36,3 +35,47 @@ What words does Tom use to compare California and Texas?
 ### --feedback--
 
 What words does Tom use to compare California and Texas?
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-1.mp3",
+      "startTime": 0.5,
+      "startTimestamp": 11.45,
+      "finishTimestamp": 15.18
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 0.5,
+      "finishTime": 3.83,
+      "dialogue": {
+        "text": "I like it. It's different from Texas, but I like it here.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 4.33
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6568c618310cf51076e23d33.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6568c618310cf51076e23d33.md
@@ -33,14 +33,14 @@ In the dialogue, Tom uses `It's` as a contraction of `It` and `is`. This contrac
     "characters": [
       {
         "character": "Tom",
-        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "position": {"x":50,"y":15,"z":1.2},
         "opacity": 0
       }
     ],
     "audio": {
       "filename": "1.1-1.mp3",
-      "startTime": 0.5,
-      "startTimestamp": 11.45,
+      "startTime": 1,
+      "startTimestamp": 11.9,
       "finishTimestamp": 15.18
     }
   },
@@ -52,8 +52,8 @@ In the dialogue, Tom uses `It's` as a contraction of `It` and `is`. This contrac
     },
     {
       "character": "Tom",
-      "startTime": 0.5,
-      "finishTime": 3.83,
+      "startTime": 1,
+      "finishTime": 3.78,
       "dialogue": {
         "text": "I like it. It's different from Texas, but I like it here.",
         "align": "center"
@@ -62,7 +62,7 @@ In the dialogue, Tom uses `It's` as a contraction of `It` and `is`. This contrac
     {
       "character": "Tom",
       "opacity": 0,
-      "startTime": 4.33
+      "startTime": 4.28
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6568c618310cf51076e23d33.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6568c618310cf51076e23d33.md
@@ -3,7 +3,6 @@ id: 6568c618310cf51076e23d33
 title: Task 18
 challengeType: 22
 dashedName: task-18
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--
@@ -24,3 +23,47 @@ In the dialogue, Tom uses `It's` as a contraction of `It` and `is`. This contrac
 ## --blanks--
 
 `It's`
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-1.mp3",
+      "startTime": 0.5,
+      "startTimestamp": 11.45,
+      "finishTimestamp": 15.18
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 0.5,
+      "finishTime": 3.83,
+      "dialogue": {
+        "text": "I like it. It's different from Texas, but I like it here.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 4.33
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6568c68b92a63810a57cffaf.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6568c68b92a63810a57cffaf.md
@@ -3,7 +3,6 @@ id: 6568c68b92a63810a57cffaf
 title: Task 19
 challengeType: 19
 dashedName: task-19
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--
@@ -57,3 +56,47 @@ Correct! In this context, `It's` refers to California, which Tom is describing i
 ## --video-solution--
 
 4
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-1.mp3",
+      "startTime": 0.5,
+      "startTimestamp": 11.45,
+      "finishTimestamp": 15.18
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 0.5,
+      "finishTime": 3.83,
+      "dialogue": {
+        "text": "I like it. It's different from Texas, but I like it here.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 4.33
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6568c68b92a63810a57cffaf.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6568c68b92a63810a57cffaf.md
@@ -66,14 +66,14 @@ Correct! In this context, `It's` refers to California, which Tom is describing i
     "characters": [
       {
         "character": "Tom",
-        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "position": {"x":50,"y":15,"z":1.2},
         "opacity": 0
       }
     ],
     "audio": {
       "filename": "1.1-1.mp3",
-      "startTime": 0.5,
-      "startTimestamp": 11.45,
+      "startTime": 1,
+      "startTimestamp": 11.9,
       "finishTimestamp": 15.18
     }
   },
@@ -85,8 +85,8 @@ Correct! In this context, `It's` refers to California, which Tom is describing i
     },
     {
       "character": "Tom",
-      "startTime": 0.5,
-      "finishTime": 3.83,
+      "startTime": 1,
+      "finishTime": 3.78,
       "dialogue": {
         "text": "I like it. It's different from Texas, but I like it here.",
         "align": "center"
@@ -95,7 +95,7 @@ Correct! In this context, `It's` refers to California, which Tom is describing i
     {
       "character": "Tom",
       "opacity": 0,
-      "startTime": 4.33
+      "startTime": 4.28
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6568c759cb59e810dfaa1506.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6568c759cb59e810dfaa1506.md
@@ -3,7 +3,6 @@ id: 6568c759cb59e810dfaa1506
 title: Task 20
 challengeType: 19
 dashedName: task-20
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--
@@ -56,3 +55,47 @@ Incorrect. The phrase `I like it here` shows a definite positive sentiment, not 
 ## --video-solution--
 
 3
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-1.mp3",
+      "startTime": 0.5,
+      "startTimestamp": 11.45,
+      "finishTimestamp": 15.18
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 0.5,
+      "finishTime": 3.83,
+      "dialogue": {
+        "text": "I like it. It's different from Texas, but I like it here.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 4.33
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6568c759cb59e810dfaa1506.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/6568c759cb59e810dfaa1506.md
@@ -65,14 +65,14 @@ Incorrect. The phrase `I like it here` shows a definite positive sentiment, not 
     "characters": [
       {
         "character": "Tom",
-        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "position": {"x":50,"y":15,"z":1.2},
         "opacity": 0
       }
     ],
     "audio": {
       "filename": "1.1-1.mp3",
-      "startTime": 0.5,
-      "startTimestamp": 11.45,
+      "startTime": 1,
+      "startTimestamp": 11.9,
       "finishTimestamp": 15.18
     }
   },
@@ -84,8 +84,8 @@ Incorrect. The phrase `I like it here` shows a definite positive sentiment, not 
     },
     {
       "character": "Tom",
-      "startTime": 0.5,
-      "finishTime": 3.83,
+      "startTime": 1,
+      "finishTime": 3.78,
       "dialogue": {
         "text": "I like it. It's different from Texas, but I like it here.",
         "align": "center"
@@ -94,7 +94,7 @@ Incorrect. The phrase `I like it here` shows a definite positive sentiment, not 
     {
       "character": "Tom",
       "opacity": 0,
-      "startTime": 4.33
+      "startTime": 4.28
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a0d0e74f6a40d87328d38.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a0d0e74f6a40d87328d38.md
@@ -61,14 +61,14 @@ Listen again. Focus on the word Tom uses after `I` and before `here`.
     "characters": [
       {
         "character": "Tom",
-        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "position": {"x":50,"y":15,"z":1.2},
         "opacity": 0
       }
     ],
     "audio": {
       "filename": "1.1-1.mp3",
-      "startTime": 0.5,
-      "startTimestamp": 11.45,
+      "startTime": 1,
+      "startTimestamp": 11.9,
       "finishTimestamp": 15.18
     }
   },
@@ -80,8 +80,8 @@ Listen again. Focus on the word Tom uses after `I` and before `here`.
     },
     {
       "character": "Tom",
-      "startTime": 0.5,
-      "finishTime": 3.83,
+      "startTime": 1,
+      "finishTime": 3.78,
       "dialogue": {
         "text": "I like it. It's different from Texas, but I like it here.",
         "align": "center"
@@ -90,7 +90,7 @@ Listen again. Focus on the word Tom uses after `I` and before `here`.
     {
       "character": "Tom",
       "opacity": 0,
-      "startTime": 4.33
+      "startTime": 4.28
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a0d0e74f6a40d87328d38.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a0d0e74f6a40d87328d38.md
@@ -3,7 +3,6 @@ id: 656a0d0e74f6a40d87328d38
 title: Task 21
 challengeType: 19
 dashedName: task-21
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--
@@ -52,3 +51,47 @@ Listen again. Focus on the word Tom uses after `I` and before `here`.
 ## --video-solution--
 
 4
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-1.mp3",
+      "startTime": 0.5,
+      "startTimestamp": 11.45,
+      "finishTimestamp": 15.18
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 0.5,
+      "finishTime": 3.83,
+      "dialogue": {
+        "text": "I like it. It's different from Texas, but I like it here.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 4.33
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a0dde6087df0dd5729d6e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a0dde6087df0dd5729d6e.md
@@ -45,7 +45,7 @@ Maria wants to guide Tom to a place in the office.
     "characters": [
       {
         "character": "Maria",
-        "position": { "x": 50, "y": 0, "z": 1.5 },
+        "position": {"x":50,"y":0,"z":1.5},
         "opacity": 0
       }
     ],
@@ -64,8 +64,8 @@ Maria wants to guide Tom to a place in the office.
     },
     {
       "character": "Maria",
-      "startTime": 0.5,
-      "finishTime": 2.4,
+      "startTime": 1,
+      "finishTime": 2.5,
       "dialogue": {
         "text": "Great. Let me show you to your desk.",
         "align": "center"
@@ -74,7 +74,7 @@ Maria wants to guide Tom to a place in the office.
     {
       "character": "Maria",
       "opacity": 0,
-      "startTime": 2.9
+      "startTime": 3
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a0dde6087df0dd5729d6e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a0dde6087df0dd5729d6e.md
@@ -3,7 +3,6 @@ id: 656a0dde6087df0dd5729d6e
 title: Task 22
 challengeType: 22
 dashedName: task-22
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--
@@ -36,3 +35,47 @@ Maria wants to guide Tom to a place in the office.
 ### --feedback--
 
 Maria wants to guide Tom to a place in the office.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Maria",
+        "position": { "x": 50, "y": 0, "z": 1.5 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-1.mp3",
+      "startTime": 1,
+      "startTimestamp": 15.5,
+      "finishTimestamp": 17.42
+    }
+  },
+  "commands": [
+    {
+      "character": "Maria",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Maria",
+      "startTime": 0.5,
+      "finishTime": 2.4,
+      "dialogue": {
+        "text": "Great. Let me show you to your desk.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Maria",
+      "opacity": 0,
+      "startTime": 2.9
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a0eaf7d37610e43662464.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a0eaf7d37610e43662464.md
@@ -46,3 +46,47 @@ This phrase is about demonstrating or guiding, not hiding or buying.
 ## --video-solution--
 
 2
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Maria",
+        "position": {"x":50,"y":0,"z":1.5},
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-1.mp3",
+      "startTime": 1,
+      "startTimestamp": 15.5,
+      "finishTimestamp": 17.42
+    }
+  },
+  "commands": [
+    {
+      "character": "Maria",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Maria",
+      "startTime": 1,
+      "finishTime": 2.5,
+      "dialogue": {
+        "text": "Great. Let me show you to your desk.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Maria",
+      "opacity": 0,
+      "startTime": 3
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a0eaf7d37610e43662464.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a0eaf7d37610e43662464.md
@@ -3,7 +3,6 @@ id: 656a0eaf7d37610e43662464
 title: Task 23
 challengeType: 19
 dashedName: task-23
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a0f4f303dce0e865e746b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a0f4f303dce0e865e746b.md
@@ -3,7 +3,6 @@ id: 656a0f4f303dce0e865e746b
 title: Task 24
 challengeType: 19
 dashedName: task-24
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a0f4f303dce0e865e746b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a0f4f303dce0e865e746b.md
@@ -46,3 +46,47 @@ Pay attention to the place mentioned after `let me show you`.
 ## --video-solution--
 
 3
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Maria",
+        "position": {"x":50,"y":0,"z":1.5},
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-1.mp3",
+      "startTime": 1,
+      "startTimestamp": 15.5,
+      "finishTimestamp": 17.42
+    }
+  },
+  "commands": [
+    {
+      "character": "Maria",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Maria",
+      "startTime": 1,
+      "finishTime": 2.5,
+      "dialogue": {
+        "text": "Great. Let me show you to your desk.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Maria",
+      "opacity": 0,
+      "startTime": 3
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a10141825a30eb81ff4db.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a10141825a30eb81ff4db.md
@@ -50,3 +50,47 @@ Desks are furniture items, not wearable objects. You can't put on a desk like a 
 ## --video-solution--
 
 2
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Maria",
+        "position": {"x":50,"y":0,"z":1.5},
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-1.mp3",
+      "startTime": 1,
+      "startTimestamp": 15.5,
+      "finishTimestamp": 17.42
+    }
+  },
+  "commands": [
+    {
+      "character": "Maria",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Maria",
+      "startTime": 1,
+      "finishTime": 2.5,
+      "dialogue": {
+        "text": "Great. Let me show you to your desk.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Maria",
+      "opacity": 0,
+      "startTime": 3
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a10141825a30eb81ff4db.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a10141825a30eb81ff4db.md
@@ -3,7 +3,6 @@ id: 656a10141825a30eb81ff4db
 title: Task 25
 challengeType: 19
 dashedName: task-25
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a10aaa023200eddd09d88.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a10aaa023200eddd09d88.md
@@ -50,3 +50,47 @@ We don't draw with chairs. Think about a tool used with computers.
 ## --video-solution--
 
 3
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Maria",
+        "position": {"x":50,"y":0,"z":1.5},
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-1.mp3",
+      "startTime": 1,
+      "startTimestamp": 17.75,
+      "finishTimestamp": 20.3
+    }
+  },
+  "commands": [
+    {
+      "character": "Maria",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Maria",
+      "startTime": 1,
+      "finishTime": 3.4,
+      "dialogue": {
+        "text": "Do you see the desk with a drawing tablet and a computer?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Maria",
+      "opacity": 0,
+      "startTime": 3.9
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a10aaa023200eddd09d88.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a10aaa023200eddd09d88.md
@@ -3,7 +3,6 @@ id: 656a10aaa023200eddd09d88
 title: Task 26
 challengeType: 19
 dashedName: task-26
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a1298f2a0400f56b31e25.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a1298f2a0400f56b31e25.md
@@ -45,15 +45,15 @@ Listen to the sentence.
     "characters": [
       {
         "character": "Maria",
-        "position": { "x": 50, "y": 0, "z": 1.5 },
+        "position": {"x":50,"y":0,"z":1.5},
         "opacity": 0
       }
     ],
     "audio": {
       "filename": "1.1-1.mp3",
       "startTime": 1,
-      "startTimestamp": 17.6,
-      "finishTimestamp": 20.4
+      "startTimestamp": 17.75,
+      "finishTimestamp": 20.3
     }
   },
   "commands": [
@@ -64,8 +64,8 @@ Listen to the sentence.
     },
     {
       "character": "Maria",
-      "startTime": 0.5,
-      "finishTime": 3.8,
+      "startTime": 1,
+      "finishTime": 3.4,
       "dialogue": {
         "text": "Do you see the desk with a drawing tablet and a computer?",
         "align": "center"
@@ -74,7 +74,7 @@ Listen to the sentence.
     {
       "character": "Maria",
       "opacity": 0,
-      "startTime": 4.3
+      "startTime": 3.9
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a137523a9bc0f9d3bae01.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a137523a9bc0f9d3bae01.md
@@ -3,14 +3,12 @@ id: 656a137523a9bc0f9d3bae01
 title: Task 29
 challengeType: 19
 dashedName: task-29
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--
 AUDIO REFERENCE:
 Maria: Great! Let me show you to your desk. Do you see the desk with a drawing tablet and a computer? That's your workspace.
 -->
-
 
 # --description--
 
@@ -53,3 +51,47 @@ Think about where Tom will be doing his work.
 ## --video-solution--
 
 3
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Maria",
+        "position": { "x": 50, "y": 0, "z": 1.5 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-1.mp3",
+      "startTime": 1,
+      "startTimestamp": 17.6,
+      "finishTimestamp": 21.6
+    }
+  },
+  "commands": [
+    {
+      "character": "Maria",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Maria",
+      "startTime": 0.5,
+      "finishTime": 4.7,
+      "dialogue": {
+        "text": "Do you see the desk with a drawing tablet and a computer? That's your workspace.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Maria",
+      "opacity": 0,
+      "startTime": 5.2
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a137523a9bc0f9d3bae01.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a137523a9bc0f9d3bae01.md
@@ -61,15 +61,15 @@ Think about where Tom will be doing his work.
     "characters": [
       {
         "character": "Maria",
-        "position": { "x": 50, "y": 0, "z": 1.5 },
+        "position": {"x":50,"y":0,"z":1.5},
         "opacity": 0
       }
     ],
     "audio": {
       "filename": "1.1-1.mp3",
       "startTime": 1,
-      "startTimestamp": 17.6,
-      "finishTimestamp": 21.6
+      "startTimestamp": 17.75,
+      "finishTimestamp": 21.5
     }
   },
   "commands": [
@@ -80,8 +80,8 @@ Think about where Tom will be doing his work.
     },
     {
       "character": "Maria",
-      "startTime": 0.5,
-      "finishTime": 4.7,
+      "startTime": 1,
+      "finishTime": 4.8,
       "dialogue": {
         "text": "Do you see the desk with a drawing tablet and a computer? That's your workspace.",
         "align": "center"
@@ -90,7 +90,7 @@ Think about where Tom will be doing his work.
     {
       "character": "Maria",
       "opacity": 0,
-      "startTime": 5.2
+      "startTime": 5.3
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a13f01a59cb0fc9d52149.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a13f01a59cb0fc9d52149.md
@@ -68,7 +68,7 @@ Does Tom sound happy or unhappy with his new `workspace`?
     "audio": {
       "filename": "1.1-1.mp3",
       "startTime": 1,
-      "startTimestamp": 21.6,
+      "startTimestamp": 22,
       "finishTimestamp": 25.1
     }
   },
@@ -80,8 +80,8 @@ Does Tom sound happy or unhappy with his new `workspace`?
     },
     {
       "character": "Tom",
-      "startTime": 0.7,
-      "finishTime": 4.3,
+      "startTime": 1,
+      "finishTime": 3.8,
       "dialogue": {
         "text": "Everything looks great. Thanks for showing me around the place, Maria.",
         "align": "center"
@@ -90,7 +90,7 @@ Does Tom sound happy or unhappy with his new `workspace`?
     {
       "character": "Tom",
       "opacity": 0,
-      "startTime": 4.8
+      "startTime": 4.3
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a13f01a59cb0fc9d52149.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a13f01a59cb0fc9d52149.md
@@ -3,7 +3,6 @@ id: 656a13f01a59cb0fc9d52149
 title: Task 30
 challengeType: 19
 dashedName: task-30
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--
@@ -52,3 +51,47 @@ Does Tom sound happy or unhappy with his new `workspace`?
 ## --video-solution--
 
 3
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": {"x":50,"y":15,"z":1.2},
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-1.mp3",
+      "startTime": 1,
+      "startTimestamp": 21.6,
+      "finishTimestamp": 25.1
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 0.7,
+      "finishTime": 4.3,
+      "dialogue": {
+        "text": "Everything looks great. Thanks for showing me around the place, Maria.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 4.8
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a14b0e1c43d0ffabd15a9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a14b0e1c43d0ffabd15a9.md
@@ -3,7 +3,6 @@ id: 656a14b0e1c43d0ffabd15a9
 title: Task 31
 challengeType: 19
 dashedName: task-31
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--
@@ -52,3 +51,47 @@ Tom is expressing gratitude for a specific action Maria did in the workplace. Li
 ## --video-solution--
 
 2
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": {"x":50,"y":15,"z":1.2},
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-1.mp3",
+      "startTime": 1,
+      "startTimestamp": 21.6,
+      "finishTimestamp": 25.1
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 0.7,
+      "finishTime": 4.3,
+      "dialogue": {
+        "text": "Everything looks great. Thanks for showing me around the place, Maria.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 4.8
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a14b0e1c43d0ffabd15a9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a14b0e1c43d0ffabd15a9.md
@@ -68,7 +68,7 @@ Tom is expressing gratitude for a specific action Maria did in the workplace. Li
     "audio": {
       "filename": "1.1-1.mp3",
       "startTime": 1,
-      "startTimestamp": 21.6,
+      "startTimestamp": 22,
       "finishTimestamp": 25.1
     }
   },
@@ -80,8 +80,8 @@ Tom is expressing gratitude for a specific action Maria did in the workplace. Li
     },
     {
       "character": "Tom",
-      "startTime": 0.7,
-      "finishTime": 4.3,
+      "startTime": 1,
+      "finishTime": 3.8,
       "dialogue": {
         "text": "Everything looks great. Thanks for showing me around the place, Maria.",
         "align": "center"
@@ -90,7 +90,7 @@ Tom is expressing gratitude for a specific action Maria did in the workplace. Li
     {
       "character": "Tom",
       "opacity": 0,
-      "startTime": 4.8
+      "startTime": 4.3
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a18189b21f51037e518b4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a18189b21f51037e518b4.md
@@ -3,7 +3,6 @@ id: 656a18189b21f51037e518b4
 title: Task 32
 challengeType: 22
 dashedName: task-32
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--
@@ -53,7 +52,7 @@ What did Maria do for Tom that he's expressing gratitude for?
     "audio": {
       "filename": "1.1-1.mp3",
       "startTime": 1,
-      "startTimestamp": 21.6,
+      "startTimestamp": 22,
       "finishTimestamp": 25.1
     }
   },
@@ -65,8 +64,8 @@ What did Maria do for Tom that he's expressing gratitude for?
     },
     {
       "character": "Tom",
-      "startTime": 0.7,
-      "finishTime": 4.3,
+      "startTime": 1,
+      "finishTime": 3.8,
       "dialogue": {
         "text": "Everything looks great. Thanks for showing me around the place, Maria.",
         "align": "center"
@@ -75,7 +74,7 @@ What did Maria do for Tom that he's expressing gratitude for?
     {
       "character": "Tom",
       "opacity": 0,
-      "startTime": 4.8
+      "startTime": 4.3
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a18189b21f51037e518b4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a18189b21f51037e518b4.md
@@ -36,3 +36,47 @@ What did Maria do for Tom that he's expressing gratitude for?
 ### --feedback--
 
 What did Maria do for Tom that he's expressing gratitude for?
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": {"x":50,"y":15,"z":1.2},
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-1.mp3",
+      "startTime": 1,
+      "startTimestamp": 21.6,
+      "finishTimestamp": 25.1
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 0.7,
+      "finishTime": 4.3,
+      "dialogue": {
+        "text": "Everything looks great. Thanks for showing me around the place, Maria.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 4.8
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a2b1c7216c026fcd156c7.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a2b1c7216c026fcd156c7.md
@@ -3,7 +3,6 @@ id: 656a2b1c7216c026fcd156c7
 title: Task 33
 challengeType: 22
 dashedName: task-33
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--
@@ -36,3 +35,47 @@ Think about a common casual greeting.
 ### --feedback--
 
 Think about a common casual greeting.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 0,
+      "finishTimestamp": 3.52
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 1,
+      "finishTime": 4.15,
+      "dialogue": {
+        "text": "Hi there. I'm Tom. I'm the new graphic designer.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 4.65
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a2bfbfc3336274c874bed.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a2bfbfc3336274c874bed.md
@@ -46,3 +46,47 @@ Tom clearly states his job title after introducing himself.
 ## --video-solution--
 
 3
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 0,
+      "finishTimestamp": 3.52
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 1,
+      "finishTime": 4.15,
+      "dialogue": {
+        "text": "Hi there. I'm Tom. I'm the new graphic designer.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 4.65
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a2bfbfc3336274c874bed.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a2bfbfc3336274c874bed.md
@@ -3,7 +3,6 @@ id: 656a2bfbfc3336274c874bed
 title: Task 34
 challengeType: 19
 dashedName: task-34
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a3f5be79ce02dcc157d6b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a3f5be79ce02dcc157d6b.md
@@ -26,3 +26,47 @@ What is the best article to show that Tom is the only new graphic designer in th
 ### --feedback--
 
 When specifying a unique role or position, think about which article would be the most appropriate.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 0,
+      "finishTimestamp": 3.52
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 1,
+      "finishTime": 4.15,
+      "dialogue": {
+        "text": "Hi there. I'm Tom. I'm the new graphic designer.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 4.65
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a3f5be79ce02dcc157d6b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a3f5be79ce02dcc157d6b.md
@@ -3,7 +3,6 @@ id: 656a3f5be79ce02dcc157d6b
 title: Task 35
 challengeType: 22
 dashedName: task-35
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a3fd085a6e92dfbaee96a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a3fd085a6e92dfbaee96a.md
@@ -69,7 +69,7 @@ Sophie introduces herself with her job title in the dialogue.
       "filename": "1.1-2.mp3",
       "startTime": 1,
       "startTimestamp": 4.2,
-      "finishTimestamp": 7.88
+      "finishTimestamp": 6.66
     }
   },
   "commands": [
@@ -81,16 +81,16 @@ Sophie introduces herself with her job title in the dialogue.
     {
       "character": "Sophie",
       "startTime": 1,
-      "finishTime": 4.35,
+      "finishTime": 3.46,
       "dialogue": {
-        "text": "Oh, hi, Tom. I'm Sophie. I'm a developer. Where are you from, Tom?",
+        "text": "Oh, hi, Tom. I'm Sophie. I'm a developer.",
         "align": "center"
       }
     },
     {
       "character": "Sophie",
       "opacity": 0,
-      "startTime": 4.85
+      "startTime": 3.96
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a3fd085a6e92dfbaee96a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a3fd085a6e92dfbaee96a.md
@@ -81,7 +81,7 @@ Sophie introduces herself with her job title in the dialogue.
     {
       "character": "Sophie",
       "startTime": 1,
-      "finishTime": 4.18,
+      "finishTime": 4.35,
       "dialogue": {
         "text": "Oh, hi, Tom. I'm Sophie. I'm a developer. Where are you from, Tom?",
         "align": "center"
@@ -90,7 +90,7 @@ Sophie introduces herself with her job title in the dialogue.
     {
       "character": "Sophie",
       "opacity": 0,
-      "startTime": 4.68
+      "startTime": 4.85
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a3fd085a6e92dfbaee96a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a3fd085a6e92dfbaee96a.md
@@ -3,7 +3,6 @@ id: 656a3fd085a6e92dfbaee96a
 title: Task 36
 challengeType: 19
 dashedName: task-36
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--
@@ -52,3 +51,47 @@ Sophie introduces herself with her job title in the dialogue.
 ## --video-solution--
 
 2
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 4.2,
+      "finishTimestamp": 7.88
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 4.18,
+      "dialogue": {
+        "text": "Oh, hi, Tom. I'm Sophie. I'm a developer. Where are you from, Tom?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 4.68
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a401d1b00af2e25b0fd8b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a401d1b00af2e25b0fd8b.md
@@ -31,3 +31,47 @@ No
 ## --video-solution--
 
 2
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 4.2,
+      "finishTimestamp": 7.88
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 4.35,
+      "dialogue": {
+        "text": "Oh, hi, Tom. I'm Sophie. I'm a developer. Where are you from, Tom?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 4.85
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a401d1b00af2e25b0fd8b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a401d1b00af2e25b0fd8b.md
@@ -49,7 +49,7 @@ No
       "filename": "1.1-2.mp3",
       "startTime": 1,
       "startTimestamp": 4.2,
-      "finishTimestamp": 7.88
+      "finishTimestamp": 6.66
     }
   },
   "commands": [
@@ -61,16 +61,16 @@ No
     {
       "character": "Sophie",
       "startTime": 1,
-      "finishTime": 4.35,
+      "finishTime": 3.46,
       "dialogue": {
-        "text": "Oh, hi, Tom. I'm Sophie. I'm a developer. Where are you from, Tom?",
+        "text": "Oh, hi, Tom. I'm Sophie. I'm a developer.",
         "align": "center"
       }
     },
     {
       "character": "Sophie",
       "opacity": 0,
-      "startTime": 4.85
+      "startTime": 3.96
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a401d1b00af2e25b0fd8b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a401d1b00af2e25b0fd8b.md
@@ -3,7 +3,6 @@ id: 656a401d1b00af2e25b0fd8b
 title: Task 37
 challengeType: 19
 dashedName: task-37
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a417f7f9daf2e9aae6831.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a417f7f9daf2e9aae6831.md
@@ -3,7 +3,6 @@ id: 656a417f7f9daf2e9aae6831
 title: Task 38
 challengeType: 19
 dashedName: task-38
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a417f7f9daf2e9aae6831.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a417f7f9daf2e9aae6831.md
@@ -60,7 +60,7 @@ In which statement does the term CEO refer to a specific person known to both th
       "filename": "1.1-2.mp3",
       "startTime": 1,
       "startTimestamp": 4.2,
-      "finishTimestamp": 7.88
+      "finishTimestamp": 6.66
     }
   },
   "commands": [
@@ -72,16 +72,16 @@ In which statement does the term CEO refer to a specific person known to both th
     {
       "character": "Sophie",
       "startTime": 1,
-      "finishTime": 4.35,
+      "finishTime": 3.46,
       "dialogue": {
-        "text": "Oh, hi, Tom. I'm Sophie. I'm a developer. Where are you from, Tom?",
+        "text": "Oh, hi, Tom. I'm Sophie. I'm a developer.",
         "align": "center"
       }
     },
     {
       "character": "Sophie",
       "opacity": 0,
-      "startTime": 4.85
+      "startTime": 3.96
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a417f7f9daf2e9aae6831.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a417f7f9daf2e9aae6831.md
@@ -42,3 +42,47 @@ In which statement does the term CEO refer to a specific person known to both th
 ## --video-solution--
 
 1
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 4.2,
+      "finishTimestamp": 7.88
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 4.35,
+      "dialogue": {
+        "text": "Oh, hi, Tom. I'm Sophie. I'm a developer. Where are you from, Tom?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 4.85
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a421a905e792eca05d447.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a421a905e792eca05d447.md
@@ -3,7 +3,6 @@ id: 656a421a905e792eca05d447
 title: Task 39
 challengeType: 19
 dashedName: task-39
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a421a905e792eca05d447.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a421a905e792eca05d447.md
@@ -68,7 +68,7 @@ Listen again.
     "audio": {
       "filename": "1.1-2.mp3",
       "startTime": 1,
-      "startTimestamp": 4.2,
+      "startTimestamp": 6.98,
       "finishTimestamp": 7.88
     }
   },
@@ -81,16 +81,16 @@ Listen again.
     {
       "character": "Sophie",
       "startTime": 1,
-      "finishTime": 4.35,
+      "finishTime": 1.9,
       "dialogue": {
-        "text": "Oh, hi, Tom. I'm Sophie. I'm a developer. Where are you from, Tom?",
+        "text": "Where are you from, Tom?",
         "align": "center"
       }
     },
     {
       "character": "Sophie",
       "opacity": 0,
-      "startTime": 4.85
+      "startTime": 2.4
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a421a905e792eca05d447.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a421a905e792eca05d447.md
@@ -51,3 +51,47 @@ Listen again.
 ## --video-solution--
 
 4
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 4.2,
+      "finishTimestamp": 7.88
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 4.35,
+      "dialogue": {
+        "text": "Oh, hi, Tom. I'm Sophie. I'm a developer. Where are you from, Tom?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 4.85
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a4297fcc0d72ef9b60c21.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a4297fcc0d72ef9b60c21.md
@@ -27,3 +27,47 @@ When you want to share where you were born or where you grew up, you can state y
 ### --feedback--
 
 Think about the common expression used to talk about one's origin.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 8.2,
+      "finishTimestamp": 10.22
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 1,
+      "finishTime": 2.8,
+      "dialogue": {
+        "text": "I'm from Texas. How about you?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 3.3
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a4297fcc0d72ef9b60c21.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a4297fcc0d72ef9b60c21.md
@@ -3,7 +3,6 @@ id: 656a4297fcc0d72ef9b60c21
 title: Task 40
 challengeType: 22
 dashedName: task-40
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a4e97fa176a2fed5011fc.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a4e97fa176a2fed5011fc.md
@@ -51,3 +51,47 @@ Tom uses a common follow-up question after sharing his own origin.
 ## --video-solution--
 
 2
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 8.2,
+      "finishTimestamp": 10.22
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 1,
+      "finishTime": 2.8,
+      "dialogue": {
+        "text": "I'm from Texas. How about you?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 3.3
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a4e97fa176a2fed5011fc.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a4e97fa176a2fed5011fc.md
@@ -3,7 +3,6 @@ id: 656a4e97fa176a2fed5011fc
 title: Task 41
 challengeType: 19
 dashedName: task-41
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a4ef5de14f8301be5764b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a4ef5de14f8301be5764b.md
@@ -22,3 +22,47 @@ dashedName: task-42
 ### --feedback--
 
 The blank is looking for a subject and a verb to indicate someone's origin.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 8.2,
+      "finishTimestamp": 10.22
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 1,
+      "finishTime": 2.8,
+      "dialogue": {
+        "text": "I'm from Texas. How about you?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 3.3
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a4ef5de14f8301be5764b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a4ef5de14f8301be5764b.md
@@ -3,7 +3,6 @@ id: 656a4ef5de14f8301be5764b
 title: Task 42
 challengeType: 22
 dashedName: task-42
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a4f714165773059ce7ad4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a4f714165773059ce7ad4.md
@@ -3,7 +3,6 @@ id: 656a4f714165773059ce7ad4
 title: Task 43
 challengeType: 22
 dashedName: task-43
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a4f714165773059ce7ad4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a4f714165773059ce7ad4.md
@@ -29,3 +29,47 @@ In the context of the dialogue, `here` refers to the location of the speaker, po
 ### --feedback--
 
 Sophie uses a word to indicate she's from the same location they are currently in.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 10.6,
+      "finishTimestamp": 12.64
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 2.8,
+      "dialogue": {
+        "text": "I'm from here in California. Welcome aboard.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 3.3
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a4fcaa739b7308ad795bf.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a4fcaa739b7308ad795bf.md
@@ -27,3 +27,47 @@ When you want to talk about all the people in a particular group without excepti
 ### --feedback--
 
 Think about a word that includes all people in a group.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 12.85,
+      "finishTimestamp": 15.7
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 1,
+      "finishTime": 3.25,
+      "dialogue": {
+        "text": "Thanks. Everybody is so nice around here.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 3.75
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a4fcaa739b7308ad795bf.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a4fcaa739b7308ad795bf.md
@@ -3,7 +3,6 @@ id: 656a4fcaa739b7308ad795bf
 title: Task 44
 challengeType: 22
 dashedName: task-44
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a503aa1f2c630b3951067.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a503aa1f2c630b3951067.md
@@ -3,7 +3,6 @@ id: 656a503aa1f2c630b3951067
 title: Task 45
 challengeType: 19
 dashedName: task-45
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a503aa1f2c630b3951067.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a503aa1f2c630b3951067.md
@@ -51,3 +51,47 @@ Tom refers to a specific kind of desk which allows people to work while standing
 ## --video-solution--
 
 3
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 16.2,
+      "finishTimestamp": 19.75
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 1,
+      "finishTime": 4.15,
+      "dialogue": {
+        "text": "Hey, is this one of those standing desks? These are great.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 4.65
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a509eeac7e030e2a16bab.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a509eeac7e030e2a16bab.md
@@ -35,3 +35,47 @@ Listen again.
 ### --feedback--
 
 Listen again.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 16.2,
+      "finishTimestamp": 19.75
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 1,
+      "finishTime": 4.15,
+      "dialogue": {
+        "text": "Hey, is this one of those standing desks? These are great.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 4.65
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a509eeac7e030e2a16bab.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a509eeac7e030e2a16bab.md
@@ -3,7 +3,6 @@ id: 656a509eeac7e030e2a16bab
 title: Task 46
 challengeType: 22
 dashedName: task-46
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a510695ccb03109117af0.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a510695ccb03109117af0.md
@@ -3,7 +3,6 @@ id: 656a510695ccb03109117af0
 title: Task 47
 challengeType: 19
 dashedName: task-47
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a51895811ed31345b2eaf.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a51895811ed31345b2eaf.md
@@ -3,7 +3,6 @@ id: 656a51895811ed31345b2eaf
 title: Task 48
 challengeType: 19
 dashedName: task-48
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a51effc10b2316bad8479.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a51effc10b2316bad8479.md
@@ -3,7 +3,6 @@ id: 656a51effc10b2316bad8479
 title: Task 49
 challengeType: 22
 dashedName: task-49
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a52680e234b3191131cc5.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a52680e234b3191131cc5.md
@@ -3,7 +3,6 @@ id: 656a52680e234b3191131cc5
 title: Task 50
 challengeType: 19
 dashedName: task-50
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a52da3392f631b9f3e022.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a52da3392f631b9f3e022.md
@@ -3,7 +3,6 @@ id: 656a52da3392f631b9f3e022
 title: Task 51
 challengeType: 22
 dashedName: task-51
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a52da3392f631b9f3e022.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a52da3392f631b9f3e022.md
@@ -18,7 +18,7 @@ In workplaces, especially in offices, there's a focus on ergonomics and health. 
 
 ## --sentence--
 
-`These are great! It is good to _ _ a little instead of _ all the time.`
+`It is good to _ _ a little instead of _ all the time.`
 
 ## --blanks--
 
@@ -43,3 +43,47 @@ Think of the two actions that are commonly contrasted in discussions about offic
 ### --feedback--
 
 Think of the two actions that are commonly contrasted in discussions about office ergonomics.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 19.96,
+      "finishTimestamp": 22.92
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 1,
+      "finishTime": 3.46,
+      "dialogue": {
+        "text": "It's good to stand up a little instead of just sitting all the time.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 3.96
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a533c5a7e5231e15b93b4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a533c5a7e5231e15b93b4.md
@@ -51,3 +51,47 @@ Tom is talking about an alternative to sitting continuously at the workplace.
 ## --video-solution--
 
 4
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 19.96,
+      "finishTimestamp": 22.92
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 1,
+      "finishTime": 3.46,
+      "dialogue": {
+        "text": "It's good to stand up a little instead of just sitting all the time.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 3.96
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a533c5a7e5231e15b93b4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a533c5a7e5231e15b93b4.md
@@ -3,7 +3,6 @@ id: 656a533c5a7e5231e15b93b4
 title: Task 52
 challengeType: 19
 dashedName: task-52
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a538cc4109d3209f5f536.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a538cc4109d3209f5f536.md
@@ -12,18 +12,62 @@ Sophie: That is true.
 
 # --description--
 
-When you want to express agreement or affirmation to what someone has just said, you can use phrases like `That is true`. It's a way to show you are in alignment with the previous statement.
+When you want to express agreement or affirmation to what someone has just said, you can use phrases like `That's so true` or `That is true`. It's a way to show you are in alignment with the previous statement.
 
 # --fillInTheBlank--
 
 ## --sentence--
 
-`_ is true.`
+`_ so true.`
 
 ## --blanks--
 
-`That`
+`That's`
 
 ### --feedback--
 
 Think of a term that indicates agreement with a prior statement.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 23.22,
+      "finishTimestamp": 26.48
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 3.76,
+      "dialogue": {
+        "text": "That's so true. I'm a bit inactive sitting all the time.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 4.26
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a538cc4109d3209f5f536.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a538cc4109d3209f5f536.md
@@ -3,7 +3,6 @@ id: 656a538cc4109d3209f5f536
 title: Task 53
 challengeType: 22
 dashedName: task-53
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a549c4d9b91326cfe1863.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a549c4d9b91326cfe1863.md
@@ -3,7 +3,6 @@ id: 656a549c4d9b91326cfe1863
 title: Task 55
 challengeType: 22
 dashedName: task-55
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a55ea17414032d482d278.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a55ea17414032d482d278.md
@@ -3,7 +3,6 @@ id: 656a55ea17414032d482d278
 title: Task 57
 challengeType: 19
 dashedName: task-57
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a55ea17414032d482d278.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a55ea17414032d482d278.md
@@ -51,3 +51,47 @@ Sophie comments on how much she sits during work. Which word would best describe
 ## --video-solution--
 
 3
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 23.22,
+      "finishTimestamp": 26.48
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 3.76,
+      "dialogue": {
+        "text": "That's so true. I'm a bit inactive sitting all the time.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 4.26
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a56f89acf253314e9f6d6.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a56f89acf253314e9f6d6.md
@@ -3,7 +3,6 @@ id: 656a56f89acf253314e9f6d6
 title: Task 58
 challengeType: 19
 dashedName: task-58
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a56f89acf253314e9f6d6.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a56f89acf253314e9f6d6.md
@@ -46,3 +46,47 @@ This doesn't necessarily mean inactivity. Sophie specifically refers to her lack
 ## --video-solution--
 
 3
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 23.22,
+      "finishTimestamp": 26.48
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 3.76,
+      "dialogue": {
+        "text": "That's so true. I'm a bit inactive sitting all the time.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 4.26
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a575febfa2c333c495c2f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a575febfa2c333c495c2f.md
@@ -35,3 +35,47 @@ Listen again.
 ### --feedback--
 
 Listen again.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 26.78,
+      "finishTimestamp": 28.62
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 2.34,
+      "dialogue": {
+        "text": "This is a good alternative for me.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 2.84
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a575febfa2c333c495c2f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a575febfa2c333c495c2f.md
@@ -3,7 +3,6 @@ id: 656a575febfa2c333c495c2f
 title: Task 59
 challengeType: 22
 dashedName: task-59
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a57d2c0603e33638c7770.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a57d2c0603e33638c7770.md
@@ -46,3 +46,47 @@ This doesn't relate to the context of the dialogue or the meaning of `alternativ
 ## --video-solution--
 
 2
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 26.78,
+      "finishTimestamp": 28.62
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 2.34,
+      "dialogue": {
+        "text": "This is a good alternative for me.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 2.84
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a57d2c0603e33638c7770.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a57d2c0603e33638c7770.md
@@ -3,7 +3,6 @@ id: 656a57d2c0603e33638c7770
 title: Task 60
 challengeType: 19
 dashedName: task-60
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a584f57a1a9338e3cb347.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a584f57a1a9338e3cb347.md
@@ -3,7 +3,6 @@ id: 656a584f57a1a9338e3cb347
 title: Task 61
 challengeType: 22
 dashedName: task-61
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a584f57a1a9338e3cb347.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a584f57a1a9338e3cb347.md
@@ -30,3 +30,47 @@ Words like `your` and `my` are used to show possession. `Your` refers to somethi
 ### --feedback--
 
 `Your` indicates possession for the listener, while `my` indicates possession for the speaker. In this dialogue, Sophie is making a comparison between Tom's desk (the listener's) and her own desk (the speaker's).
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 28.62,
+      "finishTimestamp": 32.08
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 3.96,
+      "dialogue": {
+        "text": "But hey, now your desk is just like my desk. You're in luck.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 4.46
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a58b31bc9f233debc2bc9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a58b31bc9f233debc2bc9.md
@@ -3,7 +3,6 @@ id: 656a58b31bc9f233debc2bc9
 title: Task 62
 challengeType: 22
 dashedName: task-62
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a58b31bc9f233debc2bc9.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656a58b31bc9f233debc2bc9.md
@@ -36,3 +36,47 @@ Listen again.
 ### --feedback--
 
 Listen again.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 28.62,
+      "finishTimestamp": 32.08
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 3.96,
+      "dialogue": {
+        "text": "But hey, now your desk is just like my desk. You're in luck.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 4.46
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab31ebccec247fde7cee4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab31ebccec247fde7cee4.md
@@ -3,7 +3,6 @@ id: 656ab31ebccec247fde7cee4
 title: Task 63
 challengeType: 22
 dashedName: task-63
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab31ebccec247fde7cee4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab31ebccec247fde7cee4.md
@@ -18,7 +18,7 @@ Tom: Oh, awesome. My computer and drawing tablet are great, too.
 
 ## --sentence--
 
-`Oh, _. My computer and drawing tablet are great, too.`
+`_. My computer and drawing tablet are great, too.`
 
 ## --blanks--
 
@@ -27,3 +27,47 @@ Tom: Oh, awesome. My computer and drawing tablet are great, too.
 ### --feedback--
 
 Listen for a word that means `very good` or `I really like it.`
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 32.3,
+      "finishTimestamp": 36
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 1,
+      "finishTime": 4.25,
+      "dialogue": {
+        "text": "Awesome. My computer and drawing tablet are great too.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 4.75
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab3bfc9e49d4841672043.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab3bfc9e49d4841672043.md
@@ -46,3 +46,47 @@ He doesn't think they're good.
 ## --video-solution--
 
 3
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 32.3,
+      "finishTimestamp": 36
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 1,
+      "finishTime": 4.25,
+      "dialogue": {
+        "text": "Awesome. My computer and drawing tablet are great too.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 4.75
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab3bfc9e49d4841672043.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab3bfc9e49d4841672043.md
@@ -3,7 +3,6 @@ id: 656ab3bfc9e49d4841672043
 title: Task 64
 challengeType: 19
 dashedName: task-64
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab4205a4054486ef3b691.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab4205a4054486ef3b691.md
@@ -3,7 +3,6 @@ id: 656ab4205a4054486ef3b691
 title: Task 65
 challengeType: 22
 dashedName: task-65
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab4205a4054486ef3b691.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab4205a4054486ef3b691.md
@@ -35,3 +35,47 @@ Tom is using words to say his things are good. What words show that he thinks th
 ### --feedback--
 
 Tom is using words to say his things are good. What words show that he thinks they're good?
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 32.3,
+      "finishTimestamp": 36
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 1,
+      "finishTime": 4.25,
+      "dialogue": {
+        "text": "Awesome. My computer and drawing tablet are great too.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 4.75
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab48697d63748952254a4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab48697d63748952254a4.md
@@ -18,7 +18,7 @@ The pronoun `they` is often used to refer to a group of people or entities. In t
 
 ## --sentence--
 
-`Yeah. Here in the company, _ _ very attentive to these details.`
+`Yeah, at this company, _ _ very attentive to these details.`
 
 ## --blanks--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab48697d63748952254a4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab48697d63748952254a4.md
@@ -35,3 +35,47 @@ Think about a pronoun that represents a group of people and the appropriate verb
 ### --feedback--
 
 Think about a pronoun that represents a group of people and the appropriate verb `to be` form to go with it.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 37,
+      "finishTimestamp": 40.2
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 3.85,
+      "dialogue": {
+        "text": "Yeah, at this company, they're very attentive to these details.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 4.35
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab48697d63748952254a4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab48697d63748952254a4.md
@@ -3,7 +3,6 @@ id: 656ab48697d63748952254a4
 title: Task 66
 challengeType: 22
 dashedName: task-66
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab50005c38348b94da7a3.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab50005c38348b94da7a3.md
@@ -3,7 +3,6 @@ id: 656ab50005c38348b94da7a3
 title: Task 67
 challengeType: 22
 dashedName: task-67
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab5a3ee689949124d2e39.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab5a3ee689949124d2e39.md
@@ -3,7 +3,6 @@ id: 656ab5a3ee689949124d2e39
 title: Task 68
 challengeType: 19
 dashedName: task-68
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab61f20aa9d494cee5466.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab61f20aa9d494cee5466.md
@@ -3,7 +3,6 @@ id: 656ab61f20aa9d494cee5466
 title: Task 69
 challengeType: 19
 dashedName: task-69
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab66db70b464974489b79.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab66db70b464974489b79.md
@@ -3,7 +3,6 @@ id: 656ab66db70b464974489b79
 title: Task 70
 challengeType: 22
 dashedName: task-70
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab6f67515b149a377009d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab6f67515b149a377009d.md
@@ -3,7 +3,6 @@ id: 656ab6f67515b149a377009d
 title: Task 71
 challengeType: 19
 dashedName: task-71
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab76473a1ee49d537698d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab76473a1ee49d537698d.md
@@ -46,3 +46,47 @@ When you're attentive, you are listening or paying attention, not ignoring.
 ## --video-solution--
 
 3
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 37,
+      "finishTimestamp": 40.2
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 3.85,
+      "dialogue": {
+        "text": "Yeah, at this company, they're very attentive to these details.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 4.35
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab76473a1ee49d537698d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab76473a1ee49d537698d.md
@@ -3,7 +3,6 @@ id: 656ab76473a1ee49d537698d
 title: Task 72
 challengeType: 19
 dashedName: task-72
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab7e9be47c04a2518dbed.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab7e9be47c04a2518dbed.md
@@ -7,13 +7,13 @@ dashedName: task-73
 
 # --description--
 
-The phrase `to be into` is an informal way to say that someone really likes something or is interested in a particular activity or topic.
+The phrase `you are into` is an informal way to say that someone really likes something or is interested in a particular activity or topic.
 
 # --question--
 
 ## --text--
 
-What does the phrase `to be into` mean?
+What does the phrase `you are into` mean?
 
 ## --answers--
 
@@ -21,7 +21,7 @@ To go inside
 
 ### --feedback--
 
-This is a literal interpretation, but `to be into` is more about liking or being interested in something.
+This is a literal interpretation, but `you are into` is more about liking or being interested in something.
 
 ---
 
@@ -46,3 +46,47 @@ This is another literal interpretation. Think about showing interest or liking.
 ## --video-solution--
 
 3
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 40.25,
+      "finishTimestamp": 43.05
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 3.5,
+      "dialogue": {
+        "text": "You're going to like it here if you're into cutting edge gadgets.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 4
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab7e9be47c04a2518dbed.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab7e9be47c04a2518dbed.md
@@ -78,7 +78,7 @@ This is another literal interpretation. Think about showing interest or liking.
       "startTime": 1,
       "finishTime": 3.5,
       "dialogue": {
-        "text": "You're going to like it here if you're into cutting edge gadgets.",
+        "text": "You're going to like it here if you're into cutting-edge gadgets.",
         "align": "center"
       }
     },

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab828bd06214a51193f3d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab828bd06214a51193f3d.md
@@ -7,7 +7,7 @@ dashedName: task-74
 
 # --description--
 
-When you want to say that you have a strong interest in something, you can use the phrase `to be into`. This phrase shows what someone likes or enjoys.
+When you want to say that you have a strong interest in something, you can use the phrase `I am into it`. This phrase shows what someone likes or enjoys.
 
 # --fillInTheBlank--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab828bd06214a51193f3d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab828bd06214a51193f3d.md
@@ -3,7 +3,6 @@ id: 656ab828bd06214a51193f3d
 title: Task 74
 challengeType: 22
 dashedName: task-74
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab8a1d294e14a920320d2.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab8a1d294e14a920320d2.md
@@ -78,7 +78,7 @@ Large machines
       "startTime": 1,
       "finishTime": 3.5,
       "dialogue": {
-        "text": "You're going to like it here if you're into cutting edge gadgets.",
+        "text": "You're going to like it here if you're into cutting-edge gadgets.",
         "align": "center"
       }
     },

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab8a1d294e14a920320d2.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab8a1d294e14a920320d2.md
@@ -3,7 +3,6 @@ id: 656ab8a1d294e14a920320d2
 title: Task 75
 challengeType: 19
 dashedName: task-75
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab8a1d294e14a920320d2.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ab8a1d294e14a920320d2.md
@@ -46,3 +46,47 @@ Large machines
 ## --video-solution--
 
 2
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 40.25,
+      "finishTimestamp": 43.05
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 3.5,
+      "dialogue": {
+        "text": "You're going to like it here if you're into cutting edge gadgets.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 4
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656aba8d560d3c4b069ae7a8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656aba8d560d3c4b069ae7a8.md
@@ -18,7 +18,7 @@ Sophie: Yeah. Here in the company, they are very attentive to these details. You
 
 ## --sentence--
 
-`Yeah. Here in the company, they are very _ to these _. You are going to like it here if you are into _ gadgets.`
+`Yeah, at this company, they're very _ to these _. You are going to like it here if you are into _ gadgets.`
 
 ## --blanks--
 
@@ -84,7 +84,7 @@ Listen carefully to the dialogue and focus on the words that describe the compan
       "startTime": 4.45,
       "finishTime": 7.1,
       "dialogue": {
-        "text": "You're going to like it here if you're into cutting edge gadgets.",
+        "text": "You're going to like it here if you're into cutting-edge gadgets.",
         "align": "center"
       }
     },

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656aba8d560d3c4b069ae7a8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656aba8d560d3c4b069ae7a8.md
@@ -43,3 +43,56 @@ Listen carefully to the dialogue and focus on the words that describe the compan
 ### --feedback--
 
 Listen carefully to the dialogue and focus on the words that describe the company's approach to gadgets and the type of gadgets mentioned.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 37,
+      "finishTimestamp": 43.05
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 3.85,
+      "dialogue": {
+        "text": "Yeah, at this company, they're very attentive to these details.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "startTime": 4.45,
+      "finishTime": 7.1,
+      "dialogue": {
+        "text": "You're going to like it here if you're into cutting edge gadgets.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 7.6
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656aba8d560d3c4b069ae7a8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656aba8d560d3c4b069ae7a8.md
@@ -3,7 +3,6 @@ id: 656aba8d560d3c4b069ae7a8
 title: Task 76
 challengeType: 22
 dashedName: task-76
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656abac861f4a04b312b0421.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656abac861f4a04b312b0421.md
@@ -3,7 +3,6 @@ id: 656abac861f4a04b312b0421
 title: Task 77
 challengeType: 22
 dashedName: task-77
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656abac861f4a04b312b0421.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656abac861f4a04b312b0421.md
@@ -18,7 +18,7 @@ The demonstrative pronoun `these` points to specific items or details that are c
 
 ## --sentence--
 
-`Yeah. Here in the company, they are very attentive to _ details.`
+`Yeah, at this company, they're very attentive to _ details.`
 
 ## --blanks--
 
@@ -68,7 +68,7 @@ Think of a demonstrative pronoun that can be used to highlight specific details 
       "startTime": 4.45,
       "finishTime": 7.1,
       "dialogue": {
-        "text": "You're going to like it here if you're into cutting edge gadgets.",
+        "text": "You're going to like it here if you're into cutting-edge gadgets.",
         "align": "center"
       }
     },

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656abac861f4a04b312b0421.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656abac861f4a04b312b0421.md
@@ -27,3 +27,56 @@ The demonstrative pronoun `these` points to specific items or details that are c
 ### --feedback--
 
 Think of a demonstrative pronoun that can be used to highlight specific details or items being discussed, especially when they are near in context or location.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 37,
+      "finishTimestamp": 43.05
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 3.85,
+      "dialogue": {
+        "text": "Yeah, at this company, they're very attentive to these details.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "startTime": 4.45,
+      "finishTime": 7.1,
+      "dialogue": {
+        "text": "You're going to like it here if you're into cutting edge gadgets.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 7.6
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656abb977f9ecf4b821aed11.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656abb977f9ecf4b821aed11.md
@@ -51,3 +51,56 @@ The context doesn't suggest that Sophie is discussing people when mentioning `th
 ## --video-solution--
 
 3
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 37,
+      "finishTimestamp": 43.05
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 3.85,
+      "dialogue": {
+        "text": "Yeah, at this company, they're very attentive to these details.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "startTime": 4.45,
+      "finishTime": 7.1,
+      "dialogue": {
+        "text": "You're going to like it here if you're into cutting edge gadgets.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 7.6
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656abb977f9ecf4b821aed11.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656abb977f9ecf4b821aed11.md
@@ -92,7 +92,7 @@ The context doesn't suggest that Sophie is discussing people when mentioning `th
       "startTime": 4.45,
       "finishTime": 7.1,
       "dialogue": {
-        "text": "You're going to like it here if you're into cutting edge gadgets.",
+        "text": "You're going to like it here if you're into cutting-edge gadgets.",
         "align": "center"
       }
     },

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656abb977f9ecf4b821aed11.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656abb977f9ecf4b821aed11.md
@@ -3,7 +3,6 @@ id: 656abb977f9ecf4b821aed11
 title: Task 78
 challengeType: 19
 dashedName: task-78
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656abcd4cccfc84bf50f861b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656abcd4cccfc84bf50f861b.md
@@ -3,7 +3,6 @@ id: 656abcd4cccfc84bf50f861b
 title: Task 79
 challengeType: 19
 dashedName: task-79
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656abd3412f31c4c2483de5c.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656abd3412f31c4c2483de5c.md
@@ -3,7 +3,6 @@ id: 656abd3412f31c4c2483de5c
 title: Task 80
 challengeType: 19
 dashedName: task-80
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656abe0ac290774c4de173d4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656abe0ac290774c4de173d4.md
@@ -3,7 +3,6 @@ id: 656abe0ac290774c4de173d4
 title: Task 81
 challengeType: 22
 dashedName: task-81
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cad88af98af049df17177.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cad88af98af049df17177.md
@@ -3,7 +3,6 @@ id: 656cad88af98af049df17177
 title: Task 82
 challengeType: 19
 dashedName: task-82
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cad88af98af049df17177.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cad88af98af049df17177.md
@@ -46,3 +46,47 @@ The phrase indicates excitement more than relaxation.
 ## --video-solution--
 
 3
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 43.68,
+      "finishTimestamp": 49.1
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 1,
+      "finishTime": 6.15,
+      "dialogue": {
+        "text": "This is so cool. A standing desk, an ergonomic chair, and an ergonomic mouse.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 6.65
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656caddea3aba304c6172571.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656caddea3aba304c6172571.md
@@ -3,7 +3,6 @@ id: 656caddea3aba304c6172571
 title: Task 83
 challengeType: 22
 dashedName: task-83
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656caddea3aba304c6172571.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656caddea3aba304c6172571.md
@@ -35,3 +35,47 @@ Listen to the audio and try to locate a word that relates to comfort and design 
 ### --feedback--
 
 Listen to the audio and try to locate a word that relates to comfort and design in the workplace, especially used to prevent strains or injuries.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 43.68,
+      "finishTimestamp": 49.1
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 1,
+      "finishTime": 6.15,
+      "dialogue": {
+        "text": "This is so cool. A standing desk, an ergonomic chair, and an ergonomic mouse.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 6.65
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656caf2085b7ab04ff9a6b3f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656caf2085b7ab04ff9a6b3f.md
@@ -43,3 +43,47 @@ The word following the article is `information`. As it starts with the sound of 
 ### --feedback--
 
 `an` should be used if the word following it starts with a vowel sound.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 43.68,
+      "finishTimestamp": 49.1
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 1,
+      "finishTime": 6.15,
+      "dialogue": {
+        "text": "This is so cool. A standing desk, an ergonomic chair, and an ergonomic mouse.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 6.65
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656caf2085b7ab04ff9a6b3f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656caf2085b7ab04ff9a6b3f.md
@@ -3,7 +3,6 @@ id: 656caf2085b7ab04ff9a6b3f
 title: Task 84
 challengeType: 22
 dashedName: task-84
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656caf89ead43c0523378566.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656caf89ead43c0523378566.md
@@ -3,7 +3,6 @@ id: 656caf89ead43c0523378566
 title: Task 85
 challengeType: 19
 dashedName: task-85
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656caf89ead43c0523378566.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656caf89ead43c0523378566.md
@@ -46,3 +46,47 @@ Consider the sound that starts the noun after the article. `A` is used before co
 ## --video-solution--
 
 3
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 43.68,
+      "finishTimestamp": 49.1
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 1,
+      "finishTime": 6.15,
+      "dialogue": {
+        "text": "This is so cool. A standing desk, an ergonomic chair, and an ergonomic mouse.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 6.65
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cb0b3e4e30f0550131acd.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cb0b3e4e30f0550131acd.md
@@ -3,7 +3,6 @@ id: 656cb0b3e4e30f0550131acd
 title: Task 86
 challengeType: 22
 dashedName: task-86
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cb18802ef22057a58db13.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cb18802ef22057a58db13.md
@@ -23,7 +23,7 @@ How would you complete the following sentence.
 
 ## --text--
 
-Which article would you use in place of the blank in this sentence: `You must be ___ Sofia, the project manager.`
+Which article would you use in place of the blank in this sentence: `You must be _ Sofia, the project manager.`
 
 ## --answers--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cb18802ef22057a58db13.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cb18802ef22057a58db13.md
@@ -3,7 +3,6 @@ id: 656cb18802ef22057a58db13
 title: Task 87
 challengeType: 19
 dashedName: task-87
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cb2526a741405b2b34870.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cb2526a741405b2b34870.md
@@ -3,7 +3,6 @@ id: 656cb2526a741405b2b34870
 title: Task 88
 challengeType: 22
 dashedName: task-88
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cb2526a741405b2b34870.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cb2526a741405b2b34870.md
@@ -18,7 +18,7 @@ Tom: This is so cool. A Standing Desk, an ergonomic chair and an ergonomic mouse
 
 ## --sentence--
 
-`Ergonomic chair, ergonomic mouse. Man, _ _ perfect.`
+`A standing desk, an ergonomic chair, and an ergonomic mouse. Man, _ _ perfect.`
 
 ## --blanks--
 
@@ -52,8 +52,8 @@ Listen to the audio again.
     "audio": {
       "filename": "1.1-2.mp3",
       "startTime": 1,
-      "startTimestamp": 43.68,
-      "finishTimestamp": 49.1
+      "startTimestamp": 45.02,
+      "finishTimestamp": 50.86
     }
   },
   "commands": [
@@ -65,16 +65,25 @@ Listen to the audio again.
     {
       "character": "Tom",
       "startTime": 1,
-      "finishTime": 6.15,
+      "finishTime": 4.8,
       "dialogue": {
-        "text": "This is so cool. A standing desk, an ergonomic chair, and an ergonomic mouse.",
+        "text": "A standing desk, an ergonomic chair, and an ergonomic mouse.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "startTime": 5.1,
+      "finishTime": 6.6,
+      "dialogue": {
+        "text": "Man, everything is perfect.",
         "align": "center"
       }
     },
     {
       "character": "Tom",
       "opacity": 0,
-      "startTime": 6.65
+      "startTime": 7.1
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cb2526a741405b2b34870.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cb2526a741405b2b34870.md
@@ -35,3 +35,47 @@ Listen to the audio again.
 ### --feedback--
 
 Listen to the audio again.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 43.68,
+      "finishTimestamp": 49.1
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 1,
+      "finishTime": 6.15,
+      "dialogue": {
+        "text": "This is so cool. A standing desk, an ergonomic chair, and an ergonomic mouse.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 6.65
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cb2ee9d60f205d362b1de.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cb2ee9d60f205d362b1de.md
@@ -3,7 +3,6 @@ id: 656cb2ee9d60f205d362b1de
 title: Task 89
 challengeType: 19
 dashedName: task-89
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cb2ee9d60f205d362b1de.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cb2ee9d60f205d362b1de.md
@@ -71,7 +71,7 @@ Tom mentions this workplace Item.
       },
       {
         "character": "Sophie",
-        "position": { "x": 70, "y": 0, "z": 1.25 },
+        "position": { "x": 75, "y": 0, "z": 1.25 },
         "opacity": 0
       }
     ],
@@ -99,7 +99,7 @@ Tom mentions this workplace Item.
       "finishTime": 3.85,
       "dialogue": {
         "text": "Yeah, at this company, they're very attentive to these details.",
-        "align": "center"
+        "align": "right"
       }
     },
     {
@@ -108,7 +108,7 @@ Tom mentions this workplace Item.
       "finishTime": 7.1,
       "dialogue": {
         "text": "You're going to like it here if you're into cutting edge gadgets.",
-        "align": "center"
+        "align": "right"
       }
     },
     {
@@ -117,7 +117,7 @@ Tom mentions this workplace Item.
       "finishTime": 12.45,
       "dialogue": {
         "text": "This is so cool. A standing desk, an ergonomic chair, and an ergonomic mouse.",
-        "align": "center"
+        "align": "left"
       }
     },
     {

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cb2ee9d60f205d362b1de.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cb2ee9d60f205d362b1de.md
@@ -56,3 +56,80 @@ Tom mentions this workplace Item.
 ## --video-solution--
 
 4
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 25, "y": 15, "z": 1.2 },
+        "opacity": 0
+      },
+      {
+        "character": "Sophie",
+        "position": { "x": 70, "y": 0, "z": 1.25 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 37,
+      "finishTimestamp": 49.1
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 3.85,
+      "dialogue": {
+        "text": "Yeah, at this company, they're very attentive to these details.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "startTime": 4.45,
+      "finishTime": 7.1,
+      "dialogue": {
+        "text": "You're going to like it here if you're into cutting edge gadgets.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "startTime": 7.3,
+      "finishTime": 12.45,
+      "dialogue": {
+        "text": "This is so cool. A standing desk, an ergonomic chair, and an ergonomic mouse.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 12.95
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 12.95
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cb2ee9d60f205d362b1de.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cb2ee9d60f205d362b1de.md
@@ -78,7 +78,7 @@ Tom mentions this workplace Item.
     "audio": {
       "filename": "1.1-2.mp3",
       "startTime": 1,
-      "startTimestamp": 37,
+      "startTimestamp": 40.35,
       "finishTimestamp": 49.1
     }
   },
@@ -96,25 +96,16 @@ Tom mentions this workplace Item.
     {
       "character": "Sophie",
       "startTime": 1,
-      "finishTime": 3.85,
+      "finishTime": 3.7,
       "dialogue": {
-        "text": "Yeah, at this company, they're very attentive to these details.",
-        "align": "right"
-      }
-    },
-    {
-      "character": "Sophie",
-      "startTime": 4.45,
-      "finishTime": 7.1,
-      "dialogue": {
-        "text": "You're going to like it here if you're into cutting edge gadgets.",
+        "text": "You're going to like it here if you're into cutting-edge gadgets.",
         "align": "right"
       }
     },
     {
       "character": "Tom",
-      "startTime": 7.3,
-      "finishTime": 12.45,
+      "startTime": 4.2,
+      "finishTime": 9.5,
       "dialogue": {
         "text": "This is so cool. A standing desk, an ergonomic chair, and an ergonomic mouse.",
         "align": "left"
@@ -123,12 +114,12 @@ Tom mentions this workplace Item.
     {
       "character": "Tom",
       "opacity": 0,
-      "startTime": 12.95
+      "startTime": 10
     },
     {
       "character": "Sophie",
       "opacity": 0,
-      "startTime": 12.95
+      "startTime": 10
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cb3592aa0460609993b10.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cb3592aa0460609993b10.md
@@ -51,3 +51,47 @@ She's talking about Tom, not herself.
 ## --video-solution--
 
 2
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 53.15,
+      "finishTimestamp": 57.2
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 4.75,
+      "dialogue": {
+        "text": "So nice to have someone so energetic like you and the team. Are you ready to begin?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 5.25
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cb3592aa0460609993b10.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cb3592aa0460609993b10.md
@@ -68,8 +68,8 @@ She's talking about Tom, not herself.
     "audio": {
       "filename": "1.1-2.mp3",
       "startTime": 1,
-      "startTimestamp": 53.15,
-      "finishTimestamp": 57.2
+      "startTimestamp": 53.22,
+      "finishTimestamp": 55.86
     }
   },
   "commands": [
@@ -81,16 +81,16 @@ She's talking about Tom, not herself.
     {
       "character": "Sophie",
       "startTime": 1,
-      "finishTime": 4.75,
+      "finishTime": 3.3,
       "dialogue": {
-        "text": "So nice to have someone so energetic like you and the team. Are you ready to begin?",
+        "text": "So nice to have someone so energetic like you in the team.",
         "align": "center"
       }
     },
     {
       "character": "Sophie",
       "opacity": 0,
-      "startTime": 5.25
+      "startTime": 3.8
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cb3592aa0460609993b10.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cb3592aa0460609993b10.md
@@ -3,7 +3,6 @@ id: 656cb3592aa0460609993b10
 title: Task 90
 challengeType: 19
 dashedName: task-90
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cb39802398f062c461e2c.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cb39802398f062c461e2c.md
@@ -44,8 +44,8 @@ The adjective here points out a positive trait.
     "audio": {
       "filename": "1.1-2.mp3",
       "startTime": 1,
-      "startTimestamp": 53.15,
-      "finishTimestamp": 57.2
+      "startTimestamp": 53.22,
+      "finishTimestamp": 55.86
     }
   },
   "commands": [
@@ -57,16 +57,16 @@ The adjective here points out a positive trait.
     {
       "character": "Sophie",
       "startTime": 1,
-      "finishTime": 4.75,
+      "finishTime": 3.3,
       "dialogue": {
-        "text": "So nice to have someone so energetic like you and the team. Are you ready to begin?",
+        "text": "So nice to have someone so energetic like you in the team.",
         "align": "center"
       }
     },
     {
       "character": "Sophie",
       "opacity": 0,
-      "startTime": 5.25
+      "startTime": 3.8
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cb39802398f062c461e2c.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cb39802398f062c461e2c.md
@@ -3,7 +3,6 @@ id: 656cb39802398f062c461e2c
 title: Task 91
 challengeType: 22
 dashedName: task-91
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cb39802398f062c461e2c.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cb39802398f062c461e2c.md
@@ -27,3 +27,47 @@ Being `energetic` means having a lot of energy, enthusiasm, and a readiness to a
 ### --feedback--
 
 The adjective here points out a positive trait.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 53.15,
+      "finishTimestamp": 57.2
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 4.75,
+      "dialogue": {
+        "text": "So nice to have someone so energetic like you and the team. Are you ready to begin?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 5.25
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cb3f8df42660676854d29.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cb3f8df42660676854d29.md
@@ -51,3 +51,47 @@ Listen again. Sophie's question is about starting or commencing something, not a
 ## --video-solution--
 
 4
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-2.mp3",
+      "startTime": 1,
+      "startTimestamp": 53.15,
+      "finishTimestamp": 57.2
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 4.75,
+      "dialogue": {
+        "text": "So nice to have someone so energetic like you and the team. Are you ready to begin?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 5.25
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cb3f8df42660676854d29.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cb3f8df42660676854d29.md
@@ -3,7 +3,6 @@ id: 656cb3f8df42660676854d29
 title: Task 92
 challengeType: 19
 dashedName: task-92
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc35036d0a00fe17e7cee.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc35036d0a00fe17e7cee.md
@@ -26,3 +26,47 @@ When you're very hungry, you can emphasize this feeling by using the word `so` b
 ### --feedback--
 
 Tom is using a word to emphasize or increase the intensity of his feeling of hunger.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-3.mp3",
+      "startTime": 1,
+      "startTimestamp": 0,
+      "finishTimestamp": 3.3
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 1,
+      "finishTime": 3.9,
+      "dialogue": {
+        "text": "Wow, I'm so hungry. Is it lunchtime?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 4.4
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc35036d0a00fe17e7cee.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc35036d0a00fe17e7cee.md
@@ -3,7 +3,6 @@ id: 656cc35036d0a00fe17e7cee
 title: Task 93
 challengeType: 22
 dashedName: task-93
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc3b856f1d01011bfc027.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc3b856f1d01011bfc027.md
@@ -50,3 +50,47 @@ Evening
 ## --video-solution--
 
 2
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-3.mp3",
+      "startTime": 1,
+      "startTimestamp": 0,
+      "finishTimestamp": 3.3
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 1,
+      "finishTime": 3.9,
+      "dialogue": {
+        "text": "Wow, I'm so hungry. Is it lunchtime?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 4.4
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc3b856f1d01011bfc027.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc3b856f1d01011bfc027.md
@@ -3,7 +3,6 @@ id: 656cc3b856f1d01011bfc027
 title: Task 94
 challengeType: 19
 dashedName: task-94
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc4aa4726711043189619.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc4aa4726711043189619.md
@@ -3,7 +3,6 @@ id: 656cc4aa4726711043189619
 title: Task 95
 challengeType: 22
 dashedName: task-95
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc4aa4726711043189619.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc4aa4726711043189619.md
@@ -10,7 +10,8 @@ AUDIO REFERENCE:
 Tom: Wow, I'm so hungry. Is it lunch time?
 -->
 
---description--
+# --description--
+
 The pronoun `it` is often used in English to talk about the weather, the time, dates, and distances. In this context, `it` refers to a specific time of the day, lunch time.
 
 # --fillInTheBlank--
@@ -26,3 +27,47 @@ The pronoun `it` is often used in English to talk about the weather, the time, d
 ### --feedback--
 
 Tom is asking about a specific time of the day. He uses a pronoun to refer to that time.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-3.mp3",
+      "startTime": 1,
+      "startTimestamp": 0,
+      "finishTimestamp": 3.3
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 1,
+      "finishTime": 3.9,
+      "dialogue": {
+        "text": "Wow, I'm so hungry. Is it lunchtime?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 4.4
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc523e668741073c4e916.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc523e668741073c4e916.md
@@ -51,3 +51,47 @@ This order is incorrect for asking questions.
 ## --video-solution--
 
 4
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-3.mp3",
+      "startTime": 1,
+      "startTimestamp": 0,
+      "finishTimestamp": 3.3
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 1,
+      "finishTime": 3.9,
+      "dialogue": {
+        "text": "Wow, I'm so hungry. Is it lunchtime?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 4.4
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc523e668741073c4e916.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc523e668741073c4e916.md
@@ -3,7 +3,6 @@ id: 656cc523e668741073c4e916
 title: Task 96
 challengeType: 19
 dashedName: task-96
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc523e668741073c4e916.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc523e668741073c4e916.md
@@ -18,7 +18,7 @@ To ask a question using `it is`, you change the order. Instead of `it is`, you s
 
 ## --text--
 
-Which of the following is a correct question form using `it is`?
+Which of the following is a correct form of a question?
 
 ## --answers--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc5d403162710a3fae634.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc5d403162710a3fae634.md
@@ -64,15 +64,21 @@ This is a question form, not a positive answer.
     "characters": [
       {
         "character": "Tom",
-        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "position": { "x": 25, "y": 15, "z": 1.2 },
+        "opacity": 0
+      },
+      {
+        "character": "Sophie",
+        "position": { "x": 75, "y": 0, "z": 1.25 },
         "opacity": 0
       }
+
     ],
     "audio": {
       "filename": "1.1-3.mp3",
       "startTime": 1,
       "startTimestamp": 0,
-      "finishTimestamp": 3.3
+      "finishTimestamp": 5.1
     }
   },
   "commands": [
@@ -82,18 +88,37 @@ This is a question form, not a positive answer.
       "startTime": 0
     },
     {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
       "character": "Tom",
       "startTime": 1,
       "finishTime": 3.9,
       "dialogue": {
         "text": "Wow, I'm so hungry. Is it lunchtime?",
-        "align": "center"
+        "align": "left"
+      }
+    },
+        {
+      "character": "Sophie",
+      "startTime": 4.4,
+      "finishTime": 5.5,
+      "dialogue": {
+        "text": "Yes, it is.",
+        "align": "right"
       }
     },
     {
       "character": "Tom",
       "opacity": 0,
-      "startTime": 4.4
+      "startTime": 6
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 6
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc5d403162710a3fae634.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc5d403162710a3fae634.md
@@ -3,7 +3,6 @@ id: 656cc5d403162710a3fae634
 title: Task 97
 challengeType: 19
 dashedName: task-97
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc5d403162710a3fae634.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc5d403162710a3fae634.md
@@ -54,3 +54,47 @@ This is a question form, not a positive answer.
 ## --video-solution--
 
 3
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-3.mp3",
+      "startTime": 1,
+      "startTimestamp": 0,
+      "finishTimestamp": 3.3
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 1,
+      "finishTime": 3.9,
+      "dialogue": {
+        "text": "Wow, I'm so hungry. Is it lunchtime?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 4.4
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc6259c711d10cde2c486.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc6259c711d10cde2c486.md
@@ -36,3 +36,72 @@ Sophie is confirming or agreeing with Tom's question about lunch time. She uses 
 ### --feedback--
 
 Sophie is confirming or agreeing with Tom's question about lunch time. She uses an affirmative phrase to do so.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 25, "y": 15, "z": 1.2 },
+        "opacity": 0
+      },
+      {
+        "character": "Sophie",
+        "position": { "x": 75, "y": 0, "z": 1.25 },
+        "opacity": 0
+      }
+
+    ],
+    "audio": {
+      "filename": "1.1-3.mp3",
+      "startTime": 1,
+      "startTimestamp": 0,
+      "finishTimestamp": 5.1
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 1,
+      "finishTime": 3.9,
+      "dialogue": {
+        "text": "Wow, I'm so hungry. Is it lunchtime?",
+        "align": "left"
+      }
+    },
+        {
+      "character": "Sophie",
+      "startTime": 4.4,
+      "finishTime": 5.5,
+      "dialogue": {
+        "text": "Yes, it is.",
+        "align": "right"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 6
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 6
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc6259c711d10cde2c486.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc6259c711d10cde2c486.md
@@ -3,7 +3,6 @@ id: 656cc6259c711d10cde2c486
 title: Task 98
 challengeType: 22
 dashedName: task-98
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc6981cbf2711196a284f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc6981cbf2711196a284f.md
@@ -3,7 +3,6 @@ id: 656cc6981cbf2711196a284f
 title: Task 99
 challengeType: 22
 dashedName: task-99
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc6981cbf2711196a284f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc6981cbf2711196a284f.md
@@ -35,3 +35,47 @@ Tom is asking Sophie about her plans. When forming questions in the present simp
 ### --feedback--
 
 Tom is asking Sophie about her plans. When forming questions in the present simple tense about someone's actions or choices, you start with `are` followed by `you`.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-3.mp3",
+      "startTime": 1,
+      "startTimestamp": 5.2,
+      "finishTimestamp": 7.66
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 1,
+      "finishTime": 2.85,
+      "dialogue": {
+        "text": "Are you eating here or are you going out?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 3.35
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc6dd00af9f117f10446b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc6dd00af9f117f10446b.md
@@ -3,7 +3,6 @@ id: 656cc6dd00af9f117f10446b
 title: Task 100
 challengeType: 22
 dashedName: task-100
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc6dd00af9f117f10446b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc6dd00af9f117f10446b.md
@@ -27,3 +27,47 @@ The word `here` is an adverb that indicates a location or place. It refers to th
 ### --feedback--
 
 Tom is asking Sophie if she is eating in their current location or if she has plans to eat elsewhere.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-3.mp3",
+      "startTime": 1,
+      "startTimestamp": 5.2,
+      "finishTimestamp": 7.66
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 1,
+      "finishTime": 2.85,
+      "dialogue": {
+        "text": "Are you eating here or are you going out?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 3.35
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc73e6b1c6811a73b04bb.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc73e6b1c6811a73b04bb.md
@@ -51,3 +51,47 @@ Being in a romantic relationship
 ## --video-solution--
 
 2
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-3.mp3",
+      "startTime": 1,
+      "startTimestamp": 5.2,
+      "finishTimestamp": 7.66
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 1,
+      "finishTime": 2.85,
+      "dialogue": {
+        "text": "Are you eating here or are you going out?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 3.35
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc73e6b1c6811a73b04bb.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc73e6b1c6811a73b04bb.md
@@ -3,7 +3,6 @@ id: 656cc73e6b1c6811a73b04bb
 title: Task 101
 challengeType: 19
 dashedName: task-101
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc7a3f479f511d56ab246.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc7a3f479f511d56ab246.md
@@ -3,7 +3,6 @@ id: 656cc7a3f479f511d56ab246
 title: Task 102
 challengeType: 22
 dashedName: task-102
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc7a3f479f511d56ab246.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc7a3f479f511d56ab246.md
@@ -28,3 +28,47 @@ Sophie: Today, I'm going out. I can show you some places around here. Are you in
 ### --feedback--
 
 Sophie is talking about her plans for the current day.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-3.mp3",
+      "startTime": 1,
+      "startTimestamp": 8.2,
+      "finishTimestamp": 12.7
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 5.2,
+      "dialogue": {
+        "text": "Today, I'm going out. I can show you some places around here. Are you interested?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 5.7
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc833fe9c0611feeb5b26.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc833fe9c0611feeb5b26.md
@@ -51,3 +51,47 @@ A past action
 ## --video-solution--
 
 3
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-3.mp3",
+      "startTime": 1,
+      "startTimestamp": 8.2,
+      "finishTimestamp": 12.7
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 5.2,
+      "dialogue": {
+        "text": "Today, I'm going out. I can show you some places around here. Are you interested?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 5.7
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc833fe9c0611feeb5b26.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc833fe9c0611feeb5b26.md
@@ -3,7 +3,6 @@ id: 656cc833fe9c0611feeb5b26
 title: Task 103
 challengeType: 19
 dashedName: task-103
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc86fc6a990122ac6c6a1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc86fc6a990122ac6c6a1.md
@@ -3,7 +3,6 @@ id: 656cc86fc6a990122ac6c6a1
 title: Task 104
 challengeType: 22
 dashedName: task-104
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc86fc6a990122ac6c6a1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc86fc6a990122ac6c6a1.md
@@ -27,3 +27,47 @@ Sophie: Today, I'm going out. I can show you some places around here. Are you in
 ### --feedback--
 
 Sophie is expressing her capability or possibility of showing Tom some places.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-3.mp3",
+      "startTime": 1,
+      "startTimestamp": 8.2,
+      "finishTimestamp": 12.7
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 5.2,
+      "dialogue": {
+        "text": "Today, I'm going out. I can show you some places around here. Are you interested?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 5.7
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc8dafb6343124f729ec5.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc8dafb6343124f729ec5.md
@@ -3,7 +3,6 @@ id: 656cc8dafb6343124f729ec5
 title: Task 105
 challengeType: 19
 dashedName: task-105
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc8dafb6343124f729ec5.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc8dafb6343124f729ec5.md
@@ -51,3 +51,47 @@ One place
 ## --video-solution--
 
 3
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-3.mp3",
+      "startTime": 1,
+      "startTimestamp": 8.2,
+      "finishTimestamp": 12.7
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 5.2,
+      "dialogue": {
+        "text": "Today, I'm going out. I can show you some places around here. Are you interested?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 5.7
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc92ecdebaa1278505e87.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc92ecdebaa1278505e87.md
@@ -3,7 +3,6 @@ id: 656cc92ecdebaa1278505e87
 title: Task 106
 challengeType: 19
 dashedName: task-106
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc92ecdebaa1278505e87.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc92ecdebaa1278505e87.md
@@ -51,3 +51,47 @@ Sophie is talking about real locations near their current spot.
 ## --video-solution--
 
 3
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-3.mp3",
+      "startTime": 1,
+      "startTimestamp": 8.2,
+      "finishTimestamp": 12.7
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 5.2,
+      "dialogue": {
+        "text": "Today, I'm going out. I can show you some places around here. Are you interested?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 5.7
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc98cfe781112ace7d3ee.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc98cfe781112ace7d3ee.md
@@ -3,7 +3,6 @@ id: 656cc98cfe781112ace7d3ee
 title: Task 107
 challengeType: 22
 dashedName: task-107
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc98cfe781112ace7d3ee.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cc98cfe781112ace7d3ee.md
@@ -43,3 +43,47 @@ Sophie is offering to show Tom various locations near their current spot.
 ### --feedback--
 
 Sophie is offering to show Tom various locations near their current spot.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-3.mp3",
+      "startTime": 1,
+      "startTimestamp": 8.2,
+      "finishTimestamp": 12.7
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 5.2,
+      "dialogue": {
+        "text": "Today, I'm going out. I can show you some places around here. Are you interested?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 5.7
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cca055e5d1912d9784ce1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cca055e5d1912d9784ce1.md
@@ -51,3 +51,47 @@ Sophie is offering to show places, not asking for suggestions.
 ## --video-solution--
 
 2
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-3.mp3",
+      "startTime": 1,
+      "startTimestamp": 8.2,
+      "finishTimestamp": 12.7
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 5.2,
+      "dialogue": {
+        "text": "Today, I'm going out. I can show you some places around here. Are you interested?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 5.7
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cca055e5d1912d9784ce1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cca055e5d1912d9784ce1.md
@@ -3,7 +3,6 @@ id: 656cca055e5d1912d9784ce1
 title: Task 108
 challengeType: 19
 dashedName: task-108
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cca6bb44ce5130a759829.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cca6bb44ce5130a759829.md
@@ -3,7 +3,6 @@ id: 656cca6bb44ce5130a759829
 title: Task 109
 challengeType: 19
 dashedName: task-109
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cca6bb44ce5130a759829.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cca6bb44ce5130a759829.md
@@ -51,3 +51,47 @@ Tom is expressing strong agreement, not asking for clarification.
 ## --video-solution--
 
 3
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-3.mp3",
+      "startTime": 1,
+      "startTimestamp": 12.85,
+      "finishTimestamp": 16.1
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 1,
+      "finishTime": 3.85,
+      "dialogue": {
+        "text": "Of course. Any favorite lunch spot around here, Sophie?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 4.35
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ccd12c27bf013529db8ce.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ccd12c27bf013529db8ce.md
@@ -3,7 +3,6 @@ id: 656ccd12c27bf013529db8ce
 title: Task 110
 challengeType: 19
 dashedName: task-110
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ccd12c27bf013529db8ce.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ccd12c27bf013529db8ce.md
@@ -46,3 +46,47 @@ Tom is specifically asking about a preferred spot, not Sophie's lunch habits.
 ## --video-solution--
 
 2
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-3.mp3",
+      "startTime": 1,
+      "startTimestamp": 12.85,
+      "finishTimestamp": 16.1
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 1,
+      "finishTime": 3.85,
+      "dialogue": {
+        "text": "Of course. Any favorite lunch spot around here, Sophie?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 4.35
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ccd8bafe46d138451d176.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ccd8bafe46d138451d176.md
@@ -3,7 +3,6 @@ id: 656ccd8bafe46d138451d176
 title: Task 111
 challengeType: 22
 dashedName: task-111
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ccd8bafe46d138451d176.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ccd8bafe46d138451d176.md
@@ -44,3 +44,47 @@ Listen to how Tom asks Sophie about a place she prefers to eat lunch.
 ### --feedback--
 
 Listen to how Tom asks Sophie about a place she prefers to eat lunch. 
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-3.mp3",
+      "startTime": 1,
+      "startTimestamp": 12.85,
+      "finishTimestamp": 16.1
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 1,
+      "finishTime": 3.85,
+      "dialogue": {
+        "text": "Of course. Any favorite lunch spot around here, Sophie?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 4.35
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ccde87f42ec13b19c5dab.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ccde87f42ec13b19c5dab.md
@@ -46,3 +46,47 @@ Cafés are related to food and beverages, not clothes.
 ## --video-solution--
 
 2
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-3.mp3",
+      "startTime": 1,
+      "startTimestamp": 16.74,
+      "finishTimestamp": 20.34
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 4.3,
+      "dialogue": {
+        "text": "I know a nice one. It's a café right down the street. Is that okay for you?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 4.8
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ccde87f42ec13b19c5dab.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ccde87f42ec13b19c5dab.md
@@ -3,7 +3,6 @@ id: 656ccde87f42ec13b19c5dab
 title: Task 112
 challengeType: 19
 dashedName: task-112
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cce4130c4d313e92ed22e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cce4130c4d313e92ed22e.md
@@ -51,3 +51,47 @@ Listen closely to where Sophie says the café is located.
 ## --video-solution--
 
 3
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-3.mp3",
+      "startTime": 1,
+      "startTimestamp": 16.74,
+      "finishTimestamp": 20.34
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 4.3,
+      "dialogue": {
+        "text": "I know a nice one. It's a café right down the street. Is that okay for you?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 4.8
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cce4130c4d313e92ed22e.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cce4130c4d313e92ed22e.md
@@ -3,7 +3,6 @@ id: 656cce4130c4d313e92ed22e
 title: Task 113
 challengeType: 19
 dashedName: task-113
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cce9ebec3c01412c0e564.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cce9ebec3c01412c0e564.md
@@ -51,3 +51,47 @@ The phrase doesn't specify the café's position in or outside a building.
 ## --video-solution--
 
 3
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-3.mp3",
+      "startTime": 1,
+      "startTimestamp": 16.74,
+      "finishTimestamp": 20.34
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 4.3,
+      "dialogue": {
+        "text": "I know a nice one. It's a café right down the street. Is that okay for you?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 4.8
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cce9ebec3c01412c0e564.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cce9ebec3c01412c0e564.md
@@ -3,7 +3,6 @@ id: 656cce9ebec3c01412c0e564
 title: Task 114
 challengeType: 19
 dashedName: task-114
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ccf01c07406143b90ff84.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ccf01c07406143b90ff84.md
@@ -51,3 +51,47 @@ Sophie is inquiring about Tom's preference, not ownership.
 ## --video-solution--
 
 2
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-3.mp3",
+      "startTime": 1,
+      "startTimestamp": 16.74,
+      "finishTimestamp": 20.34
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 4.3,
+      "dialogue": {
+        "text": "I know a nice one. It's a café right down the street. Is that okay for you?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 4.8
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ccf01c07406143b90ff84.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ccf01c07406143b90ff84.md
@@ -3,7 +3,6 @@ id: 656ccf01c07406143b90ff84
 title: Task 115
 challengeType: 19
 dashedName: task-115
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ccf6255561e1467afd1c6.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ccf6255561e1467afd1c6.md
@@ -3,7 +3,6 @@ id: 656ccf6255561e1467afd1c6
 title: Task 116
 challengeType: 19
 dashedName: task-116
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ccf6255561e1467afd1c6.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ccf6255561e1467afd1c6.md
@@ -51,3 +51,47 @@ Tom is responding directly to Sophie's suggestion.
 ## --video-solution--
 
 3
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-3.mp3",
+      "startTime": 1,
+      "startTimestamp": 20.4,
+      "finishTimestamp": 21.3
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 1,
+      "finishTime": 1.55,
+      "dialogue": {
+        "text": "Sounds great.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 2.05
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ccfb763eddb149831854d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ccfb763eddb149831854d.md
@@ -14,7 +14,7 @@ Tom: Sounds great!
 
 When someone hears something they like or agree with, they might respond with a positive expression to show enthusiasm or agreement.
 
---instructions--
+# --instructions--
 
 What does Tom say in the dialogue?
 
@@ -22,7 +22,7 @@ What does Tom say in the dialogue?
 
 ## --sentence--
 
-`_ _!`
+`_ _.`
 
 ## --blanks--
 
@@ -39,3 +39,47 @@ Tom is expressing his agreement and excitement about the idea.
 ### --feedback--
 
 Tom is expressing his agreement and excitement about the idea.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-3.mp3",
+      "startTime": 1,
+      "startTimestamp": 20.4,
+      "finishTimestamp": 21.3
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 1,
+      "finishTime": 1.55,
+      "dialogue": {
+        "text": "Sounds great.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 2.05
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ccfb763eddb149831854d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656ccfb763eddb149831854d.md
@@ -3,7 +3,6 @@ id: 656ccfb763eddb149831854d
 title: Task 117
 challengeType: 22
 dashedName: task-117
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd00707c0d614c38e7416.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd00707c0d614c38e7416.md
@@ -3,7 +3,6 @@ id: 656cd00707c0d614c38e7416
 title: Task 118
 challengeType: 19
 dashedName: task-118
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd00707c0d614c38e7416.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd00707c0d614c38e7416.md
@@ -46,3 +46,47 @@ The phrase refers to pausing or resting, not beginning a new task.
 ## --video-solution--
 
 3
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-3.mp3",
+      "startTime": 1,
+      "startTimestamp": 21.9,
+      "finishTimestamp": 24.04
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 2.85,
+      "dialogue": {
+        "text": "Yeah, it's nice to have a break from the office.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 3.35
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd061eb49fb14f672f77f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd061eb49fb14f672f77f.md
@@ -3,7 +3,6 @@ id: 656cd061eb49fb14f672f77f
 title: Task 119
 challengeType: 22
 dashedName: task-119
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd061eb49fb14f672f77f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd061eb49fb14f672f77f.md
@@ -43,3 +43,47 @@ Sophie is talking about taking a short rest or pause from the office work.
 ### --feedback--
 
 Sophie is talking about taking a short rest or pause from the office work.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-3.mp3",
+      "startTime": 1,
+      "startTimestamp": 21.9,
+      "finishTimestamp": 24.04
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 2.85,
+      "dialogue": {
+        "text": "Yeah, it's nice to have a break from the office.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 3.35
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd0c550a08915211f32ce.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd0c550a08915211f32ce.md
@@ -3,7 +3,6 @@ id: 656cd0c550a08915211f32ce
 title: Task 120
 challengeType: 19
 dashedName: task-120
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd0c550a08915211f32ce.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd0c550a08915211f32ce.md
@@ -46,3 +46,47 @@ Again, the phrase indicates that walking is sufficient.
 ## --video-solution--
 
 3
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-3.mp3",
+      "startTime": 1,
+      "startTimestamp": 25.65,
+      "finishTimestamp": 27.56
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 1,
+      "finishTime": 2.55,
+      "dialogue": {
+        "text": "Is the cafe within walking distance?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 3.05
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd118ca4f1115500a4bf8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd118ca4f1115500a4bf8.md
@@ -35,3 +35,47 @@ Tom is inquiring if the café is close enough to reach on foot without the need 
 ### --feedback--
 
 Tom is inquiring if the café is close enough to reach on foot without the need for transportation.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-3.mp3",
+      "startTime": 1,
+      "startTimestamp": 25.65,
+      "finishTimestamp": 27.56
+    }
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Tom",
+      "startTime": 1,
+      "finishTime": 2.55,
+      "dialogue": {
+        "text": "Is the cafe within walking distance?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Tom",
+      "opacity": 0,
+      "startTime": 3.05
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd118ca4f1115500a4bf8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd118ca4f1115500a4bf8.md
@@ -3,7 +3,6 @@ id: 656cd118ca4f1115500a4bf8
 title: Task 121
 challengeType: 22
 dashedName: task-121
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd17584250515779ca7e5.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd17584250515779ca7e5.md
@@ -51,3 +51,47 @@ Sophie provides information about the café's location.
 ## --video-solution--
 
 2
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-3.mp3",
+      "startTime": 1,
+      "startTimestamp": 28,
+      "finishTimestamp": 30.65
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 3.2,
+      "dialogue": {
+        "text": "Well, it's not far. Come on, we can go together.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 3.7
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd17584250515779ca7e5.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd17584250515779ca7e5.md
@@ -12,7 +12,7 @@ Sophie: Well, it is not far.
 
 # --description--
 
-You can use `it is not` to make negative statements in the present simple. It negates or says something isn't a certain way.
+You can use `it is not` to make negative statements in the present simple. It negates or says something isn't a certain way. `It's` is a contraction of `it` and `is`.
 
 # --question--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd17584250515779ca7e5.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd17584250515779ca7e5.md
@@ -3,7 +3,6 @@ id: 656cd17584250515779ca7e5
 title: Task 122
 challengeType: 19
 dashedName: task-122
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd1ca72b3e615a33c05b6.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd1ca72b3e615a33c05b6.md
@@ -43,3 +43,47 @@ Sophie is negating or contradicting the idea that the café is at a significant 
 ### --feedback--
 
 Sophie is negating or contradicting the idea that the café is at a significant distance.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-3.mp3",
+      "startTime": 1,
+      "startTimestamp": 28,
+      "finishTimestamp": 30.65
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 3.2,
+      "dialogue": {
+        "text": "Well, it's not far. Come on, we can go together.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 3.7
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd1ca72b3e615a33c05b6.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd1ca72b3e615a33c05b6.md
@@ -3,7 +3,6 @@ id: 656cd1ca72b3e615a33c05b6
 title: Task 123
 challengeType: 22
 dashedName: task-123
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd1ca72b3e615a33c05b6.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd1ca72b3e615a33c05b6.md
@@ -18,19 +18,11 @@ In English, you can use a certain structure to indicate that something is not in
 
 ## --sentence--
 
-`Well, _ _ _ far.`
+`Well, _ _ far.`
 
 ## --blanks--
 
-`it`
-
-### --feedback--
-
-Sophie is negating or contradicting the idea that the café is at a significant distance.
-
----
-
-`is`
+`it's`
 
 ### --feedback--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd22d91db1915cb11f584.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd22d91db1915cb11f584.md
@@ -55,3 +55,47 @@ There's no mention of waiting for a third person in the conversation.
 ## --video-solution--
 
 3
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-3.mp3",
+      "startTime": 1,
+      "startTimestamp": 28,
+      "finishTimestamp": 30.65
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 3.2,
+      "dialogue": {
+        "text": "Well, it's not far. Come on, we can go together.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 3.7
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd22d91db1915cb11f584.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd22d91db1915cb11f584.md
@@ -3,7 +3,6 @@ id: 656cd22d91db1915cb11f584
 title: Task 124
 challengeType: 19
 dashedName: task-124
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd27f38f17f15f06f6ed6.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd27f38f17f15f06f6ed6.md
@@ -18,7 +18,7 @@ When two or more people decide to accompany each other to a place or event, they
 
 ## --sentence--
 
-`C'mon, we can _ _.`
+`Come on, we can _ _.`
 
 ## --blanks--
 
@@ -52,7 +52,7 @@ Sophie is suggesting that they both head to the café at the same time as a pair
     "audio": {
       "filename": "1.1-3.mp3",
       "startTime": 1,
-      "startTimestamp": 28,
+      "startTimestamp": 29.2,
       "finishTimestamp": 30.65
     }
   },
@@ -65,16 +65,16 @@ Sophie is suggesting that they both head to the café at the same time as a pair
     {
       "character": "Sophie",
       "startTime": 1,
-      "finishTime": 3.2,
+      "finishTime": 2.4,
       "dialogue": {
-        "text": "Well, it's not far. Come on, we can go together.",
+        "text": "Come on, we can go together.",
         "align": "center"
       }
     },
     {
       "character": "Sophie",
       "opacity": 0,
-      "startTime": 3.7
+      "startTime": 2.9
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd27f38f17f15f06f6ed6.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd27f38f17f15f06f6ed6.md
@@ -3,7 +3,6 @@ id: 656cd27f38f17f15f06f6ed6
 title: Task 125
 challengeType: 22
 dashedName: task-125
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd27f38f17f15f06f6ed6.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd27f38f17f15f06f6ed6.md
@@ -35,3 +35,47 @@ Sophie is suggesting that they both head to the café at the same time as a pair
 ### --feedback--
 
 Sophie is suggesting that they both head to the café at the same time as a pair.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-3.mp3",
+      "startTime": 1,
+      "startTimestamp": 28,
+      "finishTimestamp": 30.65
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 3.2,
+      "dialogue": {
+        "text": "Well, it's not far. Come on, we can go together.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 3.7
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd31045ce74162adef6c7.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd31045ce74162adef6c7.md
@@ -55,3 +55,167 @@ Both Tom and Sophie are planning to go to the café together.
 ## --video-solution--
 
 3
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company2-center.png",
+    "characters": [
+      {
+        "character": "Tom",
+        "position": { "x": -25, "y": 0, "z": 1 }
+      },
+      {
+        "character": "Sophie",
+        "position": { "x": 125, "y": 0, "z": 1 }
+      }
+    ],
+    "audio": {
+      "filename": "1.1-3.mp3",
+      "startTime": 1.2
+    },
+    "alwaysShowDialogue": true
+  },
+  "commands": [
+    {
+      "character": "Tom",
+      "position": { "x": 25, "y": 0, "z": 1 },
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "position": { "x": 70, "y": 0, "z": 1 },
+      "startTime": 0.5
+    },
+    {
+      "character": "Tom",
+      "startTime": 1,
+      "finishTime": 4.4,
+      "dialogue": {
+        "text": "Wow, I'm so hungry. Is it lunch time?",
+        "align": "left"
+      }
+    },
+    {
+      "character": "Sophie",
+      "startTime": 5,
+      "finishTime": 6.4,
+      "dialogue": {
+        "text": "Yes, it is.",
+        "align": "right"
+      }
+    },
+    {
+      "character": "Tom",
+      "startTime": 6.6,
+      "finishTime": 8.5,
+      "dialogue": {
+        "text": "Are you eating here or are you going out?",
+        "align": "left"
+      }
+    },
+    {
+      "character": "Sophie",
+      "startTime": 9.1,
+      "finishTime": 10.8,
+      "dialogue": {
+        "text": "Today, I'm going out.",
+        "align": "right"
+      }
+    },
+    {
+      "character": "Sophie",
+      "startTime": 11,
+      "finishTime": 14,
+      "dialogue": {
+        "text": "I can show you some places around here. Are you interested?",
+        "align": "right"
+      }
+    },
+    {
+      "character": "Tom",
+      "startTime": 14,
+      "finishTime": 17.2,
+      "dialogue": {
+        "text": "Of course. Any favorite lunch spot around here, Sophie?",
+        "align": "left"
+      }
+    },
+    {
+      "character": "Sophie",
+      "startTime": 17.4,
+      "finishTime": 20.5,
+      "dialogue": {
+        "text": "I know a nice one. It's a café right down the street.",
+        "align": "right"
+      }
+    },
+    {
+      "character": "Sophie",
+      "startTime": 20.5,
+      "finishTime": 21.3,
+      "dialogue": {
+        "text": "Is that OK for you?",
+        "align": "right"
+      }
+    },
+    {
+      "character": "Tom",
+      "startTime": 21.5,
+      "finishTime": 22.7,
+      "dialogue": {
+        "text": "Sounds great!",
+        "align": "left"
+      }
+    },
+    {
+      "character": "Sophie",
+      "startTime": 23.1,
+      "finishTime": 25.2,
+      "dialogue": {
+        "text": "Yeah. It's nice to have a break from the office.",
+        "align": "right"
+      }
+    },
+    {
+      "character": "Tom",
+      "startTime": 25.4,
+      "finishTime": 28.7,
+      "dialogue": {
+        "text": "It is. Is the café within walking distance?",
+        "align": "left"
+      }
+    },
+    {
+      "character": "Sophie",
+      "startTime": 29.1,
+      "finishTime": 30.4,
+      "dialogue": {
+        "text": "Well, it's not far.",
+        "align": "right"
+      }
+    },
+    {
+      "character": "Sophie",
+      "startTime": 30.5,
+      "finishTime": 32.1,
+      "dialogue": {
+        "text": "Come on. We can go together.",
+        "align": "right"
+      }
+    },
+    {
+      "character": "Sophie",
+      "position": { "x": 125, "y": 0, "z": 1 },
+      "startTime": 32.6
+    },
+    {
+      "character": "Tom",
+      "position": { "x": -25, "y": 0, "z": 1 },
+      "startTime": 33.1
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd31045ce74162adef6c7.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd31045ce74162adef6c7.md
@@ -3,7 +3,6 @@ id: 656cd31045ce74162adef6c7
 title: Task 126
 challengeType: 19
 dashedName: task-126
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd52f0f43551be96b4640.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd52f0f43551be96b4640.md
@@ -3,7 +3,6 @@ id: 656cd52f0f43551be96b4640
 title: Task 127
 challengeType: 19
 dashedName: task-127
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd52f0f43551be96b4640.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd52f0f43551be96b4640.md
@@ -46,3 +46,47 @@ It's not about not knowing the person, but noticing them. Try again.
 ## --video-solution--
 
 3
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "cafe.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-4.mp3",
+      "startTime": 1,
+      "startTimestamp": 0,
+      "finishTimestamp": 3.02
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 3.52,
+      "dialogue": {
+        "text": "Oh, look who's here! Hey, Brian. How is everything?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 4.02
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd63a45146d1c2c51e682.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd63a45146d1c2c51e682.md
@@ -7,13 +7,13 @@ dashedName: task-129
 
 # --description--
 
-The question `how is everything?` is a way to ask someone how they are and how things are going in their life.
+The question `How is everything?` is a way to ask someone how they are and how things are going in their life.
 
 # --question--
 
 ## --text--
 
-What does `how is everything?` mean?
+What does `How is everything?` mean?
 
 ## --answers--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd63a45146d1c2c51e682.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd63a45146d1c2c51e682.md
@@ -46,3 +46,47 @@ It's not just about family.
 ## --video-solution--
 
 3
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "cafe.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-4.mp3",
+      "startTime": 1,
+      "startTimestamp": 0,
+      "finishTimestamp": 3.02
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 3.52,
+      "dialogue": {
+        "text": "Oh, look who's here! Hey, Brian. How is everything?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 4.02
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd63a45146d1c2c51e682.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd63a45146d1c2c51e682.md
@@ -3,7 +3,6 @@ id: 656cd63a45146d1c2c51e682
 title: Task 129
 challengeType: 19
 dashedName: task-129
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd6a37495961c5f242c5d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd6a37495961c5f242c5d.md
@@ -3,7 +3,6 @@ id: 656cd6a37495961c5f242c5d
 title: Task 130
 challengeType: 19
 dashedName: task-130
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd6a37495961c5f242c5d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd6a37495961c5f242c5d.md
@@ -51,3 +51,47 @@ She doesn’t ask for reasons. Try again.
 ## --video-solution--
 
 4
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "cafe.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-4.mp3",
+      "startTime": 1,
+      "startTimestamp": 0,
+      "finishTimestamp": 3.02
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 3.52,
+      "dialogue": {
+        "text": "Oh, look who's here! Hey, Brian. How is everything?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 4.02
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd7da364a181cb1038846.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd7da364a181cb1038846.md
@@ -11,7 +11,7 @@ Sophie: Oh, look who's here! Hey, Brian! How is everything?
 Brian: Sophie! Great to see you here.
 -->
 
---description--
+# --description--
 
 Here, Brian is grateful to see Sophie.
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd7da364a181cb1038846.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd7da364a181cb1038846.md
@@ -13,7 +13,7 @@ Brian: Sophie! Great to see you here.
 
 # --description--
 
-Here, Brian is grateful to see Sophie.
+Here, Brian is grateful to see Sophie. Listen to the video and fill in the blanks below.
 
 # --fillInTheBlank--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd7da364a181cb1038846.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd7da364a181cb1038846.md
@@ -3,7 +3,6 @@ id: 656cd7da364a181cb1038846
 title: Task 131
 challengeType: 22
 dashedName: task-131
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd7da364a181cb1038846.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd7da364a181cb1038846.md
@@ -28,3 +28,47 @@ Here, Brian is grateful to see Sophie.
 ### --feedback--
 
 The dialogue shows surprise, a friendly question and an answer.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "cafe.png",
+    "characters": [
+      {
+        "character": "Brian",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-4.mp3",
+      "startTime": 1,
+      "startTimestamp": 3.45,
+      "finishTimestamp": 5.56
+    }
+  },
+  "commands": [
+    {
+      "character": "Brian",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Brian",
+      "startTime": 1,
+      "finishTime": 2.5,
+      "dialogue": {
+        "text": "Sophie. Great to see you here!",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Brian",
+      "opacity": 0,
+      "startTime": 3
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd83ad397f61ce1259ad6.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd83ad397f61ce1259ad6.md
@@ -3,7 +3,6 @@ id: 656cd83ad397f61ce1259ad6
 title: Task 132
 challengeType: 22
 dashedName: task-132
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd83ad397f61ce1259ad6.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd83ad397f61ce1259ad6.md
@@ -27,3 +27,48 @@ When you want to present one person to another, you can use the phrase `let me i
 ### --feedback--
 
 Sophie uses a phrase that suggests she's presenting Tom to Brian.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "cafe.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-4.mp3",
+      "startTime": 1,
+      "startTimestamp": 7,
+      "finishTimestamp": 11.76
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 5.76,
+      "dialogue": {
+        "text": "Brian, let me introduce you to Tom. Tom, this is Brian. He's a web developer.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 6.26
+    }
+  ]
+}
+```
+

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd8d68948d11d201308d4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd8d68948d11d201308d4.md
@@ -57,3 +57,48 @@ Sophie is doing the introduction, not asking Brian to do so.
 ## --video-solution--
 
 1
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "cafe.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-4.mp3",
+      "startTime": 1,
+      "startTimestamp": 7,
+      "finishTimestamp": 11.76
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 5.76,
+      "dialogue": {
+        "text": "Brian, let me introduce you to Tom. Tom, this is Brian. He's a web developer.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 6.26
+    }
+  ]
+}
+```
+

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd8d68948d11d201308d4.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd8d68948d11d201308d4.md
@@ -3,7 +3,6 @@ id: 656cd8d68948d11d201308d4
 title: Task 133
 challengeType: 19
 dashedName: task-133
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd983328ab41d5bd929d0.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd983328ab41d5bd929d0.md
@@ -3,7 +3,6 @@ id: 656cd983328ab41d5bd929d0
 title: Task 134
 challengeType: 19
 dashedName: task-134
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd983328ab41d5bd929d0.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd983328ab41d5bd929d0.md
@@ -13,7 +13,7 @@ Notice this part of the dialogue:
 
 `Tom, this is Brian. He's a web developer. Brian, this is Tom. He's our new graphic designer and he is from Texas.`
 
-In the dialogue, after introducing Brian, Sophie uses `he` to talk about Brian's job. Later, she uses `he` again to talk about Tom and his job. 
+In the dialogue, after introducing Brian, Sophie uses `he` to talk about Brian's job. Later, she uses `he` again to talk about Tom and his job.
 
 By using `he`, Sophie doesn't have to repeat the names `Brian` and `Tom`. This is the power of the pronouns.
 
@@ -72,7 +72,7 @@ In the dialogue, which word is used to refer to Brian without repeating his name
       "filename": "1.1-4.mp3",
       "startTime": 1,
       "startTimestamp": 7,
-      "finishTimestamp": 11.76
+      "finishTimestamp": 16.02
     }
   },
   "commands": [
@@ -92,10 +92,18 @@ In the dialogue, which word is used to refer to Brian without repeating his name
     },
     {
       "character": "Sophie",
+      "startTime": 5.8,
+      "finishTime": 10,
+      "dialogue": {
+        "text": "Brian, this is Tom. He's our new graphic designer and he is from Texas.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
       "opacity": 0,
-      "startTime": 6.26
+      "startTime": 10.5
     }
   ]
 }
 ```
-

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd983328ab41d5bd929d0.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd983328ab41d5bd929d0.md
@@ -54,3 +54,48 @@ In the dialogue, which word is used to refer to Brian without repeating his name
 ## --video-solution--
 
 4
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "cafe.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-4.mp3",
+      "startTime": 1,
+      "startTimestamp": 7,
+      "finishTimestamp": 11.76
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 5.76,
+      "dialogue": {
+        "text": "Brian, let me introduce you to Tom. Tom, this is Brian. He's a web developer.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 6.26
+    }
+  ]
+}
+```
+

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd9f4e30e6d1d81f0e62d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd9f4e30e6d1d81f0e62d.md
@@ -30,3 +30,48 @@ For third person singular (`he`, `she`, `it`), the verb `be` is conjugated as `i
 ### --feedback--
 
 For third person singular (`he`, `she`, `it`), the verb `be` is conjugated as `is`.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "cafe.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-4.mp3",
+      "startTime": 1,
+      "startTimestamp": 7,
+      "finishTimestamp": 11.76
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 5.76,
+      "dialogue": {
+        "text": "Brian, let me introduce you to Tom. Tom, this is Brian. He's a web developer.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 6.26
+    }
+  ]
+}
+```
+

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd9f4e30e6d1d81f0e62d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd9f4e30e6d1d81f0e62d.md
@@ -3,7 +3,6 @@ id: 656cd9f4e30e6d1d81f0e62d
 title: Task 135
 challengeType: 22
 dashedName: task-135
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd9f4e30e6d1d81f0e62d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cd9f4e30e6d1d81f0e62d.md
@@ -48,7 +48,7 @@ For third person singular (`he`, `she`, `it`), the verb `be` is conjugated as `i
       "filename": "1.1-4.mp3",
       "startTime": 1,
       "startTimestamp": 7,
-      "finishTimestamp": 11.76
+      "finishTimestamp": 16.02
     }
   },
   "commands": [
@@ -68,10 +68,18 @@ For third person singular (`he`, `she`, `it`), the verb `be` is conjugated as `i
     },
     {
       "character": "Sophie",
+      "startTime": 5.8,
+      "finishTime": 10,
+      "dialogue": {
+        "text": "Brian, this is Tom. He's our new graphic designer and he is from Texas.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
       "opacity": 0,
-      "startTime": 6.26
+      "startTime": 10.5
     }
   ]
 }
 ```
-

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cda3cd706aa1daa128704.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cda3cd706aa1daa128704.md
@@ -3,7 +3,6 @@ id: 656cda3cd706aa1daa128704
 title: Task 136
 challengeType: 22
 dashedName: task-136
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cdab71161371dd6b0a401.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cdab71161371dd6b0a401.md
@@ -46,3 +46,47 @@ Which of the following sentences is correct?
 ## --video-solution--
 
 1
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "cafe.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-4.mp3",
+      "startTime": 1,
+      "startTimestamp": 12.15,
+      "finishTimestamp": 16.02
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 4.55,
+      "dialogue": {
+        "text": "Brian, this is Tom. He's our new graphic designer and he is from Texas.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 5.05
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cdab71161371dd6b0a401.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cdab71161371dd6b0a401.md
@@ -3,7 +3,6 @@ id: 656cdab71161371dd6b0a401
 title: Task 137
 challengeType: 19
 dashedName: task-137
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cdb10b568061e0bd6757f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cdb10b568061e0bd6757f.md
@@ -3,7 +3,6 @@ id: 656cdb10b568061e0bd6757f
 title: Task 138
 challengeType: 22
 dashedName: task-138
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cdb10b568061e0bd6757f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cdb10b568061e0bd6757f.md
@@ -7,13 +7,7 @@ dashedName: task-138
 
 # --description--
 
-The word `our` is a possessive pronoun. It shows that something belongs to or is related to a group that includes the speaker. In the dialogue, Sophie uses `our` to talk about Tom to indicate that he is part of their company.
-
-Consider this part of the dialogue:
-
-`Brian, this is Tom. He's our new graphic designer and he is from Texas.`
-
-Here, Sophie is indicating that Tom belongs to the same company or group as she does.
+The word `our` is a possessive pronoun. It shows that something belongs to or is related to a group that includes the speaker. In the dialogue, Sophie uses `our` to talk about Tom and indicate that he is part of their company.
 
 # --fillInTheBlank--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cdb10b568061e0bd6757f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656cdb10b568061e0bd6757f.md
@@ -28,3 +28,47 @@ Here, Sophie is indicating that Tom belongs to the same company or group as she 
 ### --feedback--
 
 Think about who Tom belongs to. Sophie is indicating that Tom is now part of a team or group that includes her.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "cafe.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-4.mp3",
+      "startTime": 1,
+      "startTimestamp": 12.15,
+      "finishTimestamp": 16.02
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 4.55,
+      "dialogue": {
+        "text": "Brian, this is Tom. He's our new graphic designer and he is from Texas.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 5.05
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1936ab6cfb04e2ca6944.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1936ab6cfb04e2ca6944.md
@@ -3,7 +3,6 @@ id: 656d1936ab6cfb04e2ca6944
 title: Task 141
 challengeType: 22
 dashedName: task-141
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1936ab6cfb04e2ca6944.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1936ab6cfb04e2ca6944.md
@@ -18,7 +18,7 @@ A `workmate` refers to someone you work with. It's another word for colleague or
 
 ## --sentence--
 
-`Great! Sophie is a great _. She is very kind and helpful.`
+`Sophie is a great _. She is very kind and helpful.`
 
 ## --blanks--
 
@@ -27,3 +27,47 @@ A `workmate` refers to someone you work with. It's another word for colleague or
 ### --feedback--
 
 Brian is talking about someone he and Tom both know from their job.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "cafe.png",
+    "characters": [
+      {
+        "character": "Brian",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-4.mp3",
+      "startTime": 1,
+      "startTimestamp": 18.75,
+      "finishTimestamp": 22.3
+    }
+  },
+  "commands": [
+    {
+      "character": "Brian",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Brian",
+      "startTime": 1,
+      "finishTime": 4.5,
+      "dialogue": {
+        "text": "Sophie is a great workmate. She's very kind and helpful.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Brian",
+      "opacity": 0,
+      "startTime": 5
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d199a0d5c10050b7e8241.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d199a0d5c10050b7e8241.md
@@ -51,3 +51,47 @@ She is very kind.
 ## --video-solution--
 
 4
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "cafe.png",
+    "characters": [
+      {
+        "character": "Brian",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-4.mp3",
+      "startTime": 1,
+      "startTimestamp": 18.75,
+      "finishTimestamp": 22.3
+    }
+  },
+  "commands": [
+    {
+      "character": "Brian",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Brian",
+      "startTime": 1,
+      "finishTime": 4.5,
+      "dialogue": {
+        "text": "Sophie is a great workmate. She's very kind and helpful.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Brian",
+      "opacity": 0,
+      "startTime": 5
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d199a0d5c10050b7e8241.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d199a0d5c10050b7e8241.md
@@ -3,7 +3,6 @@ id: 656d199a0d5c10050b7e8241
 title: Task 142
 challengeType: 19
 dashedName: task-142
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d19d9ab6e0c052edfb1e7.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d19d9ab6e0c052edfb1e7.md
@@ -18,7 +18,7 @@ Someone who is `helpful` is ready to give assistance or support. When you descri
 
 ## --sentence--
 
-`Great! Sophie is a great workmate. She is very kind and _.`
+`Sophie is a great workmate. She is very kind and _.`
 
 ## --blanks--
 
@@ -27,3 +27,47 @@ Someone who is `helpful` is ready to give assistance or support. When you descri
 ### --feedback--
 
 Brian is describing Sophie's positive attributes. He's referring to her willingness to assist or support.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "cafe.png",
+    "characters": [
+      {
+        "character": "Brian",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-4.mp3",
+      "startTime": 1,
+      "startTimestamp": 18.75,
+      "finishTimestamp": 22.3
+    }
+  },
+  "commands": [
+    {
+      "character": "Brian",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Brian",
+      "startTime": 1,
+      "finishTime": 4.5,
+      "dialogue": {
+        "text": "Sophie is a great workmate. She's very kind and helpful.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Brian",
+      "opacity": 0,
+      "startTime": 5
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d19d9ab6e0c052edfb1e7.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d19d9ab6e0c052edfb1e7.md
@@ -3,7 +3,6 @@ id: 656d19d9ab6e0c052edfb1e7
 title: Task 143
 challengeType: 22
 dashedName: task-143
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1a520285050552702fc1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1a520285050552702fc1.md
@@ -3,7 +3,6 @@ id: 656d1a520285050552702fc1
 title: Task 144
 challengeType: 19
 dashedName: task-144
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1a520285050552702fc1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1a520285050552702fc1.md
@@ -56,3 +56,73 @@ Sophie's response is playful and modest, not angry.
 ## --video-solution--
 
 2
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "cafe.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 25, "y": 15, "z": 1.3 },
+        "opacity": 0
+      },
+      {
+        "character": "Brian",
+        "position": { "x": 75, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-4.mp3",
+      "startTime": 1,
+      "startTimestamp": 18.75,
+      "finishTimestamp": 23.85
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Brian",
+      "opacity": 1,
+      "startTime": 0
+    },
+
+    {
+      "character": "Brian",
+      "startTime": 1,
+      "finishTime": 4.5,
+      "dialogue": {
+        "text": "Sophie is a great workmate. She's very kind and helpful.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sophie",
+      "startTime": 4.75,
+      "finishTime": 5.7,
+      "dialogue": {
+        "text": "Oh, come on, Brian.",
+        "align": "center"
+      }
+    },
+
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 6.2
+    },
+    {
+      "character": "Brian",
+      "opacity": 0,
+      "startTime": 6.2
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1a520285050552702fc1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1a520285050552702fc1.md
@@ -19,7 +19,7 @@ In conversations, people sometimes use expressions to show modesty. Sophie's ans
 
 ## --text--
 
-Why does Sophie say `Oh, c'mon, Brian!`?
+Why does Sophie say `Oh, come on, Brian!`?
 
 ## --answers--
 
@@ -100,7 +100,7 @@ Sophie's response is playful and modest, not angry.
       "finishTime": 4.5,
       "dialogue": {
         "text": "Sophie is a great workmate. She's very kind and helpful.",
-        "align": "center"
+        "align": "right"
       }
     },
     {
@@ -109,7 +109,7 @@ Sophie's response is playful and modest, not angry.
       "finishTime": 5.7,
       "dialogue": {
         "text": "Oh, come on, Brian.",
-        "align": "center"
+        "align": "left"
       }
     },
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1ad4fbdb51057f0f0714.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1ad4fbdb51057f0f0714.md
@@ -13,7 +13,7 @@ The phrase `it is true` is used to confirm or agree with what someone else said.
 
 ## --text--
 
-In the dialogue, how does Brian respond when Sophie says, `Oh, c'mon, Brian!`?
+In the dialogue, how does Brian respond when Sophie says, `Oh, come on, Brian!`?
 
 ## --answers--
 
@@ -93,7 +93,7 @@ Brian continues on the same topic, praising Sophie.
       "finishTime": 1.44,
       "dialogue": {
         "text": "Oh, come on, Brian.",
-        "align": "center"
+        "align": "left"
       }
     },
     {

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1ad4fbdb51057f0f0714.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1ad4fbdb51057f0f0714.md
@@ -50,3 +50,71 @@ Brian continues on the same topic, praising Sophie.
 ## --video-solution--
 
 3
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "cafe.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      },
+      {
+        "character": "Brian",
+        "position": { "x": 75, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-4.mp3",
+      "startTime": 1,
+      "startTimestamp": 22.84,
+      "finishTimestamp": 28.16
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Brian",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 1.44,
+      "dialogue": {
+        "text": "Oh, come on, Brian.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Brian",
+      "startTime": 2,
+      "finishTime": 7.25,
+      "dialogue": {
+        "text": "But it's true. She's the person to go to if you need help.",
+        "align": "right"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 7.75
+    },
+    {
+      "character": "Brian",
+      "opacity": 0,
+      "startTime": 7.75
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1ad4fbdb51057f0f0714.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1ad4fbdb51057f0f0714.md
@@ -3,7 +3,6 @@ id: 656d1ad4fbdb51057f0f0714
 title: Task 145
 challengeType: 19
 dashedName: task-145
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1b4a3be31305a9c3ee35.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1b4a3be31305a9c3ee35.md
@@ -46,3 +46,71 @@ Brian continues discussing Sophie's qualities, staying on the same topic.
 ## --video-solution--
 
 1
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "cafe.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      },
+      {
+        "character": "Brian",
+        "position": { "x": 75, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-4.mp3",
+      "startTime": 1,
+      "startTimestamp": 22.84,
+      "finishTimestamp": 28.16
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Brian",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 1.44,
+      "dialogue": {
+        "text": "Oh, come on, Brian.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Brian",
+      "startTime": 2,
+      "finishTime": 7.25,
+      "dialogue": {
+        "text": "But it's true. She's the person to go to if you need help.",
+        "align": "right"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 7.75
+    },
+    {
+      "character": "Brian",
+      "opacity": 0,
+      "startTime": 7.75
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1b4a3be31305a9c3ee35.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1b4a3be31305a9c3ee35.md
@@ -3,7 +3,6 @@ id: 656d1b4a3be31305a9c3ee35
 title: Task 146
 challengeType: 19
 dashedName: task-146
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1b4a3be31305a9c3ee35.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1b4a3be31305a9c3ee35.md
@@ -7,13 +7,13 @@ dashedName: task-146
 
 # --description--
 
-In the dialogue, the phrase `it is true` is Brian's way of confirming or agreeing with what he said earlier. When someone says `it is true`, they are indicating that they believe what they said is correct or factual. Brian uses this phrase to show that he stands by his earlier statement about Sophie, even after she reacts with `Oh, c'mon`.
+In the dialogue, the phrase `it is true` is Brian's way of confirming or agreeing with what he said earlier. When someone says `it is true`, they are indicating that they believe what they said is correct or factual. Brian uses this phrase to show that he stands by his earlier statement about Sophie, even after she reacts with `Oh, come on`.
 
 # --question--
 
 ## --text--
 
-In the dialogue, how does Brian respond when Sophie says, `Oh, c'mon, Brian!`?
+In the dialogue, how does Brian respond when Sophie says, `Oh, come on, Brian!`?
 
 ## --answers--
 
@@ -56,7 +56,7 @@ Brian continues discussing Sophie's qualities, staying on the same topic.
     "characters": [
       {
         "character": "Sophie",
-        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "position": { "x": 25, "y": 0, "z": 1.3 },
         "opacity": 0
       },
       {
@@ -68,7 +68,7 @@ Brian continues discussing Sophie's qualities, staying on the same topic.
     "audio": {
       "filename": "1.1-4.mp3",
       "startTime": 1,
-      "startTimestamp": 22.84,
+      "startTimestamp": 22.6,
       "finishTimestamp": 28.16
     }
   },
@@ -86,16 +86,16 @@ Brian continues discussing Sophie's qualities, staying on the same topic.
     {
       "character": "Sophie",
       "startTime": 1,
-      "finishTime": 1.44,
+      "finishTime": 2.4,
       "dialogue": {
         "text": "Oh, come on, Brian.",
-        "align": "center"
+        "align": "left"
       }
     },
     {
       "character": "Brian",
-      "startTime": 2,
-      "finishTime": 7.25,
+      "startTime": 3.3,
+      "finishTime": 6.35,
       "dialogue": {
         "text": "But it's true. She's the person to go to if you need help.",
         "align": "right"
@@ -104,12 +104,12 @@ Brian continues discussing Sophie's qualities, staying on the same topic.
     {
       "character": "Sophie",
       "opacity": 0,
-      "startTime": 7.75
+      "startTime": 6.85
     },
     {
       "character": "Brian",
       "opacity": 0,
-      "startTime": 7.75
+      "startTime": 6.85
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1becadf67d05d5b27bab.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1becadf67d05d5b27bab.md
@@ -56,3 +56,71 @@ In the dialogue, which word does Brian use to refer to Sophie without repeating 
 ## --video-solution--
 
 4
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "cafe.png",
+    "characters": [
+      {
+        "character": "Sophie",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      },
+      {
+        "character": "Brian",
+        "position": { "x": 75, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-4.mp3",
+      "startTime": 1,
+      "startTimestamp": 22.84,
+      "finishTimestamp": 28.16
+    }
+  },
+  "commands": [
+    {
+      "character": "Sophie",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Brian",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sophie",
+      "startTime": 1,
+      "finishTime": 1.44,
+      "dialogue": {
+        "text": "Oh, come on, Brian.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Brian",
+      "startTime": 2,
+      "finishTime": 7.25,
+      "dialogue": {
+        "text": "But it's true. She's the person to go to if you need help.",
+        "align": "right"
+      }
+    },
+    {
+      "character": "Sophie",
+      "opacity": 0,
+      "startTime": 7.75
+    },
+    {
+      "character": "Brian",
+      "opacity": 0,
+      "startTime": 7.75
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1becadf67d05d5b27bab.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1becadf67d05d5b27bab.md
@@ -3,7 +3,6 @@ id: 656d1becadf67d05d5b27bab
 title: Task 147
 challengeType: 19
 dashedName: task-147
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1becadf67d05d5b27bab.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1becadf67d05d5b27bab.md
@@ -9,7 +9,7 @@ dashedName: task-147
 
 Just like when you learned about the pronoun `he`, pronouns like `she` are used to refer to female individuals. They help avoid repetition in conversation. Look at this part of the dialogue:
 
-Sophie: `Oh, c'mon, Brian!`
+Sophie: `Oh, come on, Brian!`
 
 Brian: `But it is true. She's the person to go to if you need help!`
 
@@ -66,7 +66,7 @@ In the dialogue, which word does Brian use to refer to Sophie without repeating 
     "characters": [
       {
         "character": "Sophie",
-        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "position": { "x": 25, "y": 0, "z": 1.3 },
         "opacity": 0
       },
       {
@@ -78,7 +78,7 @@ In the dialogue, which word does Brian use to refer to Sophie without repeating 
     "audio": {
       "filename": "1.1-4.mp3",
       "startTime": 1,
-      "startTimestamp": 22.84,
+      "startTimestamp": 22.6,
       "finishTimestamp": 28.16
     }
   },
@@ -96,16 +96,16 @@ In the dialogue, which word does Brian use to refer to Sophie without repeating 
     {
       "character": "Sophie",
       "startTime": 1,
-      "finishTime": 1.44,
+      "finishTime": 2.4,
       "dialogue": {
         "text": "Oh, come on, Brian.",
-        "align": "center"
+        "align": "left"
       }
     },
     {
       "character": "Brian",
-      "startTime": 2,
-      "finishTime": 7.25,
+      "startTime": 3.3,
+      "finishTime": 6.35,
       "dialogue": {
         "text": "But it's true. She's the person to go to if you need help.",
         "align": "right"
@@ -114,12 +114,12 @@ In the dialogue, which word does Brian use to refer to Sophie without repeating 
     {
       "character": "Sophie",
       "opacity": 0,
-      "startTime": 7.75
+      "startTime": 6.85
     },
     {
       "character": "Brian",
       "opacity": 0,
-      "startTime": 7.75
+      "startTime": 6.85
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1c98a6bd5505fd346b50.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1c98a6bd5505fd346b50.md
@@ -55,3 +55,47 @@ Which two words does the contraction `She's` in the dialogue stand for?
 ## --video-solution--
 
 4
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "cafe.png",
+    "characters": [
+      {
+        "character": "Brian",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-4.mp3",
+      "startTime": 1,
+      "startTimestamp": 24.9,
+      "finishTimestamp": 28.16
+    }
+  },
+  "commands": [
+    {
+      "character": "Brian",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Brian",
+      "startTime": 1,
+      "finishTime": 3.76,
+      "dialogue": {
+        "text": "But it's true. She's the person to go to if you need help.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Brian",
+      "opacity": 0,
+      "startTime": 4.26
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1c98a6bd5505fd346b50.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1c98a6bd5505fd346b50.md
@@ -3,7 +3,6 @@ id: 656d1c98a6bd5505fd346b50
 title: Task 148
 challengeType: 19
 dashedName: task-148
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1d1f46bc820629aecc0d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1d1f46bc820629aecc0d.md
@@ -27,3 +27,47 @@ Watch the dialogue below and listen to how Brian refers to Sophie.
 ### --feedback--
 
 The contraction is used to describe a female person's characteristic.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "cafe.png",
+    "characters": [
+      {
+        "character": "Brian",
+        "position": { "x": 50, "y": 15, "z": 1.2 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-4.mp3",
+      "startTime": 1,
+      "startTimestamp": 24.9,
+      "finishTimestamp": 28.16
+    }
+  },
+  "commands": [
+    {
+      "character": "Brian",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Brian",
+      "startTime": 1,
+      "finishTime": 3.76,
+      "dialogue": {
+        "text": "But it's true. She's the person to go to if you need help.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Brian",
+      "opacity": 0,
+      "startTime": 4.26
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1d1f46bc820629aecc0d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1d1f46bc820629aecc0d.md
@@ -10,7 +10,7 @@ AUDIO REFERENCE:
 Brian: But it is true. She's the person to go to if you need help, Tom!
 -->
 
---description--
+# --description--
 
 Watch the dialogue below and listen to how Brian refers to Sophie.
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1d1f46bc820629aecc0d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1d1f46bc820629aecc0d.md
@@ -12,7 +12,7 @@ Brian: But it is true. She's the person to go to if you need help, Tom!
 
 # --description--
 
-Watch the dialogue below and listen to how Brian refers to Sophie.
+Watch the dialogue below and listen to how Brian refers to Sophie. Fill in the blanks below when you are done.
 
 # --fillInTheBlank--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1d1f46bc820629aecc0d.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d1d1f46bc820629aecc0d.md
@@ -3,7 +3,6 @@ id: 656d1d1f46bc820629aecc0d
 title: Task 149
 challengeType: 22
 dashedName: task-149
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d25e0c5d5aa11ade33754.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d25e0c5d5aa11ade33754.md
@@ -3,7 +3,6 @@ id: 656d25e0c5d5aa11ade33754
 title: Task 150
 challengeType: 19
 dashedName: task-150
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d25e0c5d5aa11ade33754.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d25e0c5d5aa11ade33754.md
@@ -46,3 +46,47 @@ While Jake may work in Security, he's not specifically a guard.
 ## --video-solution--
 
 2
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company1-reception.png",
+    "characters": [
+      {
+        "character": "Jake",
+        "position": {"x":50,"y":0,"z":1.4},
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-5.mp3",
+      "startTime": 1,
+      "startTimestamp": 0.00,
+      "finishTimestamp": 3.94
+    }
+  },
+  "commands": [
+    {
+      "character": "Jake",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Jake",
+      "startTime": 1,
+      "finishTime": 4.94,
+      "dialogue": {
+        "text": "Hey. You're Sarah, right? I'm Jake, from Security.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Jake",
+      "opacity": 0,
+      "startTime": 5.44
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2600b0ffa811dac3853f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2600b0ffa811dac3853f.md
@@ -8,7 +8,6 @@ dashedName: task-151
 <!--
 AUDIO REFERENCE:
 Jake: Hey. You are Sarah, right? I'm Jake, from Security.
-``
 -->
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2600b0ffa811dac3853f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2600b0ffa811dac3853f.md
@@ -35,3 +35,47 @@ Think about where Jake works. It's a department responsible for safety.
 ### --feedback--
 
 Think about where Jake works. It's a department responsible for safety.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company1-reception.png",
+    "characters": [
+      {
+        "character": "Jake",
+        "position": {"x":50,"y":0,"z":1.4},
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-5.mp3",
+      "startTime": 1,
+      "startTimestamp": 0.00,
+      "finishTimestamp": 3.94
+    }
+  },
+  "commands": [
+    {
+      "character": "Jake",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Jake",
+      "startTime": 1,
+      "finishTime": 4.94,
+      "dialogue": {
+        "text": "Hey. You're Sarah, right? I'm Jake, from Security.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Jake",
+      "opacity": 0,
+      "startTime": 5.44
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2600b0ffa811dac3853f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2600b0ffa811dac3853f.md
@@ -3,7 +3,6 @@ id: 656d2600b0ffa811dac3853f
 title: Task 151
 challengeType: 22
 dashedName: task-151
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d266537ff53120d194ae8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d266537ff53120d194ae8.md
@@ -3,7 +3,6 @@ id: 656d266537ff53120d194ae8
 title: Task 152
 challengeType: 19
 dashedName: task-152
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d266537ff53120d194ae8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d266537ff53120d194ae8.md
@@ -46,3 +46,47 @@ Jake isn't lending; he's providing the card for Sarah's use.
 ## --video-solution--
 
 3
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company1-reception.png",
+    "characters": [
+      {
+        "character": "Jake",
+        "position": {"x":50,"y":0,"z":1.4},
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-5.mp3",
+      "startTime": 1,
+      "startTimestamp": 4.18,
+      "finishTimestamp": 6.24
+    }
+  },
+  "commands": [
+    {
+      "character": "Jake",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Jake",
+      "startTime": 1,
+      "finishTime": 2.75,
+      "dialogue": {
+        "text": "I'm here to give you your access card.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Jake",
+      "opacity": 0,
+      "startTime": 3.25
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d26bc907ce0123546288a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d26bc907ce0123546288a.md
@@ -27,3 +27,47 @@ The phrase `I'm here to` normally talks about purpose or intention. Jake uses th
 ### --feedback--
 
 Focus on why Jake is there. 
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company1-reception.png",
+    "characters": [
+      {
+        "character": "Jake",
+        "position": {"x":50,"y":0,"z":1.4},
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-5.mp3",
+      "startTime": 1,
+      "startTimestamp": 4.18,
+      "finishTimestamp": 6.24
+    }
+  },
+  "commands": [
+    {
+      "character": "Jake",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Jake",
+      "startTime": 1,
+      "finishTime": 2.75,
+      "dialogue": {
+        "text": "I'm here to give you your access card.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Jake",
+      "opacity": 0,
+      "startTime": 3.25
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d26bc907ce0123546288a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d26bc907ce0123546288a.md
@@ -3,7 +3,6 @@ id: 656d26bc907ce0123546288a
 title: Task 153
 challengeType: 22
 dashedName: task-153
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d27271410d4125ee2ad5a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d27271410d4125ee2ad5a.md
@@ -46,3 +46,47 @@ To grant Sarah entry to certain areas.
 ## --video-solution--
 
 4
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company1-reception.png",
+    "characters": [
+      {
+        "character": "Jake",
+        "position": {"x":50,"y":0,"z":1.4},
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-5.mp3",
+      "startTime": 1,
+      "startTimestamp": 4.18,
+      "finishTimestamp": 6.24
+    }
+  },
+  "commands": [
+    {
+      "character": "Jake",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Jake",
+      "startTime": 1,
+      "finishTime": 2.75,
+      "dialogue": {
+        "text": "I'm here to give you your access card.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Jake",
+      "opacity": 0,
+      "startTime": 3.25
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d27271410d4125ee2ad5a.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d27271410d4125ee2ad5a.md
@@ -3,7 +3,6 @@ id: 656d27271410d4125ee2ad5a
 title: Task 154
 challengeType: 19
 dashedName: task-154
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d27a603926f1288bafcc0.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d27a603926f1288bafcc0.md
@@ -3,7 +3,6 @@ id: 656d27a603926f1288bafcc0
 title: Task 155
 challengeType: 22
 dashedName: task-155
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d27a603926f1288bafcc0.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d27a603926f1288bafcc0.md
@@ -43,3 +43,47 @@ The item is specifically meant for Sarah.
 ### --feedback--
 
 The item is specifically meant for Sarah.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company1-reception.png",
+    "characters": [
+      {
+        "character": "Jake",
+        "position": {"x":50,"y":0,"z":1.4},
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-5.mp3",
+      "startTime": 1,
+      "startTimestamp": 0.00,
+      "finishTimestamp": 6.24
+    }
+  },
+  "commands": [
+    {
+      "character": "Jake",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Jake",
+      "startTime": 1,
+      "finishTime": 6.94,
+      "dialogue": {
+        "text": "Hey. You're Sarah, right? I'm Jake, from Security. I'm here to give you your access card.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Jake",
+      "opacity": 0,
+      "startTime": 7.44
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d283b7ba56912bb2ceb06.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d283b7ba56912bb2ceb06.md
@@ -3,7 +3,6 @@ id: 656d283b7ba56912bb2ceb06
 title: Task 156
 challengeType: 19
 dashedName: task-156
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d283b7ba56912bb2ceb06.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d283b7ba56912bb2ceb06.md
@@ -65,37 +65,62 @@ The door is not the main subject of their conversation.
     "background": "company1-reception.png",
     "characters": [
       {
+        "character": "Jake",
+        "position": { "x": 25, "y": 0, "z": 1.4 },
+        "opacity": 0
+      },
+      {
         "character": "Sarah",
-        "position": {"x":50,"y":0,"z":1.4},
+        "position": { "x": 75, "y": 0, "z": 1.4 },
         "opacity": 0
       }
     ],
     "audio": {
       "filename": "1.1-5.mp3",
       "startTime": 1,
-      "startTimestamp": 7.54,
+      "startTimestamp": 4.18,
       "finishTimestamp": 8.96
     }
   },
   "commands": [
+    {
+      "character": "Jake",
+      "opacity": 1,
+      "startTime": 0
+    },
     {
       "character": "Sarah",
       "opacity": 1,
       "startTime": 0
     },
     {
-      "character": "Sarah",
+      "character": "Jake",
       "startTime": 1,
-      "finishTime": 2.42,
+      "finishTime": 2.75,
       "dialogue": {
-        "text": "Is it contactless?",
-        "align": "center"
+        "text": "I'm here to give you your access card.",
+        "align": "left"
       }
     },
     {
       "character": "Sarah",
+      "startTime": 3.2,
+      "finishTime": 5.5,
+      "dialogue": {
+        "text": "Thanks Jake. Is it contactless?",
+        "align": "right"
+      }
+    },
+
+    {
+      "character": "Jake",
       "opacity": 0,
-      "startTime": 2.92
+      "startTime": 6
+    },
+    {
+      "character": "Sarah",
+      "opacity": 0,
+      "startTime": 6
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d283b7ba56912bb2ceb06.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d283b7ba56912bb2ceb06.md
@@ -56,3 +56,47 @@ The door is not the main subject of their conversation.
 ## --video-solution--
 
 3
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company1-reception.png",
+    "characters": [
+      {
+        "character": "Sarah",
+        "position": {"x":50,"y":0,"z":1.4},
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-5.mp3",
+      "startTime": 1,
+      "startTimestamp": 7.54,
+      "finishTimestamp": 8.96
+    }
+  },
+  "commands": [
+    {
+      "character": "Sarah",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sarah",
+      "startTime": 1,
+      "finishTime": 2.42,
+      "dialogue": {
+        "text": "Is it contactless?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sarah",
+      "opacity": 0,
+      "startTime": 2.92
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2914e7cfc312ea00c864.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2914e7cfc312ea00c864.md
@@ -24,7 +24,7 @@ Jake also uses `it's`, the contraction for `it is`, when talking about the swipe
 
 ## --sentence--
 
-`Sarah: Thanks, Jake. Is it contactless? Jake: No, _ _. _ the good-old swipe at the door.`
+`No, _ _. _ the good-old swipe at the door.`
 
 ## --blanks--
 
@@ -49,3 +49,71 @@ The second blank is describing the card's functionality.
 ### --feedback--
 
 The third blank is describing the action needed to use the card.
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company1-reception.png",
+    "characters": [
+      {
+        "character": "Jake",
+        "position": { "x": 25, "y": 0, "z": 1.4 },
+        "opacity": 0
+      },
+      {
+        "character": "Sarah",
+        "position": { "x": 75, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-5.mp3",
+      "startTime": 1,
+      "startTimestamp": 7.54,
+      "finishTimestamp": 12.24
+    }
+  },
+  "commands": [
+    {
+      "character": "Jake",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sarah",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sarah",
+      "startTime": 1,
+      "finishTime": 2.42,
+      "dialogue": {
+        "text": "Is it contactless?",
+        "align": "right"
+      }
+    },
+    {
+      "character": "Jake",
+      "startTime": 2.5,
+      "finishTime": 5,
+      "dialogue": {
+        "text": "No, it isn't. It's the good-old swipe at the door.",
+        "align": "left"
+      }
+    },
+    {
+      "character": "Jake",
+      "opacity": 0,
+      "startTime": 5.5
+    },
+    {
+      "character": "Sarah",
+      "opacity": 0,
+      "startTime": 5.5
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2914e7cfc312ea00c864.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2914e7cfc312ea00c864.md
@@ -3,7 +3,6 @@ id: 656d2914e7cfc312ea00c864
 title: Task 157
 challengeType: 22
 dashedName: task-157
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2914e7cfc312ea00c864.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2914e7cfc312ea00c864.md
@@ -89,7 +89,7 @@ The third blank is describing the action needed to use the card.
     {
       "character": "Sarah",
       "startTime": 1,
-      "finishTime": 2.42,
+      "finishTime": 2.3,
       "dialogue": {
         "text": "Is it contactless?",
         "align": "right"
@@ -98,7 +98,7 @@ The third blank is describing the action needed to use the card.
     {
       "character": "Jake",
       "startTime": 2.5,
-      "finishTime": 5,
+      "finishTime": 5.2,
       "dialogue": {
         "text": "No, it isn't. It's the good-old swipe at the door.",
         "align": "left"
@@ -107,12 +107,12 @@ The third blank is describing the action needed to use the card.
     {
       "character": "Jake",
       "opacity": 0,
-      "startTime": 5.5
+      "startTime": 5.7
     },
     {
       "character": "Sarah",
       "opacity": 0,
-      "startTime": 5.5
+      "startTime": 5.7
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d299e9d0027131875568f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d299e9d0027131875568f.md
@@ -51,3 +51,47 @@ This is a reversed and incorrect version of `good-old`.
 ## --video-solution--
 
 1
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company1-reception.png",
+    "characters": [
+      {
+        "character": "Jake",
+        "position": {"x":50,"y":0,"z":1.4},
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-5.mp3",
+      "startTime": 1,
+      "startTimestamp": 9.30,
+      "finishTimestamp": 12.24
+    }
+  },
+  "commands": [
+    {
+      "character": "Jake",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Jake",
+      "startTime": 1,
+      "finishTime": 3.94,
+      "dialogue": {
+        "text": "No, it isn't. It's the good-old swipe at the door.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Jake",
+      "opacity": 0,
+      "startTime": 4.44
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d299e9d0027131875568f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d299e9d0027131875568f.md
@@ -61,14 +61,14 @@ This is a reversed and incorrect version of `good-old`.
     "characters": [
       {
         "character": "Jake",
-        "position": {"x":50,"y":0,"z":1.4},
+        "position": { "x": 50, "y": 0, "z": 1.4 },
         "opacity": 0
       }
     ],
     "audio": {
       "filename": "1.1-5.mp3",
       "startTime": 1,
-      "startTimestamp": 9.30,
+      "startTimestamp": 10.3,
       "finishTimestamp": 12.24
     }
   },
@@ -81,16 +81,16 @@ This is a reversed and incorrect version of `good-old`.
     {
       "character": "Jake",
       "startTime": 1,
-      "finishTime": 3.94,
+      "finishTime": 2.9,
       "dialogue": {
-        "text": "No, it isn't. It's the good-old swipe at the door.",
+        "text": "It's the good-old swipe at the door.",
         "align": "center"
       }
     },
     {
       "character": "Jake",
       "opacity": 0,
-      "startTime": 4.44
+      "startTime": 3.4
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d299e9d0027131875568f.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d299e9d0027131875568f.md
@@ -3,7 +3,6 @@ id: 656d299e9d0027131875568f
 title: Task 158
 challengeType: 19
 dashedName: task-158
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2a2ed95bfa1345fd9fd1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2a2ed95bfa1345fd9fd1.md
@@ -61,14 +61,14 @@ This is a negation and not related to what to do with the card.
     "characters": [
       {
         "character": "Jake",
-        "position": {"x":50,"y":0,"z":1.4},
+        "position": { "x": 50, "y": 0, "z": 1.4 },
         "opacity": 0
       }
     ],
     "audio": {
       "filename": "1.1-5.mp3",
       "startTime": 1,
-      "startTimestamp": 9.30,
+      "startTimestamp": 10.3,
       "finishTimestamp": 12.24
     }
   },
@@ -81,16 +81,16 @@ This is a negation and not related to what to do with the card.
     {
       "character": "Jake",
       "startTime": 1,
-      "finishTime": 3.94,
+      "finishTime": 2.9,
       "dialogue": {
-        "text": "No, it isn't. It's the good-old swipe at the door.",
+        "text": "It's the good-old swipe at the door.",
         "align": "center"
       }
     },
     {
       "character": "Jake",
       "opacity": 0,
-      "startTime": 4.44
+      "startTime": 3.4
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2a2ed95bfa1345fd9fd1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2a2ed95bfa1345fd9fd1.md
@@ -3,7 +3,6 @@ id: 656d2a2ed95bfa1345fd9fd1
 title: Task 159
 challengeType: 19
 dashedName: task-159
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2a2ed95bfa1345fd9fd1.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2a2ed95bfa1345fd9fd1.md
@@ -51,3 +51,47 @@ This is a negation and not related to what to do with the card.
 ## --video-solution--
 
 2
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company1-reception.png",
+    "characters": [
+      {
+        "character": "Jake",
+        "position": {"x":50,"y":0,"z":1.4},
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-5.mp3",
+      "startTime": 1,
+      "startTimestamp": 9.30,
+      "finishTimestamp": 12.24
+    }
+  },
+  "commands": [
+    {
+      "character": "Jake",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Jake",
+      "startTime": 1,
+      "finishTime": 3.94,
+      "dialogue": {
+        "text": "No, it isn't. It's the good-old swipe at the door.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Jake",
+      "opacity": 0,
+      "startTime": 4.44
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2aee945ce2137bd8b8b8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2aee945ce2137bd8b8b8.md
@@ -3,7 +3,6 @@ id: 656d2aee945ce2137bd8b8b8
 title: Task 160
 challengeType: 19
 dashedName: task-160
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2aee945ce2137bd8b8b8.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2aee945ce2137bd8b8b8.md
@@ -59,3 +59,47 @@ This is the correct interpretation of the `click`.
 ## --video-solution--
 
 4
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company1-reception.png",
+    "characters": [
+      {
+        "character": "Jake",
+        "position": {"x":50,"y":0,"z":1.4},
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-5.mp3",
+      "startTime": 1,
+      "startTimestamp": 12.24,
+      "finishTimestamp": 16.62
+    }
+  },
+  "commands": [
+    {
+      "character": "Jake",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Jake",
+      "startTime": 1,
+      "finishTime": 5.2,
+      "dialogue": {
+        "text": "When you hear the click, it's unlocked, and you can get in or out.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Jake",
+      "opacity": 0,
+      "startTime": 5.7
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2b6aaad95013a86cea6c.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2b6aaad95013a86cea6c.md
@@ -3,7 +3,6 @@ id: 656d2b6aaad95013a86cea6c
 title: Task 161
 challengeType: 19
 dashedName: task-161
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2b6aaad95013a86cea6c.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2b6aaad95013a86cea6c.md
@@ -46,3 +46,47 @@ There's no need to knock; the door is unlocked.
 ## --video-solution--
 
 2
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company1-reception.png",
+    "characters": [
+      {
+        "character": "Jake",
+        "position": {"x":50,"y":0,"z":1.4},
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-5.mp3",
+      "startTime": 1,
+      "startTimestamp": 12.24,
+      "finishTimestamp": 16.62
+    }
+  },
+  "commands": [
+    {
+      "character": "Jake",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Jake",
+      "startTime": 1,
+      "finishTime": 5.2,
+      "dialogue": {
+        "text": "When you hear the click, it's unlocked, and you can get in or out.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Jake",
+      "opacity": 0,
+      "startTime": 5.7
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2bc10f29b413d1a843d5.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2bc10f29b413d1a843d5.md
@@ -3,7 +3,6 @@ id: 656d2bc10f29b413d1a843d5
 title: Task 162
 challengeType: 19
 dashedName: task-162
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 # --description--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2bc10f29b413d1a843d5.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2bc10f29b413d1a843d5.md
@@ -7,7 +7,7 @@ dashedName: task-162
 
 # --description--
 
-`Five o'clock` is a way of telling time. It refers to 5:00, which can be in the morning (`AM`) or evening (`PM`). This conversation happens at the end of the work day so it is fair to assume it is `5PM`. 
+`Five o'clock` is a way of telling time. It refers to 5:00, which can be in the morning (`AM`) or evening (`PM`). This conversation happens at the end of the work day so it is fair to assume it is `5PM`.
 
 # --question--
 
@@ -46,3 +46,47 @@ You don't eat time.
 ## --video-solution--
 
 1
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company1-reception.png",
+    "characters": [
+      {
+        "character": "Jake",
+        "position": { "x": 50, "y": 0, "z": 1.4 },
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-5.mp3",
+      "startTime": 1,
+      "startTimestamp": 19.1,
+      "finishTimestamp": 20.78
+    }
+  },
+  "commands": [
+    {
+      "character": "Jake",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Jake",
+      "startTime": 1,
+      "finishTime": 2.65,
+      "dialogue": {
+        "text": "Well, it's five o'clock.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Jake",
+      "opacity": 0,
+      "startTime": 3.15
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2c2fedbd5f14055b7e7b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2c2fedbd5f14055b7e7b.md
@@ -3,7 +3,6 @@ id: 656d2c2fedbd5f14055b7e7b
 title: Task 163
 challengeType: 19
 dashedName: task-163
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2c2fedbd5f14055b7e7b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2c2fedbd5f14055b7e7b.md
@@ -55,3 +55,47 @@ The phrase isn't about forgetting.
 ## --video-solution--
 
 2
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company1-reception.png",
+    "characters": [
+      {
+        "character": "Jake",
+        "position": {"x":50,"y":0,"z":1.4},
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-5.mp3",
+      "startTime": 1,
+      "startTimestamp": 20.92,
+      "finishTimestamp": 24.23
+    }
+  },
+  "commands": [
+    {
+      "character": "Jake",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Jake",
+      "startTime": 1,
+      "finishTime": 4.31,
+      "dialogue": {
+        "text": "I guess this is it for your first day. How was it?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Jake",
+      "opacity": 0,
+      "startTime": 4.81
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2c94279eb6143485eac6.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2c94279eb6143485eac6.md
@@ -22,7 +22,7 @@ Listen to the audio and find the expression.
 
 ## --sentence--
 
-`Well, five o'clock. I guess _ _ _ for your first day.`
+`Well, five o'clock. I guess _ _ _ for your first day. How was it?`
 
 ## --blanks--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2c94279eb6143485eac6.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2c94279eb6143485eac6.md
@@ -47,3 +47,47 @@ Verb to be in the third person
 ### --feedback--
 
 It is a pronoun!
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company1-reception.png",
+    "characters": [
+      {
+        "character": "Jake",
+        "position": {"x":50,"y":0,"z":1.4},
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-5.mp3",
+      "startTime": 1,
+      "startTimestamp": 19.1,
+      "finishTimestamp": 24.23
+    }
+  },
+  "commands": [
+    {
+      "character": "Jake",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Jake",
+      "startTime": 1,
+      "finishTime": 6,
+      "dialogue": {
+        "text": "Well, It's five o'clock. I guess this is it for your first day. How was it?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Jake",
+      "opacity": 0,
+      "startTime": 6.5
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2c94279eb6143485eac6.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2c94279eb6143485eac6.md
@@ -3,7 +3,6 @@ id: 656d2c94279eb6143485eac6
 title: Task 164
 challengeType: 22
 dashedName: task-164
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2d19c570e2146b5e8835.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2d19c570e2146b5e8835.md
@@ -3,7 +3,6 @@ id: 656d2d19c570e2146b5e8835
 title: Task 165
 challengeType: 19
 dashedName: task-165
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2d19c570e2146b5e8835.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2d19c570e2146b5e8835.md
@@ -51,3 +51,47 @@ He isn't asking about Sarah's location.
 ## --video-solution--
 
 3
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company1-reception.png",
+    "characters": [
+      {
+        "character": "Jake",
+        "position": {"x":50,"y":0,"z":1.4},
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-5.mp3",
+      "startTime": 1,
+      "startTimestamp": 19.1,
+      "finishTimestamp": 24.23
+    }
+  },
+  "commands": [
+    {
+      "character": "Jake",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Jake",
+      "startTime": 1,
+      "finishTime": 6,
+      "dialogue": {
+        "text": "Well, It's five o'clock. I guess this is it for your first day. How was it?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Jake",
+      "opacity": 0,
+      "startTime": 6.5
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2d814b60b6149a03c699.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2d814b60b6149a03c699.md
@@ -3,7 +3,6 @@ id: 656d2d814b60b6149a03c699
 title: Task 166
 challengeType: 19
 dashedName: task-166
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2d814b60b6149a03c699.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2d814b60b6149a03c699.md
@@ -56,3 +56,47 @@ It's a friendly phrase.
 ## --video-solution--
 
 3
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company1-reception.png",
+    "characters": [
+      {
+        "character": "Sarah",
+        "position": {"x":50,"y":0,"z":1.4},
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-5.mp3",
+      "startTime": 1,
+      "startTimestamp": 25.04,
+      "finishTimestamp": 27.46
+    }
+  },
+  "commands": [
+    {
+      "character": "Sarah",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Sarah",
+      "startTime": 1,
+      "finishTime": 3.3,
+      "dialogue": {
+        "text": "Good, really good. See you tomorrow, then?",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Sarah",
+      "opacity": 0,
+      "startTime": 3.8
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2f31f23860155477ca7b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2f31f23860155477ca7b.md
@@ -3,7 +3,6 @@ id: 656d2f31f23860155477ca7b
 title: Task 167
 challengeType: 19
 dashedName: task-167
-audioPath: curriculum/js-music-player/We-Are-Going-to-Make-it.mp3
 ---
 
 <!--

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2f31f23860155477ca7b.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/656d2f31f23860155477ca7b.md
@@ -54,3 +54,47 @@ A great evening.
 ## --video-solution--
 
 4
+
+# --scene--
+
+```json
+{
+  "setup": {
+    "background": "company1-reception.png",
+    "characters": [
+      {
+        "character": "Jake",
+        "position": {"x":50,"y":0,"z":1.4},
+        "opacity": 0
+      }
+    ],
+    "audio": {
+      "filename": "1.1-5.mp3",
+      "startTime": 1,
+      "startTimestamp": 27.46,
+      "finishTimestamp": 29.10
+    }
+  },
+  "commands": [
+    {
+      "character": "Jake",
+      "opacity": 1,
+      "startTime": 0
+    },
+    {
+      "character": "Jake",
+      "startTime": 1,
+      "finishTime": 2.64,
+      "dialogue": {
+        "text": "Sure. Have a great evening.",
+        "align": "center"
+      }
+    },
+    {
+      "character": "Jake",
+      "opacity": 0,
+      "startTime": 3.14
+    }
+  ]
+}
+```

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/657bcf58b87d01890f9bdc93.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/657bcf58b87d01890f9bdc93.md
@@ -1,40 +1,56 @@
 ---
-id: 656a1298f2a0400f56b31e25
-title: Task 27
-challengeType: 22
-dashedName: task-27
+id: 657bcf58b87d01890f9bdc93
+title: Task 28
+challengeType: 19
+dashedName: task-28
 ---
 
 <!--
 AUDIO REFERENCE:
-Maria: Great! Let me show you to your desk. Do you see the desk with a drawing tablet and a computer? That's your workspace.
+Maria: Do you see the desk with a drawing tablet and a computer?
 -->
 
 # --description--
 
-Maria is directing Tom to his workspace and describing certain items on his desk.
+Describing objects or places with their characteristics or things related to them helps the listener to identify them easily.
 
-# --fillInTheBlank--
+# --question--
 
-## --sentence--
+## --text--
 
-`Do you see the desk with a _ _ and a computer?`
+What does Maria use to describe Tom's desk?
 
-## --blanks--
+## --answers--
 
-`drawing`
+`The desk near the window`
 
 ### --feedback--
 
-Listen to the sentence.
+Listen closely to the items Maria mentions.
 
 ---
 
-`tablet`
+`The desk with a drawing tablet and a computer`
+
+---
+
+`The desk with a coffee mug on it`
 
 ### --feedback--
 
-Listen to the sentence.
+Listen closely to the items Maria mentions.
+
+---
+
+`The desk next to hers`
+
+### --feedback--
+
+Listen closely to the items Maria mentions.
+
+## --video-solution--
+
+2
 
 # --scene--
 

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/657bcf58b87d01890f9bdc93.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/657bcf58b87d01890f9bdc93.md
@@ -61,15 +61,15 @@ Listen closely to the items Maria mentions.
     "characters": [
       {
         "character": "Maria",
-        "position": { "x": 50, "y": 0, "z": 1.5 },
+        "position": {"x":50,"y":0,"z":1.5},
         "opacity": 0
       }
     ],
     "audio": {
       "filename": "1.1-1.mp3",
       "startTime": 1,
-      "startTimestamp": 17.6,
-      "finishTimestamp": 20.4
+      "startTimestamp": 17.75,
+      "finishTimestamp": 20.3
     }
   },
   "commands": [
@@ -80,8 +80,8 @@ Listen closely to the items Maria mentions.
     },
     {
       "character": "Maria",
-      "startTime": 0.5,
-      "finishTime": 3.8,
+      "startTime": 1,
+      "finishTime": 3.4,
       "dialogue": {
         "text": "Do you see the desk with a drawing tablet and a computer?",
         "align": "center"
@@ -90,7 +90,7 @@ Listen closely to the items Maria mentions.
     {
       "character": "Maria",
       "opacity": 0,
-      "startTime": 4.3
+      "startTime": 3.9
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/657e0d0037192f3d9e3d5417.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/657e0d0037192f3d9e3d5417.md
@@ -1,32 +1,32 @@
 ---
-id: 656cda3cd706aa1daa128704
-title: Task 136
+id: 657e0d0037192f3d9e3d5417 
+title: Task 128
 challengeType: 22
-dashedName: task-136
+dashedName: task-128
 ---
 
 <!--
 AUDIO REFERENCE:
-Sophie: This is Brian. He's a web developer.
+Sophie: Oh, look who's here! Hey, Brian!
 -->
 
 # --description--
 
-The contraction `he's` is a combination of the pronoun `he` and the verb `is`. It is used to refer to a male person and describe something about him.
+Listen and fill in the blanks.
 
 # --fillInTheBlank--
 
 ## --sentence--
 
-`This is Brian. _ a web developer.`
+`Oh, _ who's here! Hey, Brian!`
 
 ## --blanks--
 
-`He's`
+`look`
 
 ### --feedback--
 
-The contraction is used to describe a male person's occupation in this context.
+Sophie is expressing surprise. Enter the word Sophie uses in the blank.
 
 # --scene--
 
@@ -44,8 +44,8 @@ The contraction is used to describe a male person's occupation in this context.
     "audio": {
       "filename": "1.1-4.mp3",
       "startTime": 1,
-      "startTimestamp": 9.1,
-      "finishTimestamp": 11.76
+      "startTimestamp": 0,
+      "finishTimestamp": 3.02
     }
   },
   "commands": [
@@ -57,16 +57,16 @@ The contraction is used to describe a male person's occupation in this context.
     {
       "character": "Sophie",
       "startTime": 1,
-      "finishTime": 3.66,
+      "finishTime": 3.52,
       "dialogue": {
-        "text": "Tom, this is Brian. He's a web developer.",
+        "text": "Oh, look who's here! Hey, Brian. How is everything?",
         "align": "center"
       }
     },
     {
       "character": "Sophie",
       "opacity": 0,
-      "startTime": 4.16
+      "startTime": 4.02
     }
   ]
 }

--- a/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/657e0d0037192f3d9e3d5417.md
+++ b/curriculum/challenges/english/21-a2-english-for-developers/learn-greetings-in-your-first-day-at-the-office/657e0d0037192f3d9e3d5417.md
@@ -12,13 +12,13 @@ Sophie: Oh, look who's here! Hey, Brian!
 
 # --description--
 
-Listen and fill in the blanks.
+Listen to the video and fill in the blank below.
 
 # --fillInTheBlank--
 
 ## --sentence--
 
-`Oh, _ who's here! Hey, Brian!`
+`Oh, _ who's here! Hey, Brian. How is everything?`
 
 ## --blanks--
 


### PR DESCRIPTION
This adds the videos to all of the block 1.1 challenges. I added videos in many places where there wasn't an audio reference in the markdown - they seemed to fit. When reviewing, we should make sure that we have the videos where we want them, and not where we don't.

It makes some slight tweaks in a couple other files, as well.

To test this:
-Download the english assets here: https://github.com/moT01/english-assets
-Serve the assets folder on port 8080 - I run `http-server` while in the english-assets folder
-Let me know if you need help with that

Edit: Alternatively, change the domain variable in `scene-assets.tsx` to `const domain = 'https://cdn.freecodecamp.org/curriculum/english/animation-assets';`


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
