### PR TITLE
fix(client): add punctuation to a sentence in footer

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -306,7 +306,7 @@
     "page-number": "{{pageNumber}} of {{totalPages}}"
   },
   "footer": {
-    "tax-exempt-status": "freeCodeCamp is a donor-supported tax-exempt 501(c)(3) charitable organization (United States Federal Tax Identification Number: 82-0779546)",
+    "tax-exempt-status": "freeCodeCamp is a donor-supported tax-exempt 501(c)(3) charitable organization (United States Federal Tax Identification Number: 82-0779546).",
     "mission-statement": "Our mission: to help people learn to code for free. We accomplish this by creating thousands of videos, articles, and interactive coding lessons - all freely available to the public.",
     "donation-initiatives": "Donations to freeCodeCamp go toward our education initiatives, and help pay for servers, services, and staff.",
     "donate-text": "You can <1>make a tax-deductible donation here</1>.",

--- a/docs/how-to-work-on-localized-client-webapp.md
+++ b/docs/how-to-work-on-localized-client-webapp.md
@@ -255,6 +255,8 @@ In the above example, the key and a variable are set in the attributes of the `T
 
 To change text on the client side of things, go to the relevant `.json` file, find the key that is being used in the React component, and change the value to the new text you want. You should search the codebase for that key to make sure it isn't being used elsewhere. Or, if it is, that the changes make sense in all places.
 
+Run `pnpm run clean-and-develop` to apply the change.
+
 ## Adding Text
 
 If the text you want to add to the client exists in the relevant `.json` file, use the existing key. Otherwise, create a new key.
@@ -264,10 +266,12 @@ The English file is the "source of truth" for all of the `.json` files sharing t
 > [!NOTE]
 > Use English text for all languages if the file is translated through Crowdin. The tests will fail if you don't.
 
-It would be nice to keep the keys in the same order across all the files as well. Also, try to put all punctuation, spacing, quotes, etc in the JSON files and not in the components or server files.
+It would be nice to keep the keys in the same order across all the files as well. Also, try to put all punctuation, spacing, quotes, etc. in the JSON files and not in the components or server files.
 
 > [!NOTE]
 > The underscore (`_`) is a reserved character for keys in the client-side files. See [the documentation](https://www.i18next.com/translation-function/plurals) for how they are used.
+
+Run `pnpm run clean-and-develop` to apply the change.
 
 ## Proposing a Pull Request (PR)
 

--- a/docs/troubleshooting-development-issues.md
+++ b/docs/troubleshooting-development-issues.md
@@ -14,7 +14,7 @@ If you are on a different OS or are still facing issues, see [getting help](#get
 
 ## Issues with Missing UI, Fonts, Language Strings, or Build Errors
 
-When you build the client, Gatsby will cache the Fonts, language strings, and UI. If one of them isn't cached, run the following:
+When you build the client, Gatsby will cache the fonts, language strings, and UI. If one of them isn't cached, run the following:
 
 ```bash
 pnpm run clean


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Adds punctuation to a sentence in the footer
- Updates the contributing guide to mention the `pnpm run clean-and-develop` command when working with translation strings. This came up a couple times recently on Discord:
  - https://discord.com/channels/692816967895220344/715074489422970962/1181058818919125032
  - https://discord.com/channels/692816967895220344/715074489422970962/1184325047473668196

<!-- Feel free to add any additional description of changes below this line -->
