### PR TITLE
fix(curriculum): allow space in cafe css project step 36

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f3c866de7a5b784048f94b1.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f3c866de7a5b784048f94b1.md
@@ -32,7 +32,7 @@ Your first `article` element should have the `item` class.
 ```js
 const el = document.querySelectorAll('article')[0];
 
-assert.equal(el.className,'item');
+assert.equal(el.className, 'item');
 ```
 
 # --seed--

--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f3c866de7a5b784048f94b1.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-basic-css-by-building-a-cafe-menu/5f3c866de7a5b784048f94b1.md
@@ -16,19 +16,23 @@ To get them on the same line, you need to apply some styling to the `p` elements
 You should apply the `item` class to your `article` element.
 
 ```js
-assert(code.match(/<article\s*class=('|")item\1\s*>/i))
+const el = document.querySelector('article.item');
+assert.exists(el);
 ```
 
 You should only have one `item` class element.
 
 ```js
-assert($('.item').length === 1);
+const elements = document.querySelectorAll('.item');
+assert.lengthOf(elements, 1);
 ```
 
 Your first `article` element should have the `item` class.
 
 ```js
-assert($('article')[0].className === 'item');
+const el = document.querySelectorAll('article')[0];
+
+assert.equal(el.className,'item');
 ```
 
 # --seed--


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [X] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [X] My pull request targets the `main` branch of freeCodeCamp.
- [X] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Ref https://github.com/freeCodeCamp/freeCodeCamp/issues/52549

<!-- Feel free to add any additional description of changes below this line -->
I updated the challenge to no longer use regular expressions and removed jQuery in an effort to ensure classes can have a space before and after the equal sign. If there are no further issues and the other two pull requests are merged, then the issue can be closed.